### PR TITLE
Ensure kind name uniqueness for pymatgen structures with partial occupancies

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2305,10 +2305,54 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         a = pymatgen.structure.Structure(lattice=[[4,0,0],[0,4,0],[0,0,4]],
                                          species=[Fe1,Fe2],
                                          coords=[[0,0,0],[0.5,0.5,0.5]])
-                
+
         with self.assertRaises(ValueError): 
             StructureData(pymatgen=a)
-        
+
+    @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
+    @unittest.skipIf(has_pymatgen() and StrictVersion(get_pymatgen_version()) != StrictVersion('4.5.3'),
+                     "Mismatch in the version of pymatgen (expected 4.5.3)")
+    def test_multiple_kinds_partial_occupancies(self):
+        """
+        Tests that a structure with multiple sites with the same element but different
+        partial occupancies, get their own unique kind name
+        """
+        from aiida.orm.data.structure import StructureData
+        import pymatgen
+
+        Mg1 = pymatgen.structure.Composition({'Mg': 0.50})
+        Mg2 = pymatgen.structure.Composition({'Mg': 0.25})
+
+        a = pymatgen.structure.Structure(
+            lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]],
+            species=[Mg1, Mg2],
+            coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
+        )
+
+        structure = StructureData(pymatgen=a)
+
+    @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
+    @unittest.skipIf(has_pymatgen() and StrictVersion(get_pymatgen_version()) != StrictVersion('4.5.3'),
+                     "Mismatch in the version of pymatgen (expected 4.5.3)")
+    def test_multiple_kinds_alloy(self):
+        """
+        Tests that a structure with multiple sites with the same alloy symbols but different
+        weights, get their own unique kind name
+        """
+        from aiida.orm.data.structure import StructureData
+        import pymatgen
+
+        alloy_one = pymatgen.structure.Composition({'Mg': 0.25, 'Al': 0.75})
+        alloy_two = pymatgen.structure.Composition({'Mg': 0.45, 'Al': 0.55})
+
+        a = pymatgen.structure.Structure(
+            lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]],
+            species=[alloy_one, alloy_two],
+            coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
+        )
+
+        structure = StructureData(pymatgen=a)
+
 
 class TestPymatgenFromStructureData(AiidaTestCase):
     """

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -844,24 +844,22 @@ class StructureData(Data):
             :param specie: a pymatgen specie
             :return: a string
             """
-            has_spin = any([specie.as_dict().get('properties',{}).get('spin',0)!=0
+            has_spin = any([specie.as_dict().get('properties', {}).get('spin', 0) != 0
                             for specie in species_and_occu.keys()])
-                            
-            if has_spin and (len(species_and_occu.items())>1
-                             or any([weight!=1.0 for weight in species_and_occu.values()])):
-                raise ValueError("Cannot set partial occupancies and spins "
-                                     "at the same time")
-            
+
+            if has_spin and (len(species_and_occu.items()) > 1
+                             or any([weight != 1.0 for weight in species_and_occu.values()])):
+                raise ValueError('Cannot set partial occupancies and spins at the same time')
+
             if not has_spin:
-                return Kind(symbols=[x[0].symbol for x in species_and_occu.items()],
-                            weights=[x[1] for x in species_and_occu.items()]).name
-            
+                return None
+
+            spin = species_and_occu.keys()[0].as_dict().get('properties', {}).get('spin', 0)
+
+            if spin < 0:
+                return specie.symbol + '1'
             else:
-                spin = species_and_occu.keys()[0].as_dict().get('properties',{}).get('spin',0)
-                if spin<0:
-                    return specie.symbol+'1'
-                else:
-                    return specie.symbol+'2'
+                return specie.symbol + '2'
         
         self.cell = struct.lattice.matrix.tolist()
         self.pbc = [True, True, True]
@@ -871,10 +869,17 @@ class StructureData(Data):
                 kind_name = site.properties['kind_name']
             else:
                 kind_name = build_kind_name(site.species_and_occu)
-            self.append_atom(symbols=[x[0].symbol for x in site.species_and_occu.items()],
-                         weights=[x[1] for x in site.species_and_occu.items()],
-                         position=site.coords.tolist(),
-                         name=kind_name)
+
+            inputs = {
+                'symbols': [x[0].symbol for x in site.species_and_occu.items()],
+                'weights': [x[1] for x in site.species_and_occu.items()],
+                'position': site.coords.tolist()
+            }
+
+            if kind_name is not None:
+                inputs['name'] = kind_name
+
+            self.append_atom(**inputs)
 
     def _validate(self):
         """


### PR DESCRIPTION
Fixes #1356 

The kind name used to be passed directly to append_atom when there was no
spin species, but this would give the same name to all sites with the
same symbol but potentially different occupancies, causing append_atom
to rightfully throw a ValueError