### PR TITLE
Fixing the check on the number of allocated nodes (machines) on PBS/Torque schedulers

### DIFF
--- a/aiida/scheduler/plugins/pbsbaseclasses.py
+++ b/aiida/scheduler/plugins/pbsbaseclasses.py
@@ -555,7 +555,7 @@ class PbsBaseClass(object):
 
             # Double check of redundant info
             if (this_job.allocated_machines is not None and this_job.num_machines is not None):
-                if len(this_job.allocated_machines) != this_job.num_machines:
+                if len(set(machine.name for machine in this_job.allocated_machines)) != this_job.num_machines:
                     self.logger.error("The length of the list of allocated "
                                       "nodes ({}) is different from the "
                                       "expected number of nodes ({})!".format(


### PR DESCRIPTION
In some cases, for some torque schedulers, the same host can appear multiple times in the list, e.g.
`exec_host = qmobile/1+qmobile/0`
and this still counts as a single host (with two cpus). Indeed in this case, earlier a warning was issued, because `Resource_List.nodect = 1`
(this was submitted with `#PBS -l nodes=1:ppn=2,walltime=00:30:00`)