### PR TITLE
Migrate the type and process type string of built in calculation plugins

### DIFF
--- a/aiida/backends/djsite/db/migrations/0019_migrate_builtin_calculations.py
+++ b/aiida/backends/djsite/db/migrations/0019_migrate_builtin_calculations.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,too-few-public-methods
+"""Migration to reflect the name change of the built in calculation entry points in the database."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from django.db import migrations
+
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.19'
+DOWN_REVISION = '1.0.18'
+
+
+class Migration(migrations.Migration):
+    """Migration to remove entry point groups from process type strings and prefix unknown types with a marker."""
+
+    dependencies = [
+        ('db', '0018_django_1_11'),
+    ]
+
+    operations = [
+        # The built in calculation plugins `arithmetic.add` and `templatereplacer` have been moved and their entry point
+        # renamed. In the change the `simpleplugins` namespace was dropped so we migrate the existing nodes.
+        migrations.RunSQL(
+            sql="""
+            UPDATE db_dbnode SET type = 'calculation.job.arithmetic.add.ArithmeticAddCalculation.'
+            WHERE type = 'calculation.job.simpleplugins.arithmetic.add.ArithmeticAddCalculation.';
+
+            UPDATE db_dbnode SET type = 'calculation.job.templatereplacer.TemplatereplacerCalculation.'
+            WHERE type = 'calculation.job.simpleplugins.templatereplacer.TemplatereplacerCalculation.';
+
+            UPDATE db_dbnode SET process_type = 'aiida.calculations:arithmetic.add'
+            WHERE process_type = 'aiida.calculations:simpleplugins.arithmetic.add';
+
+            UPDATE db_dbnode SET process_type = 'aiida.calculations:templatereplacer'
+            WHERE process_type = 'aiida.calculations:simpleplugins.templatereplacer';
+
+            UPDATE db_dbattribute AS a SET tval = 'arithmetic.add'
+            FROM db_dbnode AS n WHERE a.dbnode_id = n.id
+                AND a.key = 'input_plugin'
+                AND a.tval = 'simpleplugins.arithmetic.add'
+                AND n.type = 'data.code.Code.';
+
+            UPDATE db_dbattribute AS a SET tval = 'templatereplacer'
+            FROM db_dbnode AS n WHERE a.dbnode_id = n.id
+                AND a.key = 'input_plugin'
+                AND a.tval = 'simpleplugins.templatereplacer'
+                AND n.type = 'data.code.Code.';
+            """,
+            reverse_sql="""
+            UPDATE db_dbnode SET type = 'calculation.job.simpleplugins.arithmetic.add.ArithmeticAddCalculation.'
+            WHERE type = 'calculation.job.arithmetic.add.ArithmeticAddCalculation.';
+
+            UPDATE db_dbnode SET type = 'calculation.job.simpleplugins.templatereplacer.TemplatereplacerCalculation.'
+            WHERE type = 'calculation.job.templatereplacer.TemplatereplacerCalculation.';
+
+            UPDATE db_dbnode SET process_type = 'aiida.calculations:simpleplugins.arithmetic.add'
+            WHERE process_type = 'aiida.calculations:arithmetic.add';
+
+            UPDATE db_dbnode SET process_type = 'aiida.calculations:simpleplugins.templatereplacer'
+            WHERE process_type = 'aiida.calculations:templatereplacer';
+
+            UPDATE db_dbattribute AS a SET tval = 'simpleplugins.arithmetic.add'
+            FROM db_dbnode AS n WHERE a.dbnode_id = n.id
+                AND a.key = 'input_plugin'
+                AND a.tval = 'arithmetic.add'
+                AND n.type = 'data.code.Code.';
+
+            UPDATE db_dbattribute AS a SET tval = 'simpleplugins.templatereplacer'
+            FROM db_dbnode AS n WHERE a.dbnode_id = n.id
+                AND a.key = 'input_plugin'
+                AND a.tval = 'templatereplacer'
+                AND n.type = 'data.code.Code.';
+            """),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-LATEST_MIGRATION = '0018_django_1_11'
+LATEST_MIGRATION = '0019_migrate_builtin_calculations'
 
 def _update_schema_version(version, apps, schema_editor):
     from aiida.backends.djsite.utils import set_db_schema_version

--- a/aiida/backends/sqlalchemy/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name
+"""Migration to reflect the name change of the built in calculation entry points in the database.
+
+Revision ID: 140c971ae0a3
+Revises: 162b99bca4a2
+Create Date: 2018-12-06 12:42:01.897037
+
+"""
+from __future__ import absolute_import
+from alembic import op
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '140c971ae0a3'
+down_revision = '162b99bca4a2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Migrations for the upgrade."""
+    conn = op.get_bind()  # pylint: disable=no-member
+
+    # The built in calculation plugins `arithmetic.add` and `templatereplacer` have been moved and their entry point
+    # renamed. In the change the `simpleplugins` namespace was dropped so we migrate the existing nodes.
+    statement = text("""
+        UPDATE db_dbnode SET type = 'calculation.job.arithmetic.add.ArithmeticAddCalculation.'
+        WHERE type = 'calculation.job.simpleplugins.arithmetic.add.ArithmeticAddCalculation.';
+
+        UPDATE db_dbnode SET type = 'calculation.job.templatereplacer.TemplatereplacerCalculation.'
+        WHERE type = 'calculation.job.simpleplugins.templatereplacer.TemplatereplacerCalculation.';
+
+        UPDATE db_dbnode SET process_type = 'aiida.calculations:arithmetic.add'
+        WHERE process_type = 'aiida.calculations:simpleplugins.arithmetic.add';
+
+        UPDATE db_dbnode SET process_type = 'aiida.calculations:templatereplacer'
+        WHERE process_type = 'aiida.calculations:simpleplugins.templatereplacer';
+
+        UPDATE db_dbnode SET attributes = jsonb_set(attributes, '{"input_plugin"}', '"arithmetic.add"')
+        WHERE attributes @> '{"input_plugin": "simpleplugins.arithmetic.add"}'
+        AND type = 'data.code.Code.';
+
+        UPDATE db_dbnode SET attributes = jsonb_set(attributes, '{"input_plugin"}', '"templatereplacer"')
+        WHERE attributes @> '{"input_plugin": "simpleplugins.templatereplacer"}'
+        AND type = 'data.code.Code.';
+    """)
+    conn.execute(statement)
+
+
+def downgrade():
+    """Migrations for the downgrade."""
+    conn = op.get_bind()  # pylint: disable=no-member
+
+    statement = text("""
+        UPDATE db_dbnode SET type = 'calculation.job.simpleplugins.arithmetic.add.ArithmeticAddCalculation.'
+        WHERE type = 'calculation.job.arithmetic.add.ArithmeticAddCalculation.';
+
+        UPDATE db_dbnode SET type = 'calculation.job.simpleplugins.templatereplacer.TemplatereplacerCalculation.'
+        WHERE type = 'calculation.job.templatereplacer.TemplatereplacerCalculation.';
+
+        UPDATE db_dbnode SET process_type = 'aiida.calculations:simpleplugins.arithmetic.add'
+        WHERE process_type = 'aiida.calculations:arithmetic.add';
+
+        UPDATE db_dbnode SET process_type = 'aiida.calculations:simpleplugins.templatereplacer'
+        WHERE process_type = 'aiida.calculations:templatereplacer';
+
+        UPDATE db_dbnode SET attributes = jsonb_set(attributes, '{"input_plugin"}', '"simpleplugins.arithmetic.add"')
+        WHERE attributes @> '{"input_plugin": "arithmetic.add"}'
+        AND type = 'data.code.Code.';
+
+        UPDATE db_dbnode SET attributes = jsonb_set(attributes, '{"input_plugin"}', '"simpleplugins.templatereplacer"')
+        WHERE attributes @> '{"input_plugin": "templatereplacer"}'
+        AND type = 'data.code.Code.';
+    """)
+    conn.execute(statement)


### PR DESCRIPTION
Fixes #2306 

The built in calculation entry points were recently moved and renamed
but no migration was put in.

This requires renaming the node types, process types and the input plugin
attribute of code instances.