### PR TITLE
Add exception for `calculation.job.JobCalculation` process type inference

### DIFF
--- a/aiida/manage/database/integrity/plugins.py
+++ b/aiida/manage/database/integrity/plugins.py
@@ -135,9 +135,13 @@ def infer_calculation_entry_point(type_strings):
         if inferred_entry_point_name in entry_point_names:
             entry_point_string = '{entry_point_group}:{entry_point_name}'.format(
                 entry_point_group=entry_point_group, entry_point_name=inferred_entry_point_name)
-        else:
+        elif inferred_entry_point_name:
             entry_point_string = '{plugin_name}.{plugin_class}'.format(
                 plugin_name=inferred_entry_point_name, plugin_class=plugin_class)
+        else:
+            # If there is no inferred entry point name, i.e. there is no module name, use an empty string as fall back
+            # This should only be the case for the type string `calculation.job.JobCalculation.`
+            entry_point_string = ''
 
         mapping_node_type_to_entry_point[type_string] = entry_point_string
 


### PR DESCRIPTION
Fixes #2406 

In the migration following the provenance redesign, the process type had
to be inferred from the existing type string for `JobCalculation` nodes.
The function `infer_calculation_entry_point` did not account for literal
`calculation.job.JobCalculation.` type strings being present and would
return `.JobCalculation` as the fallback process type. However, it makes
more sense to just have an empty process type string in this case, as
would be the case for a base `CalcJobNode` instance.