### PR TITLE
[WIP] BandsData: fix _prepare_gnuplot() and matplotlib_header_template

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -213,7 +213,7 @@ def _show_xmgrace(exec_name, list_bands):
             'agr', setnumber_offset=current_band_number, color_number=(iband + 1 % max_num_agr_colors))
         # write a tempfile
         tempf = tempfile.NamedTemporaryFile('w+', suffix='.agr')
-        tempf.write(text)
+        tempf.write(text.decode("utf-8"))
         tempf.flush()
         list_files.append(tempf)
         # update the number of bands already plotted

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -993,7 +993,7 @@ class BandsData(KpointsData):
         script.append(u'plot "{}" with l lc rgb "#000000"'.format(os.path.basename(dat_filename).replace('"', '\"')))
 
         script_data = u"\n".join(script) + u"\n"
-        extra_files = {dat_filename: raw_data.encode('utf-8')}
+        extra_files = {dat_filename: raw_data}
 
         return script_data.encode('utf-8'), extra_files
 
@@ -1661,7 +1661,6 @@ print_comment = False
 # see e.g. http://matplotlib.org/1.3.0/examples/pylab_examples/usetex_baseline_test.html
 matplotlib_header_template = Template('''# -*- coding: utf-8 -*-
 
-from __future__ import print_statement
 from matplotlib import rc
 # Uncomment to change default font
 #rc('font',**{'family':'sans-serif','sans-serif':['Helvetica']})


### PR DESCRIPTION
fixes #2756
fixes #2462

* _prepare_gnuplot():
Remove raw_data.encode('utf-8') call that tries to convert
previously converted bytes object

* matplotlib_header_template:
remove `from __future__ import print_statement`