### PR TITLE
Short circuit execution of calculation functions when caching

### DIFF
--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -377,12 +377,13 @@ class TestWorkchain(AiidaTestCase):
             def define(cls, spec):
                 super(IllegalWorkChain, cls).define(spec)
                 spec.outline(cls.illegal)
+                spec.outputs.dynamic = True
 
             def illegal(self):
                 self.out('not_allowed', orm.Int(2))
 
         with self.assertRaises(ValueError):
-            launch.run(IllegalWorkChain)
+            result = launch.run(IllegalWorkChain)
 
     def test_same_input_node(self):
 

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -148,7 +148,11 @@ class CalcJob(Process):
 
     @override
     def run(self):
-        """Run the calculation, we put it in the TOSUBMIT state and then wait for it to be completed."""
+        """Run the calculation job.
+
+        This means invoking the `presubmit` and storing the temporary folder in the node's repository. Then we move the
+        process in the `Wait` state, waiting for the `UPLOAD` transport task to be started.
+        """
         from aiida.orm import Code, load_node
         from aiida.common.folders import SandboxFolder, SubmitTestFolder
         from aiida.common.exceptions import InputValidationError

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -398,6 +398,13 @@ class FunctionProcess(Process):
         from aiida.orm import Data
         from .exit_code import ExitCode
 
+        # The following conditional is required for the caching to properly work. Even if the source node has a process
+        # state of `Finished` the cached process will still enter the running state. The process state will have then
+        # been overridden by the engine to `Running` so we cannot check that, but if the `exit_status` is anything other
+        # than `None`, it should mean this node was taken from the cache, so the process should not be rerun.
+        if self.node.exit_status is not None:
+            return self.node.exit_status
+
         # Split the inputs into positional and keyword arguments
         args = [None] * len(self._func_args)
         kwargs = {}


### PR DESCRIPTION
Fixes #3119 

The caching of `CalcFunctionNodes` was working properly, however, the
process would still be executed afterwards. Somewhat surprisingly this
did not seem to cause obvious side effects or exceptions elsewhere. The
symptom that brought this to light is the fact that the result node that
was returned was unstored, despite the actual outputs being stored and
recorded properly. The origin of the problem is that the caching takes
place in the `Node.store` method, which is called indirectly by the
`Process.on_entered` when the process is created. However, in the case
that the node is created from a cached node, the `Process` is not
informed and merrily continues on its way calling `run`.

This problem was already addressed in the `CalcJob` class, where in the
`run` method the node was checked whether it already had an exit status
attribute. This would mean the node was cached from an already finished
calculation and so the method returns immediately. Note that this works,
because for a `ProcessNode` to be even considered a valid cache node, it
has to be `finished_ok` meaning it always has an `exit_status` attribute.
See the `ProcessNode.is_valid_cache` property.

To fix the problem for calculation functions, we simply add the same
check. Note that we cannot easily abstract this to the parent `Process`
class and have the sub classes call the super first, because they will
then have to check the result of the super call and return the value if
it is not `None`, which is not necessarily a cleaner solution then the
code duplication solution chosen here.

Another thing to keep in mind is that this is now only done for the
`FunctionProcess` and `CalcJob` process classes so the check is not
applied for the `WorkChain`. However, for now this is not problematic
since `WorkChainNodes` are not cachable anyway.