### PR TITLE
Ensure immutability of `CalcJobNode` hash before and after storing

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1095,8 +1095,7 @@ class Node(Entity):
             {
                 key: val
                 for key, val in self.attributes_items()
-                if (key not in self._hash_ignored_attributes and
-                    key not in getattr(self, '_updatable_attributes', tuple()))
+                if key not in self._hash_ignored_attributes and key not in self._updatable_attributes  # pylint: disable=unsupported-membership-test
             },
             self._repository._get_base_folder(),  # pylint: disable=protected-access
             self.computer.uuid if self.computer is not None else None

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -477,7 +477,7 @@ class ProcessNode(Sealable, Node):
 
         :returns: True if this process node is valid to be used for caching, False otherwise
         """
-        return super(ProcessNode, self).is_valid_cache and self.is_finished_ok
+        return super(ProcessNode, self).is_valid_cache and self.is_finished
 
     def _get_objects_to_hash(self):
         """


### PR DESCRIPTION
Fixes #3125 

The `Node._get_objects_to_hash` method, which returns all the objects of
a `Node` instance that should be included in computing its hash, also
included the file repository. This proved problematic for the
`CalcJobNode` sub class. The hash of a node is computed during the store
method, in order to determine if it can be cached from an existing node
with an identical hash. However, at that point, the repository of the
node is empty, but as soon as the node is stored and process is started,
the input files that are generated by the `CalcJob` class based on the
inputs, are stored in the repository of the node. If the hash were to be
recomputed at that point, it would be different from the original hash
computed during storing. This breaks the caching mechanism.

Since the input files that are written to the repository by the `CalcJob`
are derivatives of the input nodes (which are included in the hash), and
therefore do not semantically add anything to the provenance, we can
simply ignore them. Since this only applies to the `CalcJobNode`, we
simply override the method in that sub class and omit the repository.

N.B.: in this commit we also loosen the condition of when a completed
process node is considered to be a valid cache. Before only processes
that finished successfully (i.e. with process state `finished` and an
exit status `0`) were considered valid caches. This is loosened to also
accept non-zero exit statuses. The new rule then considers all processes
that have `finished` as a valid cache, excluding only `excepted` and
`killed` processes.