### PR TITLE
Implement a `PluginVersionProvider` for processes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,6 @@
         aiida/backends/sqlalchemy/models/node.py|
         aiida/backends/sqlalchemy/models/settings.py|
         aiida/backends/sqlalchemy/models/user.py|
-        aiida/backends/sqlalchemy/models/utils.py|
         aiida/backends/sqlalchemy/queries.py|
         aiida/backends/sqlalchemy/tests/test_generic.py|
         aiida/backends/sqlalchemy/tests/__init__.py|
@@ -128,7 +127,6 @@
         aiida/plugins/entry.py|
         aiida/plugins/info.py|
         aiida/plugins/registry.py|
-        aiida/plugins/utils.py|
         aiida/schedulers/datastructures.py|
         aiida/schedulers/plugins/direct.py|
         aiida/schedulers/plugins/lsf.py|

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -141,6 +141,7 @@ DB_TEST_LIST = {
         'orm.utils.repository': ['aiida.backends.tests.orm.utils.test_repository'],
         'parsers.parser': ['aiida.backends.tests.parsers.test_parser'],
         'plugin_loader': ['aiida.backends.tests.test_plugin_loader'],
+        'plugins.utils': ['aiida.backends.tests.plugins.test_utils'],
         'query': ['aiida.backends.tests.test_query'],
         'restapi': ['aiida.backends.tests.test_restapi'],
         'tools.data.orbital': ['aiida.backends.tests.tools.data.orbital.test_orbitals'],

--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -120,6 +120,18 @@ class TestProcessFunction(AiidaTestCase):
         super(TestProcessFunction, self).tearDown()
         self.assertIsNone(Process.current())
 
+    def test_plugin_version(self):
+        """Test the version attributes of a process function."""
+        from aiida import __version__ as version_core
+
+        _, node = self.function_args_with_default.run_get_node()
+
+        # Since the "plugin" i.e. the process function is defined in `aiida-core` the `version.plugin` is the same as
+        # the version of `aiida-core` itself
+        version_info = node.get_attribute('version')
+        self.assertEqual(version_info['core'], version_core)
+        self.assertEqual(version_info['plugin'], version_core)
+
     def test_process_state(self):
         """Test the process state for a process function."""
         _, node = self.function_args_with_default.run_get_node()

--- a/aiida/backends/tests/plugins/test_utils.py
+++ b/aiida/backends/tests/plugins/test_utils.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for utilities dealing with plugins and entry points."""
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+from aiida import __version__ as version_core
+from aiida.backends.testbase import AiidaTestCase
+from aiida.engine import calcfunction, WorkChain
+from aiida.plugins import CalculationFactory
+from aiida.plugins.utils import PluginVersionProvider
+
+
+class TestPluginVersionProvider(AiidaTestCase):
+    """Tests for the :py:class:`~aiida.plugins.utils.PluginVersionProvider` utility class."""
+
+    # pylint: disable=no-init,old-style-class,too-few-public-methods,no-member
+
+    def setUp(self):
+        super(TestPluginVersionProvider, self).setUp()
+        self.provider = PluginVersionProvider()
+
+    @staticmethod
+    def create_dynamic_plugin_module(plugin, plugin_version, add_module_to_sys=True, add_version=True):
+        """Create a fake dynamic module with a certain `plugin` entity, a class or function and the given version."""
+        import sys
+        import types
+        import uuid
+
+        # Create a new module with a unique name and add the `plugin` and `plugin_version` as attributes
+        module_name = 'TestModule{}'.format(str(uuid.uuid4())[:5])
+        dynamic_module = types.ModuleType(module_name, 'Dynamically created module for testing purposes')
+        setattr(plugin, '__module__', dynamic_module.__name__)
+        setattr(dynamic_module, plugin.__name__, plugin)
+
+        # For tests that need to fail, this flag can be set to `False`
+        if add_version:
+            setattr(dynamic_module, '__version__', plugin_version)
+
+        # Get the `DummyClass` plugin from the dynamically created test module
+        dynamic_plugin = getattr(dynamic_module, plugin.__name__)
+
+        # Make the dynamic module importable unless the test requests not to, to test an unimportable module
+        if add_module_to_sys:
+            sys.modules[dynamic_module.__name__] = dynamic_module
+
+        return dynamic_plugin
+
+    def test_external_module_import_fail(self):
+        """Test that mapper does not except even if external module cannot be imported."""
+
+        class DummyCalcJob():
+            pass
+
+        version_plugin = '0.1.01'
+        dynamic_plugin = self.create_dynamic_plugin_module(DummyCalcJob, version_plugin, add_module_to_sys=False)
+
+        expected_version = {'version': {'core': version_core}}
+        self.assertEqual(self.provider.get_version_info(dynamic_plugin), expected_version)
+
+    def test_external_module_no_version_attribute(self):
+        """Test that mapper does not except even if external module does not define `__version__` attribute."""
+
+        class DummyCalcJob():
+            pass
+
+        version_plugin = '0.1.02'
+        dynamic_plugin = self.create_dynamic_plugin_module(DummyCalcJob, version_plugin, add_version=False)
+
+        expected_version = {'version': {'core': version_core}}
+        self.assertEqual(self.provider.get_version_info(dynamic_plugin), expected_version)
+
+    def test_external_module_class(self):
+        """Test the mapper works for a class from an external module."""
+
+        class DummyCalcJob():
+            pass
+
+        version_plugin = '0.1.17'
+        dynamic_plugin = self.create_dynamic_plugin_module(DummyCalcJob, version_plugin)
+
+        expected_version = {'version': {'core': version_core, 'plugin': version_plugin}}
+        self.assertEqual(self.provider.get_version_info(dynamic_plugin), expected_version)
+
+    def test_external_module_function(self):
+        """Test the mapper works for a function from an external module."""
+
+        @calcfunction
+        def test_calcfunction():
+            return
+
+        version_plugin = '0.2.19'
+        dynamic_plugin = self.create_dynamic_plugin_module(test_calcfunction, version_plugin)
+
+        expected_version = {'version': {'core': version_core, 'plugin': version_plugin}}
+        self.assertEqual(self.provider.get_version_info(dynamic_plugin), expected_version)
+
+    def test_calcfunction(self):
+        """Test the mapper for a `calcfunction`."""
+
+        @calcfunction
+        def test_calcfunction():
+            return
+
+        expected_version = {'version': {'core': version_core, 'plugin': version_core}}
+        self.assertEqual(self.provider.get_version_info(test_calcfunction), expected_version)
+
+    def test_calc_job(self):
+        """Test the mapper for a `CalcJob`."""
+        AddArithmeticCalculation = CalculationFactory('arithmetic.add')  # pylint: disable=invalid-name
+
+        expected_version = {'version': {'core': version_core, 'plugin': version_core}}
+        self.assertEqual(self.provider.get_version_info(AddArithmeticCalculation), expected_version)
+
+    def test_work_chain(self):
+        """Test the mapper for a `WorkChain`."""
+
+        class SomeWorkChain(WorkChain):
+            """Need to create a dummy class since there is no built-in work chain with entry point in `aiida-core`."""
+
+        expected_version = {'version': {'core': version_core, 'plugin': version_core}}
+        self.assertEqual(self.provider.get_version_info(SomeWorkChain), expected_version)

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -633,6 +633,9 @@ class Process(plumpy.Process):
 
     def _setup_metadata(self):
         """Store the metadata on the ProcessNode."""
+        version_info = self.runner.plugin_version_provider.get_version_info(self)
+        self.node.set_attribute_many(version_info)
+
         for name, metadata in self.metadata.items():
             if name in ['store_provenance', 'dry_run', 'call_link_label']:
                 continue

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -7,102 +7,71 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-utilities for:
-
-* managing the registry cache folder
-* downloading json files
-* pickling to the registry cache folder
-"""
+"""Utilities dealing with plugins and entry points."""
 from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-import io
+
+from importlib import import_module
+
+from aiida.common import AIIDA_LOGGER
+
+__all__ = ('PluginVersionProvider',)
+
+KEY_VERSION_ROOT = 'version'
+KEY_VERSION_CORE = 'core'  # The version of `aiida-core`
+KEY_VERSION_PLUGIN = 'plugin'  # The version of the plugin top level module, e.g. `aiida-quantumespresso`
 
 
-def registry_cache_folder_name():
-    """
-    return the name of the subfolder of aiida_dir where registry caches are stored.
-    """
-    return 'plugin_registry_cache'
+class PluginVersionProvider(object):
+    """Utility class that determines version information about a given plugin resource."""
 
+    # pylint: disable=useless-object-inheritance
 
-def registry_cache_folder_path():
-    """
-    return the fully resolved path to the cache folder
-    """
-    from os import path as osp
-    from aiida.manage.configuration import get_config
-    config = get_config()
-    cache_dir = registry_cache_folder_name()
-    return osp.join(config.dirpath, cache_dir)
+    def __init__(self):
+        self._cache = {}
+        self._logger = AIIDA_LOGGER.getChild('plugin_version_provider')
 
+    @property
+    def logger(self):
+        return self._logger
 
-def registry_cache_folder_exists():
-    """
-    return True if the cache folder exists, False if not
-    """
-    from os import path as osp
-    cache_dir = registry_cache_folder_path()
-    return osp.isdir(cache_dir)
+    def get_version_info(self, plugin):
+        """Get the version information for a given plugin.
 
+        .. note::
 
-def safe_create_registry_cache_folder():
-    """
-    creates the registry cache folder if it does not exist
-    """
-    from os import mkdir
-    if not registry_cache_folder_exists():
-        cache_dir = registry_cache_folder_path()
-        mkdir(cache_dir)
+            This container will keep a cache, so if this function was already called for the given ``plugin`` before
+            for this instance, the result computer at last invocation will be returned.
 
+        :param plugin: a class or function
+        :return: dictionary with the `version.core` and optionally `version.plugin` if it could be determined.
+        """
+        from aiida import __version__ as version_core
 
-def pickle_to_registry_cache_folder(obj, fname):
-    """
-    pickles a python object to the registry cache folder
-    """
-    from six.moves.cPickle import dump as pdump
-    from os import path as osp
-    safe_create_registry_cache_folder()
-    cache_dir = registry_cache_folder_path()
-    fpath = osp.join(cache_dir, fname)
-    with io.open(fpath, 'w', encoding='utf8') as cache_file:
-        pdump(obj, cache_file)
+        # If the `plugin` already exists in the cache, simply return it. On purpose we do not verify whether the version
+        # information is completed. If it failed the first time, we don't retry. If the failure was temporarily, whoever
+        # holds a reference to this instance can simply reconstruct it to start with a clean slate.
+        if plugin in self._cache:
+            return self._cache[plugin]
 
+        self._cache[plugin] = {
+            KEY_VERSION_ROOT: {
+                KEY_VERSION_CORE: version_core,
+            }
+        }
 
-def unpickle_from_registry_cache_folder(fname):
-    """
-    looks for fname in the registry cache folder and tries to unpickle from it
-    """
-    from six.moves.cPickle import load as pload
-    from os import path as osp
-    cache_dir = registry_cache_folder_path()
-    fpath = osp.join(cache_dir, fname)
-    with io.open(fpath, 'r', encoding='utf8') as cache:
-        return pload(cache)
+        try:
+            parent_module_name = plugin.__module__.split('.')[0]
+            parent_module = import_module(parent_module_name)
+        except (AttributeError, IndexError, ImportError):
+            self.logger.debug('could not determine the top level module for plugin: {}'.format(plugin))
+            return self._cache[plugin]
 
+        try:
+            version_plugin = parent_module.__version__
+        except AttributeError:
+            self.logger.debug('parent module does not define `__version__` attribute for plugin: {}'.format(plugin))
+            return self._cache[plugin]
 
-def load_json_from_url(url, errorhandler=None):
-    """
-    downloads a json file and returns the corresponding python dict
-    """
-    import requests
-    reply = requests.get(url)
-    res = None
-    try:
-        res = reply.json()
-    except Exception as e:
-        if errorhandler:
-            res = errorhandler(e)
-        else:
-            raise e
-    return res
+        self._cache[plugin][KEY_VERSION_ROOT][KEY_VERSION_PLUGIN] = version_plugin
 
-
-def value_error_msg(e):
-    msg = 'The AiiDA plugin registry seems to be temporarily unavailable.'
-    msg += ' Please try again later. If the problem persists,'
-    msg += ' look at github.com/aiidateam/aiida-registry and file an issue'
-    msg += ' if there is none yet.'
-    return msg
+        return self._cache[plugin]


### PR DESCRIPTION
Fixes #2664 and fixes #2988 

This new utility class is used by the `Runner` class to keep a mapping
of certain process classes, either `Process` sub classes or process
functions onto a dictionary of "version" information. This dictionary
now includes the version of `aiida-core` that is running as well as the
version of the top level module of the plugin, if defined. If the latter
cannot be determined for whatever reason, only the version of
`aiida-core` is returned.

This information is then retrieved by the `Process` class during the
creation process. It will store this information in the attributes of
the process node. Currently, no logic in `aiida-core` will act on this
information. Its sole purpose is to give the user slightly more info on
with what versions of core and the plugin a certain process node was
generated. The attributes can also be used in querying to filter nodes
for a sub set generated with a specific version of the plugin.

Note that "plugin" here refers to the entire package, e.g the entire
`aiida-quantumespresso` plugin. Each plugin can contain multiple entry
points for the various entry point categories, that are sometimes
individually also referred to as plugins. In the future, the version
dictionary returned by the `PluginVersionProvider` may be enriched with
a specific `entry_point` version, once that level of version granulariy
will become supported. For the time being it is not included.