### PR TITLE
Move responsability of loading profile to `ProfileParamType`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_profile.py
+++ b/aiida/backends/tests/cmdline/commands/test_profile.py
@@ -125,10 +125,10 @@ class TestVerdiProfileSetup(AiidaPostgresTestCase):
         self.assertClickSuccess(result)
         self.assertTrue(profile_name_non_default in result.output)
 
-        # Specifying `-p/--profile` should override the configured default
+        # Specifying `-p/--profile` should not override the argument default (which should be the default profile)
         result = self.cli_runner.invoke(cmd_verdi.verdi, ['-p', profile_name_non_default, 'profile', 'show'])
         self.assertClickSuccess(result)
-        self.assertTrue(profile_name_non_default in result.output)
+        self.assertTrue(profile_name_non_default not in result.output)
 
     @with_temporary_config_instance
     def test_delete_partial(self):

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -52,10 +52,10 @@ def profile_list():
 
 
 @verdi_profile.command('show')
-@arguments.PROFILE(required=False, callback=defaults.get_default_profile)
+@arguments.PROFILE(default=defaults.get_default_profile)
 def profile_show(profile):
     """Show details for PROFILE or, when not specified, the default profile."""
-    if not profile:
+    if profile is None:
         echo.echo_critical('no profile to show')
 
     echo.echo_info('Configuration for: {}'.format(profile.name))
@@ -64,7 +64,7 @@ def profile_show(profile):
 
 
 @verdi_profile.command('setdefault')
-@arguments.PROFILE()
+@arguments.PROFILE(required=True, default=None)
 def profile_setdefault(profile):
     """Set PROFILE as the default profile."""
     try:

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -14,36 +14,20 @@ from __future__ import absolute_import
 
 import click
 
-from aiida.cmdline.params import options
-from aiida.common.extendeddicts import AttributeDict
-from aiida.common import exceptions
+from aiida.cmdline.params import options, types
 
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
-@options.PROFILE()
-@click.version_option(None, '-v', '--version', message="AiiDA version %(version)s")
+@options.PROFILE(type=types.ProfileParamType(load_profile=True))
+@click.version_option(None, '-v', '--version', message='AiiDA version %(version)s')
 @click.pass_context
 def verdi(ctx, profile):
     """The command line interface of AiiDA."""
-    from aiida.manage.configuration import get_config, load_profile
+    from aiida.common import extendeddicts
+    from aiida.manage.configuration import get_config
 
     if ctx.obj is None:
-        ctx.obj = AttributeDict()
+        ctx.obj = extendeddicts.AttributeDict()
 
-    config = get_config(create=True)
-
-    # This flag will be useful for commands that need to know if the current `ctx.obj.profile` is simply the default
-    # or is set because the user specified an explicit profile through `-p/--profile`
-    ctx.obj.profile_option_used = profile is not None
-
-    if not profile:
-        try:
-            profile = config.get_profile()
-        except exceptions.ProfileConfigurationError:
-            profile = None
-
-    if profile:
-        load_profile(profile.name)
-
-    ctx.obj.config = config
+    ctx.obj.config = get_config()
     ctx.obj.profile = profile

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 import click
 
 from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
+from ...utils import defaults
 from .. import types
 from .multivalue import MultipleValueOption
 from .overridable import OverridableOption
@@ -59,6 +60,7 @@ def active_process_states():
 PROFILE = OverridableOption(
     '-p', '--profile', 'profile',
     type=types.ProfileParamType(),
+    default=defaults.get_default_profile,
     help='Execute the command for this profile instead of the default profile.')
 
 CALCULATION = OverridableOption(

--- a/aiida/cmdline/utils/defaults.py
+++ b/aiida/cmdline/utils/defaults.py
@@ -17,33 +17,23 @@ from aiida.common import exceptions
 from aiida.manage.configuration import get_config
 
 
-def get_default_profile(ctx, param, value):  # pylint: disable=unused-argument
-    """Try to get the default profile.
+def get_default_profile():  # pylint: disable=unused-argument
+    """Try to get the name of the default profile.
 
-    This should be used if the default profile should be returned lazily, at a point for example when the config
-    is not created at import time. Otherwise, the preference should go to calling `get_config` to load the actual
-    config and using `config.default_profile_name` to get the default profile name.
-
-    This all of course unless the `-p/--profile` option was used by the user which trumps everything, in which case the
-    `profile_option_used` attribute on the `ctx.obj` object will have been set and we simply return the profile that
-    was already loaded by `verdi` itself and set in `ctx.obj.profile`.
+    This utility function should only be used for defaults or callbacks in command line interface parameters.
+    Otherwise, the preference should go to calling `get_config` to load the actual config and using
+    `config.default_profile_name` to get the default profile name.
 
     :raises click.UsageError: if the config could not be loaded or no default profile exists
-    :return: the default profile
+    :return: the default profile name or None if no default is defined in the configuration
     """
-    if value:
-        return value
-
-    if ctx.obj.profile_option_used:
-        return ctx.obj.profile
-
     try:
-        config = get_config()
+        config = get_config(create=True)
     except exceptions.ConfigurationError as exception:
         echo.echo_critical(str(exception))
 
     try:
-        default_profile = config.get_profile(config.default_profile_name)
+        default_profile = config.get_profile(config.default_profile_name).name
     except exceptions.ProfileConfigurationError:
         default_profile = None
 

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import copy
 import logging
 import types
 import six
@@ -161,7 +162,9 @@ def configure_logging(with_orm=False, daemon=False, daemon_log_file=None):
     """
     from logging.config import dictConfig
 
-    config = evaluate_logging_configuration(LOGGING)
+    # Evaluate the `LOGGING` configuration to resolve the lambdas that will retrieve the correct values based on the
+    # currently configured profile. Pass a deep copy of `LOGGING` to ensure that the original remains unaltered.
+    config = evaluate_logging_configuration(copy.deepcopy(LOGGING))
     daemon_handler_name = 'daemon_log_file'
 
     # Add the daemon file handler to all loggers if daemon=True

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -41,7 +41,6 @@ def load_profile(profile=None):
     """
     from aiida.common import InvalidOperation
     from aiida.common.log import configure_logging
-    from aiida.manage.manager import get_manager, reset_manager
 
     global PROFILE
     global BACKEND_UUID
@@ -53,6 +52,7 @@ def load_profile(profile=None):
     profile = get_config().get_profile(profile)
 
     if BACKEND_UUID is not None and BACKEND_UUID != profile.uuid:
+        # Once the switching of profiles with different backends becomes possible, the backend has to be reset properly
         raise InvalidOperation('cannot switch profile because backend of another profile is already loaded')
 
     # Set the global variable and make sure the repository is configured
@@ -60,12 +60,9 @@ def load_profile(profile=None):
     PROFILE.configure_repository()
 
     # Reconfigure the logging to make sure that profile specific logging configuration options are taken into account.
-    # Also set `with_orm=True` to make sure that the `DBLogHandler` is configured as well.
-    configure_logging(with_orm=True)
-
-    manager = get_manager()
-    manager.unload_backend()
-    reset_manager()
+    # Note that we do not configure with `with_orm=True` because that will force the backend to be loaded. This should
+    # instead be done lazily in `Manager._load_backend`.
+    configure_logging()
 
     return PROFILE
 

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -77,6 +77,7 @@ class Manager(object):  # pylint: disable=useless-object-inheritance
         """
         from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
         from aiida.common import ConfigurationError, InvalidOperation
+        from aiida.common.log import configure_logging
         from aiida.manage import configuration
 
         profile = self.get_profile()
@@ -110,6 +111,10 @@ class Manager(object):  # pylint: disable=useless-object-inheritance
         elif backend_type == BACKEND_SQLA:
             from aiida.orm.implementation.sqlalchemy.backend import SqlaBackend
             self._backend = SqlaBackend()
+
+        # Reconfigure the logging with `with_orm=True` to make sure that profile specific logging configuration options
+        # are taken into account and the `DbLogHandler` is configured.
+        configure_logging(with_orm=True)
 
         return self._backend
 


### PR DESCRIPTION
Currently, the loading of the profile is done in the body of the `verdi`
command group itself. By moving this to the `ProfileParamType`, it
becomes easy for external scripts to also provide a `--profile` flag to
run the script for a profile other than the default.