### PR TITLE
Add support to filter by process label for `verdi process list`

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -38,14 +38,15 @@ def verdi_process():
 @options.GROUP(help='Only include entries that are a member of this group.')
 @options.ALL(help='Show all entries, regardless of their process state.')
 @options.PROCESS_STATE()
+@options.PROCESS_LABEL()
 @options.EXIT_STATUS()
 @options.FAILED()
 @options.PAST_DAYS()
 @options.LIMIT()
 @options.RAW()
 @decorators.with_dbenv()
-def process_list(all_entries, group, process_state, exit_status, failed, past_days, limit, project, raw, order_by,
-                 order_dir):
+def process_list(all_entries, group, process_state, process_label, exit_status, failed, past_days, limit, project, raw,
+                 order_by, order_dir):
     """Show a list of processes that are still running."""
     # pylint: disable=too-many-locals
     from tabulate import tabulate
@@ -57,7 +58,7 @@ def process_list(all_entries, group, process_state, exit_status, failed, past_da
         relationships['with_node'] = group
 
     builder = CalculationQueryBuilder()
-    filters = builder.get_filters(all_entries, process_state, exit_status, failed)
+    filters = builder.get_filters(all_entries, process_state, process_label, exit_status, failed)
     query_set = builder.get_query_set(
         relationships=relationships, filters=filters, order_by={order_by: order_dir}, past_days=past_days, limit=limit)
     projected = builder.get_projected(query_set, projections=project)

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -255,6 +255,11 @@ PROCESS_STATE = OverridableOption(
     type=types.LazyChoice(valid_process_states), cls=MultipleValueOption, default=active_process_states,
     help='Only include entries with this process state.')
 
+PROCESS_LABEL = OverridableOption(
+    '-L', '--process-label', 'process_label',
+    type=click.STRING, required=False,
+    help='Only include entries with this process label.')
+
 EXIT_STATUS = OverridableOption(
     '-E', '--exit-status', 'exit_status',
     type=click.INT,

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -44,20 +44,29 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
     def valid_projections(self):
         return self._valid_projections
 
-    def get_filters(self, all_entries=False, process_state=None, exit_status=None, failed=False, node_types=None):
+    def get_filters(self,
+                    all_entries=False,
+                    process_state=None,
+                    process_label=None,
+                    exit_status=None,
+                    failed=False,
+                    node_types=None):
         """
         Return a set of QueryBuilder filters based on typical command line options.
 
         :param node_types: a tuple of node classes to filter for (must be sub classes of Calculation)
         :param all_entries: boolean to negate filtering for process state
-        :param process_state: filter for this process state
+        :param process_state: filter for this process state attribute
+        :param process_label: filter for this process label attribute
         :param exit_status: filter for this exit status
         :param failed: boolean to filter only failed processes
         :return: dictionary of filters suitable for a QueryBuilder.append() call
         """
+        # pylint: disable=too-many-arguments
         from aiida.engine import ProcessState
 
         exit_status_attribute = self.mapper.get_attribute('exit_status')
+        process_label_attribute = self.mapper.get_attribute('process_label')
         process_state_attribute = self.mapper.get_attribute('process_state')
 
         filters = {}
@@ -69,6 +78,9 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
 
         if process_state and not all_entries:
             filters[process_state_attribute] = {'in': process_state}
+
+        if process_label is not None:
+            filters[process_label_attribute] = process_label
 
         if failed:
             filters[process_state_attribute] = {'==': ProcessState.FINISHED.value}


### PR DESCRIPTION
Fixes #3139 

The new flag `-L/--process-label` allows one to filter for the
`process_label` attribute which is also one of the default projections.