### PR TITLE
Fix bug with never resolving calculation job update futures

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value
+disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -61,7 +61,7 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancellab
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
     if node.get_state() == CalcJobState.SUBMITTING:
-        logger.warning('calculation<{}> already marked as SUBMITTING, skipping task_update_job'.format(node.pk))
+        logger.warning('CalcJob<{}> already marked as SUBMITTING, skipping task_update_job'.format(node.pk))
         raise Return(True)
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
@@ -76,16 +76,16 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancellab
             raise Return(execmanager.upload_calculation(node, transport, calc_info, script_filename))
 
     try:
-        logger.info('uploading calculation<{}>'.format(node.pk))
+        logger.info('scheduled request to upload CalcJob<{}>'.format(node.pk))
         result = yield exponential_backoff_retry(
             do_upload, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
     except plumpy.CancelledError:
         pass
     except Exception:
-        logger.warning('uploading calculation<{}> failed'.format(node.pk))
+        logger.warning('uploading CalcJob<{}> failed'.format(node.pk))
         raise TransportTaskException('upload_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        logger.info('uploading calculation<{}> successful'.format(node.pk))
+        logger.info('uploading CalcJob<{}> successful'.format(node.pk))
         node.set_state(CalcJobState.SUBMITTING)
         raise Return(result)
 
@@ -126,7 +126,7 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancellab
             raise Return(execmanager.submit_calculation(node, transport, calc_info, script_filename))
 
     try:
-        logger.info('submitting CalcJob<{}>'.format(node.pk))
+        logger.info('scheduled request to submit CalcJob<{}>'.format(node.pk))
         result = yield exponential_backoff_retry(
             do_submit, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.Interruption)
     except plumpy.Interruption:
@@ -186,7 +186,7 @@ def task_update_job(node, job_manager, cancellable):
         raise Return(job_done)
 
     try:
-        logger.info('updating CalcJob<{}>'.format(node.pk))
+        logger.info('scheduled request to update CalcJob<{}>'.format(node.pk))
         job_done = yield exponential_backoff_retry(
             do_update, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.Interruption)
     except plumpy.Interruption:
@@ -235,7 +235,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
             raise Return(execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder))
 
     try:
-        logger.info('retrieving CalcJob<{}>'.format(node.pk))
+        logger.info('scheduled request to retrieve CalcJob<{}>'.format(node.pk))
         result = yield exponential_backoff_retry(
             do_retrieve, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.Interruption)
     except plumpy.Interruption:
@@ -282,7 +282,7 @@ def task_kill_job(node, transport_queue, cancellable):
             raise Return(execmanager.kill_calculation(node, transport))
 
     try:
-        logger.info('killing CalcJob<{}>'.format(node.pk))
+        logger.info('scheduled request to kill CalcJob<{}>'.format(node.pk))
         result = yield exponential_backoff_retry(do_kill, initial_interval, max_attempts, logger=node.logger)
     except plumpy.Interruption:
         raise


### PR DESCRIPTION
Fixes #3136 
Fixes #2388 

The `JobsList` class is a container and manager of requests for updates
of the status of calculation jobs. For each request, it keeps a future
that it will update in bulk after retrieving the status of all the jobs
that it manages. This is necessary to ensure that multiple jobs use the
same update call to scheduler and not all individually, in order to not
overload the scheduler.

If the scheduler update call excepts, all the futures were properly
excepted as well and the internal cache of outstanding requests would be
cleared, before re-raising the exception. The excepted futures would
each be caught by the exponential backoff mechanism and a new request to
update the status would be scheduled. This would be registered with the
same `JobsList` instance, however, the next scheduler update would never
be called and so the futures would never be resolved, causing the
calculation jobs to "hang" indefinitely.

The problem lies in the `_ensure_updating` method. When a new request
comes in, this is the method that is called first to see if a scheduler
update call has already been scheduled. If the case, a new one does not
have to be scheduled. This is based on whether the `_update_handle`
attribute is defined. This attribute is properly reset after a scheduler
update goes through successfully, in the `updating` coroutine after the
`_update_job_info` yields. However, in the case of an exception in that
last method, the code path that resets the `_update_handle` is never
reached because the exception is re-raised after the job requests cache
is reset. The solution is simply to manually set `_update_handle` to
`None` in the except clause.