### PR TITLE
Docs: fix validator description, add warning for `ToContext`

### DIFF
--- a/docs/source/working/processes.rst
+++ b/docs/source/working/processes.rst
@@ -126,12 +126,15 @@ An example input port that explicitly sets all these attributes is the following
     spec.input('positive_number', required=False, default=Int(1), valid_type=(Int, Float), validator=is_number_positive)
 
 Here we define an input named ``positive_number`` that is not required, if a value is not explicitly passed, the default ``Int(1)`` will be used and if a value *is* passed, it should be of type ``Int`` or ``Float`` and it should be valid according to the ``is_number_positive`` validator.
-Note that the validator is nothing more than a free function which takes a single argument, being the value that is to be validated and should return ``True`` if that value is valid or ``False`` otherwise, for example:
+Note that the validator is nothing more than a free function which takes a single argument, being the value that is to be validated.
+If nothing is returned, the value is considered to be valid.
+To signal that the value is invalid and to have a validation error raised, simply return a string with the validation error message, for example:
 
 .. code:: python
 
     def is_number_positive(number):
-        return number >= 0
+        if number < 0:
+            return 'The number has to be greater or equal to zero'
 
 The ``valid_type`` can define a single type, or a tuple of valid types.
 

--- a/docs/source/working/workflows.rst
+++ b/docs/source/working/workflows.rst
@@ -375,6 +375,13 @@ Returning an instance of ``ToContext`` signals to the engine that it has to wait
 In this example, that is the ``inspect_workchain`` method.
 At this point we are sure that the process, a work chain in this case, has terminated its execution, although not necessarily successful, and we can continue the logic of the work chain.
 
+.. warning::
+
+    Using the ``ToContext`` construct alone is not enough to tell the engine that it should wait for the sub process to finish.
+    There **needs** to be at least another step in the outline to follow the step that added the awaitables.
+    If there is no more step to follow, according to the outline, the engine interprets this as the work chain being done and so it will not wait for the sub process to finish.
+    Think about it like this: if there is not even a single step to follow, there is also nothing the work chain could do with the results of the sub process, so there is no point in waiting.
+
 Sometimes one wants to launch not just one, but multiple processes at the same time that can run in parallel.
 With the mechanism described above, this will not be possible since after submitting a single process and returning the ``ToContext`` instance, the work chain has to wait for the process to be finished before it can continue.
 To solve this problem, there is another way to add futures to the context:


### PR DESCRIPTION
Fixes #3158 and fixes #3159 

The signature description of the `Port.validator` incorrectly stated
that it should return a boolean. In reality it should return nothing for
valid values and return a string with the validation error message for
invalid values.

In addition, a warning box has been added to the description of the
`ToContext` construct for `WorkChains` explaining that adding awaitables
through this mechanism will cause the `WorkChain` to wait for them to be
completed, if and only if there is a next step in the outline. If the
addition of the awaitables is done in the last step of the outline, the
engine will consider the work of the `WorkChain` as completed and will
terminate the process.