### PR TITLE
Improve the efficiency of link validation

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -844,7 +844,7 @@ class Node(Entity):
         :param link_label_filter: filters the incoming nodes by its link label. This should be a regex statement as
             one would pass directly to a QuerBuilder filter statement with the 'like' operation.
         :param link_direction: `incoming` or `outgoing` to get the incoming or outgoing links, respectively.
-        :param only_uuid: Store the uuid of nodes in the NodeTriple instead of the actual node
+        :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
         """
         if not isinstance(link_type, tuple):
             link_type = (link_type,)
@@ -892,7 +892,7 @@ class Node(Entity):
             link type, if None then returns all inputs of all link types.
         :param link_label_filter: filters the incoming nodes by its link label.
             Here wildcards (% and _) can be passed in link label filter as we are using "like" in QB.
-        :param only_uuid: Use the uuid of the nodes instead of the `Node` objects
+        :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
         """
         if not isinstance(link_type, tuple):
             link_type = (link_type,)
@@ -908,6 +908,7 @@ class Node(Entity):
 
             if only_uuid:
                 link_triple = LinkTriple(link_triple.node.uuid, link_triple.link_type, link_triple.link_label)
+
             if link_triple in link_triples:
                 raise exceptions.InternalError('Node<{}> has both a stored and cached link triple {}'.format(
                     self.pk, link_triple))
@@ -930,6 +931,7 @@ class Node(Entity):
             link type, if None then returns all outputs of all link types.
         :param link_label_filter: filters the outgoing nodes by its link label.
             Here wildcards (% and _) can be passed in link label filter as we are using "like" in QB.
+        :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
         """
         link_triples = self.get_stored_link_triples(node_class, link_type, link_label_filter, 'outgoing', only_uuid)
         return LinkManager(link_triples)


### PR DESCRIPTION
Fixes #3088 

This PR is aimed to improve the performance for input link validation #3088. The original approach in my comment in #3088 does not work since the `validate_link` the function has to deal with cached links.

The root of the problem is that `get_stored_link_triples` method returns a list of `LinkTriple` which has the node instance as its `node` attribute. When doing validations loading individual `Node` is not necessary. When link triples are requested for a node with many links, getting every connected nodes can be very slow and sometimes become a performance bottleneck. This PR adds a `only_uuid` switch to the function to include only uuids in the `LinkTriple` constructed instead of the full `Node`. When it is set to True, the `node` attribute of `LinkTriple` returned becomes a string of the uuid. The keyword is also added for `get_incoming` and `get_outgoing` methods. The `validate_link` is updated accordingly to utilize this for faster checks.


The test showed that the efficiencies are improved significantly when storing nodes with inputs links from *god-like* node which has many output links. The time used for adding a single node is plotted with the total number of nodes added below. The sqla backend is used in the test.

![performance](https://user-images.githubusercontent.com/33688599/61252958-4ac61680-a757-11e9-9013-947f00c4e0a1.png)

The time taken to store one node increases proportionally with the number of stored nodes before and after the commit, which means that the total time to store N nodes will scale with N^2. However, the slope is much smaller (by ~ 1/40) with the fix.

The code for generating the timings: 

```
from random import choice
from tqdm import tqdm
from time import time
comp = Computer.objects.all()[0]
node_data = Data()
node_data.store()



def create_calc_node():
    node = CalcJobNode()
    for i in range(10):
        k = choice('abcds')
        node.set_attribute(k, k)
    node.computer = comp
    node.set_option('resources', {'num_machines': 1, 'tot_num_mpiprocs': 12})
    return node

start = time()
timings = []
for i in tqdm(range(3000), total=3000):
    node = create_calc_node()
    node.add_incoming(node_data, link_type=LinkType.INPUT_CALC, link_label='INPUT')
    node.store()
    timings.append(time() - start)


with open('save_timings', 'w') as fh:
    for t in timings:
        fh.write('{:.3f}\n'.format(t))

```
