### PR TITLE
Update requirements for dependency `plumpy==0.14.2`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -43,7 +43,7 @@ passlib==1.7.1
 pg8000<1.13.0
 pgtest==1.2.0
 pika==1.0.0
-plumpy==0.14.1
+plumpy==0.14.2
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'
 pymatgen<=2018.12.12

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
 - psycopg2==2.8
 - paramiko==2.6.0
 - ipython>=4.0,<6.0
-- plumpy==0.14.1
+- plumpy==0.14.2
 - kiwipy[rmq]==0.5.1
 - pika==1.0.0
 - circus==0.15.0

--- a/setup.json
+++ b/setup.json
@@ -43,7 +43,7 @@
     "psycopg2-binary==2.8",
     "paramiko==2.6.0",
     "ipython>=4.0,<6.0",
-    "plumpy==0.14.1",
+    "plumpy==0.14.2",
     "kiwipy[rmq]==0.5.1",
     "pika==1.0.0",
     "circus==0.15.0",


### PR DESCRIPTION
Fixes #3166 

This patch release comes with the following changes:

 * Addition of "lazy" port namespaces, not populating defaults
 * Fixed bug in nested include rules for exposing namespaces