### PR TITLE
Fix updating existing Node Extras and clean code for import of Node extras

### DIFF
--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -243,3 +243,11 @@ class CircusCallError(AiidaException):
     """
     Raised when an attempt to contact Circus returns an error in the response
     """
+
+
+class ArchiveIntegrityError(IntegrityError):
+    """
+    Raised when there is an integrity error in an export archive.
+    This may be if a Node's repository folder is missing or a Node is missing a representation in a dictionary of
+    `data.json`.
+    """


### PR DESCRIPTION
Fixes #3186

Clean up a bit the code for importing Node Extras.
There were several iterators used, which were not "legal".

At its worst, Extras were unable to be updated for existing Nodes.

Created a new exception `ArchiveIntegrityError`, which may be raised when a key is missing for an entity PK or similar in the `data.json` file.
I have yet to implement it completely in the import/export code.

The timing should be revisited for the import in this section - when to update the Attributes/Extras, when to create new, etc.