### PR TITLE
Fix bug in tree printer of `verdi node tree`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -55,6 +55,7 @@ DB_TEST_LIST = {
         'cmdline.commands.graph': ['aiida.backends.tests.cmdline.commands.test_graph'],
         'cmdline.commands.group': ['aiida.backends.tests.cmdline.commands.test_group'],
         'cmdline.commands.import': ['aiida.backends.tests.cmdline.commands.test_import'],
+        'cmdline.commands.node': ['aiida.backends.tests.cmdline.commands.test_node'],
         'cmdline.commands.process': ['aiida.backends.tests.cmdline.commands.test_process'],
         'cmdline.commands.profile': ['aiida.backends.tests.cmdline.commands.test_profile'],
         'cmdline.commands.rehash': ['aiida.backends.tests.cmdline.commands.test_rehash'],

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for verdi node"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from click.testing import CliRunner
+
+from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
+from aiida.cmdline.commands import cmd_node
+
+
+class TestVerdiNode(AiidaTestCase):
+    """Tests for `verdi node`"""
+
+    def setUp(self):
+        self.cli_runner = CliRunner()
+
+    def test_node_tree(self):
+        """Test `verdi node tree`"""
+        node = orm.Data().store()
+        options = [str(node.pk)]
+        result = self.cli_runner.invoke(cmd_node.tree, options)
+        self.assertClickResultNoException(result)

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -167,14 +167,14 @@ def show(nodes, print_groups):
 @click.option('-d', '--depth', 'depth', default=1, help="Show children of nodes up to given depth")
 @with_dbenv()
 def tree(nodes, depth):
-    """
-    Show trees of nodes.
-    """
+    """Show tree of nodes."""
+    from aiida.common import LinkType
+
     for node in nodes:
-        NodeTreePrinter.print_node_tree(node, depth)
+        NodeTreePrinter.print_node_tree(node, depth, tuple(LinkType.__members__.values()))
 
         if len(nodes) > 1:
-            echo.echo("")
+            echo.echo('')
 
 
 class NodeTreePrinter(object):  # pylint: disable=useless-object-inheritance
@@ -193,8 +193,8 @@ class NodeTreePrinter(object):  # pylint: disable=useless-object-inheritance
         echo.echo(tmp.get_ascii(show_internal=True))
 
     @staticmethod
-    def _ctime(nodelab):
-        return nodelab[1].ctime
+    def _ctime(link_triple):
+        return link_triple.node.ctime
 
     @classmethod
     def _build_tree(cls, node, show_pk=True, max_depth=None, follow_links=None, depth=0):

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -410,7 +410,7 @@ def import_data_dj(in_path,
                         entry_data[unique_identifier]: import_entry_pk
                         for import_entry_pk, entry_data in existing_entries[model_name].items()
                     }
-                    for node in models.DbNode.objects.filter(uuid__in=import_existing_entry_pks).all():
+                    for node in models.DbNode.objects.filter(uuid__in=import_existing_entry_pks).all():  # pylint: disable=no-member
                         import_entry_uuid = str(node.uuid)
                         import_entry_pk = import_existing_entry_pks[import_entry_uuid]
 

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -543,7 +543,7 @@ Below is a list with all available subcommands.
       label        View or set the labels of one or more nodes.
       repo
       show         Show generic information on node(s).
-      tree         Show trees of nodes.
+      tree         Show tree of nodes.
 
 
 .. _verdi_plugin:


### PR DESCRIPTION
Fixes #223 

The method illegally passed `None` for `link_type` to the `get_outgoing`
method. Now it will pass all existing link types. The sorting lambda
also did not correctly dereference the `ctime` from the node instance.