### PR TITLE
allow wildcard to be used while filtering process label in cmdline

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_process.py
+++ b/aiida/backends/tests/cmdline/commands/test_process.py
@@ -251,11 +251,12 @@ class TestVerdiProcess(AiidaTestCase):
 
         # The process label should limit the query set to nodes with the given `process_label` attribute
         for flag in ['-L', '--process-label']:
-            result = self.cli_runner.invoke(cmd_process.process_list, ['-r', flag, self.process_label])
-            self.assertClickResultNoException(result)
-            self.assertEqual(len(get_result_lines(result)), 3)  # Should only match the active `WorkFunctionNodes`
-            for line in get_result_lines(result):
-                self.assertIn(self.process_label, line.strip())
+            for process_label in [self.process_label, self.process_label.replace('Dummy', '%')]:
+                result = self.cli_runner.invoke(cmd_process.process_list, ['-r', flag, process_label])
+                self.assertClickResultNoException(result)
+                self.assertEqual(len(get_result_lines(result)), 3)  # Should only match the active `WorkFunctionNodes`
+                for line in get_result_lines(result):
+                    self.assertIn(self.process_label, line.strip())
 
     def test_process_show(self):
         """Test verdi process show"""

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -260,7 +260,7 @@ PROCESS_STATE = OverridableOption(
 PROCESS_LABEL = OverridableOption(
     '-L', '--process-label', 'process_label',
     type=click.STRING, required=False,
-    help='Only include entries with this process label.')
+    help='Only include entries match this process label.')
 
 EXIT_STATUS = OverridableOption(
     '-E', '--exit-status', 'exit_status',

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -260,7 +260,7 @@ PROCESS_STATE = OverridableOption(
 PROCESS_LABEL = OverridableOption(
     '-L', '--process-label', 'process_label',
     type=click.STRING, required=False,
-    help='Only include entries match this process label.')
+    help='Only include entries whose process label matches this filter.')
 
 EXIT_STATUS = OverridableOption(
     '-E', '--exit-status', 'exit_status',

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -80,7 +80,7 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
             filters[process_state_attribute] = {'in': process_state}
 
         if process_label is not None:
-            filters[process_label_attribute] = process_label
+            filters[process_label_attribute] = {'like': process_label}
 
         if failed:
             filters[process_state_attribute] = {'==': ProcessState.FINISHED.value}

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -80,7 +80,10 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
             filters[process_state_attribute] = {'in': process_state}
 
         if process_label is not None:
-            filters[process_label_attribute] = {'like': process_label}
+            if '%' in process_label or '_' in process_label:
+                filters[process_label_attribute] = {'like': process_label}
+            else:
+                filters[process_label_attribute] = process_label
 
         if failed:
             filters[process_state_attribute] = {'==': ProcessState.FINISHED.value}


### PR DESCRIPTION
This PR changes the filter for matching `process_label` in `verdi process list` from the default
'==' (implicit exact match) to 'like', which allows wildcards to be used. For example, processes of  `PwBaseWorkChain`, `PwRelaxWorkChain` and be filtered easily with `'-L Pw%Chain'`.