### PR TITLE
Adding the `dry_run_info` attribute to a CalcJobNode

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -194,6 +194,10 @@ class CalcJob(Process):
                 with LocalTransport() as transport:
                     transport.chdir(folder.abspath)
                     upload_calculation(self.node, transport, calc_info, script_filename, dry_run=True)
+                    self.node.dry_run_info = {
+                        'folder': folder.abspath,
+                        'script_filename': script_filename
+                    }
                 return plumpy.Stop(None, True)
 
         # Launch the upload operation

--- a/docs/source/working/calculations.rst
+++ b/docs/source/working/calculations.rst
@@ -476,6 +476,28 @@ However, the ``prepare_for_submission`` method will be called.
 The inputs that it writes to the input folder will be stored in temporary folder called ``submit_test`` that will be created in the current working directory.
 Each time you perform a dry-run, a new sub folder will be created in the ``submit_test`` folder, which you allows you to perform multiple dry-runs without overwriting the previous results.
 
+Moreover, the following applies:
+
+- when calling :py:func:`~aiida.engine.launch.run` for a calculation with the
+  ``dry_run`` flag set, you will get back its results, being always an empty dictionary ``{}``;
+
+- if you call :py:func:`~aiida.engine.launch.run_get_node`, you will get back as a node
+  an unstored ``CalcJobNode``. In this case, the unstored ``CalcJobNode`` (let's call it
+  ``node``) will have an additional property ``node.dry_run_info``. This is a dictionary
+  that contains additional information on the dry-run output. In particular, it will have
+  the following keys:
+
+  - ``folder``: the absolute path to the folder within the ``submit_test`` folder
+    where the files have been created, e.g.: ``/home/user/submit_test/20190726-00019``
+
+  - ``script_filename``: the filename of the submission script that AiiDA generated
+    in the folder, e.g.: ``_aiidasubmit.sh``
+
+- if you send a dry-run to the :py:func:`~aiida.engine.launch.submit` function,
+  this will be just forwarded to run and you will get back the unstored node
+  (with the same properties as above).
+
+
 .. warning::
 
     By default the storing of provenance is enabled and this goes also for a dry run.


### PR DESCRIPTION
Fixes #2884

This is done when the node been created during a dry_run.
Also documentation added.