### PR TITLE
Add class property `Process.get_exit_statuses`

### DIFF
--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -135,6 +135,17 @@ class Process(plumpy.Process):
         if self._logger is None:
             self.set_logger(self.node.logger)
 
+    @classmethod
+    def get_exit_statuses(cls, exit_code_labels):
+        """Return the exit status (integers) for the given exit code labels.
+
+        :param exit_code_labels: a list of strings that reference exit code labels of this process class
+        :return: list of exit status integers that correspond to the given exit code labels
+        :raises AttributeError: if at least one of the labels does not correspond to an existing exit code
+        """
+        exit_codes = cls.exit_codes
+        return [getattr(exit_codes, label).status for label in exit_code_labels]
+
     @classproperty
     def exit_codes(cls):  # pylint: disable=no-self-argument
         """Return the namespace of exit codes defined for this WorkChain through its ProcessSpec.


### PR DESCRIPTION
Fixes #3215 

This utility property will return a list of exit status integers based
on a list of exit code labels. This is useful if a list of labels needs
to be mapped onto their corresponding integers.