### PR TITLE
Adding documentation on how to get the AuthInfo

### DIFF
--- a/docs/source/working_with_aiida/cookbook.rst
+++ b/docs/source/working_with_aiida/cookbook.rst
@@ -95,3 +95,32 @@ An example output would be::
       requested_wallclock_time_seconds: 82800
 
     (...)
+
+Getting an AuthInfo knowing the computer and the user
+-----------------------------------------------------
+
+If you have an ORM ``Computer`` and and ORM ``User``, the way to get
+an ``AuthInfo`` object is the following::
+
+    AuthInfo.objects.get(dbcomputer_id=computer.id, aiidauser_id=user.id)
+
+This might be useful, for instance, to then get a transport to connect to the
+computer.
+
+Here is, as an example, an useful utility function::
+
+    def get_authinfo_from_computername(computername):
+        from aiida.orm import AuthInfo, User, Computer
+        from aiida.manage.manager import get_manager
+        manager = get_manager()
+        profile = manager.get_profile()
+        return AuthInfo.objects.get(
+            dbcomputer_id=Computer.get(name=computername).id,
+            aiidauser_id=User.get(email=profile.default_user).id
+        )
+
+that you can then use, for instance, as follows::
+
+    authinfo = get_authinfo_from_computername('localhost')
+    with authinfo.get_transport() as transport:
+        print(transport.listdir())


### PR DESCRIPTION
Fixes #3195

Adds a cookbook recipe on how to get an AuthInfo
object given, e.g., a computer name, and how to then
get a Transport instance. This is not what a user would
typically do, but it is still very often useful for
intermediate users who want to e.g. perform operations
on the computer via the transport.