### PR TITLE
Update requirements for for `dev_precommit` dependencies

### DIFF
--- a/.ci/polish/cli.py
+++ b/.ci/polish/cli.py
@@ -25,48 +25,55 @@ from aiida.cmdline.utils import decorators
 @options.CODE(
     type=types.CodeParamType(entry_point='arithmetic.add'),
     required=False,
-    help='Code to perform the add operations with. Required if -C flag is specified')
+    help='Code to perform the add operations with. Required if -C flag is specified'
+)
 @click.option(
     '-C',
     '--use-calculations',
     is_flag=True,
     default=False,
     show_default=True,
-    help='Use job calculations to perform all additions')
+    help='Use job calculations to perform all additions'
+)
 @click.option(
     '-F',
     '--use-calcfunctions',
     is_flag=True,
     default=False,
     show_default=True,
-    help='Use calcfunctions to perform all substractions')
+    help='Use calcfunctions to perform all substractions'
+)
 @click.option(
     '-s',
     '--sleep',
     type=click.INT,
     default=5,
     show_default=True,
-    help='When submitting to the daemon, the number of seconds to sleep between polling the workchain process state')
+    help='When submitting to the daemon, the number of seconds to sleep between polling the workchain process state'
+)
 @click.option(
     '-t',
     '--timeout',
     type=click.INT,
     default=60,
     show_default=True,
-    help='When submitting to the daemon, the number of seconds to wait for a workchain to finish before timing out')
+    help='When submitting to the daemon, the number of seconds to wait for a workchain to finish before timing out'
+)
 @click.option(
     '-m',
     '--modulo',
     type=click.INT,
     default=1000000,
     show_default=True,
-    help='Specify an integer to modulo all intermediate and the final result to avoid integer overflow')
+    help='Specify an integer to modulo all intermediate and the final result to avoid integer overflow'
+)
 @click.option(
     '-n',
     '--dry-run',
     is_flag=True,
     default=False,
-    help='Only evaluate the expression and generate the workchain but do not launch it')
+    help='Only evaluate the expression and generate the workchain but do not launch it'
+)
 @decorators.with_dbenv()
 def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout, modulo, dry_run, daemon):
     """
@@ -150,7 +157,8 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
                 click.secho('Failed: ', fg='red', bold=True, nl=False)
                 click.secho(
                     'the workchain<{}> did not finish in time and the operation timed out'.format(workchain.pk),
-                    bold=True)
+                    bold=True
+                )
                 sys.exit(1)
 
             try:

--- a/.ci/test_fixtures.py
+++ b/.ci/test_fixtures.py
@@ -26,8 +26,9 @@ class FixtureManagerTestCase(unittest.TestCase):
 
     def setUp(self):
         self.fixture_manager = FixtureManager()
-        self.backend = BACKEND_DJANGO if os.environ.get('TEST_AIIDA_BACKEND',
-                                                        BACKEND_DJANGO) == BACKEND_DJANGO else BACKEND_SQLA
+        self.backend = BACKEND_DJANGO if os.environ.get(
+            'TEST_AIIDA_BACKEND', BACKEND_DJANGO
+        ) == BACKEND_DJANGO else BACKEND_SQLA
         self.fixture_manager.backend = self.backend
 
     def test_create_db_cluster(self):

--- a/.ci/test_plugin_testcase.py
+++ b/.ci/test_plugin_testcase.py
@@ -66,7 +66,8 @@ class PluginTestCase1(PluginTestCase):
             transport_type='local',
             scheduler_type='direct',
             workdir=temp_dir,
-            backend=cls.backend).store()
+            backend=cls.backend
+        ).store()
         return computer
 
     def test_data_loaded(self):

--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation
+disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation,no-else-raise
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,7 @@
 [style]
 based_on_style = google
 column_limit = 120
+dedent_closing_brackets = true
+coalesce_brackets = true
+split_arguments_when_comma_terminated = true
+indent_dictionary_value = false

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -31,15 +31,19 @@ from aiida.common.log import configure_logging
 from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.manage.configuration import get_config_option, get_profile, load_profile
 
-__copyright__ = (u'Copyright (c), This file is part of the AiiDA platform. '
-                 u'For further information please visit http://www.aiida.net/. All rights reserved.')
+__copyright__ = (
+    u'Copyright (c), This file is part of the AiiDA platform. '
+    u'For further information please visit http://www.aiida.net/. All rights reserved.'
+)
 __license__ = 'MIT license, see LICENSE.txt file.'
 __version__ = '1.0.0b5'
 __authors__ = 'The AiiDA team.'
-__paper__ = (u'G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky,'
-             u'"AiiDA: automated interactive infrastructure and database for computational science", '
-             u'Comp. Mat. Sci 111, 218-230 (2016); https://doi.org/10.1016/j.commatsci.2015.09.013 '
-             u'- http://www.aiida.net.')
+__paper__ = (
+    u'G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky,'
+    u'"AiiDA: automated interactive infrastructure and database for computational science", '
+    u'Comp. Mat. Sci 111, 218-230 (2016); https://doi.org/10.1016/j.commatsci.2015.09.013 '
+    u'- http://www.aiida.net.'
+)
 __paper_short__ = 'G. Pizzi et al., Comp. Mat. Sci 111, 218 (2016).'
 
 # Configure the default logging

--- a/aiida/backends/djsite/db/migrations/0015_invalidating_node_hash.py
+++ b/aiida/backends/djsite/db/migrations/0015_invalidating_node_hash.py
@@ -38,6 +38,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             """ DELETE FROM db_dbextra WHERE key='""" + _HASH_EXTRA_KEY + """';""",
-            reverse_sql=""" DELETE FROM db_dbextra WHERE key='""" + _HASH_EXTRA_KEY + """';"""),
+            reverse_sql=""" DELETE FROM db_dbextra WHERE key='""" + _HASH_EXTRA_KEY + """';"""
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0018_django_1_11.py
+++ b/aiida/backends/djsite/db/migrations/0018_django_1_11.py
@@ -107,7 +107,8 @@ class Migration(migrations.Migration):
                 related_name='user_set',
                 related_query_name='user',
                 to='auth.Group',
-                verbose_name='groups'),
+                verbose_name='groups'
+            ),
         ),
         migrations.AlterField(
             model_name='dbworkflow',

--- a/aiida/backends/djsite/db/migrations/0019_migrate_builtin_calculations.py
+++ b/aiida/backends/djsite/db/migrations/0019_migrate_builtin_calculations.py
@@ -84,6 +84,7 @@ class Migration(migrations.Migration):
                 AND a.key = 'input_plugin'
                 AND a.tval = 'templatereplacer'
                 AND n.type = 'data.code.Code.';
-            """),
+            """
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0020_provenance_redesign.py
+++ b/aiida/backends/djsite/db/migrations/0020_provenance_redesign.py
@@ -200,6 +200,7 @@ class Migration(migrations.Migration):
             UPDATE db_dblink SET type = 'returnlink'
             WHERE type = 'return';
 
-            """),
+            """
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0023_calc_job_option_attribute_keys.py
+++ b/aiida/backends/djsite/db/migrations/0023_calc_job_option_attribute_keys.py
@@ -130,6 +130,7 @@ class Migration(migrations.Migration):
                 node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
                 node.id = attribute.dbnode_id;
             -- parser_name -> parser
-            """),
+            """
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0025_move_data_within_node_module.py
+++ b/aiida/backends/djsite/db/migrations/0025_move_data_within_node_module.py
@@ -42,6 +42,7 @@ class Migration(migrations.Migration):
                 UPDATE db_dbnode
                 SET type = regexp_replace(type, '^node.data.', 'data.')
                 WHERE type LIKE 'node.data.%'
-                """),
+                """
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0028_remove_node_prefix.py
+++ b/aiida/backends/djsite/db/migrations/0028_remove_node_prefix.py
@@ -49,6 +49,7 @@ class Migration(migrations.Migration):
                 UPDATE db_dbnode
                 SET type = regexp_replace(type, '^process.', 'node.process.')
                 WHERE type LIKE 'process.%';
-                """),
+                """
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0029_rename_parameter_data_to_dict.py
+++ b/aiida/backends/djsite/db/migrations/0029_rename_parameter_data_to_dict.py
@@ -33,7 +33,9 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql=r"""UPDATE db_dbnode SET type = 'data.dict.Dict.' WHERE type = 'data.parameter.ParameterData.';""",
-            reverse_sql=
-            r"""UPDATE db_dbnode SET type = 'data.parameter.ParameterData.' WHERE type = 'data.dict.Dict.';"""),
+            reverse_sql=r"""
+                UPDATE db_dbnode SET type = 'data.parameter.ParameterData.' WHERE type = 'data.dict.Dict.';
+                """
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0032_remove_legacy_workflows.py
+++ b/aiida/backends/djsite/db/migrations/0032_remove_legacy_workflows.py
@@ -65,7 +65,8 @@ def export_workflow_data(apps, _):
     }
 
     with NamedTemporaryFile(
-            prefix='legacy-workflows', suffix='.json', dir='.', delete=delete_on_close, mode='w+') as handle:
+        prefix='legacy-workflows', suffix='.json', dir='.', delete=delete_on_close, mode='w+'
+    ) as handle:
         filename = handle.name
         json.dump(data, handle)
 

--- a/aiida/backends/djsite/db/migrations/0038_data_migration_legacy_job_calculations.py
+++ b/aiida/backends/djsite/db/migrations/0038_data_migration_legacy_job_calculations.py
@@ -104,6 +104,7 @@ class Migration(migrations.Migration):
                 SET attributes = attributes - 'state' || '{"process_state": "finished", "exit_status": 0, "process_label": "Legacy JobCalculation"}'
                 WHERE node_type = 'process.calculation.calcjob.CalcJobNode.' AND attributes @> '{"state": "FINISHED"}';
                 """,
-            reverse_sql=""),
+            reverse_sql=""
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0039_reset_hash.py
+++ b/aiida/backends/djsite/db/migrations/0039_reset_hash.py
@@ -44,6 +44,7 @@ class Migration(migrations.Migration):
         migrations.RunPython(notify_user, reverse_code=notify_user),
         migrations.RunSQL(
             """UPDATE db_dbnode SET extras = extras #- '{""" + _HASH_EXTRA_KEY + """}'::text[];""",
-            reverse_sql="""UPDATE db_dbnode SET extras = extras #- '{""" + _HASH_EXTRA_KEY + """}'::text[];"""),
+            reverse_sql="""UPDATE db_dbnode SET extras = extras #- '{""" + _HASH_EXTRA_KEY + """}'::text[];"""
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0040_data_migration_legacy_process_attributes.py
+++ b/aiida/backends/djsite/db/migrations/0040_data_migration_legacy_process_attributes.py
@@ -83,6 +83,7 @@ class Migration(migrations.Migration):
                     attributes->>'process_state' NOT IN ('created', 'running', 'waiting');
                 -- Set `sealed=True` for process nodes that do not yet have a `sealed` attribute AND are not in an active state
                 """,
-            reverse_sql=""),
+            reverse_sql=""
+        ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/subtests/migrations/test_migrations_0037_attributes_extras_settings_json.py
+++ b/aiida/backends/djsite/db/subtests/migrations/test_migrations_0037_attributes_extras_settings_json.py
@@ -84,7 +84,8 @@ class TestAttributesExtrasToJSONMigrationSimple(TestMigrations):
             hostname='localhost',
             transport_type='local',
             scheduler_type='pbspro',
-            metadata={"workdir": "/tmp/aiida"})
+            metadata={"workdir": "/tmp/aiida"}
+        )
         computer.save()
 
         node = db_node_model(node_type='data.Data.', dbcomputer_id=computer.id, user_id=self.default_user.id)
@@ -139,7 +140,8 @@ class TestAttributesExtrasToJSONMigrationManyNodes(TestMigrations):
             hostname='localhost',
             transport_type='local',
             scheduler_type='pbspro',
-            metadata={"workdir": "/tmp/aiida"})
+            metadata={"workdir": "/tmp/aiida"}
+        )
         computer.save()
 
         with transaction.atomic():
@@ -196,29 +198,34 @@ class TestSettingsToJSONMigration(TestMigrations):
             datatype='date',
             dval=timezone.datetime_to_isoformat(timezone.now()),
             description='The last time the daemon finished to run '
-            'the task \'updater\' (updater)')
+            'the task \'updater\' (updater)'
+        )
         self.settings_info['2daemon|task_start|updater2'] = dict(
             key='2daemon|task_start|updater2',
             datatype='date',
             dval=timezone.datetime_to_isoformat(timezone.now()),
             description='The last time the daemon started to run '
-            'the task \'updater\' (updater)')
+            'the task \'updater\' (updater)'
+        )
         self.settings_info['2db|backend2'] = dict(
             key='2db|backend2',
             datatype='txt',
             tval='django',
-            description='The backend used to communicate with the database.')
+            description='The backend used to communicate with the database.'
+        )
         self.settings_info['2daemon|user2'] = dict(
             key='2daemon|user2',
             datatype='txt',
             tval='aiida@theossrv5.epfl.ch',
             description='The only user that is allowed to run the AiiDA daemon on '
-            'this DB instance')
+            'this DB instance'
+        )
         self.settings_info['2db|schemaversion2'] = dict(
             key='2db|schemaversion2',
             datatype='txt',
             tval=' 1.0.8',
-            description='The version of the schema used in this database.')
+            description='The version of the schema used in this database.'
+        )
 
         with transaction.atomic():
             for setting_info in self.settings_info.values():
@@ -289,13 +296,9 @@ class DbMultipleValueAttributeBaseClass():
         return validate_attribute_key(key)
 
     @classmethod
-    def set_value(cls,
-                  key,
-                  value,
-                  with_transaction=True,
-                  subspecifier_value=None,
-                  other_attribs={},
-                  stop_if_existing=False):
+    def set_value(
+        cls, key, value, with_transaction=True, subspecifier_value=None, other_attribs={}, stop_if_existing=False
+    ):
         """
         Set a new value in the DB, possibly associated to the given subspecifier.
 
@@ -364,12 +367,14 @@ class DbMultipleValueAttributeBaseClass():
             if with_transaction:
                 transaction.savepoint_rollback(sid)
             if isinstance(exc, IntegrityError) and stop_if_existing:
-                raise UniquenessError("Impossible to create the required "
-                                      "entry "
-                                      "in table '{}', "
-                                      "another entry already exists and the creation would "
-                                      "violate an uniqueness constraint.\nFurther details: "
-                                      "{}".format(cls.__name__, exc))
+                raise UniquenessError(
+                    "Impossible to create the required "
+                    "entry "
+                    "in table '{}', "
+                    "another entry already exists and the creation would "
+                    "violate an uniqueness constraint.\nFurther details: "
+                    "{}".format(cls.__name__, exc)
+                )
             raise
 
     @classmethod
@@ -404,17 +409,21 @@ class DbMultipleValueAttributeBaseClass():
 
         if cls._subspecifier_field_name is None:
             if subspecifier_value is not None:
-                raise ValueError("You cannot specify a subspecifier value for "
-                                 "class {} because it has no subspecifiers"
-                                 "".format(cls.__name__))
+                raise ValueError(
+                    "You cannot specify a subspecifier value for "
+                    "class {} because it has no subspecifiers"
+                    "".format(cls.__name__)
+                )
             if issubclass(cls, DbAttributeFunctionality):
                 new_entry = db_attribute_base_model(key=key, **other_attribs)
             else:
                 new_entry = db_extra_base_model(key=key, **other_attribs)
         else:
             if subspecifier_value is None:
-                raise ValueError("You also have to specify a subspecifier value "
-                                 "for class {} (the {})".format(cls.__name__, cls._subspecifier_field_name))
+                raise ValueError(
+                    "You also have to specify a subspecifier value "
+                    "for class {} (the {})".format(cls.__name__, cls._subspecifier_field_name)
+                )
             further_params = other_attribs.copy()
             further_params.update({cls._subspecifier_field_name: subspecifier_value})
             # new_entry = cls(key=key, **further_params)
@@ -498,7 +507,9 @@ class DbMultipleValueAttributeBaseClass():
                 # NOTE: I do not pass other_attribs
                 list_to_return.extend(
                     cls.create_value(
-                        key=("{}{}{:d}".format(key, cls._sep, i)), value=subv, subspecifier_value=subspecifier_value))
+                        key=("{}{}{:d}".format(key, cls._sep, i)), value=subv, subspecifier_value=subspecifier_value
+                    )
+                )
 
         elif isinstance(value, dict):
 
@@ -518,14 +529,17 @@ class DbMultipleValueAttributeBaseClass():
                 # NOTE: I do not pass other_attribs
                 list_to_return.extend(
                     cls.create_value(
-                        key="{}{}{}".format(key, cls._sep, subk), value=subv, subspecifier_value=subspecifier_value))
+                        key="{}{}{}".format(key, cls._sep, subk), value=subv, subspecifier_value=subspecifier_value
+                    )
+                )
         else:
             try:
                 jsondata = json.dumps(value)
             except TypeError:
                 raise ValueError(
-                    "Unable to store the value: it must be either a basic datatype, or json-serializable: {}".format(
-                        value))
+                    "Unable to store the value: it must be either a basic datatype, or json-serializable: {}".
+                    format(value)
+                )
 
             new_entry.datatype = 'json'
             new_entry.tval = jsondata
@@ -601,7 +615,8 @@ class DbAttributeBaseClass(DbMultipleValueAttributeBaseClass):
             value,
             with_transaction=with_transaction,
             subspecifier_value=dbnode_node,
-            stop_if_existing=stop_if_existing)
+            stop_if_existing=stop_if_existing
+        )
 
     def __str__(self):
         # pylint: disable=no-member

--- a/aiida/backends/djsite/db/subtests/migrations/test_migrations_0038_data_migration_legacy_job_calculations.py
+++ b/aiida/backends/djsite/db/subtests/migrations/test_migrations_0038_data_migration_legacy_job_calculations.py
@@ -35,7 +35,8 @@ class TestLegacyJobCalcStateDataMigration(TestMigrations):
             node = self.DbNode(
                 node_type='process.calculation.calcjob.CalcJobNode.',
                 user_id=self.default_user.id,
-                attributes={'state': state})
+                attributes={'state': state}
+            )
             node.save()
 
             self.nodes[state] = node.id
@@ -47,8 +48,9 @@ class TestLegacyJobCalcStateDataMigration(TestMigrations):
             self.assertEqual(node.attributes.get('process_state', None), STATE_MAPPING[state].process_state)
             self.assertEqual(node.attributes.get('process_status', None), STATE_MAPPING[state].process_status)
             self.assertEqual(node.attributes.get('exit_status', None), STATE_MAPPING[state].exit_status)
-            self.assertEqual(node.attributes.get('process_label'),
-                             'Legacy JobCalculation')  # All nodes should have this label
+            self.assertEqual(
+                node.attributes.get('process_label'), 'Legacy JobCalculation'
+            )  # All nodes should have this label
             self.assertIsNone(node.attributes.get('state', None))  # The old state should have been removed
 
             exit_status = node.attributes.get('exit_status', None)

--- a/aiida/backends/djsite/db/subtests/migrations/test_migrations_0040_data_migration_legacy_process_attributes.py
+++ b/aiida/backends/djsite/db/subtests/migrations/test_migrations_0040_data_migration_legacy_process_attributes.py
@@ -33,7 +33,8 @@ class TestLegacyProcessAttributeDataMigration(TestMigrations):
                 '_failed': False,
                 '_aborted': False,
                 '_do_abort': False,
-            })
+            }
+        )
         node_process.save()
         self.node_process_id = node_process.id
 
@@ -47,7 +48,8 @@ class TestLegacyProcessAttributeDataMigration(TestMigrations):
                 '_failed': False,
                 '_aborted': False,
                 '_do_abort': False,
-            })
+            }
+        )
         node_process_active.save()
         self.node_process_active_id = node_process_active.id
 
@@ -62,7 +64,8 @@ class TestLegacyProcessAttributeDataMigration(TestMigrations):
                 '_failed': False,
                 '_aborted': False,
                 '_do_abort': False,
-            })
+            }
+        )
         node_data.save()
         self.node_data_id = node_data.id
 

--- a/aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py
+++ b/aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py
@@ -181,7 +181,8 @@ class TestGroupRenamingMigration(TestMigrations):
 
         # test data.upf group type_string: 'data.upf.family' -> 'data.upf'
         group_data_upf = DbGroup(
-            label='test_data_upf_group', user_id=self.default_user.id, type_string='data.upf.family')
+            label='test_data_upf_group', user_id=self.default_user.id, type_string='data.upf.family'
+        )
         group_data_upf.save()
         self.group_data_upf_pk = group_data_upf.pk
 
@@ -269,12 +270,14 @@ class TestCalcAttributeKeysMigration(TestMigrationsModelModifierV0025):
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_PROCESS_LABEL_NEW), self.process_label)
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_RESOURCES_NEW), self.resources)
         self.assertEqual(
-            self.get_attribute(self.node_calc, self.KEY_ENVIRONMENT_VARIABLES_NEW), self.environment_variables)
+            self.get_attribute(self.node_calc, self.KEY_ENVIRONMENT_VARIABLES_NEW), self.environment_variables
+        )
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_PARSER_NAME_NEW), self.parser_name)
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_PROCESS_LABEL_OLD, default=NOT_FOUND), NOT_FOUND)
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_RESOURCES_OLD, default=NOT_FOUND), NOT_FOUND)
         self.assertEqual(
-            self.get_attribute(self.node_calc, self.KEY_ENVIRONMENT_VARIABLES_OLD, default=NOT_FOUND), NOT_FOUND)
+            self.get_attribute(self.node_calc, self.KEY_ENVIRONMENT_VARIABLES_OLD, default=NOT_FOUND), NOT_FOUND
+        )
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_PARSER_NAME_OLD, default=NOT_FOUND), NOT_FOUND)
 
         # The following node should not be migrated even if its attributes have the matching keys because
@@ -282,12 +285,14 @@ class TestCalcAttributeKeysMigration(TestMigrationsModelModifierV0025):
         self.assertEqual(self.get_attribute(self.node_other, self.KEY_PROCESS_LABEL_OLD), self.process_label)
         self.assertEqual(self.get_attribute(self.node_other, self.KEY_RESOURCES_OLD), self.resources)
         self.assertEqual(
-            self.get_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_OLD), self.environment_variables)
+            self.get_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_OLD), self.environment_variables
+        )
         self.assertEqual(self.get_attribute(self.node_other, self.KEY_PARSER_NAME_OLD), self.parser_name)
         self.assertEqual(self.get_attribute(self.node_other, self.KEY_PROCESS_LABEL_NEW, default=NOT_FOUND), NOT_FOUND)
         self.assertEqual(self.get_attribute(self.node_other, self.KEY_RESOURCES_NEW, default=NOT_FOUND), NOT_FOUND)
         self.assertEqual(
-            self.get_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_NEW, default=NOT_FOUND), NOT_FOUND)
+            self.get_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_NEW, default=NOT_FOUND), NOT_FOUND
+        )
         self.assertEqual(self.get_attribute(self.node_other, self.KEY_PARSER_NAME_NEW, default=NOT_FOUND), NOT_FOUND)
 
 
@@ -339,17 +344,20 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
                 "levelno": 23,
                 "message": "calculation node 1",
                 "objname": "node.calculation.job.quantumespresso.pw.",
-            }))
+            })
+        )
         log_2 = DbLog(
             loggername='something.else logger',
             objpk=param.pk,
             objname='something.else.',
-            message='parameter data with log message')
+            message='parameter data with log message'
+        )
         log_3 = DbLog(
             loggername='TopologicalWorkflow logger',
             objpk=leg_workf.pk,
             objname='aiida.workflows.user.topologicalworkflows.topo.TopologicalWorkflow',
-            message='parameter data with log message')
+            message='parameter data with log message'
+        )
         log_4 = DbLog(
             loggername='CalculationNode logger',
             objpk=calc_2.pk,
@@ -362,7 +370,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
                 "levelno": 23,
                 "message": "calculation node 1",
                 "objname": "node.calculation.job.quantumespresso.pw.",
-            }))
+            })
+        )
         # Creating two more log records that don't correspond to a node
         log_5 = DbLog(
             loggername='CalculationNode logger',
@@ -376,7 +385,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
                 "levelno": 25,
                 "message": "calculation node 1000",
                 "objname": "node.calculation.job.quantumespresso.pw.",
-            }))
+            })
+        )
         log_6 = DbLog(
             loggername='CalculationNode logger',
             objpk=(calc_2.pk + 1001),
@@ -389,7 +399,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
                 "levelno": 24,
                 "message": "calculation node 1001",
                 "objname": "node.calculation.job.quantumespresso.pw.",
-            }))
+            })
+        )
 
         # Storing the log records
         log_1.save()
@@ -411,8 +422,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
         )
 
         # Getting the serialized Dict logs
-        param_data = DbLog.objects.filter(objpk=param.pk).filter(
-            objname='something.else.').values(*update_024.values_to_export)[:1]
+        param_data = DbLog.objects.filter(objpk=param.pk).filter(objname='something.else.'
+                                                                ).values(*update_024.values_to_export)[:1]
         serialized_param_data = dumps_json(list(param_data))
         # Getting the serialized logs for the unknown entity logs (as the export migration fuction
         # provides them) - this should coincide to the above
@@ -423,8 +434,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
 
         # Getting the serialized legacy workflow logs
         leg_wf = DbLog.objects.filter(objpk=leg_workf.pk).filter(
-            objname='aiida.workflows.user.topologicalworkflows.topo.TopologicalWorkflow').values(
-                *update_024.values_to_export)[:1]
+            objname='aiida.workflows.user.topologicalworkflows.topo.TopologicalWorkflow'
+        ).values(*update_024.values_to_export)[:1]
         serialized_leg_wf_logs = dumps_json(list(leg_wf))
         # Getting the serialized logs for the legacy workflow logs (as the export migration function
         # provides them) - this should coincide to the above
@@ -465,11 +476,11 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
         self.assertEqual(DbLog.objects.count(), 2, "There should be two log records left")
 
         # Get the node id of the log record referencing the node and verify that it is the correct one
-        dbnode_id_1 = DbLog.objects.filter(
-            pk=self.to_check['CalculationNode'][1]).values('dbnode_id')[:1].get()['dbnode_id']
+        dbnode_id_1 = DbLog.objects.filter(pk=self.to_check['CalculationNode'][1]
+                                          ).values('dbnode_id')[:1].get()['dbnode_id']
         self.assertEqual(dbnode_id_1, self.to_check['CalculationNode'][0], 'referenced node is not the expected one')
-        dbnode_id_2 = DbLog.objects.filter(
-            pk=self.to_check['CalculationNode'][3]).values('dbnode_id')[:1].get()['dbnode_id']
+        dbnode_id_2 = DbLog.objects.filter(pk=self.to_check['CalculationNode'][3]
+                                          ).values('dbnode_id')[:1].get()['dbnode_id']
         self.assertEqual(dbnode_id_2, self.to_check['CalculationNode'][2], 'referenced node is not the expected one')
 
     def test_dblog_correct_export_of_logs(self):
@@ -487,7 +498,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
 
         self.assertEqual(
             sorted(list(json.loads(self.to_check['NoNode'][0])), key=lambda k: k['id']),
-            sorted(list(json.loads(self.to_check['NoNode'][1])), key=lambda k: k['id']))
+            sorted(list(json.loads(self.to_check['NoNode'][1])), key=lambda k: k['id'])
+        )
         self.assertEqual(self.to_check['NoNode'][2], 2)
 
     def test_dblog_unique_uuids(self):
@@ -550,7 +562,8 @@ class TestDbLogMigrationBackward(TestMigrations):
                 "created": 1540118391.719085,
                 "levelno": 23,
                 "message": "calculation node 1",
-            }))
+            })
+        )
         log_2 = DbLog(
             loggername='CalculationNode logger',
             dbnode_id=calc_2.pk,
@@ -560,7 +573,8 @@ class TestDbLogMigrationBackward(TestMigrations):
                 "lineno": 360,
                 "levelno": 23,
                 "message": "calculation node 1",
-            }))
+            })
+        )
 
         # Storing the log records
         log_1.save()
@@ -586,24 +600,31 @@ class TestDbLogMigrationBackward(TestMigrations):
             self.assertEqual(
                 log_dbnode_id, log_entry.objpk,
                 "The dbnode_id ({}) of the 0024 schema version should be identical to the objpk ({}) of "
-                "the 0023 schema version.".format(log_dbnode_id, log_entry.objpk))
+                "the 0023 schema version.".format(log_dbnode_id, log_entry.objpk)
+            )
             self.assertEqual(
                 node_type, log_entry.objname,
                 "The type ({}) of the linked node of the 0024 schema version should be identical to the "
-                "objname ({}) of the 0023 schema version.".format(node_type, log_entry.objname))
+                "objname ({}) of the 0023 schema version.".format(node_type, log_entry.objname)
+            )
             self.assertEqual(
                 log_dbnode_id,
                 json.loads(log_entry.metadata)['objpk'],
                 "The dbnode_id ({}) of the 0024 schema version should be identical to the objpk ({}) of "
-                "the 0023 schema version stored in the metadata.".format(log_dbnode_id,
-                                                                         json.loads(log_entry.metadata)['objpk']))
+                "the 0023 schema version stored in the metadata.".format(
+                    log_dbnode_id,
+                    json.loads(log_entry.metadata)['objpk']
+                )
+            )
             self.assertEqual(
                 node_type,
                 json.loads(log_entry.metadata)['objname'],
                 "The type ({}) of the linked node of the 0024 schema version should be identical to the "
                 "objname ({}) of the 0023 schema version stored in the metadata.".format(
                     node_type,
-                    json.loads(log_entry.metadata)['objname']))
+                    json.loads(log_entry.metadata)['objname']
+                )
+            )
 
 
 class TestDataMoveWithinNodeMigration(TestMigrations):
@@ -812,7 +833,8 @@ class TestResetHash(TestMigrations):
             extras={
                 'something': 123,
                 '_aiida_hash': 'abcd'
-            })
+            }
+        )
         self.node.save()
 
     def test_data_migrated(self):

--- a/aiida/backends/djsite/settings.py
+++ b/aiida/backends/djsite/settings.py
@@ -39,8 +39,9 @@ if PROFILE is None:
     raise exceptions.ProfileConfigurationError('no profile has been loaded')
 
 if PROFILE.database_backend != 'django':
-    raise exceptions.ProfileConfigurationError('incommensurate database backend `{}` for profile `{}`'.format(
-        PROFILE.database_backend, PROFILE.name))
+    raise exceptions.ProfileConfigurationError(
+        'incommensurate database backend `{}` for profile `{}`'.format(PROFILE.database_backend, PROFILE.name)
+    )
 
 PROFILE_CONF = PROFILE.dictionary
 

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -165,8 +165,10 @@ def check_schema_version(profile_name):
             'Before you upgrade, make sure all calculations and workflows have finished running.\n'
             'If this is not the case, revert the code to the previous version and finish them first.\n'
             'To migrate the database to the current version, run the following commands:'
-            '\n  verdi -p {} daemon stop\n  verdi -p {} database migrate'.format(db_schema_version, code_schema_version,
-                                                                                 profile_name, profile_name))
+            '\n  verdi -p {} daemon stop\n  verdi -p {} database migrate'.format(
+                db_schema_version, code_schema_version, profile_name, profile_name
+            )
+        )
 
 
 def set_db_schema_version(version):

--- a/aiida/backends/sqlalchemy/migrations/versions/07fac78e6209_drop_computer_transport_params.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/07fac78e6209_drop_computer_transport_params.py
@@ -39,4 +39,5 @@ def downgrade():
     """Migrations for the downgrade."""
     op.add_column(
         'db_dbcomputer',
-        sa.Column('transport_params', postgresql.JSONB(astext_type=sa.Text()), autoincrement=False, nullable=True))
+        sa.Column('transport_params', postgresql.JSONB(astext_type=sa.Text()), autoincrement=False, nullable=True)
+    )

--- a/aiida/backends/sqlalchemy/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
@@ -37,7 +37,8 @@ def upgrade():
 
     # The built in calculation plugins `arithmetic.add` and `templatereplacer` have been moved and their entry point
     # renamed. In the change the `simpleplugins` namespace was dropped so we migrate the existing nodes.
-    statement = text("""
+    statement = text(
+        """
         UPDATE db_dbnode SET type = 'calculation.job.arithmetic.add.ArithmeticAddCalculation.'
         WHERE type = 'calculation.job.simpleplugins.arithmetic.add.ArithmeticAddCalculation.';
 
@@ -57,7 +58,8 @@ def upgrade():
         UPDATE db_dbnode SET attributes = jsonb_set(attributes, '{"input_plugin"}', '"templatereplacer"')
         WHERE attributes @> '{"input_plugin": "simpleplugins.templatereplacer"}'
         AND type = 'data.code.Code.';
-    """)
+    """
+    )
     conn.execute(statement)
 
 
@@ -65,7 +67,8 @@ def downgrade():
     """Migrations for the downgrade."""
     conn = op.get_bind()  # pylint: disable=no-member
 
-    statement = text("""
+    statement = text(
+        """
         UPDATE db_dbnode SET type = 'calculation.job.simpleplugins.arithmetic.add.ArithmeticAddCalculation.'
         WHERE type = 'calculation.job.arithmetic.add.ArithmeticAddCalculation.';
 
@@ -85,5 +88,6 @@ def downgrade():
         UPDATE db_dbnode SET attributes = jsonb_set(attributes, '{"input_plugin"}', '"simpleplugins.templatereplacer"')
         WHERE attributes @> '{"input_plugin": "templatereplacer"}'
         AND type = 'data.code.Code.';
-    """)
+    """
+    )
     conn.execute(statement)

--- a/aiida/backends/sqlalchemy/migrations/versions/1830c8430131_drop_node_columns_nodeversion_public.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/1830c8430131_drop_node_columns_nodeversion_public.py
@@ -19,8 +19,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-import sqlalchemy as sa
 from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1830c8430131'

--- a/aiida/backends/sqlalchemy/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
@@ -87,7 +87,8 @@ def export_workflow_data(connection):
     }
 
     with NamedTemporaryFile(
-            prefix='legacy-workflows', suffix='.json', dir='.', delete=delete_on_close, mode='w+') as handle:
+        prefix='legacy-workflows', suffix='.json', dir='.', delete=delete_on_close, mode='w+'
+    ) as handle:
         filename = handle.name
         json.dump(data, handle, default=json_serializer)
 
@@ -122,7 +123,8 @@ def downgrade():
             sa.INTEGER(),
             server_default=sa.text(u"nextval('db_dbworkflow_id_seq'::regclass)"),
             autoincrement=True,
-            nullable=False),
+            nullable=False
+        ),
         sa.Column('uuid', postgresql.UUID(), autoincrement=False, nullable=True),
         sa.Column('ctime', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=True),
         sa.Column('mtime', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=True),
@@ -140,7 +142,8 @@ def downgrade():
         sa.ForeignKeyConstraint(['user_id'], [u'db_dbuser.id'], name=u'db_dbworkflow_user_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflow_pkey'),
         sa.UniqueConstraint('uuid', name=u'db_dbworkflow_uuid_key'),
-        postgresql_ignore_search_path=False)
+        postgresql_ignore_search_path=False
+    )
     op.create_index('ix_db_dbworkflow_label', 'db_dbworkflow', ['label'], unique=False)
     op.create_table(
         'db_dbworkflowdata', sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
@@ -154,7 +157,8 @@ def downgrade():
         sa.ForeignKeyConstraint(['aiida_obj_id'], [u'db_dbnode.id'], name=u'db_dbworkflowdata_aiida_obj_id_fkey'),
         sa.ForeignKeyConstraint(['parent_id'], [u'db_dbworkflow.id'], name=u'db_dbworkflowdata_parent_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowdata_pkey'),
-        sa.UniqueConstraint('parent_id', 'name', 'data_type', name=u'db_dbworkflowdata_parent_id_name_data_type_key'))
+        sa.UniqueConstraint('parent_id', 'name', 'data_type', name=u'db_dbworkflowdata_parent_id_name_data_type_key')
+    )
     op.create_index('ix_db_dbworkflowdata_parent_id', 'db_dbworkflowdata', ['parent_id'], unique=False)
     op.create_index('ix_db_dbworkflowdata_aiida_obj_id', 'db_dbworkflowdata', ['aiida_obj_id'], unique=False)
     op.create_table(
@@ -168,7 +172,8 @@ def downgrade():
         sa.ForeignKeyConstraint(['parent_id'], [u'db_dbworkflow.id'], name=u'db_dbworkflowstep_parent_id_fkey'),
         sa.ForeignKeyConstraint(['user_id'], [u'db_dbuser.id'], name=u'db_dbworkflowstep_user_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_pkey'),
-        sa.UniqueConstraint('parent_id', 'name', name=u'db_dbworkflowstep_parent_id_name_key'))
+        sa.UniqueConstraint('parent_id', 'name', name=u'db_dbworkflowstep_parent_id_name_key')
+    )
     op.create_table(
         'db_dbworkflowstep_calculations', sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
         sa.Column('dbworkflowstep_id', sa.INTEGER(), autoincrement=False, nullable=True),
@@ -178,7 +183,8 @@ def downgrade():
         sa.ForeignKeyConstraint(['dbworkflowstep_id'], [u'db_dbworkflowstep.id'],
                                 name=u'db_dbworkflowstep_calculations_dbworkflowstep_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_calculations_pkey'),
-        sa.UniqueConstraint('dbworkflowstep_id', 'dbnode_id', name=u'db_dbworkflowstep_calculations_id_dbnode_id_key'))
+        sa.UniqueConstraint('dbworkflowstep_id', 'dbnode_id', name=u'db_dbworkflowstep_calculations_id_dbnode_id_key')
+    )
     op.create_table(
         'db_dbworkflowstep_sub_workflows', sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
         sa.Column('dbworkflowstep_id', sa.INTEGER(), autoincrement=False, nullable=True),
@@ -189,4 +195,6 @@ def downgrade():
                                 name=u'db_dbworkflowstep_sub_workflows_dbworkflowstep_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_sub_workflows_pkey'),
         sa.UniqueConstraint(
-            'dbworkflowstep_id', 'dbworkflow_id', name=u'db_dbworkflowstep_sub_workflows_id_dbworkflow__key'))
+            'dbworkflowstep_id', 'dbworkflow_id', name=u'db_dbworkflowstep_sub_workflows_id_dbworkflow__key'
+        )
+    )

--- a/aiida/backends/sqlalchemy/migrations/versions/26d561acd560_data_migration_legacy_job_calculations.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/26d561acd560_data_migration_legacy_job_calculations.py
@@ -44,7 +44,7 @@ Revises: 07fac78e6209
 Create Date: 2019-06-22 09:55:25.284168
 
 """
-# pylint: disable=invalid-name,no-member,import-error,no-name-in-module
+# pylint: disable=invalid-name,no-member,import-error,no-name-in-module,line-too-long
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -67,7 +67,8 @@ def upgrade():
     # New `CalcJobs` will have the same node type and while their active can have a `state` attribute with a value
     # of the enum `CalcJobState`, some of which match the deprecated `JobCalcState`, however, the new ones are stored
     # in lower case, so we do not run the risk of matching them by accident.
-    statement = text("""
+    statement = text(
+        """
         UPDATE db_dbnode
         SET attributes = attributes - 'state' || '{"process_state": "killed", "process_status": "Legacy `JobCalculation` with state `NEW`", "process_label": "Legacy JobCalculation"}'
         WHERE node_type = 'process.calculation.calcjob.CalcJobNode.' AND attributes @> '{"state": "NEW"}';
@@ -104,7 +105,8 @@ def upgrade():
         UPDATE db_dbnode
         SET attributes = attributes - 'state' || '{"process_state": "finished", "exit_status": 0, "process_label": "Legacy JobCalculation"}'
         WHERE node_type = 'process.calculation.calcjob.CalcJobNode.' AND attributes @> '{"state": "FINISHED"}';
-    """)
+    """
+    )
     conn.execute(statement)
 
 

--- a/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -45,15 +45,18 @@ def verify_uuid_uniqueness(table):
     from aiida.common.exceptions import IntegrityError
 
     query = text(
-        'SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM {}) AS s WHERE c > 1'.format(
-            table))
+        'SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM {}) AS s WHERE c > 1'.
+        format(table)
+    )
     conn = op.get_bind()
     duplicates = conn.execute(query).fetchall()
 
     if duplicates:
         command = '`verdi database integrity detect-duplicate-uuid {table}`'.format(table=table)
-        raise IntegrityError('Your table "{}"" contains entries with duplicate UUIDS.\nRun {} '
-                             'to return to a consistent state'.format(table, command))
+        raise IntegrityError(
+            'Your table "{}"" contains entries with duplicate UUIDS.\nRun {} '
+            'to return to a consistent state'.format(table, command)
+        )
 
 
 def upgrade():

--- a/aiida/backends/sqlalchemy/migrations/versions/61fc0913fae9_remove_node_prefix.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/61fc0913fae9_remove_node_prefix.py
@@ -34,7 +34,8 @@ def upgrade():
     conn = op.get_bind()
 
     # The `node.` prefix is being dropped from the node type string
-    statement = text(r"""
+    statement = text(
+        r"""
         UPDATE db_dbnode
         SET type = regexp_replace(type, '^node.data.', 'data.')
         WHERE type LIKE 'node.data.%';
@@ -42,7 +43,8 @@ def upgrade():
         UPDATE db_dbnode
         SET type = regexp_replace(type, '^node.process.', 'process.')
         WHERE type LIKE 'node.process.%';
-    """)
+    """
+    )
     conn.execute(statement)
 
 
@@ -50,7 +52,8 @@ def downgrade():
     """Migrations for the downgrade."""
     conn = op.get_bind()
 
-    statement = text(r"""
+    statement = text(
+        r"""
         UPDATE db_dbnode
         SET type = regexp_replace(type, '^data.', 'node.data.')
         WHERE type LIKE 'data.%';
@@ -58,5 +61,6 @@ def downgrade():
         UPDATE db_dbnode
         SET type = regexp_replace(type, '^process.', 'node.process.')
         WHERE type LIKE 'process.%';
-    """)
+    """
+    )
     conn.execute(statement)

--- a/aiida/backends/sqlalchemy/migrations/versions/6a5c2ea1439d_move_data_within_node_module.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/6a5c2ea1439d_move_data_within_node_module.py
@@ -33,11 +33,13 @@ def upgrade():
     conn = op.get_bind()
 
     # The type string for `Data` nodes changed from `data.*` to `node.data.*`.
-    statement = text(r"""
+    statement = text(
+        r"""
         UPDATE db_dbnode
         SET type = regexp_replace(type, '^data.', 'node.data.')
         WHERE type LIKE 'data.%'
-    """)
+    """
+    )
     conn.execute(statement)
 
 
@@ -45,9 +47,11 @@ def downgrade():
     """Migrations for the downgrade."""
     conn = op.get_bind()
 
-    statement = text(r"""
+    statement = text(
+        r"""
         UPDATE db_dbnode
         SET type = regexp_replace(type, '^node.data.', 'data.')
         WHERE type LIKE 'node.data.%'
-    """)
+    """
+    )
     conn.execute(statement)

--- a/aiida/backends/sqlalchemy/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
@@ -47,7 +47,8 @@ def upgrade():
     """
     conn = op.get_bind()
 
-    statement = text("""
+    statement = text(
+        """
         UPDATE db_dbnode
         SET attributes = jsonb_set(attributes, '{environment_variables}', attributes->'custom_environment_variables')
         WHERE
@@ -91,7 +92,8 @@ def upgrade():
             attributes ? 'parser' AND
             type = 'node.process.calculation.calcjob.CalcJobNode.';
         -- parser -> parser_name
-        """)
+        """
+    )
     conn.execute(statement)
 
 

--- a/aiida/backends/sqlalchemy/migrations/versions/d254fdfed416_rename_parameter_data_to_dict.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/d254fdfed416_rename_parameter_data_to_dict.py
@@ -32,9 +32,11 @@ def upgrade():
     """Migrations for the upgrade."""
     conn = op.get_bind()
 
-    statement = text(r"""
+    statement = text(
+        r"""
         UPDATE db_dbnode SET type = 'data.dict.Dict.' WHERE type = 'data.parameter.ParameterData.';
-    """)
+    """
+    )
     conn.execute(statement)
 
 
@@ -42,7 +44,9 @@ def downgrade():
     """Migrations for the downgrade."""
     conn = op.get_bind()
 
-    statement = text(r"""
+    statement = text(
+        r"""
         UPDATE db_dbnode SET type = 'data.parameter.ParameterData.' WHERE type = 'data.dict.Dict.';
-    """)
+    """
+    )
     conn.execute(statement)

--- a/aiida/backends/sqlalchemy/migrations/versions/de2eaf6978b4_simplify_user_model.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/de2eaf6978b4_simplify_user_model.py
@@ -44,11 +44,13 @@ def upgrade():
 
 def downgrade():
     """Migrations for the downgrade."""
-    op.add_column('db_dbuser',
-                  sa.Column('date_joined', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=True))
+    op.add_column(
+        'db_dbuser', sa.Column('date_joined', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=True)
+    )
     op.add_column('db_dbuser', sa.Column('password', sa.VARCHAR(length=128), autoincrement=False, nullable=True))
-    op.add_column('db_dbuser',
-                  sa.Column('last_login', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=True))
+    op.add_column(
+        'db_dbuser', sa.Column('last_login', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=True)
+    )
     op.add_column('db_dbuser', sa.Column('is_staff', sa.BOOLEAN(), autoincrement=False, nullable=True))
     op.add_column('db_dbuser', sa.Column('is_superuser', sa.BOOLEAN(), autoincrement=False, nullable=True))
     op.add_column('db_dbuser', sa.Column('is_active', sa.BOOLEAN(), autoincrement=False, nullable=True))

--- a/aiida/backends/sqlalchemy/migrations/versions/e734dd5e50d7_data_migration_legacy_process_attributes.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e734dd5e50d7_data_migration_legacy_process_attributes.py
@@ -50,7 +50,8 @@ def upgrade():
     """Migrations for the upgrade."""
     conn = op.get_bind()
 
-    statement = text("""
+    statement = text(
+        """
         UPDATE db_dbnode
         SET attributes = jsonb_set(attributes, '{"sealed"}', attributes->'_sealed')
         WHERE attributes ? '_sealed' AND node_type LIKE 'process.%';
@@ -83,7 +84,8 @@ def upgrade():
             NOT (attributes ? 'sealed') AND
             attributes->>'process_state' NOT IN ('created', 'running', 'waiting');
         -- Set `sealed=True` for process nodes that do not yet have a `sealed` attribute AND are not in an active state
-        """)
+        """
+    )
     conn.execute(statement)
 
 

--- a/aiida/backends/sqlalchemy/migrations/versions/ea2f50e7f615_dblog_create_uuid_column.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/ea2f50e7f615_dblog_create_uuid_column.py
@@ -68,8 +68,9 @@ def upgrade():
     connection = op.get_bind()
 
     # Create the UUID column
-    op.add_column('db_dblog',
-                  sa.Column('uuid', postgresql.UUID(), autoincrement=False, nullable=True, default=get_new_uuid))
+    op.add_column(
+        'db_dblog', sa.Column('uuid', postgresql.UUID(), autoincrement=False, nullable=True, default=get_new_uuid)
+    )
 
     # Populate the uuid column
     set_new_uuid(connection)

--- a/aiida/backends/sqlalchemy/tests/test_migrations.py
+++ b/aiida/backends/sqlalchemy/tests/test_migrations.py
@@ -347,8 +347,11 @@ class TestMigrationSchemaVsModelsSchema(AiidaTestCase):
 
         result = compare(self.db_url_left, self.db_url_right, set(['alembic_version']))
 
-        self.assertTrue(result.is_match, "The migration database doesn't match to the one "
-                        "created by the models.\nDifferences: " + result._dump_data(result.errors))  # pylint: disable=protected-access
+        self.assertTrue(
+            result.is_match,
+            "The migration database doesn't match to the one "
+            "created by the models.\nDifferences: " + result._dump_data(result.errors)  # pylint: disable=protected-access
+        )
 
 
 class TestProvenanceRedesignMigration(TestMigrationsSQLA):
@@ -372,12 +375,14 @@ class TestProvenanceRedesignMigration(TestMigrationsSQLA):
                 session.commit()
 
                 node_calc_job_known = DbNode(
-                    type='calculation.job.arithmetic.add.ArithmeticAddCalculation.', user_id=user.id)
+                    type='calculation.job.arithmetic.add.ArithmeticAddCalculation.', user_id=user.id
+                )
                 node_calc_job_unknown = DbNode(type='calculation.job.unknown.PluginJobCalculation.', user_id=user.id)
                 node_process = DbNode(type='calculation.process.ProcessCalculation.', user_id=user.id)
                 node_work_chain = DbNode(type='calculation.work.WorkCalculation.', user_id=user.id)
                 node_work_function = DbNode(
-                    type='calculation.work.WorkCalculation.', attributes={'function_name': 'test'}, user_id=user.id)
+                    type='calculation.work.WorkCalculation.', attributes={'function_name': 'test'}, user_id=user.id
+                )
                 node_inline = DbNode(type='calculation.inline.InlineCalculation.', user_id=user.id)
                 node_function = DbNode(type='calculation.function.FunctionCalculation.', user_id=user.id)
 
@@ -474,15 +479,18 @@ class TestGroupRenamingMigration(TestMigrationsSQLA):
                 session.add(group_user)
                 # test data.upf group type_string: 'data.upf.family' -> 'data.upf'
                 group_data_upf = DbGroup(
-                    label='test_data_upf_group', user_id=default_user.id, type_string='data.upf.family')
+                    label='test_data_upf_group', user_id=default_user.id, type_string='data.upf.family'
+                )
                 session.add(group_data_upf)
                 # test auto.import group type_string: 'aiida.import' -> 'auto.import'
                 group_autoimport = DbGroup(
-                    label='test_import_group', user_id=default_user.id, type_string='aiida.import')
+                    label='test_import_group', user_id=default_user.id, type_string='aiida.import'
+                )
                 session.add(group_autoimport)
                 # test auto.run group type_string: 'autogroup.run' -> 'auto.run'
                 group_autorun = DbGroup(
-                    label='test_autorun_group', user_id=default_user.id, type_string='autogroup.run')
+                    label='test_autorun_group', user_id=default_user.id, type_string='autogroup.run'
+                )
                 session.add(group_autorun)
 
                 session.commit()
@@ -565,7 +573,8 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 }
                 node_work = DbNode(type='node.process.workflow.WorkflowNode.', attributes=attributes, user_id=user.id)
                 node_calc = DbNode(
-                    type='node.process.calculation.calcjob.CalcJobNode.', attributes=attributes, user_id=user.id)
+                    type='node.process.calculation.calcjob.CalcJobNode.', attributes=attributes, user_id=user.id
+                )
                 # Create a node of a different type to ensure that its attributes are not updated
                 node_other = DbNode(type='node.othernode.', attributes=attributes, user_id=user.id)
 
@@ -601,7 +610,8 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 self.assertEqual(node_calc.attributes.get(self.KEY_PARSER_NAME_NEW), self.parser_name)
                 self.assertEqual(node_calc.attributes.get(self.KEY_RESOURCES_NEW), self.resources)
                 self.assertEqual(
-                    node_calc.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_NEW), self.environment_variables)
+                    node_calc.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_NEW), self.environment_variables
+                )
                 self.assertEqual(node_calc.attributes.get(self.KEY_PROCESS_LABEL_OLD, not_found), not_found)
                 self.assertEqual(node_calc.attributes.get(self.KEY_PARSER_NAME_OLD, not_found), not_found)
                 self.assertEqual(node_calc.attributes.get(self.KEY_RESOURCES_OLD, not_found), not_found)
@@ -614,7 +624,8 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 self.assertEqual(node_other.attributes.get(self.KEY_PARSER_NAME_OLD), self.parser_name)
                 self.assertEqual(node_other.attributes.get(self.KEY_RESOURCES_OLD), self.resources)
                 self.assertEqual(
-                    node_other.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_OLD), self.environment_variables)
+                    node_other.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_OLD), self.environment_variables
+                )
                 self.assertEqual(node_other.attributes.get(self.KEY_PROCESS_LABEL_NEW, not_found), not_found)
                 self.assertEqual(node_other.attributes.get(self.KEY_PARSER_NAME_NEW, not_found), not_found)
                 self.assertEqual(node_other.attributes.get(self.KEY_RESOURCES_NEW, not_found), not_found)
@@ -657,7 +668,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
         from aiida.backends.general.migrations.utils import dumps_json
 
         log_migration = importlib.import_module(
-            'aiida.backends.sqlalchemy.migrations.versions.041a79fc615f_dblog_cleaning')
+            'aiida.backends.sqlalchemy.migrations.versions.041a79fc615f_dblog_cleaning'
+        )
 
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
@@ -698,17 +710,20 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
                         "levelno": 23,
                         "message": "calculation node 1",
                         "objname": "node.calculation.job.quantumespresso.pw.",
-                    })
+                    }
+                )
                 log_2 = DbLog(
                     loggername='something.else logger',
                     objpk=param.id,
                     objname='something.else.',
-                    message='parameter data with log message')
+                    message='parameter data with log message'
+                )
                 log_3 = DbLog(
                     loggername='TopologicalWorkflow logger',
                     objpk=leg_workf.id,
                     objname='aiida.workflows.user.topologicalworkflows.topo.TopologicalWorkflow',
-                    message='parameter data with log message')
+                    message='parameter data with log message'
+                )
                 log_4 = DbLog(
                     loggername='CalculationNode logger',
                     objpk=calc_2.id,
@@ -721,7 +736,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
                         "levelno": 23,
                         "message": "calculation node 1",
                         "objname": "node.calculation.job.quantumespresso.pw.",
-                    })
+                    }
+                )
                 # Creating two more log records that don't correspond to a node
                 log_5 = DbLog(
                     loggername='CalculationNode logger',
@@ -735,7 +751,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
                         "levelno": 25,
                         "message": "calculation node 1000",
                         "objname": "node.calculation.job.quantumespresso.pw.",
-                    })
+                    }
+                )
                 log_6 = DbLog(
                     loggername='CalculationNode logger',
                     objpk=(calc_2.id + 1001),
@@ -748,7 +765,8 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
                         "levelno": 24,
                         "message": "calculation node 1001",
                         "objname": "node.calculation.job.quantumespresso.pw.",
-                    })
+                    }
+                )
 
                 session.add(log_1)
                 session.add(log_2)
@@ -776,8 +794,9 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
                     cols_to_project.append(getattr(DbLog, val))
 
                 # Getting the serialized Dict logs
-                param_data = session.query(DbLog).filter(DbLog.objpk == param.id).filter(
-                    DbLog.objname == 'something.else.').with_entities(*cols_to_project).one()
+                param_data = session.query(DbLog).filter(DbLog.objpk == param.id
+                                                        ).filter(DbLog.objname == 'something.else.'
+                                                                ).with_entities(*cols_to_project).one()
                 serialized_param_data = dumps_json([(dict(list(zip(param_data.keys(), param_data))))])
                 # Getting the serialized logs for the unknown entity logs (as the export migration fuction
                 # provides them) - this should coincide to the above

--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -38,8 +38,8 @@ class TestVerdiCalculation(AiidaTestCase):
         from aiida.engine import ProcessState
 
         cls.computer = orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct',
-            workdir='/tmp/aiida').store()
+            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+        ).store()
 
         cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
         cls.group = orm.Group(label='test_group').store()
@@ -233,10 +233,12 @@ class TestVerdiCalculation(AiidaTestCase):
 
         # Make sure add_job does not specify options 'input_filename' and 'output_filename'
         self.assertIsNone(
-            add_job.get_option('input_filename'), msg="'input_filename' should not be an option for {}".format(add_job))
+            add_job.get_option('input_filename'), msg="'input_filename' should not be an option for {}".format(add_job)
+        )
         self.assertIsNone(
             add_job.get_option('output_filename'),
-            msg="'output_filename' should not be an option for {}".format(add_job))
+            msg="'output_filename' should not be an option for {}".format(add_job)
+        )
 
         # Run `verdi calcjob inputcat add_job`
         options = [add_job.uuid]

--- a/aiida/backends/tests/cmdline/commands/test_import.py
+++ b/aiida/backends/tests/cmdline/commands/test_import.py
@@ -107,7 +107,9 @@ class TestVerdiImport(AiidaTestCase):
             group.count(),
             nodes_in_group,
             msg="The Group count should not have changed from {}. Instead it is now {}".format(
-                nodes_in_group, group.count()))
+                nodes_in_group, group.count()
+            )
+        )
 
         # Invoke `verdi import` again with new archive, making sure Group count is upped
         options = ['-G', group.label] + [archives[1]]
@@ -119,7 +121,9 @@ class TestVerdiImport(AiidaTestCase):
             group.count(),
             nodes_in_group,
             msg="There should now be more than {} nodes in group {} , instead there are {}".format(
-                nodes_in_group, group_label, group.count()))
+                nodes_in_group, group_label, group.count()
+            )
+        )
 
     def test_import_make_new_group(self):
         """Make sure imported entities are saved in new Group"""
@@ -130,7 +134,8 @@ class TestVerdiImport(AiidaTestCase):
         # Check Group does not already exist
         group_search = Group.objects.find(filters={'label': group_label})
         self.assertEqual(
-            len(group_search), 0, msg="A Group with label '{}' already exists, this shouldn't be.".format(group_label))
+            len(group_search), 0, msg="A Group with label '{}' already exists, this shouldn't be.".format(group_label)
+        )
 
         # Invoke `verdi import`, making sure there are no exceptions
         options = ['-G', group_label] + archives

--- a/aiida/backends/tests/cmdline/commands/test_process.py
+++ b/aiida/backends/tests/cmdline/commands/test_process.py
@@ -21,8 +21,8 @@ from concurrent.futures import Future
 import six
 from click.testing import CliRunner
 from tornado import gen
-import kiwipy
 import plumpy
+import kiwipy
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
@@ -50,7 +50,8 @@ class TestVerdiProcessDaemon(AiidaTestCase):
         profile = get_config().current_profile
         self.daemon_client = DaemonClient(profile)
         self.daemon_pid = subprocess.Popen(
-            self.daemon_client.cmd_string.split(), stderr=sys.stderr, stdout=sys.stdout).pid
+            self.daemon_client.cmd_string.split(), stderr=sys.stderr, stdout=sys.stdout
+        ).pid
         self.runner = get_manager().create_runner(rmq_submit=True)
         self.cli_runner = CliRunner()
 
@@ -94,7 +95,8 @@ class TestVerdiProcessDaemon(AiidaTestCase):
         # future to True. This will be our signal that we can start testing
         waiting_future = Future()
         filters = kiwipy.BroadcastFilter(
-            lambda *args, **kwargs: waiting_future.set_result(True), sender=calc.pk, subject='state_changed.*.waiting')
+            lambda *args, **kwargs: waiting_future.set_result(True), sender=calc.pk, subject='state_changed.*.waiting'
+        )
         self.runner.communicator.add_broadcast_subscriber(filters)
 
         # The process may already have been picked up by the daemon and put in the waiting state, before the subscriber
@@ -333,8 +335,9 @@ class TestVerdiProcess(AiidaTestCase):
         # Max depth should limit nesting level
         for flag in ['-m', '--max-depth']:
             for flag_value in [1, 2]:
-                result = self.cli_runner.invoke(cmd_process.process_report,
-                                                [str(grandparent.pk), flag, str(flag_value)])
+                result = self.cli_runner.invoke(
+                    cmd_process.process_report, [str(grandparent.pk), flag, str(flag_value)]
+                )
                 self.assertIsNone(result.exception, result.output)
                 self.assertEqual(len(get_result_lines(result)), flag_value)
 

--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -78,13 +78,15 @@ class TestVerdiSetup(AiidaPostgresTestCase):
         import os
 
         with tempfile.NamedTemporaryFile('w') as handle:
-            handle.write("""---
+            handle.write(
+                """---
 profile: testing
 first_name: Leopold
 last_name: Talirz
 institution: EPFL
 db_backend: {}
-email: 123@234.de""".format(self.backend))
+email: 123@234.de""".format(self.backend)
+            )
             handle.flush()
             result = self.cli_runner.invoke(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)])
         self.assertClickResultNoException(result)

--- a/aiida/backends/tests/cmdline/params/types/test_code.py
+++ b/aiida/backends/tests/cmdline/params/types/test_code.py
@@ -36,10 +36,10 @@ class TestCodeParamType(AiidaTestCase):
         cls.param_base = CodeParamType()
         cls.param_entry_point = CodeParamType(entry_point='arithmetic.add')
         cls.entity_01 = Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.entity_02 = Code(
-            remote_computer_exec=(cls.computer, '/bin/true'), input_plugin_name='arithmetic.add').store()
-        cls.entity_03 = Code(
-            remote_computer_exec=(cls.computer, '/bin/true'), input_plugin_name='templatereplacer').store()
+        cls.entity_02 = Code(remote_computer_exec=(cls.computer, '/bin/true'),
+                             input_plugin_name='arithmetic.add').store()
+        cls.entity_03 = Code(remote_computer_exec=(cls.computer, '/bin/true'),
+                             input_plugin_name='templatereplacer').store()
 
         cls.entity_01.label = 'computer_01'
         cls.entity_02.label = str(cls.entity_01.pk)

--- a/aiida/backends/tests/cmdline/params/types/test_path.py
+++ b/aiida/backends/tests/cmdline/params/types/test_path.py
@@ -62,9 +62,11 @@ class TestImportPath(AiidaTestCase):
         upper_path = ImportPath(timeout_seconds=upper)
 
         msg_lower = "timeout_seconds should have been corrected to the lower bound: '{}', but instead it is {}".format(
-            range_timeout[0], lower_path.timeout_seconds)
+            range_timeout[0], lower_path.timeout_seconds
+        )
         self.assertEqual(lower_path.timeout_seconds, range_timeout[0], msg_lower)
 
         msg_upper = "timeout_seconds should have been corrected to the upper bound: '{}', but instead it is {}".format(
-            range_timeout[1], upper_path.timeout_seconds)
+            range_timeout[1], upper_path.timeout_seconds
+        )
         self.assertEqual(upper_path.timeout_seconds, range_timeout[1], msg_upper)

--- a/aiida/backends/tests/common/test_folders.py
+++ b/aiida/backends/tests/common/test_folders.py
@@ -40,8 +40,10 @@ class FoldersTest(unittest.TestCase):
     """
 
     @classmethod
-    @unittest.skipUnless(fs_encoding_is_utf8(), ("Testing for unicode folders "
-                                                 "requires UTF-8 to be set for filesystem encoding"))
+    @unittest.skipUnless(
+        fs_encoding_is_utf8(), ("Testing for unicode folders "
+                                "requires UTF-8 to be set for filesystem encoding")
+    )
     def test_unicode(cls):
         """
         Check that there are no exceptions raised when

--- a/aiida/backends/tests/common/test_hashing.py
+++ b/aiida/backends/tests/common/test_hashing.py
@@ -68,11 +68,13 @@ class MakeHashTest(unittest.TestCase):
 
     def test_unicode_string(self):
         self.assertEqual(
-            make_hash(u'something still in ASCII'), 'd55e492596cf214d877e165cdc3394f27e82e011838474f5ba5b9824074b9e91')
+            make_hash(u'something still in ASCII'), 'd55e492596cf214d877e165cdc3394f27e82e011838474f5ba5b9824074b9e91'
+        )
 
         self.assertEqual(
             make_hash(u"öpis mit Umluut wie ä, ö, ü und emene ß"),
-            'c404bf9a62cba3518de5c2bae8c67010aff6e4051cce565fa247a7f1d71f1fc7')
+            'c404bf9a62cba3518de5c2bae8c67010aff6e4051cce565fa247a7f1d71f1fc7'
+        )
 
     def test_collection_with_ordered_sets(self):
         self.assertEqual(make_hash((1, 2, 3)), 'b6b13d50e3bee7e58371af2b303f629edf32d1be2f7717c9d14193b4b8b23e04')
@@ -95,20 +97,24 @@ class MakeHashTest(unittest.TestCase):
             make_hash({
                 'a': 'b',
                 'c': 'd'
-            }), '656ef313d44684c44977b0c75f48f27a43686c63ae44c8778ea0fe05f629b3b9')
+            }), '656ef313d44684c44977b0c75f48f27a43686c63ae44c8778ea0fe05f629b3b9'
+        )
 
         # order changes in dictionaries should give the same hashes
         self.assertEqual(
             make_hash(collections.OrderedDict([('c', 'd'), ('a', 'b')]), odict_as_unordered=True),
-            make_hash(collections.OrderedDict([('a', 'b'), ('c', 'd')]), odict_as_unordered=True))
+            make_hash(collections.OrderedDict([('a', 'b'), ('c', 'd')]), odict_as_unordered=True)
+        )
 
     def test_collection_with_odicts(self):
         # ordered dicts should always give a different hash (because they are a different type), unless told otherwise:
         self.assertNotEqual(
-            make_hash(collections.OrderedDict([('a', 'b'), ('c', 'd')])), make_hash(dict([('a', 'b'), ('c', 'd')])))
+            make_hash(collections.OrderedDict([('a', 'b'), ('c', 'd')])), make_hash(dict([('a', 'b'), ('c', 'd')]))
+        )
         self.assertEqual(
             make_hash(collections.OrderedDict([('a', 'b'), ('c', 'd')]), odict_as_unordered=True),
-            make_hash(dict([('a', 'b'), ('c', 'd')])))
+            make_hash(dict([('a', 'b'), ('c', 'd')]))
+        )
 
     def test_nested_collections(self):
         obj_a = collections.OrderedDict([
@@ -132,7 +138,8 @@ class MakeHashTest(unittest.TestCase):
 
         self.assertEqual(
             make_hash(obj_a, odict_as_unordered=True),
-            'e27bf6081c23afcb3db0ee3a24a64c73171c062c7f227fecc7f17189996add44')
+            'e27bf6081c23afcb3db0ee3a24a64c73171c062c7f227fecc7f17189996add44'
+        )
         self.assertEqual(make_hash(obj_a, odict_as_unordered=True), make_hash(obj_b, odict_as_unordered=True))
 
     def test_bytes(self):
@@ -147,21 +154,26 @@ class MakeHashTest(unittest.TestCase):
     def test_datetime(self):
         # test for timezone-naive datetime:
         self.assertEqual(
-            make_hash(datetime(2018, 8, 18, 8, 18)), '714138f1114daa5fdc74c3483260742952b71b568d634c6093bb838afad76646')
+            make_hash(datetime(2018, 8, 18, 8, 18)), '714138f1114daa5fdc74c3483260742952b71b568d634c6093bb838afad76646'
+        )
         self.assertEqual(
-            make_hash(datetime.utcfromtimestamp(0)), 'b4d97d9d486937775bcc25a5cba073f048348c3cd93d4460174a4f72a6feb285')
+            make_hash(datetime.utcfromtimestamp(0)), 'b4d97d9d486937775bcc25a5cba073f048348c3cd93d4460174a4f72a6feb285'
+        )
 
         # test with timezone-aware datetime:
         self.assertEqual(
             make_hash(datetime(2018, 8, 18, 8, 18).replace(tzinfo=pytz.timezone('US/Eastern'))),
-            '194478834b3b8bd0518cf6ca6fefacc13bea15f9c0b8f5d585a0adf2ebbd562f')
+            '194478834b3b8bd0518cf6ca6fefacc13bea15f9c0b8f5d585a0adf2ebbd562f'
+        )
         self.assertEqual(
             make_hash(datetime(2018, 8, 18, 8, 18).replace(tzinfo=pytz.timezone('Europe/Amsterdam'))),
-            'be7c7c7faaff07d796db4cbef4d3d07ed29fdfd4a38c9aded00a4c2da2b89b9c')
+            'be7c7c7faaff07d796db4cbef4d3d07ed29fdfd4a38c9aded00a4c2da2b89b9c'
+        )
 
     def test_numpy_types(self):
         self.assertEqual(
-            make_hash(np.float64(3.141)), 'b3302aad550413e14fe44d5ead10b3aeda9884055fca77f9368c48517916d4be')  # pylint: disable=no-member
+            make_hash(np.float64(3.141)), 'b3302aad550413e14fe44d5ead10b3aeda9884055fca77f9368c48517916d4be'
+        )  # pylint: disable=no-member
         self.assertEqual(make_hash(np.int64(42)), '9468692328de958d7a8039e8a2eb05cd6888b7911bbc3794d0dfebd8df3482cd')  # pylint: disable=no-member
 
     def test_unhashable_type(self):

--- a/aiida/backends/tests/common/test_utils.py
+++ b/aiida/backends/tests/common/test_utils.py
@@ -221,14 +221,18 @@ class SqlStringMatchTest(unittest.TestCase):
         for pattern, match_true, match_false in [
             (r"aa\_a%a_b", ["aa_abbbaab", "aa_aa_b", "aa_abaa_b", "aa_aaxb", "aa_abaaxb"], ["aaaba_b", "aa_abab_b"]),
             (r"^aa[\_%]b", ["^aa[_aaa]b", "^aa[_]b", "^aa[_1]b"], ["^aa[]b", "aa[1]b", "^aa_b"]),
-            (r"z^aa^a\sd[\__%]*sa$dfa&s\%d$a", [r"z^aa^a\sd[_d]*sa$dfa&s%d$a", r"z^aa^a\sd[_aaa]*sa$dfa&s%d$a"],
-             [r"z^aa^a\sd[_]*sa$dfa&s%d$a", "zaa^asd[_aa]*sa$a"])
+            (
+                r"z^aa^a\sd[\__%]*sa$dfa&s\%d$a", [r"z^aa^a\sd[_d]*sa$dfa&s%d$a", r"z^aa^a\sd[_aaa]*sa$dfa&s%d$a"],
+                [r"z^aa^a\sd[_]*sa$dfa&s%d$a", "zaa^asd[_aa]*sa$a"]
+            )
         ]:
             for sample in match_true:
                 self.assertTrue(
                     escaping.sql_string_match(string=sample, pattern=pattern),
-                    "String '{}' should have matched pattern '{}'".format(sample, pattern))
+                    "String '{}' should have matched pattern '{}'".format(sample, pattern)
+                )
             for sample in match_false:
                 self.assertFalse(
                     escaping.sql_string_match(string=sample, pattern=pattern),
-                    "String '{}' should not have matched pattern '{}'".format(sample, pattern))
+                    "String '{}' should not have matched pattern '{}'".format(sample, pattern)
+                )

--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -80,10 +80,11 @@ class TestProcessFunction(AiidaTestCase):
 
         @workfunction
         def function_defaults(
-                data_a=orm.Int(DEFAULT_INT), metadata={
-                    'label': DEFAULT_LABEL,
-                    'description': DEFAULT_DESCRIPTION
-                }):  # pylint: disable=unused-argument,dangerous-default-value,missing-docstring
+            data_a=orm.Int(DEFAULT_INT), metadata={
+                'label': DEFAULT_LABEL,
+                'description': DEFAULT_DESCRIPTION
+            }
+        ):  # pylint: disable=unused-argument,dangerous-default-value,missing-docstring
             return data_a
 
         @workfunction

--- a/aiida/backends/tests/orm/implementation/test_comments.py
+++ b/aiida/backends/tests/orm/implementation/test_comments.py
@@ -35,7 +35,8 @@ class TestBackendComment(AiidaTestCase):
     def setUp(self):
         super(TestBackendComment, self).setUp()
         self.node = self.backend.nodes.create(
-            node_type='', user=self.user, computer=self.computer, label='label', description='description').store()
+            node_type='', user=self.user, computer=self.computer, label='label', description='description'
+        ).store()
         self.comment_content = 'comment content'
 
     def create_comment(self, **kwargs):
@@ -46,7 +47,8 @@ class TestBackendComment(AiidaTestCase):
         mtime = kwargs['mtime'] if 'mtime' in kwargs else None
 
         return self.backend.comments.create(
-            node=node, user=user, content=self.comment_content, ctime=ctime, mtime=mtime)
+            node=node, user=user, content=self.comment_content, ctime=ctime, mtime=mtime
+        )
 
     def test_creation(self):
         """Test creation of a BackendComment and all its properties."""
@@ -105,7 +107,8 @@ class TestBackendComment(AiidaTestCase):
         mtime = deserialize_attributes('2019-02-27T16:27:14.798838', 'date')
 
         comment = self.backend.comments.create(
-            node=self.node, user=self.user, content=self.comment_content, mtime=mtime, ctime=ctime)
+            node=self.node, user=self.user, content=self.comment_content, mtime=mtime, ctime=ctime
+        )
 
         # Check that the ctime and mtime are the given ones
         self.assertEqual(comment.ctime, ctime)
@@ -158,7 +161,8 @@ class TestBackendComment(AiidaTestCase):
             len(orm.Comment.objects.all()),
             count,
             msg="No Comments should have been deleted. There should still be {} Comment(s), "
-            "however {} Comment(s) was/were found.".format(count, len(orm.Comment.objects.all())))
+            "however {} Comment(s) was/were found.".format(count, len(orm.Comment.objects.all()))
+        )
 
     def test_delete_many_ids(self):
         """Test `delete_many` method filtering on both `id` and `uuid`"""
@@ -176,7 +180,9 @@ class TestBackendComment(AiidaTestCase):
             count_comments_found,
             len(comment_uuids),
             msg="There should be {} Comments, instead {} Comment(s) was/were found".format(
-                len(comment_uuids), count_comments_found))
+                len(comment_uuids), count_comments_found
+            )
+        )
 
         # Delete last two comments (comment2, comment3)
         filters = {'or': [{'id': comment2.id}, {'uuid': str(comment3.uuid)}]}
@@ -191,7 +197,8 @@ class TestBackendComment(AiidaTestCase):
         """Test `delete_many` method filtering on `dbnode_id`"""
         # Create comments and separate node
         calc = self.backend.nodes.create(
-            node_type='', user=self.user, computer=self.computer, label='label', description='description').store()
+            node_type='', user=self.user, computer=self.computer, label='label', description='description'
+        ).store()
         comment1 = self.create_comment(node=calc)
         comment2 = self.create_comment()
         comment3 = self.create_comment()
@@ -206,7 +213,9 @@ class TestBackendComment(AiidaTestCase):
             count_comments_found,
             len(comment_uuids),
             msg="There should be {} Comments, instead {} Comment(s) was/were found".format(
-                len(comment_uuids), count_comments_found))
+                len(comment_uuids), count_comments_found
+            )
+        )
 
         # Delete comments for self.node
         filters = {'dbnode_id': self.node.id}
@@ -325,7 +334,8 @@ class TestBackendComment(AiidaTestCase):
         deleted_entities = self.backend.comments.delete_many(filters={'id': id_})
         self.assertEqual(
             deleted_entities, [],
-            msg="No entities should have been deleted, since Comment id {} does not exist".format(id_))
+            msg="No entities should have been deleted, since Comment id {} does not exist".format(id_)
+        )
 
         # Try to delete non-existing Comment - using delete
         # NotExistent should be raised, since no entities are found
@@ -364,7 +374,8 @@ class TestBackendComment(AiidaTestCase):
             comment_count_after,
             comment_count_before,
             msg="The number of comments changed after performing `delete_many`, "
-            "while filtering for a non-existing 'dbnode_id'")
+            "while filtering for a non-existing 'dbnode_id'"
+        )
 
     def test_delete_many_same_twice(self):
         """Test no exception is raised when entity is filtered by both `id` and `uuid`"""

--- a/aiida/backends/tests/orm/implementation/test_logs.py
+++ b/aiida/backends/tests/orm/implementation/test_logs.py
@@ -36,7 +36,8 @@ class TestBackendLog(AiidaTestCase):
     def setUp(self):
         super(TestBackendLog, self).setUp()
         self.node = self.backend.nodes.create(
-            node_type='', user=self.user, computer=self.computer, label='label', description='description').store()
+            node_type='', user=self.user, computer=self.computer, label='label', description='description'
+        ).store()
         self.log_message = 'log message'
 
     def create_log(self, **kwargs):
@@ -50,7 +51,8 @@ class TestBackendLog(AiidaTestCase):
             levelname=logging.getLevelName(LOG_LEVEL_REPORT),
             dbnode_id=dbnode_id,
             message=self.log_message,
-            metadata={'content': 'test'})
+            metadata={'content': 'test'}
+        )
 
     def test_creation(self):
         """Test creation of a BackendLog and all its properties."""
@@ -150,7 +152,8 @@ class TestBackendLog(AiidaTestCase):
             len(orm.Log.objects.all()),
             count,
             msg="No Logs should have been deleted. There should still be {} Log(s), "
-            "however {} Log(s) was/were found.".format(count, len(orm.Log.objects.all())))
+            "however {} Log(s) was/were found.".format(count, len(orm.Log.objects.all()))
+        )
 
     def test_delete_many_ids(self):
         """Test `delete_many` method filtering on both `id` and `uuid`"""
@@ -168,7 +171,8 @@ class TestBackendLog(AiidaTestCase):
         self.assertEqual(
             count_logs_found,
             len(log_uuids),
-            msg="There should be {} Logs, instead {} Log(s) was/were found".format(len(log_uuids), count_logs_found))
+            msg="There should be {} Logs, instead {} Log(s) was/were found".format(len(log_uuids), count_logs_found)
+        )
 
         # Delete last two logs (log2, log3)
         filters = {'or': [{'id': log2.id}, {'uuid': str(log3.uuid)}]}
@@ -183,7 +187,8 @@ class TestBackendLog(AiidaTestCase):
         """Test `delete_many` method filtering on `dbnode_id`"""
         # Create logs and separate node
         calc = self.backend.nodes.create(
-            node_type='', user=self.user, computer=self.computer, label='label', description='description').store()
+            node_type='', user=self.user, computer=self.computer, label='label', description='description'
+        ).store()
         log1 = self.create_log(dbnode_id=calc.id)
         log2 = self.create_log()
         log3 = self.create_log()
@@ -197,7 +202,8 @@ class TestBackendLog(AiidaTestCase):
         self.assertEqual(
             count_logs_found,
             len(log_uuids),
-            msg="There should be {} Logs, instead {} Log(s) was/were found".format(len(log_uuids), count_logs_found))
+            msg="There should be {} Logs, instead {} Log(s) was/were found".format(len(log_uuids), count_logs_found)
+        )
 
         # Delete logs for self.node
         filters = {'dbnode_id': self.node.id}
@@ -278,7 +284,8 @@ class TestBackendLog(AiidaTestCase):
         deleted_entities = self.backend.logs.delete_many(filters={'id': id_})
         self.assertEqual(
             deleted_entities, [],
-            msg="No entities should have been deleted, since Log id {} does not exist".format(id_))
+            msg="No entities should have been deleted, since Log id {} does not exist".format(id_)
+        )
 
         # Try to delete non-existing Log - using delete
         # NotExistent should be raised, since no entities are found
@@ -317,7 +324,8 @@ class TestBackendLog(AiidaTestCase):
             log_count_after,
             log_count_before,
             msg="The number of logs changed after performing `delete_many`, "
-            "while filtering for a non-existing 'dbnode_id'")
+            "while filtering for a non-existing 'dbnode_id'"
+        )
 
     def test_delete_many_same_twice(self):
         """Test no exception is raised when entity is filtered by both `id` and `uuid`"""

--- a/aiida/backends/tests/orm/implementation/test_nodes.py
+++ b/aiida/backends/tests/orm/implementation/test_nodes.py
@@ -41,7 +41,8 @@ class TestBackendNode(AiidaTestCase):
             user=self.user,
             computer=self.computer,
             label=self.node_label,
-            description=self.node_description)
+            description=self.node_description
+        )
 
     def create_node(self):
         return self.backend.nodes.create(node_type=self.node_type, user=self.user)
@@ -49,7 +50,8 @@ class TestBackendNode(AiidaTestCase):
     def test_creation(self):
         """Test creation of a BackendNode and all its properties."""
         node = self.backend.nodes.create(
-            node_type=self.node_type, user=self.user, label=self.node_label, description=self.node_description)
+            node_type=self.node_type, user=self.user, label=self.node_label, description=self.node_description
+        )
 
         # Before storing
         self.assertIsNone(node.id)
@@ -115,7 +117,8 @@ class TestBackendNode(AiidaTestCase):
             label=self.node_label,
             description=self.node_description,
             mtime=mtime,
-            ctime=ctime)
+            ctime=ctime
+        )
 
         # Check that the ctime and mtime are the given ones
         self.assertEqual(node.ctime, ctime)

--- a/aiida/backends/tests/orm/test_comments.py
+++ b/aiida/backends/tests/orm/test_comments.py
@@ -174,7 +174,8 @@ class TestComment(AiidaTestCase):
         for comment in comments:
             self.assertIn(
                 str(comment[0]),
-                [self.comment.uuid, comment_one.uuid, comment_two.uuid, comment_three.uuid, comment_five.uuid])
+                [self.comment.uuid, comment_one.uuid, comment_two.uuid, comment_three.uuid, comment_five.uuid]
+            )
 
         # Retrieve users from comments of a single node by joining specific node
         builder = orm.QueryBuilder()

--- a/aiida/backends/tests/orm/test_computers.py
+++ b/aiida/backends/tests/orm/test_computers.py
@@ -27,8 +27,8 @@ class TestComputer(AiidaTestCase):
         import tempfile
 
         new_comp = orm.Computer(
-            name='bbb', hostname='localhost', transport_type='local', scheduler_type='direct',
-            workdir='/tmp/aiida').store()
+            name='bbb', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+        ).store()
 
         # Configure the computer - no parameters for local transport
         authinfo = orm.AuthInfo(computer=new_comp, user=orm.User.objects.get_default())
@@ -46,7 +46,8 @@ class TestComputer(AiidaTestCase):
     def test_delete(self):
         """Test the deletion of a `Computer` instance."""
         new_comp = orm.Computer(
-            name='aaa', hostname='aaa', transport_type='local', scheduler_type='pbspro', workdir='/tmp/aiida').store()
+            name='aaa', hostname='aaa', transport_type='local', scheduler_type='pbspro', workdir='/tmp/aiida'
+        ).store()
 
         comp_pk = new_comp.pk
 

--- a/aiida/backends/tests/orm/test_logs.py
+++ b/aiida/backends/tests/orm/test_logs.py
@@ -308,12 +308,14 @@ class TestBackendLog(AiidaTestCase):
 
         # Check an error is raised when creating a Log with wrong metadata
         with self.assertRaises(TypeError):
-            Log(now(),
+            Log(
+                now(),
                 'loggername',
                 logging.getLevelName(LOG_LEVEL_REPORT),
                 calc.id,
                 'To keep your balance, you must keep moving',
-                metadata=wrong_metadata_format)
+                metadata=wrong_metadata_format
+            )
 
         # Check no error is raised when creating a Log with dict metadata
         correct_metadata_log = Log(
@@ -322,7 +324,8 @@ class TestBackendLog(AiidaTestCase):
             logging.getLevelName(LOG_LEVEL_REPORT),
             calc.id,
             'To keep your balance, you must keep moving',
-            metadata=correct_metadata_format)
+            metadata=correct_metadata_format
+        )
 
         # Check metadata is correctly created
         self.assertEqual(correct_metadata_log.metadata, correct_metadata_format)
@@ -334,7 +337,8 @@ class TestBackendLog(AiidaTestCase):
             logging.getLevelName(LOG_LEVEL_REPORT),
             calc.id,
             'To keep your balance, you must keep moving',
-            metadata=json_metadata_format)
+            metadata=json_metadata_format
+        )
 
         # Check metadata is correctly created
         self.assertEqual(json_metadata_log.metadata, json_metadata_format)
@@ -346,7 +350,8 @@ class TestBackendLog(AiidaTestCase):
             logging.getLevelName(LOG_LEVEL_REPORT),
             calc.id,
             'To keep your balance, you must keep moving',
-            metadata=None)
+            metadata=None
+        )
 
         # Check metadata is an empty dict for no_metadata_log
         self.assertEqual(no_metadata_log.metadata, {})

--- a/aiida/backends/tests/orm/test_querybuilder.py
+++ b/aiida/backends/tests/orm/test_querybuilder.py
@@ -26,9 +26,8 @@ class TestQueryBuilder(AiidaTestCase):
         orm.Data().store()
         orm.Data().store()
 
-        result = orm.QueryBuilder().append(
-            orm.User, tag='user', project=['email']).append(
-                orm.Data, with_user='user', project=['*']).first()
+        result = orm.QueryBuilder().append(orm.User, tag='user',
+                                           project=['email']).append(orm.Data, with_user='user', project=['*']).first()
 
         self.assertEqual(type(result), list)
         self.assertEqual(len(result), 2)

--- a/aiida/backends/tests/test_query.py
+++ b/aiida/backends/tests/test_query.py
@@ -49,35 +49,35 @@ class TestQueryBuilder(AiidaTestCase):
 
         # Asserting that the query type string and plugin type string are returned:
         for _cls, classifiers in (
-                qb._get_ormclass(orm.StructureData, None),
-                qb._get_ormclass(None, 'data.structure.StructureData.'),
+            qb._get_ormclass(orm.StructureData, None),
+            qb._get_ormclass(None, 'data.structure.StructureData.'),
         ):
             self.assertEqual(classifiers['ormclass_type_string'], orm.StructureData._plugin_type_string)  # pylint: disable=no-member
 
         for _cls, classifiers in (
-                qb._get_ormclass(orm.Group, None),
-                qb._get_ormclass(None, 'group'),
-                qb._get_ormclass(None, 'Group'),
+            qb._get_ormclass(orm.Group, None),
+            qb._get_ormclass(None, 'group'),
+            qb._get_ormclass(None, 'Group'),
         ):
             self.assertEqual(classifiers['ormclass_type_string'], 'group')
 
         for _cls, classifiers in (
-                qb._get_ormclass(orm.User, None),
-                qb._get_ormclass(None, "user"),
-                qb._get_ormclass(None, "User"),
+            qb._get_ormclass(orm.User, None),
+            qb._get_ormclass(None, "user"),
+            qb._get_ormclass(None, "User"),
         ):
             self.assertEqual(classifiers['ormclass_type_string'], 'user')
 
         for _cls, classifiers in (
-                qb._get_ormclass(orm.Computer, None),
-                qb._get_ormclass(None, 'computer'),
-                qb._get_ormclass(None, 'Computer'),
+            qb._get_ormclass(orm.Computer, None),
+            qb._get_ormclass(None, 'computer'),
+            qb._get_ormclass(None, 'Computer'),
         ):
             self.assertEqual(classifiers['ormclass_type_string'], 'computer')
 
         for _cls, classifiers in (
-                qb._get_ormclass(orm.Data, None),
-                qb._get_ormclass(None, 'data.Data.'),
+            qb._get_ormclass(orm.Data, None),
+            qb._get_ormclass(None, 'data.Data.'),
         ):
             self.assertEqual(classifiers['ormclass_type_string'], orm.Data._plugin_type_string)  # pylint: disable=no-member
 
@@ -424,10 +424,12 @@ class TestQueryBuilder(AiidaTestCase):
         qb = orm.QueryBuilder().append(cls=(orm.StructureData, orm.Dict), filters={'attributes.cat': 'miau'})
         self.assertEqual(qb.count(), 2)
         qb = orm.QueryBuilder().append(
-            entity_type=('data.structure.StructureData.', 'data.dict.Dict.'), filters={'attributes.cat': 'miau'})
+            entity_type=('data.structure.StructureData.', 'data.dict.Dict.'), filters={'attributes.cat': 'miau'}
+        )
         self.assertEqual(qb.count(), 2)
         qb = orm.QueryBuilder().append(
-            cls=(orm.StructureData, orm.Dict), filters={'attributes.cat': 'miau'}, subclassing=False)
+            cls=(orm.StructureData, orm.Dict), filters={'attributes.cat': 'miau'}, subclassing=False
+        )
         self.assertEqual(qb.count(), 2)
         qb = orm.QueryBuilder().append(
             cls=(orm.StructureData, orm.Data),
@@ -437,12 +439,14 @@ class TestQueryBuilder(AiidaTestCase):
         qb = orm.QueryBuilder().append(
             entity_type=('data.structure.StructureData.', 'data.dict.Dict.'),
             filters={'attributes.cat': 'miau'},
-            subclassing=False)
+            subclassing=False
+        )
         self.assertEqual(qb.count(), 2)
         qb = orm.QueryBuilder().append(
             entity_type=('data.structure.StructureData.', 'data.Data.'),
             filters={'attributes.cat': 'miau'},
-            subclassing=False)
+            subclassing=False
+        )
         self.assertEqual(qb.count(), 2)
 
     def test_list_behavior(self):
@@ -514,32 +518,39 @@ class TestQueryBuilder(AiidaTestCase):
         self.assertEqual(qb.get_used_tags(), ['n1', 'n2', 'e1', 'n3', 'e2', 'c1', 'nonsense'])
 
         # Now I am testing the default tags,
-        qb = orm.QueryBuilder().append(orm.StructureData).append(orm.ProcessNode).append(orm.StructureData).append(
-            orm.Dict, with_outgoing=orm.ProcessNode)
-        self.assertEqual(qb.get_used_tags(), [
-            'StructureData_1', 'ProcessNode_1', 'StructureData_1--ProcessNode_1', 'StructureData_2',
-            'ProcessNode_1--StructureData_2', 'Dict_1', 'ProcessNode_1--Dict_1'
-        ])
+        qb = orm.QueryBuilder().append(orm.StructureData
+                                      ).append(orm.ProcessNode).append(orm.StructureData
+                                                                      ).append(orm.Dict, with_outgoing=orm.ProcessNode)
+        self.assertEqual(
+            qb.get_used_tags(), [
+                'StructureData_1', 'ProcessNode_1', 'StructureData_1--ProcessNode_1', 'StructureData_2',
+                'ProcessNode_1--StructureData_2', 'Dict_1', 'ProcessNode_1--Dict_1'
+            ]
+        )
         self.assertEqual(
             qb.get_used_tags(edges=False), [
                 'StructureData_1',
                 'ProcessNode_1',
                 'StructureData_2',
                 'Dict_1',
-            ])
+            ]
+        )
         self.assertEqual(
             qb.get_used_tags(vertices=False),
-            ['StructureData_1--ProcessNode_1', 'ProcessNode_1--StructureData_2', 'ProcessNode_1--Dict_1'])
+            ['StructureData_1--ProcessNode_1', 'ProcessNode_1--StructureData_2', 'ProcessNode_1--Dict_1']
+        )
         self.assertEqual(
             qb.get_used_tags(edges=False), [
                 'StructureData_1',
                 'ProcessNode_1',
                 'StructureData_2',
                 'Dict_1',
-            ])
+            ]
+        )
         self.assertEqual(
             qb.get_used_tags(vertices=False),
-            ['StructureData_1--ProcessNode_1', 'ProcessNode_1--StructureData_2', 'ProcessNode_1--Dict_1'])
+            ['StructureData_1--ProcessNode_1', 'ProcessNode_1--StructureData_2', 'ProcessNode_1--Dict_1']
+        )
 
 
 class TestQueryHelp(AiidaTestCase):
@@ -642,7 +653,8 @@ class TestAttributes(AiidaTestCase):
                     }
                 }],
             },
-            project='uuid')
+            project='uuid'
+        )
         res_query = {str(_[0]) for _ in qb.all()}
         self.assertEqual(res_query, res_uuids)
 
@@ -682,7 +694,8 @@ class TestAttributes(AiidaTestCase):
         qb = orm.QueryBuilder().append(
             orm.Node, filters={'attributes.{}'.format(key): {
                                    'ilike': 'On%'
-                               }}, project='uuid')
+                               }}, project='uuid'
+        )
         res = [str(_) for _, in qb.all()]
         self.assertEqual(set(res), set((n_str2.uuid,)))
         qb = orm.QueryBuilder().append(orm.Node, filters={'attributes.{}'.format(key): {'like': '1'}}, project='uuid')
@@ -699,7 +712,8 @@ class TestAttributes(AiidaTestCase):
             qb = orm.QueryBuilder().append(
                 orm.Node, filters={'attributes.{}'.format(key): {
                                        'of_length': 3
-                                   }}, project='uuid')
+                                   }}, project='uuid'
+            )
             res = [str(_) for _, in qb.all()]
             self.assertEqual(set(res), set((n_arr.uuid,)))
 
@@ -729,12 +743,12 @@ class QueryBuilderLimitOffsetsTest(AiidaTestCase):
         self.assertEqual(res, tuple(range(5, 8)))
 
         # Specifying the order  explicitly the order:
-        qb = orm.QueryBuilder().append(
-            orm.Node, project='attributes.foo').order_by({orm.Node: {
-                'ctime': {
-                    'order': 'asc'
-                }
-            }})
+        qb = orm.QueryBuilder().append(orm.Node,
+                                       project='attributes.foo').order_by({orm.Node: {
+                                           'ctime': {
+                                               'order': 'asc'
+                                           }
+                                       }})
 
         res = next(zip(*qb.all()))
         self.assertEqual(res, tuple(range(10)))
@@ -750,12 +764,12 @@ class QueryBuilderLimitOffsetsTest(AiidaTestCase):
         self.assertEqual(res, tuple(range(5, 8)))
 
         # Reversing the order:
-        qb = orm.QueryBuilder().append(
-            orm.Node, project='attributes.foo').order_by({orm.Node: {
-                'ctime': {
-                    'order': 'desc'
-                }
-            }})
+        qb = orm.QueryBuilder().append(orm.Node,
+                                       project='attributes.foo').order_by({orm.Node: {
+                                           'ctime': {
+                                               'order': 'desc'
+                                           }
+                                       }})
 
         res = next(zip(*qb.all()))
         self.assertEqual(res, tuple(range(9, -1, -1)))
@@ -835,12 +849,14 @@ class QueryBuilderJoinsTests(AiidaTestCase):
         students[9].add_incoming(advisors[2], link_type=LinkType.CREATE, link_label='lover')
 
         self.assertEqual(
-            orm.QueryBuilder().append(orm.Node).append(
-                orm.Node, edge_filters={
-                    'label': {
-                        'like': 'is\\_advisor\\_%'
-                    }
-                }, tag='student').count(), 7)
+            orm.QueryBuilder().append(
+                orm.Node
+            ).append(orm.Node, edge_filters={
+                'label': {
+                    'like': 'is\\_advisor\\_%'
+                }
+            }, tag='student').count(), 7
+        )
 
         for adv_id, number_students in zip(list(range(3)), (2, 2, 3)):
             self.assertEqual(
@@ -850,7 +866,8 @@ class QueryBuilderJoinsTests(AiidaTestCase):
                     'label': {
                         'like': 'is\\_advisor\\_%'
                     }
-                }, tag='student').count(), number_students)
+                }, tag='student').count(), number_students
+            )
 
     def test_joins3_user_group(self):
         # Create another user
@@ -977,14 +994,16 @@ class QueryBuilderPath(AiidaTestCase):
                 'id': n1.pk
             }, tag='anc').append(orm.Node, with_ancestors='anc', filters={
                 'id': n8.pk
-            }).count(), 0)
+            }).count(), 0
+        )
 
         self.assertEqual(
             orm.QueryBuilder().append(orm.Node, filters={
                 'id': n8.pk
             }, tag='desc').append(orm.Node, with_descendants='desc', filters={
                 'id': n1.pk
-            }).count(), 0)
+            }).count(), 0
+        )
 
         n6.add_incoming(n5, link_type=LinkType.CREATE, link_label='link1')
         # Yet, now 2 links from 1 to 8
@@ -993,14 +1012,16 @@ class QueryBuilderPath(AiidaTestCase):
                 'id': n1.pk
             }, tag='anc').append(orm.Node, with_ancestors='anc', filters={
                 'id': n8.pk
-            }).count(), 2)
+            }).count(), 2
+        )
 
         self.assertEqual(
             orm.QueryBuilder().append(orm.Node, filters={
                 'id': n8.pk
             }, tag='desc').append(orm.Node, with_descendants='desc', filters={
                 'id': n1.pk
-            }).count(), 2)
+            }).count(), 2
+        )
 
         self.assertEqual(
             orm.QueryBuilder().append(orm.Node, filters={
@@ -1016,7 +1037,8 @@ class QueryBuilderPath(AiidaTestCase):
                         '<': 6
                     }
                 },
-            ).count(), 2)
+            ).count(), 2
+        )
         self.assertEqual(
             orm.QueryBuilder().append(orm.Node, filters={
                 'id': n8.pk
@@ -1029,7 +1051,8 @@ class QueryBuilderPath(AiidaTestCase):
                 edge_filters={
                     'depth': 5
                 },
-            ).count(), 2)
+            ).count(), 2
+        )
         self.assertEqual(
             orm.QueryBuilder().append(orm.Node, filters={
                 'id': n8.pk
@@ -1044,7 +1067,8 @@ class QueryBuilderPath(AiidaTestCase):
                         '<': 5
                     }
                 },
-            ).count(), 0)
+            ).count(), 0
+        )
 
         # TODO write a query that can filter certain paths by traversed ID # pylint: disable=fixme
         qb = orm.QueryBuilder().append(
@@ -1053,8 +1077,7 @@ class QueryBuilderPath(AiidaTestCase):
                 'id': n8.pk
             },
             tag='desc',
-        ).append(
-            orm.Node, with_descendants='desc', edge_project='path', filters={'id': n1.pk})
+        ).append(orm.Node, with_descendants='desc', edge_project='path', filters={'id': n1.pk})
         queried_path_set = {frozenset(p) for p, in qb.all()}
 
         paths_there_should_be = {
@@ -1064,11 +1087,9 @@ class QueryBuilderPath(AiidaTestCase):
 
         self.assertTrue(queried_path_set == paths_there_should_be)
 
-        qb = orm.QueryBuilder().append(
-            orm.Node, filters={
-                'id': n1.pk
-            }, tag='anc').append(
-                orm.Node, with_ancestors='anc', filters={'id': n8.pk}, edge_project='path')
+        qb = orm.QueryBuilder().append(orm.Node, filters={
+            'id': n1.pk
+        }, tag='anc').append(orm.Node, with_ancestors='anc', filters={'id': n8.pk}, edge_project='path')
 
         self.assertEqual({frozenset(p) for p, in qb.all()}, {
             frozenset([n1.pk, n2.pk, n3.pk, n5.pk, n6.pk, n7.pk, n8.pk]),
@@ -1132,8 +1153,9 @@ class TestConsistency(AiidaTestCase):
             n = orm.Data()
             n.store()
 
-        for idx, _item in enumerate(orm.QueryBuilder().append(orm.Node, project=['id',
-                                                                                 'label']).iterall(batch_size=10)):
+        for idx, _item in enumerate(
+            orm.QueryBuilder().append(orm.Node, project=['id', 'label']).iterall(batch_size=10)
+        ):
             if idx % 10 == 10:
                 n = orm.Data()
                 n.store()

--- a/aiida/backends/tests/test_restapi.py
+++ b/aiida/backends/tests/test_restapi.py
@@ -7,9 +7,8 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Unittests for REST API
-"""
+# pylint: disable=too-many-lines
+"""Unittests for REST API."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -155,14 +154,13 @@ class RESTApiTestCase(AiidaTestCase):
         # by their list index is very fragile and a pain to debug.
         # Please change this!
         computer_projections = ["id", "uuid", "name", "hostname", "transport_type", "scheduler_type"]
-        computers = orm.QueryBuilder().append(
-            orm.Computer, tag="comp", project=computer_projections).order_by({
-                'comp': [{
-                    'name': {
-                        'order': 'asc'
-                    }
-                }]
-            }).dict()
+        computers = orm.QueryBuilder().append(orm.Computer, tag="comp", project=computer_projections).order_by({
+            'comp': [{
+                'name': {
+                    'order': 'asc'
+                }
+            }]
+        }).dict()
 
         # Cast UUID into a string (e.g. in sqlalchemy it comes as a UUID object)
         computers = [_['comp'] for _ in computers]
@@ -172,14 +170,14 @@ class RESTApiTestCase(AiidaTestCase):
         cls._dummy_data["computers"] = computers
 
         calculation_projections = ["id", "uuid", "user_id", "node_type"]
-        calculations = orm.QueryBuilder().append(
-            orm.CalculationNode, tag="calc", project=calculation_projections).order_by({
-                'calc': [{
-                    'id': {
-                        'order': 'desc'
-                    }
-                }]
-            }).dict()
+        calculations = orm.QueryBuilder().append(orm.CalculationNode, tag="calc",
+                                                 project=calculation_projections).order_by({
+                                                     'calc': [{
+                                                         'id': {
+                                                             'order': 'desc'
+                                                         }
+                                                     }]
+                                                 }).dict()
 
         calculations = [_['calc'] for _ in calculations]
         for calc in calculations:
@@ -195,14 +193,13 @@ class RESTApiTestCase(AiidaTestCase):
             'data': orm.Data,
         }
         for label, dataclass in data_types.items():
-            data = orm.QueryBuilder().append(
-                dataclass, tag="data", project=data_projections).order_by({
-                    'data': [{
-                        'id': {
-                            'order': 'desc'
-                        }
-                    }]
-                }).dict()
+            data = orm.QueryBuilder().append(dataclass, tag="data", project=data_projections).order_by({
+                'data': [{
+                    'id': {
+                        'order': 'desc'
+                    }
+                }]
+            }).dict()
             data = [_['data'] for _ in data]
 
             for datum in data:
@@ -251,17 +248,19 @@ class RESTApiTestCase(AiidaTestCase):
         self.assertEqual(response["url_root"], "http://localhost/")
 
     # node details and list with limit, offset, page, perpage
-    def process_test(self,
-                     entity_type,
-                     url,
-                     full_list=False,
-                     empty_list=False,
-                     expected_list_ids=None,
-                     expected_range=None,
-                     expected_errormsg=None,
-                     uuid=None,
-                     result_node_type=None,
-                     result_name=None):
+    def process_test(
+        self,
+        entity_type,
+        url,
+        full_list=False,
+        empty_list=False,
+        expected_list_ids=None,
+        expected_range=None,
+        expected_errormsg=None,
+        uuid=None,
+        result_node_type=None,
+        result_name=None
+    ):
         # pylint: disable=too-many-arguments
         """
         Check whether response matches expected values.
@@ -328,7 +327,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_uuid = self.get_dummy_data()["computers"][1]["uuid"]
         RESTApiTestCase.process_test(
-            self, "computers", "/computers/" + str(node_uuid), expected_list_ids=[1], uuid=node_uuid)
+            self, "computers", "/computers/" + str(node_uuid), expected_list_ids=[1], uuid=node_uuid
+        )
 
     def test_computers_list(self):
         """
@@ -344,7 +344,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         database starting from the no. specified in offset
         """
         RESTApiTestCase.process_test(
-            self, "computers", "/computers?limit=2&offset=2&orderby=+id", expected_range=[2, 4])
+            self, "computers", "/computers?limit=2&offset=2&orderby=+id", expected_range=[2, 4]
+        )
 
     def test_computers_list_limit_only(self):
         """
@@ -371,7 +372,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         expected_error = "perpage key is incompatible with limit and offset"
         RESTApiTestCase.process_test(
-            self, "computers", "/computers?offset=2&limit=1&perpage=2&orderby=+id", expected_errormsg=expected_error)
+            self, "computers", "/computers?offset=2&limit=1&perpage=2&orderby=+id", expected_errormsg=expected_error
+        )
 
     def test_computers_list_page_limit_offset(self):
         """
@@ -381,7 +383,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         expected_error = "requesting a specific page is incompatible with " \
                          "limit and offset"
         RESTApiTestCase.process_test(
-            self, "computers", "/computers/page/2?offset=2&limit=1&orderby=+id", expected_errormsg=expected_error)
+            self, "computers", "/computers/page/2?offset=2&limit=1&orderby=+id", expected_errormsg=expected_error
+        )
 
     def test_complist_pagelimitoffset_perpage(self):
         """
@@ -393,7 +396,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             "/computers/page/2?offset=2&limit=1&perpage=2&orderby=+id",
-            expected_errormsg=expected_error)
+            expected_errormsg=expected_error
+        )
 
     def test_computers_list_page_default(self):
         """
@@ -412,7 +416,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         Using this formula it returns the no. of rows for requested page
         """
         RESTApiTestCase.process_test(
-            self, "computers", "/computers/page/1?perpage=2&orderby=+id", expected_range=[None, 2])
+            self, "computers", "/computers/page/1?perpage=2&orderby=+id", expected_range=[None, 2]
+        )
 
     def test_computers_list_page_perpage_exceed(self):
         """
@@ -424,7 +429,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         expected_error = "Non existent page requested. The page range is [1 : " \
                          "3]"
         RESTApiTestCase.process_test(
-            self, "computers", "/computers/page/4?perpage=2&orderby=+id", expected_errormsg=expected_error)
+            self, "computers", "/computers/page/4?perpage=2&orderby=+id", expected_errormsg=expected_error
+        )
 
     ############### list filters ########################
     def test_computers_filter_id1(self):
@@ -443,7 +449,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_pk = self.get_dummy_data()["computers"][1]["id"]
         RESTApiTestCase.process_test(
-            self, "computers", "/computers?id>" + str(node_pk) + "&orderby=+id", expected_range=[2, None])
+            self, "computers", "/computers?id>" + str(node_pk) + "&orderby=+id", expected_range=[2, None]
+        )
 
     def test_computers_filter_pk(self):
         """
@@ -474,7 +481,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         list
         """
         RESTApiTestCase.process_test(
-            self, "computers", '/computers?transport_type="local"&name="test3"&orderby=+id', expected_list_ids=[3])
+            self, "computers", '/computers?transport_type="local"&name="test3"&orderby=+id', expected_list_ids=[3]
+        )
 
     ############### list orderby ########################
     def test_computers_orderby_id_asc(self):
@@ -505,7 +513,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_pk = self.get_dummy_data()["computers"][0]["id"]
         RESTApiTestCase.process_test(
-            self, "computers", '/computers?pk>' + str(node_pk) + '&orderby=name', expected_list_ids=[1, 2, 3, 4])
+            self, "computers", '/computers?pk>' + str(node_pk) + '&orderby=name', expected_list_ids=[1, 2, 3, 4]
+        )
 
     def test_computers_orderby_name_asc_sign(self):
         """
@@ -514,7 +523,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_pk = self.get_dummy_data()["computers"][0]["id"]
         RESTApiTestCase.process_test(
-            self, "computers", '/computers?pk>' + str(node_pk) + '&orderby=+name', expected_list_ids=[1, 2, 3, 4])
+            self, "computers", '/computers?pk>' + str(node_pk) + '&orderby=+name', expected_list_ids=[1, 2, 3, 4]
+        )
 
     def test_computers_orderby_name_desc(self):
         """
@@ -523,7 +533,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_pk = self.get_dummy_data()["computers"][0]["id"]
         RESTApiTestCase.process_test(
-            self, "computers", '/computers?pk>' + str(node_pk) + '&orderby=-name', expected_list_ids=[4, 3, 2, 1])
+            self, "computers", '/computers?pk>' + str(node_pk) + '&orderby=-name', expected_list_ids=[4, 3, 2, 1]
+        )
 
     def test_computers_orderby_scheduler_type_asc(self):
         """
@@ -535,7 +546,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?transport_type="ssh"&pk>' + str(node_pk) + '&orderby=scheduler_type',
-            expected_list_ids=[1, 4, 2])
+            expected_list_ids=[1, 4, 2]
+        )
 
     def test_comp_orderby_scheduler_ascsign(self):
         """
@@ -547,7 +559,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?transport_type="ssh"&pk>' + str(node_pk) + '&orderby=+scheduler_type',
-            expected_list_ids=[1, 4, 2])
+            expected_list_ids=[1, 4, 2]
+        )
 
     def test_computers_orderby_schedulertype_desc(self):
         """
@@ -559,7 +572,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?pk>' + str(node_pk) + '&transport_type="ssh"&orderby=-scheduler_type',
-            expected_list_ids=[2, 4, 1])
+            expected_list_ids=[2, 4, 1]
+        )
 
     ############### list orderby combinations #######################
     def test_computers_orderby_mixed1(self):
@@ -573,7 +587,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?pk>' + str(node_pk) + '&orderby=transport_type,id',
-            expected_list_ids=[3, 1, 2, 4])
+            expected_list_ids=[3, 1, 2, 4]
+        )
 
     def test_computers_orderby_mixed2(self):
         """
@@ -586,7 +601,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?pk>' + str(node_pk) + '&orderby=-scheduler_type,name',
-            expected_list_ids=[2, 3, 4, 1])
+            expected_list_ids=[2, 3, 4, 1]
+        )
 
     def test_computers_orderby_mixed3(self):
         """
@@ -624,7 +640,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_pk = self.get_dummy_data()["computers"][0]["id"]
         RESTApiTestCase.process_test(
-            self, "computers", '/computers?id>' + str(node_pk) + '&hostname="test1.epfl.ch"', expected_list_ids=[1])
+            self, "computers", '/computers?id>' + str(node_pk) + '&hostname="test1.epfl.ch"', expected_list_ids=[1]
+        )
 
     def test_computers_filter_mixed2(self):
         """
@@ -636,7 +653,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?id>' + str(node_pk) + '&hostname="test3.epfl.ch"&transport_type="ssh"',
-            empty_list=True)
+            empty_list=True
+        )
 
     ############### list all parameter combinations #######################
     def test_computers_mixed1(self):
@@ -645,7 +663,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_pk = self.get_dummy_data()["computers"][0]["id"]
         RESTApiTestCase.process_test(
-            self, "computers", "/computers?id>" + str(node_pk) + "&limit=2&offset=3", expected_list_ids=[4])
+            self, "computers", "/computers?id>" + str(node_pk) + "&limit=2&offset=3", expected_list_ids=[4]
+        )
 
     def test_computers_mixed2(self):
         """
@@ -656,7 +675,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             "/computers/page/2?id>" + str(node_pk) + "&perpage=2&orderby=+id",
-            expected_list_ids=[3, 4])
+            expected_list_ids=[3, 4]
+        )
 
     def test_computers_mixed3(self):
         """
@@ -667,7 +687,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             self,
             "computers",
             '/computers?id>=' + str(node_pk) + '&transport_type="ssh"&orderby=-id&limit=2',
-            expected_list_ids=[4, 2])
+            expected_list_ids=[4, 2]
+        )
 
     ########## pass unknown url parameter ###########
     def test_computers_unknown_param(self):
@@ -685,7 +706,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         node_uuid = self.get_dummy_data()["calculations"][0]["uuid"]
         RESTApiTestCase.process_test(
-            self, "calculations", "/calculations/" + str(node_uuid), expected_list_ids=[0], uuid=node_uuid)
+            self, "calculations", "/calculations/" + str(node_uuid), expected_list_ids=[0], uuid=node_uuid
+        )
 
     ############### full list with limit, offset, page, perpage #############
     def test_calculations_list(self):
@@ -702,7 +724,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         database starting from the no. specified in offset
         """
         RESTApiTestCase.process_test(
-            self, "calculations", "/calculations?limit=1&offset=1&orderby=+id", expected_list_ids=[1])
+            self, "calculations", "/calculations?limit=1&offset=1&orderby=+id", expected_list_ids=[1]
+        )
 
     ############### calculation retrieved_inputs and retrieved_outputs  #############
     def test_calculation_retrieved_inputs(self):
@@ -737,7 +760,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             "/calculations/" + str(node_uuid) + "/io/retrieved_inputs",
             uuid=node_uuid,
             result_name="retrieved_inputs",
-            empty_list=True)
+            empty_list=True
+        )
 
     def test_calcfunction_retrieved_outputs(self):
         """
@@ -749,7 +773,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             "/calculations/" + str(node_uuid) + "/io/retrieved_outputs",
             uuid=node_uuid,
             result_name="retrieved_outputs",
-            empty_list=True)
+            empty_list=True
+        )
 
     ############### calculation inputs  #############
     def test_calculation_inputs(self):
@@ -763,7 +788,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             expected_list_ids=[5, 3],
             uuid=node_uuid,
             result_node_type="data",
-            result_name="inputs")
+            result_name="inputs"
+        )
 
     def test_calculation_input_filters(self):
         """
@@ -776,7 +802,8 @@ class RESTApiTestSuite(RESTApiTestCase):
             expected_list_ids=[3],
             uuid=node_uuid,
             result_node_type="data",
-            result_name="inputs")
+            result_name="inputs"
+        )
 
     def test_calculation_iotree(self):
         """
@@ -866,13 +893,16 @@ class RESTApiTestSuite(RESTApiTestCase):
 
             expected_visdata = """\n##########################################################################\n#               Crystallographic Information Format file \n#               Produced by PyCifRW module\n# \n#  This is a CIF file.  CIF has been adopted by the International\n#  Union of Crystallography as the standard for data archiving and \n#  transmission.\n#\n#  For information on this file format, follow the CIF links at\n#  http://www.iucr.org\n##########################################################################\n\ndata_0\nloop_\n  _atom_site_label\n  _atom_site_fract_x\n  _atom_site_fract_y\n  _atom_site_fract_z\n  _atom_site_type_symbol\n   Ba1  0.0  0.0  0.0  Ba\n \n_cell_angle_alpha                       90.0\n_cell_angle_beta                        90.0\n_cell_angle_gamma                       90.0\n_cell_length_a                          2.0\n_cell_length_b                          2.0\n_cell_length_c                          2.0\nloop_\n  _symmetry_equiv_pos_as_xyz\n   'x, y, z'\n \n_symmetry_int_tables_number             1\n_symmetry_space_group_name_H-M          'P 1'\n"""  # pylint: disable=line-too-long
             self.assertEqual(
-                simplify(response["data"]["visualization"]["str_viz_info"]["data"]), simplify(expected_visdata))
+                simplify(response["data"]["visualization"]["str_viz_info"]["data"]), simplify(expected_visdata)
+            )
             self.assertEqual(response["data"]["visualization"]["str_viz_info"]["format"], "cif")
-            self.assertEqual(response["data"]["visualization"]["dimensionality"], {
-                u'dim': 3,
-                u'value': 8.0,
-                u'label': u'volume'
-            })
+            self.assertEqual(
+                response["data"]["visualization"]["dimensionality"], {
+                    u'dim': 3,
+                    u'value': 8.0,
+                    u'label': u'volume'
+                }
+            )
             self.assertEqual(response["data"]["visualization"]["pbc"], [True, True, True])
             self.assertEqual(response["data"]["visualization"]["formula"], "Ba")
             RESTApiTestCase.compare_extra_response_data(self, "structures", url, response, uuid=node_uuid)
@@ -891,13 +921,16 @@ class RESTApiTestSuite(RESTApiTestCase):
 
             expected_visdata = "CRYSTAL\nPRIMVEC 1\n      2.0000000000       0.0000000000       0.0000000000\n      0.0000000000       2.0000000000       0.0000000000\n      0.0000000000       0.0000000000       2.0000000000\nPRIMCOORD 1\n1 1\n56       0.0000000000       0.0000000000       0.0000000000\n"  # pylint: disable=line-too-long
             self.assertEqual(
-                simplify(response["data"]["visualization"]["str_viz_info"]["data"]), simplify(expected_visdata))
+                simplify(response["data"]["visualization"]["str_viz_info"]["data"]), simplify(expected_visdata)
+            )
             self.assertEqual(response["data"]["visualization"]["str_viz_info"]["format"], "xsf")
-            self.assertEqual(response["data"]["visualization"]["dimensionality"], {
-                u'dim': 3,
-                u'value': 8.0,
-                u'label': u'volume'
-            })
+            self.assertEqual(
+                response["data"]["visualization"]["dimensionality"], {
+                    u'dim': 3,
+                    u'value': 8.0,
+                    u'label': u'volume'
+                }
+            )
             self.assertEqual(response["data"]["visualization"]["pbc"], [True, True, True])
             self.assertEqual(response["data"]["visualization"]["formula"], "Ba")
             RESTApiTestCase.compare_extra_response_data(self, "structures", url, response, uuid=node_uuid)
@@ -916,13 +949,16 @@ class RESTApiTestSuite(RESTApiTestCase):
 
             expected_visdata = "CRYSTAL\nPRIMVEC 1\n      2.0000000000       0.0000000000       0.0000000000\n      0.0000000000       2.0000000000       0.0000000000\n      0.0000000000       0.0000000000       2.0000000000\nPRIMCOORD 1\n1 1\n56       0.0000000000       0.0000000000       0.0000000000\n"  # pylint: disable=line-too-long
             self.assertEqual(
-                simplify(response["data"]["visualization"]["str_viz_info"]["data"]), simplify(expected_visdata))
+                simplify(response["data"]["visualization"]["str_viz_info"]["data"]), simplify(expected_visdata)
+            )
             self.assertEqual(response["data"]["visualization"]["str_viz_info"]["format"], "xsf")
-            self.assertEqual(response["data"]["visualization"]["dimensionality"], {
-                u'dim': 3,
-                u'value': 8.0,
-                u'label': u'volume'
-            })
+            self.assertEqual(
+                response["data"]["visualization"]["dimensionality"], {
+                    u'dim': 3,
+                    u'value': 8.0,
+                    u'label': u'volume'
+                }
+            )
             self.assertEqual(response["data"]["visualization"]["pbc"], [True, True, True])
             self.assertEqual(response["data"]["visualization"]["formula"], "Ba")
             RESTApiTestCase.compare_extra_response_data(self, "structures", url, response, uuid=node_uuid)

--- a/aiida/backends/tests/tools/data/orbital/test_orbitals.py
+++ b/aiida/backends/tests/tools/data/orbital/test_orbitals.py
@@ -59,12 +59,14 @@ class TestRealhydrogenOrbital(AiidaTestCase):
         with self.assertRaises(ValidationError):
             RealhydrogenOrbital(position=(1, 2, 3))
 
-        orbital = RealhydrogenOrbital(**{
-            'position': (-1, -2, -3),
-            'angular_momentum': 1,
-            'magnetic_number': 0,
-            'radial_nodes': 2
-        })
+        orbital = RealhydrogenOrbital(
+            **{
+                'position': (-1, -2, -3),
+                'angular_momentum': 1,
+                'magnetic_number': 0,
+                'radial_nodes': 2
+            }
+        )
         self.assertAlmostEqual(orbital.get_orbital_dict()['position'][0], -1.)
         self.assertAlmostEqual(orbital.get_orbital_dict()['position'][1], -2.)
         self.assertAlmostEqual(orbital.get_orbital_dict()['position'][2], -3.)
@@ -77,30 +79,36 @@ class TestRealhydrogenOrbital(AiidaTestCase):
         RealhydrogenOrbital = OrbitalFactory('realhydrogen')  # pylint: disable=invalid-name
 
         with self.assertRaises(ValidationError) as exc:
-            RealhydrogenOrbital(**{
-                'position': (-1, -2, -3),
-                'angular_momentum': 100,
-                'magnetic_number': 0,
-                'radial_nodes': 2
-            })
+            RealhydrogenOrbital(
+                **{
+                    'position': (-1, -2, -3),
+                    'angular_momentum': 100,
+                    'magnetic_number': 0,
+                    'radial_nodes': 2
+                }
+            )
         self.assertIn("angular_momentum", str(exc.exception))
 
         with self.assertRaises(ValidationError) as exc:
-            RealhydrogenOrbital(**{
-                'position': (-1, -2, -3),
-                'angular_momentum': 1,
-                'magnetic_number': 3,
-                'radial_nodes': 2
-            })
+            RealhydrogenOrbital(
+                **{
+                    'position': (-1, -2, -3),
+                    'angular_momentum': 1,
+                    'magnetic_number': 3,
+                    'radial_nodes': 2
+                }
+            )
         self.assertIn("magnetic number must be in the range", str(exc.exception))
 
         with self.assertRaises(ValidationError) as exc:
-            RealhydrogenOrbital(**{
-                'position': (-1, -2, -3),
-                'angular_momentum': 1,
-                'magnetic_number': 0,
-                'radial_nodes': 100
-            })
+            RealhydrogenOrbital(
+                **{
+                    'position': (-1, -2, -3),
+                    'angular_momentum': 1,
+                    'magnetic_number': 0,
+                    'radial_nodes': 100
+                }
+            )
         self.assertIn("radial_nodes", str(exc.exception))
 
     def test_optional_fields(self):
@@ -110,12 +118,14 @@ class TestRealhydrogenOrbital(AiidaTestCase):
         """
         RealhydrogenOrbital = OrbitalFactory('realhydrogen')  # pylint: disable=invalid-name
 
-        orbital = RealhydrogenOrbital(**{
-            'position': (-1, -2, -3),
-            'angular_momentum': 1,
-            'magnetic_number': 0,
-            'radial_nodes': 2
-        })
+        orbital = RealhydrogenOrbital(
+            **{
+                'position': (-1, -2, -3),
+                'angular_momentum': 1,
+                'magnetic_number': 0,
+                'radial_nodes': 2
+            }
+        )
         # Check that the optional value is there and has its default value
         self.assertEqual(orbital.get_orbital_dict()['spin'], 0)
         self.assertEqual(orbital.get_orbital_dict()['diffusivity'], None)
@@ -128,7 +138,8 @@ class TestRealhydrogenOrbital(AiidaTestCase):
                 'radial_nodes': 2,
                 'spin': 1,
                 'diffusivity': 3.1
-            })
+            }
+        )
         self.assertEqual(orbital.get_orbital_dict()['spin'], 1)
         self.assertEqual(orbital.get_orbital_dict()['diffusivity'], 3.1)
 
@@ -141,7 +152,8 @@ class TestRealhydrogenOrbital(AiidaTestCase):
                     'radial_nodes': 2,
                     'spin': 1,
                     'diffusivity': "a"
-                })
+                }
+            )
         self.assertIn("diffusivity", str(exc.exception))
 
         with self.assertRaises(ValidationError) as exc:
@@ -153,7 +165,8 @@ class TestRealhydrogenOrbital(AiidaTestCase):
                     'radial_nodes': 2,
                     'spin': 5,
                     'diffusivity': 3.1
-                })
+                }
+            )
         self.assertIn("spin", str(exc.exception))
 
     def test_unknown_fields(self):
@@ -168,7 +181,8 @@ class TestRealhydrogenOrbital(AiidaTestCase):
                     'magnetic_number': 0,
                     'radial_nodes': 2,
                     'some_strange_key': 1
-                })
+                }
+            )
         self.assertIn("some_strange_key", str(exc.exception))
 
     def test_get_name_from_quantum_numbers(self):

--- a/aiida/backends/tests/tools/importexport/migration/test_migration.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_migration.py
@@ -155,7 +155,8 @@ class TestExportFileMigration(AiidaTestCase):
             self.assertNotIn(
                 version,
                 legal_versions,
-                msg="'{}' was not expected to be a legal version, legal version: {}".format(version, legal_versions))
+                msg="'{}' was not expected to be a legal version, legal version: {}".format(version, legal_versions)
+            )
 
         # Make sure migrate_recursively throws a critical message and raises SystemExit
         for metadata in wrong_version_metadatas:
@@ -166,11 +167,13 @@ class TestExportFileMigration(AiidaTestCase):
                     'Critical: Cannot migrate from version {}'.format(metadata['export_version']),
                     exception.exception,
                     msg="Expected a critical statement for the wrong export version '{}', "
-                    "instead got {}".format(metadata['export_version'], exception.exception))
+                    "instead got {}".format(metadata['export_version'], exception.exception)
+                )
                 self.assertIsNone(
                     new_version,
                     msg="migrate_recursively should not return anything, "
-                    "hence the 'return' should be None, but instead it is {}".format(new_version))
+                    "hence the 'return' should be None, but instead it is {}".format(new_version)
+                )
 
     def test_migrate_newest_version(self):
         """
@@ -185,14 +188,17 @@ class TestExportFileMigration(AiidaTestCase):
 
             self.assertIn(
                 'Critical: Your export file is already at the newest export version {}'.format(
-                    metadata['export_version']),
+                    metadata['export_version']
+                ),
                 exception.exception,
                 msg="Expected a critical statement that the export version '{}' is the newest export version '{}', "
-                "instead got {}".format(metadata['export_version'], newest_version, exception.exception))
+                "instead got {}".format(metadata['export_version'], newest_version, exception.exception)
+            )
             self.assertIsNone(
                 new_version,
                 msg="migrate_recursively should not return anything, "
-                "hence the 'return' should be None, but instead it is {}".format(new_version))
+                "hence the 'return' should be None, but instead it is {}".format(new_version)
+            )
 
     @with_temp_dir
     def test_v02_to_newest(self, temp_dir):
@@ -224,7 +230,9 @@ class TestExportFileMigration(AiidaTestCase):
             builder.count(),
             self.struct_count,
             msg="There should be {} StructureData, instead {} were/was found".format(
-                self.struct_count, builder.count()))
+                self.struct_count, builder.count()
+            )
+        )
         for structures in builder.all():
             structure = structures[0]
             self.assertEqual(structure.label, self.known_struct_label)
@@ -277,7 +285,9 @@ class TestExportFileMigration(AiidaTestCase):
             builder.count(),
             self.struct_count,
             msg="There should be {} StructureData, instead {} were/was found".format(
-                self.struct_count, builder.count()))
+                self.struct_count, builder.count()
+            )
+        )
         for structures in builder.all():
             structure = structures[0]
             self.assertEqual(structure.label, self.known_struct_label)
@@ -330,7 +340,9 @@ class TestExportFileMigration(AiidaTestCase):
             builder.count(),
             self.struct_count,
             msg="There should be {} StructureData, instead {} were/was found".format(
-                self.struct_count, builder.count()))
+                self.struct_count, builder.count()
+            )
+        )
         for structures in builder.all():
             structure = structures[0]
             self.assertEqual(structure.label, self.known_struct_label)
@@ -383,7 +395,9 @@ class TestExportFileMigration(AiidaTestCase):
             builder.count(),
             self.struct_count,
             msg="There should be {} StructureData, instead {} were/was found".format(
-                self.struct_count, builder.count()))
+                self.struct_count, builder.count()
+            )
+        )
         for structures in builder.all():
             structure = structures[0]
             self.assertEqual(structure.label, self.known_struct_label)
@@ -436,7 +450,9 @@ class TestExportFileMigration(AiidaTestCase):
             builder.count(),
             self.struct_count,
             msg="There should be {} StructureData, instead {} were/was found".format(
-                self.struct_count, builder.count()))
+                self.struct_count, builder.count()
+            )
+        )
         for structures in builder.all():
             structure = structures[0]
             self.assertEqual(structure.label, self.known_struct_label)

--- a/aiida/backends/tests/tools/importexport/migration/test_v01_to_v02.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v01_to_v02.py
@@ -45,7 +45,8 @@ class TestMigrateV01toV02(AiidaTestCase):
         self.assertEqual(
             metadata_v1.pop('conversion_info')[-1],
             conversion_message,
-            msg="The conversion message after migration is wrong")
+            msg="The conversion message after migration is wrong"
+        )
         metadata_v2.pop('conversion_info')
 
         # Assert changes were performed correctly
@@ -53,6 +54,8 @@ class TestMigrateV01toV02(AiidaTestCase):
         self.assertDictEqual(
             metadata_v1,
             metadata_v2,
-            msg="After migration, metadata.json should equal intended metadata.json from archives")
+            msg="After migration, metadata.json should equal intended metadata.json from archives"
+        )
         self.assertDictEqual(
-            data_v1, data_v2, msg="After migration, data.json should equal intended data.json from archives")
+            data_v1, data_v2, msg="After migration, data.json should equal intended data.json from archives"
+        )

--- a/aiida/backends/tests/tools/importexport/migration/test_v02_to_v03.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v02_to_v03.py
@@ -55,7 +55,8 @@ class TestMigrateV02toV03(AiidaTestCase):
         self.assertEqual(
             metadata_v2.pop('conversion_info')[-1],
             conversion_message,
-            msg="The conversion message after migration is wrong")
+            msg="The conversion message after migration is wrong"
+        )
         metadata_v3.pop('conversion_info')
 
         # Assert changes were performed correctly
@@ -63,9 +64,11 @@ class TestMigrateV02toV03(AiidaTestCase):
         self.assertDictEqual(
             metadata_v2,
             metadata_v3,
-            msg="After migration, metadata.json should equal intended metadata.json from archives")
+            msg="After migration, metadata.json should equal intended metadata.json from archives"
+        )
         self.assertDictEqual(
-            data_v2, data_v3, msg="After migration, data.json should equal intended data.json from archives")
+            data_v2, data_v3, msg="After migration, data.json should equal intended data.json from archives"
+        )
 
     def test_migrate_v2_to_v3_complete(self):
         """Test migration for file containing complete v0.2 era possibilities"""
@@ -93,7 +96,9 @@ class TestMigrateV02toV03(AiidaTestCase):
                     entity,
                     legal_entity_names,
                     msg="'{}' should now be equal to anyone of these: {}, but is not".format(
-                        entity, legal_entity_names))
+                        entity, legal_entity_names
+                    )
+                )
 
                 if field == "all_fields_info":
                     for value in prop.values():
@@ -102,13 +107,16 @@ class TestMigrateV02toV03(AiidaTestCase):
                                 value['requires'],
                                 legal_entity_names,
                                 msg="'{}' should now be equal to anyone of these: {}, but is not".format(
-                                    value, legal_entity_names))
+                                    value, legal_entity_names
+                                )
+                            )
 
         for entity in data['export_data']:
             self.assertIn(
                 entity,
                 legal_entity_names,
-                msg="'{}' should now be equal to anyone of these: {}, but is not".format(entity, legal_entity_names))
+                msg="'{}' should now be equal to anyone of these: {}, but is not".format(entity, legal_entity_names)
+            )
 
     def test_compare_migration_with_aiida_made(self):
         """
@@ -177,14 +185,16 @@ class TestMigrateV02toV03(AiidaTestCase):
             self.assertListEqual(
                 sorted(details['migrated']),
                 sorted(details['made']),
-                msg="Number of {}-entities differ, see diff for details".format(entity))
+                msg="Number of {}-entities differ, see diff for details".format(entity)
+            )
 
         fields = {'export_data', 'groups_uuid', 'node_attributes_conversion', 'node_attributes'}
         for field in fields:
             self.assertEqual(
                 len(data_v2[field]),
                 len(data_v3[field]),
-                msg="Number of entities in {} differs for the export files".format(field))
+                msg="Number of entities in {} differs for the export files".format(field)
+            )
 
         number_of_links_v2 = {
             'unspecified': 0,
@@ -203,7 +213,8 @@ class TestMigrateV02toV03(AiidaTestCase):
         self.assertDictEqual(
             number_of_links_v2,
             number_of_links_v3,
-            msg="There are a different number of specific links in the migrated export file than the AiiDA made one.")
+            msg="There are a different number of specific links in the migrated export file than the AiiDA made one."
+        )
 
         self.assertEqual(number_of_links_v2['unspecified'], 0)
         self.assertEqual(number_of_links_v3['unspecified'], 0)

--- a/aiida/backends/tests/tools/importexport/migration/test_v03_to_v04.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v03_to_v04.py
@@ -83,16 +83,19 @@ class TestMigrateV03toV04(AiidaTestCase):
         self.assertEqual(
             metadata_v3.pop('conversion_info')[-1],
             conversion_message,
-            msg="The conversion message after migration is wrong")
+            msg="The conversion message after migration is wrong"
+        )
         metadata_v4.pop('conversion_info')
 
         # Assert changes were performed correctly
         self.assertDictEqual(
             metadata_v3,
             metadata_v4,
-            msg="After migration, metadata.json should equal intended metadata.json from archives")
+            msg="After migration, metadata.json should equal intended metadata.json from archives"
+        )
         self.assertDictEqual(
-            data_v3, data_v4, msg="After migration, data.json should equal intended data.json from archives")
+            data_v3, data_v4, msg="After migration, data.json should equal intended data.json from archives"
+        )
 
     def test_migrate_v3_to_v4_complete(self):
         """Test migration for file containing complete v0.3 era possibilities"""
@@ -149,7 +152,8 @@ class TestMigrateV03toV04(AiidaTestCase):
             self.assertIn(
                 change,
                 metadata['all_fields_info']['Node'],
-                msg="'{}' not found in metadata.json for Node".format(change))
+                msg="'{}' not found in metadata.json for Node".format(change)
+            )
 
         # Check Node types
         legal_node_types = {
@@ -163,12 +167,15 @@ class TestMigrateV03toV04(AiidaTestCase):
             self.assertIn(
                 node['node_type'],
                 legal_node_types,
-                msg="{} is not a legal node_type. Legal node types: {}".format(node['node_type'], legal_node_types))
+                msg="{} is not a legal node_type. Legal node types: {}".format(node['node_type'], legal_node_types)
+            )
             self.assertIn(
                 node['process_type'],
                 legal_process_types,
                 msg="{} is not a legal process_type. Legal process types: {}".format(
-                    node['process_type'], legal_node_types))
+                    node['process_type'], legal_node_types
+                )
+            )
 
         # Check links
         # Make sure the two illegal create links were removed during the migration
@@ -176,7 +183,8 @@ class TestMigrateV03toV04(AiidaTestCase):
             len(data['links_uuid']),
             links_count_org - 2,
             msg="Two of the org. {} links should have been removed during the migration, "
-            "instead there are now {} links".format(links_count_org, len(data['links_uuid'])))
+            "instead there are now {} links".format(links_count_org, len(data['links_uuid']))
+        )
         legal_link_types = {"unspecified", "create", "return", "input_calc", "input_work", "call_calc", "call_work"}
         for link in data['links_uuid']:
             self.assertIn(link['type'], legal_link_types)
@@ -194,7 +202,8 @@ class TestMigrateV03toV04(AiidaTestCase):
                 self.assertIn(
                     group['type_string'],
                     legal_group_type,
-                    msg="{} is not a legal Group type_string".format(group['type_string']))
+                    msg="{} is not a legal Group type_string".format(group['type_string'])
+                )
             # metadata.json
             self.assertIn(attr, metadata['all_fields_info']['Group'], msg="{} not found in metadata.json".format(attr))
 
@@ -217,19 +226,22 @@ class TestMigrateV03toV04(AiidaTestCase):
                     self.assertIn(
                         attr,
                         data[field][node_id],
-                        msg="Updated attribute name '{}' not found in {} for node_id: {}".format(attr, field, node_id))
+                        msg="Updated attribute name '{}' not found in {} for node_id: {}".format(attr, field, node_id)
+                    )
                 for old, new in optional_updated_calcjob_attrs.items():
                     self.assertNotIn(
                         old,
                         data[field][node_id],
                         msg="Old attribute '{}' found in {} for node_id: {}. "
-                        "It should now be updated to '{}' or not exist".format(old, field, node_id, new))
+                        "It should now be updated to '{}' or not exist".format(old, field, node_id, new)
+                    )
             for node_id in process_nodes:
                 for attr in updated_process_attrs:
                     self.assertIn(
                         attr,
                         data[field][node_id],
-                        msg="Updated attribute name '{}' not found in {} for node_id: {}".format(attr, field, node_id))
+                        msg="Updated attribute name '{}' not found in {} for node_id: {}".format(attr, field, node_id)
+                    )
 
         # Check TrajectoryData
         # There should be minimum one TrajectoryData in the export file
@@ -247,7 +259,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                         attr,
                         data[field][node_id],
                         msg="Updated attribute name '{}' not found in {} for TrajecteoryData node_id: {}".format(
-                            attr, field, node_id))
+                            attr, field, node_id
+                        )
+                    )
 
         # Check Computer
         removed_attrs = {'enabled'}
@@ -255,12 +269,14 @@ class TestMigrateV03toV04(AiidaTestCase):
             # data.json
             for computer in data['export_data']['Computer'].values():
                 self.assertNotIn(
-                    attr, computer, msg="'{}' should have been removed from Computer {}".format(attr, computer['name']))
+                    attr, computer, msg="'{}' should have been removed from Computer {}".format(attr, computer['name'])
+                )
             # metadata.json
             self.assertNotIn(
                 attr,
                 metadata['all_fields_info']['Computer'],
-                msg="'{}' should have been removed from Computer in metadata.json".format(attr))
+                msg="'{}' should have been removed from Computer in metadata.json".format(attr)
+            )
 
         # Check new entities
         new_entities = {'Log', 'Comment'}
@@ -280,7 +296,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                 len(data[field]),
                 attrs_count,
                 msg="New field '{}' found to have only {} entries, but should have had {} entries".format(
-                    field, len(data[field]), attrs_count))
+                    field, len(data[field]), attrs_count
+                )
+            )
 
     def test_compare_migration_with_aiida_made(self):
         """
@@ -365,7 +383,8 @@ class TestMigrateV03toV04(AiidaTestCase):
             self.assertListEqual(
                 sorted(details['migrated']),
                 sorted(details['made']),
-                msg="Number of {}-entities differ, see diff for details".format(entity))
+                msg="Number of {}-entities differ, see diff for details".format(entity)
+            )
 
         fields = {
             'groups_uuid', 'node_attributes_conversion', 'node_attributes', 'node_extras', 'node_extras_conversion'
@@ -379,7 +398,8 @@ class TestMigrateV03toV04(AiidaTestCase):
             self.assertEqual(
                 len(data_v3[field]),
                 len(data_v4[field]) - correction,
-                msg="Number of entities in {} differs for the export files".format(field))
+                msg="Number of entities in {} differs for the export files".format(field)
+            )
 
         number_of_links_v3 = {
             'unspecified': 0,
@@ -408,7 +428,8 @@ class TestMigrateV03toV04(AiidaTestCase):
         self.assertDictEqual(
             number_of_links_v3,
             number_of_links_v4,
-            msg="There are a different number of specific links in the migrated export file than the AiiDA made one.")
+            msg="There are a different number of specific links in the migrated export file than the AiiDA made one."
+        )
 
         self.assertEqual(number_of_links_v3['unspecified'], 0)
         self.assertEqual(number_of_links_v4['unspecified'], 0)
@@ -461,7 +482,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                 len(violations),
                 known_illegal_links,
                 msg="{} illegal create links were expected, instead {} was/were found".format(
-                    known_illegal_links, len(violations)))
+                    known_illegal_links, len(violations)
+                )
+            )
 
             # Migrate to v0.4
             migrate_v3_to_v4(metadata, data, folder)
@@ -470,8 +493,10 @@ class TestMigrateV03toV04(AiidaTestCase):
         self.assertEqual(
             len(data['links_uuid']),
             links_count_migrated,
-            msg="{} links were expected, instead {} was/were found".format(links_count_migrated,
-                                                                           len(data['links_uuid'])))
+            msg="{} links were expected, instead {} was/were found".format(
+                links_count_migrated, len(data['links_uuid'])
+            )
+        )
 
         workfunc_uuids = {
             value['uuid']
@@ -483,4 +508,5 @@ class TestMigrateV03toV04(AiidaTestCase):
             if link['input'] in workfunc_uuids and link['type'] == 'create':
                 violations.append(link)
         self.assertEqual(
-            len(violations), 0, msg="0 illegal links were expected, instead {} was/were found".format(len(violations)))
+            len(violations), 0, msg="0 illegal links were expected, instead {} was/were found".format(len(violations))
+        )

--- a/aiida/backends/tests/tools/importexport/migration/test_v04_to_v05.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v04_to_v05.py
@@ -84,16 +84,19 @@ class TestMigrateV04toV05(AiidaTestCase):
         self.assertEqual(
             metadata_v4.pop('conversion_info')[-1],
             conversion_message,
-            msg="The conversion message after migration is wrong")
+            msg="The conversion message after migration is wrong"
+        )
         metadata_v5.pop('conversion_info')
 
         # Assert changes were performed correctly
         self.assertDictEqual(
             metadata_v4,
             metadata_v5,
-            msg="After migration, metadata.json should equal intended metadata.json from archives")
+            msg="After migration, metadata.json should equal intended metadata.json from archives"
+        )
         self.assertDictEqual(
-            data_v4, data_v5, msg="After migration, data.json should equal intended data.json from archives")
+            data_v4, data_v5, msg="After migration, data.json should equal intended data.json from archives"
+        )
 
     def test_migrate_v4_to_v5_complete(self):
         """Test migration for file containing complete v0.4 era possibilities"""
@@ -118,7 +121,8 @@ class TestMigrateV04toV05(AiidaTestCase):
             self.assertNotIn(
                 change,
                 metadata['all_fields_info']['Computer'],
-                msg="'{}' unexpectedly found in metadata.json for Computer".format(change))
+                msg="'{}' unexpectedly found in metadata.json for Computer".format(change)
+            )
         for change in removed_node_attrs:
             # data.json
             for node in data['export_data']['Node'].values():
@@ -127,4 +131,5 @@ class TestMigrateV04toV05(AiidaTestCase):
             self.assertNotIn(
                 change,
                 metadata['all_fields_info']['Node'],
-                msg="'{}' unexpectedly found in metadata.json for Node".format(change))
+                msg="'{}' unexpectedly found in metadata.json for Node".format(change)
+            )

--- a/aiida/backends/tests/tools/importexport/migration/test_v05_to_v06.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v05_to_v06.py
@@ -56,16 +56,19 @@ class TestMigrateV05toV06(AiidaTestCase):
         self.assertEqual(
             metadata_v5.pop('conversion_info')[-1],
             conversion_message,
-            msg="The conversion message after migration is wrong")
+            msg="The conversion message after migration is wrong"
+        )
         metadata_v6.pop('conversion_info')
 
         # Assert changes were performed correctly
         self.assertDictEqual(
             metadata_v5,
             metadata_v6,
-            msg="After migration, metadata.json should equal intended metadata.json from archives")
+            msg="After migration, metadata.json should equal intended metadata.json from archives"
+        )
         self.assertDictEqual(
-            data_v5, data_v6, msg="After migration, data.json should equal intended data.json from archives")
+            data_v5, data_v6, msg="After migration, data.json should equal intended data.json from archives"
+        )
 
     def test_migrate_v5_to_v6_calc_states(self):
         """Test the data migration of legacy `JobCalcState` attributes.
@@ -136,8 +139,10 @@ class TestMigrateV05toV06(AiidaTestCase):
             break
 
         else:
-            raise RuntimeError('the archive `export_v0.5_simple.aiida` did not contain a node with the attribute '
-                               '`scheduler_lastchecktime` which is required for this test.')
+            raise RuntimeError(
+                'the archive `export_v0.5_simple.aiida` did not contain a node with the attribute '
+                '`scheduler_lastchecktime` which is required for this test.'
+            )
 
     def test_migrate_v5_to_v6_complete(self):
         """Test migration for file containing complete v0.5 era possibilities"""

--- a/aiida/backends/tests/tools/importexport/migration/test_v06_to_v07.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v06_to_v07.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils.archives import get_json_files
 from aiida.tools.importexport.migration.utils import verify_metadata_version
-from aiida.tools.importexport.migration.v06_to_v07 import (migrate_v6_to_v7,
-                                                           migration_data_migration_legacy_process_attributes)
+from aiida.tools.importexport.migration.v06_to_v07 import (
+    migrate_v6_to_v7, migration_data_migration_legacy_process_attributes
+)
 
 
 class TestMigrateV06toV07(AiidaTestCase):
@@ -56,16 +57,19 @@ class TestMigrateV06toV07(AiidaTestCase):
         self.assertEqual(
             metadata_v6.pop('conversion_info')[-1],
             conversion_message,
-            msg="The conversion message after migration is wrong")
+            msg="The conversion message after migration is wrong"
+        )
         metadata_v7.pop('conversion_info')
 
         # Assert changes were performed correctly
         self.assertDictEqual(
             metadata_v6,
             metadata_v7,
-            msg="After migration, metadata.json should equal intended metadata.json from archives")
+            msg="After migration, metadata.json should equal intended metadata.json from archives"
+        )
         self.assertDictEqual(
-            data_v6, data_v7, msg="After migration, data.json should equal intended data.json from archives")
+            data_v6, data_v7, msg="After migration, data.json should equal intended data.json from archives"
+        )
 
     def test_migrate_v6_to_v7_complete(self):
         """Test migration for file containing complete v0.6 era possibilities"""
@@ -88,17 +92,21 @@ class TestMigrateV06toV07(AiidaTestCase):
                     self.assertNotIn(
                         attr,
                         attrs,
-                        msg="key '{}' should have been removed from attributes for Node <pk={}>".format(attr, node_pk))
+                        msg="key '{}' should have been removed from attributes for Node <pk={}>".format(attr, node_pk)
+                    )
 
                 # Check new attributes were added successfully
                 for attr in new_attrs:
                     self.assertIn(
-                        attr, attrs, msg="key '{}' was not added to attributes for Node <pk={}>".format(attr, node_pk))
+                        attr, attrs, msg="key '{}' was not added to attributes for Node <pk={}>".format(attr, node_pk)
+                    )
                     self.assertEqual(
                         attrs[attr],
                         new_attrs[attr],
                         msg="key '{}' should have had the value {}, but did instead have {}".format(
-                            attr, new_attrs[attr], attrs[attr]))
+                            attr, new_attrs[attr], attrs[attr]
+                        )
+                    )
 
         # Check Attribute and Link have been removed
         illegal_entities = {'Attribute', 'Link'}
@@ -107,7 +115,8 @@ class TestMigrateV06toV07(AiidaTestCase):
                 self.assertNotIn(
                     entity,
                     metadata[dict_],
-                    msg="key '{}' should have been removed from '{}' in metadata.json".format(entity, dict_))
+                    msg="key '{}' should have been removed from '{}' in metadata.json".format(entity, dict_)
+                )
 
     def test_migration_0040_integrity_error(self):
         """Check IntegrityError is raised for different cases during migration 0040"""

--- a/aiida/backends/tests/tools/importexport/orm/test_codes.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_codes.py
@@ -98,10 +98,12 @@ class TestCode(AiidaTestCase):
         self.assertListEqual(sorted(export_links), sorted(import_links))
         self.assertEqual(
             len(export_links), links_count, "Expected to find only one link from code to "
-            "the calculation node before export. {} found.".format(len(export_links)))
+            "the calculation node before export. {} found.".format(len(export_links))
+        )
         self.assertEqual(
             len(import_links), links_count, "Expected to find only one link from code to "
-            "the calculation node after import. {} found.".format(len(import_links)))
+            "the calculation node after import. {} found.".format(len(import_links))
+        )
 
     @with_temp_dir
     def test_solo_code(self, temp_dir):

--- a/aiida/backends/tests/tools/importexport/orm/test_computers.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_computers.py
@@ -115,8 +115,10 @@ class TestComputer(AiidaTestCase):
         # did not change.
         builder = orm.QueryBuilder()
         builder.append(orm.Computer, project=['name', 'uuid', 'id'])
-        self.assertEqual(builder.count(), 1, "Found {} computers"
-                         "but only one computer should be found.".format(builder.count()))
+        self.assertEqual(
+            builder.count(), 1, "Found {} computers"
+            "but only one computer should be found.".format(builder.count())
+        )
         self.assertEqual(six.text_type(builder.first()[0]), comp_name, "The computer name is not correct.")
         self.assertEqual(six.text_type(builder.first()[1]), comp_uuid, "The computer uuid is not correct.")
         self.assertEqual(builder.first()[2], comp_id, "The computer id is not correct.")
@@ -209,8 +211,10 @@ class TestComputer(AiidaTestCase):
         # did not change.
         builder = orm.QueryBuilder()
         builder.append(orm.Computer, project=['name'])
-        self.assertEqual(builder.count(), 1, "Found {} computers"
-                         "but only one computer should be found.".format(builder.count()))
+        self.assertEqual(
+            builder.count(), 1, "Found {} computers"
+            "but only one computer should be found.".format(builder.count())
+        )
         self.assertEqual(six.text_type(builder.first()[0]), comp1_name, "The computer name is not correct.")
 
     @with_temp_dir
@@ -290,9 +294,11 @@ class TestComputer(AiidaTestCase):
         # Check that there are no calculations
         builder = orm.QueryBuilder()
         builder.append(orm.CalcJobNode, project=['*'])
-        self.assertEqual(builder.count(), 0, "There should not be any "
-                         "calculations in the database at "
-                         "this point.")
+        self.assertEqual(
+            builder.count(), 0, "There should not be any "
+            "calculations in the database at "
+            "this point."
+        )
 
         # Import all the calculations
         import_data(filename1, silent=True)
@@ -367,7 +373,8 @@ class TestComputer(AiidaTestCase):
             builder.append(
                 orm.Computer, project=['metadata'], tag="comp", filters={'name': {
                     '!==': self.computer.name
-                }})
+                }}
+            )
             self.assertEqual(builder.count(), 1, "Expected only one computer")
 
             res = builder.dict()[0]

--- a/aiida/backends/tests/tools/importexport/orm/test_groups.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_groups.py
@@ -199,7 +199,8 @@ class TestGroups(AiidaTestCase):
             import_data(filename, group=group_label, silent=True)
         exc = exc.exception
         self.assertEqual(
-            str(exc), "group must be a Group entity", msg="The error message should be the same for both backends.")
+            str(exc), "group must be a Group entity", msg="The error message should be the same for both backends."
+        )
 
         # Import properly now, providing the Group object
         import_data(filename, group=group, silent=True)
@@ -210,7 +211,8 @@ class TestGroups(AiidaTestCase):
             builder.count(),
             1,
             msg="There should be exactly one Group with label {}. "
-            "Instead {} was found.".format(group_label, builder.count()))
+            "Instead {} was found.".format(group_label, builder.count())
+        )
         imported_group = load_group(builder.all()[0][0])
         self.assertEqual(imported_group.uuid, group_uuid)
         for node in imported_group.nodes:

--- a/aiida/backends/tests/tools/importexport/orm/test_links.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_links.py
@@ -214,10 +214,10 @@ class TestLinks(AiidaTestCase):
         # predecessor(INPUT, CREATE)/successor(CALL, RETURN, CREATE) links.
         export_list = [(work1, [data1, data2, data3, data4, calc1, work1, work2]),
                        (work2, [data1, data3, data4, calc1, work2]), (data3, [data1, data3, data4, calc1]),
-                       (data4, [data1, data3, data4, calc1]), (data5, [data1, data3, data4, data5, data6, calc1,
-                                                                       calc2]),
-                       (data6, [data1, data3, data4, data5, data6, calc1, calc2]), (calc1, [data1, data3, data4,
-                                                                                            calc1]),
+                       (data4, [data1, data3, data4, calc1]),
+                       (data5, [data1, data3, data4, data5, data6, calc1, calc2]),
+                       (data6, [data1, data3, data4, data5, data6, calc1,
+                                calc2]), (calc1, [data1, data3, data4, calc1]),
                        (calc2, [data1, data3, data4, data5, data6, calc1, calc2]), (data1, [data1]), (data2, [data2])]
 
         return graph_nodes, export_list[export_combination]
@@ -276,10 +276,13 @@ class TestLinks(AiidaTestCase):
             edge_project=['label', 'type'],
             edge_filters={
                 'type': {
-                    'in': (LinkType.INPUT_CALC.value, LinkType.INPUT_WORK.value, LinkType.CREATE.value,
-                           LinkType.RETURN.value, LinkType.CALL_CALC.value, LinkType.CALL_WORK.value)
+                    'in': (
+                        LinkType.INPUT_CALC.value, LinkType.INPUT_WORK.value, LinkType.CREATE.value,
+                        LinkType.RETURN.value, LinkType.CALL_CALC.value, LinkType.CALL_WORK.value
+                    )
                 }
-            })
+            }
+        )
         export_links = builder.all()
 
         export_file = os.path.join(temp_dir, 'export.tar.gz')
@@ -320,7 +323,8 @@ class TestLinks(AiidaTestCase):
                 export_target_uuids, imported_node_uuids,
                 "Problem in comparison of export node: " + str(export_node_str) + "\n" + "Expected set: " +
                 str(export_target_uuids) + "\n" + "Imported set: " + str(imported_node_uuids) + "\n" + "Difference: " +
-                str([_ for _ in export_target_uuids.symmetric_difference(imported_node_uuids)]))
+                str([_ for _ in export_target_uuids.symmetric_difference(imported_node_uuids)])
+            )
 
     @with_temp_dir
     def test_high_level_workflow_links(self, temp_dir):
@@ -351,15 +355,19 @@ class TestLinks(AiidaTestCase):
                     edge_project=['label', 'type'],
                     edge_filters={
                         'type': {
-                            'in': (LinkType.INPUT_CALC.value, LinkType.INPUT_WORK.value, LinkType.CREATE.value,
-                                   LinkType.RETURN.value, LinkType.CALL_CALC.value, LinkType.CALL_WORK.value)
+                            'in': (
+                                LinkType.INPUT_CALC.value, LinkType.INPUT_WORK.value, LinkType.CREATE.value,
+                                LinkType.RETURN.value, LinkType.CALL_CALC.value, LinkType.CALL_WORK.value
+                            )
                         }
-                    })
+                    }
+                )
 
                 self.assertEqual(
                     builder.count(),
                     13,
-                    msg="Failed with c1={}, c2={}, w1={}, w2={}".format(calcs[0], calcs[1], works[0], works[1]))
+                    msg="Failed with c1={}, c2={}, w1={}, w2={}".format(calcs[0], calcs[1], works[0], works[1])
+                )
 
                 export_links = builder.all()
 
@@ -377,7 +385,8 @@ class TestLinks(AiidaTestCase):
                 self.assertSetEqual(
                     set(export_set),
                     set(import_set),
-                    msg="Failed with c1={}, c2={}, w1={}, w2={}".format(calcs[0], calcs[1], works[0], works[1]))
+                    msg="Failed with c1={}, c2={}, w1={}, w2={}".format(calcs[0], calcs[1], works[0], works[1])
+                )
 
     @with_temp_dir
     def test_links_for_workflows(self, temp_dir):

--- a/aiida/backends/tests/tools/importexport/test_specific_import.py
+++ b/aiida/backends/tests/tools/importexport/test_specific_import.py
@@ -56,7 +56,8 @@ class TestSpecificImport(AiidaTestCase):
                     'dual': 4,
                     'cutoff_units': 'Ry'
                 },
-            }).store()
+            }
+        ).store()
 
         with tempfile.NamedTemporaryFile() as handle:
             nodes = [parameters]

--- a/aiida/backends/tests/tools/visualization/test_graph.py
+++ b/aiida/backends/tests/tools/visualization/test_graph.py
@@ -149,7 +149,8 @@ class TestVisGraph(AiidaTestCase):
             graph.edges,
             set([(nodes.pd0.pk, nodes.calc1.pk, LinkPair(LinkType.INPUT_CALC, 'input1')),
                  (nodes.pd1.pk, nodes.calc1.pk, LinkPair(LinkType.INPUT_CALC, 'input2')),
-                 (nodes.wc1.pk, nodes.calc1.pk, LinkPair(LinkType.CALL_CALC, 'call1'))]))
+                 (nodes.wc1.pk, nodes.calc1.pk, LinkPair(LinkType.CALL_CALC, 'call1'))])
+        )
 
     def test_graph_add_outgoing(self):
         """ test adding a node and all its outgoing nodes to a graph"""
@@ -162,7 +163,8 @@ class TestVisGraph(AiidaTestCase):
         self.assertEqual(
             graph.edges,
             set([(nodes.calcf1.pk, nodes.pd3.pk, LinkPair(LinkType.CREATE, 'output1')),
-                 (nodes.calcf1.pk, nodes.fd1.pk, LinkPair(LinkType.CREATE, 'output2'))]))
+                 (nodes.calcf1.pk, nodes.fd1.pk, LinkPair(LinkType.CREATE, 'output2'))])
+        )
 
     def test_graph_recurse_ancestors(self):
         """ test adding nodes and all its (recursed) incoming nodes to a graph"""
@@ -179,7 +181,8 @@ class TestVisGraph(AiidaTestCase):
                  (nodes.pd1.pk, nodes.calc1.pk, LinkPair(LinkType.INPUT_CALC, 'input2')),
                  (nodes.wc1.pk, nodes.calc1.pk, LinkPair(LinkType.CALL_CALC, 'call1')),
                  (nodes.pd0.pk, nodes.wc1.pk, LinkPair(LinkType.INPUT_WORK, 'input1')),
-                 (nodes.pd1.pk, nodes.wc1.pk, LinkPair(LinkType.INPUT_WORK, 'input2'))]))
+                 (nodes.pd1.pk, nodes.wc1.pk, LinkPair(LinkType.INPUT_WORK, 'input2'))])
+        )
 
     def test_graph_recurse_ancestors_filter_links(self):
         """ test adding nodes and all its (recursed) incoming nodes to a graph, but filter link types"""
@@ -193,7 +196,8 @@ class TestVisGraph(AiidaTestCase):
             graph.edges,
             set([(nodes.calc1.pk, nodes.rd1.pk, LinkPair(LinkType.CREATE, 'output')),
                  (nodes.pd0.pk, nodes.calc1.pk, LinkPair(LinkType.INPUT_CALC, 'input1')),
-                 (nodes.pd1.pk, nodes.calc1.pk, LinkPair(LinkType.INPUT_CALC, 'input2'))]))
+                 (nodes.pd1.pk, nodes.calc1.pk, LinkPair(LinkType.INPUT_CALC, 'input2'))])
+        )
 
     def test_graph_recurse_descendants(self):
         """ test adding nodes and all its (recursed) incoming nodes to a graph"""
@@ -209,7 +213,8 @@ class TestVisGraph(AiidaTestCase):
                 (nodes.rd1.pk, nodes.calcf1.pk, LinkPair(LinkType.INPUT_CALC, 'input1')),
                 (nodes.calcf1.pk, nodes.pd3.pk, LinkPair(LinkType.CREATE, 'output1')),
                 (nodes.calcf1.pk, nodes.fd1.pk, LinkPair(LinkType.CREATE, 'output2')),
-            ]))
+            ])
+        )
 
     def test_graph_graphviz_source(self):
         """ test the output of graphviz source """
@@ -252,7 +257,8 @@ class TestVisGraph(AiidaTestCase):
         # dedent before comparison
         self.assertEqual(
             sorted([l.strip() for l in graph.graphviz.source.splitlines()]),
-            sorted([l.strip() for l in expected.splitlines()]))
+            sorted([l.strip() for l in expected.splitlines()])
+        )
 
     def test_graph_graphviz_source_pstate(self):
         """ test the output of graphviz source, with the `pstate_node_styles` function """
@@ -295,4 +301,5 @@ class TestVisGraph(AiidaTestCase):
         # dedent before comparison
         self.assertEqual(
             sorted([l.strip() for l in graph.graphviz.source.splitlines()]),
-            sorted([l.strip() for l in expected.splitlines()]))
+            sorted([l.strip() for l in expected.splitlines()])
+        )

--- a/aiida/calculations/plugins/arithmetic/add.py
+++ b/aiida/calculations/plugins/arithmetic/add.py
@@ -32,9 +32,11 @@ class ArithmeticAddCalculation(CalcJob):
         spec.input('y', valid_type=(orm.Int, orm.Float), help='The right operand.')
         spec.output('sum', valid_type=(orm.Int, orm.Float), help='The sum of the left and right operand.')
         spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
+            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.'
+        )
         spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.')
+            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.'
+        )
         spec.exit_code(120, 'ERROR_INVALID_OUTPUT', message='The output file contains invalid output.')
 
     def prepare_for_submission(self, folder):

--- a/aiida/cmdline/__init__.py
+++ b/aiida/cmdline/__init__.py
@@ -19,5 +19,7 @@ from .params.types import *
 from .utils.decorators import *
 from .utils.echo import *
 
-__all__ = (params.arguments.__all__ + params.options.__all__ + params.types.__all__ + utils.decorators.__all__ +
-           utils.echo.__all__)
+__all__ = (
+    params.arguments.__all__ + params.options.__all__ + params.types.__all__ + utils.decorators.__all__ +
+    utils.echo.__all__
+)

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -18,11 +18,13 @@ import click_completion
 click_completion.init()
 
 # Import to populate the `verdi` sub commands
-from aiida.cmdline.commands import (cmd_calcjob, cmd_code, cmd_comment, cmd_completioncommand, cmd_computer, cmd_config,
-                                    cmd_data, cmd_database, cmd_daemon, cmd_devel, cmd_export, cmd_graph, cmd_group,
-                                    cmd_import, cmd_node, cmd_plugin, cmd_process, cmd_profile, cmd_rehash, cmd_restapi,
-                                    cmd_run, cmd_setup, cmd_shell, cmd_status, cmd_user)
+from aiida.cmdline.commands import (
+    cmd_calcjob, cmd_code, cmd_comment, cmd_completioncommand, cmd_computer, cmd_config, cmd_data, cmd_database,
+    cmd_daemon, cmd_devel, cmd_export, cmd_graph, cmd_group, cmd_import, cmd_node, cmd_plugin, cmd_process, cmd_profile,
+    cmd_rehash, cmd_restapi, cmd_run, cmd_setup, cmd_shell, cmd_status, cmd_user
+)
 
 # Import to populate the `verdi data` sub commands
-from aiida.cmdline.commands.cmd_data import (cmd_array, cmd_bands, cmd_cif, cmd_dict, cmd_remote, cmd_structure,
-                                             cmd_trajectory, cmd_upf)
+from aiida.cmdline.commands.cmd_data import (
+    cmd_array, cmd_bands, cmd_cif, cmd_dict, cmd_remote, cmd_structure, cmd_trajectory, cmd_upf
+)

--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -102,11 +102,12 @@ def calcjob_inputcat(calcjob, path):
         content = calcjob.get_object_content(path)
     except Exception as exception:  # pylint: disable=broad-except
         # No path available or is incorrect
-        echo.echo_critical('"{}" and its process class "{}" do not define a default input file '
-                           '(option "input_filename" not found).\n'
-                           'Please specify a path explicitly.\n'
-                           'Exception: {}'.format(calcjob.__class__.__name__, calcjob.process_class.__name__,
-                                                  exception))
+        echo.echo_critical(
+            '"{}" and its process class "{}" do not define a default input file '
+            '(option "input_filename" not found).\n'
+            'Please specify a path explicitly.\n'
+            'Exception: {}'.format(calcjob.__class__.__name__, calcjob.process_class.__name__, exception)
+        )
     else:
         echo.echo(content)
 
@@ -141,11 +142,12 @@ def calcjob_outputcat(calcjob, path):
         content = retrieved.get_object_content(path)
     except Exception as exception:  # pylint: disable=broad-except
         # No path available or is incorrect
-        echo.echo_critical('"{}" and its process class "{}" do not define a default output file '
-                           '(option "output_filename" not found).\n'
-                           'Please specify a path explicitly.\n'
-                           'Exception: {}'.format(calcjob.__class__.__name__, calcjob.process_class.__name__,
-                                                  exception))
+        echo.echo_critical(
+            '"{}" and its process class "{}" do not define a default output file '
+            '(option "output_filename" not found).\n'
+            'Please specify a path explicitly.\n'
+            'Exception: {}'.format(calcjob.__class__.__name__, calcjob.process_class.__name__, exception)
+        )
     else:
         echo.echo(content)
 

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -87,7 +87,8 @@ def _computer_test_no_unexpected_output(transport, scheduler, authinfo):  # pyli
         echo.echo_error("* ERROR! The command 'echo -n' returned a non-zero return code ({})!".format(retval))
         return False
     if stdout:
-        echo.echo_error(u"""* ERROR! There is some spurious output in the standard output,
+        echo.echo_error(
+            u"""* ERROR! There is some spurious output in the standard output,
 that we report below between the === signs:
 =========================================================
 {}
@@ -98,10 +99,12 @@ remove the code, but just to disable it for non-interactive
 shells, see comments in issue #1980 on GitHub:
 https://github.com/aiidateam/aiida-core/issues/1890
 (and in the AiiDA documentation, linked from that issue)
-""".format(stdout))
+""".format(stdout)
+        )
         return False
     if stderr:
-        echo.echo_error(u"""* ERROR! There is some spurious output in the stderr,
+        echo.echo_error(
+            u"""* ERROR! There is some spurious output in the stderr,
 that we report below between the === signs:
 =========================================================
 {}
@@ -112,7 +115,8 @@ remove the code, but just to disable it for non-interactive
 shells, see comments in issue #1980 on GitHub:
 https://github.com/aiidateam/aiida-core/issues/1890
 (and in the AiiDA documentation, linked from that issue)
-""".format(stderr))
+""".format(stderr)
+        )
         return False
 
     echo.echo("      [OK]")
@@ -242,9 +246,11 @@ def computer_setup(ctx, non_interactive, **kwargs):
     from aiida.orm.utils.builders.computer import ComputerBuilder
 
     if kwargs['label'] in get_computer_names():
-        echo.echo_critical('A computer called {c} already exists. '
-                           'Use "verdi computer duplicate {c}" to set up a new '
-                           'computer starting from the settings of {c}.'.format(c=kwargs['label']))
+        echo.echo_critical(
+            'A computer called {c} already exists. '
+            'Use "verdi computer duplicate {c}" to set up a new '
+            'computer starting from the settings of {c}.'.format(c=kwargs['label'])
+        )
 
     if not non_interactive:
         try:
@@ -348,15 +354,17 @@ def computer_enable(computer, user):
     try:
         authinfo = computer.get_authinfo(user)
     except NotExistent:
-        echo.echo_critical("User with email '{}' is not configured for computer '{}' yet.".format(
-            user.email, computer.name))
+        echo.echo_critical(
+            "User with email '{}' is not configured for computer '{}' yet.".format(user.email, computer.name)
+        )
 
     if not authinfo.enabled:
         authinfo.enabled = True
         echo.echo_info("Computer '{}' enabled for user {}.".format(computer.name, user.get_full_name()))
     else:
-        echo.echo_info("Computer '{}' was already enabled for user {} {}.".format(computer.name, user.first_name,
-                                                                                  user.last_name))
+        echo.echo_info(
+            "Computer '{}' was already enabled for user {} {}.".format(computer.name, user.first_name, user.last_name)
+        )
 
 
 @verdi_computer.command('disable')
@@ -372,15 +380,17 @@ def computer_disable(computer, user):
     try:
         authinfo = computer.get_authinfo(user)
     except NotExistent:
-        echo.echo_critical("User with email '{}' is not configured for computer '{}' yet.".format(
-            user.email, computer.name))
+        echo.echo_critical(
+            "User with email '{}' is not configured for computer '{}' yet.".format(user.email, computer.name)
+        )
 
     if authinfo.enabled:
         authinfo.enabled = False
         echo.echo_info("Computer '{}' disabled for user {}.".format(computer.name, user.get_full_name()))
     else:
-        echo.echo_info("Computer '{}' was already disabled for user {} {}.".format(computer.name, user.first_name,
-                                                                                   user.last_name))
+        echo.echo_info(
+            "Computer '{}' was already disabled for user {} {}.".format(computer.name, user.first_name, user.last_name)
+        )
 
 
 @verdi_computer.command('list')
@@ -434,9 +444,11 @@ def computer_rename(computer, new_name):
     except ValidationError as error:
         echo.echo_critical("Invalid input! {}".format(error))
     except UniquenessError as error:
-        echo.echo_critical("Uniqueness error encountered! Probably a "
-                           "computer with name '{}' already exists"
-                           "".format(new_name))
+        echo.echo_critical(
+            "Uniqueness error encountered! Probably a "
+            "computer with name '{}' already exists"
+            "".format(new_name)
+        )
         echo.echo_critical("(Message was: {})".format(error))
 
     echo.echo_success("Computer '{}' renamed to '{}'".format(old_name, new_name))
@@ -558,7 +570,8 @@ def computer_configure():
 
 @computer_configure.command('show')
 @click.option(
-    '--defaults', is_flag=True, default=False, help='Show the default configuration settings for this computer.')
+    '--defaults', is_flag=True, default=False, help='Show the default configuration settings for this computer.'
+)
 @click.option('--as-option-string', is_flag=True)
 @options.USER()
 @arguments.COMPUTER()
@@ -585,11 +598,11 @@ def computer_config_show(computer, user, defaults, as_option_string):
             t_opt = transport_cls.auth_options[option.name]
             if config.get(option.name) or config.get(option.name) is False:
                 if t_opt.get('switch'):
-                    option_value = option.opts[-1] if config.get(option.name) else '--no-{}'.format(
-                        option.name.replace('_', '-'))
+                    option_value = option.opts[-1] if config.get(option.name
+                                                                ) else '--no-{}'.format(option.name.replace('_', '-'))
                 elif t_opt.get('is_flag'):
-                    is_default = config.get(option.name) == transport_cli.transport_option_default(
-                        option.name, computer)
+                    is_default = config.get(option.name
+                                           ) == transport_cli.transport_option_default(option.name, computer)
                     option_value = option.opts[-1] if is_default else ''
                 else:
                     option_value = '{}={}'.format(option.opts[-1], option.type(config[option.name]))

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -107,13 +107,15 @@ def bands_show(data, fmt):
     type=click.FLOAT,
     default=None,
     help='The minimum value for the y axis.'
-    ' Default: minimum of all bands')
+    ' Default: minimum of all bands'
+)
 @click.option(
     '--y-max-lim',
     type=click.FLOAT,
     default=None,
     help='The maximum value for the y axis.'
-    ' Default: maximum of all bands')
+    ' Default: maximum of all bands'
+)
 @click.option(
     '-o',
     '--output',
@@ -121,13 +123,15 @@ def bands_show(data, fmt):
     default=None,
     help="If present, store the output directly on a file "
     "with the given name. It is essential to use this option "
-    "if more than one file needs to be created.")
+    "if more than one file needs to be created."
+)
 @options.FORCE(help="If passed, overwrite files without checking.")
 @click.option(
     '--prettify-format',
     default=None,
     type=click.Choice(Prettifier.get_prettifiers()),
-    help='The style of labels for the prettifier')
+    help='The style of labels for the prettifier'
+)
 @decorators.with_dbenv()
 def bands_export(fmt, y_min_lim, y_max_lim, output, force, prettify_format, datum):
     """Export BandsData objects."""

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -44,8 +44,9 @@ def cif_list(raw, formula_mode, past_days, groups, all_users):
     elements = None
     elements_only = False
 
-    entry_list = data_list(CifData, LIST_PROJECT_HEADERS, elements, elements_only, formula_mode, past_days, groups,
-                           all_users)
+    entry_list = data_list(
+        CifData, LIST_PROJECT_HEADERS, elements, elements_only, formula_mode, past_days, groups, all_users
+    )
 
     counter = 0
     cif_list_data = list()

--- a/aiida/cmdline/commands/cmd_data/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_export.py
@@ -24,7 +24,8 @@ EXPORT_OPTIONS = [
         'reduce_symmetry',
         is_flag=True,
         default=None,
-        help='Do (default) or do not perform symmetry reduction.'),
+        help='Do (default) or do not perform symmetry reduction.'
+    ),
     click.option(
         '--parameter-data',
         type=click.INT,
@@ -35,26 +36,30 @@ EXPORT_OPTIONS = [
         " Dict in the output, aforementioned"
         " Dict is picked automatically. Instead, the"
         " option is used in the case the calculation produces"
-        " more than a single instance of Dict."),
+        " more than a single instance of Dict."
+    ),
     click.option(
         '--dump-aiida-database/--no-dump-aiida-database',
         'dump_aiida_database',
         is_flag=True,
         default=None,
-        help='Export (default) or do not export AiiDA database to the CIF file.'),
+        help='Export (default) or do not export AiiDA database to the CIF file.'
+    ),
     click.option(
         '--exclude-external-contents/--no-exclude-external-contents',
         'exclude_external_contents',
         is_flag=True,
         default=None,
-        help='Do not (default) or do save the contents for external resources even if URIs are provided'),
+        help='Do not (default) or do save the contents for external resources even if URIs are provided'
+    ),
     click.option('--gzip/--no-gzip', is_flag=True, default=None, help='Do or do not (default) gzip large files.'),
     click.option(
         '--gzip-threshold',
         type=click.INT,
         default=None,
         help="Specify the minimum size of exported file which should"
-        " be gzipped."),
+        " be gzipped."
+    ),
     click.option(
         '-o',
         '--output',
@@ -62,7 +67,8 @@ EXPORT_OPTIONS = [
         default=None,
         help="If present, store the output directly on a file "
         "with the given name. It is essential to use this option "
-        "if more than one file needs to be created."),
+        "if more than one file needs to be created."
+    ),
     options.FORCE(help="Overwrite files without checking."),
 ]
 
@@ -102,13 +108,17 @@ def data_export(node, output_fname, fileformat, other_args=None, overwrite=False
         else:
             filetext, extra_files = node._exportcontent(fileformat, main_file_name=output_fname, **other_args)
             if extra_files:
-                echo.echo_critical("This format requires to write more than one file.\n"
-                                   "You need to pass the -o option to specify a file name.")
+                echo.echo_critical(
+                    "This format requires to write more than one file.\n"
+                    "You need to pass the -o option to specify a file name."
+                )
             else:
                 echo.echo(filetext.decode('utf-8'))
     except TypeError as err:
         # This typically occurs for parameters that are passed down to the
         # methods in, e.g., BandsData, but they are not accepted
-        echo.echo_critical("TypeError, perhaps a parameter is not "
-                           "supported by the specific format?\nError "
-                           "message: {}".format(err))
+        echo.echo_critical(
+            "TypeError, perhaps a parameter is not "
+            "supported by the specific format?\nError "
+            "message: {}".format(err)
+        )

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -36,14 +36,17 @@ def remote_ls(ls_long, path, datum):
     try:
         content = datum.listdir_withattributes(path=path)
     except (IOError, OSError) as err:
-        echo.echo_critical('Unable to access the remote folde or file, check if it exists.\n'
-                           'Original error: {}'.format(str(err)))
+        echo.echo_critical(
+            'Unable to access the remote folde or file, check if it exists.\n'
+            'Original error: {}'.format(str(err))
+        )
     for metadata in content:
         if ls_long:
             mtime = datetime.datetime.fromtimestamp(metadata['attributes'].st_mtime)
             pre_line = '{} {:10}  {}  '.format(
                 get_mode_string(metadata['attributes'].st_mode), metadata['attributes'].st_size,
-                mtime.strftime("%d %b %Y %H:%M"))
+                mtime.strftime("%d %b %Y %H:%M")
+            )
             click.echo(pre_line, nl=False)
         if metadata['isdir']:
             click.echo(click.style(metadata['name'], fg='blue'))

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -29,17 +29,20 @@ SHOW_OPTIONS = [
         '--sampling-stepsize',
         type=click.INT,
         default=None,
-        help="Sample positions in plot every sampling_stepsize timestep"),
+        help="Sample positions in plot every sampling_stepsize timestep"
+    ),
     click.option(
         '--stepsize',
         type=click.INT,
         default=None,
-        help="The stepsize for the trajectory, set it higher to reduce number of points"),
+        help="The stepsize for the trajectory, set it higher to reduce number of points"
+    ),
     click.option('--mintime', type=click.INT, default=None, help="The time to plot from"),
     click.option('--maxtime', type=click.INT, default=None, help="The time to plot to"),
     click.option('--indices', type=click.INT, cls=MultipleValueOption, default=None, help="Show only these indices"),
     click.option(
-        '--dont-block', 'block', is_flag=True, default=True, help="Don't block interpreter when showing plot."),
+        '--dont-block', 'block', is_flag=True, default=True, help="Don't block interpreter when showing plot."
+    ),
 ]
 
 
@@ -70,8 +73,10 @@ def _show_jmol(exec_name, trajectory_list, **kwargs):
             echo.echo_info("the call to {} ended with an error.".format(exec_name))
         except OSError as err:
             if err.errno == 2:
-                echo.echo_critical("No executable '{}' found. Add to the path, "
-                                   "or try with an absolute path.".format(exec_name))
+                echo.echo_critical(
+                    "No executable '{}' found. Add to the path, "
+                    "or try with an absolute path.".format(exec_name)
+                )
             else:
                 raise
 
@@ -99,8 +104,10 @@ def _show_xcrysden(exec_name, object_list, **kwargs):
             echo.echo_info("the call to {} ended with an error.".format(exec_name))
         except OSError as err:
             if err.errno == 2:
-                echo.echo_critical("No executable '{}' found. Add to the path, "
-                                   "or try with an absolute path.".format(exec_name))
+                echo.echo_critical(
+                    "No executable '{}' found. Add to the path, "
+                    "or try with an absolute path.".format(exec_name)
+                )
             else:
                 raise
 
@@ -159,8 +166,10 @@ def _show_vesta(exec_name, structure_list):
             echo.echo_info("the call to {} ended with an error.".format(exec_name))
         except OSError as err:
             if err.errno == 2:
-                echo.echo_critical("No executable '{}' found. Add to the path, "
-                                   "or try with an absolute path.".format(exec_name))
+                echo.echo_critical(
+                    "No executable '{}' found. Add to the path, "
+                    "or try with an absolute path.".format(exec_name)
+                )
             else:
                 raise
 
@@ -188,8 +197,10 @@ def _show_vmd(exec_name, structure_list):
             echo.echo_info("the call to {} ended with an error.".format(exec_name))
         except OSError as err:
             if err.errno == 2:
-                echo.echo_critical("No executable '{}' found. Add to the path, "
-                                   "or try with an absolute path.".format(exec_name))
+                echo.echo_critical(
+                    "No executable '{}' found. Add to the path, "
+                    "or try with an absolute path.".format(exec_name)
+                )
             else:
                 raise
 
@@ -210,7 +221,8 @@ def _show_xmgrace(exec_name, list_bands):
         nbnds = bnds.get_bands().shape[1]
         # pylint: disable=protected-access
         text, _ = bnds._exportcontent(
-            'agr', setnumber_offset=current_band_number, color_number=(iband + 1 % max_num_agr_colors))
+            'agr', setnumber_offset=current_band_number, color_number=(iband + 1 % max_num_agr_colors)
+        )
         # write a tempfile
         tempf = tempfile.NamedTemporaryFile('w+', suffix='.agr')
         tempf.write(text)

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -40,12 +40,16 @@ def _store_structure(new_structure, dry_run):
     :param dry_run: if True, do not store but print a different message
     """
     if dry_run:
-        echo.echo('  Successfully imported structure {} (not storing it, dry-run requested)'.format(
-            new_structure.get_formula()))
+        echo.echo(
+            '  Successfully imported structure {} (not storing it, dry-run requested)'.format(
+                new_structure.get_formula()
+            )
+        )
     else:
         new_structure.store()
-        echo.echo('  Successfully imported structure {} (PK = {})'.format(new_structure.get_formula(),
-                                                                          new_structure.pk))
+        echo.echo(
+            '  Successfully imported structure {} (PK = {})'.format(new_structure.get_formula(), new_structure.pk)
+        )
 
 
 @verdi_data.group('structure')
@@ -65,8 +69,9 @@ def structure_list(elements, raw, formula_mode, past_days, groups, all_users):
     from tabulate import tabulate
 
     elements_only = False
-    lst = data_list(StructureData, LIST_PROJECT_HEADERS, elements, elements_only, formula_mode, past_days, groups,
-                    all_users)
+    lst = data_list(
+        StructureData, LIST_PROJECT_HEADERS, elements, elements_only, formula_mode, past_days, groups, all_users
+    )
 
     entry_list = []
     for [pid, label, akinds, asites] in lst:
@@ -168,20 +173,23 @@ def structure_import():
     type=click.FLOAT,
     show_default=True,
     default=1.0,
-    help="The factor by which the cell accomodating the structure should be increased (angstrom).")
+    help="The factor by which the cell accomodating the structure should be increased (angstrom)."
+)
 @click.option(
     '--vacuum-addition',
     type=click.FLOAT,
     show_default=True,
     default=10.0,
-    help='The distance to add to the unit cell after vacuum factor was applied to expand in each dimension (angstrom).')
+    help='The distance to add to the unit cell after vacuum factor was applied to expand in each dimension (angstrom).'
+)
 @click.option(
     '--pbc',
     type=click.INT,
     nargs=3,
     show_default=True,
     default=[0, 0, 0],
-    help='Set periodic boundary conditions for each lattice direction, where 0 means periodic and 1 means periodic')
+    help='Set periodic boundary conditions for each lattice direction, where 0 means periodic and 1 means periodic.'
+)
 @options.DRY_RUN()
 @decorators.with_dbenv()
 def import_aiida_xyz(filename, vacuum_factor, vacuum_addition, pbc, dry_run):
@@ -227,8 +235,10 @@ def import_qetools_pwinput(filename, dry_run):
     try:
         import qe_tools
     except ImportError:
-        echo.echo_critical("You have not installed the package qe-tools. \n"
-                           "You can install it with: pip install qe-tools")
+        echo.echo_critical(
+            "You have not installed the package qe-tools. \n"
+            "You can install it with: pip install qe-tools"
+        )
     from aiida.tools.data.structure import get_structuredata_from_qetools
 
     try:

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -44,8 +44,9 @@ def trajectory_list(raw, past_days, groups, all_users):
     elements = None
     elements_only = False
     formulamode = None
-    entry_list = data_list(TrajectoryData, LIST_PROJECT_HEADERS, elements, elements_only, formulamode, past_days,
-                           groups, all_users)
+    entry_list = data_list(
+        TrajectoryData, LIST_PROJECT_HEADERS, elements, elements_only, formulamode, past_days, groups, all_users
+    )
 
     counter = 0
     struct_list_data = list()

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -34,7 +34,8 @@ def upf():
     '--stop-if-existing',
     is_flag=True,
     default=False,
-    help='Interrupt pseudos import if a pseudo was already present in the AiiDA database')
+    help='Interrupt pseudos import if a pseudo was already present in the AiiDA database'
+)
 @decorators.with_dbenv()
 def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
     """
@@ -56,7 +57,8 @@ def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
     'with_description',
     is_flag=True,
     default=False,
-    help="Show also the description for the UPF family")
+    help="Show also the description for the UPF family"
+)
 @options.WITH_ELEMENTS()
 @decorators.with_dbenv()
 def upf_listfamilies(elements, with_description):
@@ -79,7 +81,8 @@ def upf_listfamilies(elements, with_description):
         project=["label", "description"],
         filters={"type_string": {
             '==': UPFGROUP_TYPE
-        }})
+        }}
+    )
 
     query.distinct()
     if query.count() > 0:

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -51,7 +51,8 @@ def database_migrate(force):
 
     expected_answer = 'MIGRATE NOW'
     confirm_message = 'If you have completed the steps above and want to migrate profile "{}", type {}'.format(
-        profile.name, expected_answer)
+        profile.name, expected_answer
+    )
 
     try:
         response = click.prompt(confirm_message)
@@ -76,9 +77,11 @@ def verdi_database_integrity():
     '--table',
     type=click.Choice(TABLES_UUID_DEDUPLICATION),
     default='db_dbnode',
-    help='The database table to operate on.')
+    help='The database table to operate on.'
+)
 @click.option(
-    '-a', '--apply-patch', is_flag=True, help='Actually apply the proposed changes instead of performing a dry run.')
+    '-a', '--apply-patch', is_flag=True, help='Actually apply the proposed changes instead of performing a dry run.'
+)
 def detect_duplicate_uuid(table, apply_patch):
     """Detect and solve entities with duplicate UUIDs in a given database table.
 

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -73,35 +73,43 @@ def inspect(archive, version, data, meta_data):
     '--input-forward/--no-input-forward',
     default=False,
     show_default=True,
-    help='Follow forward INPUT links (recursively) when calculating the node set to export.')
+    help='Follow forward INPUT links (recursively) when calculating the node set to export.'
+)
 @click.option(
     '--create-reversed/--no-create-reversed',
     default=True,
     show_default=True,
-    help='Follow reverse CREATE links (recursively) when calculating the node set to export.')
+    help='Follow reverse CREATE links (recursively) when calculating the node set to export.'
+)
 @click.option(
     '--return-reversed/--no-return-reversed',
     default=False,
     show_default=True,
-    help='Follow reverse RETURN links (recursively) when calculating the node set to export.')
+    help='Follow reverse RETURN links (recursively) when calculating the node set to export.'
+)
 @click.option(
     '--call-reversed/--no-call-reversed',
     default=False,
     show_default=True,
-    help='Follow reverse CALL links (recursively) when calculating the node set to export.')
+    help='Follow reverse CALL links (recursively) when calculating the node set to export.'
+)
 @click.option(
     '--include-logs/--exclude-logs',
     default=True,
     show_default=True,
-    help='Include or exclude logs for node(s) in export.')
+    help='Include or exclude logs for node(s) in export.'
+)
 @click.option(
     '--include-comments/--exclude-comments',
     default=True,
     show_default=True,
-    help='Include or exclude comments for node(s) in export. (Will also export extra users who commented).')
+    help='Include or exclude comments for node(s) in export. (Will also export extra users who commented).'
+)
 @decorators.with_dbenv()
-def create(output_file, codes, computers, groups, nodes, archive_format, force, input_forward, create_reversed,
-           return_reversed, call_reversed, include_comments, include_logs):
+def create(
+    output_file, codes, computers, groups, nodes, archive_format, force, input_forward, create_reversed,
+    return_reversed, call_reversed, include_comments, include_logs
+):
     """
     Export various entities, such as Codes, Computers, Groups and Nodes, to an archive file for backup or
     sharing purposes.

--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -30,26 +30,32 @@ def verdi_graph():
 @click.option(
     '-l',
     '--link-types',
-    help=("The link types to include: "
-          "'data' includes only 'input_calc' and 'create' links (data provenance only), "
-          "'logic' includes only 'input_work' and 'return' links (logical provenance only)."),
+    help=(
+        "The link types to include: "
+        "'data' includes only 'input_calc' and 'create' links (data provenance only), "
+        "'logic' includes only 'input_work' and 'return' links (logical provenance only)."
+    ),
     default="all",
-    type=click.Choice(['all', 'data', 'logic']))
+    type=click.Choice(['all', 'data', 'logic'])
+)
 @click.option(
     '--identifier',
     help="the type of identifier to use within the node text",
     default="uuid",
-    type=click.Choice(['pk', 'uuid', 'label']))
+    type=click.Choice(['pk', 'uuid', 'label'])
+)
 @click.option(
     '-a',
     '--ancestor-depth',
     help='The maximum depth when recursing upwards, if not set it will recurse to the end.',
-    type=click.IntRange(min=0))
+    type=click.IntRange(min=0)
+)
 @click.option(
     '-d',
     '--descendant-depth',
     help='The maximum depth when recursing through the descendants. If not set it will recurse to the end.',
-    type=click.IntRange(min=0))
+    type=click.IntRange(min=0)
+)
 @click.option('-o', '--process-out', is_flag=True, help='Show outgoing links for all processes.')
 @click.option('-i', '--process-in', is_flag=True, help='Show incoming links for all processes.')
 @options.VERBOSE(help="Print verbose information of the graph traversal.")
@@ -58,12 +64,15 @@ def verdi_graph():
     '--engine',
     help="The graphviz engine, e.g. 'dot', 'circo', ... "
     "(see http://www.graphviz.org/doc/info/output.html)",
-    default='dot')
+    default='dot'
+)
 @click.option('-f', '--output-format', help="The output format used for rendering ('pdf', 'png', etc.).", default='pdf')
 @click.option('-s', '--show', is_flag=True, help="Open the rendered result with the default application.")
 @decorators.with_dbenv()
-def generate(root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine,
-             verbose, output_format, show):
+def generate(
+    root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine, verbose,
+    output_format, show
+):
     """
     Generate a graph from a ROOT_NODE (specified by pk or uuid).
     """
@@ -81,7 +90,8 @@ def generate(root_node, link_types, identifier, ancestor_depth, descendant_depth
         link_types=link_types,
         annotate_links="both",
         include_process_outputs=process_out,
-        print_func=print_func)
+        print_func=print_func
+    )
     echo.echo_info("Recursing descendants, max depth={}".format(descendant_depth))
     graph.recurse_descendants(
         root_node,
@@ -89,8 +99,10 @@ def generate(root_node, link_types, identifier, ancestor_depth, descendant_depth
         link_types=link_types,
         annotate_links="both",
         include_process_inputs=process_in,
-        print_func=print_func)
+        print_func=print_func
+    )
     output_file_name = graph.graphviz.render(
-        filename='{}.{}'.format(root_node.pk, engine), format=output_format, view=show, cleanup=True)
+        filename='{}.{}'.format(root_node.pk, engine), format=output_format, view=show, cleanup=True
+    )
 
     echo.echo_success("Output file: {}".format(output_file_name))

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -78,9 +78,11 @@ def group_delete(group, clear, force):
     label = group.label
 
     if group.count() > 0 and not clear:
-        echo.echo_critical(
-            ('Group<{}> contains {} nodes. Pass `--clear` if you want to empty it before deleting the group'.format(
-                label, group.count())))
+        echo.echo_critical((
+            'Group<{}> contains {} nodes. Pass `--clear` if you want to empty it before deleting the group'.format(
+                label, group.count()
+            )
+        ))
 
     if not force:
         click.confirm('Are you sure to delete Group<{}>?'.format(label), abort=True)
@@ -129,7 +131,8 @@ def group_description(group, description):
     '--uuid',
     is_flag=True,
     default=False,
-    help="Show UUIDs together with PKs. Note: if the --raw option is also passed, PKs are not printed, but oly UUIDs.")
+    help="Show UUIDs together with PKs. Note: if the --raw option is also passed, PKs are not printed, but oly UUIDs."
+)
 @arguments.GROUP()
 @with_dbenv()
 def group_show(group, raw, uuid):
@@ -191,7 +194,8 @@ def user_defined_group():
     '--user',
     'user_email',
     type=click.STRING,
-    help="Add a filter to show only groups belonging to a specific user")
+    help="Add a filter to show only groups belonging to a specific user"
+)
 @click.option('-a', '--all-types', is_flag=True, default=False, help="Show groups of all types")
 @click.option(
     '-t',
@@ -200,9 +204,11 @@ def user_defined_group():
     type=types.LazyChoice(valid_group_type_strings),
     default=user_defined_group,
     help="Show groups of a specific type, instead of user-defined groups. Start with semicolumn if you want to "
-    "specify aiida-internal type")
+    "specify aiida-internal type"
+)
 @click.option(
-    '-d', '--with-description', 'with_description', is_flag=True, default=False, help="Show also the group description")
+    '-d', '--with-description', 'with_description', is_flag=True, default=False, help="Show also the group description"
+)
 @click.option('-C', '--count', is_flag=True, default=False, help="Show also the number of nodes in the group")
 @options.PAST_DAYS(help="add a filter to show only groups created in the past N days", default=None)
 @click.option(
@@ -210,23 +216,28 @@ def user_defined_group():
     '--startswith',
     type=click.STRING,
     default=None,
-    help="add a filter to show only groups for which the name begins with STRING")
+    help="add a filter to show only groups for which the name begins with STRING"
+)
 @click.option(
     '-e',
     '--endswith',
     type=click.STRING,
     default=None,
-    help="add a filter to show only groups for which the name ends with STRING")
+    help="add a filter to show only groups for which the name ends with STRING"
+)
 @click.option(
     '-c',
     '--contains',
     type=click.STRING,
     default=None,
-    help="add a filter to show only groups for which the name contains STRING")
+    help="add a filter to show only groups for which the name contains STRING"
+)
 @options.NODE(help="Show only the groups that contain the node")
 @with_dbenv()
-def group_list(all_users, user_email, all_types, group_type, with_description, count, past_days, startswith, endswith,
-               contains, node):
+def group_list(
+    all_users, user_email, all_types, group_type, with_description, count, past_days, startswith, endswith, contains,
+    node
+):
     """Show a list of groups."""
     # pylint: disable=too-many-branches,too-many-arguments, too-many-locals
     import datetime

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -82,7 +82,8 @@ def _try_import(migration_performed, file_to_import, archive, group, migration, 
                         "Do you want to try and migrate {} to the newest export file version?\n"
                         "Note: This will not change your current file.".format(archive),
                         default=True,
-                        abort=True)
+                        abort=True
+                    )
             else:
                 # Abort
                 echo.echo_critical(str(exception))
@@ -121,10 +122,13 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
     # Migration
     try:
         ctx.invoke(
-            migrate, input_file=file_to_import, output_file=temp_folder.get_abs_path(temp_out_file), silent=False)
+            migrate, input_file=file_to_import, output_file=temp_folder.get_abs_path(temp_out_file), silent=False
+        )
     except Exception:
-        echo.echo_error("an exception occurred while migrating the archive {}.\n"
-                        "Use 'verdi export migrate' to update this export file.".format(archive))
+        echo.echo_error(
+            "an exception occurred while migrating the archive {}.\n"
+            "Use 'verdi export migrate' to update this export file.".format(archive)
+        )
         echo.echo(traceback.format_exc())
         if not non_interactive:
             click.confirm('do you want to continue?', abort=True)
@@ -142,11 +146,13 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
     type=click.STRING,
     cls=options.MultipleValueOption,
     help="Discover all URL targets pointing to files with the .aiida extension for these HTTP addresses. "
-    "Automatically discovered archive URLs will be downloadeded and added to ARCHIVES for importing")
+    "Automatically discovered archive URLs will be downloadeded and added to ARCHIVES for importing"
+)
 @options.GROUP(
     type=GroupParamType(create_if_not_exist=True),
     help='Specify group to which all the import nodes will be added. If such a group does not exist, it will be'
-    ' created automatically.')
+    ' created automatically.'
+)
 @click.option(
     '-e',
     '--extras-mode-existing',
@@ -158,7 +164,8 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
     "keep_existing: import all extras and keep original value of existing extras. "
     "update_existing: import all extras and overwrite value of existing extras. "
     "mirror: import all extras and remove any existing extras that are not present in the archive. "
-    "none: do not import any extras.")
+    "none: do not import any extras."
+)
 @click.option(
     '-n',
     '--extras-mode-new',
@@ -166,24 +173,28 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
     default='import',
     help="Specify whether to import extras of new nodes: "
     "import: import extras. "
-    "none: do not import extras.")
+    "none: do not import extras."
+)
 @click.option(
     '--comment-mode',
     type=click.Choice(COMMENT_MODE),
     default='newest',
     help="Specify the way to import Comments with identical UUIDs: "
     "newest: Only the newest Comments (based on mtime) (default)."
-    "overwrite: Replace existing Comments with those from the import file.")
+    "overwrite: Replace existing Comments with those from the import file."
+)
 @click.option(
     '--migration/--no-migration',
     default=True,
     show_default=True,
-    help="Force migration of export file archives, if needed.")
+    help="Force migration of export file archives, if needed."
+)
 @options.NON_INTERACTIVE()
 @decorators.with_dbenv()
 @click.pass_context
-def cmd_import(ctx, archives, webpages, group, extras_mode_existing, extras_mode_new, comment_mode, migration,
-               non_interactive):
+def cmd_import(
+    ctx, archives, webpages, group, extras_mode_existing, extras_mode_new, comment_mode, migration, non_interactive
+):
     """Import one or multiple exported AiiDA archives
 
     The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -260,7 +260,8 @@ class NodeTreePrinter(object):  # pylint: disable=useless-object-inheritance
         # pylint: disable=unused-variable
         for entry in sorted(node.get_outgoing(link_type=follow_links).all(), key=cls._ctime):
             child_str = cls._build_tree(
-                entry.node, show_pk, follow_links=follow_links, max_depth=max_depth, depth=depth + 1)
+                entry.node, show_pk, follow_links=follow_links, max_depth=max_depth, depth=depth + 1
+            )
             if child_str:
                 children.append(child_str)
 

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -32,7 +32,8 @@ def verdi_process():
 
 @verdi_process.command('list')
 @options.PROJECT(
-    type=click.Choice(CalculationQueryBuilder.valid_projections), default=CalculationQueryBuilder.default_projections)
+    type=click.Choice(CalculationQueryBuilder.valid_projections), default=CalculationQueryBuilder.default_projections
+)
 @options.ORDER_BY()
 @options.ORDER_DIRECTION()
 @options.GROUP(help='Only include entries that are a member of this group.')
@@ -45,8 +46,10 @@ def verdi_process():
 @options.LIMIT()
 @options.RAW()
 @decorators.with_dbenv()
-def process_list(all_entries, group, process_state, process_label, exit_status, failed, past_days, limit, project, raw,
-                 order_by, order_dir):
+def process_list(
+    all_entries, group, process_state, process_label, exit_status, failed, past_days, limit, project, raw, order_by,
+    order_dir
+):
     """Show a list of processes that are still running."""
     # pylint: disable=too-many-locals
     from tabulate import tabulate
@@ -60,7 +63,8 @@ def process_list(all_entries, group, process_state, process_label, exit_status, 
     builder = CalculationQueryBuilder()
     filters = builder.get_filters(all_entries, process_state, process_label, exit_status, failed)
     query_set = builder.get_query_set(
-        relationships=relationships, filters=filters, order_by={order_by: order_dir}, past_days=past_days, limit=limit)
+        relationships=relationships, filters=filters, order_by={order_by: order_dir}, past_days=past_days, limit=limit
+    )
     projected = builder.get_projected(query_set, projections=project)
 
     headers = projected.pop(0)
@@ -127,9 +131,11 @@ def process_call_root(processes):
     '--levelname',
     type=click.Choice(LOG_LEVELS.keys()),
     default='REPORT',
-    help='Filter the results by name of the log level.')
+    help='Filter the results by name of the log level.'
+)
 @click.option(
-    '-m', '--max-depth', 'max_depth', type=int, default=None, help='Limit the number of levels to be printed.')
+    '-m', '--max-depth', 'max_depth', type=int, default=None, help='Limit the number of levels to be printed.'
+)
 @decorators.with_dbenv()
 def process_report(processes, levelname, indent_size, max_depth):
     """Show the log report for one or multiple processes."""
@@ -164,7 +170,8 @@ def process_status(processes):
 @click.option(
     '--wait/--no-wait',
     default=False,
-    help="Wait for the action to be completed otherwise return as soon as it's scheduled.")
+    help="Wait for the action to be completed otherwise return as soon as it's scheduled."
+)
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_kill(processes, timeout, wait):
@@ -195,7 +202,8 @@ def process_kill(processes, timeout, wait):
 @click.option(
     '--wait/--no-wait',
     default=False,
-    help="Wait for the action to be completed otherwise return as soon as it's scheduled.")
+    help="Wait for the action to be completed otherwise return as soon as it's scheduled."
+)
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_pause(processes, timeout, wait):
@@ -226,7 +234,8 @@ def process_pause(processes, timeout, wait):
 @click.option(
     '--wait/--no-wait',
     default=False,
-    help="Wait for the action to be completed otherwise return as soon as it's scheduled.")
+    help="Wait for the action to be completed otherwise return as soon as it's scheduled."
+)
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_play(processes, timeout, wait):
@@ -334,8 +343,9 @@ def process_actions(futures_map, infinitive, present, past, wait=False, timeout=
                     echo.echo_success('scheduled {} Process<{}>'.format(infinitive, process.pk))
                     scheduled[result] = process
                 else:
-                    echo.echo_error('got unexpected response when {} Process<{}>: {}'.format(
-                        present, process.pk, result))
+                    echo.echo_error(
+                        'got unexpected response when {} Process<{}>: {}'.format(present, process.pk, result)
+                    )
 
         if wait and scheduled:
             echo.echo_info('waiting for process(es) {}'.format(','.join([str(proc.pk) for proc in scheduled.values()])))
@@ -353,8 +363,9 @@ def process_actions(futures_map, infinitive, present, past, wait=False, timeout=
                     elif result is False:
                         echo.echo_error('problem {} Process<{}>'.format(present, process.pk))
                     else:
-                        echo.echo_error('got unexpected response when {} Process<{}>: {}'.format(
-                            present, process.pk, result))
+                        echo.echo_error(
+                            'got unexpected response when {} Process<{}>: {}'.format(present, process.pk, result)
+                        )
 
     except futures.TimeoutError:
         echo.echo_error('timed out trying to {} processes {}'.format(infinitive, futures_map.values()))

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -82,14 +82,17 @@ def profile_setdefault(profile):
     '--include-config/--skip-config',
     default=True,
     show_default=True,
-    help='Include deletion of entry in configuration file.')
+    help='Include deletion of entry in configuration file.'
+)
 @click.option(
-    '--include-db/--skip-db', default=True, show_default=True, help='Include deletion of associated database.')
+    '--include-db/--skip-db', default=True, show_default=True, help='Include deletion of associated database.'
+)
 @click.option(
     '--include-repository/--skip-repository',
     default=True,
     show_default=True,
-    help='Include deletion of associated file repository.')
+    help='Include deletion of associated file repository.'
+)
 @arguments.PROFILES(required=True)
 def profile_delete(force, include_config, include_db, include_repository, profiles):
     """
@@ -105,4 +108,5 @@ def profile_delete(force, include_config, include_db, include_repository, profil
             non_interactive=force,
             include_db=include_db,
             include_repository=include_repository,
-            include_config=include_config)
+            include_config=include_config
+        )

--- a/aiida/cmdline/commands/cmd_rehash.py
+++ b/aiida/cmdline/commands/cmd_rehash.py
@@ -27,7 +27,8 @@ from aiida.cmdline.utils import decorators, echo
     '--entry-point',
     type=PluginParamType(group=('aiida.calculations', 'aiida.data', 'aiida.workflows'), load=True),
     default=None,
-    help='Only include nodes that are class or sub class of the class identified by this entry point.')
+    help='Only include nodes that are class or sub class of the class identified by this entry point.'
+)
 @decorators.with_dbenv()
 def rehash(nodes, entry_point):
     """Recompute the hash for nodes in the database

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -34,14 +34,16 @@ CONFIG_DIR = os.path.join(os.path.split(os.path.abspath(aiida.restapi.__file__))
     '--config-dir',
     type=click.Path(exists=True),
     default=CONFIG_DIR,
-    help='the path of the configuration directory')
+    help='the path of the configuration directory'
+)
 @click.option('--debug', 'debug', is_flag=True, default=False, help='run app in debug mode')
 @click.option(
     '--wsgi-profile',
     'wsgi_profile',
     is_flag=True,
     default=False,
-    help='to use WSGI profiler middleware for finding bottlenecks in web application')
+    help='to use WSGI profiler middleware for finding bottlenecks in web application'
+)
 @click.option('--hookup/--no-hookup', 'hookup', is_flag=True, default=True, help='to hookup app')
 def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup):
     """
@@ -65,7 +67,8 @@ def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup):
         debug=debug,
         wsgi_profile=wsgi_profile,
         hookup=hookup,
-        catch_internal_server=True)
+        catch_internal_server=True
+    )
 
     # Invoke the runner
     run_api(App, AiidaApi, **kwargs)

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -43,19 +43,22 @@ def update_environment(new_argv):
 @click.option('-n', '--group-name', type=click.STRING, required=False, help='Specify the name of the auto group')
 @click.option('-e', '--exclude', cls=MultipleValueOption, default=[], help='Exclude these classes from auto grouping')
 @click.option(
-    '-i', '--include', cls=MultipleValueOption, default=['all'], help='Include these classes from auto grouping')
+    '-i', '--include', cls=MultipleValueOption, default=['all'], help='Include these classes from auto grouping'
+)
 @click.option(
     '-E',
     '--excludesubclasses',
     cls=MultipleValueOption,
     default=[],
-    help='Exclude these classes and their sub classes from auto grouping')
+    help='Exclude these classes and their sub classes from auto grouping'
+)
 @click.option(
     '-I',
     '--includesubclasses',
     cls=MultipleValueOption,
     default=[],
-    help='Include these classes and their sub classes from auto grouping')
+    help='Include these classes and their sub classes from auto grouping'
+)
 @decorators.with_dbenv()
 def run(scriptname, varargs, group, group_name, exclude, excludesubclasses, include, includesubclasses):
     # pylint: disable=too-many-arguments,exec-used

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -38,8 +38,10 @@ from aiida.manage.manager import get_manager
 @options_setup.SETUP_DATABASE_PASSWORD()
 @options_setup.SETUP_REPOSITORY_URI()
 @options.CONFIG_FILE()
-def setup(non_interactive, profile, email, first_name, last_name, institution, db_engine, db_backend, db_host, db_port,
-          db_name, db_username, db_password, repository):
+def setup(
+    non_interactive, profile, email, first_name, last_name, institution, db_engine, db_backend, db_host, db_port,
+    db_name, db_username, db_password, repository
+):
     """Setup a new profile."""
     # pylint: disable=too-many-arguments,too-many-locals,unused-argument
     from aiida import orm
@@ -72,7 +74,8 @@ def setup(non_interactive, profile, email, first_name, last_name, institution, d
         backend.migrate()
     except Exception as exception:  # pylint: disable=broad-except
         echo.echo_critical(
-            'database migration failed, probably because connection details are incorrect:\n{}'.format(exception))
+            'database migration failed, probably because connection details are incorrect:\n{}'.format(exception)
+        )
     else:
         echo.echo_success('database migration completed.')
 
@@ -84,7 +87,8 @@ def setup(non_interactive, profile, email, first_name, last_name, institution, d
 
     # Create the user if it does not yet exist
     created, user = orm.User.objects.get_or_create(
-        email=email, first_name=first_name, last_name=last_name, institution=institution)
+        email=email, first_name=first_name, last_name=last_name, institution=institution
+    )
     if created:
         user.store()
     profile.default_user = user.email
@@ -115,8 +119,10 @@ def setup(non_interactive, profile, email, first_name, last_name, institution, d
 @options_setup.QUICKSETUP_REPOSITORY_URI()
 @options.CONFIG_FILE()
 @click.pass_context
-def quicksetup(ctx, non_interactive, profile, email, first_name, last_name, institution, db_engine, db_backend, db_host,
-               db_port, db_name, db_username, db_password, su_db_name, su_db_username, su_db_password, repository):
+def quicksetup(
+    ctx, non_interactive, profile, email, first_name, last_name, institution, db_engine, db_backend, db_host, db_port,
+    db_name, db_username, db_password, su_db_name, su_db_username, su_db_password, repository
+):
     """Setup a new profile where the database is automatically created and configured."""
     # pylint: disable=too-many-arguments,too-many-locals
     from aiida.manage.external.postgres import Postgres, manual_setup_instructions
@@ -142,13 +148,15 @@ def quicksetup(ctx, non_interactive, profile, email, first_name, last_name, inst
         if create:
             postgres.create_db(db_username, db_name)
     except Exception as exception:
-        echo.echo_error('\n'.join([
-            'Oops! quicksetup was unable to create the AiiDA database for you.',
-            'For AiiDA to work, please either create the database yourself as follows:',
-            manual_setup_instructions(dbuser=su_db_username, dbname=su_db_name), '',
-            'Alternatively, give your (operating system) user permission to create postgresql databases' +
-            'and run quicksetup again.', ''
-        ]))
+        echo.echo_error(
+            '\n'.join([
+                'Oops! quicksetup was unable to create the AiiDA database for you.',
+                'For AiiDA to work, please either create the database yourself as follows:',
+                manual_setup_instructions(dbuser=su_db_username, dbname=su_db_name), '',
+                'Alternatively, give your (operating system) user permission to create postgresql databases' +
+                'and run quicksetup again.', ''
+            ])
+        )
         raise exception
 
     # The contextual defaults or `verdi setup` are not being called when `invoking`, so we have to explicitly define

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -27,12 +27,14 @@ from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 @click.option(
     '--no-startup',
     is_flag=True,
-    help='When using plain Python, ignore the PYTHONSTARTUP environment variable and ~/.pythonrc.py script.')
+    help='When using plain Python, ignore the PYTHONSTARTUP environment variable and ~/.pythonrc.py script.'
+)
 @click.option(
     '-i',
     '--interface',
     type=click.Choice(AVAILABLE_SHELLS.keys()),
-    help='Specify an interactive interpreter interface.')
+    help='Specify an interactive interpreter interface.'
+)
 def shell(plain, no_startup, interface):
     """Start a python shell with preloaded AiiDA environment."""
 

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -78,34 +78,39 @@ def user_list():
     prompt='User email',
     help='Email address that serves as the user name and a way to identify data created by it.',
     type=types.UserParamType(create=True),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 @click.option(
     '--first-name',
     prompt='First name',
     help='First name of the user.',
     type=click.STRING,
     contextual_default=partial(get_user_attribute_default, 'first_name'),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 @click.option(
     '--last-name',
     prompt='Last name',
     help='Last name of the user.',
     type=click.STRING,
     contextual_default=partial(get_user_attribute_default, 'last_name'),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 @click.option(
     '--institution',
     prompt='Institution',
     help='Institution of the user.',
     type=click.STRING,
     contextual_default=partial(get_user_attribute_default, 'institution'),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 @click.option(
     '--set-default',
     prompt='Set as default?',
     help='Set the user as the default user for the current profile.',
     is_flag=True,
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 @click.pass_context
 @decorators.with_dbenv()
 def user_configure(ctx, user, first_name, last_name, institution, set_default):

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -7,7 +7,6 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# yapf: disable
 """Module with pre-defined reusable commandline options that can be used as `click` decorators."""
 from __future__ import division
 from __future__ import print_function
@@ -58,358 +57,392 @@ def active_process_states():
 
 
 PROFILE = OverridableOption(
-    '-p', '--profile', 'profile',
+    '-p',
+    '--profile',
+    'profile',
     type=types.ProfileParamType(),
     default=defaults.get_default_profile,
-    help='Execute the command for this profile instead of the default profile.')
+    help='Execute the command for this profile instead of the default profile.'
+)
 
 CALCULATION = OverridableOption(
-    '-C', '--calculation', 'calculation',
+    '-C',
+    '--calculation',
+    'calculation',
     type=types.CalculationParamType(),
-    help='A single calculation identified by its ID or UUID.')
+    help='A single calculation identified by its ID or UUID.'
+)
 
 CALCULATIONS = OverridableOption(
-    '-C', '--calculations', 'calculations',
-    type=types.CalculationParamType(), cls=MultipleValueOption,
-    help='One or multiple calculations identified by their ID or UUID.')
+    '-C',
+    '--calculations',
+    'calculations',
+    type=types.CalculationParamType(),
+    cls=MultipleValueOption,
+    help='One or multiple calculations identified by their ID or UUID.'
+)
 
 CODE = OverridableOption(
-    '-X', '--code', 'code',
-    type=types.CodeParamType(),
-    help='A single code identified by its ID, UUID or label.')
+    '-X', '--code', 'code', type=types.CodeParamType(), help='A single code identified by its ID, UUID or label.'
+)
 
 CODES = OverridableOption(
-    '-X', '--codes', 'codes',
-    type=types.CodeParamType(), cls=MultipleValueOption,
-    help='One or multiple codes identified by their ID, UUID or label.')
+    '-X',
+    '--codes',
+    'codes',
+    type=types.CodeParamType(),
+    cls=MultipleValueOption,
+    help='One or multiple codes identified by their ID, UUID or label.'
+)
 
 COMPUTER = OverridableOption(
-    '-Y', '--computer', 'computer',
+    '-Y',
+    '--computer',
+    'computer',
     type=types.ComputerParamType(),
-    help='A single computer identified by its ID, UUID or label.')
+    help='A single computer identified by its ID, UUID or label.'
+)
 
 COMPUTERS = OverridableOption(
-    '-Y', '--computers', 'computers',
-    type=types.ComputerParamType(), cls=MultipleValueOption,
-    help='One or multiple computers identified by their ID, UUID or label.')
+    '-Y',
+    '--computers',
+    'computers',
+    type=types.ComputerParamType(),
+    cls=MultipleValueOption,
+    help='One or multiple computers identified by their ID, UUID or label.'
+)
 
 DATUM = OverridableOption(
-    '-D', '--datum', 'datum',
-    type=types.DataParamType(),
-    help='A single datum identified by its ID, UUID or label.')
+    '-D', '--datum', 'datum', type=types.DataParamType(), help='A single datum identified by its ID, UUID or label.'
+)
 
 DATA = OverridableOption(
-    '-D', '--data', 'data',
-    type=types.DataParamType(), cls=MultipleValueOption,
-    help='One or multiple data identified by their ID, UUID or label.')
+    '-D',
+    '--data',
+    'data',
+    type=types.DataParamType(),
+    cls=MultipleValueOption,
+    help='One or multiple data identified by their ID, UUID or label.'
+)
 
 GROUP = OverridableOption(
-    '-G', '--group', 'group',
-    type=types.GroupParamType(),
-    help='A single group identified by its ID, UUID or label.')
+    '-G', '--group', 'group', type=types.GroupParamType(), help='A single group identified by its ID, UUID or label.'
+)
 
 GROUPS = OverridableOption(
-    '-G', '--groups', 'groups',
-    type=types.GroupParamType(), cls=MultipleValueOption,
-    help='One or multiple groups identified by their ID, UUID or label.')
+    '-G',
+    '--groups',
+    'groups',
+    type=types.GroupParamType(),
+    cls=MultipleValueOption,
+    help='One or multiple groups identified by their ID, UUID or label.'
+)
 
 NODE = OverridableOption(
-    '-N', '--node', 'node',
-    type=types.NodeParamType(),
-    help='A single node identified by its ID or UUID.')
+    '-N', '--node', 'node', type=types.NodeParamType(), help='A single node identified by its ID or UUID.'
+)
 
 NODES = OverridableOption(
-    '-N', '--nodes', 'nodes',
-    type=types.NodeParamType(), cls=MultipleValueOption,
-    help='One or multiple nodes identified by their ID or UUID.')
+    '-N',
+    '--nodes',
+    'nodes',
+    type=types.NodeParamType(),
+    cls=MultipleValueOption,
+    help='One or multiple nodes identified by their ID or UUID.'
+)
 
-FORCE = OverridableOption(
-    '-f', '--force',
-    is_flag=True, default=False,
-    help='Do not ask for confirmation.')
+FORCE = OverridableOption('-f', '--force', is_flag=True, default=False, help='Do not ask for confirmation.')
 
-SILENT = OverridableOption(
-    '-s', '--silent',
-    is_flag=True, default=False,
-    help='Suppress any output printed to stdout.')
+SILENT = OverridableOption('-s', '--silent', is_flag=True, default=False, help='Suppress any output printed to stdout.')
 
 VISUALIZATION_FORMAT = OverridableOption(
-    '-F', '--format', 'fmt', show_default=True, help='Format of the visualized output.')
+    '-F', '--format', 'fmt', show_default=True, help='Format of the visualized output.'
+)
 
-INPUT_FORMAT = OverridableOption(
-    '-F', '--format', 'fmt', show_default=True, help='Format of the input file.')
+INPUT_FORMAT = OverridableOption('-F', '--format', 'fmt', show_default=True, help='Format of the input file.')
 
-EXPORT_FORMAT = OverridableOption(
-    '-F', '--format', 'fmt', show_default=True, help='Format of the exported file.')
+EXPORT_FORMAT = OverridableOption('-F', '--format', 'fmt', show_default=True, help='Format of the exported file.')
 
 ARCHIVE_FORMAT = OverridableOption(
-    '-F', '--archive-format',
-    type=click.Choice(['zip', 'zip-uncompressed', 'tar.gz']), default='zip', show_default=True,
-    help='The format of the archive file.')
+    '-F',
+    '--archive-format',
+    type=click.Choice(['zip', 'zip-uncompressed', 'tar.gz']),
+    default='zip',
+    show_default=True,
+    help='The format of the archive file.'
+)
 
 NON_INTERACTIVE = OverridableOption(
-    '-n', '--non-interactive',
-    is_flag=True, is_eager=True,
-    help='Non-interactive mode: never prompt for input.')
+    '-n', '--non-interactive', is_flag=True, is_eager=True, help='Non-interactive mode: never prompt for input.'
+)
 
-DRY_RUN = OverridableOption(
-    '-n', '--dry-run', is_flag=True,
-    help='Perform a dry run.')
+DRY_RUN = OverridableOption('-n', '--dry-run', is_flag=True, help='Perform a dry run.')
 
 USER_EMAIL = OverridableOption(
     '--email',
-    type=click.STRING, prompt='Email Address (identifies your data when sharing)',
+    type=click.STRING,
+    prompt='Email Address (identifies your data when sharing)',
     help='Email address that will be associated with your data and will be exported along with it, '
-    'should you choose to share any of your work.')
+    'should you choose to share any of your work.'
+)
 
 USER_FIRST_NAME = OverridableOption(
-    '--first-name',
-    type=click.STRING, prompt='First name',
-    help='First name of the user.')
+    '--first-name', type=click.STRING, prompt='First name', help='First name of the user.'
+)
 
-USER_LAST_NAME = OverridableOption(
-    '--last-name',
-    type=click.STRING, prompt='Last name',
-    help='Last name of the user.')
+USER_LAST_NAME = OverridableOption('--last-name', type=click.STRING, prompt='Last name', help='Last name of the user.')
 
 USER_INSTITUTION = OverridableOption(
-    '--institution',
-    type=click.STRING, prompt='Institution',
-    help='Institution name of the user.')
+    '--institution', type=click.STRING, prompt='Institution', help='Institution name of the user.'
+)
 
 BACKEND = OverridableOption(
     '--backend',
-    type=click.Choice([BACKEND_DJANGO, BACKEND_SQLA]), default=BACKEND_DJANGO,
-    help='Database backend to use.')
+    type=click.Choice([BACKEND_DJANGO, BACKEND_SQLA]),
+    default=BACKEND_DJANGO,
+    help='Database backend to use.'
+)
 
-DB_HOST = OverridableOption(
-    '--db-host',
-    type=click.STRING,
-    help='Database server host.')
+DB_HOST = OverridableOption('--db-host', type=click.STRING, help='Database server host.')
 
-DB_PORT = OverridableOption(
-    '--db-port',
-    type=click.INT,
-    help='Database server port.')
+DB_PORT = OverridableOption('--db-port', type=click.INT, help='Database server port.')
 
-DB_USERNAME = OverridableOption(
-    '--db-username',
-    type=click.STRING,
-    help='Database user name.')
+DB_USERNAME = OverridableOption('--db-username', type=click.STRING, help='Database user name.')
 
-DB_PASSWORD = OverridableOption(
-    '--db-password',
-    type=click.STRING,
-    help='Database user password.')
+DB_PASSWORD = OverridableOption('--db-password', type=click.STRING, help='Database user password.')
 
-DB_NAME = OverridableOption(
-    '--db-name',
-    type=click.STRING,
-    help='Database name.')
+DB_NAME = OverridableOption('--db-name', type=click.STRING, help='Database name.')
 
 REPOSITORY_PATH = OverridableOption(
-    '--repository',
-    type=click.Path(file_okay=False),
-    help='Absolute path for the file system repository.')
+    '--repository', type=click.Path(file_okay=False), help='Absolute path for the file system repository.'
+)
 
 PROFILE_ONLY_CONFIG = OverridableOption(
-    '--only-config',
-    is_flag=True, default=False,
-    help='Only configure the user and skip creating the database.')
+    '--only-config', is_flag=True, default=False, help='Only configure the user and skip creating the database.'
+)
 
 PROFILE_SET_DEFAULT = OverridableOption(
-    '--set-default',
-    is_flag=True, default=False,
-    help='Set the profile as the new default.')
+    '--set-default', is_flag=True, default=False, help='Set the profile as the new default.'
+)
 
 PREPEND_TEXT = OverridableOption(
-    '--prepend-text',
-    type=click.STRING, default='',
-    help='Bash script to be executed before an action.')
+    '--prepend-text', type=click.STRING, default='', help='Bash script to be executed before an action.'
+)
 
 APPEND_TEXT = OverridableOption(
-    '--append-text',
-    type=click.STRING, default='',
-    help='Bash script to be executed after an action has completed.')
+    '--append-text', type=click.STRING, default='', help='Bash script to be executed after an action has completed.'
+)
 
-LABEL = OverridableOption(
-    '-L', '--label',
-    type=click.STRING, metavar='LABEL',
-    help='Short name to be used as a label.')
+LABEL = OverridableOption('-L', '--label', type=click.STRING, metavar='LABEL', help='Short name to be used as a label.')
 
 DESCRIPTION = OverridableOption(
-    '-D', '--description',
-    type=click.STRING, metavar='DESCRIPTION', default='', required=False,
-    help='A detailed description.')
+    '-D',
+    '--description',
+    type=click.STRING,
+    metavar='DESCRIPTION',
+    default='',
+    required=False,
+    help='A detailed description.'
+)
 
 INPUT_PLUGIN = OverridableOption(
-    '-P', '--input-plugin',
-    type=types.PluginParamType(group='calculations'),
-    help='Calculation input plugin string.')
+    '-P', '--input-plugin', type=types.PluginParamType(group='calculations'), help='Calculation input plugin string.'
+)
 
 CALC_JOB_STATE = OverridableOption(
-    '-s', '--calc-job-state', 'calc_job_state',
-    type=types.LazyChoice(valid_calc_job_states), cls=MultipleValueOption,
-    help='Only include entries with this calculation job state.')
+    '-s',
+    '--calc-job-state',
+    'calc_job_state',
+    type=types.LazyChoice(valid_calc_job_states),
+    cls=MultipleValueOption,
+    help='Only include entries with this calculation job state.'
+)
 
 PROCESS_STATE = OverridableOption(
-    '-S', '--process-state', 'process_state',
-    type=types.LazyChoice(valid_process_states), cls=MultipleValueOption, default=active_process_states,
-    help='Only include entries with this process state.')
+    '-S',
+    '--process-state',
+    'process_state',
+    type=types.LazyChoice(valid_process_states),
+    cls=MultipleValueOption,
+    default=active_process_states,
+    help='Only include entries with this process state.'
+)
 
 PROCESS_LABEL = OverridableOption(
-    '-L', '--process-label', 'process_label',
-    type=click.STRING, required=False,
-    help='Only include entries whose process label matches this filter.')
+    '-L',
+    '--process-label',
+    'process_label',
+    type=click.STRING,
+    required=False,
+    help='Only include entries whose process label matches this filter.'
+)
 
 EXIT_STATUS = OverridableOption(
-    '-E', '--exit-status', 'exit_status',
-    type=click.INT,
-    help='Only include entries with this exit status.')
+    '-E', '--exit-status', 'exit_status', type=click.INT, help='Only include entries with this exit status.'
+)
 
 FAILED = OverridableOption(
-    '-X', '--failed', 'failed',
-    is_flag=True, default=False,
-    help='Only include entries that have failed.')
+    '-X', '--failed', 'failed', is_flag=True, default=False, help='Only include entries that have failed.'
+)
 
 LIMIT = OverridableOption(
-    '-l', '--limit', 'limit',
-    type=click.INT, default=None,
-    help='Limit the number of entries to display.')
+    '-l', '--limit', 'limit', type=click.INT, default=None, help='Limit the number of entries to display.'
+)
 
 PROJECT = OverridableOption(
-    '-P', '--project', 'project',
-    cls=MultipleValueOption,
-    help='Select the list of entity attributes to project.')
+    '-P', '--project', 'project', cls=MultipleValueOption, help='Select the list of entity attributes to project.'
+)
 
 ORDER_BY = OverridableOption(
-    '-O', '--order-by', 'order_by',
-    type=click.Choice(['id', 'ctime']), default='ctime', show_default=True,
-    help='Order the entries by this attribute.')
+    '-O',
+    '--order-by',
+    'order_by',
+    type=click.Choice(['id', 'ctime']),
+    default='ctime',
+    show_default=True,
+    help='Order the entries by this attribute.'
+)
 
 ORDER_DIRECTION = OverridableOption(
-    '-D', '--order-direction', 'order_dir',
-    type=click.Choice(['asc', 'desc']), default='asc', show_default=True,
-    help='List the entries in ascending or descending order')
+    '-D',
+    '--order-direction',
+    'order_dir',
+    type=click.Choice(['asc', 'desc']),
+    default='asc',
+    show_default=True,
+    help='List the entries in ascending or descending order'
+)
 
 PAST_DAYS = OverridableOption(
-    '-p', '--past-days', 'past_days',
-    type=click.INT, metavar='PAST_DAYS',
-    help='Only include entries created in the last PAST_DAYS number of days.')
+    '-p',
+    '--past-days',
+    'past_days',
+    type=click.INT,
+    metavar='PAST_DAYS',
+    help='Only include entries created in the last PAST_DAYS number of days.'
+)
 
 OLDER_THAN = OverridableOption(
-    '-o', '--older-than', 'older_than',
-    type=click.INT, metavar='OLDER_THAN',
-    help='Only include entries created before OLDER_THAN days ago.')
+    '-o',
+    '--older-than',
+    'older_than',
+    type=click.INT,
+    metavar='OLDER_THAN',
+    help='Only include entries created before OLDER_THAN days ago.'
+)
 
 ALL = OverridableOption(
-    '-a', '--all', 'all_entries',
-    is_flag=True, default=False,
-    help='Include all entries, disregarding all other filter options and flags.')
-
-ALL_STATES = OverridableOption(
-    '-A', '--all-states',
+    '-a',
+    '--all',
+    'all_entries',
     is_flag=True,
-    help='Do not limit to items in running state.')
+    default=False,
+    help='Include all entries, disregarding all other filter options and flags.'
+)
+
+ALL_STATES = OverridableOption('-A', '--all-states', is_flag=True, help='Do not limit to items in running state.')
 
 ALL_USERS = OverridableOption(
-    '-A', '--all-users', 'all_users',
-    is_flag=True, default=False,
-    help='Include all entries regardless of the owner.')
+    '-A', '--all-users', 'all_users', is_flag=True, default=False, help='Include all entries regardless of the owner.'
+)
 
 GROUP_CLEAR = OverridableOption(
-    '-c', '--clear',
-    is_flag=True, default=False,
-    help='Remove all the nodes from the group.')
+    '-c', '--clear', is_flag=True, default=False, help='Remove all the nodes from the group.'
+)
 
 RAW = OverridableOption(
-    '-r', '--raw', 'raw',
-    is_flag=True, default=False,
-    help='Display only raw query results, without any headers or footers.')
+    '-r',
+    '--raw',
+    'raw',
+    is_flag=True,
+    default=False,
+    help='Display only raw query results, without any headers or footers.'
+)
 
-HOSTNAME = OverridableOption(
-    '-H', '--hostname',
-    help='Hostname.')
+HOSTNAME = OverridableOption('-H', '--hostname', help='Hostname.')
 
 TRANSPORT = OverridableOption(
-    '-T', '--transport',
-    type=types.PluginParamType(group='transports'), required=True,
-    help='Transport type.')
+    '-T', '--transport', type=types.PluginParamType(group='transports'), required=True, help='Transport type.'
+)
 
 SCHEDULER = OverridableOption(
-    '-S', '--scheduler',
-    type=types.PluginParamType(group='schedulers'), required=True,
-    help='Scheduler type.')
+    '-S', '--scheduler', type=types.PluginParamType(group='schedulers'), required=True, help='Scheduler type.'
+)
 
-USER = OverridableOption(
-    '-u', '--user', 'user',
-    type=types.UserParamType(),
-    help='Email address of the user.')
+USER = OverridableOption('-u', '--user', 'user', type=types.UserParamType(), help='Email address of the user.')
 
-PORT = OverridableOption(
-    '-P', '--port', 'port',
-    type=click.INT,
-    help='Port number.')
+PORT = OverridableOption('-P', '--port', 'port', type=click.INT, help='Port number.')
 
-FREQUENCY = OverridableOption(
-    '-F', '--frequency', 'frequency',
-    type=click.INT)
+FREQUENCY = OverridableOption('-F', '--frequency', 'frequency', type=click.INT)
 
-VERBOSE = OverridableOption(
-    '-v', '--verbose',
-    is_flag=True, default=False,
-    help='Be more verbose in printing output.')
+VERBOSE = OverridableOption('-v', '--verbose', is_flag=True, default=False, help='Be more verbose in printing output.')
 
 TIMEOUT = OverridableOption(
-    '-t', '--timeout',
-    type=click.FLOAT, default=5.0, show_default=True,
-    help='Time in seconds to wait for a response before timing out.')
+    '-t',
+    '--timeout',
+    type=click.FLOAT,
+    default=5.0,
+    show_default=True,
+    help='Time in seconds to wait for a response before timing out.'
+)
 
 FORMULA_MODE = OverridableOption(
-    '-f', '--formula-mode',
+    '-f',
+    '--formula-mode',
     type=click.Choice(['hill', 'hill_compact', 'reduce', 'group', 'count', 'count_compact']),
     default='hill',
-    help='Mode for printing the chemical formula.')
+    help='Mode for printing the chemical formula.'
+)
 
 TRAJECTORY_INDEX = OverridableOption(
-    '-i', '--trajectory-index', 'trajectory_index',
+    '-i',
+    '--trajectory-index',
+    'trajectory_index',
     type=click.INT,
     default=None,
-    help='Specific step of the Trajecotry to select.')
+    help='Specific step of the Trajecotry to select.'
+)
 
 WITH_ELEMENTS = OverridableOption(
-    '-e', '--with-elements', 'elements',
+    '-e',
+    '--with-elements',
+    'elements',
     type=click.STRING,
     cls=MultipleValueOption,
     default=None,
-    help='Only select objects containing these elements.')
+    help='Only select objects containing these elements.'
+)
 
 WITH_ELEMENTS_EXCLUSIVE = OverridableOption(
-    '-E', '--with-elements-exclusive', 'elements_exclusive',
+    '-E',
+    '--with-elements-exclusive',
+    'elements_exclusive',
     type=click.STRING,
     cls=MultipleValueOption,
     default=None,
-    help='Only select objects containing only these and no other elements.')
+    help='Only select objects containing only these and no other elements.'
+)
 
-CONFIG_FILE = ConfigFileOption(
-    '--config', help='Load option values from configuration file in yaml format.')
+CONFIG_FILE = ConfigFileOption('--config', help='Load option values from configuration file in yaml format.')
 
 IDENTIFIER = OverridableOption(
-    '-i', '--identifier', 'identifier',
+    '-i',
+    '--identifier',
+    'identifier',
     help='The type of identifier used for specifying each node.',
     default='pk',
-    type=click.Choice(['pk', 'uuid']))
+    type=click.Choice(['pk', 'uuid'])
+)
 
 DICT_FORMAT = OverridableOption(
-    '-f', '--format', 'fmt',
+    '-f',
+    '--format',
+    'fmt',
     type=click.Choice(list(echo.VALID_DICT_FORMATS_MAPPING.keys())),
     default=list(echo.VALID_DICT_FORMATS_MAPPING.keys())[0],
     help='The format of the output data.'
 )
 
 DICT_KEYS = OverridableOption(
-    '-k', '--keys',
-    type=click.STRING,
-    cls=MultipleValueOption,
-    help='Filter the output by one or more keys.'
+    '-k', '--keys', type=click.STRING, cls=MultipleValueOption, help='Filter the output by one or more keys.'
 )

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -33,7 +33,8 @@ ON_COMPUTER = OverridableOption(
     default=True,
     cls=InteractiveOption,
     prompt='Installed on target computer?',
-    help='Whether the code is installed on the target computer or should be copied each time from a local path.')
+    help='Whether the code is installed on the target computer or should be copied each time from a local path.'
+)
 
 REMOTE_ABS_PATH = OverridableOption(
     '--remote-abs-path',
@@ -42,7 +43,8 @@ REMOTE_ABS_PATH = OverridableOption(
     prompt_fn=is_on_computer,
     type=types.AbsolutePathParamType(dir_okay=False),
     cls=InteractiveOption,
-    help=('[if --on-computer]: the absolute path to the executable on the remote machine.'))
+    help=('[if --on-computer]: the absolute path to the executable on the remote machine.')
+)
 
 FOLDER = OverridableOption(
     '--code-folder',
@@ -51,7 +53,8 @@ FOLDER = OverridableOption(
     prompt_fn=is_not_on_computer,
     type=click.Path(file_okay=False, exists=True, readable=True),
     cls=InteractiveOption,
-    help=('[if --store-in-db]: directory containing the executable and all other files necessary for running it.'))
+    help=('[if --store-in-db]: directory containing the executable and all other files necessary for running it.')
+)
 
 REL_PATH = OverridableOption(
     '--code-rel-path',
@@ -60,21 +63,25 @@ REL_PATH = OverridableOption(
     prompt_fn=is_not_on_computer,
     type=click.Path(dir_okay=False),
     cls=InteractiveOption,
-    help=('[if --store-in-db]: relative path of the executable inside the code-folder.'))
+    help=('[if --store-in-db]: relative path of the executable inside the code-folder.')
+)
 
 LABEL = options.LABEL.clone(prompt='Label', cls=InteractiveOption, help='A label to refer to this code.')
 
 DESCRIPTION = options.DESCRIPTION.clone(
-    prompt='Description', cls=InteractiveOption, help='A human-readable description of this code.')
+    prompt='Description', cls=InteractiveOption, help='A human-readable description of this code.'
+)
 
 INPUT_PLUGIN = options.INPUT_PLUGIN.clone(
     prompt='Default calculation input plugin',
     cls=InteractiveOption,
-    help='Default calculation plugin to use for this code.')
+    help='Default calculation plugin to use for this code.'
+)
 
 COMPUTER = options.COMPUTER.clone(
     prompt='Computer',
     cls=InteractiveOption,
     required_fn=is_on_computer,
     prompt_fn=is_on_computer,
-    help='Name of the computer, on which the code resides.')
+    help='Name of the computer, on which the code resides.'
+)

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -37,7 +37,8 @@ def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-na
             raise ImportError("Unable to load the '{}' scheduler".format(scheduler_ep.name))
     else:
         raise ValidationError(
-            "The should_call_... function should always be run (and prompted) AFTER asking for a scheduler")
+            "The should_call_... function should always be run (and prompted) AFTER asking for a scheduler"
+        )
 
     job_resource_cls = scheduler_cls.job_resource_class
     if job_resource_cls is None:
@@ -48,16 +49,19 @@ def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-na
 
 
 LABEL = options.LABEL.clone(
-    prompt='Computer label', cls=InteractiveOption, required=True, type=types.NonEmptyStringParamType())
+    prompt='Computer label', cls=InteractiveOption, required=True, type=types.NonEmptyStringParamType()
+)
 
 HOSTNAME = options.HOSTNAME.clone(
     prompt='Hostname',
     cls=InteractiveOption,
     required=True,
-    help='The fully qualified hostname of this computer; for local transports, use localhost.')
+    help='The fully qualified hostname of this computer; for local transports, use localhost.'
+)
 
 DESCRIPTION = options.DESCRIPTION.clone(
-    prompt='Description', cls=InteractiveOption, help='A human-readable description of this computer.')
+    prompt='Description', cls=InteractiveOption, help='A human-readable description of this computer.'
+)
 
 TRANSPORT = options.TRANSPORT.clone(prompt='Transport plugin', cls=InteractiveOption)
 
@@ -69,7 +73,8 @@ SHEBANG = OverridableOption(
     default='#!/bin/bash',
     cls=InteractiveOption,
     help='This line specifies the first line of the submission script for this computer.',
-    type=types.ShebangParamType())
+    type=types.ShebangParamType()
+)
 
 WORKDIR = OverridableOption(
     '-w',
@@ -80,7 +85,8 @@ WORKDIR = OverridableOption(
     help='The absolute path of the directory on the computer where AiiDA will '
     'run the calculations (typically, the scratch of the computer). You '
     'can use the {username} replacement, that will be replaced by your '
-    'username on the remote computer.')
+    'username on the remote computer.'
+)
 
 MPI_RUN_COMMAND = OverridableOption(
     '-m',
@@ -92,7 +98,8 @@ MPI_RUN_COMMAND = OverridableOption(
     'programs. You can use the {tot_num_mpiprocs} replacement, that will be '
     'replaced by the total number of cpus, or the other scheduler-dependent '
     'replacement fields (see the scheduler docs for more information).',
-    type=types.MpirunCommandParamType())
+    type=types.MpirunCommandParamType()
+)
 
 MPI_PROCS_PER_MACHINE = OverridableOption(
     '--mpiprocs-per-machine',

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -160,7 +160,8 @@ SETUP_PROFILE = OverridableOption(
     required=True,
     is_eager=True,
     type=types.ProfileParamType(cannot_exist=True),
-    cls=InteractiveOption)
+    cls=InteractiveOption
+)
 
 SETUP_USER_EMAIL = OverridableOption(
     '--email',
@@ -170,7 +171,8 @@ SETUP_USER_EMAIL = OverridableOption(
     default=get_config_option('user.email'),
     required_fn=lambda x: get_config_option('user.email') is None,
     required=True,
-    cls=InteractiveOption)
+    cls=InteractiveOption
+)
 
 SETUP_USER_FIRST_NAME = OverridableOption(
     '--first-name',
@@ -181,7 +183,8 @@ SETUP_USER_FIRST_NAME = OverridableOption(
     default=get_config_option('user.first_name'),
     required_fn=lambda x: get_config_option('user.first_name') is None,
     required=True,
-    cls=InteractiveOption)
+    cls=InteractiveOption
+)
 
 SETUP_USER_LAST_NAME = OverridableOption(
     '--last-name',
@@ -192,7 +195,8 @@ SETUP_USER_LAST_NAME = OverridableOption(
     default=get_config_option('user.last_name'),
     required_fn=lambda x: get_config_option('user.last_name') is None,
     required=True,
-    cls=InteractiveOption)
+    cls=InteractiveOption
+)
 
 SETUP_USER_INSTITUTION = OverridableOption(
     '--institution',
@@ -203,7 +207,8 @@ SETUP_USER_INSTITUTION = OverridableOption(
     default=get_config_option('user.institution'),
     required_fn=lambda x: get_config_option('user.institution') is None,
     required=True,
-    cls=InteractiveOption)
+    cls=InteractiveOption
+)
 
 SETUP_USER_PASSWORD = OverridableOption(
     '--password',
@@ -214,100 +219,120 @@ SETUP_USER_PASSWORD = OverridableOption(
     type=click.STRING,
     default=PASSWORD_UNCHANGED,
     confirmation_prompt=True,
-    cls=InteractiveOption)
+    cls=InteractiveOption
+)
 
 QUICKSETUP_DATABASE_ENGINE = OverridableOption(
     '--db-engine',
     help='Engine to use to connect to the database.',
     default='postgresql_psycopg2',
-    type=click.Choice(['postgresql_psycopg2']))
+    type=click.Choice(['postgresql_psycopg2'])
+)
 
 QUICKSETUP_DATABASE_BACKEND = OverridableOption(
     '--db-backend',
     help='Backend type to use to map the database.',
     default=BACKEND_DJANGO,
-    type=click.Choice([BACKEND_DJANGO, BACKEND_SQLA]))
+    type=click.Choice([BACKEND_DJANGO, BACKEND_SQLA])
+)
 
 QUICKSETUP_DATABASE_HOSTNAME = OverridableOption(
-    '--db-host', help='Hostname to connect to the database.', default=DEFAULT_DBINFO['host'], type=click.STRING)
+    '--db-host', help='Hostname to connect to the database.', default=DEFAULT_DBINFO['host'], type=click.STRING
+)
 
 QUICKSETUP_DATABASE_PORT = OverridableOption(
-    '--db-port', help='Port to connect to the database.', default=DEFAULT_DBINFO['port'], type=click.INT)
+    '--db-port', help='Port to connect to the database.', default=DEFAULT_DBINFO['port'], type=click.INT
+)
 
 QUICKSETUP_DATABASE_NAME = OverridableOption(
-    '--db-name', help='Name of the database to create.', type=click.STRING, callback=get_quicksetup_database_name)
+    '--db-name', help='Name of the database to create.', type=click.STRING, callback=get_quicksetup_database_name
+)
 
 QUICKSETUP_DATABASE_USERNAME = OverridableOption(
-    '--db-username', help='Name of the database user to create.', type=click.STRING, callback=get_quicksetup_username)
+    '--db-username', help='Name of the database user to create.', type=click.STRING, callback=get_quicksetup_username
+)
 
 QUICKSETUP_DATABASE_PASSWORD = OverridableOption(
     '--db-password',
     help='Password to connect to the database.',
     type=click.STRING,
     hide_input=True,
-    callback=get_quicksetup_password)
+    callback=get_quicksetup_password
+)
 
 QUICKSETUP_SUPERUSER_DATABASE_USERNAME = OverridableOption(
-    '--su-db-username', help='User name of the database super user.', type=click.STRING, default=DEFAULT_DBINFO['user'])
+    '--su-db-username', help='User name of the database super user.', type=click.STRING, default=DEFAULT_DBINFO['user']
+)
 
 QUICKSETUP_SUPERUSER_DATABASE_NAME = OverridableOption(
     '--su-db-name',
     help='Name of the template database to connect to as the database superuser.',
     type=click.STRING,
-    default=DEFAULT_DBINFO['database'])
+    default=DEFAULT_DBINFO['database']
+)
 
 QUICKSETUP_SUPERUSER_DATABASE_PASSWORD = OverridableOption(
     '--su-db-password',
     help='Password to connect as the database superuser.',
     type=click.STRING,
     hide_input=True,
-    default=DEFAULT_DBINFO['password'])
+    default=DEFAULT_DBINFO['password']
+)
 
 QUICKSETUP_REPOSITORY_URI = OverridableOption(
     '--repository',
     help='Absolute path for the file system repository.',
     type=click.Path(file_okay=False),
-    callback=get_quicksetup_repository_uri)
+    callback=get_quicksetup_repository_uri
+)
 
 SETUP_DATABASE_ENGINE = QUICKSETUP_DATABASE_ENGINE.clone(
     prompt='Database engine',
     contextual_default=functools.partial(get_profile_attribute_default, ('database_engine', 'postgresql_psycopg2')),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_DATABASE_BACKEND = QUICKSETUP_DATABASE_BACKEND.clone(
     prompt='Database backend',
     contextual_default=functools.partial(get_profile_attribute_default, ('database_backend', BACKEND_DJANGO)),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_DATABASE_HOSTNAME = QUICKSETUP_DATABASE_HOSTNAME.clone(
     prompt='Database hostname',
     contextual_default=functools.partial(get_profile_attribute_default, ('database_hostname', 'localhost')),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_DATABASE_PORT = QUICKSETUP_DATABASE_PORT.clone(
     prompt='Database port',
     contextual_default=functools.partial(get_profile_attribute_default, ('database_port', 5432)),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_DATABASE_NAME = QUICKSETUP_DATABASE_NAME.clone(
     prompt='Database name',
     required=True,
     contextual_default=functools.partial(get_profile_attribute_default, ('database_name', None)),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_DATABASE_USERNAME = QUICKSETUP_DATABASE_USERNAME.clone(
     prompt='Database username',
     required=True,
     contextual_default=functools.partial(get_profile_attribute_default, ('database_username', None)),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_DATABASE_PASSWORD = QUICKSETUP_DATABASE_PASSWORD.clone(
     prompt='Database password',
     required=True,
     contextual_default=functools.partial(get_profile_attribute_default, ('database_password', None)),
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)
 
 SETUP_REPOSITORY_URI = QUICKSETUP_REPOSITORY_URI.clone(
     prompt='Repository directory',
     contextual_default=get_repository_path_default,
-    cls=options.interactive.InteractiveOption)
+    cls=options.interactive.InteractiveOption
+)

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -76,7 +76,9 @@ class InteractiveOption(ConditionalOption):
         if not self._prompt:
             raise TypeError(
                 "Interactive options need to have a prompt specified, but '{}' does not have a prompt defined".format(
-                    self.name))
+                    self.name
+                )
+            )
 
         # other kwargs
         self.switch = switch
@@ -140,7 +142,8 @@ class InteractiveOption(ConditionalOption):
             prompt_suffix=click.style(': ', fg=self.PROMPT_COLOR),
             default=self._get_default(ctx),
             hide_input=self.hide_input,
-            confirmation_prompt=self.confirmation_prompt)
+            confirmation_prompt=self.confirmation_prompt
+        )
 
     def ctrl_help(self):
         """control behaviour when help is requested from the prompt"""

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -31,8 +31,9 @@ from .user import UserParamType
 from .test_module import TestModuleParamType
 from .workflow import WorkflowParamType
 
-__all__ = ('LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType',
-           'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
-           'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType',
-           'ShebangParamType', 'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType',
-           'ProcessParamType', 'ImportPath')
+__all__ = (
+    'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType',
+    'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
+    'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType',
+    'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType', 'ImportPath'
+)

--- a/aiida/cmdline/params/types/code.py
+++ b/aiida/cmdline/params/types/code.py
@@ -49,7 +49,10 @@ class CodeParamType(IdentifierParamType):
         if code and self._entry_point is not None:
             entry_point = code.get_input_plugin_name()
             if entry_point != self._entry_point:
-                raise click.BadParameter('the retrieved Code<{}> has plugin type "{}" while "{}" is required'.format(
-                    code.pk, entry_point, self._entry_point))
+                raise click.BadParameter(
+                    'the retrieved Code<{}> has plugin type "{}" while "{}" is required'.format(
+                        code.pk, entry_point, self._entry_point
+                    )
+                )
 
         return code

--- a/aiida/cmdline/params/types/computer.py
+++ b/aiida/cmdline/params/types/computer.py
@@ -81,8 +81,10 @@ class MpirunCommandParamType(StringParamType):
             except ImportError:
                 self.fail("Unable to load the '{}' scheduler".format(scheduler_ep.name))
         else:
-            self.fail("Scheduler not specified for this computer! The mpirun-command must always be asked "
-                      "after asking for the scheduler.")
+            self.fail(
+                "Scheduler not specified for this computer! The mpirun-command must always be asked "
+                "after asking for the scheduler."
+            )
 
         # Prepare some substitution values to check if it is all ok
         subst = {i: 'value' for i in job_resource_keys}

--- a/aiida/cmdline/params/types/identifier.py
+++ b/aiida/cmdline/params/types/identifier.py
@@ -113,8 +113,11 @@ class IdentifierParamType(click.ParamType):
                     raise RuntimeError('failed to load the entry point {}: {}'.format(entry_point, exception))
 
                 if not issubclass(sub_class, loader.orm_base_class):
-                    raise RuntimeError('the class {} of entry point {} is not a sub class of {}'.format(
-                        sub_class, entry_point, loader.orm_base_class))
+                    raise RuntimeError(
+                        'the class {} of entry point {} is not a sub class of {}'.format(
+                            sub_class, entry_point, loader.orm_base_class
+                        )
+                    )
                 else:
                     sub_classes.append(sub_class)
 

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -75,7 +75,9 @@ class ImportPath(click.Path):
             self.fail(
                 '{0} "{1}" could not be reached within {2} s.\n'
                 'It may be neither a valid {3} nor a valid URL.'.format(
-                    self.path_type, click._compat.filename_to_ui(url), self.timeout_seconds, self.name), param, ctx)
+                    self.path_type, click._compat.filename_to_ui(url), self.timeout_seconds, self.name
+                ), param, ctx
+            )
 
         return url
 

--- a/aiida/cmdline/params/types/plugin.py
+++ b/aiida/cmdline/params/types/plugin.py
@@ -179,11 +179,15 @@ class PluginParamType(click.ParamType):
             matching_groups = [group for group, entry_point in self._entry_points if entry_point.name == name]
 
             if len(matching_groups) > 1:
-                raise ValueError("entry point '{}' matches more than one valid entry point group [{}], "
-                                 "please specify an explicit group prefix".format(name, ' '.join(matching_groups)))
+                raise ValueError(
+                    "entry point '{}' matches more than one valid entry point group [{}], "
+                    "please specify an explicit group prefix".format(name, ' '.join(matching_groups))
+                )
             elif not matching_groups:
-                raise ValueError("entry point '{}' is not valid for any of the allowed "
-                                 "entry point groups: {}".format(name, ' '.join(self.groups)))
+                raise ValueError(
+                    "entry point '{}' is not valid for any of the allowed "
+                    "entry point groups: {}".format(name, ' '.join(self.groups))
+                )
             else:
                 group = matching_groups[0]
 

--- a/aiida/cmdline/utils/ascii_vis.py
+++ b/aiida/cmdline/utils/ascii_vis.py
@@ -124,7 +124,8 @@ def build_tree(node, node_label=None, show_pk=True, max_depth=1, follow_links_of
 
         for child in sorted(outputs, key=lambda node: node.ctime):
             relatives.append(
-                build_tree(child, node_label, show_pk, max_depth, follow_links_of_type, descend, depth + 1))
+                build_tree(child, node_label, show_pk, max_depth, follow_links_of_type, descend, depth + 1)
+            )
 
         if relatives:
             out_values.append('({})'.format(', '.join(relatives)))

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -241,8 +241,9 @@ def get_calcjob_report(calcjob):
     report = []
 
     if calcjob_state == CalcJobState.WITHSCHEDULER:
-        state_string = '{}, scheduler state: {}'.format(calcjob_state,
-                                                        scheduler_state if scheduler_state else '(unknown)')
+        state_string = '{}, scheduler state: {}'.format(
+            calcjob_state, scheduler_state if scheduler_state else '(unknown)'
+        )
     else:
         state_string = '{}'.format(calcjob_state)
 
@@ -329,7 +330,8 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
             # for now, CALL links are the only ones allowing calc-calc
             # (we here really want instead to follow CALL links)
             with_incoming='workcalculation',
-            tag='subworkchains')
+            tag='subworkchains'
+        )
         result = list(itertools.chain(*builder.distinct().all()))
 
         # This will return a single flat list of tuples, where the first element
@@ -366,7 +368,8 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
             time=entry.time,
             width_id=width_id,
             width_levelname=width_levelname,
-            indent=' ' * (depth * indent_size))
+            indent=' ' * (depth * indent_size)
+        )
         report.append(line)
 
     return '\n'.join(report)

--- a/aiida/cmdline/utils/daemon.py
+++ b/aiida/cmdline/utils/daemon.py
@@ -89,8 +89,10 @@ def get_daemon_status(client):
         'workers': workers_info
     }
 
-    template = ('Daemon is running as PID {pid} since {time}\nActive workers [{nworkers}]:\n{workers}\n'
-                'Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers')
+    template = (
+        'Daemon is running as PID {pid} since {time}\nActive workers [{nworkers}]:\n{workers}\n'
+        'Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers'
+    )
 
     return template.format(**info)
 
@@ -122,7 +124,8 @@ def delete_stale_pid_file(client):
                 raise StartCircusNotFound()  # Also this is a case in which the process is not there anymore
         except (psutil.AccessDenied, psutil.NoSuchProcess, StartCircusNotFound):
             echo.echo_warning(
-                'Deleted apparently stale daemon PID file as its associated process<{}> does not exist anymore'.format(
-                    pid))
+                'Deleted apparently stale daemon PID file as its associated process<{}> does not exist anymore'.
+                format(pid)
+            )
             if os.path.isfile(client.circus_pid_file):
                 os.remove(client.circus_pid_file)

--- a/aiida/cmdline/utils/multi_line_input.py
+++ b/aiida/cmdline/utils/multi_line_input.py
@@ -60,13 +60,17 @@ def edit_pre_post(pre=None, post=None, summary=None):
             pre, post = mlinput.split(separator)
         except ValueError as err:
             if str(err) == "need more than 1 value to unpack":
-                raise InputValidationError("Looks like you modified the "
-                                           "separator that should NOT be modified. Please be "
-                                           "careful!")
+                raise InputValidationError(
+                    "Looks like you modified the "
+                    "separator that should NOT be modified. Please be "
+                    "careful!"
+                )
             elif str(err) == "too many values to unpack":
-                raise InputValidationError("Looks like you have more than one "
-                                           "separator, while only one is needed "
-                                           "(and allowed). Please be careful!")
+                raise InputValidationError(
+                    "Looks like you have more than one "
+                    "separator, while only one is needed "
+                    "(and allowed). Please be careful!"
+                )
             else:
                 raise err
 

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -22,9 +22,10 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
     # have to be manually projected from composing its individual projection constituents
     _compound_projections = ('state',)
     _default_projections = ('pk', 'ctime', 'process_label', 'state', 'process_status')
-    _valid_projections = ('pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'process_status', 'exit_status',
-                          'sealed', 'process_label', 'label', 'description', 'node_type', 'paused', 'process_type',
-                          'job_state', 'scheduler_state')
+    _valid_projections = (
+        'pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'process_status', 'exit_status', 'sealed',
+        'process_label', 'label', 'description', 'node_type', 'paused', 'process_type', 'job_state', 'scheduler_state'
+    )
 
     def __init__(self, mapper=None):
         if mapper is None:
@@ -44,13 +45,15 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
     def valid_projections(self):
         return self._valid_projections
 
-    def get_filters(self,
-                    all_entries=False,
-                    process_state=None,
-                    process_label=None,
-                    exit_status=None,
-                    failed=False,
-                    node_types=None):
+    def get_filters(
+        self,
+        all_entries=False,
+        process_state=None,
+        process_label=None,
+        exit_status=None,
+        failed=False,
+        node_types=None
+    ):
         """
         Return a set of QueryBuilder filters based on typical command line options.
 

--- a/aiida/cmdline/utils/query/mapping.py
+++ b/aiida/cmdline/utils/query/mapping.py
@@ -118,8 +118,8 @@ class CalculationProjectionMapper(ProjectionMapper):
             'mtime':
             lambda value: formatting.format_relative_time(value['mtime']),
             'state':
-            lambda value: formatting.format_state(value[process_state_key], value[process_paused_key], value[
-                exit_status_key]),
+            lambda value: formatting.
+            format_state(value[process_state_key], value[process_paused_key], value[exit_status_key]),
             'process_state':
             lambda value: formatting.format_process_state(value[process_state_key]),
             'sealed':

--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -114,9 +114,8 @@ def get_regex_pattern_from_sql(sql_pattern):
                 # with ALL tokens passed (there could be more occurrences of tokens_to_apply[0])
                 # Instead, for the first part, we know that we found the FIRST occurrence of tokens_to_apply[0]
                 # so I pass the list without the first element
-                return tokenizer(
-                    first, tokens_to_apply=tokens_to_apply[1:]) + dict(SQL_TO_REGEX_TOKENS)[sep] + tokenizer(
-                        rest, tokens_to_apply=tokens_to_apply)
+                return tokenizer(first, tokens_to_apply=tokens_to_apply[1:]
+                                ) + dict(SQL_TO_REGEX_TOKENS)[sep] + tokenizer(rest, tokens_to_apply=tokens_to_apply)
             # Here sep is empty: it means also rest is empty, and we just
             # return (recursively) the tokenizer on the first part, avoiding
             # infinite loops

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -12,14 +12,16 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-__all__ = ('AiidaException', 'NotExistent', 'MultipleObjectsError', 'RemoteOperationError', 'ContentNotExistent',
-           'FailedError', 'StoringNotAllowed', 'ModificationNotAllowed', 'IntegrityError', 'UniquenessError',
-           'EntryPointError', 'MissingEntryPointError', 'MultipleEntryPointError', 'LoadingEntryPointError',
-           'InvalidOperation', 'ParsingError', 'InternalError', 'PluginInternalError', 'ValidationError',
-           'ConfigurationError', 'ProfileConfigurationError', 'MissingConfigurationError', 'ConfigurationVersionError',
-           'DbContentError', 'InputValidationError', 'FeatureNotAvailable', 'FeatureDisabled', 'LicensingException',
-           'TestsNotAllowedError', 'UnsupportedSpeciesError', 'DanglingLinkError', 'TransportTaskException',
-           'IncompatibleArchiveVersionError', 'OutputParsingError')
+__all__ = (
+    'AiidaException', 'NotExistent', 'MultipleObjectsError', 'RemoteOperationError', 'ContentNotExistent',
+    'FailedError', 'StoringNotAllowed', 'ModificationNotAllowed', 'IntegrityError', 'UniquenessError',
+    'EntryPointError', 'MissingEntryPointError', 'MultipleEntryPointError', 'LoadingEntryPointError',
+    'InvalidOperation', 'ParsingError', 'InternalError', 'PluginInternalError', 'ValidationError', 'ConfigurationError',
+    'ProfileConfigurationError', 'MissingConfigurationError', 'ConfigurationVersionError', 'DbContentError',
+    'InputValidationError', 'FeatureNotAvailable', 'FeatureDisabled', 'LicensingException', 'TestsNotAllowedError',
+    'UnsupportedSpeciesError', 'DanglingLinkError', 'TransportTaskException', 'IncompatibleArchiveVersionError',
+    'OutputParsingError'
+)
 
 
 class AiidaException(Exception):

--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -67,8 +67,10 @@ class AttributeDict(dict):
         try:
             self[attr] = value
         except KeyError:
-            raise AttributeError("AttributeError: '{}' is not a valid attribute of the object "
-                                 "'{}'".format(attr, self.__class__.__name__))
+            raise AttributeError(
+                "AttributeError: '{}' is not a valid attribute of the object "
+                "'{}'".format(attr, self.__class__.__name__)
+            )
 
     def __delattr__(self, attr):
         """Delete a key as an attribute.
@@ -222,8 +224,9 @@ class DefaultFieldsAttributeDict(AttributeDict):
                 try:
                     validator(self[key])
                 except Exception as exc:
-                    raise exceptions.ValidationError("Invalid value for key '{}' [{}]: {}".format(
-                        key, exc.__class__.__name__, exc))
+                    raise exceptions.ValidationError(
+                        "Invalid value for key '{}' [{}]: {}".format(key, exc.__class__.__name__, exc)
+                    )
 
     def __setattr__(self, attr, value):
         """

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -60,8 +60,10 @@ class Folder(object):  # pylint: disable=useless-object-inheritance
 
             # check that it is a subfolder
             if not os.path.commonprefix([abspath, folder_limit]) == folder_limit:
-                raise ValueError("The absolute path for this folder is not within the "
-                                 "folder_limit. abspath={}, folder_limit={}.".format(abspath, folder_limit))
+                raise ValueError(
+                    "The absolute path for this folder is not within the "
+                    "folder_limit. abspath={}, folder_limit={}.".format(abspath, folder_limit)
+                )
 
         self._abspath = abspath
         self._folder_limit = folder_limit
@@ -532,8 +534,10 @@ class RepositoryFolder(Folder):
         Pass the uuid as a string.
         """
         if section not in VALID_SECTIONS:
-            retstr = ("Repository section '{}' not allowed. "
-                      "Valid sections are: {}".format(section, ",".join(VALID_SECTIONS)))
+            retstr = (
+                "Repository section '{}' not allowed. "
+                "Valid sections are: {}".format(section, ",".join(VALID_SECTIONS))
+            )
             raise ValueError(retstr)
         self._section = section
         self._uuid = uuid
@@ -552,7 +556,8 @@ class RepositoryFolder(Folder):
             get_repository_folder('repository'), six.text_type(section),
             six.text_type(uuid)[:2],
             six.text_type(uuid)[2:4],
-            six.text_type(uuid)[4:])
+            six.text_type(uuid)[4:]
+        )
         dest = os.path.join(entity_dir, six.text_type(subfolder))
 
         # Internal variable of this class

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -80,8 +80,7 @@ try:
     using_sysrandom = True
 except NotImplementedError:
     import warnings
-    warnings.warn('A secure pseudo-random number generator is not available '  # pylint: disable=no-member
-                  'on your system. Falling back to Mersenne Twister.')
+    warnings.warn('A secure pseudo-random number generator is not available. Falling back to Mersenne Twister.')  # pylint: disable=no-member
     using_sysrandom = False  # pylint: disable=invalid-name
 
 
@@ -185,16 +184,16 @@ def _(val, **kwargs):
 @_make_hash.register(abc.Sequence)
 def _(sequence_obj, **kwargs):
     # unpack the list and use the elements
-    return [_single_digest('list(')] + list(chain.from_iterable(
-        _make_hash(i, **kwargs) for i in sequence_obj)) + [_END_DIGEST]
+    return [_single_digest('list(')] + list(chain.from_iterable(_make_hash(i, **kwargs) for i in sequence_obj)
+                                           ) + [_END_DIGEST]
 
 
 @_make_hash.register(abc.Set)
 def _(set_obj, **kwargs):
     # turn the set objects into a list of hashes which are always sortable,
     # then return a flattened list of the hashes
-    return [_single_digest('set(')] + list(chain.from_iterable(sorted(
-        _make_hash(i, **kwargs) for i in set_obj))) + [_END_DIGEST]
+    return [_single_digest('set(')] + list(chain.from_iterable(sorted(_make_hash(i, **kwargs) for i in set_obj))
+                                          ) + [_END_DIGEST]
 
 
 @_make_hash.register(abc.Mapping)
@@ -206,8 +205,10 @@ def _(mapping, **kwargs):
             yield (_make_hash(key, **kwargs), value)
 
     return [_single_digest('dict(')] + list(
-        chain.from_iterable((k_digest + _make_hash(val, **kwargs))
-                            for k_digest, val in sorted(hashed_key_mapping(), key=itemgetter(0)))) + [_END_DIGEST]
+        chain.from_iterable(
+            (k_digest + _make_hash(val, **kwargs)) for k_digest, val in sorted(hashed_key_mapping(), key=itemgetter(0))
+        )
+    ) + [_END_DIGEST]
 
 
 @_make_hash.register(OrderedDict)
@@ -222,8 +223,8 @@ def _(mapping, **kwargs):
         return _make_hash.registry[abc.Mapping](mapping)
 
     return ([_single_digest('odict(')] + list(
-        chain.from_iterable(
-            (_make_hash(key, **kwargs) + _make_hash(val, **kwargs)) for key, val in mapping.items())) + [_END_DIGEST])
+        chain.from_iterable((_make_hash(key, **kwargs) + _make_hash(val, **kwargs)) for key, val in mapping.items())
+    ) + [_END_DIGEST])
 
 
 @_make_hash.register(numbers.Real)
@@ -243,8 +244,9 @@ def _(val, **kwargs):
     return [
         _single_digest(
             'complex', u"{}!{}".format(
-                float_to_text(val.real, sig=AIIDA_FLOAT_PRECISION),
-                float_to_text(val.imag, sig=AIIDA_FLOAT_PRECISION)).encode('utf-8'))
+                float_to_text(val.real, sig=AIIDA_FLOAT_PRECISION), float_to_text(val.imag, sig=AIIDA_FLOAT_PRECISION)
+            ).encode('utf-8')
+        )
     ]
 
 

--- a/aiida/common/lang.py
+++ b/aiida/common/lang.py
@@ -101,8 +101,10 @@ def protected_decorator(check=False):
                     calling_class = stack()[1][0].f_locals['self']
                     assert self is calling_class
                 except (KeyError, AssertionError):
-                    raise RuntimeError("Cannot access protected function {} from outside"
-                                       " class hierarchy".format(func.__name__))
+                    raise RuntimeError(
+                        "Cannot access protected function {} from outside"
+                        " class hierarchy".format(func.__name__)
+                    )
 
                 return func(self, *args, **kwargs)
         else:

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -78,16 +78,20 @@ def validate_list_of_string_tuples(val, tuple_length):
     """
     from aiida.common.exceptions import ValidationError
 
-    err_msg = ("the value must be a list (or tuple) "
-               "of length-N list (or tuples), whose elements are strings; "
-               "N={}".format(tuple_length))
+    err_msg = (
+        "the value must be a list (or tuple) "
+        "of length-N list (or tuples), whose elements are strings; "
+        "N={}".format(tuple_length)
+    )
 
     if not isinstance(val, (list, tuple)):
         raise ValidationError(err_msg)
 
     for element in val:
-        if (not isinstance(element, (list, tuple)) or (len(element) != tuple_length) or
-                not all(isinstance(s, six.string_types) for s in element)):
+        if (
+            not isinstance(element, (list, tuple)) or (len(element) != tuple_length) or
+            not all(isinstance(s, six.string_types) for s in element)
+        ):
             raise ValidationError(err_msg)
 
     return True
@@ -274,19 +278,26 @@ def are_dir_trees_equal(dir1, dir2):
     # Directory comparison
     dirs_cmp = filecmp.dircmp(dir1, dir2)
     if dirs_cmp.left_only or dirs_cmp.right_only or dirs_cmp.funny_files:
-        return (False, "Left directory: {}, right directory: {}, files only "
-                "in left directory: {}, files only in right directory: "
-                "{}, not comparable files: {}".format(dir1, dir2, dirs_cmp.left_only, dirs_cmp.right_only,
-                                                      dirs_cmp.funny_files))
+        return (
+            False, "Left directory: {}, right directory: {}, files only "
+            "in left directory: {}, files only in right directory: "
+            "{}, not comparable files: {}".format(
+                dir1, dir2, dirs_cmp.left_only, dirs_cmp.right_only, dirs_cmp.funny_files
+            )
+        )
 
     # If the directories contain the same files, compare the common files
     (_, mismatch, errors) = filecmp.cmpfiles(dir1, dir2, dirs_cmp.common_files, shallow=False)
     if mismatch:
-        return (False, "The following files in the directories {} and {} "
-                "don't match: {}".format(dir1, dir2, mismatch))
+        return (
+            False, "The following files in the directories {} and {} "
+            "don't match: {}".format(dir1, dir2, mismatch)
+        )
     if errors:
-        return (False, "The following files in the directories {} and {} "
-                "aren't regular: {}".format(dir1, dir2, errors))
+        return (
+            False, "The following files in the directories {} and {} "
+            "aren't regular: {}".format(dir1, dir2, errors)
+        )
 
     for common_dir in dirs_cmp.common_dirs:
         new_dir1 = os.path.join(dir1, common_dir)
@@ -450,8 +461,9 @@ class Prettifier(object):  # pylint: disable=useless-object-inheritance
         try:
             self._prettifier_f = self.prettifiers[format]  # pylint: disable=unsubscriptable-object
         except KeyError:
-            raise ValueError("Unknown prettifier format {}; valid formats: {}".format(
-                format, ", ".join(self.get_prettifiers())))
+            raise ValueError(
+                "Unknown prettifier format {}; valid formats: {}".format(format, ", ".join(self.get_prettifiers()))
+            )
 
     def prettify(self, label):
         """

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -102,8 +102,10 @@ class DaemonClient(object):  # pylint: disable=too-many-public-methods,useless-o
         """
         from aiida.common.exceptions import ConfigurationError
         if VERDI_BIN is None:
-            raise ConfigurationError("Unable to find 'verdi' in the path. Make sure that you are working "
-                                     "in a virtual environment, or that at least the 'verdi' executable is on the PATH")
+            raise ConfigurationError(
+                "Unable to find 'verdi' in the path. Make sure that you are working "
+                "in a virtual environment, or that at least the 'verdi' executable is on the PATH"
+            )
         return '{} -p {} devel run_daemon'.format(VERDI_BIN, self.profile.name)
 
     @property

--- a/aiida/engine/persistence.py
+++ b/aiida/engine/persistence.py
@@ -63,14 +63,16 @@ class AiiDAPersister(plumpy.Persister):
             bundle = plumpy.Bundle(process, plumpy.LoadSaveContext(loader=get_object_loader()))
         except ValueError:
             # Couldn't create the bundle
-            raise plumpy.PersistenceError("Failed to create a bundle for '{}': {}".format(
-                process, traceback.format_exc()))
+            raise plumpy.PersistenceError(
+                "Failed to create a bundle for '{}': {}".format(process, traceback.format_exc())
+            )
 
         try:
             process.node.set_checkpoint(serialize.serialize(bundle))
         except Exception:
-            raise plumpy.PersistenceError("Failed to store a checkpoint for '{}': {}".format(
-                process, traceback.format_exc()))
+            raise plumpy.PersistenceError(
+                "Failed to store a checkpoint for '{}': {}".format(process, traceback.format_exc())
+            )
 
         return bundle
 
@@ -93,8 +95,9 @@ class AiiDAPersister(plumpy.Persister):
         try:
             calculation = load_node(pid)
         except (MultipleObjectsError, NotExistent):
-            raise plumpy.PersistenceError("Failed to load the node for process<{}>: {}".format(
-                pid, traceback.format_exc()))
+            raise plumpy.PersistenceError(
+                "Failed to load the node for process<{}>: {}".format(pid, traceback.format_exc())
+            )
 
         checkpoint = calculation.checkpoint
 
@@ -104,8 +107,9 @@ class AiiDAPersister(plumpy.Persister):
         try:
             bundle = serialize.deserialize(checkpoint)
         except Exception:
-            raise plumpy.PersistenceError("Failed to load the checkpoint for process<{}>: {}".format(
-                pid, traceback.format_exc()))
+            raise plumpy.PersistenceError(
+                "Failed to load the checkpoint for process<{}>: {}".format(pid, traceback.format_exc())
+            )
 
         return bundle
 

--- a/aiida/engine/processes/__init__.py
+++ b/aiida/engine/processes/__init__.py
@@ -21,5 +21,7 @@ from .ports import *
 from .process import *
 from .workchains import *
 
-__all__ = (builder.__all__ + calcjobs.__all__ + exit_code.__all__ + functions.__all__ + ports.__all__ + process.__all__
-           + workchains.__all__)
+__all__ = (
+    builder.__all__ + calcjobs.__all__ + exit_code.__all__ + functions.__all__ + ports.__all__ + process.__all__ +
+    workchains.__all__
+)

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -301,7 +301,8 @@ class FunctionProcess(Process):
                 Process.define.__name__: classmethod(_define),
                 '_func_args': args,
                 '_node_class': node_class
-            })
+            }
+        )
 
     @classmethod
     def validate_inputs(cls, *args, **kwargs):  # pylint: disable=unused-argument
@@ -434,7 +435,9 @@ class FunctionProcess(Process):
             for name, value in result.items():
                 self.out(name, value)
         else:
-            raise TypeError("Function process returned an output with unsupported type '{}'\n"
-                            "Must be a Data type or a mapping of {{string: Data}}".format(result.__class__))
+            raise TypeError(
+                "Function process returned an output with unsupported type '{}'\n"
+                "Must be a Data type or a mapping of {{string: Data}}".format(result.__class__)
+            )
 
         return ExitCode()

--- a/aiida/engine/processes/futures.py
+++ b/aiida/engine/processes/futures.py
@@ -14,8 +14,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 import tornado.gen
 
-import kiwipy
 import plumpy
+import kiwipy
 
 __all__ = ('CalculationFuture',)
 

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -19,8 +19,10 @@ from plumpy import ports
 
 from aiida.common.lang import type_check
 
-__all__ = ('PortNamespace', 'InputPort', 'OutputPort', 'CalcJobOutputPort', 'WithNonDb', 'WithSerialize',
-           'PORT_NAMESPACE_SEPARATOR')
+__all__ = (
+    'PortNamespace', 'InputPort', 'OutputPort', 'CalcJobOutputPort', 'WithNonDb', 'WithSerialize',
+    'PORT_NAMESPACE_SEPARATOR'
+)
 
 PORT_NAME_MAX_CONSECUTIVE_UNDERSCORES = 1  # pylint: disable=invalid-name
 PORT_NAMESPACE_SEPARATOR = '__'  # The character sequence to represent a nested port namespace in a flat link label

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -23,9 +23,9 @@ import six
 from six.moves import filter, range
 from pika.exceptions import ConnectionClosed
 
-from kiwipy.communications import UnroutableError
 import plumpy
 from plumpy import ProcessState
+from kiwipy.communications import UnroutableError
 
 from aiida import orm
 from aiida.common import exceptions

--- a/aiida/engine/processes/process_spec.py
+++ b/aiida/engine/processes/process_spec.py
@@ -99,7 +99,10 @@ class CalcJobProcessSpec(ProcessSpec):
         valid_type_required = Dict
 
         if valid_type_port is not valid_type_required:
-            raise ValueError('the valid type of a default output has to be a {} but it is {}'.format(
-                valid_type_port, valid_type_required))
+            raise ValueError(
+                'the valid type of a default output has to be a {} but it is {}'.format(
+                    valid_type_port, valid_type_required
+                )
+            )
 
         self._default_output_node = port_name

--- a/aiida/engine/processes/workchains/awaitable.py
+++ b/aiida/engine/processes/workchains/awaitable.py
@@ -59,11 +59,13 @@ def construct_awaitable(target):
     else:
         raise ValueError('invalid class for awaitable target: {}'.format(type(target)))
 
-    awaitable = Awaitable(**{
-        'pk': target.pk,
-        'action': AwaitableAction.ASSIGN,
-        'target': awaitable_target,
-        'outputs': False,
-    })
+    awaitable = Awaitable(
+        **{
+            'pk': target.pk,
+            'action': AwaitableAction.ASSIGN,
+            'target': awaitable_target,
+            'outputs': False,
+        }
+    )
 
     return awaitable

--- a/aiida/manage/backup/backup_setup.py
+++ b/aiida/manage/backup/backup_setup.py
@@ -64,7 +64,8 @@ class BackupSetup(object):  # pylint: disable=useless-object-inheritance
         # Setting the oldest backup timestamp
         oldest_object_bk = utils.ask_question(
             "Please provide the oldest backup timestamp "
-            "(e.g. 2014-07-18 13:54:53.688484+00:00). ", datetime.datetime, True)
+            "(e.g. 2014-07-18 13:54:53.688484+00:00). ", datetime.datetime, True
+        )
 
         if oldest_object_bk is None:
             backup_variables[AbstractBackup.OLDEST_OBJECT_BK_KEY] = None
@@ -75,25 +76,26 @@ class BackupSetup(object):  # pylint: disable=useless-object-inheritance
         backup_variables[AbstractBackup.BACKUP_DIR_KEY] = file_backup_folder_abs
 
         # Setting the days_to_backup
-        backup_variables[AbstractBackup.DAYS_TO_BACKUP_KEY] = utils.ask_question(
-            "Please provide the number of days to backup.", int, True)
+        backup_variables[AbstractBackup.DAYS_TO_BACKUP_KEY
+                        ] = utils.ask_question("Please provide the number of days to backup.", int, True)
 
         # Setting the end date
         end_date_of_backup_key = utils.ask_question(
             "Please provide the end date of the backup " + "(e.g. 2014-07-18 13:54:53.688484+00:00).",
-            datetime.datetime, True)
+            datetime.datetime, True
+        )
         if end_date_of_backup_key is None:
             backup_variables[AbstractBackup.END_DATE_OF_BACKUP_KEY] = None
         else:
             backup_variables[AbstractBackup.END_DATE_OF_BACKUP_KEY] = str(end_date_of_backup_key)
 
         # Setting the backup periodicity
-        backup_variables[AbstractBackup.PERIODICITY_KEY] = utils.ask_question("Please periodicity (in days).", int,
-                                                                              False)
+        backup_variables[AbstractBackup.PERIODICITY_KEY
+                        ] = utils.ask_question("Please periodicity (in days).", int, False)
 
         # Setting the backup threshold
-        backup_variables[AbstractBackup.BACKUP_LENGTH_THRESHOLD_KEY] = utils.ask_question(
-            "Please provide the backup threshold (in hours).", int, False)
+        backup_variables[AbstractBackup.BACKUP_LENGTH_THRESHOLD_KEY
+                        ] = utils.ask_question("Please provide the backup threshold (in hours).", int, False)
 
         return backup_variables
 
@@ -167,12 +169,14 @@ class BackupSetup(object):  # pylint: disable=useless-object-inheritance
         """Run the backup."""
         conf_backup_folder_abs = self.create_dir(
             "Please provide the backup folder by providing the full path.",
-            os.path.join(os.path.expanduser(AIIDA_CONFIG_FOLDER), self._conf_backup_folder_rel))
+            os.path.join(os.path.expanduser(AIIDA_CONFIG_FOLDER), self._conf_backup_folder_rel)
+        )
 
         file_backup_folder_abs = self.create_dir(
             "Please provide the destination folder of the backup (normally in "
-            "the previously provided backup folder).", os.path.join(conf_backup_folder_abs,
-                                                                    self._file_backup_folder_rel))
+            "the previously provided backup folder).",
+            os.path.join(conf_backup_folder_abs, self._file_backup_folder_rel)
+        )
 
         # The template backup configuration file
         template_conf_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), self._backup_info_tmpl_filename)
@@ -181,14 +185,16 @@ class BackupSetup(object):  # pylint: disable=useless-object-inheritance
         try:
             shutil.copy(template_conf_path, conf_backup_folder_abs)
         except Exception:
-            self._logger.error("Error copying the file %s to the directory %s", template_conf_path,
-                               conf_backup_folder_abs)
+            self._logger.error(
+                "Error copying the file %s to the directory %s", template_conf_path, conf_backup_folder_abs
+            )
             raise
 
         if utils.query_yes_no(
-                "A sample configuration file was copied to {}. "
-                "Would you like to ".format(conf_backup_folder_abs) + "see the configuration parameters explanation?",
-                default="yes"):
+            "A sample configuration file was copied to {}. "
+            "Would you like to ".format(conf_backup_folder_abs) + "see the configuration parameters explanation?",
+            default="yes"
+        ):
             self.print_info()
 
         # Construct the path to the backup configuration file
@@ -204,13 +210,16 @@ class BackupSetup(object):  # pylint: disable=useless-object-inheritance
                 json.dump(backup_variables, backup_info_file)
         # If the backup parameters are configured manually
         else:
-            sys.stdout.write("Please rename the file {} ".format(self._backup_info_tmpl_filename) +
-                             "found in {} to ".format(conf_backup_folder_abs) +
-                             "{} and ".format(self._backup_info_filename) +
-                             "change the backup parameters accordingly.\n")
-            sys.stdout.write("Please adapt the startup script accordingly to point to the " +
-                             "correct backup configuration file. For the moment, it points " +
-                             "to {}\n".format(os.path.join(conf_backup_folder_abs, self._backup_info_filename)))
+            sys.stdout.write(
+                "Please rename the file {} ".format(self._backup_info_tmpl_filename) +
+                "found in {} to ".format(conf_backup_folder_abs) + "{} and ".format(self._backup_info_filename) +
+                "change the backup parameters accordingly.\n"
+            )
+            sys.stdout.write(
+                "Please adapt the startup script accordingly to point to the " +
+                "correct backup configuration file. For the moment, it points " +
+                "to {}\n".format(os.path.join(conf_backup_folder_abs, self._backup_info_filename))
+            )
 
         # The contents of the startup script
         if configuration.PROFILE.database_backend == BACKEND_DJANGO:

--- a/aiida/manage/backup/backup_sqlalchemy.py
+++ b/aiida/manage/backup/backup_sqlalchemy.py
@@ -54,7 +54,8 @@ class Backup(AbstractBackup):
         :return:
         """
         q_nodes = aiida.backends.sqlalchemy.get_scoped_session().query(DbNode).filter(
-            DbNode.mtime >= start_of_backup).filter(DbNode.mtime <= backup_end_for_this_round)
+            DbNode.mtime >= start_of_backup
+        ).filter(DbNode.mtime <= backup_end_for_this_round)
 
         return [q_nodes]
 

--- a/aiida/manage/caching.py
+++ b/aiida/manage/caching.py
@@ -78,7 +78,8 @@ def _get_config(config_file):
             config[key] = [get_object_from_string(c) for c in config[key]]
     except (ValueError) as err:
         six.raise_from(
-            exceptions.ConfigurationError("Unknown class given in 'cache_config.yml': '{}'".format(err)), err)
+            exceptions.ConfigurationError("Unknown class given in 'cache_config.yml': '{}'".format(err)), err
+        )
     return config
 
 

--- a/aiida/manage/configuration/migrations/utils.py
+++ b/aiida/manage/configuration/migrations/utils.py
@@ -45,7 +45,9 @@ def config_needs_migrating(config):
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         raise exceptions.ConfigurationVersionError(
             'The configuration file has version {} which is not compatible with the current version {}.'.format(
-                current_version, CURRENT_CONFIG_VERSION))
+                current_version, CURRENT_CONFIG_VERSION
+            )
+        )
 
     return CURRENT_CONFIG_VERSION > current_version
 

--- a/aiida/manage/configuration/options.py
+++ b/aiida/manage/configuration/options.py
@@ -21,8 +21,9 @@ NO_DEFAULT = ()
 DEFAULT_DAEMON_TIMEOUT = 20  # Default timeout in seconds for circus client calls
 VALID_LOG_LEVELS = ['CRITICAL', 'ERROR', 'WARNING', 'REPORT', 'INFO', 'DEBUG']
 
-Option = collections.namedtuple('Option',
-                                ['name', 'key', 'valid_type', 'valid_values', 'default', 'description', 'global_only'])
+Option = collections.namedtuple(
+    'Option', ['name', 'key', 'valid_type', 'valid_values', 'default', 'description', 'global_only']
+)
 
 
 def get_option(option_name):
@@ -80,8 +81,10 @@ def parse_option(option_name, option_value):
 
     if option.valid_values is not None:
         if value not in option.valid_values:
-            raise ValueError('{} is not among the list of accepted values for option {}.\nThe valid values are: '
-                             '{}'.format(value, option.name, ', '.join(option.valid_values)))
+            raise ValueError(
+                '{} is not among the list of accepted values for option {}.\nThe valid values are: '
+                '{}'.format(value, option.name, ', '.join(option.valid_values))
+            )
 
     return option, value
 

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -88,8 +88,11 @@ class Profile(object):  # pylint: disable=useless-object-inheritance,too-many-pu
                     internal_key = self._map_config_to_internal[internal_key]
                 except KeyError:
                     from aiida.cmdline.utils import echo
-                    echo.echo_warning('removed unsupported key `{}` with value `{}` from profile `{}`'.format(
-                        internal_key, value, name))
+                    echo.echo_warning(
+                        'removed unsupported key `{}` with value `{}` from profile `{}`'.format(
+                            internal_key, value, name
+                        )
+                    )
                     continue
             setattr(self, internal_key, value)
 
@@ -280,8 +283,9 @@ class Profile(object):  # pylint: disable=useless-object-inheritance,too-many-pu
             os.makedirs(self.repository_path)
         except OSError as exception:
             if exception.errno != errno.EEXIST:
-                raise exceptions.ConfigurationError('could not create the configured repository `{}`: {}'.format(
-                    self.repository_path, str(exception)))
+                raise exceptions.ConfigurationError(
+                    'could not create the configured repository `{}`: {}'.format(self.repository_path, str(exception))
+                )
 
     @property
     def filepaths(self):

--- a/aiida/manage/configuration/setup.py
+++ b/aiida/manage/configuration/setup.py
@@ -41,8 +41,10 @@ def delete_repository(profile, non_interactive=True):
         echo.echo_info("Associated file repository '{}' is not a directory.".format(repo_path))
         return
 
-    if non_interactive or click.confirm("Delete associated file repository '{}'?\n"
-                                        "WARNING: All data will be lost.".format(repo_path)):
+    if non_interactive or click.confirm(
+        "Delete associated file repository '{}'?\n"
+        "WARNING: All data will be lost.".format(repo_path)
+    ):
         echo.echo_info("Deleting directory '{}'.".format(repo_path))
         import shutil
         shutil.rmtree(repo_path)
@@ -72,8 +74,10 @@ def delete_db(profile, non_interactive=True, verbose=False):
     database_name = profile.database_name
     if not postgres.db_exists(database_name):
         echo.echo_info("Associated database '{}' does not exist.".format(database_name))
-    elif non_interactive or click.confirm("Delete associated database '{}'?\n"
-                                          "WARNING: All data will be lost.".format(database_name)):
+    elif non_interactive or click.confirm(
+        "Delete associated database '{}'?\n"
+        "WARNING: All data will be lost.".format(database_name)
+    ):
         echo.echo_info("Deleting database '{}'.".format(database_name))
         postgres.drop_db(database_name)
 
@@ -84,8 +88,10 @@ def delete_db(profile, non_interactive=True, verbose=False):
     if not postgres.dbuser_exists(user):
         echo.echo_info("Associated database user '{}' does not exist.".format(user))
     elif users.count(user) > 1:
-        echo.echo_info("Associated database user '{}' is used by other profiles "
-                       "and will not be deleted.".format(user))
+        echo.echo_info(
+            "Associated database user '{}' is used by other profiles "
+            "and will not be deleted.".format(user)
+        )
     elif non_interactive or click.confirm("Delete database user '{}'?".format(user)):
         echo.echo_info("Deleting user '{}'.".format(user))
         postgres.drop_dbuser(user)
@@ -102,9 +108,10 @@ def delete_from_config(profile, non_interactive=True):
     """
     from aiida.manage.configuration import get_config
 
-    if non_interactive or click.confirm("Delete configuration for profile '{}'?\n"
-                                        "WARNING: Permanently removes profile from the list of AiiDA profiles.".format(
-                                            profile.name)):
+    if non_interactive or click.confirm(
+        "Delete configuration for profile '{}'?\n"
+        "WARNING: Permanently removes profile from the list of AiiDA profiles.".format(profile.name)
+    ):
         echo.echo_info("Deleting configuration for profile '{}'.".format(profile.name))
         config = get_config()
         config.remove_profile(profile.name)

--- a/aiida/manage/database/delete/nodes.py
+++ b/aiida/manage/database/delete/nodes.py
@@ -19,13 +19,9 @@ import click
 from aiida.cmdline.utils import echo
 
 
-def delete_nodes(pks,
-                 follow_calls=False,
-                 follow_returns=False,
-                 dry_run=False,
-                 force=False,
-                 disable_checks=False,
-                 verbosity=0):
+def delete_nodes(
+    pks, follow_calls=False, follow_returns=False, dry_run=False, force=False, disable_checks=False, verbosity=0
+):
     """
     Delete nodes by a list of pks
 
@@ -87,11 +83,13 @@ def delete_nodes(pks,
     while operational_set:
         # new_pks_set are the the pks of all nodes that are connected to the operational node set
         # with the links specified.
-        new_pks_set = set(i for i, in QueryBuilder().append(Node, filters={
-            'id': {
-                'in': operational_set
-            }
-        }).append(Node, project='id', edge_filters=edge_filters).iterall())
+        new_pks_set = set(
+            i for i, in QueryBuilder().append(Node, filters={
+                'id': {
+                    'in': operational_set
+                }
+            }).append(Node, project='id', edge_filters=edge_filters).iterall()
+        )
         # The operational set is only those pks that haven't been yet put into the pks_set_to_delete.
         operational_set = new_pks_set.difference(pks_set_to_delete)
 
@@ -99,13 +97,17 @@ def delete_nodes(pks,
         pks_set_to_delete = pks_set_to_delete.union(new_pks_set)
 
     if verbosity > 0:
-        echo.echo("I {} delete {} node{}".format('would' if dry_run else 'will', len(pks_set_to_delete),
-                                                 's' if len(pks_set_to_delete) > 1 else ''))
+        echo.echo(
+            "I {} delete {} node{}".format(
+                'would' if dry_run else 'will', len(pks_set_to_delete), 's' if len(pks_set_to_delete) > 1 else ''
+            )
+        )
         if verbosity > 1:
             builder = QueryBuilder().append(
                 Node, filters={'id': {
                     'in': pks_set_to_delete
-                }}, project=('uuid', 'id', 'node_type', 'label'))
+                }}, project=('uuid', 'id', 'node_type', 'label')
+            )
             echo.echo("The nodes I {} delete:".format('would' if dry_run else 'will'))
             for uuid, pk, type_string, label in builder.iterall():
                 try:
@@ -131,17 +133,22 @@ def delete_nodes(pks,
             }},
             edge_filters={'type': {
                 'in': link_types_to_follow
-            }})
+            }}
+        )
         caller_to_called2delete = called_qb.all()
 
         if verbosity > 0 and caller_to_called2delete:
             calculation_pks_losing_called = set(next(zip(*caller_to_called2delete)))
-            echo.echo("\n{} calculation{} {} lose at least one called instance".format(
-                len(calculation_pks_losing_called), 's' if len(calculation_pks_losing_called) > 1 else '',
-                'would' if dry_run else 'will'))
+            echo.echo(
+                "\n{} calculation{} {} lose at least one called instance".format(
+                    len(calculation_pks_losing_called), 's' if len(calculation_pks_losing_called) > 1 else '',
+                    'would' if dry_run else 'will'
+                )
+            )
             if verbosity > 1:
                 echo.echo(
-                    "These are the calculations that {} lose a called instance:".format('would' if dry_run else 'will'))
+                    "These are the calculations that {} lose a called instance:".format('would' if dry_run else 'will')
+                )
                 for calc_losing_called_pk in calculation_pks_losing_called:
                     echo.echo('  ', load_node(calc_losing_called_pk))
 
@@ -156,17 +163,23 @@ def delete_nodes(pks,
             }},
             edge_filters={'type': {
                 '==': LinkType.CREATE.value
-            }})
+            }}
+        )
 
         creator_to_created2delete = created_qb.all()
         if verbosity > 0 and creator_to_created2delete:
             calculation_pks_losing_created = set(next(zip(*creator_to_created2delete)))
-            echo.echo("\n{} calculation{} {} lose at least one created data-instance".format(
-                len(calculation_pks_losing_created), 's' if len(calculation_pks_losing_created) > 1 else '',
-                'would' if dry_run else 'will'))
+            echo.echo(
+                "\n{} calculation{} {} lose at least one created data-instance".format(
+                    len(calculation_pks_losing_created), 's' if len(calculation_pks_losing_created) > 1 else '',
+                    'would' if dry_run else 'will'
+                )
+            )
             if verbosity > 1:
-                echo.echo("These are the calculations that {} lose a created data-instance:".format(
-                    'would' if dry_run else 'will'))
+                echo.echo(
+                    "These are the calculations that {} lose a created data-instance:".
+                    format('would' if dry_run else 'will')
+                )
                 for calc_losing_created_pk in calculation_pks_losing_created:
                     echo.echo('  ', load_node(calc_losing_created_pk))
 
@@ -194,17 +207,21 @@ def delete_nodes(pks,
         # I pass now to the log the information for calculations losing created data or called instances
         for calc_pk, calc_type_string, link_label in caller_to_called2delete:
             calc = load_node(calc_pk)
-            calc.logger.warning("User {} deleted "
-                                "an instance of type {} "
-                                "called with the label {} "
-                                "by this calculation".format(user_email, calc_type_string, link_label))
+            calc.logger.warning(
+                "User {} deleted "
+                "an instance of type {} "
+                "called with the label {} "
+                "by this calculation".format(user_email, calc_type_string, link_label)
+            )
 
         for calc_pk, data_type_string, link_label in creator_to_created2delete:
             calc = load_node(calc_pk)
-            calc.logger.warning("User {} deleted "
-                                "an instance of type {} "
-                                "created with the label {} "
-                                "by this calculation".format(user_email, data_type_string, link_label))
+            calc.logger.warning(
+                "User {} deleted "
+                "an instance of type {} "
+                "created with the label {} "
+                "by this calculation".format(user_email, data_type_string, link_label)
+            )
 
     # If we are here, we managed to delete the entries from the DB.
     # I can now delete the folders

--- a/aiida/manage/database/integrity/__init__.py
+++ b/aiida/manage/database/integrity/__init__.py
@@ -44,8 +44,10 @@ def write_database_integrity_violation(results, headers, reason_message, action_
         echo.echo('')
         echo.echo_warning(
             '\n{}\nFound one or multiple records that violate the integrity of the database\nViolation reason: {}\n'
-            'Performed action: {}\nViolators written to: {}\n{}\n'.format(WARNING_BORDER, reason_message,
-                                                                          action_message, handle.name, WARNING_BORDER))
+            'Performed action: {}\nViolators written to: {}\n{}\n'.format(
+                WARNING_BORDER, reason_message, action_message, handle.name, WARNING_BORDER
+            )
+        )
 
         handle.write('# {}\n'.format(datetime.utcnow().isoformat()))
         handle.write('# Violation reason: {}\n'.format(reason_message))

--- a/aiida/manage/database/integrity/duplicate_uuid.py
+++ b/aiida/manage/database/integrity/duplicate_uuid.py
@@ -43,7 +43,8 @@ def verify_uuid_uniqueness(table):
     if duplicates:
         raise exceptions.IntegrityError(
             'Table {table:} contains rows with duplicate UUIDS: run '
-            '`verdi database integrity detect-duplicate-uuid -t {table:}` to address the problem'.format(table=table))
+            '`verdi database integrity detect-duplicate-uuid -t {table:}` to address the problem'.format(table=table)
+        )
 
 
 def apply_new_uuid_mapping(table, mapping):

--- a/aiida/manage/database/integrity/plugins.py
+++ b/aiida/manage/database/integrity/plugins.py
@@ -134,10 +134,12 @@ def infer_calculation_entry_point(type_strings):
 
         if inferred_entry_point_name in entry_point_names:
             entry_point_string = '{entry_point_group}:{entry_point_name}'.format(
-                entry_point_group=entry_point_group, entry_point_name=inferred_entry_point_name)
+                entry_point_group=entry_point_group, entry_point_name=inferred_entry_point_name
+            )
         elif inferred_entry_point_name:
             entry_point_string = '{plugin_name}.{plugin_class}'.format(
-                plugin_name=inferred_entry_point_name, plugin_class=plugin_class)
+                plugin_name=inferred_entry_point_name, plugin_class=plugin_class
+            )
         else:
             # If there is no inferred entry point name, i.e. there is no module name, use an empty string as fall back
             # This should only be the case for the type string `calculation.job.JobCalculation.`

--- a/aiida/manage/database/integrity/sql/nodes.py
+++ b/aiida/manage/database/integrity/sql/nodes.py
@@ -54,11 +54,13 @@ SELECT_NODES_WITH_INVALID_TYPE = """
     WHERE node.node_type NOT SIMILAR TO %(valid_node_types)s;
     """
 
-INVALID_NODE_SELECT_STATEMENTS = (AttributeDict({
-    'sql': SELECT_NODES_WITH_INVALID_TYPE,
-    'parameters': {
-        'valid_node_types': VALID_NODE_TYPE_STRING
-    },
-    'headers': ['ID', 'UUID', 'Type'],
-    'message': 'detected nodes with invalid type'
-}),)
+INVALID_NODE_SELECT_STATEMENTS = (
+    AttributeDict({
+        'sql': SELECT_NODES_WITH_INVALID_TYPE,
+        'parameters': {
+            'valid_node_types': VALID_NODE_TYPE_STRING
+        },
+        'headers': ['ID', 'UUID', 'Type'],
+        'message': 'detected nodes with invalid type'
+    }),
+)

--- a/aiida/manage/external/pgsu.py
+++ b/aiida/manage/external/pgsu.py
@@ -197,7 +197,8 @@ def prompt_db_info(interactive, dbinfo):
             access = True
         else:
             dbinfo_new['password'] = click.prompt(
-                'postgres password of {}'.format(dbinfo_new['user']), hide_input=True, type=str, default='')
+                'postgres password of {}'.format(dbinfo_new['user']), hide_input=True, type=str, default=''
+            )
             if not dbinfo_new.get('password'):
                 dbinfo_new.pop('password')
     return dbinfo_new
@@ -305,8 +306,10 @@ def _execute_psql(command, user='postgres', quiet=True, interactive=False, **kwa
     if host and host != 'localhost':
         option_str += ' -h {}'.format(host)
     elif not quiet:
-        click.echo("Warning: Found host 'localhost' but dropping '-h localhost' option for psql " +
-                   "since this may cause psql to switch to password-based authentication.")
+        click.echo(
+            "Warning: Found host 'localhost' but dropping '-h localhost' option for psql " +
+            "since this may cause psql to switch to password-based authentication."
+        )
 
     port = kwargs.pop('port', None)
     if port:

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -28,9 +28,11 @@ from .pgsu import PGSU, PostgresConnectionMode, DEFAULT_DBINFO
 
 _CREATE_USER_COMMAND = 'CREATE USER "{}" WITH PASSWORD \'{}\''
 _DROP_USER_COMMAND = 'DROP USER "{}"'
-_CREATE_DB_COMMAND = ('CREATE DATABASE "{}" OWNER "{}" ENCODING \'UTF8\' '
-                      'LC_COLLATE=\'en_US.UTF-8\' LC_CTYPE=\'en_US.UTF-8\' '
-                      'TEMPLATE=template0')
+_CREATE_DB_COMMAND = (
+    'CREATE DATABASE "{}" OWNER "{}" ENCODING \'UTF8\' '
+    'LC_COLLATE=\'en_US.UTF-8\' LC_CTYPE=\'en_US.UTF-8\' '
+    'TEMPLATE=template0'
+)
 _DROP_DB_COMMAND = 'DROP DATABASE "{}"'
 _GRANT_PRIV_COMMAND = 'GRANT ALL PRIVILEGES ON DATABASE "{}" TO "{}"'
 _GET_USERS_COMMAND = "SELECT usename FROM pg_user WHERE usename='{}'"
@@ -72,7 +74,9 @@ class Postgres(PGSU):
         dbinfo.update(
             dict(
                 host=profile.database_hostname or DEFAULT_DBINFO['host'],
-                port=profile.database_port or DEFAULT_DBINFO['port']))
+                port=profile.database_port or DEFAULT_DBINFO['port']
+            )
+        )
 
         return Postgres(dbinfo=dbinfo, **kwargs)
 

--- a/aiida/manage/fixtures.py
+++ b/aiida/manage/fixtures.py
@@ -503,7 +503,8 @@ class PluginTestCase(unittest.TestCase):
         cls.fixture_manager = _GLOBAL_FIXTURE_MANAGER
         if not cls.fixture_manager.has_profile_open():
             raise ValueError(
-                "Fixture mananger has no open profile. Please use aiida.manage.fixtures.TestRunner to run these tests.")
+                "Fixture mananger has no open profile. Please use aiida.manage.fixtures.TestRunner to run these tests."
+            )
 
         cls.backend = get_manager().get_backend()
 

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=cyclic-import
 """AiiDA manager for global settings"""
 from __future__ import division
 from __future__ import print_function
@@ -307,7 +308,8 @@ class Manager(object):  # pylint: disable=useless-object-inheritance
             loop=runner_loop,
             persister=self.get_persister(),
             load_context=plumpy.LoadSaveContext(runner=runner),
-            loader=persistence.get_object_loader())
+            loader=persistence.get_object_loader()
+        )
 
         def callback(*args, **kwargs):
             return plumpy.create_task(functools.partial(task_receiver, *args, **kwargs), loop=runner_loop)

--- a/aiida/orm/__init__.py
+++ b/aiida/orm/__init__.py
@@ -24,5 +24,7 @@ from .querybuilder import *
 from .users import *
 from .utils import *
 
-__all__ = (authinfos.__all__ + comments.__all__ + computers.__all__ + entities.__all__ + groups.__all__ + logs.__all__ +
-           nodes.__all__ + querybuilder.__all__ + users.__all__ + utils.__all__)
+__all__ = (
+    authinfos.__all__ + comments.__all__ + computers.__all__ + entities.__all__ + groups.__all__ + logs.__all__ +
+    nodes.__all__ + querybuilder.__all__ + users.__all__ + utils.__all__
+)

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -146,7 +146,8 @@ class AuthInfo(entities.Entity):
         try:
             transport_class = TransportFactory(transport_type)
         except exceptions.EntryPointError as exception:
-            raise exceptions.ConfigurationError('transport type `{}` could not be loaded: {}'.format(
-                transport_type, exception))
+            raise exceptions.ConfigurationError(
+                'transport type `{}` could not be loaded: {}'.format(transport_type, exception)
+            )
 
         return transport_class(machine=computer.hostname, **self.get_auth_params())

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -61,8 +61,9 @@ class Computer(entities.Entity):
             """Delete the computer with the given id"""
             return self._backend.computers.delete(id)
 
-    def __init__(self, name, hostname, description='', transport_type='', scheduler_type='', workdir=None,
-                 backend=None):
+    def __init__(
+        self, name, hostname, description='', transport_type='', scheduler_type='', workdir=None, backend=None
+    ):
         """Construct a new computer
 
         :type name: str
@@ -82,7 +83,8 @@ class Computer(entities.Entity):
             hostname=hostname,
             description=description,
             transport_type=transport_type,
-            scheduler_type=scheduler_type)
+            scheduler_type=scheduler_type
+        )
         super(Computer, self).__init__(model)
         if workdir is not None:
             self.set_workdir(workdir)
@@ -271,10 +273,12 @@ class Computer(entities.Entity):
             return
 
         if not isinstance(def_cpus_per_machine, six.integer_types) or def_cpus_per_machine <= 0:
-            raise exceptions.ValidationError("Invalid value for default_mpiprocs_per_machine, "
-                                             "must be a positive integer, or an empty "
-                                             "string if you do not want to provide a "
-                                             "default value.")
+            raise exceptions.ValidationError(
+                "Invalid value for default_mpiprocs_per_machine, "
+                "must be a positive integer, or an empty "
+                "string if you do not want to provide a "
+                "default value."
+            )
 
     # endregion
 
@@ -446,8 +450,9 @@ class Computer(entities.Entity):
         :return: The minimum interval (in seconds)
         :rtype: float
         """
-        return self.get_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL,
-                                 self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT)
+        return self.get_property(
+            self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT
+        )
 
     def set_minimum_job_poll_interval(self, interval):
         """
@@ -636,8 +641,11 @@ class Computer(entities.Entity):
         try:
             return TransportFactory(self.get_transport_type())
         except exceptions.EntryPointError as exception:
-            raise exceptions.ConfigurationError('No transport found for {} [type {}], message: {}'.format(
-                self.name, self.get_transport_type(), exception))
+            raise exceptions.ConfigurationError(
+                'No transport found for {} [type {}], message: {}'.format(
+                    self.name, self.get_transport_type(), exception
+                )
+            )
 
     def get_scheduler(self):
         """
@@ -651,8 +659,11 @@ class Computer(entities.Entity):
             # I call the init without any parameter
             return scheduler_class()
         except exceptions.EntryPointError as exception:
-            raise exceptions.ConfigurationError('No scheduler found for {} [type {}], message: {}'.format(
-                self.name, self.get_scheduler_type(), exception))
+            raise exceptions.ConfigurationError(
+                'No scheduler found for {} [type {}], message: {}'.format(
+                    self.name, self.get_scheduler_type(), exception
+                )
+            )
 
     def configure(self, user=None, **kwargs):
         """
@@ -671,8 +682,11 @@ class Computer(entities.Entity):
 
         if not set(kwargs.keys()).issubset(valid_keys):
             invalid_keys = [key for key in kwargs if key not in valid_keys]
-            raise ValueError('{transport}: received invalid authentication parameter(s) "{invalid}"'.format(
-                transport=transport_cls, invalid=invalid_keys))
+            raise ValueError(
+                '{transport}: received invalid authentication parameter(s) "{invalid}"'.format(
+                    transport=transport_cls, invalid=invalid_keys
+                )
+            )
 
         try:
             authinfo = self.get_authinfo(user)
@@ -780,8 +794,8 @@ class Computer(entities.Entity):
                 "valid_choices": {
                     "local": {
                         "doc":
-                        "Support copy and command execution on the same host on which AiiDA is running via direct file "
-                        "copy and execution commands."
+                        "Support copy and command execution on the same host on which AiiDA is running via direct "
+                        "file copy and execution commands."
                     },
                     "ssh": {
                         "doc":

--- a/aiida/orm/convert.py
+++ b/aiida/orm/convert.py
@@ -31,8 +31,9 @@ from aiida.orm.implementation import BackendComputer, BackendGroup, BackendUser,
 
 @singledispatch
 def get_orm_entity(backend_entity):
-    raise TypeError("No corresponding AiiDA ORM class exists for backend instance {}".format(
-        backend_entity.__class__.__name__))
+    raise TypeError(
+        "No corresponding AiiDA ORM class exists for backend instance {}".format(backend_entity.__class__.__name__)
+    )
 
 
 @get_orm_entity.register(Mapping)

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -122,8 +122,9 @@ class Collection(typing.Generic[EntityType]):  # pylint: disable=unsubscriptable
         if not res:
             raise exceptions.NotExistent("No {} with filter '{}' found".format(self.entity_type.__name__, filters))
         if len(res) > 1:
-            raise exceptions.MultipleObjectsError("Multiple {}s found with the same id '{}'".format(
-                self.entity_type.__name__, id))
+            raise exceptions.MultipleObjectsError(
+                "Multiple {}s found with the same id '{}'".format(self.entity_type.__name__, id)
+            )
 
         return res[0]
 

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -60,8 +60,10 @@ class Group(entities.Entity):
 
             if 'type_string' in kwargs:
                 if not isinstance(kwargs['type_string'], six.string_types):
-                    raise exceptions.ValidationError("type_string must be {}, you provided an object of type "
-                                                     "{}".format(str, type(kwargs['type_string'])))
+                    raise exceptions.ValidationError(
+                        "type_string must be {}, you provided an object of type "
+                        "{}".format(str, type(kwargs['type_string']))
+                    )
 
                 filters['type_string'] = kwargs['type_string']
 
@@ -107,15 +109,18 @@ class Group(entities.Entity):
 
         # Check that chosen type_string is allowed
         if not isinstance(type_string, six.string_types):
-            raise exceptions.ValidationError("type_string must be {}, you provided an object of type "
-                                             "{}".format(str, type(type_string)))
+            raise exceptions.ValidationError(
+                "type_string must be {}, you provided an object of type "
+                "{}".format(str, type(type_string))
+            )
 
         backend = backend or get_manager().get_backend()
         user = user or users.User.objects(backend).get_default()
         type_check(user, users.User)
 
         model = backend.groups.create(
-            label=label, user=user.backend_entity, description=description, type_string=type_string)
+            label=label, user=user.backend_entity, description=description, type_string=type_string
+        )
         super(Group, self).__init__(model)
 
     def __repr__(self):
@@ -293,8 +298,10 @@ class Group(entities.Entity):
         filters = {}
         if 'type_string' in kwargs:
             if not isinstance(kwargs['type_string'], six.string_types):
-                raise exceptions.ValidationError("type_string must be {}, you provided an object of type "
-                                                 "{}".format(str, type(kwargs['type_string'])))
+                raise exceptions.ValidationError(
+                    "type_string must be {}, you provided an object of type "
+                    "{}".format(str, type(kwargs['type_string']))
+                )
 
         query = QueryBuilder()
         for key, val in kwargs.items():

--- a/aiida/orm/implementation/__init__.py
+++ b/aiida/orm/implementation/__init__.py
@@ -23,5 +23,7 @@ from .nodes import *
 from .querybuilder import *
 from .users import *
 
-__all__ = (authinfos.__all__ + backends.__all__ + comments.__all__ + computers.__all__ + groups.__all__ + logs.__all__ +
-           nodes.__all__ + querybuilder.__all__ + users.__all__)
+__all__ = (
+    authinfos.__all__ + backends.__all__ + comments.__all__ + computers.__all__ + groups.__all__ + logs.__all__ +
+    nodes.__all__ + querybuilder.__all__ + users.__all__
+)

--- a/aiida/orm/implementation/django/authinfos.py
+++ b/aiida/orm/implementation/django/authinfos.py
@@ -154,10 +154,12 @@ class DjangoAuthInfoCollection(BackendAuthInfoCollection):
         try:
             authinfo = DbAuthInfo.objects.get(dbcomputer=computer.id, aiidauser=user.id)
         except ObjectDoesNotExist:
-            raise exceptions.NotExistent('User<{}> has no configuration for Computer<{}>'.format(
-                user.email, computer.name))
+            raise exceptions.NotExistent(
+                'User<{}> has no configuration for Computer<{}>'.format(user.email, computer.name)
+            )
         except MultipleObjectsReturned:
-            raise exceptions.MultipleObjectsError('User<{}> has multiple configurations for Computer<{}>'.format(
-                user.email, computer.name))
+            raise exceptions.MultipleObjectsError(
+                'User<{}> has multiple configurations for Computer<{}>'.format(user.email, computer.name)
+            )
         else:
             return self.from_dbmodel(authinfo)

--- a/aiida/orm/implementation/django/computers.py
+++ b/aiida/orm/implementation/django/computers.py
@@ -135,5 +135,7 @@ class DjangoComputerCollection(BackendComputerCollection):
         try:
             models.DbComputer.objects.filter(pk=pk).delete()
         except ProtectedError:
-            raise exceptions.InvalidOperation("Unable to delete the requested computer: there"
-                                              "is at least one node using this computer")
+            raise exceptions.InvalidOperation(
+                "Unable to delete the requested computer: there"
+                "is at least one node using this computer"
+            )

--- a/aiida/orm/implementation/django/convert.py
+++ b/aiida/orm/implementation/django/convert.py
@@ -30,8 +30,9 @@ def get_backend_entity(dbmodel, backend):  # pylint: disable=unused-argument
 
     :param dbmodel: the db model instance
     """
-    raise TypeError('No corresponding AiiDA backend class exists for the DbModel instance {}'.format(
-        dbmodel.__class__.__name__))
+    raise TypeError(
+        'No corresponding AiiDA backend class exists for the DbModel instance {}'.format(dbmodel.__class__.__name__)
+    )
 
 
 @get_backend_entity.register(djmodels.DbUser)
@@ -104,7 +105,8 @@ def _(dbmodel, backend):
         email=dbmodel.email,
         first_name=dbmodel.first_name,
         last_name=dbmodel.last_name,
-        institution=dbmodel.institution)
+        institution=dbmodel.institution
+    )
     return users.DjangoUser.from_dbmodel(djuser_instance, backend)
 
 
@@ -142,7 +144,8 @@ def _(dbmodel, backend):
         description=dbmodel.description,
         transport_type=dbmodel.transport_type,
         scheduler_type=dbmodel.scheduler_type,
-        metadata=dbmodel.metadata)
+        metadata=dbmodel.metadata
+    )
     return computers.DjangoComputer.from_dbmodel(djcomputer_instance, backend)
 
 
@@ -164,7 +167,8 @@ def _(dbmodel, backend):
         dbcomputer_id=dbmodel.dbcomputer_id,
         user_id=dbmodel.user_id,
         attributes=dbmodel.attributes,
-        extras=dbmodel.extras)
+        extras=dbmodel.extras
+    )
 
     from . import nodes
     return nodes.DjangoNode.from_dbmodel(djnode_instance, backend)
@@ -201,7 +205,8 @@ def _(dbmodel, backend):
         ctime=dbmodel.ctime,
         mtime=dbmodel.mtime,
         user_id=dbmodel.user_id,
-        content=dbmodel.content)
+        content=dbmodel.content
+    )
     return comments.DjangoComment.from_dbmodel(djcomment, backend)
 
 

--- a/aiida/orm/implementation/django/groups.py
+++ b/aiida/orm/implementation/django/groups.py
@@ -46,7 +46,8 @@ class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # 
         super(DjangoGroup, self).__init__(backend)
 
         self._dbmodel = utils.ModelWrapper(
-            models.DbGroup(label=label, description=description, user=user.dbmodel, type_string=type_string))
+            models.DbGroup(label=label, description=description, user=user.dbmodel, type_string=type_string)
+        )
 
     @property
     def label(self):
@@ -205,17 +206,19 @@ class DjangoGroupCollection(BackendGroupCollection):
 
     ENTITY_CLASS = DjangoGroup
 
-    def query(self,
-              label=None,
-              type_string=None,
-              pk=None,
-              uuid=None,
-              nodes=None,
-              user=None,
-              node_attributes=None,
-              past_days=None,
-              label_filters=None,
-              **kwargs):  # pylint: disable=too-many-arguments
+    def query(
+        self,
+        label=None,
+        type_string=None,
+        pk=None,
+        uuid=None,
+        nodes=None,
+        user=None,
+        node_attributes=None,
+        past_days=None,
+        label_filters=None,
+        **kwargs
+    ):  # pylint: disable=too-many-arguments
         # pylint: disable=too-many-branches,too-many-locals
         from .nodes import DjangoNode
 
@@ -244,9 +247,11 @@ class DjangoGroupCollection(BackendGroupCollection):
 
             for node in nodes:
                 if not isinstance(node, (DjangoNode, models.DbNode)):
-                    raise TypeError("At least one of the elements passed as "
-                                    "nodes for the query on Group is neither "
-                                    "a Node nor a DbNode")
+                    raise TypeError(
+                        "At least one of the elements passed as "
+                        "nodes for the query on Group is neither "
+                        "a Node nor a DbNode"
+                    )
                 pk_list.append(node.pk)
 
             queryobject &= Q(dbnodes__in=pk_list)
@@ -285,7 +290,8 @@ class DjangoGroupCollection(BackendGroupCollection):
                     # this should be ok.
                     groups_pk = groups_pk.intersection(
                         models.DbGroup.objects.filter(pk__in=groups_pk, dbnodes__dbattributes__key=k,
-                                                      **query_dict).values_list('pk', flat=True))
+                                                      **query_dict).values_list('pk', flat=True)
+                    )
 
         retlist = []
         # Return sorted by pk

--- a/aiida/orm/implementation/django/logs.py
+++ b/aiida/orm/implementation/django/logs.py
@@ -36,7 +36,8 @@ class DjangoLog(entities.DjangoModelEntity[models.DbLog], BackendLog):
             levelname=levelname,
             dbnode_id=dbnode_id,
             message=message,
-            metadata=metadata or {})
+            metadata=metadata or {}
+        )
 
     @property
     def uuid(self):

--- a/aiida/orm/implementation/django/nodes.py
+++ b/aiida/orm/implementation/django/nodes.py
@@ -37,16 +37,18 @@ class DjangoNode(entities.DjangoModelEntity[models.DbNode], BackendNode):
     MODEL_CLASS = models.DbNode
     LINK_CLASS = models.DbLink
 
-    def __init__(self,
-                 backend,
-                 node_type,
-                 user,
-                 computer=None,
-                 process_type=None,
-                 label='',
-                 description='',
-                 ctime=None,
-                 mtime=None):
+    def __init__(
+        self,
+        backend,
+        node_type,
+        user,
+        computer=None,
+        process_type=None,
+        label='',
+        description='',
+        ctime=None,
+        mtime=None
+    ):
         """Construct a new `BackendNode` instance wrapping a new `DbNode` instance.
 
         :param backend: the backend

--- a/aiida/orm/implementation/django/querybuilder.py
+++ b/aiida/orm/implementation/django/querybuilder.py
@@ -205,8 +205,10 @@ class DjangoQueryBuilder(BackendQueryBuilder):
                 raise InputValidationError("You have to give an integer when comparing to a length")
         elif operator in ('like', 'ilike'):
             if not isinstance(value, six.string_types):
-                raise InputValidationError("Value for operator {} has to be a string (you gave {})"
-                                           "".format(operator, value))
+                raise InputValidationError(
+                    "Value for operator {} has to be a string (you gave {})"
+                    "".format(operator, value)
+                )
         elif operator == 'in':
             value_type_set = set(type(i) for i in value)
             if len(value_type_set) > 1:
@@ -225,7 +227,9 @@ class DjangoQueryBuilder(BackendQueryBuilder):
                             is_attribute=is_attribute,
                             alias=alias,
                             column=column,
-                            column_name=column_name))
+                            column_name=column_name
+                        )
+                    )
             if operator == 'and':
                 expr = and_(*expressions_for_this_path)
             elif operator == 'or':
@@ -234,7 +238,8 @@ class DjangoQueryBuilder(BackendQueryBuilder):
         if expr is None:
             if is_attribute:
                 expr = self.get_filter_expr_from_attributes(
-                    operator, value, attr_key, column=column, column_name=column_name, alias=alias)
+                    operator, value, attr_key, column=column, column_name=column_name, alias=alias
+                )
             else:
                 if column is None:
                     if (alias is None) and (column_name is None):
@@ -317,8 +322,10 @@ class DjangoQueryBuilder(BackendQueryBuilder):
             #  Possible types are object, array, string, number, boolean, and null.
             valid_types = ('object', 'array', 'string', 'number', 'boolean', 'null')
             if value not in valid_types:
-                raise InputValidationError("value {} for of_type is not among valid types\n"
-                                           "{}".format(value, valid_types))
+                raise InputValidationError(
+                    "value {} for of_type is not among valid types\n"
+                    "{}".format(value, valid_types)
+                )
             expr = jsonb_typeof(database_entity) == value
         elif operator == 'like':
             type_filter, casted_entity = cast_according_to_type(database_entity, value)
@@ -334,18 +341,21 @@ class DjangoQueryBuilder(BackendQueryBuilder):
         elif operator == 'has_key':
             expr = database_entity.cast(JSONB).has_key(value)  # noqa
         elif operator == 'of_length':
-            expr = case(
-                [(jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) == value)],
-                else_=False)
+            expr = case([
+                (jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) == value)
+            ],
+                        else_=False)
 
         elif operator == 'longer':
-            expr = case(
-                [(jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) > value)],
-                else_=False)
+            expr = case([
+                (jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) > value)
+            ],
+                        else_=False)
         elif operator == 'shorter':
-            expr = case(
-                [(jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) < value)],
-                else_=False)
+            expr = case([
+                (jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) < value)
+            ],
+                        else_=False)
         else:
             raise InputValidationError("Unknown operator {} for filters in JSON field".format(operator))
         return expr
@@ -470,8 +480,8 @@ class DjangoQueryBuilder(BackendQueryBuilder):
                     yield {
                         tag: {
                             self.get_corresponding_property(
-                                get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema):
-                            self.get_aiida_res(attrkey, this_result[index_in_sql_result])
+                                get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema
+                            ): self.get_aiida_res(attrkey, this_result[index_in_sql_result])
                             for attrkey, index_in_sql_result in projected_entities_dict.items()
                         } for tag, projected_entities_dict in tag_to_projected_properties_dict.items()
                     }
@@ -483,8 +493,8 @@ class DjangoQueryBuilder(BackendQueryBuilder):
                         yield {
                             tag: {
                                 self.get_corresponding_property(
-                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema):
-                                self.get_aiida_res(attrkey, this_result)
+                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema
+                                ): self.get_aiida_res(attrkey, this_result)
                                 for attrkey, position in projected_entities_dict.items()
                             } for tag, projected_entities_dict in tag_to_projected_properties_dict.items()
                         }
@@ -493,8 +503,8 @@ class DjangoQueryBuilder(BackendQueryBuilder):
                         yield {
                             tag: {
                                 self.get_corresponding_property(
-                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema):
-                                self.get_aiida_res(attrkey, this_result)
+                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema
+                                ): self.get_aiida_res(attrkey, this_result)
                                 for attrkey, position in projected_entities_dict.items()
                             } for tag, projected_entities_dict in tag_to_projected_properties_dict.items()
                         }

--- a/aiida/orm/implementation/django/users.py
+++ b/aiida/orm/implementation/django/users.py
@@ -32,7 +32,8 @@ class DjangoUser(entities.DjangoModelEntity[models.DbUser], BackendUser):
         # pylint: disable=too-many-arguments
         super(DjangoUser, self).__init__(backend)
         self._dbmodel = utils.ModelWrapper(
-            DbUser(email=email, first_name=first_name, last_name=last_name, institution=institution))
+            DbUser(email=email, first_name=first_name, last_name=last_name, institution=institution)
+        )
 
     @property
     def email(self):

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -206,17 +206,19 @@ class BackendGroupCollection(backends.BackendCollection[BackendGroup]):
 
     @abc.abstractmethod
     # pylint: disable=too-many-arguments
-    def query(self,
-              label=None,
-              type_string=None,
-              pk=None,
-              uuid=None,
-              nodes=None,
-              user=None,
-              node_attributes=None,
-              past_days=None,
-              label_filters=None,
-              **kwargs):
+    def query(
+        self,
+        label=None,
+        type_string=None,
+        pk=None,
+        uuid=None,
+        nodes=None,
+        user=None,
+        node_attributes=None,
+        past_days=None,
+        label_filters=None,
+        **kwargs
+    ):
         """
         Query for groups.
 

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -280,10 +280,12 @@ class BackendQueryBuilder(object):
         try:
             return getattr(alias, colname)
         except AttributeError:
-            raise exceptions.InputValidationError("{} is not a column of {}\n"
-                                                  "Valid columns are:\n"
-                                                  "{}".format(
-                                                      colname,
-                                                      alias,
-                                                      '\n'.join(alias._sa_class_manager.mapper.c.keys())  # pylint: disable=protected-access
-                                                  ))
+            raise exceptions.InputValidationError(
+                "{} is not a column of {}\n"
+                "Valid columns are:\n"
+                "{}".format(
+                    colname,
+                    alias,
+                    '\n'.join(alias._sa_class_manager.mapper.c.keys())  # pylint: disable=protected-access
+                )
+            )

--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -153,10 +153,12 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
         try:
             authinfo = session.query(DbAuthInfo).filter_by(dbcomputer_id=computer.id, aiidauser_id=user.id).one()
         except NoResultFound:
-            raise exceptions.NotExistent('User<{}> has no configuration for Computer<{}>'.format(
-                user.email, computer.name))
+            raise exceptions.NotExistent(
+                'User<{}> has no configuration for Computer<{}>'.format(user.email, computer.name)
+            )
         except MultipleResultsFound:
-            raise exceptions.MultipleObjectsError('User<{}> has multiple configurations for Computer<{}>'.format(
-                user.email, computer.name))
+            raise exceptions.MultipleObjectsError(
+                'User<{}> has multiple configurations for Computer<{}>'.format(user.email, computer.name)
+            )
         else:
             return self.from_dbmodel(authinfo)

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -146,4 +146,5 @@ class SqlaComputerCollection(BackendComputerCollection):
         except SQLAlchemyError as exc:
             raise exceptions.InvalidOperation(
                 "Unable to delete the requested computer: it is possible that there "
-                "is at least one node using this computer (original message: {})".format(exc))
+                "is at least one node using this computer (original message: {})".format(exc)
+            )

--- a/aiida/orm/implementation/sqlalchemy/convert.py
+++ b/aiida/orm/implementation/sqlalchemy/convert.py
@@ -41,8 +41,9 @@ def get_backend_entity(dbmodel, backend):  # pylint: disable=unused-argument
     """
     Default get_backend_entity
     """
-    raise TypeError("No corresponding AiiDA backend class exists for the model class '{}'".format(
-        dbmodel.__class__.__name__))
+    raise TypeError(
+        "No corresponding AiiDA backend class exists for the model class '{}'".format(dbmodel.__class__.__name__)
+    )
 
 
 ################################

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -276,17 +276,19 @@ class SqlaGroupCollection(BackendGroupCollection):
 
     ENTITY_CLASS = SqlaGroup
 
-    def query(self,
-              label=None,
-              type_string=None,
-              pk=None,
-              uuid=None,
-              nodes=None,
-              user=None,
-              node_attributes=None,
-              past_days=None,
-              label_filters=None,
-              **kwargs):  # pylint: disable=too-many-arguments
+    def query(
+        self,
+        label=None,
+        type_string=None,
+        pk=None,
+        uuid=None,
+        nodes=None,
+        user=None,
+        node_attributes=None,
+        past_days=None,
+        label_filters=None,
+        **kwargs
+    ):  # pylint: disable=too-many-arguments
         # pylint: disable=too-many-branches
         from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode
 
@@ -309,15 +311,20 @@ class SqlaGroupCollection(BackendGroupCollection):
                 nodes = [nodes]
 
             if not all(isinstance(n, (SqlaNode, DbNode)) for n in nodes):
-                raise TypeError("At least one of the elements passed as "
-                                "nodes for the query on Group is neither "
-                                "a Node nor a DbNode")
+                raise TypeError(
+                    "At least one of the elements passed as "
+                    "nodes for the query on Group is neither "
+                    "a Node nor a DbNode"
+                )
 
             # In the case of the Node orm from Sqlalchemy, there is an id
             # property on it.
-            sub_query = (session.query(table_groups_nodes).filter(
-                table_groups_nodes.c["dbnode_id"].in_([n.id for n in nodes]),
-                table_groups_nodes.c["dbgroup_id"] == DbGroup.id).exists())
+            sub_query = (
+                session.query(table_groups_nodes).filter(
+                    table_groups_nodes.c["dbnode_id"].in_([n.id for n in nodes]),
+                    table_groups_nodes.c["dbgroup_id"] == DbGroup.id
+                ).exists()
+            )
 
             filters.append(sub_query)
         if user:

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -39,7 +39,9 @@ class SqlaLog(entities.SqlaModelEntity[models.DbLog], BackendLog):
                 levelname=levelname,
                 dbnode_id=dbnode_id,
                 message=message,
-                metadata=metadata))
+                metadata=metadata
+            )
+        )
 
     @property
     def uuid(self):

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -37,16 +37,18 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
 
     MODEL_CLASS = models.DbNode
 
-    def __init__(self,
-                 backend,
-                 node_type,
-                 user,
-                 computer=None,
-                 process_type=None,
-                 label='',
-                 description='',
-                 ctime=None,
-                 mtime=None):
+    def __init__(
+        self,
+        backend,
+        node_type,
+        user,
+        computer=None,
+        process_type=None,
+        label='',
+        description='',
+        ctime=None,
+        mtime=None
+    ):
         """Construct a new `BackendNode` instance wrapping a new `DbNode` instance.
 
         :param backend: the backend

--- a/aiida/orm/implementation/sqlalchemy/querybuilder.py
+++ b/aiida/orm/implementation/sqlalchemy/querybuilder.py
@@ -238,8 +238,10 @@ class SqlaQueryBuilder(BackendQueryBuilder):
                 raise InputValidationError("You have to give an integer when comparing to a length")
         elif operator in ('like', 'ilike'):
             if not isinstance(value, six.string_types):
-                raise InputValidationError("Value for operator {} has to be a string (you gave {})"
-                                           "".format(operator, value))
+                raise InputValidationError(
+                    "Value for operator {} has to be a string (you gave {})"
+                    "".format(operator, value)
+                )
 
         elif operator == 'in':
             value_type_set = set(type(i) for i in value)
@@ -259,7 +261,9 @@ class SqlaQueryBuilder(BackendQueryBuilder):
                             is_attribute=is_attribute,
                             alias=alias,
                             column=column,
-                            column_name=column_name))
+                            column_name=column_name
+                        )
+                    )
             if operator == 'and':
                 expr = and_(*expressions_for_this_path)
             elif operator == 'or':
@@ -268,7 +272,8 @@ class SqlaQueryBuilder(BackendQueryBuilder):
         if expr is None:
             if is_attribute:
                 expr = self.get_filter_expr_from_attributes(
-                    operator, value, attr_key, column=column, column_name=column_name, alias=alias)
+                    operator, value, attr_key, column=column, column_name=column_name, alias=alias
+                )
             else:
                 if column is None:
                     if (alias is None) and (column_name is None):
@@ -332,8 +337,10 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             #  Possible types are object, array, string, number, boolean, and null.
             valid_types = ('object', 'array', 'string', 'number', 'boolean', 'null')
             if value not in valid_types:
-                raise InputValidationError("value {} for of_type is not among valid types\n"
-                                           "{}".format(value, valid_types))
+                raise InputValidationError(
+                    "value {} for of_type is not among valid types\n"
+                    "{}".format(value, valid_types)
+                )
             expr = jsonb_typeof(database_entity) == value
         elif operator == 'like':
             type_filter, casted_entity = cast_according_to_type(database_entity, value)
@@ -349,18 +356,21 @@ class SqlaQueryBuilder(BackendQueryBuilder):
         elif operator == 'has_key':
             expr = database_entity.cast(JSONB).has_key(value)  # noqa
         elif operator == 'of_length':
-            expr = case(
-                [(jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) == value)],
-                else_=False)
+            expr = case([
+                (jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) == value)
+            ],
+                        else_=False)
 
         elif operator == 'longer':
-            expr = case(
-                [(jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) > value)],
-                else_=False)
+            expr = case([
+                (jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) > value)
+            ],
+                        else_=False)
         elif operator == 'shorter':
-            expr = case(
-                [(jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) < value)],
-                else_=False)
+            expr = case([
+                (jsonb_typeof(database_entity) == 'array', jsonb_array_length(database_entity.cast(JSONB)) < value)
+            ],
+                        else_=False)
         else:
             raise InputValidationError("Unknown operator {} for filters in JSON field".format(operator))
         return expr
@@ -495,8 +505,8 @@ class SqlaQueryBuilder(BackendQueryBuilder):
                     yield {
                         tag: {
                             self.get_corresponding_property(
-                                get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema):
-                            self.get_aiida_res(attrkey, this_result[index_in_sql_result])
+                                get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema
+                            ): self.get_aiida_res(attrkey, this_result[index_in_sql_result])
                             for attrkey, index_in_sql_result in projected_entities_dict.items()
                         } for tag, projected_entities_dict in tag_to_projected_properties_dict.items()
                     }
@@ -508,8 +518,8 @@ class SqlaQueryBuilder(BackendQueryBuilder):
                         yield {
                             tag: {
                                 self.get_corresponding_property(
-                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema):
-                                self.get_aiida_res(attrkey, this_result)
+                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema
+                                ): self.get_aiida_res(attrkey, this_result)
                                 for attrkey, position in projected_entities_dict.items()
                             } for tag, projected_entities_dict in tag_to_projected_properties_dict.items()
                         }
@@ -518,8 +528,8 @@ class SqlaQueryBuilder(BackendQueryBuilder):
                         yield {
                             tag: {
                                 self.get_corresponding_property(
-                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema):
-                                self.get_aiida_res(attrkey, this_result)
+                                    get_table_name(tag_to_alias_map[tag]), attrkey, self.inner_to_outer_schema
+                                ): self.get_aiida_res(attrkey, this_result)
                                 for attrkey, position in projected_entities_dict.items()
                             } for tag, projected_entities_dict in tag_to_projected_properties_dict.items()
                         }

--- a/aiida/orm/implementation/sqlalchemy/users.py
+++ b/aiida/orm/implementation/sqlalchemy/users.py
@@ -28,7 +28,8 @@ class SqlaUser(entities.SqlaModelEntity[DbUser], BackendUser):
         # pylint: disable=too-many-arguments
         super(SqlaUser, self).__init__(backend)
         self._dbmodel = utils.ModelWrapper(
-            DbUser(email=email, first_name=first_name, last_name=last_name, institution=institution))
+            DbUser(email=email, first_name=first_name, last_name=last_name, institution=institution)
+        )
 
     @property
     def email(self):

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -77,7 +77,8 @@ class Log(entities.Entity):
                 levelname=record.levelname,
                 dbnode_id=dbnode_id,
                 message=message,
-                metadata=metadata)
+                metadata=metadata
+            )
 
         def get_logs_for(self, entity, order_by=None):
             """
@@ -175,7 +176,8 @@ class Log(entities.Entity):
             levelname=levelname,
             dbnode_id=dbnode_id,
             message=message,
-            metadata=metadata)
+            metadata=metadata
+        )
         super(Log, self).__init__(model)
         self.store()  # Logs are immutable and automatically stored
 

--- a/aiida/orm/nodes/data/__init__.py
+++ b/aiida/orm/nodes/data/__init__.py
@@ -31,6 +31,8 @@ from .str import Str
 from .structure import StructureData
 from .upf import UpfData
 
-__all__ = ('Data', 'BaseType', 'ArrayData', 'BandsData', 'KpointsData', 'ProjectionData', 'TrajectoryData', 'XyData',
-           'Bool', 'CifData', 'Code', 'Float', 'FolderData', 'Int', 'List', 'OrbitalData', 'Dict', 'RemoteData',
-           'SinglefileData', 'Str', 'StructureData', 'UpfData', 'NumericType')
+__all__ = (
+    'Data', 'BaseType', 'ArrayData', 'BandsData', 'KpointsData', 'ProjectionData', 'TrajectoryData', 'XyData', 'Bool',
+    'CifData', 'Code', 'Float', 'FolderData', 'Int', 'List', 'OrbitalData', 'Dict', 'RemoteData', 'SinglefileData',
+    'Str', 'StructureData', 'UpfData', 'NumericType'
+)

--- a/aiida/orm/nodes/data/array/array.py
+++ b/aiida/orm/nodes/data/array/array.py
@@ -158,8 +158,10 @@ class ArrayData(Data):
 
         # Check if the name is valid
         if not name or re.sub('[0-9a-zA-Z_]', '', name):
-            raise ValueError("The name assigned to the array ({}) is not valid,"
-                             "it can only contain digits, letters and underscores")
+            raise ValueError(
+                "The name assigned to the array ({}) is not valid,"
+                "it can only contain digits, letters and underscores"
+            )
 
         # Write the array to a temporary file, and then add it to the repository of the node
         with tempfile.NamedTemporaryFile() as handle:
@@ -188,6 +190,8 @@ class ArrayData(Data):
         properties = self._arraynames_from_properties()
 
         if set(files) != set(properties):
-            raise ValidationError("Mismatch of files and properties for ArrayData"
-                                  " node (pk= {}): {} vs. {}".format(self.pk, files, properties))
+            raise ValidationError(
+                "Mismatch of files and properties for ArrayData"
+                " node (pk= {}): {} vs. {}".format(self.pk, files, properties)
+            )
         super(ArrayData, self)._validate()

--- a/aiida/orm/nodes/data/array/kpoints.py
+++ b/aiida/orm/nodes/data/array/kpoints.py
@@ -47,8 +47,9 @@ class KpointsData(ArrayData):
         """
         try:
             mesh = self.get_kpoints_mesh()
-            return "Kpoints mesh: {}x{}x{} (+{:.1f},{:.1f},{:.1f})".format(mesh[0][0], mesh[0][1], mesh[0][2],
-                                                                           mesh[1][0], mesh[1][1], mesh[1][2])
+            return "Kpoints mesh: {}x{}x{} (+{:.1f},{:.1f},{:.1f})".format(
+                mesh[0][0], mesh[0][1], mesh[0][2], mesh[1][0], mesh[1][1], mesh[1][2]
+            )
         except AttributeError:
             try:
                 return '(Path of {} kpts)'.format(len(self.get_kpoints()))
@@ -196,8 +197,10 @@ class KpointsData(ArrayData):
         from aiida.orm import StructureData
 
         if not isinstance(structuredata, StructureData):
-            raise ValueError("An instance of StructureData should be passed to "
-                             "the KpointsData, found instead {}".format(structuredata.__class__))
+            raise ValueError(
+                "An instance of StructureData should be passed to "
+                "the KpointsData, found instead {}".format(structuredata.__class__)
+            )
         cell = structuredata.cell
         self.set_cell(cell, structuredata.pbc)
 
@@ -357,9 +360,11 @@ class KpointsData(ArrayData):
                 # replace empty list by Gamma point
                 kpoints = numpy.array([[0., 0., 0.]])
             else:
-                raise ValueError("empty kpoints list is valid only in zero dimension"
-                                 "; instead here with have {} dimensions"
-                                 "".format(self._dimension))
+                raise ValueError(
+                    "empty kpoints list is valid only in zero dimension"
+                    "; instead here with have {} dimensions"
+                    "".format(self._dimension)
+                )
 
         if len(kpoints.shape) <= 1:
             # list of scalars is accepted only in the 0D and 1D cases
@@ -373,8 +378,10 @@ class KpointsData(ArrayData):
             raise ValueError("kpoints must be an array of type floats. Found instead {}".format(kpoints.dtype))
 
         if kpoints.shape[1] < self._dimension:
-            raise ValueError("In a system which has {0} dimensions, kpoint need"
-                             "more than {0} coordinates (found instead {1})".format(self._dimension, kpoints.shape[1]))
+            raise ValueError(
+                "In a system which has {0} dimensions, kpoint need"
+                "more than {0} coordinates (found instead {1})".format(self._dimension, kpoints.shape[1])
+            )
 
         if weights is not None:
             weights = numpy.array(weights)
@@ -431,8 +438,10 @@ class KpointsData(ArrayData):
                 fill_values = [fill_values] * (3 - the_kpoints.shape[1])
 
             if len(fill_values) < 3 - the_kpoints.shape[1]:
-                raise ValueError("fill_values should be either a scalar or a "
-                                 "length-{} list".format(3 - the_kpoints.shape[1]))
+                raise ValueError(
+                    "fill_values should be either a scalar or a "
+                    "length-{} list".format(3 - the_kpoints.shape[1])
+                )
             else:
                 tmp_kpoints = numpy.zeros((the_kpoints.shape[0], 0))
                 i_kpts = 0
@@ -444,12 +453,14 @@ class KpointsData(ArrayData):
                     # - if it's non-periodic, fill with one of the values in
                     # fill_values
                     if self.pbc[idim]:
-                        tmp_kpoints = numpy.hstack((tmp_kpoints, the_kpoints[:, i_kpts].reshape((the_kpoints.shape[0],
-                                                                                                 1))))
+                        tmp_kpoints = numpy.hstack(
+                            (tmp_kpoints, the_kpoints[:, i_kpts].reshape((the_kpoints.shape[0], 1)))
+                        )
                         i_kpts += 1
                     else:
-                        tmp_kpoints = numpy.hstack((tmp_kpoints, numpy.ones(
-                            (the_kpoints.shape[0], 1)) * fill_values[i_fill]))
+                        tmp_kpoints = numpy.hstack(
+                            (tmp_kpoints, numpy.ones((the_kpoints.shape[0], 1)) * fill_values[i_fill])
+                        )
                         i_fill += 1
                 the_kpoints = tmp_kpoints
 

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -69,16 +69,20 @@ class TrajectoryData(ArrayData):
                 raise ValueError("TrajectoryData.cells must have shape (s,3,3), with s=number of steps")
         numatoms = len(symbols)
         if positions.shape != (numsteps, numatoms, 3):
-            raise ValueError("TrajectoryData.positions must have shape (s,n,3), "
-                             "with s=number of steps and n=number of symbols")
+            raise ValueError(
+                "TrajectoryData.positions must have shape (s,n,3), "
+                "with s=number of steps and n=number of symbols"
+            )
         if times is not None:
             if times.shape != (numsteps,):
                 raise ValueError("TrajectoryData.times must have shape (s,), with s=number of steps")
         if velocities is not None:
             if velocities.shape != (numsteps, numatoms, 3):
-                raise ValueError("TrajectoryData.velocities, if not None, must "
-                                 "have shape (s,n,3), "
-                                 "with s=number of steps and n=number of symbols")
+                raise ValueError(
+                    "TrajectoryData.velocities, if not None, must "
+                    "have shape (s,n,3), "
+                    "with s=number of steps and n=number of symbols"
+                )
 
     def set_trajectory(self, symbols, positions, stepids=None, cells=None, times=None, velocities=None):  # pylint: disable=too-many-arguments
         r"""
@@ -200,12 +204,16 @@ class TrajectoryData(ArrayData):
         from aiida.common.exceptions import ValidationError
 
         try:
-            self._internal_validate(self.get_stepids(), self.get_cells(), self.symbols, self.get_positions(),
-                                    self.get_times(), self.get_velocities())
+            self._internal_validate(
+                self.get_stepids(), self.get_cells(), self.symbols, self.get_positions(), self.get_times(),
+                self.get_velocities()
+            )
         # Should catch TypeErrors, ValueErrors, and KeyErrors for missing arrays
         except Exception as exception:
-            raise ValidationError("The TrajectoryData did not validate. "
-                                  "Error: {} with message {}".format(type(exception).__name__, exception))
+            raise ValidationError(
+                "The TrajectoryData did not validate. "
+                "Error: {} with message {}".format(type(exception).__name__, exception)
+            )
 
     @property
     def numsteps(self):
@@ -337,8 +345,10 @@ class TrajectoryData(ArrayData):
         :raises KeyError: if you did not store the trajectory yet.
         """
         if index >= self.numsteps:
-            raise IndexError("You have only {} steps, but you are looking beyond"
-                             " (index={})".format(self.numsteps, index))
+            raise IndexError(
+                "You have only {} steps, but you are looking beyond"
+                " (index={})".format(self.numsteps, index)
+            )
 
         vel = self.get_velocities()
         if vel is not None:
@@ -383,16 +393,20 @@ class TrajectoryData(ArrayData):
             kind_names = []
             for k in custom_kinds:
                 if not isinstance(k, Kind):
-                    raise TypeError("Each element of the custom_kinds list must "
-                                    "be a aiida.orm.nodes.data.structure.Kind object")
+                    raise TypeError(
+                        "Each element of the custom_kinds list must "
+                        "be a aiida.orm.nodes.data.structure.Kind object"
+                    )
                 kind_names.append(k.name)
             if len(kind_names) != len(set(kind_names)):
                 raise ValueError("Multiple kinds with the same name passed as custom_kinds")
             if set(kind_names) != set(symbols):
-                raise ValueError("If you pass custom_kinds, you have to "
-                                 "pass one Kind object for each symbol "
-                                 "that is present in the trajectory. You "
-                                 "passed {}, but the symbols are {}".format(sorted(kind_names), sorted(symbols)))
+                raise ValueError(
+                    "If you pass custom_kinds, you have to "
+                    "pass one Kind object for each symbol "
+                    "that is present in the trajectory. You "
+                    "passed {}, but the symbols are {}".format(sorted(kind_names), sorted(symbols))
+                )
 
         struc = StructureData(cell=cell)
         if custom_kinds is not None:
@@ -531,12 +545,15 @@ class TrajectoryData(ArrayData):
             raise ValidationError("symbols must be set before importing positional data")
 
         positions = array(
-            [[list(position) for _, position in atoms] for _, _, atoms in xyz_parser_iterator(inputstring)])
+            [[list(position) for _, position in atoms] for _, _, atoms in xyz_parser_iterator(inputstring)]
+        )
 
         if positions.shape != (numsteps, numsites, 3):
-            raise ValueError("TrajectoryData.positions must have shape (s,n,3), "
-                             "with s=number of steps={} and "
-                             "n=number of symbols={}".format(numsteps, numsites))
+            raise ValueError(
+                "TrajectoryData.positions must have shape (s,n,3), "
+                "with s=number of steps={} and "
+                "n=number of symbols={}".format(numsteps, numsites)
+            )
 
         self.set_array('positions', positions)
 
@@ -562,12 +579,15 @@ class TrajectoryData(ArrayData):
             raise ValidationError("symbols must be set before importing positional data")
 
         velocities = array(
-            [[list(velocity) for _, velocity in atoms] for _, _, atoms in xyz_parser_iterator(inputstring)])
+            [[list(velocity) for _, velocity in atoms] for _, _, atoms in xyz_parser_iterator(inputstring)]
+        )
 
         if velocities.shape != (numsteps, numsites, 3):
-            raise ValueError("TrajectoryData.positions must have shape (s,n,3), "
-                             "with s=number of steps={} and "
-                             "n=number of symbols={}".format(numsteps, numsites))
+            raise ValueError(
+                "TrajectoryData.positions must have shape (s,n,3), "
+                "with s=number of steps={} and "
+                "n=number of symbols={}".format(numsteps, numsites)
+            )
 
         self.set_array('velocities', velocities)
 
@@ -672,12 +692,14 @@ class TrajectoryData(ArrayData):
         try:
             from mayavi import mlab
         except ImportError:
-            raise ImportError("Unable to import the mayavi package, that is required to"
-                              "use the plotting feature you requested. "
-                              "Please install it first and then call this command again "
-                              "(note that the installation of mayavi is quite complicated "
-                              "and requires that you already installed the python numpy "
-                              "package, as well as the vtk package")
+            raise ImportError(
+                "Unable to import the mayavi package, that is required to"
+                "use the plotting feature you requested. "
+                "Please install it first and then call this command again "
+                "(note that the installation of mayavi is quite complicated "
+                "and requires that you already installed the python numpy "
+                "package, as well as the vtk package"
+            )
         from ase.data.colors import jmol_colors
         from ase.data import atomic_numbers
 
@@ -737,8 +759,9 @@ class TrajectoryData(ArrayData):
         for iat, ele in enumerate(symbols):
             if ele in elements:
                 for idim in range(3):
-                    storage_dict[ele][idim] = np.concatenate((storage_dict[ele][idim],
-                                                              positions[:, iat, idim].flatten()))
+                    storage_dict[ele][idim] = np.concatenate(
+                        (storage_dict[ele][idim], positions[:, iat, idim].flatten())
+                    )
 
         for ele in elements:
             storage_dict[ele] = np.array(storage_dict[ele]).T
@@ -796,7 +819,8 @@ class TrajectoryData(ArrayData):
                     color=tuple(jmol_colors[atomic_numbers[ele]].tolist()),
                     scale_mode='none',
                     scale_factor=0.3,
-                    opacity=0.3)
+                    opacity=0.3
+                )
 
         mlab.view(azimuth=155, elevation=70, distance='auto')
         mlab.show()

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -152,9 +152,11 @@ def pycifrw_from_cif(datablocks, loops=None, names=None):
         pass
 
     if names and len(names) < len(datablocks):
-        raise ValueError("Not enough names supplied for "
-                         "datablocks: {} (names) < "
-                         "{} (datablocks)".format(len(names), len(datablocks)))
+        raise ValueError(
+            "Not enough names supplied for "
+            "datablocks: {} (names) < "
+            "{} (datablocks)".format(len(names), len(datablocks))
+        )
     for i, values in enumerate(datablocks):
         name = str(i)
         if names:
@@ -173,10 +175,12 @@ def pycifrw_from_cif(datablocks, loops=None, names=None):
                     if row_size is None:
                         row_size = len(tag_values)
                     elif row_size != len(tag_values):
-                        raise ValueError("Number of values for tag "
-                                         "'{}' is different from "
-                                         "the others in the same "
-                                         "loop".format(tag))
+                        raise ValueError(
+                            "Number of values for tag "
+                            "'{}' is different from "
+                            "the others in the same "
+                            "loop".format(tag)
+                        )
                     if row_size == 0:
                         continue
                     datablock.AddItem(tag, tag_values)
@@ -237,14 +241,9 @@ class CifData(SinglefileData):
     _values = None
     _ase = None
 
-    def __init__(self,
-                 ase=None,
-                 file=None,
-                 values=None,
-                 source=None,
-                 scan_type='standard',
-                 parse_policy='eager',
-                 **kwargs):
+    def __init__(
+        self, ase=None, file=None, values=None, source=None, scan_type='standard', parse_policy='eager', **kwargs
+    ):
         # pylint: disable=too-many-arguments, redefined-builtin
 
         args = {
@@ -350,9 +349,11 @@ class CifData(SinglefileData):
             if use_first:
                 return (cifs[0], False)
 
-            raise ValueError("More than one copy of a CIF file "
-                             "with the same MD5 has been found in "
-                             "the DB. pks={}".format(",".join([str(i.pk) for i in cifs])))
+            raise ValueError(
+                "More than one copy of a CIF file "
+                "with the same MD5 has been found in "
+                "the DB. pks={}".format(",".join([str(i.pk) for i in cifs]))
+            )
 
         return cifs[0], False
 

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -166,12 +166,17 @@ class Data(Node):
             func = exporters[fileformat]
         except KeyError:
             if exporters.keys():
-                raise ValueError("The format {} is not implemented for {}. "
-                                 "Currently implemented are: {}.".format(fileformat, self.__class__.__name__,
-                                                                         ",".join(exporters.keys())))
+                raise ValueError(
+                    "The format {} is not implemented for {}. "
+                    "Currently implemented are: {}.".format(
+                        fileformat, self.__class__.__name__, ",".join(exporters.keys())
+                    )
+                )
             else:
-                raise ValueError("The format {} is not implemented for {}. "
-                                 "No formats are implemented yet.".format(fileformat, self.__class__.__name__))
+                raise ValueError(
+                    "The format {} is not implemented for {}. "
+                    "No formats are implemented yet.".format(fileformat, self.__class__.__name__)
+                )
 
         return func(main_file_name=main_file_name, **kwargs)
 
@@ -252,8 +257,9 @@ class Data(Node):
         """
         exporter_prefix = '_prepare_'
         method_names = dir(cls)  # get list of class methods names
-        valid_format_names = [i[len(exporter_prefix):] for i in method_names if i.startswith(exporter_prefix)
-                             ]  # filter them
+        valid_format_names = [
+            i[len(exporter_prefix):] for i in method_names if i.startswith(exporter_prefix)
+        ]  # filter them
         return sorted(valid_format_names)
 
     def importstring(self, inputstring, fileformat, **kwargs):
@@ -269,12 +275,17 @@ class Data(Node):
             func = importers[fileformat]
         except KeyError:
             if importers.keys():
-                raise ValueError("The format {} is not implemented for {}. "
-                                 "Currently implemented are: {}.".format(fileformat, self.__class__.__name__,
-                                                                         ",".join(importers.keys())))
+                raise ValueError(
+                    "The format {} is not implemented for {}. "
+                    "Currently implemented are: {}.".format(
+                        fileformat, self.__class__.__name__, ",".join(importers.keys())
+                    )
+                )
             else:
-                raise ValueError("The format {} is not implemented for {}. "
-                                 "No formats are implemented yet.".format(fileformat, self.__class__.__name__))
+                raise ValueError(
+                    "The format {} is not implemented for {}. "
+                    "No formats are implemented yet.".format(fileformat, self.__class__.__name__)
+                )
 
         # func is bound to self by getattr in _get_importers()
         func(inputstring, **kwargs)
@@ -327,12 +338,17 @@ class Data(Node):
             func = converters[object_format]
         except KeyError:
             if converters.keys():
-                raise ValueError("The format {} is not implemented for {}. "
-                                 "Currently implemented are: {}.".format(object_format, self.__class__.__name__,
-                                                                         ",".join(converters.keys())))
+                raise ValueError(
+                    "The format {} is not implemented for {}. "
+                    "Currently implemented are: {}.".format(
+                        object_format, self.__class__.__name__, ",".join(converters.keys())
+                    )
+                )
             else:
-                raise ValueError("The format {} is not implemented for {}. "
-                                 "No formats are implemented yet.".format(object_format, self.__class__.__name__))
+                raise ValueError(
+                    "The format {} is not implemented for {}. "
+                    "No formats are implemented yet.".format(object_format, self.__class__.__name__)
+                )
 
         return func(*args)
 

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -119,5 +119,6 @@ class SinglefileData(Data):
         objects = self.list_object_names()
 
         if [filename] != objects:
-            raise exceptions.ValidationError('respository files {} do not match the `filename` attribute {}.'.format(
-                objects, filename))
+            raise exceptions.ValidationError(
+                'respository files {} do not match the `filename` attribute {}.'.format(objects, filename)
+            )

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -120,7 +120,8 @@ class Node(Entity):
             raise ValueError('the user cannot be None')
 
         backend_entity = backend.nodes.create(
-            node_type=self.class_node_type, user=user.backend_entity, computer=computer, **kwargs)
+            node_type=self.class_node_type, user=user.backend_entity, computer=computer, **kwargs
+        )
         super(Node, self).__init__(backend_entity)
 
     def __repr__(self):
@@ -829,12 +830,9 @@ class Node(Entity):
 
         self._incoming_cache.append(link_triple)
 
-    def get_stored_link_triples(self,
-                                node_class=None,
-                                link_type=(),
-                                link_label_filter=None,
-                                link_direction='incoming',
-                                only_uuid=False):
+    def get_stored_link_triples(
+        self, node_class=None, link_type=(), link_label_filter=None, link_direction='incoming', only_uuid=False
+    ):
         """Return the list of stored link triples directly incoming to or outgoing of this node.
 
         Note this will only return link triples that are stored in the database. Anything in the cache is ignored.
@@ -872,14 +870,16 @@ class Node(Entity):
                 with_incoming='main',
                 project=node_project,
                 edge_project=['type', 'label'],
-                edge_filters=edge_filters)
+                edge_filters=edge_filters
+            )
         else:
             builder.append(
                 node_class,
                 with_outgoing='main',
                 project=node_project,
                 edge_project=['type', 'label'],
-                edge_filters=edge_filters)
+                edge_filters=edge_filters
+            )
 
         return [LinkTriple(entry[0], LinkType(entry[1]), entry[2]) for entry in builder.all()]
 
@@ -899,7 +899,8 @@ class Node(Entity):
 
         if self.is_stored:
             link_triples = self.get_stored_link_triples(
-                node_class, link_type, link_label_filter, 'incoming', only_uuid=only_uuid)
+                node_class, link_type, link_label_filter, 'incoming', only_uuid=only_uuid
+            )
         else:
             link_triples = []
 
@@ -910,8 +911,9 @@ class Node(Entity):
                 link_triple = LinkTriple(link_triple.node.uuid, link_triple.link_type, link_triple.link_label)
 
             if link_triple in link_triples:
-                raise exceptions.InternalError('Node<{}> has both a stored and cached link triple {}'.format(
-                    self.pk, link_triple))
+                raise exceptions.InternalError(
+                    'Node<{}> has both a stored and cached link triple {}'.format(self.pk, link_triple)
+                )
 
             if not link_type or link_triple.link_type in link_type:
                 if link_label_filter is not None:
@@ -1051,7 +1053,8 @@ class Node(Entity):
         for link_triple in self._incoming_cache:
             if not link_triple.node.is_stored:
                 raise exceptions.ModificationNotAllowed(
-                    'Cannot store because source node of link triple {} is not stored'.format(link_triple))
+                    'Cannot store because source node of link triple {} is not stored'.format(link_triple)
+                )
 
     def _store_from_cache(self, cache_node, with_transaction):
         """Store this node from an existing cache node."""

--- a/aiida/orm/nodes/process/calculation/calcfunction.py
+++ b/aiida/orm/nodes/process/calculation/calcfunction.py
@@ -44,4 +44,5 @@ class CalcFunctionNode(FunctionCalculationMixin, CalculationNode):
             raise ValueError(
                 'trying to return an already stored Data node from a @calcfunction, however, @calcfunctions cannot '
                 'return data. If you stored the node yourself, simply do not call `store()` yourself. If you want to '
-                'return an input node, use a @workfunction instead.')
+                'return an input node, use a @workfunction instead.'
+            )

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -75,8 +75,9 @@ class CalcJobNode(CalculationNode):
                     self._tools = tools_class(self)
                 except exceptions.EntryPointError as exception:
                     self._tools = CalculationTools(self)
-                    self.logger.warning('could not load the calculation tools entry point {}: {}'.format(
-                        entry_point.name, exception))
+                    self.logger.warning(
+                        'could not load the calculation tools entry point {}: {}'.format(entry_point.name, exception)
+                    )
 
         return self._tools
 
@@ -132,8 +133,8 @@ class CalcJobNode(CalculationNode):
         return objects
 
     def get_hash(self, ignore_errors=True, ignored_folder_content=('raw_input',), **kwargs):  # pylint: disable=arguments-differ
-        return super(CalcJobNode, self).get_hash(
-            ignore_errors=ignore_errors, ignored_folder_content=ignored_folder_content, **kwargs)
+        return super(CalcJobNode, self
+                    ).get_hash(ignore_errors=ignore_errors, ignored_folder_content=ignored_folder_content, **kwargs)
 
     def get_builder_restart(self):
         """Return a `ProcessBuilder` that is ready to relaunch the same `CalcJob` that created this node.
@@ -186,7 +187,8 @@ class CalcJobNode(CalculationNode):
             scheduler.create_job_resource(**resources)
         except (TypeError, ValueError) as exc:
             raise exceptions.ValidationError(
-                "Invalid resources for the scheduler of the specified computer: {}".format(exc))
+                "Invalid resources for the scheduler of the specified computer: {}".format(exc)
+            )
 
     @property
     def _raw_input_folder(self):

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -117,8 +117,11 @@ class ProcessNode(Sealable, Node):
         try:
             process_class = load_entry_point_from_string(self.process_type)
         except exceptions.EntryPointError as exception:
-            raise ValueError('could not load process class for entry point {} for CalcJobNode<{}>: {}'.format(
-                self.pk, self.process_type, exception))
+            raise ValueError(
+                'could not load process class for entry point {} for CalcJobNode<{}>: {}'.format(
+                    self.pk, self.process_type, exception
+                )
+            )
         except ValueError:
             try:
                 import importlib
@@ -126,8 +129,11 @@ class ProcessNode(Sealable, Node):
                 module = importlib.import_module(module_name)
                 process_class = getattr(module, class_name)
             except (ValueError, ImportError):
-                raise ValueError('could not load process class CalcJobNode<{}> given its `process_type`: {}'.format(
-                    self.pk, self.process_type))
+                raise ValueError(
+                    'could not load process class CalcJobNode<{}> given its `process_type`: {}'.format(
+                        self.pk, self.process_type
+                    )
+                )
 
         return process_class
 

--- a/aiida/orm/nodes/process/workflow/workflow.py
+++ b/aiida/orm/nodes/process/workflow/workflow.py
@@ -69,4 +69,5 @@ class WorkflowNode(ProcessNode):
             raise ValueError(
                 'Workflow<{}> tried returning an unstored `Data` node. This likely means new `Data` is being created '
                 'inside the workflow. In order to preserve data provenance, use a `calcfunction` to create this node '
-                'and return its output from the workflow'.format(self.process_label))
+                'and return its output from the workflow'.format(self.process_label)
+            )

--- a/aiida/orm/nodes/process/workflow/workfunction.py
+++ b/aiida/orm/nodes/process/workflow/workfunction.py
@@ -43,4 +43,5 @@ class WorkFunctionNode(FunctionCalculationMixin, WorkflowNode):
         if link_type is LinkType.RETURN and not target.is_stored:
             raise ValueError(
                 'trying to return an unstored Data node from a @workfunction, however, @workfunctions cannot create '
-                'data. You probably want to use a @calcfunction instead.')
+                'data. You probably want to use a @calcfunction instead.'
+            )

--- a/aiida/orm/utils/__init__.py
+++ b/aiida/orm/utils/__init__.py
@@ -17,13 +17,9 @@ import six
 __all__ = ('load_code', 'load_computer', 'load_group', 'load_node')
 
 
-def load_entity(entity_loader=None,
-                identifier=None,
-                pk=None,
-                uuid=None,
-                label=None,
-                sub_classes=None,
-                query_with_dashes=True):
+def load_entity(
+    entity_loader=None, identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True
+):
     # pylint: disable=too-many-arguments
     """
     Load an entity instance by one of its identifiers: pk, uuid or label
@@ -84,7 +80,8 @@ def load_entity(entity_loader=None,
         identifier_type = None
 
     return entity_loader.load_entity(
-        identifier, identifier_type, sub_classes=sub_classes, query_with_dashes=query_with_dashes)
+        identifier, identifier_type, sub_classes=sub_classes, query_with_dashes=query_with_dashes
+    )
 
 
 def load_code(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -115,7 +112,8 @@ def load_code(identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
         uuid=uuid,
         label=label,
         sub_classes=sub_classes,
-        query_with_dashes=query_with_dashes)
+        query_with_dashes=query_with_dashes
+    )
 
 
 def load_computer(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -146,7 +144,8 @@ def load_computer(identifier=None, pk=None, uuid=None, label=None, sub_classes=N
         uuid=uuid,
         label=label,
         sub_classes=sub_classes,
-        query_with_dashes=query_with_dashes)
+        query_with_dashes=query_with_dashes
+    )
 
 
 def load_group(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -177,7 +176,8 @@ def load_group(identifier=None, pk=None, uuid=None, label=None, sub_classes=None
         uuid=uuid,
         label=label,
         sub_classes=sub_classes,
-        query_with_dashes=query_with_dashes)
+        query_with_dashes=query_with_dashes
+    )
 
 
 def load_node(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -206,4 +206,5 @@ def load_node(identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
         uuid=uuid,
         label=label,
         sub_classes=sub_classes,
-        query_with_dashes=query_with_dashes)
+        query_with_dashes=query_with_dashes
+    )

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -60,8 +60,10 @@ class CodeBuilder(object):  # pylint: disable=useless-object-inheritance
             code = Code(local_executable=self._get_and_count('code_rel_path', used), files=file_list)
         else:
             code = Code(
-                remote_computer_exec=(self._get_and_count('computer', used),
-                                      self._get_and_count('remote_abs_path', used)))
+                remote_computer_exec=(
+                    self._get_and_count('computer', used), self._get_and_count('remote_abs_path', used)
+                )
+            )
 
         code.label = self._get_and_count('label', used)
         code.description = self._get_and_count('description', used)
@@ -71,8 +73,9 @@ class CodeBuilder(object):  # pylint: disable=useless-object-inheritance
 
         # Complain if there are keys that are passed but not used
         if passed_keys - used:
-            raise self.CodeValidationError('Unknown parameters passed to the CodeBuilder: {}'.format(", ".join(
-                sorted(passed_keys - used))))
+            raise self.CodeValidationError(
+                'Unknown parameters passed to the CodeBuilder: {}'.format(", ".join(sorted(passed_keys - used)))
+            )
 
         return code
 
@@ -169,8 +172,9 @@ class CodeBuilder(object):  # pylint: disable=useless-object-inheritance
     def validate_code_type(self):
         """Make sure the code type is set correctly"""
         if self._get('code_type') and self.code_type not in self.CodeType:
-            raise self.CodeValidationError('invalid code type: must be one of {}, not {}'.format(
-                list(self.CodeType), self.code_type))
+            raise self.CodeValidationError(
+                'invalid code type: must be one of {}, not {}'.format(list(self.CodeType), self.code_type)
+            )
 
     def validate_upload(self):
         """If the code is stored and uploaded, catch invalid on-computer attributes"""

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -96,11 +96,15 @@ class ComputerBuilder(object):  # pylint: disable=useless-object-inheritance
             try:
                 mpiprocs_per_machine = int(mpiprocs_per_machine)
             except ValueError:
-                raise self.ComputerValidationError("Invalid value provided for mpiprocs_per_machine, "
-                                                   "must be a valid integer")
+                raise self.ComputerValidationError(
+                    "Invalid value provided for mpiprocs_per_machine, "
+                    "must be a valid integer"
+                )
             if mpiprocs_per_machine <= 0:
-                raise self.ComputerValidationError("Invalid value provided for mpiprocs_per_machine, "
-                                                   "must be positive")
+                raise self.ComputerValidationError(
+                    "Invalid value provided for mpiprocs_per_machine, "
+                    "must be positive"
+                )
             computer.set_default_mpiprocs_per_machine(mpiprocs_per_machine)
 
         mpirun_command_internal = self._get_and_count('mpirun_command', used).strip().split(" ")
@@ -111,8 +115,9 @@ class ComputerBuilder(object):  # pylint: disable=useless-object-inheritance
 
         # Complain if there are keys that are passed but not used
         if passed_keys - used:
-            raise self.ComputerValidationError('Unknown parameters passed to the ComputerBuilder: {}'.format(", ".join(
-                sorted(passed_keys - used))))
+            raise self.ComputerValidationError(
+                'Unknown parameters passed to the ComputerBuilder: {}'.format(", ".join(sorted(passed_keys - used)))
+            )
 
         return computer
 

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -114,6 +114,7 @@ def validate_link(source, target, link_type, link_label):
     :raise TypeError: if `source` or `target` is not a Node instance, or `link_type` is not a `LinkType` enum
     :raise ValueError: if the proposed link is invalid
     """
+    # yapf: disable
     from aiida.common.links import LinkType, validate_link_label
     from aiida.orm import Node, Data, CalculationNode, WorkflowNode
 
@@ -300,7 +301,8 @@ class LinkManager(object):  # pylint: disable=useless-object-inheritance
                     matching_entry = entry.node
                 else:
                     raise exceptions.MultipleObjectsError(
-                        'more than one neighbor with the label {} found'.format(label))
+                        'more than one neighbor with the label {} found'.format(label)
+                    )
 
         if matching_entry is None:
             raise exceptions.NotExistent('no neighbor with the label {} found'.format(label))

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -21,8 +21,10 @@ from aiida.common.exceptions import MultipleObjectsError, NotExistent
 from aiida.common.lang import abstractclassmethod, classproperty
 from aiida.orm.querybuilder import QueryBuilder
 
-__all__ = ('get_loader', 'OrmEntityLoader', 'CalculationEntityLoader', 'CodeEntityLoader', 'ComputerEntityLoader',
-           'GroupEntityLoader', 'NodeEntityLoader')
+__all__ = (
+    'get_loader', 'OrmEntityLoader', 'CalculationEntityLoader', 'CodeEntityLoader', 'ComputerEntityLoader',
+    'GroupEntityLoader', 'NodeEntityLoader'
+)
 
 
 def get_loader(orm_class):

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -99,8 +99,9 @@ class NodeLinksManager(object):  # pylint: disable=too-few-public-methods,useles
 
     def __str__(self):
         """Return a string representation of the manager"""
-        return "Manager for {} {} links for node pk={}".format("incoming" if self._incoming else "outgoing",
-                                                               self._link_type.value.upper(), self._node.pk)
+        return "Manager for {} {} links for node pk={}".format(
+            "incoming" if self._incoming else "outgoing", self._link_type.value.upper(), self._node.pk
+        )
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, str(self))

--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -32,8 +32,10 @@ from aiida.common.constants import AIIDA_FLOAT_PRECISION  # pylint: disable=wron
 # therefore is not allowed in individual attribute or extra keys.
 FIELD_SEPARATOR = '.'
 
-__all__ = ('load_node_class', 'get_type_string_from_class', 'get_query_type_from_type_string', 'AbstractNodeMeta',
-           'validate_attribute_extra_key', 'clean_value')
+__all__ = (
+    'load_node_class', 'get_type_string_from_class', 'get_query_type_from_type_string', 'AbstractNodeMeta',
+    'validate_attribute_extra_key', 'clean_value'
+)
 
 
 def load_node_class(type_string):
@@ -170,7 +172,8 @@ def validate_attribute_extra_key(key):
 
     if FIELD_SEPARATOR in key:
         raise exceptions.ValidationError(
-            'key for attributes or extras cannot contain the character `{}`'.format(FIELD_SEPARATOR))
+            'key for attributes or extras cannot contain the character `{}`'.format(FIELD_SEPARATOR)
+        )
 
 
 def clean_value(value):

--- a/aiida/orm/utils/serialize.py
+++ b/aiida/orm/utils/serialize.py
@@ -188,9 +188,11 @@ yaml.add_representer(Bundle, represent_bundle, Dumper=AiiDADumper)
 yaml.add_representer(AttributeDict, partial(represent_mapping, _ATTRIBUTE_DICT_TAG), Dumper=AiiDADumper)
 yaml.add_constructor(_ATTRIBUTE_DICT_TAG, partial(mapping_constructor, AttributeDict), Loader=AiiDALoader)
 yaml.add_representer(
-    AttributesFrozendict, partial(represent_mapping, _PLUMPY_ATTRIBUTES_FROZENDICT_TAG), Dumper=AiiDADumper)
+    AttributesFrozendict, partial(represent_mapping, _PLUMPY_ATTRIBUTES_FROZENDICT_TAG), Dumper=AiiDADumper
+)
 yaml.add_constructor(
-    _PLUMPY_ATTRIBUTES_FROZENDICT_TAG, partial(mapping_constructor, AttributesFrozendict), Loader=AiiDALoader)
+    _PLUMPY_ATTRIBUTES_FROZENDICT_TAG, partial(mapping_constructor, AttributesFrozendict), Loader=AiiDALoader
+)
 yaml.add_constructor(_PLUMPY_BUNDLE, bundle_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_NODE_TAG, node_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_GROUP_TAG, group_constructor, Loader=AiiDALoader)

--- a/aiida/plugins/factories.py
+++ b/aiida/plugins/factories.py
@@ -15,8 +15,10 @@ from __future__ import absolute_import
 
 from .entry_point import load_entry_point
 
-__all__ = ('BaseFactory', 'CalculationFactory', 'DataFactory', 'DbImporterFactory', 'OrbitalFactory', 'ParserFactory',
-           'SchedulerFactory', 'TransportFactory', 'WorkflowFactory')
+__all__ = (
+    'BaseFactory', 'CalculationFactory', 'DataFactory', 'DbImporterFactory', 'OrbitalFactory', 'ParserFactory',
+    'SchedulerFactory', 'TransportFactory', 'WorkflowFactory'
+)
 
 
 def BaseFactory(group, name):

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -66,9 +66,11 @@ class App(Flask):
                 # Generic server-side error (not to make the api crash if an
                 # unhandled exception is raised. Caution is never enough!!)
                 else:
-                    response = jsonify(
-                        {'message': 'Internal server error. The original '
-                         'message was: \"{}\"'.format(error)})
+                    response = jsonify({
+                        'message':
+                        'Internal server error. The original '
+                        'message was: \"{}\"'.format(error)
+                    })
                     response.status_code = 500
 
                 return response
@@ -105,7 +107,8 @@ class AiidaApi(Api):
             "/server/endpoints/",
             endpoint='server',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         ## Add resources and endpoints to the api
         self.add_resource(
@@ -118,7 +121,8 @@ class AiidaApi(Api):
             '/computers/schema/',
             endpoint='computers',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             Node,
@@ -140,7 +144,8 @@ class AiidaApi(Api):
             '/nodes/<id>/content/visualization/',
             endpoint='nodes',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             Calculation,
@@ -162,7 +167,8 @@ class AiidaApi(Api):
             '/calculations/<id>/content/extras/',
             endpoint='calculations',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             Data,
@@ -184,7 +190,8 @@ class AiidaApi(Api):
             '/data/<id>/content/download/',
             endpoint='data',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             Code,
@@ -206,7 +213,8 @@ class AiidaApi(Api):
             '/codes/<id>/content/download/',
             endpoint='codes',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             StructureData,
@@ -228,7 +236,8 @@ class AiidaApi(Api):
             '/structures/<id>/content/download/',
             endpoint='structures',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             KpointsData,
@@ -249,7 +258,8 @@ class AiidaApi(Api):
             '/kpoints/<id>/content/visualization/',
             endpoint='kpoints',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             BandsData,
@@ -270,7 +280,8 @@ class AiidaApi(Api):
             '/bands/<id>/content/visualization/',
             endpoint='bands',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             UpfData,
@@ -292,7 +303,8 @@ class AiidaApi(Api):
             '/upfs/<id>/content/download/',
             endpoint='upfs',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             CifData,
@@ -314,7 +326,8 @@ class AiidaApi(Api):
             '/cifs/<id>/content/download/',
             endpoint='cifs',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             User,
@@ -325,7 +338,8 @@ class AiidaApi(Api):
             '/users/<id>/',
             endpoint='users',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
         self.add_resource(
             Group,
@@ -336,7 +350,8 @@ class AiidaApi(Api):
             '/groups/<id>/',
             endpoint='groups',
             strict_slashes=False,
-            resource_class_kwargs=kwargs)
+            resource_class_kwargs=kwargs
+        )
 
     def handle_error(self, e):
         """

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -239,13 +239,9 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
 
         return (resource_type, page, node_id, query_type)
 
-    def validate_request(self,
-                         limit=None,
-                         offset=None,
-                         perpage=None,
-                         page=None,
-                         query_type=None,
-                         is_querystring_defined=False):
+    def validate_request(
+        self, limit=None, offset=None, perpage=None, page=None, query_type=None, is_querystring_defined=False
+    ):
         # pylint: disable=fixme,no-self-use,too-many-arguments,too-many-branches
         """
         Performs various checks on the consistency of the request.
@@ -263,9 +259,11 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
             raise RestValidationError("requesting a specific page is incompatible with limit and offset")
         # 3. perpage requires that the path contains a page request
         if perpage is not None and page is None:
-            raise RestValidationError("perpage key requires that a page is "
-                                      "requested (i.e. the path must contain "
-                                      "/page/)")
+            raise RestValidationError(
+                "perpage key requires that a page is "
+                "requested (i.e. the path must contain "
+                "/page/)"
+            )
         # 4. No querystring if query type = schema'
         if query_type in ('schema') and is_querystring_defined:
             raise RestInputValidationError("schema requests do not allow specifying a query string")
@@ -317,8 +315,10 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
         # previous,
         #  and next page
         if page > last_page or page < 1:
-            raise RestInputValidationError("Non existent page requested. The "
-                                           "page range is [{} : {}]".format(first_page, last_page))
+            raise RestInputValidationError(
+                "Non existent page requested. The "
+                "page range is [{} : {}]".format(first_page, last_page)
+            )
 
         limit = perpage
         offset = (page - 1) * perpage
@@ -680,8 +680,10 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
         # if limit is None:
         #     limit = self.limit_default
 
-        return (limit, offset, perpage, orderby, filters, alist, nalist, elist, nelist, downloadformat, visformat,
-                filename, rtype, tree_in_limit, tree_out_limit)
+        return (
+            limit, offset, perpage, orderby, filters, alist, nalist, elist, nelist, downloadformat, visformat, filename,
+            rtype, tree_in_limit, tree_out_limit
+        )
 
     def parse_query_string(self, query_string):
         # pylint: disable=too-many-locals
@@ -707,8 +709,10 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
         # key types
         key = Word(alphas + '_', alphanums + '_')
         # operators
-        operator = (Literal('=like=') | Literal('=ilike=') | Literal('=in=') | Literal('=notin=') | Literal('=') |
-                    Literal('!=') | Literal('>=') | Literal('>') | Literal('<=') | Literal('<'))
+        operator = (
+            Literal('=like=') | Literal('=ilike=') | Literal('=in=') | Literal('=notin=') | Literal('=') |
+            Literal('!=') | Literal('>=') | Literal('>') | Literal('<=') | Literal('<')
+        )
         # Value types
         value_num = ppc.number
         value_bool = (Literal('true') | Literal('false')).addParseAction(lambda toks: bool(toks[0]))
@@ -720,11 +724,13 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
         #  them and convert them to datetime objects
         # Date
         value_date = Combine(
-            Word(nums, exact=4) + Literal('-') + Word(nums, exact=2) + Literal('-') + Word(nums, exact=2))
+            Word(nums, exact=4) + Literal('-') + Word(nums, exact=2) + Literal('-') + Word(nums, exact=2)
+        )
         # Time
         value_time = Combine(
             Literal('T') + Word(nums, exact=2) + Optional(Literal(':') + Word(nums, exact=2)) +
-            Optional(Literal(':') + Word(nums, exact=2)))
+            Optional(Literal(':') + Word(nums, exact=2))
+        )
         # Shift
         value_shift = Combine(Word('+-', exact=1) + Word(nums, exact=2) + Optional(Literal(':') + Word(nums, exact=2)))
         # Combine atomic values
@@ -757,21 +763,24 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
             try:
                 dtobj = dtparser.parse(datetime_string)
             except ValueError:
-                raise RestInputValidationError("time value has wrong format. The "
-                                               "right format is "
-                                               "<date>T<time><offset>, "
-                                               "where <date> is expressed as "
-                                               "[YYYY]-[MM]-[DD], "
-                                               "<time> is expressed as [HH]:[MM]:["
-                                               "SS], "
-                                               "<offset> is expressed as +/-[HH]:["
-                                               "MM] "
-                                               "given with "
-                                               "respect to UTC")
+                raise RestInputValidationError(
+                    "time value has wrong format. The "
+                    "right format is "
+                    "<date>T<time><offset>, "
+                    "where <date> is expressed as "
+                    "[YYYY]-[MM]-[DD], "
+                    "<time> is expressed as [HH]:[MM]:["
+                    "SS], "
+                    "<offset> is expressed as +/-[HH]:["
+                    "MM] "
+                    "given with "
+                    "respect to UTC"
+                )
             if dtobj.tzinfo is not None and dtobj.utcoffset() is not None:
                 tzoffset_minutes = int(dtobj.utcoffset().total_seconds() // 60)
                 return DatetimePrecision(
-                    dtobj.replace(tzinfo=FixedOffsetTimezone(offset=tzoffset_minutes, name=None)), precision)
+                    dtobj.replace(tzinfo=FixedOffsetTimezone(offset=tzoffset_minutes, name=None)), precision
+                )
 
             return DatetimePrecision(dtobj.replace(tzinfo=FixedOffsetTimezone(offset=0, name=None)), precision)
 
@@ -811,13 +820,15 @@ class Utils(object):  # pylint: disable=useless-object-inheritance
             field_list = [entry for entry in fields.asList() if entry[0] != "_"]
 
         except ParseException as err:
-            raise RestInputValidationError("The query string format is invalid. "
-                                           "Parser returned this massage: \"{"
-                                           "}.\" Please notice that the column "
-                                           "number "
-                                           "is counted from "
-                                           "the first character of the query "
-                                           "string.".format(err))
+            raise RestInputValidationError(
+                "The query string format is invalid. "
+                "Parser returned this massage: \"{"
+                "}.\" Please notice that the column "
+                "number "
+                "is counted from "
+                "the first character of the query "
+                "string.".format(err)
+            )
 
         ## return the translator instructions elaborated from the field_list
         return self.build_translator_parameters(field_list)

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -80,7 +80,8 @@ class ServerInfo(Resource):
             path=path,
             query_string=request.query_string.decode('utf-8'),
             resource_type="Info",
-            data=response)
+            data=response
+        )
         return self.utils.build_response(status=200, headers=headers, data=data)
 
 
@@ -125,8 +126,10 @@ class BaseResource(Resource):
         (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
 
         # pylint: disable=unused-variable
-        (limit, offset, perpage, orderby, filters, _alist, _nalist, _elist, _nelist, _downloadformat, _visformat,
-         _filename, _rtype, tree_in_limit, tree_out_limit) = self.utils.parse_query_string(query_string)
+        (
+            limit, offset, perpage, orderby, filters, _alist, _nalist, _elist, _nelist, _downloadformat, _visformat,
+            _filename, _rtype, tree_in_limit, tree_out_limit
+        ) = self.utils.parse_query_string(query_string)
 
         ## Validate request
         self.utils.validate_request(
@@ -135,7 +138,8 @@ class BaseResource(Resource):
             perpage=perpage,
             page=page,
             query_type=query_type,
-            is_querystring_defined=(bool(query_string)))
+            is_querystring_defined=(bool(query_string))
+        )
 
         ## Treat the schema case which does not imply access to the DataBase
         if query_type == 'schema':
@@ -173,7 +177,8 @@ class BaseResource(Resource):
             id=node_id,
             query_string=request.query_string.decode('utf-8'),
             resource_type=resource_type,
-            data=results)
+            data=results
+        )
 
         return self.utils.build_response(status=200, headers=headers, data=data)
 
@@ -221,8 +226,10 @@ class Node(Resource):
         ## Parse request
         (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
 
-        (limit, offset, perpage, orderby, filters, alist, nalist, elist, nelist, downloadformat, visformat, filename,
-         rtype, tree_in_limit, tree_out_limit) = self.utils.parse_query_string(query_string)
+        (
+            limit, offset, perpage, orderby, filters, alist, nalist, elist, nelist, downloadformat, visformat, filename,
+            rtype, tree_in_limit, tree_out_limit
+        ) = self.utils.parse_query_string(query_string)
 
         ## Validate request
         self.utils.validate_request(
@@ -231,7 +238,8 @@ class Node(Resource):
             perpage=perpage,
             page=page,
             query_type=query_type,
-            is_querystring_defined=(bool(query_string)))
+            is_querystring_defined=(bool(query_string))
+        )
 
         ## Treat the schema case which does not imply access to the DataBase
         if query_type == 'schema':
@@ -244,8 +252,10 @@ class Node(Resource):
 
         ## Treat the statistics
         elif query_type == "statistics":
-            (limit, offset, perpage, orderby, filters, alist, nalist, elist, nelist, downloadformat, visformat,
-             filename, rtype, tree_in_limit, tree_out_limit) = self.utils.parse_query_string(query_string)
+            (
+                limit, offset, perpage, orderby, filters, alist, nalist, elist, nelist, downloadformat, visformat,
+                filename, rtype, tree_in_limit, tree_out_limit
+            ) = self.utils.parse_query_string(query_string)
             headers = self.utils.build_headers(url=request.url, total_count=0)
             if filters:
                 usr = filters["user"]["=="]
@@ -272,7 +282,8 @@ class Node(Resource):
                 downloadformat=downloadformat,
                 visformat=visformat,
                 filename=filename,
-                rtype=rtype)
+                rtype=rtype
+            )
 
             ## Count results
             total_count = self.trans.get_total_count()
@@ -298,7 +309,8 @@ class Node(Resource):
                         response = make_response(data)
                         response.headers['content-type'] = 'application/octet-stream'
                         response.headers['Content-Disposition'] = 'attachment; filename="{}"'.format(
-                            results["download"]["filename"])
+                            results["download"]["filename"]
+                        )
                         return response
 
                     results = results["download"]["data"]
@@ -316,7 +328,8 @@ class Node(Resource):
                         response = make_response(data)
                         response.headers['content-type'] = 'application/octet-stream'
                         response.headers['Content-Disposition'] = 'attachment; filename="{}"'.format(
-                            results[query_type]["filename"])
+                            results[query_type]["filename"]
+                        )
                         return response
 
                 headers = self.utils.build_headers(url=request.url, total_count=total_count)
@@ -330,7 +343,8 @@ class Node(Resource):
             id=node_id,
             query_string=request.query_string.decode('utf-8'),
             resource_type=resource_type,
-            data=results)
+            data=results
+        )
 
         return self.utils.build_response(status=200, headers=headers, data=data)
 

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -244,11 +244,13 @@ class BaseTranslator(object):
                             self._query_help["filters"][tag][filter_key] \
                                 = filter_value
         else:
-            raise InputValidationError("Pass data in dictionary format where "
-                                       "keys are the tag names given in the "
-                                       "path in query_help and and their values"
-                                       " are the dictionary of filters want "
-                                       "to add for that tag name.")
+            raise InputValidationError(
+                "Pass data in dictionary format where "
+                "keys are the tag names given in the "
+                "path in query_help and and their values"
+                " are the dictionary of filters want "
+                "to add for that tag name."
+            )
 
     def get_default_projections(self):
         """
@@ -285,11 +287,13 @@ class BaseTranslator(object):
                     self._query_help["path"][1]["with_user"] = "user"
                     self._query_help["project"]["user"] = self._default_user_projections
         else:
-            raise InputValidationError("Pass data in dictionary format where "
-                                       "keys are the tag names given in the "
-                                       "path in query_help and values are the "
-                                       "list of the names you want to project "
-                                       "in the final output")
+            raise InputValidationError(
+                "Pass data in dictionary format where "
+                "keys are the tag names given in the "
+                "path in query_help and values are the "
+                "list of the names you want to project "
+                "in the final output"
+            )
 
     def set_order(self, orders):
         """
@@ -300,9 +304,11 @@ class BaseTranslator(object):
         """
         ## Validate input
         if not isinstance(orders, dict):
-            raise InputValidationError("orders has to be a dictionary"
-                                       "compatible with the 'order_by' section"
-                                       "of the query_help")
+            raise InputValidationError(
+                "orders has to be a dictionary"
+                "compatible with the 'order_by' section"
+                "of the query_help"
+            )
 
         ## Auxiliary_function to get the ordering cryterion
         def def_order(columns):
@@ -330,20 +336,22 @@ class BaseTranslator(object):
         for tag, columns in orders.items():
             self._query_help['order_by'][tag] = def_order(columns)
 
-    def set_query(self,
-                  filters=None,
-                  orders=None,
-                  projections=None,
-                  query_type=None,
-                  node_id=None,
-                  alist=None,
-                  nalist=None,
-                  elist=None,
-                  nelist=None,
-                  downloadformat=None,
-                  visformat=None,
-                  filename=None,
-                  rtype=None):
+    def set_query(
+        self,
+        filters=None,
+        orders=None,
+        projections=None,
+        query_type=None,
+        node_id=None,
+        alist=None,
+        nalist=None,
+        elist=None,
+        nelist=None,
+        downloadformat=None,
+        visformat=None,
+        filename=None,
+        rtype=None
+    ):
         # pylint: disable=too-many-arguments,unused-argument
         """
         Adds filters, default projections, order specs to the query_help,
@@ -546,9 +554,11 @@ class BaseTranslator(object):
         except MultipleObjectsError:
             raise RestValidationError("More than one node found. Provide longer starting pattern for id.")
         except NotExistent:
-            raise RestValidationError("either no object's id starts"
-                                      " with '{}' or the corresponding object"
-                                      " is not of type aiida.orm.{}".format(node_id, self._aiida_type))
+            raise RestValidationError(
+                "either no object's id starts"
+                " with '{}' or the corresponding object"
+                " is not of type aiida.orm.{}".format(node_id, self._aiida_type)
+            )
         else:
             # create a permanent filter
             self._id_filter = {'id': {'==': pk}}

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -129,16 +129,18 @@ class NodeTranslator(BaseTranslator):
         self._subclasses = self._get_subclasses()
         self._backend = get_manager().get_backend()
 
-    def set_query_type(self,
-                       query_type,
-                       alist=None,
-                       nalist=None,
-                       elist=None,
-                       nelist=None,
-                       downloadformat=None,
-                       visformat=None,
-                       filename=None,
-                       rtype=None):
+    def set_query_type(
+        self,
+        query_type,
+        alist=None,
+        nalist=None,
+        elist=None,
+        nelist=None,
+        downloadformat=None,
+        visformat=None,
+        filename=None,
+        rtype=None
+    ):
         """
         sets one of the mutually exclusive values for self._result_type and
         self._content_type.
@@ -185,20 +187,22 @@ class NodeTranslator(BaseTranslator):
                 self._result_type: self.__label__
             })
 
-    def set_query(self,
-                  filters=None,
-                  orders=None,
-                  projections=None,
-                  query_type=None,
-                  node_id=None,
-                  alist=None,
-                  nalist=None,
-                  elist=None,
-                  nelist=None,
-                  downloadformat=None,
-                  visformat=None,
-                  filename=None,
-                  rtype=None):
+    def set_query(
+        self,
+        filters=None,
+        orders=None,
+        projections=None,
+        query_type=None,
+        node_id=None,
+        alist=None,
+        nalist=None,
+        elist=None,
+        nelist=None,
+        downloadformat=None,
+        visformat=None,
+        filename=None,
+        rtype=None
+    ):
         """
         Adds filters, default projections, order specs to the query_help,
         and initializes the qb object
@@ -222,8 +226,10 @@ class NodeTranslator(BaseTranslator):
 
         ## Check the compatibility of query_type and id
         if query_type != "default" and id is None:
-            raise ValidationError("non default result/content can only be "
-                                  "applied to a specific node (specify an id)")
+            raise ValidationError(
+                "non default result/content can only be "
+                "applied to a specific node (specify an id)"
+            )
 
         ## Set the type of query
         self.set_query_type(
@@ -235,7 +241,8 @@ class NodeTranslator(BaseTranslator):
             downloadformat=downloadformat,
             visformat=visformat,
             filename=filename,
-            rtype=rtype)
+            rtype=rtype
+        )
 
         ## Define projections
         if self._content_type is not None:

--- a/aiida/schedulers/plugins/pbspro.py
+++ b/aiida/schedulers/plugins/pbspro.py
@@ -52,8 +52,9 @@ class PbsproScheduler(PbsBaseClass):
     ## for the time being, but I can redefine it if needed.
     # _map_status = _map_status_pbs_common
 
-    def _get_resource_lines(self, num_machines, num_mpiprocs_per_machine, num_cores_per_machine, max_memory_kb,
-                            max_wallclock_seconds):
+    def _get_resource_lines(
+        self, num_machines, num_mpiprocs_per_machine, num_cores_per_machine, max_memory_kb, max_wallclock_seconds
+    ):
         """
         Return the lines for machines, memory and wallclock relative
         to pbspro.
@@ -75,9 +76,11 @@ class PbsproScheduler(PbsBaseClass):
                 if tot_secs <= 0:
                     raise ValueError
             except ValueError:
-                raise ValueError("max_wallclock_seconds must be "
-                                 "a positive integer (in seconds)! It is instead '{}'"
-                                 "".format(max_wallclock_seconds))
+                raise ValueError(
+                    "max_wallclock_seconds must be "
+                    "a positive integer (in seconds)! It is instead '{}'"
+                    "".format(max_wallclock_seconds)
+                )
             hours = tot_secs // 3600
             tot_minutes = tot_secs % 3600
             minutes = tot_minutes // 60
@@ -90,9 +93,11 @@ class PbsproScheduler(PbsBaseClass):
                 if virtual_memory_kb <= 0:
                     raise ValueError
             except ValueError:
-                raise ValueError("max_memory_kb must be "
-                                 "a positive integer (in kB)! It is instead '{}'"
-                                 "".format((max_memory_kb)))
+                raise ValueError(
+                    "max_memory_kb must be "
+                    "a positive integer (in kB)! It is instead '{}'"
+                    "".format((max_memory_kb))
+                )
             select_string += ":mem={}kb".format(virtual_memory_kb)
 
         return_lines.append("#PBS -l {}".format(select_string))

--- a/aiida/schedulers/plugins/torque.py
+++ b/aiida/schedulers/plugins/torque.py
@@ -46,8 +46,9 @@ class TorqueScheduler(PbsBaseClass):
     ## for the time being, but I can redefine it if needed.
     # _map_status = _map_status_pbs_common
 
-    def _get_resource_lines(self, num_machines, num_mpiprocs_per_machine, num_cores_per_machine, max_memory_kb,
-                            max_wallclock_seconds):
+    def _get_resource_lines(
+        self, num_machines, num_mpiprocs_per_machine, num_cores_per_machine, max_memory_kb, max_wallclock_seconds
+    ):
         """
         Return the lines for machines, memory and wallclock relative
         to pbspro.
@@ -68,9 +69,11 @@ class TorqueScheduler(PbsBaseClass):
                 if tot_secs <= 0:
                     raise ValueError
             except ValueError:
-                raise ValueError("max_wallclock_seconds must be "
-                                 "a positive integer (in seconds)! It is instead '{}'"
-                                 "".format(max_wallclock_seconds))
+                raise ValueError(
+                    "max_wallclock_seconds must be "
+                    "a positive integer (in seconds)! It is instead '{}'"
+                    "".format(max_wallclock_seconds)
+                )
             hours = tot_secs // 3600
             tot_minutes = tot_secs % 3600
             minutes = tot_minutes // 60
@@ -85,9 +88,11 @@ class TorqueScheduler(PbsBaseClass):
                 if virtual_memory_kb <= 0:
                     raise ValueError
             except ValueError:
-                raise ValueError("max_memory_kb must be "
-                                 "a positive integer (in kB)! It is instead '{}'"
-                                 "".format((max_memory_kb)))
+                raise ValueError(
+                    "max_memory_kb must be "
+                    "a positive integer (in kB)! It is instead '{}'"
+                    "".format((max_memory_kb))
+                )
             # There is always something before, at least the total #
             # of nodes
             select_string += ",mem={}kb".format(virtual_memory_kb)

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -403,7 +403,8 @@ stderr:
 
         self.transport.chdir(working_directory)
         retval, stdout, stderr = self.transport.exec_command_wait(
-            self._get_submit_command(escape_for_bash(submit_script)))
+            self._get_submit_command(escape_for_bash(submit_script))
+        )
         return self._parse_submit_output(retval, stdout, stderr)
 
     def kill(self, jobid):

--- a/aiida/tools/data/array/kpoints/__init__.py
+++ b/aiida/tools/data/array/kpoints/__init__.py
@@ -56,8 +56,10 @@ def get_kpoints_path(structure, method='seekpath', **kwargs):
         try:
             seekpath.check_seekpath_is_installed()
         except ImportError:
-            raise ValueError("selected method is 'seekpath' but the package is not installed\n"
-                             "Either install it or pass method='legacy' as input to the function call")
+            raise ValueError(
+                "selected method is 'seekpath' but the package is not installed\n"
+                "Either install it or pass method='legacy' as input to the function call"
+            )
 
     method = _GET_KPOINTS_PATH_METHODS[method]
 
@@ -99,8 +101,10 @@ def get_explicit_kpoints_path(structure, method='seekpath', **kwargs):
         try:
             seekpath.check_seekpath_is_installed()
         except ImportError:
-            raise ValueError("selected method is 'seekpath' but the package is not installed\n"
-                             "Either install it or pass method='legacy' as input to the function call")
+            raise ValueError(
+                "selected method is 'seekpath' but the package is not installed\n"
+                "Either install it or pass method='legacy' as input to the function call"
+            )
 
     method = _GET_EXPLICIT_KPOINTS_PATH_METHODS[method]
 
@@ -225,7 +229,8 @@ def _legacy_get_explicit_kpoints_path(structure, **kwargs):
         raise ValueError("unknown arguments {}".format(args_unknown))
 
     point_coords, path, bravais_info, explicit_kpoints, labels = legacy.get_explicit_kpoints_path(
-        cell=structure.cell, pbc=structure.pbc, **kwargs)
+        cell=structure.cell, pbc=structure.pbc, **kwargs
+    )
 
     kpoints = KpointsData()
     kpoints.set_cell(structure.cell)
@@ -277,8 +282,10 @@ def get_kpointsdata_from_qetools(qetools_instance):
     try:
         import qe_tools  # pylint: disable=unused-variable,unused-import
     except ImportError:
-        raise ValueError("You have not installed the package qe-tools. "
-                         "You can install it with: pip install qe-tools")
+        raise ValueError(
+            "You have not installed the package qe-tools. "
+            "You can install it with: pip install qe-tools"
+        )
     from aiida.tools.data.structure import get_structuredata_from_qetools
 
     # Initialize the KpointsData node
@@ -296,13 +303,16 @@ def get_kpointsdata_from_qetools(qetools_instance):
         kpointsdata.set_kpoints(
             np.array(qetools_instance.k_points['points']) * (2. * np.pi / alat),
             weights=qetools_instance.k_points['weights'],
-            cartesian=True)
+            cartesian=True
+        )
     elif qetools_instance.k_points['type'] == 'automatic':
         kpointsdata.set_kpoints_mesh(qetools_instance.k_points['points'], offset=qetools_instance.k_points['offset'])
     elif qetools_instance.k_points['type'] == 'gamma':
         kpointsdata.set_kpoints_mesh([1, 1, 1])
     else:
-        raise NotImplementedError('Support for creating KpointsData from input units of {} is'
-                                  'not yet implemented'.format(qetools_instance.k_points['type']))
+        raise NotImplementedError(
+            'Support for creating KpointsData from input units of {} is'
+            'not yet implemented'.format(qetools_instance.k_points['type'])
+        )
 
     return kpointsdata

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -150,7 +150,8 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
         else:
             # If it now succeeds, non-unity occupancies were the culprit
             raise InvalidOccupationsError(
-                'detected atomic sites with an occupation number larger than the occupation tolerance')
+                'detected atomic sites with an occupation number larger than the occupation tolerance'
+            )
 
     return {'structure': StructureData(pymatgen_structure=structures[0])}
 
@@ -169,17 +170,21 @@ def refine_inline(node):
     from aiida.orm.nodes.data.structure import StructureData, ase_refine_cell
 
     if len(node.values.keys()) > 1:
-        raise ValueError("CifData seems to contain more than one data "
-                         "block -- multiblock CIF files are not "
-                         "supported yet")
+        raise ValueError(
+            "CifData seems to contain more than one data "
+            "block -- multiblock CIF files are not "
+            "supported yet"
+        )
 
     name = list(node.values.keys())[0]
 
     original_atoms = node.get_ase(index=None)
     if len(original_atoms) > 1:
-        raise ValueError("CifData seems to contain more than one crystal "
-                         "structure -- such refinement is not supported "
-                         "yet")
+        raise ValueError(
+            "CifData seems to contain more than one crystal "
+            "structure -- such refinement is not supported "
+            "yet"
+        )
 
     original_atoms = original_atoms[0]
 

--- a/aiida/tools/data/orbital/orbital.py
+++ b/aiida/tools/data/orbital/orbital.py
@@ -135,7 +135,8 @@ class Orbital(object):  # pylint: disable=useless-object-inheritance
         if entry_point is None:
             raise ValidationError(
                 "Unable to detect entry point for current class {}, maybe you did not register an entry point for it?".
-                format(self.__class__))
+                format(self.__class__)
+            )
 
         validated_dict['_orbital_type'] = entry_point.name
 

--- a/aiida/tools/data/orbital/realhydrogen.py
+++ b/aiida/tools/data/orbital/realhydrogen.py
@@ -281,7 +281,8 @@ class RealhydrogenOrbital(Orbital):
     """
     _base_fields_required = tuple(
         list(Orbital._base_fields_required) +
-        [('angular_momentum', validate_l), ('magnetic_number', validate_m), ('radial_nodes', validate_n)])
+        [('angular_momentum', validate_l), ('magnetic_number', validate_m), ('radial_nodes', validate_n)]
+    )
 
     _base_fields_optional = tuple(
         list(Orbital._base_fields_optional) + [
@@ -291,18 +292,22 @@ class RealhydrogenOrbital(Orbital):
             ('z_orientation', validate_len3_list_or_none, None),
             ('spin_orientation', validate_len3_list_or_none, None),
             ('diffusivity', validate_float_or_none, None),
-        ])
+        ]
+    )
 
     def __str__(self):
         orb_dict = self.get_orbital_dict()
         try:
             orb_name = self.get_name_from_quantum_numbers(
-                orb_dict['angular_momentum'], magnetic_number=orb_dict['magnetic_number'])
-            position_string = "{:.4f},{:.4f},{:.4f}".format(orb_dict['position'][0], orb_dict['position'][1],
-                                                            orb_dict['position'][2])
+                orb_dict['angular_momentum'], magnetic_number=orb_dict['magnetic_number']
+            )
+            position_string = "{:.4f},{:.4f},{:.4f}".format(
+                orb_dict['position'][0], orb_dict['position'][1], orb_dict['position'][2]
+            )
             out_string = "r{} {} orbital {} @ {}".format(
                 orb_dict['radial_nodes'], orb_name,
-                "for kind '{}'".format(orb_dict['kind_name']) if orb_dict['kind_name'] else "", position_string)
+                "for kind '{}'".format(orb_dict['kind_name']) if orb_dict['kind_name'] else "", position_string
+            )
         except KeyError:
             # Should not happen, but we want it not to crash in __str__
             out_string = "(not all parameters properly set)"
@@ -328,13 +333,15 @@ class RealhydrogenOrbital(Orbital):
         else:
             accepted_range = [0, -angular_momentum]
         if magnetic_number < min(accepted_range) or magnetic_number > max(accepted_range):
-            raise ValidationError("the magnetic number must be in the range [{}, {}]".format(
-                min(accepted_range), max(accepted_range)))
+            raise ValidationError(
+                "the magnetic number must be in the range [{}, {}]".format(min(accepted_range), max(accepted_range))
+            )
 
         # Check if it is a known combination
         try:
             self.get_name_from_quantum_numbers(
-                validated_dict['angular_momentum'], magnetic_number=validated_dict['magnetic_number'])
+                validated_dict['angular_momentum'], magnetic_number=validated_dict['magnetic_number']
+            )
         except ValidationError:
             raise ValidationError("Invalid angular momentum magnetic number combination")
 
@@ -352,8 +359,10 @@ class RealhydrogenOrbital(Orbital):
             if any([CONVERSION_DICT[x][y]['angular_momentum'] == angular_momentum for y in CONVERSION_DICT[x]])
         ]
         if not orbital_name:
-            raise InputValidationError("No orbital name corresponding to the "
-                                       "angular_momentum {} could be found".format(angular_momentum))
+            raise InputValidationError(
+                "No orbital name corresponding to the "
+                "angular_momentum {} could be found".format(angular_momentum)
+            )
         if magnetic_number is not None:
             # finds angular momentum
             orbital_name = orbital_name[0]
@@ -363,9 +372,11 @@ class RealhydrogenOrbital(Orbital):
             ]
 
             if not orbital_name:
-                raise InputValidationError("No orbital name corresponding to "
-                                           "the magnetic_number {} could be "
-                                           "found".format(magnetic_number))
+                raise InputValidationError(
+                    "No orbital name corresponding to "
+                    "the magnetic_number {} could be "
+                    "found".format(magnetic_number)
+                )
         return orbital_name[0]
 
     @classmethod

--- a/aiida/tools/data/structure/__init__.py
+++ b/aiida/tools/data/structure/__init__.py
@@ -138,8 +138,10 @@ def spglib_tuple_to_structure(structure_tuple, kind_info=None, kinds=None):  # p
             # For each site
             symbols = [elements[num]['symbol'] for num in numbers]
         except KeyError as exc:
-            raise ValueError("You did not pass kind_info, but at least one number "
-                             "is not a valid Z number: {}".format(exc.args[0]))
+            raise ValueError(
+                "You did not pass kind_info, but at least one number "
+                "is not a valid Z number: {}".format(exc.args[0])
+            )
 
         _kind_info = {elements[num]['symbol']: num for num in set(numbers)}
         # Get the default kinds
@@ -208,14 +210,20 @@ def xyz_parser_iterator(xyz_string):
                     raise
                 else:
                     # otherwise we got too less entries
-                    raise TypeError("Number of atom entries ({}) is smaller than the number of atoms ({})".format(
-                        self._catom, self._natoms))
+                    raise TypeError(
+                        "Number of atom entries ({}) is smaller than the number of atoms ({})".format(
+                            self._catom, self._natoms
+                        )
+                    )
 
             self._catom += 1
 
             if self._catom > self._natoms:
-                raise TypeError("Number of atom entries ({}) is larger than the number of atoms ({})".format(
-                    self._catom, self._natoms))
+                raise TypeError(
+                    "Number of atom entries ({}) is larger than the number of atoms ({})".format(
+                        self._catom, self._natoms
+                    )
+                )
 
             return (match.group('sym'), (float(match.group('x')), float(match.group('y')), float(match.group('z'))))
 
@@ -234,7 +242,8 @@ def xyz_parser_iterator(xyz_string):
 (?P<x> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? ) [ \t]+     # Get x
 (?P<y> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? ) [ \t]+     # Get y
 (?P<z> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? )            # Get z
-""", re.X | re.M)
+""", re.X | re.M
+    )
     pos_block_regex = re.compile(
         r"""
                                                             # First line contains an integer
@@ -275,7 +284,8 @@ def xyz_parser_iterator(xyz_string):
         [\n]                                                # line break at the end
     )+
 )                                                           # A positions block should be one or more lines
-                    """, re.X | re.M)
+                    """, re.X | re.M
+    )
 
     for block in pos_block_regex.finditer(xyz_string):
         natoms = int(block.group('natoms'))
@@ -306,8 +316,10 @@ def get_structuredata_from_qetools(qetools_instance):
     try:
         import qe_tools  # pylint: disable=unused-variable,unused-import
     except ImportError:
-        raise ValueError("You have not installed the package qe-tools. "
-                         "You can install it with: pip install qe-tools")
+        raise ValueError(
+            "You have not installed the package qe-tools. "
+            "You can install it with: pip install qe-tools"
+        )
 
     valid_elements_regex = re.compile(
         """
@@ -324,7 +336,8 @@ Ac | Th | Pa | U  | Np | Pu | Am | Cm | Bk | Cf | Es | Fm | Md | No | Lr | # Act
     )
     [^a-z]  # Any specification of an element is followed by some number
             # or capital letter or special character.
-""", re.X | re.I)
+""", re.X | re.I
+    )
 
     structure_dict = qetools_instance.get_structure_from_qeinput()
     # instance and set the cell
@@ -333,8 +346,10 @@ Ac | Th | Pa | U  | Np | Pu | Am | Cm | Bk | Cf | Es | Fm | Md | No | Lr | # Act
     structuredata.set_cell(structure_dict['cell'])
 
     #################  KINDS ##########################
-    for mass, name, pseudo in zip(structure_dict['species']['masses'], structure_dict['species']['names'],
-                                  structure_dict['species']['pseudo_file_names']):
+    for mass, name, pseudo in zip(
+        structure_dict['species']['masses'], structure_dict['species']['names'],
+        structure_dict['species']['pseudo_file_names']
+    ):
         try:
             # IMPORTANT: The symbols is parsed from the Pseudo file name
             # Is this the best way??

--- a/aiida/tools/dbimporters/plugins/materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/materialsproject.py
@@ -47,9 +47,12 @@ class MaterialsProjectImporter(DbImporter):
                 api_key = os.environ['PMG_MAPI_KEY']
             except KeyError as exc:
                 raise_from(
-                    KeyError('API key not supplied and PMG_MAPI_KEY environment '
-                             'variable not set. Either pass it when initializing the class, '
-                             'or set the environment variable PMG_MAPI_KEY to your API key.'), exc)
+                    KeyError(
+                        'API key not supplied and PMG_MAPI_KEY environment '
+                        'variable not set. Either pass it when initializing the class, '
+                        'or set the environment variable PMG_MAPI_KEY to your API key.'
+                    ), exc
+                )
             api_key = None
 
         self._api_key = api_key
@@ -61,7 +64,8 @@ class MaterialsProjectImporter(DbImporter):
         Verify the supplied API key by issuing a request to Materials Project.
         """
         response = requests.get(
-            'https://www.materialsproject.org/rest/v1/api_check', headers={'X-API-KEY': self._api_key})
+            'https://www.materialsproject.org/rest/v1/api_check', headers={'X-API-KEY': self._api_key}
+        )
         response_content = response.json()  # a dict
         if 'error' in response_content:
             raise RuntimeError(response_content['error'])
@@ -103,8 +107,10 @@ class MaterialsProjectImporter(DbImporter):
         try:
             query = kwargs['query']
         except AttributeError:
-            raise AttributeError('Make sure the supplied dictionary has `query` as a key. This '
-                                 'should contain a dictionary with the right query needed.')
+            raise AttributeError(
+                'Make sure the supplied dictionary has `query` as a key. This '
+                'should contain a dictionary with the right query needed.'
+            )
         try:
             properties = kwargs['properties']
         except AttributeError:

--- a/aiida/tools/dbimporters/plugins/tcod.py
+++ b/aiida/tools/dbimporters/plugins/tcod.py
@@ -69,11 +69,13 @@ class TcodEntry(CodEntry):
 
     _license = 'CC0'
 
-    def __init__(self,
-                 uri,
-                 db_name='Theoretical Crystallography Open Database',
-                 db_uri='http://www.crystallography.net/tcod',
-                 **kwargs):
+    def __init__(
+        self,
+        uri,
+        db_name='Theoretical Crystallography Open Database',
+        db_uri='http://www.crystallography.net/tcod',
+        **kwargs
+    ):
         """
         Creates an instance of
         :py:class:`aiida.tools.dbimporters.plugins.tcod.TcodEntry`, related

--- a/aiida/tools/importexport/dbexport/utils.py
+++ b/aiida/tools/importexport/dbexport/utils.py
@@ -81,7 +81,8 @@ def fill_in_query(partial_query, originating_entity_str, current_entity_str, tag
         tag=entity_separator.join(tag_suffixes) + entity_separator + current_entity_str,
         project=project_cols,
         outerjoin=True,
-        **mydict)
+        **mydict
+    )
 
     # prepare the recursion for the referenced entities
     foreign_fields = {
@@ -115,10 +116,12 @@ def check_licences(node_licenses, allowed_licenses, forbidden_licenses):
                     if license_ not in allowed_licenses:
                         raise LicensingException
             except LicensingException:
-                raise LicensingException("Node {} is licensed "
-                                         "under {} license, which "
-                                         "is not in the list of "
-                                         "allowed licenses".format(pk, license_))
+                raise LicensingException(
+                    "Node {} is licensed "
+                    "under {} license, which "
+                    "is not in the list of "
+                    "allowed licenses".format(pk, license_)
+                )
         if forbidden_licenses is not None:
             try:
                 if isfunction(forbidden_licenses):
@@ -131,10 +134,12 @@ def check_licences(node_licenses, allowed_licenses, forbidden_licenses):
                     if license_ in forbidden_licenses:
                         raise LicensingException
             except LicensingException:
-                raise LicensingException("Node {} is licensed "
-                                         "under {} license, which "
-                                         "is in the list of "
-                                         "forbidden licenses".format(pk, license_))
+                raise LicensingException(
+                    "Node {} is licensed "
+                    "under {} license, which "
+                    "is in the list of "
+                    "forbidden licenses".format(pk, license_)
+                )
 
 
 def serialize_field(data, track_conversion=False):
@@ -223,8 +228,9 @@ def serialize_dict(datadict, remove_fields=None, rename_fields=None, track_conve
             # rename_fields.get(key,key): use the replacement if found in rename_fields,
             # otherwise use 'key' as the default value.
             if track_conversion:
-                (ret_dict[rename_fields.get(key, key)], conversions[rename_fields.get(key, key)]) = serialize_field(
-                    data=value, track_conversion=track_conversion)
+                (ret_dict[rename_fields.get(key, key)],
+                 conversions[rename_fields.get(key,
+                                               key)]) = serialize_field(data=value, track_conversion=track_conversion)
             else:
                 ret_dict[rename_fields.get(key, key)] = serialize_field(data=value, track_conversion=track_conversion)
 
@@ -265,6 +271,7 @@ def check_process_nodes_sealed(nodes):
     sealed_nodes = {_[0] for _ in sealed_nodes}
 
     if sealed_nodes != nodes:
-        raise InvalidOperation("All ProcessNodes must be sealed before they can be exported. "
-                               "Node(s) with PK(s): {} is/are not sealed.".format(', '.join(
-                                   str(pk) for pk in nodes - sealed_nodes)))
+        raise InvalidOperation(
+            "All ProcessNodes must be sealed before they can be exported. "
+            "Node(s) with PK(s): {} is/are not sealed.".format(', '.join(str(pk) for pk in nodes - sealed_nodes))
+        )

--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -7,19 +7,16 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-""" Export a zip-file """
+"""Export a zip-file."""
 # pylint: disable=useless-object-inheritance,missing-docstring,redefined-builtin
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-import time
 import zipfile
 
 import six
-
-__all__ = ('export_zip',)
 
 
 class MyWritingZipFile(object):
@@ -80,7 +77,8 @@ class ZipFolder(object):
             else:
                 compression = zipfile.ZIP_STORED
             self._zipfile = zipfile.ZipFile(
-                zipfolder_or_fname, mode=the_mode, compression=compression, allowZip64=allowZip64)
+                zipfolder_or_fname, mode=the_mode, compression=compression, allowZip64=allowZip64
+            )
             self._pwd = subfolder
         else:
             if mode is not None:
@@ -148,17 +146,3 @@ class ZipFolder(object):
                     self._zipfile.write(real_src, real_dest)
         else:
             self._zipfile.write(src, base_filename)
-
-
-def export_zip(what, outfile='testzip', overwrite=False, silent=False, use_compression=True, **kwargs):
-    """Export in a zipped folder"""
-    from aiida.tools.importexport.dbexport import export_tree
-
-    if not overwrite and os.path.exists(outfile):
-        raise IOError("the output file '{}' already exists".format(outfile))
-
-    time_start = time.time()
-    with ZipFolder(outfile, mode='w', use_compression=use_compression) as folder:
-        export_tree(what, folder=folder, silent=silent, **kwargs)
-    if not silent:
-        print("File written in {:10.3g} s.".format(time.time() - time_start))

--- a/aiida/tools/importexport/dbimport/backends/utils.py
+++ b/aiida/tools/importexport/dbimport/backends/utils.py
@@ -73,8 +73,10 @@ def merge_comment(incoming_comment, comment_mode):
 
     # Invalid comment_mode
     else:
-        raise ValueError("Unknown comment_mode value: {}. Should be "
-                         "either 'newest' or 'overwrite'".format(comment_mode))
+        raise ValueError(
+            "Unknown comment_mode value: {}. Should be "
+            "either 'newest' or 'overwrite'".format(comment_mode)
+        )
 
 
 def merge_extras(old_extras, new_extras, mode):
@@ -128,9 +130,12 @@ def merge_extras(old_extras, new_extras, mode):
             final_extras[key] = new_extras[key]
         for key in collided_keys:
             if old_extras[key] != new_extras[key]:
-                if click.confirm('The extra {} collided, would you'
-                                 ' like to overwrite its value?\nOld value: {}\nNew value: {}\n'.format(
-                                     key, old_extras[key], new_extras[key])):
+                if click.confirm(
+                    'The extra {} collided, would you'
+                    ' like to overwrite its value?\nOld value: {}\nNew value: {}\n'.format(
+                        key, old_extras[key], new_extras[key]
+                    )
+                ):
                     final_extras[key] = new_extras[key]
 
     # Slow, but more general implementation
@@ -158,9 +163,12 @@ def merge_extras(old_extras, new_extras, mode):
         elif mode[2] == 'a':
             for key in collided_keys:
                 if old_extras[key] != new_extras[key]:
-                    if click.confirm('The extra {} collided, would you'
-                                     ' like to overwrite its value?\nOld value: {}\nNew value: {}\n'.format(
-                                         key, old_extras[key], new_extras[key])):
+                    if click.confirm(
+                        'The extra {} collided, would you'
+                        ' like to overwrite its value?\nOld value: {}\nNew value: {}\n'.format(
+                            key, old_extras[key], new_extras[key]
+                        )
+                    ):
                         final_extras[key] = new_extras[key]
                     else:
                         final_extras[key] = old_extras[key]

--- a/aiida/tools/importexport/migration/v03_to_v04.py
+++ b/aiida/tools/importexport/migration/v03_to_v04.py
@@ -85,8 +85,10 @@ def migration_add_node_uuid_unique_constraint(data):
         all_uuids = [content['uuid'] for content in data['export_data'][entry_type].values()]
         unique_uuids = set(all_uuids)
         if len(all_uuids) != len(unique_uuids):
-            echo.echo_critical("""{}s with exactly the same UUID found, cannot proceed further. Please contact AiiDA
-            developers: http://www.aiida.net/mailing-list/ to help you resolve this issue.""".format(entry_type))
+            echo.echo_critical(
+                """{}s with exactly the same UUID found, cannot proceed further. Please contact AiiDA
+            developers: http://www.aiida.net/mailing-list/ to help you resolve this issue.""".format(entry_type)
+            )
 
 
 def migration_migrate_builtin_calculations(data):
@@ -135,7 +137,8 @@ def migration_provenance_redesign(data):  # pylint: disable=too-many-locals,too-
     if calcjobs_to_migrate:
         # step1: rename the type column of process nodes
         mapping_node_entry = infer_calculation_entry_point(
-            type_strings=[e['type'] for e in calcjobs_to_migrate.values()])
+            type_strings=[e['type'] for e in calcjobs_to_migrate.values()]
+        )
         for uuid, content in calcjobs_to_migrate.items():
             type_string = content['type']
             entry_point_string = mapping_node_entry[type_string]
@@ -176,10 +179,10 @@ def migration_provenance_redesign(data):  # pylint: disable=too-many-locals,too-
 
     # calculations with outgoing CALL links
     calculation_uuids = {
-        value['uuid']
-        for value in data['export_data'].get('Node', {}).values()
-        if (value.get('type', '').startswith('calculation.job.') or
-            value.get('type', '').startswith('calculation.inline.'))
+        value['uuid'] for value in data['export_data'].get('Node', {}).values() if (
+            value.get('type', '').startswith('calculation.job.') or
+            value.get('type', '').startswith('calculation.inline.')
+        )
     }
     warning_message = 'detected calculation nodes with outgoing `call` links.'
     delete_wrong_links(calculation_uuids, 'calllink', headers, warning_message, action_message)
@@ -191,10 +194,10 @@ def migration_provenance_redesign(data):  # pylint: disable=too-many-locals,too-
     # outgoing CREATE links from FunctionCalculation and WorkCalculation nodes
     warning_message = 'detected outgoing `create` links from FunctionCalculation and/or WorkCalculation nodes.'
     work_uuids = {
-        value['uuid']
-        for value in data['export_data'].get('Node', {}).values()
-        if (value.get('type', '').startswith('calculation.function') or
-            value.get('type', '').startswith('calculation.work'))
+        value['uuid'] for value in data['export_data'].get('Node', {}).values() if (
+            value.get('type', '').startswith('calculation.function') or
+            value.get('type', '').startswith('calculation.work')
+        )
     }
     delete_wrong_links(work_uuids, 'createlink', headers, warning_message, action_message)
 
@@ -205,8 +208,10 @@ def migration_provenance_redesign(data):  # pylint: disable=too-many-locals,too-
 
         #  WorkCalculations that have a `function_name` attribute are FunctionCalculations
         if node.get('type', '') == 'calculation.work.WorkCalculation.':
-            if ('function_name' in data['node_attributes'][node_id] and
-                    data['node_attributes'][node_id]['function_name'] is not None):
+            if (
+                'function_name' in data['node_attributes'][node_id] and
+                data['node_attributes'][node_id]['function_name'] is not None
+            ):
                 # for some reason for the workchains the 'function_name' attribute is present but has None value
                 node['type'] = 'node.process.workflow.workfunction.WorkFunctionNode.'
             else:
@@ -344,7 +349,8 @@ def migration_trajectory_symbols_to_attribute(data, folder):
         if content.get('type', '') == 'node.data.array.trajectory.TrajectoryData.':
             uuid = content['uuid']
             symbols_path = os.path.join(
-                folder.get_abs_path('nodes'), uuid[0:2], uuid[2:4], uuid[4:], 'path', 'symbols.npy')
+                folder.get_abs_path('nodes'), uuid[0:2], uuid[2:4], uuid[4:], 'path', 'symbols.npy'
+            )
             symbols = np.load(symbols_path).tolist()
             os.remove(symbols_path)
             # Update 'node_attributes'

--- a/aiida/tools/importexport/migration/v06_to_v07.py
+++ b/aiida/tools/importexport/migration/v06_to_v07.py
@@ -93,8 +93,10 @@ def migration_data_migration_legacy_process_attributes(data):
                           "that should never have been allowed to be exported."
         write_database_integrity_violation(illegal_cases, headers, warning_message)
 
-        raise IntegrityError("Your export archive is corrupt! "
-                             "Please see the log-file in your current directory for more details.")
+        raise IntegrityError(
+            "Your export archive is corrupt! "
+            "Please see the log-file in your current directory for more details."
+        )
 
 
 def remove_attribute_link_metadata(metadata):

--- a/aiida/tools/importexport/utils.py
+++ b/aiida/tools/importexport/utils.py
@@ -16,8 +16,9 @@ from __future__ import print_function
 
 from six.moves.html_parser import HTMLParser
 
-from aiida.tools.importexport.config import (NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME,
-                                             USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME)
+from aiida.tools.importexport.config import (
+    NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME, USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME
+)
 
 
 def schema_to_entity_names(class_string):
@@ -35,8 +36,9 @@ def schema_to_entity_names(class_string):
     if class_string in ("aiida.backends.djsite.db.models.DbGroup", "aiida.backends.sqlalchemy.models.group.DbGroup"):
         return GROUP_ENTITY_NAME
 
-    if class_string in ("aiida.backends.djsite.db.models.DbComputer",
-                        "aiida.backends.sqlalchemy.models.computer.DbComputer"):
+    if class_string in (
+        "aiida.backends.djsite.db.models.DbComputer", "aiida.backends.sqlalchemy.models.computer.DbComputer"
+    ):
         return COMPUTER_ENTITY_NAME
 
     if class_string in ("aiida.backends.djsite.db.models.DbUser", "aiida.backends.sqlalchemy.models.user.DbUser"):
@@ -45,8 +47,9 @@ def schema_to_entity_names(class_string):
     if class_string in ("aiida.backends.djsite.db.models.DbLog", "aiida.backends.sqlalchemy.models.log.DbLog"):
         return LOG_ENTITY_NAME
 
-    if class_string in ("aiida.backends.djsite.db.models.DbComment",
-                        "aiida.backends.sqlalchemy.models.comment.DbComment"):
+    if class_string in (
+        "aiida.backends.djsite.db.models.DbComment", "aiida.backends.sqlalchemy.models.comment.DbComment"
+    ):
         return COMMENT_ENTITY_NAME
 
 

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -252,13 +252,9 @@ def get_node_id_label(node, id_type):
     raise ValueError("node_id_type not recognised: {}".format(id_type))
 
 
-def _add_graphviz_node(graph,
-                       node,
-                       node_style_func,
-                       node_sublabel_func,
-                       style_override=None,
-                       include_sublabels=True,
-                       id_type="pk"):
+def _add_graphviz_node(
+    graph, node, node_style_func, node_sublabel_func, style_override=None, include_sublabels=True, id_type="pk"
+):
     """create a node in the graph
 
     The first line of the node text is always '<node.name> (<node.pk>)'.
@@ -298,8 +294,10 @@ def _add_graphviz_node(graph,
         node_style = node_style_func(node)
 
         label = [
-            "{} ({})".format(node.__class__.__name__ if node.process_label is None else node.process_label,
-                             get_node_id_label(node, id_type))
+            "{} ({})".format(
+                node.__class__.__name__ if node.process_label is None else node.process_label,
+                get_node_id_label(node, id_type)
+            )
         ]
 
     if include_sublabels:
@@ -342,16 +340,18 @@ class Graph(object):
 
     # pylint: disable=useless-object-inheritance
 
-    def __init__(self,
-                 engine=None,
-                 graph_attr=None,
-                 global_node_style=None,
-                 global_edge_style=None,
-                 include_sublabels=True,
-                 link_style_fn=None,
-                 node_style_fn=None,
-                 node_sublabel_fn=None,
-                 node_id_type="pk"):
+    def __init__(
+        self,
+        engine=None,
+        graph_attr=None,
+        global_node_style=None,
+        global_edge_style=None,
+        include_sublabels=True,
+        link_style_fn=None,
+        node_style_fn=None,
+        node_sublabel_fn=None,
+        node_id_type="pk"
+    ):
         """a class to create graphviz graphs of the AiiDA node provenance
 
         Nodes and edges, are cached, so that they are only created once
@@ -440,7 +440,8 @@ class Graph(object):
                 node_sublabel_func=self._node_sublabels,
                 style_override=style,
                 include_sublabels=self._include_sublabels,
-                id_type=self._node_id_type)
+                id_type=self._node_id_type
+            )
             self._nodes.add(node.pk)
         return node
 
@@ -510,7 +511,8 @@ class Graph(object):
             self.add_node(link_triple.node)
             link_pair = LinkPair(link_triple.link_type, link_triple.link_label)
             style = self._link_styles(
-                link_pair, add_label=annotate_links in ["label", "both"], add_type=annotate_links in ["type", "both"])
+                link_pair, add_label=annotate_links in ["label", "both"], add_type=annotate_links in ["type", "both"]
+            )
             self.add_edge(link_triple.node, node, link_pair, style=style)
             nodes.append(link_triple.node.pk if return_pks else link_triple.node)
 
@@ -540,20 +542,23 @@ class Graph(object):
             self.add_node(link_triple.node)
             link_pair = LinkPair(link_triple.link_type, link_triple.link_label)
             style = self._link_styles(
-                link_pair, add_label=annotate_links in ["label", "both"], add_type=annotate_links in ["type", "both"])
+                link_pair, add_label=annotate_links in ["label", "both"], add_type=annotate_links in ["type", "both"]
+            )
             self.add_edge(node, link_triple.node, link_pair, style=style)
             nodes.append(link_triple.node.pk if return_pks else link_triple.node)
 
         return nodes
 
-    def recurse_descendants(self,
-                            origin,
-                            depth=None,
-                            link_types=(),
-                            annotate_links=False,
-                            origin_style=(),
-                            include_process_inputs=False,
-                            print_func=None):
+    def recurse_descendants(
+        self,
+        origin,
+        depth=None,
+        link_types=(),
+        annotate_links=False,
+        origin_style=(),
+        include_process_inputs=False,
+        print_func=None
+    ):
         """add nodes and edges from an origin recursively,
         following outgoing links
 
@@ -590,7 +595,8 @@ class Graph(object):
             new_nodes = []
             for node in leaf_nodes:
                 outgoing_nodes = self.add_outgoing(
-                    node, link_types=link_types, annotate_links=annotate_links, return_pks=False)
+                    node, link_types=link_types, annotate_links=annotate_links, return_pks=False
+                )
                 if outgoing_nodes and print_func:
                     print_func("  {} -> {}".format(node.pk, [on.pk for on in outgoing_nodes]))
                 new_nodes.extend(outgoing_nodes)
@@ -606,14 +612,16 @@ class Graph(object):
                 leaf_nodes.append(new_node)
                 traversed_pks.append(new_node.pk)
 
-    def recurse_ancestors(self,
-                          origin,
-                          depth=None,
-                          link_types=(),
-                          annotate_links=False,
-                          origin_style=(),
-                          include_process_outputs=False,
-                          print_func=None):
+    def recurse_ancestors(
+        self,
+        origin,
+        depth=None,
+        link_types=(),
+        annotate_links=False,
+        origin_style=(),
+        include_process_outputs=False,
+        print_func=None
+    ):
         """add nodes and edges from an origin recursively,
         following incoming links
 
@@ -650,7 +658,8 @@ class Graph(object):
             new_nodes = []
             for node in last_nodes:
                 incoming_nodes = self.add_incoming(
-                    node, link_types=link_types, annotate_links=annotate_links, return_pks=False)
+                    node, link_types=link_types, annotate_links=annotate_links, return_pks=False
+                )
                 if incoming_nodes and print_func:
                     print_func("  {} -> {}".format(node.pk, [n.pk for n in incoming_nodes]))
                 new_nodes.extend(incoming_nodes)
@@ -666,14 +675,16 @@ class Graph(object):
                 last_nodes.append(new_node)
                 traversed_pks.append(new_node.pk)
 
-    def add_origin_to_targets(self,
-                              origin,
-                              target_cls,
-                              target_filters=None,
-                              include_target_inputs=False,
-                              include_target_outputs=False,
-                              origin_style=(),
-                              annotate_links=False):
+    def add_origin_to_targets(
+        self,
+        origin,
+        target_cls,
+        target_filters=None,
+        include_target_inputs=False,
+        include_target_outputs=False,
+        origin_style=(),
+        annotate_links=False
+    ):
         """Add nodes and edges from an origin node to all nodes of a target node class.
 
         :param origin: node or node pk/uuid
@@ -707,15 +718,15 @@ class Graph(object):
                         "id": origin_node.pk
                     },
                     'tag': "origin"
-                },
-                         {
-                             'cls': target_cls,
-                             'filters': target_filters,
-                             'with_ancestors': 'origin',
-                             'tag': "target",
-                             'project': "*"
-                         }]
-            })
+                }, {
+                    'cls': target_cls,
+                    'filters': target_filters,
+                    'with_ancestors': 'origin',
+                    'tag': "target",
+                    'project': "*"
+                }]
+            }
+        )
 
         for (target_node,) in query.iterall():
             self.add_node(target_node)
@@ -727,15 +738,17 @@ class Graph(object):
             if include_target_outputs:
                 self.add_outgoing(target_node, annotate_links=annotate_links)
 
-    def add_origins_to_targets(self,
-                               origin_cls,
-                               target_cls,
-                               origin_filters=None,
-                               target_filters=None,
-                               include_target_inputs=False,
-                               include_target_outputs=False,
-                               origin_style=(),
-                               annotate_links=False):
+    def add_origins_to_targets(
+        self,
+        origin_cls,
+        target_cls,
+        origin_filters=None,
+        target_filters=None,
+        include_target_inputs=False,
+        include_target_outputs=False,
+        origin_style=(),
+        annotate_links=False
+    ):
         """Add nodes and edges from all nodes of an origin class to all node of a target node class.
 
         :param origin_cls: origin node class
@@ -764,7 +777,8 @@ class Graph(object):
                 "filters": origin_filters,
                 'tag': "origin",
                 'project': "*"
-            }]})
+            }]}
+        )
 
         for (node,) in query.iterall():
             self.add_origin_to_targets(
@@ -774,4 +788,5 @@ class Graph(object):
                 include_target_inputs=include_target_inputs,
                 include_target_outputs=include_target_outputs,
                 origin_style=origin_style,
-                annotate_links=annotate_links)
+                annotate_links=annotate_links
+            )

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -30,9 +30,11 @@ TRANSPORT_PARAMS = []
 def match_comp_transport(ctx, param, computer, transport_type):
     """Check the computer argument against the transport type."""
     if computer.get_transport_type() != transport_type:
-        echo.echo_critical('Computer {} has transport of type "{}", not {}!'.format(computer.name,
-                                                                                    computer.get_transport_type(),
-                                                                                    transport_type))
+        echo.echo_critical(
+            'Computer {} has transport of type "{}", not {}!'.format(
+                computer.name, computer.get_transport_type(), transport_type
+            )
+        )
     return computer
 
 
@@ -111,7 +113,8 @@ def create_option(name, spec):
     kwargs = {}
     if 'default' not in spec:
         kwargs['contextual_default'] = interactive_default(
-            'ssh', name, also_noninteractive=spec.pop('non_interactive_default', False))
+            'ssh', name, also_noninteractive=spec.pop('non_interactive_default', False)
+        )
     kwargs['cls'] = InteractiveOption
     kwargs.update(spec)
     if existing_option:

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -764,7 +764,8 @@ class LocalTransport(Transport):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=self.getcwd(),
-            preexec_fn=os.setsid)
+            preexec_fn=os.setsid
+        )
 
         return proc.stdin, proc.stdout, proc.stderr, proc
 
@@ -816,8 +817,7 @@ class LocalTransport(Transport):
         script = ' ; '.join([
             'if [ -d {escaped_remotedir} ]', 'then cd {escaped_remotedir}', 'bash', "else echo ' ** The directory'",
             "echo ' ** {remotedir}'", "echo ' ** seems to have been deleted, I logout...'", 'fi'
-        ]).format(
-            escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir)
+        ]).format(escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir)
         cmd = 'bash -c "{}"'.format(script)
         return cmd
 

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -54,12 +54,14 @@ class Transport(object):
     _valid_auth_params = None
     _MAGIC_CHECK = re.compile('[*?[]')
     _valid_auth_options = []
-    _common_auth_options = [('safe_interval', {
-        'type': float,
-        'prompt': 'Connection cooldown time (s)',
-        'help': 'Minimum time interval in seconds between consecutive connection openings',
-        'callback': validate_positive_number
-    })]
+    _common_auth_options = [(
+        'safe_interval', {
+            'type': float,
+            'prompt': 'Connection cooldown time (s)',
+            'help': 'Minimum time interval in seconds between consecutive connection openings',
+            'callback': validate_positive_number
+        }
+    )]
 
     def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         """
@@ -675,8 +677,10 @@ class Transport(object):
                 self.logger.warning("There was nonempty stderr in the whoami command: {}".format(stderr))
             return username.strip()
 
-        self.logger.error("Problem executing whoami. Exit code: {}, stdout: '{}', "
-                          "stderr: '{}'".format(retval, username, stderr))
+        self.logger.error(
+            "Problem executing whoami. Exit code: {}, stdout: '{}', "
+            "stderr: '{}'".format(retval, username, stderr)
+        )
         raise IOError("Error while executing whoami. Exit code: {}".format(retval))
 
     def path_exists(self, path):

--- a/setup.json
+++ b/setup.json
@@ -110,15 +110,12 @@
       "aiida-export-migration-tests==0.7.0"
     ],
     "dev_precommit": [
-      "astroid==2.1.0; python_version>='3.0'",
-      "pylint==2.2.2; python_version>='3.0'",
-      "pre-commit==1.14.4",
-      "yapf==0.26.0",
-      "prospector==1.1.5",
-      "pylint==1.9.4; python_version<'3.0'",
-      "pylint==2.2.2; python_version>='3.0'",
+      "pre-commit==1.17.0",
+      "yapf==0.28.0",
+      "prospector==1.1.7",
       "pylint-django==0.11.1; python_version<'3.0'",
-      "pylint-django==2.0.5; python_version>='3.0'",
+      "pylint==1.9.4; python_version<'3.0'",
+      "pylint==2.3.1; python_version>='3.0'",
       "pep8-naming==0.4.1",
       "toml==0.10.0"
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,13 @@ if __name__ == '__main__':
         += SETUP_JSON['extras_require']['rest'] \
         + SETUP_JSON['extras_require']['atomic_tools']
 
-    SETUP_JSON['extras_require']['all'] = list(
-        {item for sublist in SETUP_JSON['extras_require'].values() for item in sublist if item != 'bpython'})
+    SETUP_JSON['extras_require']['all'] = list({
+        item for sublist in SETUP_JSON['extras_require'].values() for item in sublist if item != 'bpython'
+    })
 
     setup(
         packages=find_packages(),
         long_description=open(path.join(THIS_FOLDER, 'README.md')).read(),
         long_description_content_type='text/markdown',
-        **SETUP_JSON)
+        **SETUP_JSON
+    )

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -242,9 +242,11 @@ def validate_pyproject():
 
     if reentry_requirement not in pyproject_toml_requires:
         click.echo(
-            'Reentry requirement from {} {} is not mirrored in {}'.format(FILEPATH_SETUP_JSON, reentry_requirement,
-                                                                          FILEPATH_TOML),
-            err=True)
+            'Reentry requirement from {} {} is not mirrored in {}'.format(
+                FILEPATH_SETUP_JSON, reentry_requirement, FILEPATH_TOML
+            ),
+            err=True
+        )
         sys.exit(1)
 
 
@@ -261,7 +263,8 @@ def update_environment_yml():
     yaml.add_representer(
         OrderedDict,
         lambda self, data: yaml.representer.SafeRepresenter.represent_dict(self, data.items()),
-        Dumper=yaml.SafeDumper)
+        Dumper=yaml.SafeDumper
+    )
 
     # fix incompatibilities between conda and pypi
     replacements = {'psycopg2-binary': 'psycopg2', 'graphviz': 'python-graphviz'}
@@ -290,7 +293,8 @@ def update_environment_yml():
     with open(file_path, 'w') as env_file:
         env_file.write('# Usage: conda env create -n myenvname -f environment.yml python=3.6\n')
         yaml.safe_dump(
-            environment, env_file, explicit_start=True, default_flow_style=False, encoding='utf-8', allow_unicode=True)
+            environment, env_file, explicit_start=True, default_flow_style=False, encoding='utf-8', allow_unicode=True
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #2546 

An update in `prospector` which finally fixes incompatibility issues
with `pylint` and `astroid` allows us to unpin their version
requirements. At the same time, the versions of `yapf` and `precommit`
are upped. The former results in a lot of new formatting rules which are
also applied and committed.