### PR TITLE
Make sure `verdi` commands respect PEP 257 docstring conventions

### DIFF
--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -30,8 +30,7 @@ def verdi_calcjob():
 @verdi_calcjob.command('gotocomputer')
 @arguments.CALCULATION('calcjob', type=CalculationParamType(sub_classes=('aiida.node:process.calculation.calcjob',)))
 def calcjob_gotocomputer(calcjob):
-    """
-    Open a shell and go to the calcjob folder on the computer
+    """Open a shell and go to the calcjob folder on the computer.
 
     This command opens a ssh connection to the folder on the remote
     computer on which the calcjob is being/has been executed.
@@ -83,9 +82,9 @@ def calcjob_res(calcjob, fmt, keys):
 @click.argument('path', type=click.STRING, required=False)
 @decorators.with_dbenv()
 def calcjob_inputcat(calcjob, path):
-    """
-    Show the contents of a file with relative PATH in the raw input folder of the CALCULATION.
+    """Show the contents of an input file of a CALCULATION.
 
+    The PATH argument can be used to indicate a specific file using its relative path in the repository.
     If PATH is not specified, the default input file path will be used, if defined by the calcjob plugin class.
     """
     # Get path from the given CalcJobNode if not defined by user
@@ -117,9 +116,9 @@ def calcjob_inputcat(calcjob, path):
 @click.argument('path', type=click.STRING, required=False)
 @decorators.with_dbenv()
 def calcjob_outputcat(calcjob, path):
-    """
-    Show the contents of a file with relative PATH in the retrieved folder of the CALCULATION.
+    """Show the contents of an output file of a CALCULATION.
 
+    The PATH argument can be used to indicate a specific file using its relative path in the repository.
     If PATH is not specified, the default output file path will be used, if defined by the calcjob plugin class.
     Content can only be shown after the daemon has retrieved the remote files.
     """
@@ -158,9 +157,9 @@ def calcjob_outputcat(calcjob, path):
 @click.argument('path', type=click.STRING, required=False)
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calcjob_inputls(calcjob, path, color):
-    """
-    Show the list of files in the directory with relative PATH in the raw input folder of the CALCULATION.
+    """Show the list of inputs files for the given CALCULATION.
 
+    The PATH argument can be used to specify a sub directory in the input folder.
     If PATH is not specified, the base path of the input folder will be used.
     """
     from aiida.cmdline.utils.repository import list_repository_contents
@@ -177,9 +176,9 @@ def calcjob_inputls(calcjob, path, color):
 @click.argument('path', type=click.STRING, required=False)
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calcjob_outputls(calcjob, path, color):
-    """
-    Show the list of files in the directory with relative PATH in the retrieved folder of the CALCULATION.
+    """Show the list of output files of the CALCULATION.
 
+    The PATH argument can be used to specify a sub directory in the output folder.
     If PATH is not specified, the base path of the retrieved folder will be used.
     Content can only be shown after the daemon has retrieved the remote files.
     """
@@ -204,8 +203,7 @@ def calcjob_outputls(calcjob, path, color):
 @options.COMPUTERS(help='include only calcjobs that were ran on these computers')
 @options.FORCE()
 def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force):
-    """
-    Clean all content of all output remote folders of calcjobs.
+    """Clean all content of all output remote folders of calcjobs.
 
     If no explicit calcjobs are specified as arguments, one or both of the -p and -o options has to be specified.
     If both are specified, a logical AND is done between the two, i.e. the calcjobs that will be cleaned have been

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -125,7 +125,7 @@ def setup_code(non_interactive, **kwargs):
 @click.pass_context
 @with_dbenv()
 def code_duplicate(ctx, code, non_interactive, **kwargs):
-    """Create duplicate of existing Code."""
+    """Create duplicate of an existing Code."""
     from aiida.common.exceptions import ValidationError
     from aiida.orm.utils.builders.code import CodeBuilder
 
@@ -174,7 +174,10 @@ def show(code, verbose):
 @arguments.CODES()
 @with_dbenv()
 def delete(codes):
-    """Delete codes that have not yet been used for calculations, i.e. if it has outgoing links."""
+    """Delete a Code.
+
+    Note, one can only deleted codes that have not yet been used for calculations, i.e. if it has outgoing links.
+    """
     from aiida.common.exceptions import InvalidOperation
     from aiida.orm import Node
 
@@ -193,7 +196,10 @@ def delete(codes):
 @arguments.CODES()
 @with_dbenv()
 def hide(codes):
-    """Hide one or more codes from the `verdi code list` command."""
+    """Hide one or more codes.
+
+    Hidden codes do not show up by default in the output of `verdi code list`.
+    """
     for code in codes:
         code.hide()
         echo.echo_success('Code<{}> {} hidden'.format(code.pk, code.full_label))
@@ -203,7 +209,10 @@ def hide(codes):
 @arguments.CODES()
 @with_dbenv()
 def reveal(codes):
-    """Reveal one or more hidden codes to the `verdi code list` command."""
+    """Reveal one or more hidden codes.
+
+    Hidden codes do not show up by default in the output of `verdi code list`.
+    """
     for code in codes:
         code.reveal()
         echo.echo_success('Code<{}> {} revealed'.format(code.pk, code.full_label))
@@ -214,7 +223,7 @@ def reveal(codes):
 @arguments.LABEL()
 @with_dbenv()
 def relabel(code, label):
-    """Relabel a code."""
+    """Relabel a Code."""
     old_label = code.full_label
 
     try:

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -36,9 +36,7 @@ def verdi_computer():
 
 
 def get_computer_names():
-    """
-    Retrieve the list of computers in the DB.
-    """
+    """Retrieve the list of computers in the DB."""
     from aiida.orm.querybuilder import QueryBuilder
     builder = QueryBuilder()
     builder.append(entity_type='computer', project=['name'])
@@ -53,8 +51,7 @@ def prompt_for_computer_configuration(computer):  # pylint: disable=unused-argum
 
 
 def _computer_test_get_jobs(transport, scheduler, authinfo):  # pylint: disable=unused-argument
-    """
-    Internal test to check if it is possible to check the queue state.
+    """Internal test to check if it is possible to check the queue state.
 
     :param transport: an open transport
     :param scheduler: the corresponding scheduler class
@@ -68,8 +65,7 @@ def _computer_test_get_jobs(transport, scheduler, authinfo):  # pylint: disable=
 
 
 def _computer_test_no_unexpected_output(transport, scheduler, authinfo):  # pylint: disable=unused-argument
-    """
-    Test that there is no unexpected output from the connection.
+    """Test that there is no unexpected output from the connection.
 
     This can happen if e.g. there is some spurious command in the
     .bashrc or .bash_profile that is not guarded in case of non-interactive
@@ -124,9 +120,7 @@ https://github.com/aiidateam/aiida-core/issues/1890
 
 
 def _computer_create_temp_file(transport, scheduler, authinfo):  # pylint: disable=unused-argument
-    """
-    Internal test to check if it is possible to create a temporary file
-    and then delete it in the work directory
+    """Internal test to check if it is possible to create a temporary file and then delete it in the work directory
 
     :note: exceptions could be raised
 
@@ -194,8 +188,7 @@ def _computer_create_temp_file(transport, scheduler, authinfo):  # pylint: disab
 
 
 def get_parameter_default(parameter, ctx):
-    """
-    Get the value for a specific parameter from the computer_builder or the default value of that option
+    """Get the value for a specific parameter from the computer_builder or the default value of that option.
 
     :param parameter: parameter name
     :param ctx: click context of the command
@@ -469,8 +462,7 @@ def computer_rename(computer, new_name):
 @arguments.COMPUTER()
 @with_dbenv()
 def computer_test(user, print_traceback, computer):
-    """
-    Test the connection to a computer.
+    """Test the connection to a computer.
 
     It tries to connect, to get the list of calculations on the queue and
     to perform other tests.
@@ -544,11 +536,9 @@ def computer_test(user, print_traceback, computer):
 @arguments.COMPUTER()
 @with_dbenv()
 def computer_delete(computer):
-    """
-    Configure the authentication information for a given computer
+    """Configure the authentication information for a given computer.
 
-    Does not delete the computer if there are calculations that are using
-    it.
+    Does not delete the computer if there are calculations that are using it.
     """
     from aiida.common.exceptions import InvalidOperation
     from aiida import orm

--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -26,7 +26,11 @@ from aiida.cmdline.utils import echo
 @click.option('--unset', is_flag=True, help='Remove the line matching the option name from the config file.')
 @click.pass_context
 def verdi_config(ctx, option, value, globally, unset):
-    """Set, unset and get profile specific or global configuration options."""
+    """Inspect and manage configuration options.
+
+    By default the command is applied to the default or specified profile.
+    With the `--global` flag, the command is applied to the global instance.
+    """
     config = ctx.obj.config
     profile = ctx.obj.profile
 

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -38,8 +38,7 @@ def upf():
 )
 @decorators.with_dbenv()
 def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
-    """
-    Upload a new pseudopotential family.
+    """Upload a new pseudopotential family.
 
     Returns the numbers of files found and the number of nodes uploaded.
 
@@ -62,9 +61,7 @@ def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
 @options.WITH_ELEMENTS()
 @decorators.with_dbenv()
 def upf_listfamilies(elements, with_description):
-    """
-    Print on screen the list of upf families installed
-    """
+    """Print the list of upf families installed."""
     from aiida import orm
     from aiida.plugins import DataFactory
     from aiida.orm.nodes.data.upf import UPFGROUP_TYPE
@@ -109,8 +106,8 @@ def upf_listfamilies(elements, with_description):
 @arguments.GROUP()
 @decorators.with_dbenv()
 def upf_exportfamily(folder, group):
-    """
-    Export a pseudopotential family into a folder.
+    """Export a pseudopotential family into a folder.
+
     Call without parameters to get some help.
     """
     if group.is_empty:
@@ -129,9 +126,7 @@ def upf_exportfamily(folder, group):
 @click.argument('filename', type=click.Path(exists=True, dir_okay=False, resolve_path=True))
 @decorators.with_dbenv()
 def upf_import(filename):
-    """
-    Import upf data object
-    """
+    """Import upf data object."""
     from aiida.orm import UpfData
 
     node, _ = UpfData.get_or_create(filename)

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -68,7 +68,7 @@ def database_migrate(force):
 
 @verdi_database.group('integrity')
 def verdi_database_integrity():
-    """Various commands that will check the integrity of the database and fix potential issues when asked."""
+    """Commands that will check the integrity of the database."""
 
 
 @verdi_database_integrity.command('detect-duplicate-uuid')
@@ -83,7 +83,7 @@ def verdi_database_integrity():
     '-a', '--apply-patch', is_flag=True, help='Actually apply the proposed changes instead of performing a dry run.'
 )
 def detect_duplicate_uuid(table, apply_patch):
-    """Detect and solve entities with duplicate UUIDs in a given database table.
+    """Detect and remove duplicate UUIDs in given table.
 
     Before aiida-core v1.0.0, there was no uniqueness constraint on the UUID column of the node table in the database
     and a few other tables as well. This made it possible to store multiple entities with identical UUIDs in the same

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -160,9 +160,9 @@ def devel_tests(paths, verbose):  # pylint: disable=too-many-locals,too-many-sta
         sys.exit(len(test_failures) + len(test_errors))
 
 
-@verdi_devel.command('play')
+@verdi_devel.command('play', hidden=True)
 def devel_play():
-    """Open a browser and play the Aida triumphal march by Giuseppe Verdi."""
+    """Open a browser and play Giuseppe Verdi's Aida triumphal march."""
     import webbrowser
 
     webbrowser.open_new('http://upload.wikimedia.org/wikipedia/commons/3/32/Triumphal_March_from_Aida.ogg')

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -37,7 +37,7 @@ def verdi_export():
 @click.option('-d', '--data', is_flag=True, help='Print the data contents and exit.')
 @click.option('-m', '--meta-data', is_flag=True, help='Print the meta data contents and exit.')
 def inspect(archive, version, data, meta_data):
-    """Inspect the contents of an exported archive without importing the content.
+    """Inspect the contents of an exported archive without importing it.
 
     By default a summary of the archive contents will be printed. The various options can be used to change exactly what
     information is displayed.
@@ -110,8 +110,9 @@ def create(
     output_file, codes, computers, groups, nodes, archive_format, force, input_forward, create_reversed,
     return_reversed, call_reversed, include_comments, include_logs
 ):
-    """
-    Export various entities, such as Codes, Computers, Groups and Nodes, to an archive file for backup or
+    """Create an export archive.
+
+    Various entities, such as Codes, Computers, Groups and Nodes can be exported to an archive file for backup or
     sharing purposes.
     """
     from aiida.tools.importexport import export, export_zip
@@ -166,9 +167,7 @@ def create(
 @options.SILENT()
 def migrate(input_file, output_file, force, silent, archive_format):
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
-    """
-    Migrate an existing export archive file to the most recent version of the export format
-    """
+    """Migrate an existing export archive to the most recent version."""
     import tarfile
     import zipfile
 

--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -21,8 +21,7 @@ from aiida.cmdline.utils import decorators, echo
 
 @verdi.group('graph')
 def verdi_graph():
-    """Create visual representations of part of the provenance graph.
-    """
+    """Create visual representations of the provenance graph."""
 
 
 @verdi_graph.command('generate')
@@ -73,9 +72,7 @@ def generate(
     root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine, verbose,
     output_format, show
 ):
-    """
-    Generate a graph from a ROOT_NODE (specified by pk or uuid).
-    """
+    """Generate a graph from a given ROOT_NODE."""
     # pylint: disable=too-many-arguments
     from aiida.tools.visualization import Graph
     print_func = echo.echo_info if verbose else None

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -136,7 +136,7 @@ def group_description(group, description):
 @arguments.GROUP()
 @with_dbenv()
 def group_show(group, raw, uuid):
-    """Show information on a given group. Pass the GROUP as a parameter."""
+    """Show information for a given GROUP."""
     from tabulate import tabulate
 
     from aiida.common.utils import str_timedelta
@@ -323,7 +323,7 @@ def group_list(
 @click.argument('group_label', nargs=1, type=click.STRING)
 @with_dbenv()
 def group_create(group_label):
-    """Create a new empty group with the name GROUP_NAME."""
+    """Create a new group with the name GROUP_NAME."""
     from aiida import orm
     from aiida.orm import GroupTypeString
 
@@ -340,7 +340,7 @@ def group_create(group_label):
 @click.argument('destination_group', nargs=1, type=click.STRING)
 @with_dbenv()
 def group_copy(source_group, destination_group):
-    """Add all nodes that belong to source group to the destination group (which may or may not exist)."""
+    """Create a copy of the given GROUP."""
     from aiida import orm
 
     dest_group, created = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -38,7 +38,7 @@ class ExtrasImportCode(Enum):
 
 
 def _try_import(migration_performed, file_to_import, archive, group, migration, non_interactive, **kwargs):
-    """Utility function for `verdi import` to try to import archive
+    """Utility function for `verdi import` to try to import archive.
 
     :param migration_performed: Boolean to determine the exception message to throw for IncompatibleArchiveVersionError
     :param file_to_import: Absolute path, including filename, of file to be migrated.
@@ -99,7 +99,8 @@ def _try_import(migration_performed, file_to_import, archive, group, migration, 
 
 
 def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive, **kwargs):  # pylint: disable=unused-argument
-    """Utility function for `verdi import` to migrate archive
+    """Utility function for `verdi import` to migrate archive.
+
     Invoke click command `verdi export migrate`, passing in the archive,
     outputting the migrated archive in a temporary SandboxFolder.
     Try again to import the now migrated file, after a successful migration.
@@ -195,7 +196,7 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
 def cmd_import(
     ctx, archives, webpages, group, extras_mode_existing, extras_mode_new, comment_mode, migration, non_interactive
 ):
-    """Import one or multiple exported AiiDA archives
+    """Import one or multiple export archives.
 
     The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.
     """

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -27,7 +27,7 @@ def verdi_node():
 
 @verdi_node.group('repo')
 def verdi_node_repo():
-    pass
+    """Commands to interact with a node's repository."""
 
 
 @verdi_node_repo.command('cat')

--- a/aiida/cmdline/commands/cmd_plugin.py
+++ b/aiida/cmdline/commands/cmd_plugin.py
@@ -21,7 +21,7 @@ from aiida.plugins.entry_point import entry_point_group_to_module_path_map
 
 @verdi.group('plugin')
 def verdi_plugin():
-    """Inspect installed plugins for various entry point categories."""
+    """Inspect installed plugins."""
 
 
 @verdi_plugin.command('list')

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -103,7 +103,7 @@ def process_show(processes):
 @arguments.PROCESSES()
 @decorators.with_dbenv()
 def process_call_root(processes):
-    """Show the root process of the call stack for the given processes."""
+    """Show the root process of the call stack for PROCESSES."""
     for process in processes:
 
         caller = process.caller

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -54,7 +54,9 @@ def profile_list():
 @verdi_profile.command('show')
 @arguments.PROFILE(default=defaults.get_default_profile)
 def profile_show(profile):
-    """Show details for PROFILE or, when not specified, the default profile."""
+    """Show details for PROFILE.
+
+    If no PROFILE is specified, then the current default is used."""
     if profile is None:
         echo.echo_critical('no profile to show')
 
@@ -95,8 +97,8 @@ def profile_setdefault(profile):
 )
 @arguments.PROFILES(required=True)
 def profile_delete(force, include_config, include_db, include_repository, profiles):
-    """
-    Delete PROFILES (names, separated by spaces) from the aiida config file,
+    """Delete one or multiple PROFILES.
+
     including the associated databases and file repositories.
     """
     from aiida.manage.configuration.setup import delete_profile

--- a/aiida/cmdline/commands/cmd_rehash.py
+++ b/aiida/cmdline/commands/cmd_rehash.py
@@ -31,7 +31,7 @@ from aiida.cmdline.utils import decorators, echo
 )
 @decorators.with_dbenv()
 def rehash(nodes, entry_point):
-    """Recompute the hash for nodes in the database
+    """Recompute the hash for nodes in the database.
 
     The set of nodes that will be rehashed can be filtered by their identifier and/or based on their class.
     """

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -46,8 +46,7 @@ CONFIG_DIR = os.path.join(os.path.split(os.path.abspath(aiida.restapi.__file__))
 )
 @click.option('--hookup/--no-hookup', 'hookup', is_flag=True, default=True, help='to hookup app')
 def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup):
-    """
-    Run the AiiDA REST API server
+    """Run the REST API server.
 
     Example Usage:
 

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -123,7 +123,7 @@ def quicksetup(
     ctx, non_interactive, profile, email, first_name, last_name, institution, db_engine, db_backend, db_host, db_port,
     db_name, db_username, db_password, su_db_name, su_db_username, su_db_password, repository
 ):
-    """Setup a new profile where the database is automatically created and configured."""
+    """Setup a new profile with automatic database creation."""
     # pylint: disable=too-many-arguments,too-many-locals
     from aiida.manage.external.postgres import Postgres, manual_setup_instructions
 

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -46,7 +46,7 @@ STATUS_SYMBOLS = {
 
 @verdi.command('status')
 def verdi_status():
-    """Print status of AiiDA services."""
+    """Print status of services."""
     # pylint: disable=broad-except,too-many-statements
     from aiida.cmdline.utils.daemon import get_daemon_status, delete_stale_pid_file
     from aiida.common.utils import Capturing, get_repository_folder

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -199,11 +199,11 @@ Below is a list with all available subcommands.
 
     Commands:
       cleanworkdir  Clean all content of all output remote folders of calcjobs.
-      gotocomputer  Open a shell and go to the calcjob folder on the computer...
-      inputcat      Show the contents of a file with relative PATH in the raw...
-      inputls       Show the list of files in the directory with relative PATH...
-      outputcat     Show the contents of a file with relative PATH in the...
-      outputls      Show the list of files in the directory with relative PATH...
+      gotocomputer  Open a shell and go to the calcjob folder on the computer.
+      inputcat      Show the contents of an input file of a CALCULATION.
+      inputls       Show the list of inputs files for the given CALCULATION.
+      outputcat     Show the contents of an output file of a CALCULATION.
+      outputls      Show the list of output files of the CALCULATION.
       res           Print data from the result output node of a calcjob.
 
 
@@ -222,12 +222,12 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      delete     Delete codes that have not yet been used for calculations, i.e.
-      duplicate  Create duplicate of existing Code.
-      hide       Hide one or more codes from the `verdi code list` command.
+      delete     Delete a Code.
+      duplicate  Create duplicate of an existing Code.
+      hide       Hide one or more codes.
       list       List the codes in the database.
-      relabel    Relabel a code.
-      reveal     Reveal one or more hidden codes to the `verdi code list`...
+      relabel    Relabel a Code.
+      reveal     Reveal one or more hidden codes.
       setup      Setup a new Code.
       show       Display detailed information for the given CODE.
 
@@ -289,7 +289,7 @@ Below is a list with all available subcommands.
 
     Commands:
       configure  Configure a computer with one of the available transport types.
-      delete     Configure the authentication information for a given computer...
+      delete     Configure the authentication information for a given computer.
       disable    Disable the computer for the given user.
       duplicate  Duplicate a computer.
       enable     Enable the computer for the given user.
@@ -309,7 +309,10 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] OPTION_NAME OPTION_VALUE
 
-      Set, unset and get profile specific or global configuration options.
+      Inspect and manage configuration options.
+
+      By default the command is applied to the default or specified profile.
+      With the `--global` flag, the command is applied to the global instance.
 
     Options:
       --global  Apply the option configuration wide.
@@ -381,7 +384,7 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      integrity  Various commands that will check the integrity of the database...
+      integrity  Commands that will check the integrity of the database.
       migrate    Migrate the database to the latest schema version.
 
 
@@ -400,7 +403,6 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      play        Open a browser and play the Aida triumphal march by Giuseppe...
       run_daemon  Run a daemon instance in the current interpreter.
       tests       Run the unittest suite or parts of it.
 
@@ -420,10 +422,9 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      create   Export various entities, such as Codes, Computers, Groups and...
-      inspect  Inspect the contents of an exported archive without importing
-               the...
-      migrate  Migrate an existing export archive file to the most recent...
+      create   Create an export archive.
+      inspect  Inspect the contents of an exported archive without importing it.
+      migrate  Migrate an existing export archive to the most recent version.
 
 
 .. _verdi_graph:
@@ -435,13 +436,13 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
-      Create visual representations of part of the provenance graph.
+      Create visual representations of the provenance graph.
 
     Options:
       --help  Show this message and exit.
 
     Commands:
-      generate  Generate a graph from a ROOT_NODE (specified by pk or uuid).
+      generate  Generate a graph from a given ROOT_NODE.
 
 
 .. _verdi_group:
@@ -460,15 +461,14 @@ Below is a list with all available subcommands.
 
     Commands:
       add-nodes     Add NODES to the given GROUP.
-      copy          Add all nodes that belong to source group to the
-                    destination...
-      create        Create a new empty group with the name GROUP_NAME.
+      copy          Create a copy of the given GROUP.
+      create        Create a new group with the name GROUP_NAME.
       delete        Delete a GROUP.
       description   Change the description of the given GROUP to DESCRIPTION.
       list          Show a list of groups.
       relabel       Change the label of the given GROUP to LABEL.
       remove-nodes  Remove NODES from the given GROUP.
-      show          Show information on a given group.
+      show          Show information for a given GROUP.
 
 
 .. _verdi_import:
@@ -480,7 +480,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] [--] [ARCHIVES]...
 
-      Import one or multiple exported AiiDA archives
+      Import one or multiple export archives.
 
       The ARCHIVES can be specified by their relative or absolute file path, or
       their HTTP URL.
@@ -543,7 +543,7 @@ Below is a list with all available subcommands.
       description  View or set the descriptions of one or more nodes.
       extras       Show the extras of one or more nodes.
       label        View or set the labels of one or more nodes.
-      repo
+      repo         Commands to interact with a node's repository.
       show         Show generic information on node(s).
       tree         Show tree of nodes.
 
@@ -557,7 +557,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
-      Inspect installed plugins for various entry point categories.
+      Inspect installed plugins.
 
     Options:
       --help  Show this message and exit.
@@ -581,7 +581,7 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      call-root  Show the root process of the call stack for the given...
+      call-root  Show the root process of the call stack for PROCESSES.
       kill       Kill running processes.
       list       Show a list of processes that are still running.
       pause      Pause running processes.
@@ -607,10 +607,10 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      delete      Delete PROFILES (names, separated by spaces) from the aiida...
+      delete      Delete one or multiple PROFILES.
       list        Displays list of all available profiles.
       setdefault  Set PROFILE as the default profile.
-      show        Show details for PROFILE or, when not specified, the default...
+      show        Show details for PROFILE.
 
 
 .. _verdi_quicksetup:
@@ -622,8 +622,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Setup a new profile where the database is automatically created and
-      configured.
+      Setup a new profile with automatic database creation.
 
     Options:
       -n, --non-interactive           Non-interactive mode: never prompt for
@@ -665,7 +664,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] [NODES]...
 
-      Recompute the hash for nodes in the database
+      Recompute the hash for nodes in the database.
 
       The set of nodes that will be rehashed can be filtered by their identifier
       and/or based on their class.
@@ -685,7 +684,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Run the AiiDA REST API server
+      Run the REST API server.
 
       Example Usage:
 
@@ -796,7 +795,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Print status of AiiDA services.
+      Print status of services.
 
     Options:
       --help  Show this message and exit.

--- a/docs/source/working_with_aiida/index.rst
+++ b/docs/source/working_with_aiida/index.rst
@@ -14,26 +14,26 @@ This will make understanding and using ``verdi`` a lot easier!
 * :ref:`comment<verdi_comment>`:  Inspect, create and manage node comments.
 * :ref:`completioncommand<verdi_completioncommand>`:  Return the bash code to activate completion.
 * :ref:`computer<verdi_computer>`:  Setup and manage computers.
-* :ref:`config<verdi_config>`:  Set, unset and get profile specific or global configuration options.
+* :ref:`config<verdi_config>`:  Inspect and manage configuration options.
 * :ref:`daemon<verdi_daemon>`:  Inspect and manage the daemon.
 * :ref:`data<verdi_data>`:  Inspect, create and manage data nodes.
 * :ref:`database<verdi_database>`:  Inspect and manage the database.
 * :ref:`devel<verdi_devel>`:  Commands for developers.
 * :ref:`export<verdi_export>`:  Create and manage export archives.
-* :ref:`graph<verdi_graph>`:  Create visual representations of part of the provenance graph.
+* :ref:`graph<verdi_graph>`:  Create visual representations of the provenance graph.
 * :ref:`group<verdi_group>`:  Create, inspect and manage groups.
-* :ref:`import<verdi_import>`:  Import one or multiple exported AiiDA archives
+* :ref:`import<verdi_import>`:  Import one or multiple export archives.
 * :ref:`node<verdi_node>`:  Inspect, create and manage nodes.
-* :ref:`plugin<verdi_plugin>`:  Inspect installed plugins for various entry point categories.
+* :ref:`plugin<verdi_plugin>`:  Inspect installed plugins.
 * :ref:`process<verdi_process>`:  Inspect and manage processes.
 * :ref:`profile<verdi_profile>`:  Inspect and manage the configured profiles.
-* :ref:`quicksetup<verdi_quicksetup>`:  Setup a new profile where the database is automatically created and configured.
-* :ref:`rehash<verdi_rehash>`:  Recompute the hash for nodes in the database
-* :ref:`restapi<verdi_restapi>`:  Run the AiiDA REST API server
+* :ref:`quicksetup<verdi_quicksetup>`:  Setup a new profile with automatic database creation.
+* :ref:`rehash<verdi_rehash>`:  Recompute the hash for nodes in the database.
+* :ref:`restapi<verdi_restapi>`:  Run the REST API server.
 * :ref:`run<verdi_run>`:  Execute an AiiDA script.
 * :ref:`setup<verdi_setup>`:  Setup a new profile.
 * :ref:`shell<verdi_shell>`:  Start a python shell with preloaded AiiDA environment.
-* :ref:`status<verdi_status>`:  Print status of AiiDA services.
+* :ref:`status<verdi_status>`:  Print status of services.
 * :ref:`user<verdi_user>`:  Inspect and manage users.
 
 .. END_OF_VERDI_OVERVIEW_MARKER


### PR DESCRIPTION
Fixes #3196 

The PEP states that a docstring should start with a single short
description ending with a full stop. The `click` library will take this
as the short help message when displaying the help message of the parent
group. When the message is also sufficienty short, no ellipsis will be
displayed.

P.S.: the "easter-egg" is now a proper hidden easter egg.