### PR TITLE
Make sure all CLI help strings are short and consistent

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -12,6 +12,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
+import errno
+import tempfile
+
 from click.testing import CliRunner
 
 from aiida import orm
@@ -131,3 +135,345 @@ class TestVerdiNode(AiidaTestCase):
                 options = [flag, fmt, str(self.node.uuid)]
                 result = self.cli_runner.invoke(cmd_node.extras, options)
                 self.assertIsNone(result.exception, result.output)
+
+
+def delete_temporary_file(filepath):
+    """
+    Attempt to delete a file, given an absolute path. If the deletion fails because the file does not exist
+    the exception will be caught and passed. Any other exceptions will raise.
+
+    :param filepath: the absolute file path
+    """
+    try:
+        os.remove(filepath)
+    except OSError as exception:
+        if exception.errno != errno.ENOENT:
+            raise
+        else:
+            pass
+
+
+class TestVerdiGraph(AiidaTestCase):
+    """Tests for the ``verdi node graph`` command."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestVerdiGraph, cls).setUpClass()
+        from aiida.orm import Data
+
+        cls.node = Data().store()
+
+        # some of the export tests write in the current directory,
+        # make sure it is writeable and we don't pollute the current one
+        cls.old_cwd = os.getcwd()
+        cls.cwd = tempfile.mkdtemp(__name__)
+        os.chdir(cls.cwd)
+
+    @classmethod
+    def tearDownClass(cls, *args, **kwargs):
+        os.chdir(cls.old_cwd)
+        os.rmdir(cls.cwd)
+
+    def setUp(self):
+        self.cli_runner = CliRunner()
+
+    def test_generate_graph(self):
+        """
+        Test that the default graph can be generated
+        The command should run without error and should produce the .dot file
+        """
+        # Get a PK of a node which exists
+        root_node = str(self.node.pk)
+        filename = root_node + '.dot.pdf'
+        options = [root_node]
+        try:
+            result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+            self.assertIsNone(result.exception, result.output)
+            self.assertTrue(os.path.isfile(filename))
+        finally:
+            delete_temporary_file(filename)
+
+    def test_catch_bad_pk(self):
+        """
+        Test that an invalid root_node pk (non-numeric, negative, or decimal),
+        or non-existent pk will produce an error
+        """
+        from aiida.orm import load_node
+        from aiida.common.exceptions import NotExistent
+
+        # Forbidden pk
+        for root_node in ['xyz', '-5', '3.14']:
+            options = [root_node]
+            filename = root_node + '.dot.pdf'
+            try:
+                result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                self.assertIsNotNone(result.exception)
+                self.assertFalse(os.path.isfile(filename))
+            finally:
+                delete_temporary_file(filename)
+
+        # Non-existant pk
+
+        # Check that an arbitrary pk definately can't be loaded
+        root_node = 123456789
+        try:
+            node = load_node(pk=root_node)
+            self.assertIsNone(node)
+        except NotExistent:
+            pass
+        #  Make sure verdi graph rejects this non-existant pk
+        try:
+            filename = str(root_node) + '.dot.pdf'
+            options = [str(root_node)]
+            result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+            self.assertIsNotNone(result.exception)
+            self.assertFalse(os.path.isfile(filename))
+        finally:
+            delete_temporary_file(filename)
+
+    def test_check_recursion_flags(self):
+        """
+        Test the ancestor-depth and descendent-depth options.
+        Test that they don't fail and that, if specified, they only accept
+        positive ints
+        """
+        root_node = str(self.node.pk)
+        filename = root_node + '.dot.pdf'
+
+        # Test that the options don't fail
+        for opt in ['-a', '--ancestor-depth', '-d', '--descendant-depth']:
+            options = [opt, None, root_node]
+            try:
+                result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                self.assertIsNone(result.exception, result.output)
+                self.assertTrue(os.path.isfile(filename))
+            finally:
+                delete_temporary_file(filename)
+
+        # Test that the options accept zero or a positive int
+        for opt in ['-a', '--ancestor-depth', '-d', '--descendant-depth']:
+            for value in ['0', '1']:
+                options = [opt, value, root_node]
+                try:
+                    result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                    self.assertIsNone(result.exception, result.output)
+                    self.assertTrue(os.path.isfile(filename))
+                finally:
+                    delete_temporary_file(filename)
+
+        # Check the options reject any values that are not positive ints
+        for flag in ['-a', '--ancestor-depth', '-d', '--descendant-depth']:
+            for badvalue in ['xyz', '3.14', '-5']:
+                options = [flag, badvalue, root_node]
+                try:
+                    result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                    self.assertIsNotNone(result.exception)
+                    self.assertFalse(os.path.isfile(filename))
+                finally:
+                    delete_temporary_file(filename)
+
+    def test_check_io_flags(self):
+        """
+        Test the input and output flags work.
+        """
+        root_node = str(self.node.pk)
+        filename = root_node + '.dot.pdf'
+
+        for flag in ['-i', '--process-in', '-o', '--process-out']:
+            options = [flag, root_node]
+            try:
+                result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                self.assertIsNone(result.exception, result.output)
+                self.assertTrue(os.path.isfile(filename))
+            finally:
+                delete_temporary_file(filename)
+
+    def test_output_format(self):
+        """
+        Test that the output file format can be specified
+        """
+        root_node = str(self.node.pk)
+
+        for option in ['-f', '--output-format']:
+
+            # Test different formats. Could exhaustively test the formats
+            # supported on a given OS (printed by '$ dot -T?') but here
+            # we just use the built-ins dot and canon as a minimal check that
+            # the option works. After all, this test is for the cmdline.
+            for fileformat in ['pdf', 'png']:
+                filename = root_node + '.dot.' + fileformat
+                options = [option, fileformat, root_node]
+                try:
+                    result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                    self.assertIsNone(result.exception, result.output)
+                    self.assertTrue(os.path.isfile(filename))
+                finally:
+                    delete_temporary_file(filename)
+
+    def test_node_id_label_format(self):
+        """
+        Test that the node id label format can be specified
+        """
+        root_node = str(self.node.pk)
+        filename = root_node + '.dot.pdf'
+
+        for id_label_type in ['uuid', 'pk', 'label']:
+            options = ['--identifier', id_label_type, root_node]
+            try:
+                result = self.cli_runner.invoke(cmd_node.graph_generate, options)
+                self.assertIsNone(result.exception, result.output)
+                self.assertTrue(os.path.isfile(filename))
+            finally:
+                delete_temporary_file(filename)
+
+
+COMMENT = u'Well I never...'
+
+
+class TestVerdiUserCommand(AiidaTestCase):
+    """Tests for the ``verdi node comment`` command."""
+
+    def setUp(self):
+        self.cli_runner = CliRunner()
+        self.node = orm.Data().store()
+
+    def test_comment_show_simple(self):
+        """Test simply calling the show command (without data to show)."""
+        result = self.cli_runner.invoke(cmd_node.comment_show, [], catch_exceptions=False)
+        self.assertEqual(result.output, '')
+        self.assertEqual(result.exit_code, 0)
+
+    def test_comment_show(self):
+        """Test showing an existing comment."""
+        self.node.add_comment(COMMENT)
+
+        options = [str(self.node.pk)]
+        result = self.cli_runner.invoke(cmd_node.comment_show, options, catch_exceptions=False)
+        self.assertNotEqual(result.output.find(COMMENT), -1)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_comment_add(self):
+        """Test adding a comment."""
+        options = ['-N', str(self.node.pk), '--', '{}'.format(COMMENT)]
+        result = self.cli_runner.invoke(cmd_node.comment_add, options, catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
+        comment = self.node.get_comments()
+        self.assertEqual(len(comment), 1)
+        self.assertEqual(comment[0].content, COMMENT)
+
+    def test_comment_remove(self):
+        """Test removing a comment."""
+        comment = self.node.add_comment(COMMENT)
+
+        self.assertEqual(len(self.node.get_comments()), 1)
+
+        options = [str(comment.pk), '--force']
+        result = self.cli_runner.invoke(cmd_node.comment_remove, options, catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(self.node.get_comments()), 0)
+
+
+class TestVerdiRehash(AiidaTestCase):
+    """Tests for the ``verdi node rehash`` command."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestVerdiRehash, cls).setUpClass(*args, **kwargs)
+        from aiida.orm import Data, Bool, Float, Int
+
+        cls.node_base = Data().store()
+        cls.node_bool_true = Bool(True).store()
+        cls.node_bool_false = Bool(False).store()
+        cls.node_float = Float(1.0).store()
+        cls.node_int = Int(1).store()
+
+    def setUp(self):
+        self.cli_runner = CliRunner()
+
+    def test_rehash_interactive_yes(self):
+        """Passing no options and answering 'Y' to the command will rehash all 5 nodes."""
+        expected_node_count = 5
+        options = []  # no option, will ask in the prompt
+        result = self.cli_runner.invoke(cmd_node.rehash, options, input='y')
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_interactive_no(self):
+        """Passing no options and answering 'N' to the command will abort the command."""
+        options = []  # no option, will ask in the prompt
+        result = self.cli_runner.invoke(cmd_node.rehash, options, input='n')
+        self.assertIsInstance(result.exception, SystemExit)
+        self.assertIn('ExitCode.CRITICAL', str(result.exception))
+
+    def test_rehash(self):
+        """Passing no options to the command will rehash all 5 nodes."""
+        expected_node_count = 5
+        options = ['-f']  # force, so no questions are asked
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_bool(self):
+        """Limiting the queryset by defining an entry point, in this case bool, should limit nodes to 2."""
+        expected_node_count = 2
+        options = ['-f', '-e', 'aiida.data:bool']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_float(self):
+        """Limiting the queryset by defining an entry point, in this case float, should limit nodes to 1."""
+        expected_node_count = 1
+        options = ['-f', '-e', 'aiida.data:float']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_int(self):
+        """Limiting the queryset by defining an entry point, in this case int, should limit nodes to 1."""
+        expected_node_count = 1
+        options = ['-f', '-e', 'aiida.data:int']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_explicit_pk(self):
+        """Limiting the queryset by defining explicit identifiers, should limit nodes to 2 in this example."""
+        expected_node_count = 2
+        options = ['-f', str(self.node_bool_true.pk), str(self.node_float.uuid)]
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_explicit_pk_and_entry_point(self):
+        """Limiting the queryset by defining explicit identifiers and entry point, should limit nodes to 1."""
+        expected_node_count = 1
+        options = ['-f', '-e', 'aiida.data:bool', str(self.node_bool_true.pk), str(self.node_float.uuid)]
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_entry_point_no_matches(self):
+        """Limiting the queryset by defining explicit entry point, with no nodes should exit with non-zero status."""
+        options = ['-f', '-e', 'aiida.data:structure']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertIsNotNone(result.exception)
+
+    def test_rehash_invalid_entry_point(self):
+        """Passing an invalid entry point should exit with non-zero status."""
+
+        # Incorrect entry point group
+        options = ['-f', '-e', 'data:structure']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertIsNotNone(result.exception)
+
+        # Non-existent entry point name
+        options = ['-f', '-e', 'aiida.data:inexistant']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertIsNotNone(result.exception)
+
+        # Incorrect syntax, no colon to join entry point group and name
+        options = ['-f', '-e', 'aiida.data.structure']
+        result = self.cli_runner.invoke(cmd_node.rehash, options)
+        self.assertIsNotNone(result.exception)

--- a/aiida/backends/tests/cmdline/commands/test_rehash.py
+++ b/aiida/backends/tests/cmdline/commands/test_rehash.py
@@ -35,10 +35,25 @@ class TestVerdiRehash(AiidaTestCase):
     def setUp(self):
         self.cli_runner = CliRunner()
 
+    def test_rehash_interactive_yes(self):
+        """Passing no options and answering 'Y' to the command will rehash all 5 nodes."""
+        expected_node_count = 5
+        options = []  # no option, will ask in the prompt
+        result = self.cli_runner.invoke(cmd_rehash.rehash, options, input='y')
+        self.assertClickResultNoException(result)
+        self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
+
+    def test_rehash_interactive_no(self):
+        """Passing no options and answering 'N' to the command will abort the command."""
+        options = []  # no option, will ask in the prompt
+        result = self.cli_runner.invoke(cmd_rehash.rehash, options, input='n')
+        self.assertIsInstance(result.exception, SystemExit)
+        self.assertIn('ExitCode.CRITICAL', str(result.exception))
+
     def test_rehash(self):
         """Passing no options to the command will rehash all 5 nodes."""
         expected_node_count = 5
-        options = []
+        options = ['-f']  # force, so no questions are asked
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertClickResultNoException(result)
         self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
@@ -46,7 +61,7 @@ class TestVerdiRehash(AiidaTestCase):
     def test_rehash_bool(self):
         """Limiting the queryset by defining an entry point, in this case bool, should limit nodes to 2."""
         expected_node_count = 2
-        options = ['-e', 'aiida.data:bool']
+        options = ['-f', '-e', 'aiida.data:bool']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertClickResultNoException(result)
         self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
@@ -54,7 +69,7 @@ class TestVerdiRehash(AiidaTestCase):
     def test_rehash_float(self):
         """Limiting the queryset by defining an entry point, in this case float, should limit nodes to 1."""
         expected_node_count = 1
-        options = ['-e', 'aiida.data:float']
+        options = ['-f', '-e', 'aiida.data:float']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertClickResultNoException(result)
         self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
@@ -62,7 +77,7 @@ class TestVerdiRehash(AiidaTestCase):
     def test_rehash_int(self):
         """Limiting the queryset by defining an entry point, in this case int, should limit nodes to 1."""
         expected_node_count = 1
-        options = ['-e', 'aiida.data:int']
+        options = ['-f', '-e', 'aiida.data:int']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertClickResultNoException(result)
         self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
@@ -70,7 +85,7 @@ class TestVerdiRehash(AiidaTestCase):
     def test_rehash_explicit_pk(self):
         """Limiting the queryset by defining explicit identifiers, should limit nodes to 2 in this example."""
         expected_node_count = 2
-        options = [str(self.node_bool_true.pk), str(self.node_float.uuid)]
+        options = ['-f', str(self.node_bool_true.pk), str(self.node_float.uuid)]
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertClickResultNoException(result)
         self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
@@ -78,14 +93,14 @@ class TestVerdiRehash(AiidaTestCase):
     def test_rehash_explicit_pk_and_entry_point(self):
         """Limiting the queryset by defining explicit identifiers and entry point, should limit nodes to 1."""
         expected_node_count = 1
-        options = ['-e', 'aiida.data:bool', str(self.node_bool_true.pk), str(self.node_float.uuid)]
+        options = ['-f', '-e', 'aiida.data:bool', str(self.node_bool_true.pk), str(self.node_float.uuid)]
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertClickResultNoException(result)
         self.assertTrue('{} nodes'.format(expected_node_count) in result.output)
 
     def test_rehash_entry_point_no_matches(self):
         """Limiting the queryset by defining explicit entry point, with no nodes should exit with non-zero status."""
-        options = ['-e', 'aiida.data:structure']
+        options = ['-f', '-e', 'aiida.data:structure']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertIsNotNone(result.exception)
 
@@ -93,16 +108,16 @@ class TestVerdiRehash(AiidaTestCase):
         """Passing an invalid entry point should exit with non-zero status."""
 
         # Incorrect entry point group
-        options = ['-e', 'data:structure']
+        options = ['-f', '-e', 'data:structure']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertIsNotNone(result.exception)
 
         # Non-existent entry point name
-        options = ['-e', 'aiida.data:inexistant']
+        options = ['-f', '-e', 'aiida.data:inexistant']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertIsNotNone(result.exception)
 
         # Incorrect syntax, no colon to join entry point group and name
-        options = ['-e', 'aiida.data.structure']
+        options = ['-f', '-e', 'aiida.data.structure']
         result = self.cli_runner.invoke(cmd_rehash.rehash, options)
         self.assertIsNotNone(result.exception)

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -23,8 +23,3 @@ from aiida.cmdline.commands import (
     cmd_daemon, cmd_devel, cmd_export, cmd_graph, cmd_group, cmd_import, cmd_node, cmd_plugin, cmd_process, cmd_profile,
     cmd_rehash, cmd_restapi, cmd_run, cmd_setup, cmd_shell, cmd_status, cmd_user
 )
-
-# Import to populate the `verdi data` sub commands
-from aiida.cmdline.commands.cmd_data import (
-    cmd_array, cmd_bands, cmd_cif, cmd_dict, cmd_remote, cmd_structure, cmd_trajectory, cmd_upf
-)

--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -31,7 +31,7 @@ def verdi_calcjob():
 @arguments.CALCULATION('calcjob', type=CalculationParamType(sub_classes=('aiida.node:process.calculation.calcjob',)))
 def calcjob_gotocomputer(calcjob):
     """
-    Open a shell and go to the calcjob folder on the computer
+    Open a shell in the remote folder on the calcjob.
 
     This command opens a ssh connection to the folder on the remote
     computer on which the calcjob is being/has been executed.
@@ -59,7 +59,7 @@ def calcjob_gotocomputer(calcjob):
 @options.DICT_FORMAT()
 @decorators.with_dbenv()
 def calcjob_res(calcjob, fmt, keys):
-    """Print data from the result output node of a calcjob."""
+    """Print data from the result output Dict node of a calcjob."""
     from aiida.cmdline.utils.echo import echo_dictionary
 
     try:
@@ -84,7 +84,9 @@ def calcjob_res(calcjob, fmt, keys):
 @decorators.with_dbenv()
 def calcjob_inputcat(calcjob, path):
     """
-    Show the contents of a file with relative PATH in the raw input folder of the CALCULATION.
+    Show the contents of one of the calcjob input files.
+
+    You can specify the relative PATH in the raw input folder of the CalcJob.
 
     If PATH is not specified, the default input file path will be used, if defined by the calcjob plugin class.
     """
@@ -118,7 +120,9 @@ def calcjob_inputcat(calcjob, path):
 @decorators.with_dbenv()
 def calcjob_outputcat(calcjob, path):
     """
-    Show the contents of a file with relative PATH in the retrieved folder of the CALCULATION.
+    Show the contents of one of the calcjob retrieved outputs.
+
+    You can specify the relative PATH in the retrieved folder of the CalcJob.
 
     If PATH is not specified, the default output file path will be used, if defined by the calcjob plugin class.
     Content can only be shown after the daemon has retrieved the remote files.
@@ -159,7 +163,9 @@ def calcjob_outputcat(calcjob, path):
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calcjob_inputls(calcjob, path, color):
     """
-    Show the list of files in the directory with relative PATH in the raw input folder of the CALCULATION.
+    Show the list of the generated calcjob input files.
+
+    You can specify a relative PATH in the raw input folder of the CalcJob.
 
     If PATH is not specified, the base path of the input folder will be used.
     """
@@ -178,7 +184,9 @@ def calcjob_inputls(calcjob, path, color):
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calcjob_outputls(calcjob, path, color):
     """
-    Show the list of files in the directory with relative PATH in the retrieved folder of the CALCULATION.
+    Show the list of the retrieved calcjob output files.
+
+    You can specify a relative PATH in the retrieved folder of the CalcJob.
 
     If PATH is not specified, the base path of the retrieved folder will be used.
     Content can only be shown after the daemon has retrieved the remote files.

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -78,7 +78,7 @@ def set_code_builder(ctx, param, value):
 @options.CONFIG_FILE()
 @with_dbenv()
 def setup_code(non_interactive, **kwargs):
-    """Setup a new Code."""
+    """Setup a new code."""
     from aiida.common.exceptions import ValidationError
     from aiida.orm.utils.builders.code import CodeBuilder
 
@@ -125,7 +125,7 @@ def setup_code(non_interactive, **kwargs):
 @click.pass_context
 @with_dbenv()
 def code_duplicate(ctx, code, non_interactive, **kwargs):
-    """Create duplicate of existing Code."""
+    """Duplicate a code allowing to change some parameters."""
     from aiida.common.exceptions import ValidationError
     from aiida.orm.utils.builders.code import CodeBuilder
 
@@ -166,7 +166,7 @@ def code_duplicate(ctx, code, non_interactive, **kwargs):
 @options.VERBOSE()
 @with_dbenv()
 def show(code, verbose):
-    """Display detailed information for the given CODE."""
+    """Display detailed information for a code."""
     click.echo(tabulate.tabulate(code.get_full_text_info(verbose)))
 
 
@@ -174,7 +174,11 @@ def show(code, verbose):
 @arguments.CODES()
 @with_dbenv()
 def delete(codes):
-    """Delete codes that have not yet been used for calculations, i.e. if it has outgoing links."""
+    """Delete a code.
+
+    Note that it is possible to delete a code only if it has not yet been used
+    as an input of a calculation, i.e., if it does not have outgoing links.
+    """
     from aiida.common.exceptions import InvalidOperation
     from aiida.orm import Node
 
@@ -193,7 +197,7 @@ def delete(codes):
 @arguments.CODES()
 @with_dbenv()
 def hide(codes):
-    """Hide one or more codes from the `verdi code list` command."""
+    """Hide one or more codes from `verdi code list`."""
     for code in codes:
         code.hide()
         echo.echo_success('Code<{}> {} hidden'.format(code.pk, code.full_label))
@@ -203,7 +207,7 @@ def hide(codes):
 @arguments.CODES()
 @with_dbenv()
 def reveal(codes):
-    """Reveal one or more hidden codes to the `verdi code list` command."""
+    """Reveal one or more hidden codes in `verdi code list`."""
     for code in codes:
         code.reveal()
         echo.echo_success('Code<{}> {} revealed'.format(code.pk, code.full_label))
@@ -233,7 +237,7 @@ def relabel(code, label):
 @click.option('-o', '--show-owner', 'show_owner', is_flag=True, default=False, help='Show owners of codes.')
 @with_dbenv()
 def code_list(computer, input_plugin, all_entries, all_users, show_owner):
-    """List the codes in the database."""
+    """List the available codes."""
     from aiida.orm import Code  # pylint: disable=redefined-outer-name
     from aiida import orm
 
@@ -318,7 +322,7 @@ def code_list(computer, input_plugin, all_entries, all_users, show_owner):
 
 
 def print_list_res(qb_query, show_owner):
-    """Print list of codes."""
+    """Print a list of available codes."""
     # pylint: disable=invalid-name
     for tuple_ in qb_query.all():
         if len(tuple_) == 3:

--- a/aiida/cmdline/commands/cmd_comment.py
+++ b/aiida/cmdline/commands/cmd_comment.py
@@ -16,100 +16,58 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
-from aiida.cmdline.utils import decorators, echo, multi_line_input
-from aiida.common import exceptions
+from aiida.cmdline.utils import decorators
 
 
 @verdi.group('comment')
+@decorators.deprecated_command("This command has been deprecated. Please use 'verdi node comment' instead.")
 def verdi_comment():
     """Inspect, create and manage node comments."""
 
 
 @verdi_comment.command()
-@options.NODES()
+@decorators.deprecated_command("This command has been deprecated. Please use 'verdi node comment add' instead.")
+@options.NODES(required=True)
 @click.argument('content', type=click.STRING, required=False)
+@click.pass_context
 @decorators.with_dbenv()
-def add(nodes, content):
-    """Add a comment to one or multiple nodes."""
-    if not content:
-        content = multi_line_input.edit_comment()
-
-    for node in nodes:
-        node.add_comment(content)
-
-    echo.echo_success('comment added to {} nodes'.format(len(nodes)))
+def add(ctx, nodes, content):  # pylint: disable=too-many-arguments, unused-argument
+    """Add a comment to one or more nodes."""
+    from aiida.cmdline.commands.cmd_node import comment_add
+    ctx.forward(comment_add)
 
 
 @verdi_comment.command()
+@decorators.deprecated_command("This command has been deprecated. Please use 'verdi node comment update' instead.")
 @click.argument('comment_id', type=int, metavar='COMMENT_ID')
 @click.argument('content', type=click.STRING, required=False)
+@click.pass_context
 @decorators.with_dbenv()
-def update(comment_id, content):
-    """Update a comment."""
-    from aiida.orm.comments import Comment
-
-    try:
-        comment = Comment.objects.get(comment_id)
-    except (exceptions.NotExistent, exceptions.MultipleObjectsError):
-        echo.echo_critical('comment<{}> not found'.format(comment_id))
-
-    if content is None:
-        content = multi_line_input.edit_comment(comment.content)
-
-    comment.set_content(content)
-
-    echo.echo_success('comment<{}> updated'.format(comment_id))
+def update(ctx, comment_id, content):  # pylint: disable=too-many-arguments, unused-argument
+    """Update a comment of a node."""
+    from aiida.cmdline.commands.cmd_node import comment_update
+    ctx.forward(comment_update)
 
 
 @verdi_comment.command()
+@decorators.deprecated_command("This command has been deprecated. Please use 'verdi node comment show' instead.")
 @options.USER()
 @arguments.NODES()
+@click.pass_context
 @decorators.with_dbenv()
-def show(user, nodes):
-    """Show the comments for one or multiple nodes."""
-    for node in nodes:
-
-        all_comments = node.get_comments()
-
-        if user is not None:
-            comments = [comment for comment in all_comments if comment.user.email == user.email]
-
-            if not comments:
-                valid_users = ', '.join(set(comment.user.email for comment in all_comments))
-                echo.echo_warning('no comments found for user {}'.format(user))
-                echo.echo_info('valid users found for Node<{}>: {}'.format(node.pk, valid_users))
-
-        else:
-            comments = all_comments
-
-        for comment in comments:
-            comment_msg = [
-                '***********************************************************',
-                'Comment<{}> for Node<{}> by {}'.format(comment.id, node.pk, comment.user.email),
-                'Created on {}'.format(comment.ctime.strftime('%Y-%m-%d %H:%M')),
-                'Last modified on {}'.format(comment.mtime.strftime('%Y-%m-%d %H:%M')),
-                '\n{}\n'.format(comment.content),
-            ]
-            echo.echo('\n'.join(comment_msg))
-
-        if not comments:
-            echo.echo_info('no comments found')
+def show(ctx, user, nodes):  # pylint: disable=too-many-arguments, unused-argument
+    """Show the comments of one or multiple nodes."""
+    from aiida.cmdline.commands.cmd_node import comment_show
+    ctx.forward(comment_show)
 
 
 @verdi_comment.command()
+@decorators.deprecated_command("This command has been deprecated. Please use 'verdi node comment remove' instead.")
 @options.FORCE()
-@click.argument('comment', type=int, required=False, metavar='COMMENT_ID')
+@click.argument('comment', type=int, required=True, metavar='COMMENT_ID')
+@click.pass_context
 @decorators.with_dbenv()
-def remove(force, comment):
-    """Remove a comment."""
-    from aiida.orm.comments import Comment
-
-    if not force:
-        click.confirm('Are you sure you want to remove comment<{}>'.format(comment), abort=True)
-
-    try:
-        Comment.objects.delete(comment)
-    except exceptions.NotExistent as exception:
-        echo.echo_critical('failed to remove comment<{}>: {}'.format(comment, exception))
-    else:
-        echo.echo_success('removed comment<{}>'.format(comment))
+def remove(ctx, force, comment):  # pylint: disable=too-many-arguments, unused-argument
+    """Remove a comment of a node."""
+    from aiida.cmdline.commands.cmd_node import comment_remove
+    ctx.forward(comment_remove)

--- a/aiida/cmdline/commands/cmd_completioncommand.py
+++ b/aiida/cmdline/commands/cmd_completioncommand.py
@@ -21,7 +21,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 @verdi.command('completioncommand')
 def verdi_completioncommand():
     """
-    Return the bash code to activate completion.
+    Return the code to activate bash completion.
 
     :note: this command is mainly for back-compatibility.
         You should rather use:;

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -242,7 +242,7 @@ def set_computer_builder(ctx, param, value):
 @click.pass_context
 @with_dbenv()
 def computer_setup(ctx, non_interactive, **kwargs):
-    """Add a computer."""
+    """Create a new computer."""
     from aiida.orm.utils.builders.computer import ComputerBuilder
 
     if kwargs['label'] in get_computer_names():
@@ -298,7 +298,7 @@ def computer_setup(ctx, non_interactive, **kwargs):
 @click.pass_context
 @with_dbenv()
 def computer_duplicate(ctx, computer, non_interactive, **kwargs):
-    """Duplicate a computer."""
+    """Duplicate a computer allowing to change some parameters."""
     from aiida import orm
     from aiida.orm.utils.builders.computer import ComputerBuilder
 
@@ -398,7 +398,7 @@ def computer_disable(computer, user):
 @options.RAW(help='Show only the computer names, one per line.')
 @with_dbenv()
 def computer_list(all_entries, raw):
-    """List available computers."""
+    """List all available computers."""
     from aiida.orm import Computer, User
 
     if not raw:
@@ -421,7 +421,7 @@ def computer_list(all_entries, raw):
 @arguments.COMPUTER()
 @with_dbenv()
 def computer_show(computer):
-    """Show information for a computer."""
+    """Show detailed information for a computer."""
     echo.echo(computer.full_text_info)
 
 
@@ -545,10 +545,9 @@ def computer_test(user, print_traceback, computer):
 @with_dbenv()
 def computer_delete(computer):
     """
-    Configure the authentication information for a given computer
+    Delete a computer.
 
-    Does not delete the computer if there are calculations that are using
-    it.
+    Note that it is not possible to delete the computer if there are calculations that are using it.
     """
     from aiida.common.exceptions import InvalidOperation
     from aiida import orm
@@ -565,7 +564,7 @@ def computer_delete(computer):
 
 @verdi_computer.group('configure')
 def computer_configure():
-    """Configure a computer with one of the available transport types."""
+    """Configure the Authinfo details for a computer (and user)."""
 
 
 @computer_configure.command('show')
@@ -576,7 +575,7 @@ def computer_configure():
 @options.USER()
 @arguments.COMPUTER()
 def computer_config_show(computer, user, defaults, as_option_string):
-    """Show the current or default configuration for COMPUTER."""
+    """Show the current configuration for a computer."""
     import tabulate
     from aiida.common.escaping import escape_for_bash
 

--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -26,7 +26,7 @@ from aiida.cmdline.utils import echo
 @click.option('--unset', is_flag=True, help='Remove the line matching the option name from the config file.')
 @click.pass_context
 def verdi_config(ctx, option, value, globally, unset):
-    """Set, unset and get profile specific or global configuration options."""
+    """Configure profile-specific or global AiiDA options."""
     config = ctx.obj.config
     profile = ctx.obj.profile
 

--- a/aiida/cmdline/commands/cmd_data/cmd_array.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_array.py
@@ -18,7 +18,7 @@ from aiida.cmdline.params import arguments, options, types
 
 @verdi_data.group('array')
 def array():
-    """Manipulate ArrayData objects."""
+    """Manipulate ArrayData objects (numpy arrays)."""
 
 
 @array.command('show')

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -33,7 +33,7 @@ VISUALIZATION_FORMATS = ['xmgrace']
 
 @verdi_data.group('bands')
 def bands():
-    """Manipulate BandsData objects."""
+    """Manipulate BandsData objects (band structures)."""
 
 
 # pylint: disable=too-many-arguments

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -29,7 +29,7 @@ VISUALIZATION_FORMATS = ['jmol', 'vesta']
 
 @verdi_data.group('cif')
 def cif():
-    """Manipulation of CIF data objects."""
+    """Manipulate CifData objects (crystal structures in .cif format)."""
 
 
 @cif.command('list')
@@ -92,7 +92,7 @@ def cif_show(data, fmt):
 @arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:cif',)))
 @decorators.with_dbenv()
 def cif_content(data):
-    """Show the content of the file behind CifData objects."""
+    """Show the content of the CIF file."""
     for node in data:
         try:
             echo.echo(node.get_content())
@@ -121,7 +121,7 @@ def cif_export(**kwargs):
 @click.argument('filename', type=click.Path(exists=True, dir_okay=False, resolve_path=True))
 @decorators.with_dbenv()
 def cif_import(filename):
-    """Import structure into CifData object."""
+    """Import .cif file into CifData object."""
     from aiida.orm import CifData
 
     try:

--- a/aiida/cmdline/commands/cmd_data/cmd_dict.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_dict.py
@@ -18,7 +18,7 @@ from aiida.cmdline.params import arguments, options, types
 
 @verdi_data.group('dict')
 def dictionary():
-    """View and manipulate Dict objects."""
+    """Manipulate Dict objects (python dictionaries)."""
 
 
 @dictionary.command('show')

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -23,7 +23,13 @@ from aiida.common.files import get_mode_string
 
 @verdi_data.group('remote')
 def remote():
-    """Managing RemoteData objects."""
+    """Manipulate RemoteData objects (reference to remote folders).
+
+    A RemoteData can be thought as a "symbolic link" to a folder on one of the
+    Computers set up in AiiDA (e.g. where a CalcJob will run).
+    This folder is called "remote" in the sense that it is on a Computer and
+    not in the AiiDA repository. Note, however, that the "remote" computer
+    could also be "localhost"."""
 
 
 @remote.command('ls')
@@ -31,7 +37,7 @@ def remote():
 @click.option('-l', '--long', 'ls_long', is_flag=True, default=False, help='Display also file metadata.')
 @click.option('-p', '--path', type=click.STRING, default='.', help='The folder to list.')
 def remote_ls(ls_long, path, datum):
-    """List directory content on remote RemoteData objects."""
+    """List content of a (sub)directory in a RemoteData object."""
     import datetime
     try:
         content = datum.listdir_withattributes(path=path)
@@ -58,7 +64,7 @@ def remote_ls(ls_long, path, datum):
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:remote',)))
 @click.argument('path', type=click.STRING)
 def remote_cat(datum, path):
-    """Show the content of remote files in RemoteData objects."""
+    """Show content of a file in a RemoteData object."""
     import os
     import sys
     import tempfile
@@ -81,7 +87,7 @@ def remote_cat(datum, path):
 @remote.command('show')
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:remote',)))
 def remote_show(datum):
-    """Show information on a RemoteData object."""
+    """Show information for a RemoteData object."""
     click.echo('- Remote computer name:')
     click.echo('  {}'.format(datum.get_computer_name()))
     click.echo('- Remote folder full path:')

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -54,7 +54,7 @@ def _store_structure(new_structure, dry_run):
 
 @verdi_data.group('structure')
 def structure():
-    """Manipulation of StructureData objects."""
+    """Manipulate StructureData objects (crystal structures)."""
 
 
 # pylint: disable=too-many-locals,too-many-branches
@@ -64,7 +64,7 @@ def structure():
 @list_options
 @decorators.with_dbenv()
 def structure_list(elements, raw, formula_mode, past_days, groups, all_users):
-    """List stored StructureData objects."""
+    """List StructureData objects."""
     from aiida.orm.nodes.data.structure import StructureData, get_formula, get_symbols_string
     from tabulate import tabulate
 
@@ -150,7 +150,7 @@ def structure_show(data, fmt):
 @export_options
 @decorators.with_dbenv()
 def structure_export(**kwargs):
-    """Export StructureData object."""
+    """Export StructureData object to file."""
     node = kwargs.pop('datum')
     output = kwargs.pop('output')
     fmt = kwargs.pop('fmt')
@@ -163,7 +163,7 @@ def structure_export(**kwargs):
 
 @structure.group('import')
 def structure_import():
-    """Import crystal structures from a file."""
+    """Import a crystal structure from file into a StructureData object."""
 
 
 @structure_import.command('aiida-xyz')

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -30,14 +30,14 @@ VISUALIZATION_FORMATS = ['jmol', 'xcrysden', 'mpl_heatmap', 'mpl_pos']
 
 @verdi_data.group('trajectory')
 def trajectory():
-    """View and manipulate TrajectoryData instances."""
+    """Manipulate TrajectoryData objects (molecular trajectories)."""
 
 
 @trajectory.command('list')
 @list_options
 @decorators.with_dbenv()
 def trajectory_list(raw, past_days, groups, all_users):
-    """List trajectories stored in database."""
+    """List TrajectoryData objects stored in the database."""
     from aiida.orm import TrajectoryData
     from tabulate import tabulate
 
@@ -73,7 +73,7 @@ def trajectory_list(raw, past_days, groups, all_users):
 @show_options
 @decorators.with_dbenv()
 def trajectory_show(data, fmt):
-    """Visualize trajectory."""
+    """Visualize a trajectory."""
     try:
         show_function = getattr(cmd_show, '_show_{}'.format(fmt))
     except AttributeError:
@@ -89,7 +89,7 @@ def trajectory_show(data, fmt):
 @export_options
 @decorators.with_dbenv()
 def trajectory_export(**kwargs):
-    """Export trajectory."""
+    """Export trajectory to file."""
     node = kwargs.pop('datum')
     output = kwargs.pop('output')
     fmt = kwargs.pop('fmt')

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -23,7 +23,7 @@ from aiida.cmdline.utils import decorators, echo
 
 @verdi_data.group('upf')
 def upf():
-    """Manipulation of the upf families."""
+    """Manipulate UpfData objects (UPF-format pseudopotentials)."""
 
 
 @upf.command('uploadfamily')
@@ -39,7 +39,7 @@ def upf():
 @decorators.with_dbenv()
 def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
     """
-    Upload a new pseudopotential family.
+    Create a new UPF family from a folder of UPF files.
 
     Returns the numbers of files found and the number of nodes uploaded.
 
@@ -63,7 +63,7 @@ def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
 @decorators.with_dbenv()
 def upf_listfamilies(elements, with_description):
     """
-    Print on screen the list of upf families installed
+    List all UPF families that exist in the database.
     """
     from aiida import orm
     from aiida.plugins import DataFactory
@@ -130,7 +130,7 @@ def upf_exportfamily(folder, group):
 @decorators.with_dbenv()
 def upf_import(filename):
     """
-    Import upf data object
+    Import a UPF pseudopotential from a file.
     """
     from aiida.orm import UpfData
 

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -68,7 +68,7 @@ def database_migrate(force):
 
 @verdi_database.group('integrity')
 def verdi_database_integrity():
-    """Various commands that will check the integrity of the database and fix potential issues when asked."""
+    """Check the integrity of the database and fix potential issues."""
 
 
 @verdi_database_integrity.command('detect-duplicate-uuid')
@@ -83,7 +83,7 @@ def verdi_database_integrity():
     '-a', '--apply-patch', is_flag=True, help='Actually apply the proposed changes instead of performing a dry run.'
 )
 def detect_duplicate_uuid(table, apply_patch):
-    """Detect and solve entities with duplicate UUIDs in a given database table.
+    """Detect and fix entities with duplicate UUIDs.
 
     Before aiida-core v1.0.0, there was no uniqueness constraint on the UUID column of the node table in the database
     and a few other tables as well. This made it possible to store multiple entities with identical UUIDs in the same

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -160,9 +160,9 @@ def devel_tests(paths, verbose):  # pylint: disable=too-many-locals,too-many-sta
         sys.exit(len(test_failures) + len(test_errors))
 
 
-@verdi_devel.command('play')
+@verdi_devel.command('play', hidden=True)
 def devel_play():
-    """Open a browser and play the Aida triumphal march by Giuseppe Verdi."""
+    """Play the Aida triumphal march by Giuseppe Verdi."""
     import webbrowser
 
     webbrowser.open_new('http://upload.wikimedia.org/wikipedia/commons/3/32/Triumphal_March_from_Aida.ogg')

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -37,7 +37,7 @@ def verdi_export():
 @click.option('-d', '--data', is_flag=True, help='Print the data contents and exit.')
 @click.option('-m', '--meta-data', is_flag=True, help='Print the meta data contents and exit.')
 def inspect(archive, version, data, meta_data):
-    """Inspect the contents of an exported archive without importing the content.
+    """Inspect contents of an exported archive without importing it.
 
     By default a summary of the archive contents will be printed. The various options can be used to change exactly what
     information is displayed.
@@ -111,8 +111,10 @@ def create(
     return_reversed, call_reversed, include_comments, include_logs
 ):
     """
-    Export various entities, such as Codes, Computers, Groups and Nodes, to an archive file for backup or
-    sharing purposes.
+    Export parts of the AiiDA database to file for sharing.
+
+    Various entities can be exported, such as Codes, Computers, Groups, Nodes,
+    Comments, Logs, ...
     """
     from aiida.tools.importexport import export, export_zip
 
@@ -167,7 +169,7 @@ def create(
 def migrate(input_file, output_file, force, silent, archive_format):
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """
-    Migrate an existing export archive file to the most recent version of the export format
+    Migrate an old export archive file to the most recent format.
     """
     import tarfile
     import zipfile

--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -16,16 +16,17 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
-from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils import decorators
 
 
 @verdi.group('graph')
+@decorators.deprecated_command("This command group has been deprecated. Please use 'verdi node graph' instead.")
 def verdi_graph():
-    """Create visual representations of part of the provenance graph.
-    """
+    """Create visual representations of the provenance graph."""
 
 
 @verdi_graph.command('generate')
+@decorators.deprecated_command("This command has been deprecated. Please use 'verdi node graph generate' instead.")
 @arguments.NODE('root_node')
 @click.option(
     '-l',
@@ -68,41 +69,15 @@ def verdi_graph():
 )
 @click.option('-f', '--output-format', help="The output format used for rendering ('pdf', 'png', etc.).", default='pdf')
 @click.option('-s', '--show', is_flag=True, help='Open the rendered result with the default application.')
+@click.pass_context
 @decorators.with_dbenv()
-def generate(
-    root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine, verbose,
+def generate(  # pylint: disable=too-many-arguments, unused-argument
+    ctx, root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine, verbose,
     output_format, show
 ):
     """
     Generate a graph from a ROOT_NODE (specified by pk or uuid).
     """
-    # pylint: disable=too-many-arguments
-    from aiida.tools.visualization import Graph
-    print_func = echo.echo_info if verbose else None
-    link_types = {'all': (), 'logic': ('input_work', 'return'), 'data': ('input_calc', 'create')}[link_types]
+    from aiida.cmdline.commands.cmd_node import graph_generate as node_generate
 
-    echo.echo_info('Initiating graphviz engine: {}'.format(engine))
-    graph = Graph(engine=engine, node_id_type=identifier)
-    echo.echo_info('Recursing ancestors, max depth={}'.format(ancestor_depth))
-    graph.recurse_ancestors(
-        root_node,
-        depth=ancestor_depth,
-        link_types=link_types,
-        annotate_links='both',
-        include_process_outputs=process_out,
-        print_func=print_func
-    )
-    echo.echo_info('Recursing descendants, max depth={}'.format(descendant_depth))
-    graph.recurse_descendants(
-        root_node,
-        depth=descendant_depth,
-        link_types=link_types,
-        annotate_links='both',
-        include_process_inputs=process_in,
-        print_func=print_func
-    )
-    output_file_name = graph.graphviz.render(
-        filename='{}.{}'.format(root_node.pk, engine), format=output_format, view=show, cleanup=True
-    )
-
-    echo.echo_success('Output file: {}'.format(output_file_name))
+    ctx.forward(node_generate)

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -23,7 +23,7 @@ from aiida.cmdline.utils.decorators import with_dbenv
 
 @verdi.group('group')
 def verdi_group():
-    """Create, inspect and manage groups."""
+    """Create, inspect and manage groups of nodes."""
 
 
 @verdi_group.command('add-nodes')
@@ -32,7 +32,7 @@ def verdi_group():
 @arguments.NODES()
 @with_dbenv()
 def group_add_nodes(group, force, nodes):
-    """Add NODES to the given GROUP."""
+    """Add nodes to the a group."""
     if not force:
         click.confirm('Do you really want to add {} nodes to Group<{}>?'.format(len(nodes), group.label), abort=True)
 
@@ -46,7 +46,7 @@ def group_add_nodes(group, force, nodes):
 @options.FORCE()
 @with_dbenv()
 def group_remove_nodes(group, nodes, clear, force):
-    """Remove NODES from the given GROUP."""
+    """Remove nodes from a group."""
     if clear:
         message = 'Do you really want to remove ALL the nodes from Group<{}>?'.format(group.label)
     else:
@@ -67,7 +67,7 @@ def group_remove_nodes(group, nodes, clear, force):
 @options.FORCE()
 @with_dbenv()
 def group_delete(group, clear, force):
-    """Delete a GROUP.
+    """Delete a group.
 
     Note that a group that contains nodes cannot be deleted if it contains any nodes. If you still want to delete the
     group, use the `-c/--clear` flag to remove the contents before deletion. Note that in any case, the nodes themselves
@@ -99,7 +99,7 @@ def group_delete(group, clear, force):
 @click.argument('label', type=click.STRING)
 @with_dbenv()
 def group_relabel(group, label):
-    """Change the label of the given GROUP to LABEL."""
+    """Change the label of a group."""
     try:
         group.label = label
     except UniquenessError as exception:
@@ -113,7 +113,7 @@ def group_relabel(group, label):
 @click.argument('description', type=click.STRING, required=False)
 @with_dbenv()
 def group_description(group, description):
-    """Change the description of the given GROUP to DESCRIPTION.
+    """Change the description of a group.
 
     If no DESCRIPTION is defined, the current description will simply be echoed.
     """
@@ -136,7 +136,7 @@ def group_description(group, description):
 @arguments.GROUP()
 @with_dbenv()
 def group_show(group, raw, uuid):
-    """Show information on a given group. Pass the GROUP as a parameter."""
+    """Show information for a given group."""
     from tabulate import tabulate
 
     from aiida.common.utils import str_timedelta
@@ -238,7 +238,7 @@ def group_list(
     all_users, user_email, all_types, group_type, with_description, count, past_days, startswith, endswith, contains,
     node
 ):
-    """Show a list of groups."""
+    """Show a list of existing groups."""
     # pylint: disable=too-many-branches,too-many-arguments, too-many-locals
     import datetime
     from aiida.common.escaping import escape_for_sql_like
@@ -323,7 +323,7 @@ def group_list(
 @click.argument('group_label', nargs=1, type=click.STRING)
 @with_dbenv()
 def group_create(group_label):
-    """Create a new empty group with the name GROUP_NAME."""
+    """Create an empty group with a given name."""
     from aiida import orm
     from aiida.orm import GroupTypeString
 
@@ -340,7 +340,10 @@ def group_create(group_label):
 @click.argument('destination_group', nargs=1, type=click.STRING)
 @with_dbenv()
 def group_copy(source_group, destination_group):
-    """Add all nodes that belong to source group to the destination group (which may or may not exist)."""
+    """Duplicate a group.
+
+    More in detail, add all nodes from the source group to the destination group.
+    Note that the destination group may not exist."""
     from aiida import orm
 
     dest_group, created = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -195,9 +195,9 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
 def cmd_import(
     ctx, archives, webpages, group, extras_mode_existing, extras_mode_new, comment_mode, migration, non_interactive
 ):
-    """Import one or multiple exported AiiDA archives
+    """Import data from an AiiDA archive file.
 
-    The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.
+    The archive can be specified by its relative or absolute file path, or its HTTP URL.
     """
     from six.moves import urllib
 

--- a/aiida/cmdline/commands/cmd_plugin.py
+++ b/aiida/cmdline/commands/cmd_plugin.py
@@ -21,7 +21,7 @@ from aiida.plugins.entry_point import entry_point_group_to_module_path_map
 
 @verdi.group('plugin')
 def verdi_plugin():
-    """Inspect installed plugins for various entry point categories."""
+    """Inspect AiiDA plugins."""
 
 
 @verdi_plugin.command('list')

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -50,7 +50,10 @@ def process_list(
     all_entries, group, process_state, process_label, exit_status, failed, past_days, limit, project, raw, order_by,
     order_dir
 ):
-    """Show a list of processes that are still running."""
+    """Show a list of running or terminated processes.
+
+    By default, only those that are still running are shown, but there are options
+    to show also the finished ones."""
     # pylint: disable=too-many-locals
     from tabulate import tabulate
     from aiida.cmdline.utils.common import print_last_process_state_change, check_worker_load
@@ -92,7 +95,7 @@ def process_list(
 @arguments.PROCESSES()
 @decorators.with_dbenv()
 def process_show(processes):
-    """Show a summary for one or multiple processes."""
+    """Show details for one or multiple processes."""
     from aiida.cmdline.utils.common import get_node_info
 
     for process in processes:
@@ -103,7 +106,7 @@ def process_show(processes):
 @arguments.PROCESSES()
 @decorators.with_dbenv()
 def process_call_root(processes):
-    """Show the root process of the call stack for the given processes."""
+    """Show root process of the call stack for the given processes."""
     for process in processes:
 
         caller = process.caller
@@ -156,7 +159,7 @@ def process_report(processes, levelname, indent_size, max_depth):
 @verdi_process.command('status')
 @arguments.PROCESSES()
 def process_status(processes):
-    """Print the status of the process."""
+    """Print the status of one or multiple processes."""
     from aiida.cmdline.utils.ascii_vis import format_call_graph
 
     for process in processes:
@@ -239,7 +242,7 @@ def process_pause(processes, timeout, wait):
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_play(processes, timeout, wait):
-    """Play paused processes."""
+    """Play (unpause) paused processes."""
 
     controller = get_manager().get_process_controller()
 

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -29,7 +29,7 @@ def verdi_profile():
 
 @verdi_profile.command('list')
 def profile_list():
-    """Displays list of all available profiles."""
+    """Display a list of all available profiles."""
 
     try:
         config = get_config()
@@ -54,7 +54,7 @@ def profile_list():
 @verdi_profile.command('show')
 @arguments.PROFILE(default=defaults.get_default_profile)
 def profile_show(profile):
-    """Show details for PROFILE or, when not specified, the default profile."""
+    """Show details for a profile."""
     if profile is None:
         echo.echo_critical('no profile to show')
 
@@ -66,7 +66,7 @@ def profile_show(profile):
 @verdi_profile.command('setdefault')
 @arguments.PROFILE(required=True, default=None)
 def profile_setdefault(profile):
-    """Set PROFILE as the default profile."""
+    """Set a profile as the default one."""
     try:
         config = get_config()
     except (exceptions.MissingConfigurationError, exceptions.ConfigurationError) as exception:
@@ -96,8 +96,11 @@ def profile_setdefault(profile):
 @arguments.PROFILES(required=True)
 def profile_delete(force, include_config, include_db, include_repository, profiles):
     """
-    Delete PROFILES (names, separated by spaces) from the aiida config file,
-    including the associated databases and file repositories.
+    Delete one or more profiles.
+
+    You can specify more profile names (separated by spaces).
+    These will be removed from the aiida config file,
+    and the associated databases and file repositories will also be removed.
     """
     from aiida.manage.configuration.setup import delete_profile
 

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -47,7 +47,7 @@ CONFIG_DIR = os.path.join(os.path.split(os.path.abspath(aiida.restapi.__file__))
 @click.option('--hookup/--no-hookup', 'hookup', is_flag=True, default=True, help='to hookup app')
 def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup):
     """
-    Run the AiiDA REST API server
+    Run the AiiDA REST API server.
 
     Example Usage:
 

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -62,7 +62,7 @@ def update_environment(new_argv):
 @decorators.with_dbenv()
 def run(scriptname, varargs, group, group_name, exclude, excludesubclasses, include, includesubclasses):
     # pylint: disable=too-many-arguments,exec-used
-    """Execute an AiiDA script."""
+    """Execute scripts with preloaded AiiDA environment."""
     from aiida.cmdline.utils.shell import DEFAULT_MODULES_LIST
     from aiida.orm import autogroup
 

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -123,7 +123,7 @@ def quicksetup(
     ctx, non_interactive, profile, email, first_name, last_name, institution, db_engine, db_backend, db_host, db_port,
     db_name, db_username, db_password, su_db_name, su_db_username, su_db_password, repository
 ):
-    """Setup a new profile where the database is automatically created and configured."""
+    """Setup a new profile in a fully automated fashion."""
     # pylint: disable=too-many-arguments,too-many-locals
     from aiida.manage.external.postgres import Postgres, manual_setup_instructions
 

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -57,7 +57,7 @@ def verdi_user():
 @verdi_user.command('list')
 @decorators.with_dbenv()
 def user_list():
-    """Displays list of all users."""
+    """Show a list of all users."""
     from aiida.orm import User
 
     default_user = User.objects.get_default()
@@ -141,6 +141,6 @@ def user_configure(ctx, user, first_name, last_name, institution, set_default):
 @click.pass_context
 @decorators.with_dbenv()
 def user_set_default(ctx, user):
-    """Set the USER as the default user."""
+    """Set a user as the default user for the profile."""
     set_default_user(ctx.obj.profile, user)
     echo.echo_success('set `{}` as the new default user for profile `{}`'.format(user.email, ctx.obj.profile.name))

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -194,7 +194,7 @@ def deprecated_command(message):
         if not profile.is_test_profile:
             template = templates.env.get_template('deprecated.tpl')
             width = 80
-            echo.echo(template.render(msg=wrap(message, width), width=width))
+            echo.echo(template.render(msg=wrap(message, width - 4), width=width))
 
         return wrapped(*args, **kwargs)
 

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -199,12 +199,12 @@ Below is a list with all available subcommands.
 
     Commands:
       cleanworkdir  Clean all content of all output remote folders of calcjobs.
-      gotocomputer  Open a shell and go to the calcjob folder on the computer...
-      inputcat      Show the contents of a file with relative PATH in the raw...
-      inputls       Show the list of files in the directory with relative PATH...
-      outputcat     Show the contents of a file with relative PATH in the...
-      outputls      Show the list of files in the directory with relative PATH...
-      res           Print data from the result output node of a calcjob.
+      gotocomputer  Open a shell in the remote folder on the calcjob.
+      inputcat      Show the contents of one of the calcjob input files.
+      inputls       Show the list of the generated calcjob input files.
+      outputcat     Show the contents of one of the calcjob retrieved outputs.
+      outputls      Show the list of the retrieved calcjob output files.
+      res           Print data from the result output Dict node of a calcjob.
 
 
 .. _verdi_code:
@@ -222,14 +222,14 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      delete     Delete codes that have not yet been used for calculations, i.e.
-      duplicate  Create duplicate of existing Code.
-      hide       Hide one or more codes from the `verdi code list` command.
-      list       List the codes in the database.
+      delete     Delete a code.
+      duplicate  Duplicate a code allowing to change some parameters.
+      hide       Hide one or more codes from `verdi code list`.
+      list       List the available codes.
       relabel    Relabel a code.
-      reveal     Reveal one or more hidden codes to the `verdi code list`...
-      setup      Setup a new Code.
-      show       Display detailed information for the given CODE.
+      reveal     Reveal one or more hidden codes in `verdi code list`.
+      setup      Setup a new code.
+      show       Display detailed information for a code.
 
 
 .. _verdi_comment:
@@ -247,10 +247,10 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      add     Add a comment to one or multiple nodes.
-      remove  Remove a comment.
-      show    Show the comments for one or multiple nodes.
-      update  Update a comment.
+      add     Add a comment to one or more nodes.
+      remove  Remove a comment of a node.
+      show    Show the comments of one or multiple nodes.
+      update  Update a comment of a node.
 
 
 .. _verdi_completioncommand:
@@ -262,7 +262,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Return the bash code to activate completion.
+      Return the code to activate bash completion.
 
       :note: this command is mainly for back-compatibility.     You should
       rather use:;
@@ -288,15 +288,15 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      configure  Configure a computer with one of the available transport types.
-      delete     Configure the authentication information for a given computer...
+      configure  Configure the Authinfo details for a computer (and user).
+      delete     Delete a computer.
       disable    Disable the computer for the given user.
-      duplicate  Duplicate a computer.
+      duplicate  Duplicate a computer allowing to change some parameters.
       enable     Enable the computer for the given user.
-      list       List available computers.
+      list       List all available computers.
       rename     Rename a computer.
-      setup      Add a computer.
-      show       Show information for a computer.
+      setup      Create a new computer.
+      show       Show detailed information for a computer.
       test       Test the connection to a computer.
 
 
@@ -309,7 +309,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] OPTION_NAME OPTION_VALUE
 
-      Set, unset and get profile specific or global configuration options.
+      Configure profile-specific or global AiiDA options.
 
     Options:
       --global  Apply the option configuration wide.
@@ -355,16 +355,6 @@ Below is a list with all available subcommands.
     Options:
       --help  Show this message and exit.
 
-    Commands:
-      array       Manipulate ArrayData objects.
-      bands       Manipulate BandsData objects.
-      cif         Manipulation of CIF data objects.
-      dict        View and manipulate Dict objects.
-      remote      Managing RemoteData objects.
-      structure   Manipulation of StructureData objects.
-      trajectory  View and manipulate TrajectoryData instances.
-      upf         Manipulation of the upf families.
-
 
 .. _verdi_database:
 
@@ -381,7 +371,7 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      integrity  Various commands that will check the integrity of the database...
+      integrity  Check the integrity of the database and fix potential issues.
       migrate    Migrate the database to the latest schema version.
 
 
@@ -400,7 +390,6 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      play        Open a browser and play the Aida triumphal march by Giuseppe...
       run_daemon  Run a daemon instance in the current interpreter.
       tests       Run the unittest suite or parts of it.
 
@@ -420,10 +409,9 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      create   Export various entities, such as Codes, Computers, Groups and...
-      inspect  Inspect the contents of an exported archive without importing
-               the...
-      migrate  Migrate an existing export archive file to the most recent...
+      create   Export parts of the AiiDA database to file for sharing.
+      inspect  Inspect contents of an exported archive without importing it.
+      migrate  Migrate an old export archive file to the most recent format.
 
 
 .. _verdi_graph:
@@ -435,7 +423,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
-      Create visual representations of part of the provenance graph.
+      Create visual representations of the provenance graph.
 
     Options:
       --help  Show this message and exit.
@@ -453,22 +441,21 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
-      Create, inspect and manage groups.
+      Create, inspect and manage groups of nodes.
 
     Options:
       --help  Show this message and exit.
 
     Commands:
-      add-nodes     Add NODES to the given GROUP.
-      copy          Add all nodes that belong to source group to the
-                    destination...
-      create        Create a new empty group with the name GROUP_NAME.
-      delete        Delete a GROUP.
-      description   Change the description of the given GROUP to DESCRIPTION.
-      list          Show a list of groups.
-      relabel       Change the label of the given GROUP to LABEL.
-      remove-nodes  Remove NODES from the given GROUP.
-      show          Show information on a given group.
+      add-nodes     Add nodes to the a group.
+      copy          Duplicate a group.
+      create        Create an empty group with a given name.
+      delete        Delete a group.
+      description   Change the description of a group.
+      list          Show a list of existing groups.
+      relabel       Change the label of a group.
+      remove-nodes  Remove nodes from a group.
+      show          Show information for a given group.
 
 
 .. _verdi_import:
@@ -480,10 +467,10 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] [--] [ARCHIVES]...
 
-      Import one or multiple exported AiiDA archives
+      Import data from an AiiDA archive file.
 
-      The ARCHIVES can be specified by their relative or absolute file path, or
-      their HTTP URL.
+      The archive can be specified by its relative or absolute file path, or its
+      HTTP URL.
 
     Options:
       -w, --webpages TEXT...          Discover all URL targets pointing to files
@@ -539,13 +526,16 @@ Below is a list with all available subcommands.
 
     Commands:
       attributes   Show the attributes of one or more nodes.
+      comment      Inspect, create and manage node comments.
       delete       Delete nodes and everything that originates from them.
-      description  View or set the descriptions of one or more nodes.
+      description  View or set the description of one or more nodes.
       extras       Show the extras of one or more nodes.
-      label        View or set the labels of one or more nodes.
-      repo
-      show         Show generic information on node(s).
-      tree         Show tree of nodes.
+      graph        Create visual representations of the provenance graph.
+      label        View or set the label of one or more nodes.
+      rehash       Recompute the hash for nodes in the database.
+      repo         Inspect the content of a node repository folder.
+      show         Show generic information on one or more nodes.
+      tree         Show a tree of nodes starting from a given node.
 
 
 .. _verdi_plugin:
@@ -557,7 +547,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
-      Inspect installed plugins for various entry point categories.
+      Inspect AiiDA plugins.
 
     Options:
       --help  Show this message and exit.
@@ -581,14 +571,14 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      call-root  Show the root process of the call stack for the given...
+      call-root  Show root process of the call stack for the given processes.
       kill       Kill running processes.
-      list       Show a list of processes that are still running.
+      list       Show a list of running or terminated processes.
       pause      Pause running processes.
-      play       Play paused processes.
+      play       Play (unpause) paused processes.
       report     Show the log report for one or multiple processes.
-      show       Show a summary for one or multiple processes.
-      status     Print the status of the process.
+      show       Show details for one or multiple processes.
+      status     Print the status of one or multiple processes.
       watch      Watch the state transitions for a process.
 
 
@@ -607,10 +597,10 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      delete      Delete PROFILES (names, separated by spaces) from the aiida...
-      list        Displays list of all available profiles.
-      setdefault  Set PROFILE as the default profile.
-      show        Show details for PROFILE or, when not specified, the default...
+      delete      Delete one or more profiles.
+      list        Display a list of all available profiles.
+      setdefault  Set a profile as the default one.
+      show        Show details for a profile.
 
 
 .. _verdi_quicksetup:
@@ -622,8 +612,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Setup a new profile where the database is automatically created and
-      configured.
+      Setup a new profile in a fully automated fashion.
 
     Options:
       -n, --non-interactive           Non-interactive mode: never prompt for
@@ -665,7 +654,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] [NODES]...
 
-      Recompute the hash for nodes in the database
+      Recompute the hash for nodes in the database.
 
       The set of nodes that will be rehashed can be filtered by their identifier
       and/or based on their class.
@@ -673,6 +662,7 @@ Below is a list with all available subcommands.
     Options:
       -e, --entry-point PLUGIN  Only include nodes that are class or sub class of
                                 the class identified by this entry point.
+      -f, --force               Do not ask for confirmation.
       --help                    Show this message and exit.
 
 
@@ -685,7 +675,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Run the AiiDA REST API server
+      Run the AiiDA REST API server.
 
       Example Usage:
 
@@ -712,7 +702,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] [--] SCRIPTNAME [VARARGS]...
 
-      Execute an AiiDA script.
+      Execute scripts with preloaded AiiDA environment.
 
     Options:
       -g, --group                   Enables the autogrouping  [default: True]
@@ -818,8 +808,8 @@ Below is a list with all available subcommands.
 
     Commands:
       configure    Configure a new or existing user.
-      list         Displays list of all users.
-      set-default  Set the USER as the default user.
+      list         Show a list of all users.
+      set-default  Set a user as the default user for the profile.
 
 
 

--- a/docs/source/working_with_aiida/index.rst
+++ b/docs/source/working_with_aiida/index.rst
@@ -12,25 +12,25 @@ This will make understanding and using ``verdi`` a lot easier!
 * :ref:`calcjob<verdi_calcjob>`:  Inspect and manage calcjobs.
 * :ref:`code<verdi_code>`:  Setup and manage codes.
 * :ref:`comment<verdi_comment>`:  Inspect, create and manage node comments.
-* :ref:`completioncommand<verdi_completioncommand>`:  Return the bash code to activate completion.
+* :ref:`completioncommand<verdi_completioncommand>`:  Return the code to activate bash completion.
 * :ref:`computer<verdi_computer>`:  Setup and manage computers.
-* :ref:`config<verdi_config>`:  Set, unset and get profile specific or global configuration options.
+* :ref:`config<verdi_config>`:  Configure profile-specific or global AiiDA options.
 * :ref:`daemon<verdi_daemon>`:  Inspect and manage the daemon.
 * :ref:`data<verdi_data>`:  Inspect, create and manage data nodes.
 * :ref:`database<verdi_database>`:  Inspect and manage the database.
 * :ref:`devel<verdi_devel>`:  Commands for developers.
 * :ref:`export<verdi_export>`:  Create and manage export archives.
-* :ref:`graph<verdi_graph>`:  Create visual representations of part of the provenance graph.
-* :ref:`group<verdi_group>`:  Create, inspect and manage groups.
-* :ref:`import<verdi_import>`:  Import one or multiple exported AiiDA archives
+* :ref:`graph<verdi_graph>`:  Create visual representations of the provenance graph.
+* :ref:`group<verdi_group>`:  Create, inspect and manage groups of nodes.
+* :ref:`import<verdi_import>`:  Import data from an AiiDA archive file.
 * :ref:`node<verdi_node>`:  Inspect, create and manage nodes.
-* :ref:`plugin<verdi_plugin>`:  Inspect installed plugins for various entry point categories.
+* :ref:`plugin<verdi_plugin>`:  Inspect AiiDA plugins.
 * :ref:`process<verdi_process>`:  Inspect and manage processes.
 * :ref:`profile<verdi_profile>`:  Inspect and manage the configured profiles.
-* :ref:`quicksetup<verdi_quicksetup>`:  Setup a new profile where the database is automatically created and configured.
-* :ref:`rehash<verdi_rehash>`:  Recompute the hash for nodes in the database
-* :ref:`restapi<verdi_restapi>`:  Run the AiiDA REST API server
-* :ref:`run<verdi_run>`:  Execute an AiiDA script.
+* :ref:`quicksetup<verdi_quicksetup>`:  Setup a new profile in a fully automated fashion.
+* :ref:`rehash<verdi_rehash>`:  Recompute the hash for nodes in the database.
+* :ref:`restapi<verdi_restapi>`:  Run the AiiDA REST API server.
+* :ref:`run<verdi_run>`:  Execute scripts with preloaded AiiDA environment.
 * :ref:`setup<verdi_setup>`:  Setup a new profile.
 * :ref:`shell<verdi_shell>`:  Start a python shell with preloaded AiiDA environment.
 * :ref:`status<verdi_status>`:  Print status of AiiDA services.

--- a/setup.json
+++ b/setup.json
@@ -141,6 +141,7 @@
       "bands = aiida.cmdline.commands.cmd_data.cmd_bands:bands",
       "cif = aiida.cmdline.commands.cmd_data.cmd_cif:cif",
       "dict = aiida.cmdline.commands.cmd_data.cmd_dict:dictionary",
+      "remote = aiida.cmdline.commands.cmd_data.cmd_remote:remote",
       "structure = aiida.cmdline.commands.cmd_data.cmd_structure:structure",
       "trajectory = aiida.cmdline.commands.cmd_data.cmd_trajectory:trajectory",
       "upf = aiida.cmdline.commands.cmd_data.cmd_upf:upf"


### PR DESCRIPTION
Fixes #3196
Supersedes #3222 and therefore closes #3222

This makes all commands conform to PEP 257
(in particular dot at the end of the first line)
so that they are properly displayed by click.

I have also used the occasion to put a confirmation
prompt in `verdi rehash` as I realised it would
just rehash without asking. I've added also a force
option to avoid questions asked (e.g. for tests).

I have noticed also that `verdi comment add` and
`verdi comment delete` did not have some arguments
marked as required, but then the command would fail.
Since not passing the argument does not make much sense,
I have made those required.

Finally, I have moved the `verdi rehash`, `verdi graph`
and `verdi comment` inside `verdi node`, but left them
there with a deprecation warning to be backwards-compatible.

Tests have been added for the actual `verdi node xxx` commands,
and the old ones left in there to make sure also the deprecated
commands still work. These tests will be removed when the
deprecated commands will be removed.