### PR TITLE
Globally disable pylint `useless-object-inheritance`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation,no-else-raise
+disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation,no-else-raise,useless-object-inheritance
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/aiida/backends/tests/common/test_hashing.py
+++ b/aiida/backends/tests/common/test_hashing.py
@@ -178,7 +178,7 @@ class MakeHashTest(unittest.TestCase):
 
     def test_unhashable_type(self):
 
-        class MadeupClass(object):  # pylint: disable=useless-object-inheritance
+        class MadeupClass(object):
             pass
 
         with self.assertRaises(ValueError):

--- a/aiida/backends/tests/common/test_lang.py
+++ b/aiida/backends/tests/common/test_lang.py
@@ -22,7 +22,7 @@ protected_unchecked = lang.protected_decorator(check=False)  # pylint: disable=i
 class Protected(object):
     """Class to test the protected decorator."""
 
-    # pylint: disable=no-self-use,useless-object-inheritance
+    # pylint: disable=no-self-use
 
     def member_internal(self):
         """Class method that is allowed to call the protected methods."""
@@ -56,7 +56,7 @@ class Protected(object):
 class TestProtectedDecorator(AiidaTestCase):
     """Tests for the :py:func:`~aiida.common.lang.protected` decorator."""
 
-    # pylint: disable=unused-variable,useless-object-inheritance
+    # pylint: disable=unused-variable
 
     def test_free_function(self):
         """Decorating a free function should raise."""

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -233,7 +233,7 @@ def tree(nodes, depth):
             echo.echo('')
 
 
-class NodeTreePrinter(object):  # pylint: disable=useless-object-inheritance
+class NodeTreePrinter(object):
     """Utility functions for printing node trees."""
 
     @classmethod

--- a/aiida/cmdline/params/arguments/overridable.py
+++ b/aiida/cmdline/params/arguments/overridable.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 import click
 
 
-class OverridableArgument(object):  # pylint: disable=useless-object-inheritance
+class OverridableArgument(object):
     """
     Wrapper around click.argument that increases reusability
 

--- a/aiida/cmdline/params/options/overridable.py
+++ b/aiida/cmdline/params/options/overridable.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 import click
 
 
-class OverridableOption(object):  # pylint: disable=useless-object-inheritance
+class OverridableOption(object):
     """
     Wrapper around click option that increases reusability
 

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -15,7 +15,7 @@ from aiida.common.lang import classproperty
 from aiida.cmdline.utils.query.mapping import CalculationProjectionMapper
 
 
-class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inheritance
+class CalculationQueryBuilder(object):
     """Utility class to construct a QueryBuilder instance for Calculation nodes and project the query set."""
 
     # This tuple serves to mark compound projections that cannot explicitly be projected in the QueryBuilder, but will

--- a/aiida/cmdline/utils/query/mapping.py
+++ b/aiida/cmdline/utils/query/mapping.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from aiida.cmdline.utils.query import formatting
 
 
-class ProjectionMapper(object):  # pylint: disable=useless-object-inheritance
+class ProjectionMapper(object):
     """
     Class to map projection names from the CLI to entity labels, attributes and formatters.
 

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -29,7 +29,7 @@ class CorruptArchive(Exception):
     """Raised when an operation is applied to a corrupt export archive, e.g. missing files or invalid formats."""
 
 
-class Archive(object):  # pylint: disable=useless-object-inheritance
+class Archive(object):
     """Utility class to operate on exported archive files or directories.
 
     The main usage should be to construct the class with the filepath of the export archive as an argument.

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -34,7 +34,7 @@ CALC_JOB_DRY_RUN_BASE_PATH = 'submit_test'
 VALID_SECTIONS = ['node']
 
 
-class Folder(object):  # pylint: disable=useless-object-inheritance
+class Folder(object):
     """
     A class to manage generic folders, avoiding to get out of
     specific given folder borders.

--- a/aiida/common/lang.py
+++ b/aiida/common/lang.py
@@ -148,7 +148,7 @@ protected = protected_decorator(check=False)  # pylint: disable=invalid-name
 override = override_decorator(check=False)  # pylint: disable=invalid-name
 
 
-class classproperty(object):  # pylint: disable=too-few-public-methods,invalid-name,useless-object-inheritance
+class classproperty(object):  # pylint: disable=too-few-public-methods,invalid-name
     """
     A class that, when used as a decorator, works as if the
     two decorators @property and @classmethod where applied together
@@ -192,7 +192,7 @@ class abstractstaticmethod(staticmethod):  # pylint: disable=too-few-public-meth
         super(abstractstaticmethod, self).__init__(callable)
 
 
-class combomethod(object):  # pylint: disable=invalid-name,too-few-public-methods,useless-object-inheritance
+class combomethod(object):  # pylint: disable=invalid-name,too-few-public-methods
     """
     A decorator that wraps a function that can be both a classmethod or
     instancemethod and behaves accordingly::
@@ -234,7 +234,7 @@ class combomethod(object):  # pylint: disable=invalid-name,too-few-public-method
         return _wrapper
 
 
-class EmptyContextManager(object):  # pylint: disable=too-few-public-methods,useless-object-inheritance
+class EmptyContextManager(object):  # pylint: disable=too-few-public-methods
     """
     A dummy/no-op context manager.
     """

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -247,7 +247,7 @@ def grouper(n, iterable):  # pylint: disable=invalid-name
         yield chunk
 
 
-class ArrayCounter(object):  # pylint: disable=useless-object-inheritance
+class ArrayCounter(object):
     """
     A counter & a method that increments it and returns its value.
     It is used in various tests.
@@ -309,7 +309,7 @@ def are_dir_trees_equal(dir1, dir2):
     return True, 'The given directories ({} and {}) are equal'.format(dir1, dir2)
 
 
-class Prettifier(object):  # pylint: disable=useless-object-inheritance
+class Prettifier(object):
     """
     Class to manage prettifiers (typically for labels of kpoints
     in band plots)
@@ -532,7 +532,7 @@ def strip_prefix(full_string, prefix):
     return full_string
 
 
-class Capturing(object):  # pylint: disable=useless-object-inheritance
+class Capturing(object):
     """
     This class captures stdout and returns it
     (as a list, split by lines).
@@ -593,7 +593,7 @@ class Capturing(object):  # pylint: disable=useless-object-inheritance
         return iter(self.stdout_lines)
 
 
-class ErrorAccumulator(object):  # pylint: disable=useless-object-inheritance
+class ErrorAccumulator(object):
     """
     Allows to run a number of functions and collect all the errors they raise
 

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -60,7 +60,7 @@ def get_daemon_client(profile_name=None):
     return DaemonClient(profile)
 
 
-class DaemonClient(object):  # pylint: disable=too-many-public-methods,useless-object-inheritance
+class DaemonClient(object):  # pylint: disable=too-many-public-methods
     """
     Extension of the Profile which also provides handles to retrieve profile specific
     properties related to the daemon client

--- a/aiida/engine/processes/calcjobs/manager.py
+++ b/aiida/engine/processes/calcjobs/manager.py
@@ -25,7 +25,7 @@ from aiida.common import exceptions, lang
 __all__ = ('JobsList', 'JobManager')
 
 
-class JobsList(object):  # pylint: disable=useless-object-inheritance
+class JobsList(object):
     """Manager of calculation jobs submitted with a specific ``AuthInfo``, i.e. computer configured for a specific user.
 
     This container of active calculation jobs is used to update their status periodically in batches, ensuring that
@@ -266,8 +266,6 @@ class JobManager(object):
     will be maintained. Note, however, that since each ``Runner`` will create its own job manager, these guarantees
     only hold per runner.
     """
-
-    # pylint: disable=useless-object-inheritance
 
     def __init__(self, transport_queue):
         self._transport_queue = transport_queue

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -29,7 +29,7 @@ PORT_NAMESPACE_SEPARATOR = '__'  # The character sequence to represent a nested 
 OutputPort = ports.OutputPort  # pylint: disable=invalid-name
 
 
-class WithNonDb(object):  # pylint: disable=useless-object-inheritance
+class WithNonDb(object):
     """
     A mixin that adds support to a port to flag a that should not be stored
     in the database using the non_db=True flag.
@@ -70,7 +70,7 @@ class WithNonDb(object):  # pylint: disable=useless-object-inheritance
         self._non_db = non_db
 
 
-class WithSerialize(object):  # pylint: disable=useless-object-inheritance
+class WithSerialize(object):
     """
     A mixin that adds support for a serialization function which is automatically applied on inputs
     that are not AiiDA data types.

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -37,7 +37,7 @@ ResultAndNode = collections.namedtuple('ResultAndNode', ['result', 'node'])
 ResultAndPk = collections.namedtuple('ResultAndPk', ['result', 'pk'])
 
 
-class Runner(object):  # pylint: disable=useless-object-inheritance,too-many-public-methods
+class Runner(object):  # pylint: disable=too-many-public-methods
     """Class that can launch processes by running in the current interpreter or by submitting them to the daemon."""
 
     _persister = None

--- a/aiida/engine/transports.py
+++ b/aiida/engine/transports.py
@@ -23,14 +23,14 @@ _LOGGER = logging.getLogger(__name__)
 class TransportRequest(object):
     """ Information kept about request for a transport object """
 
-    # pylint: disable=too-few-public-methods,useless-object-inheritance
+    # pylint: disable=too-few-public-methods
     def __init__(self):
         super(TransportRequest, self).__init__()
         self.future = concurrent.Future()
         self.count = 0
 
 
-class TransportQueue(object):  # pylint: disable=useless-object-inheritance
+class TransportQueue(object):
     """
     A queue to get transport objects from authinfo.  This class allows clients
     to register their interest in a transport object which will be provided at

--- a/aiida/manage/backup/backup_base.py
+++ b/aiida/manage/backup/backup_base.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Base abstract Backup class for all backends."""
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division

--- a/aiida/manage/backup/backup_base.py
+++ b/aiida/manage/backup/backup_base.py
@@ -7,7 +7,6 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Base abstract Backup class for all backends."""
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division

--- a/aiida/manage/backup/backup_setup.py
+++ b/aiida/manage/backup/backup_setup.py
@@ -29,7 +29,7 @@ from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
 from aiida.manage.backup import backup_utils as utils
 
 
-class BackupSetup(object):  # pylint: disable=useless-object-inheritance
+class BackupSetup(object):
     """
     This class setups the main backup script related information & files like::
 

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -26,7 +26,7 @@ from .settings import DEFAULT_UMASK, DEFAULT_CONFIG_INDENT_SIZE
 __all__ = ('Config',)
 
 
-class Config(object):  # pylint: disable=useless-object-inheritance,too-many-public-methods
+class Config(object):  # pylint: disable=too-many-public-methods
     """Object that represents the configuration file of an AiiDA instance."""
 
     KEY_VERSION = 'CONFIG_VERSION'

--- a/aiida/manage/configuration/migrations/migrations.py
+++ b/aiida/manage/configuration/migrations/migrations.py
@@ -22,7 +22,7 @@ CURRENT_CONFIG_VERSION = 3
 OLDEST_COMPATIBLE_CONFIG_VERSION = 3
 
 
-class ConfigMigration(object):  # pylint: disable=useless-object-inheritance
+class ConfigMigration(object):
     """Defines a config migration."""
 
     def __init__(self, migrate_function, version, version_oldest_compatible):

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -35,7 +35,7 @@ CIRCUS_PUBSUB_SOCKET_TEMPLATE = 'circus.p.sock'
 CIRCUS_STATS_SOCKET_TEMPLATE = 'circus.s.sock'
 
 
-class Profile(object):  # pylint: disable=useless-object-inheritance,too-many-public-methods
+class Profile(object):  # pylint: disable=too-many-public-methods
     """Class that models a profile as it is stored in the configuration file of an AiiDA instance."""
 
     RMQ_PREFIX = 'aiida-{uuid}'

--- a/aiida/manage/external/pgsu.py
+++ b/aiida/manage/external/pgsu.py
@@ -42,7 +42,7 @@ class PostgresConnectionMode(IntEnum):
     PSQL = 2
 
 
-class PGSU(object):  # pylint: disable=useless-object-inheritance
+class PGSU(object):
     """
     Connect to an existing PostgreSQL cluster as the `postgres` superuser and execute SQL commands.
 

--- a/aiida/manage/fixtures.py
+++ b/aiida/manage/fixtures.py
@@ -60,7 +60,7 @@ class FixtureError(Exception):
         return repr(self.msg)
 
 
-class FixtureManager(object):  # pylint: disable=too-many-public-methods,useless-object-inheritance
+class FixtureManager(object):  # pylint: disable=too-many-public-methods
     """
     Manage the life cycle of a completely separated and temporary AiiDA environment
 

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -20,7 +20,7 @@ __all__ = ('get_manager', 'reset_manager')
 MANAGER = None
 
 
-class Manager(object):  # pylint: disable=useless-object-inheritance
+class Manager(object):
     """
     Manager singleton to provide global versions of commonly used profile/settings related objects
     and methods to facilitate their construction.

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -164,7 +164,7 @@ class Collection(typing.Generic[EntityType]):  # pylint: disable=unsubscriptable
         return [_[0] for _ in self.query().all()]
 
 
-class Entity(object):  # pylint: disable=useless-object-inheritance
+class Entity(object):
     """An AiiDA entity"""
 
     _objects = None

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -102,7 +102,6 @@ class Collection(typing.Generic[EntityType]):  # pylint: disable=unsubscriptable
         :return: a new query builder instance
         :rtype: :class:`aiida.orm.QueryBuilder`
         """
-        # pylint: disable=no-self-use
         from . import querybuilder
 
         query = querybuilder.QueryBuilder()

--- a/aiida/orm/implementation/backends.py
+++ b/aiida/orm/implementation/backends.py
@@ -25,8 +25,6 @@ EntityType = typing.TypeVar('EntityType')  # pylint: disable=invalid-name
 class Backend(object):
     """The public interface that defines a backend factory that creates backend specific concrete objects."""
 
-    # pylint: disable=useless-object-inheritance
-
     @abc.abstractmethod
     def migrate(self):
         """Migrate the database to the latest schema version."""
@@ -126,8 +124,6 @@ class Backend(object):
 @six.add_metaclass(abc.ABCMeta)
 class BackendEntity(object):
     """An first-class entity in the backend"""
-
-    # pylint: disable=useless-object-inheritance
 
     def __init__(self, backend):
         self._backend = backend

--- a/aiida/orm/implementation/django/utils.py
+++ b/aiida/orm/implementation/django/utils.py
@@ -31,7 +31,7 @@ class ModelWrapper(object):
     * `setattr`: if the item corresponds to a mutable model field, changes are flushed after performing the change
     """
 
-    # pylint: disable=too-many-instance-attributes,useless-object-inheritance
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, model, auto_flush=()):
         """Construct the ModelWrapper.

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -25,7 +25,7 @@ __all__ = ('BackendQueryBuilder',)
 class BackendQueryBuilder(object):
     """Backend query builder interface"""
 
-    # pylint: disable=invalid-name,too-many-public-methods,useless-object-inheritance
+    # pylint: disable=invalid-name,too-many-public-methods
 
     outer_to_inner_schema = None
     inner_to_outer_schema = None

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -145,7 +145,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
     def nodes(self):
         """Get an iterator to all the nodes in the group"""
 
-        class Iterator(object):  # pylint: disable=useless-object-inheritance
+        class Iterator(object):
             """Nodes iterator"""
 
             def __init__(self, dbnodes, backend):

--- a/aiida/orm/implementation/sqlalchemy/utils.py
+++ b/aiida/orm/implementation/sqlalchemy/utils.py
@@ -35,7 +35,7 @@ class ModelWrapper(object):
     * `setattr`: if the item corresponds to a mutable model field, changes are flushed after performing the change
     """
 
-    # pylint: disable=too-many-instance-attributes,useless-object-inheritance
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, model, auto_flush=()):
         """Construct the ModelWrapper.

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -20,7 +20,7 @@ from aiida.cmdline.params.types.plugin import PluginParamType
 from aiida.common.utils import ErrorAccumulator
 
 
-class CodeBuilder(object):  # pylint: disable=useless-object-inheritance
+class CodeBuilder(object):
     """Build a code with validation of attribute combinations"""
 
     def __init__(self, **kwargs):

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -16,7 +16,7 @@ from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common.utils import ErrorAccumulator
 
 
-class ComputerBuilder(object):  # pylint: disable=useless-object-inheritance
+class ComputerBuilder(object):
     """Build a computer with validation of attribute combinations"""
 
     @staticmethod

--- a/aiida/orm/utils/calcjob.py
+++ b/aiida/orm/utils/calcjob.py
@@ -17,7 +17,7 @@ from aiida.common import exceptions
 __all__ = ('CalcJobResultManager',)
 
 
-class CalcJobResultManager(object):  # pylint: disable=useless-object-inheritance
+class CalcJobResultManager(object):
     """
     Utility class to easily access the contents of the 'default output' node of a `CalcJobNode`.
 

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -188,7 +188,7 @@ def validate_link(source, target, link_type, link_label):
             target.uuid, link_type, link_label, source.uuid))
 
 
-class LinkManager(object):  # pylint: disable=useless-object-inheritance
+class LinkManager(object):
     """
     Class to convert a list of LinkTriple tuples into an iterator.
 

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -68,8 +68,6 @@ class IdentifierType(Enum):
 class OrmEntityLoader(object):
     """Base class for entity loaders."""
 
-    # pylint: disable=useless-object-inheritance
-
     label_ambiguity_breaker = '!'
 
     @classproperty

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -21,7 +21,7 @@ from aiida.common.links import LinkType
 __all__ = ('NodeLinksManager', 'AttributeManager')
 
 
-class NodeLinksManager(object):  # pylint: disable=too-few-public-methods,useless-object-inheritance
+class NodeLinksManager(object):  # pylint: disable=too-few-public-methods
     """
     A manager that allows to inspect, with tab-completion, nodes linked to a given one.
     See an example of its use in `CalculationNode.inputs`.
@@ -107,7 +107,7 @@ class NodeLinksManager(object):  # pylint: disable=too-few-public-methods,useles
         return '<{}: {}>'.format(self.__class__.__name__, str(self))
 
 
-class AttributeManager(object):  # pylint: disable=too-few-public-methods,useless-object-inheritance
+class AttributeManager(object):  # pylint: disable=too-few-public-methods
     """
     An object used internally to return the attributes as a dictionary.
     This is currently used in :py:class:`~aiida.orm.nodes.data.dict.Dict`,

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -20,7 +20,7 @@ from aiida.common.lang import override
 from aiida.common.lang import classproperty
 
 
-class FunctionCalculationMixin(object):  # pylint: disable=useless-object-inheritance
+class FunctionCalculationMixin(object):
     """
     This mixin should be used for ProcessNode subclasses that are used to record the execution
     of a python function. For example the process nodes that are used for a function that
@@ -117,7 +117,7 @@ class FunctionCalculationMixin(object):  # pylint: disable=useless-object-inheri
         return self.get_object_content(self.FUNCTION_SOURCE_FILE_PATH)
 
 
-class Sealable(object):  # pylint: disable=useless-object-inheritance
+class Sealable(object):
     """Mixin to mark a Node as `sealable`."""
     # pylint: disable=no-member,unsupported-membership-test
 

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -30,7 +30,7 @@ class FileType(enum.Enum):
 File = collections.namedtuple('File', ['name', 'type'])
 
 
-class Repository(object):  # pylint: disable=useless-object-inheritance
+class Repository(object):
     """Class that represents the repository of a `Node` instance."""
 
     # Name to be used for the Repository section

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -29,8 +29,6 @@ __all__ = ('Parser',)
 class Parser(object):
     """Base class for a Parser that can parse the outputs produced by a CalcJob process."""
 
-    # pylint: disable=useless-object-inheritance
-
     def __init__(self, node):
         """Construct the Parser instance.
 

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -26,8 +26,6 @@ KEY_VERSION_PLUGIN = 'plugin'  # The version of the plugin top level module, e.g
 class PluginVersionProvider(object):
     """Utility class that determines version information about a given plugin resource."""
 
-    # pylint: disable=useless-object-inheritance
-
     def __init__(self):
         self._cache = {}
         self._logger = AIIDA_LOGGER.getChild('plugin_version_provider')

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -64,7 +64,7 @@ class CustomJSONEncoder(JSONEncoder):
 
 
 class DatetimePrecision(object):
-    # pylint: disable=too-few-public-methods,useless-object-inheritance
+    # pylint: disable=too-few-public-methods
     """
     A simple class which stores a datetime object with its precision. No
     internal check is done (cause itis not possible).
@@ -88,7 +88,7 @@ class DatetimePrecision(object):
         self.precision = precision
 
 
-class Utils(object):  # pylint: disable=useless-object-inheritance
+class Utils(object):
     """
     A class that gathers all the utility functions for parsing URI,
     validating request, pass it to the translator, and building HTTP response

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -29,7 +29,7 @@ class BaseTranslator(object):
     Generic class for translator. It contains the methods
     required to build a related QueryBuilder object
     """
-    # pylint: disable=useless-object-inheritance,too-many-instance-attributes,fixme
+    # pylint: disable=too-many-instance-attributes,fixme
 
     # A label associated to the present class
     __label__ = None

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -32,7 +32,7 @@ class SchedulerParsingError(SchedulerError):
     pass
 
 
-@six.add_metaclass(ABCMeta)  # pylint: disable=useless-object-inheritance
+@six.add_metaclass(ABCMeta)
 class Scheduler(object):
     """
     Base class for all schedulers.

--- a/aiida/tools/calculations/base.py
+++ b/aiida/tools/calculations/base.py
@@ -22,7 +22,7 @@ __all__ = ('CalculationTools',)
 class CalculationTools(object):
     """Base class for CalculationTools."""
 
-    # pylint: disable=too-few-public-methods,useless-object-inheritance
+    # pylint: disable=too-few-public-methods
 
     def __init__(self, node):
         self._node = node

--- a/aiida/tools/data/orbital/orbital.py
+++ b/aiida/tools/data/orbital/orbital.py
@@ -83,7 +83,7 @@ def validate_len3_list_or_none(value):
     return validate_len3_list(value)
 
 
-class Orbital(object):  # pylint: disable=useless-object-inheritance
+class Orbital(object):
     """
     Base class for Orbitals. Can handle certain basic fields, their setting
     and validation. More complex Orbital objects should then inherit from

--- a/aiida/tools/data/structure/__init__.py
+++ b/aiida/tools/data/structure/__init__.py
@@ -186,7 +186,7 @@ def xyz_parser_iterator(xyz_string):
     :param xyz_string: a string containing XYZ-structured text
     """
 
-    class BlockIterator(object):  # pylint: disable=useless-object-inheritance
+    class BlockIterator(object):
         """
         An iterator for wrapping the iterator returned by `match.finditer`
         to extract the required fields directly from the match object

--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Export a zip-file."""
-# pylint: disable=useless-object-inheritance,missing-docstring,redefined-builtin
+# pylint: disable=missing-docstring,redefined-builtin
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -338,16 +338,18 @@ def _add_graphviz_edge(graph, in_node, out_node, style=None):
 class Graph(object):
     """a class to create graphviz graphs of the AiiDA node provenance"""
 
-    def __init__(self,
-                 engine=None,
-                 graph_attr=None,
-                 global_node_style=None,
-                 global_edge_style=None,
-                 include_sublabels=True,
-                 link_style_fn=None,
-                 node_style_fn=None,
-                 node_sublabel_fn=None,
-                 node_id_type="pk"):
+    def __init__(
+        self,
+        engine=None,
+        graph_attr=None,
+        global_node_style=None,
+        global_edge_style=None,
+        include_sublabels=True,
+        link_style_fn=None,
+        node_style_fn=None,
+        node_sublabel_fn=None,
+        node_id_type='pk'
+    ):
         """a class to create graphviz graphs of the AiiDA node provenance
 
         Nodes and edges, are cached, so that they are only created once

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -338,20 +338,16 @@ def _add_graphviz_edge(graph, in_node, out_node, style=None):
 class Graph(object):
     """a class to create graphviz graphs of the AiiDA node provenance"""
 
-    # pylint: disable=useless-object-inheritance
-
-    def __init__(
-        self,
-        engine=None,
-        graph_attr=None,
-        global_node_style=None,
-        global_edge_style=None,
-        include_sublabels=True,
-        link_style_fn=None,
-        node_style_fn=None,
-        node_sublabel_fn=None,
-        node_id_type='pk'
-    ):
+    def __init__(self,
+                 engine=None,
+                 graph_attr=None,
+                 global_node_style=None,
+                 global_edge_style=None,
+                 include_sublabels=True,
+                 link_style_fn=None,
+                 node_style_fn=None,
+                 node_sublabel_fn=None,
+                 node_id_type="pk"):
         """a class to create graphviz graphs of the AiiDA node provenance
 
         Nodes and edges, are cached, so that they are only created once

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -47,7 +47,7 @@ class Transport(object):
     Abstract class for a generic transport (ssh, local, ...)
     Contains the set of minimal methods
     """
-    # pylint: disable=too-many-public-methods,useless-object-inheritance,bad-option-value
+    # pylint: disable=too-many-public-methods
 
     # To be defined in the subclass
     # See the ssh or local plugin to see the format


### PR DESCRIPTION
Add `useless-object-inheritance` to the global pylint disable list and
remove all instances of it being suppressed in aiida-core.