### PR TITLE
Rework export archive extraction

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_export.py
+++ b/aiida/backends/tests/cmdline/commands/test_export.py
@@ -212,21 +212,6 @@ class TestVerdiExport(AiidaTestCase):
             finally:
                 delete_temporary_file(filename_output)
 
-    def test_migrate_tar_gz(self):
-        """Test that -F/--archive-format option can be used to write a tar.gz instead."""
-        filename_input = get_archive_file(self.penultimate_archive, filepath=self.fixture_archive)
-        filename_output = next(tempfile._get_candidate_names())  # pylint: disable=protected-access
-
-        for option in ['-F', '--archive-format']:
-            try:
-                options = [option, 'tar.gz', filename_input, filename_output]
-                result = self.cli_runner.invoke(cmd_export.migrate, options)
-                self.assertIsNone(result.exception, result.output)
-                self.assertTrue(os.path.isfile(filename_output))
-                self.assertTrue(tarfile.is_tarfile(filename_output))
-            finally:
-                delete_temporary_file(filename_output)
-
     def test_inspect(self):
         """Test the functionality of `verdi export inspect`."""
         archives = []

--- a/aiida/backends/tests/cmdline/commands/test_import.py
+++ b/aiida/backends/tests/cmdline/commands/test_import.py
@@ -71,20 +71,19 @@ class TestVerdiImport(AiidaTestCase):
         """Test import for archive folder from disk"""
         import os
 
-        from aiida.common.folders import SandboxFolder
-        from aiida.tools.importexport.common.archive import extract_zip
+        from aiida.tools.importexport import Archive
 
-        archive = get_archive_file(self.newest_archive, filepath=self.archive_path)
+        archive_filepath = get_archive_file(self.newest_archive, filepath=self.archive_path)
 
-        with SandboxFolder() as temp_dir:
-            extract_zip(archive, temp_dir, silent=True)
+        with Archive(archive_filepath, silent=True) as archive:
+            archive.unpack()
 
-            # Make sure the JSON files and the nodes subfolder was correctly extracted,
+            # Make sure the JSON files and the nodes subfolder exists and are correctly extracted,
             # then try to import it by passing the extracted folder to `verdi import`.
             for name in {'metadata.json', 'data.json', 'nodes'}:
-                self.assertTrue(os.path.exists(os.path.join(temp_dir.abspath, name)))
+                self.assertTrue(os.path.exists(os.path.join(archive.folder.abspath, name)))
 
-            result = self.cli_runner.invoke(cmd_import.cmd_import, [temp_dir.abspath])
+            result = self.cli_runner.invoke(cmd_import.cmd_import, [archive.folder.abspath])
 
             self.assertIsNone(result.exception, msg=result.output)
             self.assertEqual(result.exit_code, 0, msg=result.output)

--- a/aiida/backends/tests/tools/importexport/common/test_archive.py
+++ b/aiida/backends/tests/tools/importexport/common/test_archive.py
@@ -10,9 +10,8 @@
 """Tests for the Archive class."""
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common.exceptions import InvalidOperation
 from aiida.backends.tests.utils.archives import get_archive_file
-from aiida.tools.importexport import Archive, CorruptArchive
+from aiida.tools.importexport import CorruptArchive, InvalidArchiveOperation, Archive
 
 
 class TestCommonArchive(AiidaTestCase):
@@ -20,7 +19,7 @@ class TestCommonArchive(AiidaTestCase):
 
     def test_context_required(self):
         """Verify that accessing a property of an Archive outside of a context manager raises."""
-        with self.assertRaises(InvalidOperation):
+        with self.assertRaises(InvalidArchiveOperation):
             filepath = get_archive_file('export_v0.1_simple.aiida', filepath='export/migrate')
             archive = Archive(filepath)
             archive.version_format  # pylint: disable=pointless-statement

--- a/aiida/backends/tests/tools/importexport/test_specific_import.py
+++ b/aiida/backends/tests/tools/importexport/test_specific_import.py
@@ -267,7 +267,6 @@ class TestSpecificImport(AiidaTestCase):
             'Unable to find the repository folder for Node with UUID={}'.format(node_uuid), str(exc.exception)
         )
 
-    @unittest.skip('Reenable when issue #3199 is solve (PR #3242): Fix `extract_tree`')
     @with_temp_dir
     def test_empty_repo_folder_export(self, temp_dir):
         """Check a Node's empty repository folder is exported properly"""

--- a/aiida/backends/tests/tools/importexport/test_specific_import.py
+++ b/aiida/backends/tests/tools/importexport/test_specific_import.py
@@ -13,8 +13,6 @@ import os
 import shutil
 import tempfile
 
-import unittest
-
 import numpy as np
 
 from aiida import orm

--- a/aiida/backends/tests/utils/archives.py
+++ b/aiida/backends/tests/utils/archives.py
@@ -10,14 +10,8 @@
 """Test utility to import, inspect, or migrate AiiDA export archives."""
 
 import os
-import io
-import tarfile
-import zipfile
 
-from aiida.common import json
-from aiida.common.exceptions import NotExistent
-from aiida.tools.importexport.common.archive import extract_tar, extract_zip
-from aiida.common.folders import SandboxFolder
+from aiida.tools.importexport.common.archive import Archive
 
 
 def get_archive_file(archive, filepath=None, external_module=None):
@@ -83,82 +77,15 @@ def import_archive(archive, filepath=None, external_module=None):
     import_data(dirpath_archive, silent=True)
 
 
-def get_json_files(archive, silent=True, filepath=None, external_module=None):
-    """Get metadata.json and data.json from an exported AiiDA archive
+class NoContextArchive(Archive):
+    """Test class for :py:class:`aiida.tools.importexport.common.archive.Archive` that breaks rule of context"""
 
-    :param archive: the relative filename of the archive
-    :param silent: Whether or not the extraction should be silent
-    :param filepath: str of directories of where to find archive (starting "/"s are irrelevant)
-    :param external_module: string with name of external module, where archive can be found
-    """
-    # Get archive
-    dirpath_archive = get_archive_file(archive, filepath=filepath, external_module=external_module)
+    def __init__(self, filepath='_test_filename.aiida', metadata=None, data=None, unpacked=True, **kwargs):
+        super(NoContextArchive, self).__init__(filepath, **kwargs)
+        self._silent = True
+        self._meta_data = metadata
+        self._data = data
+        self._unpacked = unpacked
 
-    # Unpack archive
-    with SandboxFolder(sandbox_in_repo=False) as folder:
-        if zipfile.is_zipfile(dirpath_archive):
-            extract_zip(dirpath_archive, folder, silent=silent)
-        elif tarfile.is_tarfile(dirpath_archive):
-            extract_tar(dirpath_archive, folder, silent=silent)
-        else:
-            raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
-
-        try:
-            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
-                data = json.load(fhandle)
-            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
-                metadata = json.load(fhandle)
-        except IOError:
-            raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
-
-    # Return metadata.json and data.json
-    return metadata, data
-
-
-def migrate_archive(input_file, output_file, silent=True):
-    """Migrate contents using `migrate_recursively`
-    This is essentially similar to `verdi export migrate`.
-    However, since this command may be disabled, this function simulates it and keeps the tests working.
-
-    :param input_file: filename with full path for archive to be migrated
-    :param output_file: filename with full path for archive to be created after migration
-    """
-    from aiida.tools.importexport.migration import migrate_recursively
-
-    # Unpack archive, migrate, and re-pack archive
-    with SandboxFolder(sandbox_in_repo=False) as folder:
-        if zipfile.is_zipfile(input_file):
-            extract_zip(input_file, folder, silent=silent)
-        elif tarfile.is_tarfile(input_file):
-            extract_tar(input_file, folder, silent=silent)
-        else:
-            raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
-
-        try:
-            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
-                data = json.load(fhandle)
-            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
-                metadata = json.load(fhandle)
-        except IOError:
-            raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
-
-        # Migrate
-        migrate_recursively(metadata, data, folder)
-
-        # Write json files
-        with io.open(folder.get_abs_path('data.json'), 'wb') as fhandle:
-            json.dump(data, fhandle, indent=4)
-
-        with io.open(folder.get_abs_path('metadata.json'), 'wb') as fhandle:
-            json.dump(metadata, fhandle, indent=4)
-
-        # Pack archive
-        compression = zipfile.ZIP_DEFLATED
-        with zipfile.ZipFile(output_file, mode='w', compression=compression, allowZip64=True) as archive:
-            src = folder.abspath
-            for dirpath, dirnames, filenames in os.walk(src):
-                relpath = os.path.relpath(dirpath, src)
-                for filename in dirnames + filenames:
-                    real_src = os.path.join(dirpath, filename)
-                    real_dest = os.path.join(relpath, filename)
-                    archive.write(real_src, real_dest)
+    def _ensure_within_context(self):
+        """Do not raise if not within context"""

--- a/aiida/tools/importexport/__init__.py
+++ b/aiida/tools/importexport/__init__.py
@@ -19,5 +19,6 @@ Tests: <tree>/aiida/backends/tests/test_export_and_import.py
 from .dbexport import *
 from .dbimport import *
 from .common import *
+from .migration import *
 
-__all__ = (dbexport.__all__ + dbimport.__all__ + common.__all__)
+__all__ = (dbexport.__all__ + dbimport.__all__ + common.__all__ + migration.__all__)

--- a/aiida/tools/importexport/common/archive.py
+++ b/aiida/tools/importexport/common/archive.py
@@ -18,15 +18,32 @@ import zipfile
 from wrapt import decorator
 
 from aiida.common import json
-from aiida.common.exceptions import InvalidOperation
 from aiida.common.folders import SandboxFolder
 from aiida.tools.importexport.common.config import NODES_EXPORT_SUBFOLDER
-from aiida.tools.importexport.common.exceptions import CorruptArchive
+from aiida.tools.importexport.common.exceptions import CorruptArchive, InvalidArchiveOperation
 
-__all__ = ('Archive', 'extract_zip', 'extract_tar', 'extract_tree')
+__all__ = ('Archive', 'extract_zip', 'extract_tar')
 
 FILENAME_DATA = 'data.json'
 FILENAME_METADATA = 'metadata.json'
+JSON_FILES = [FILENAME_DATA, FILENAME_METADATA]
+
+
+@decorator
+def ensure_within_context(wrapped, instance, args, kwargs):
+    """Decorator to ensure that the instance is called within a context manager."""
+    if instance:
+        instance._ensure_within_context()  # pylint: disable=protected-access
+    return wrapped(*args, **kwargs)
+
+
+@decorator
+def ensure_unpacked(wrapped, instance, args, kwargs):
+    """Decorator to ensure that the archive is unpacked before entering the decorated function."""
+    if instance and not instance.unpacked:
+        instance.unpack()
+
+    return wrapped(*args, **kwargs)
 
 
 class Archive:
@@ -40,15 +57,21 @@ class Archive:
             archive.version
 
     """
+    MANDATORY_DATA_KEYS = {'node_attributes', 'node_extras', 'export_data', 'links_uuid', 'groups_uuid'}
+    MANDATORY_METADATA_KEYS = {'aiida_version', 'export_version', 'all_fields_info', 'unique_identifiers'}
 
-    def __init__(self, filepath, silent=True, sandbox_in_repo=True):
+    def __init__(self, filepath, output_filepath=None, overwrite=False, silent=True, sandbox_in_repo=True):
         self._filepath = filepath
+        self._output_filepath = output_filepath
+        self._overwrite = overwrite
         self._silent = silent
         self._sandbox_in_repo = sandbox_in_repo
         self._folder = None
         self._unpacked = False
+        self._keep = False
         self._data = None
         self._meta_data = None
+        self._archive_format = None
 
     def __enter__(self):
         """Instantiate a SandboxFolder into which the archive can be lazily unpacked."""
@@ -56,36 +79,31 @@ class Archive:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        """Clean the sandbox folder if it was instatiated."""
-        if self.folder and isinstance(self.folder, SandboxFolder):
+        """Clean the sandbox folder if it was instantiated."""
+        if not self.keep and self.folder:
             self.folder.erase()
 
-    @decorator
-    def ensure_within_context(wrapped, instance, args, kwargs):  # pylint: disable=no-self-argument
-        """Decorator to ensure that the instance is called within a context manager."""
-        if instance and not instance.folder:
-            raise InvalidOperation('the Archive class should be used within a context')
-
-        return wrapped(*args, **kwargs)  # pylint: disable=not-callable
-
-    @decorator
-    def ensure_unpacked(wrapped, instance, args, kwargs):  # pylint: disable=no-self-argument
-        """Decorator to ensure that the archive is unpacked before entering the decorated function."""
-        if instance and not instance.unpacked:
-            instance.unpack()
-
-        return wrapped(*args, **kwargs)  # pylint: disable=not-callable
+    def _ensure_within_context(self):
+        """Overridable function that processes decorator ``@ensure_within_context``"""
+        if not self.folder:
+            raise InvalidArchiveOperation('the Archive class should be used within a context')
 
     @ensure_within_context
     def unpack(self):
         """Unpack the archive and store the contents in a sandbox."""
         try:
+            self._archive_format = 'zip'
             if os.path.isdir(self.filepath):
-                self._folder = extract_tree(self.filepath, self.folder)
+                self._redirect_archive_folder()
+                # Update self.folder to be a Folder()
+                # Since we are now dealing with source data, we do not want to delete the folder upon exit.
+                # self._folder = get_tree(self.filepath)
+                self._keep = True
             elif tarfile.is_tarfile(self.filepath):
                 extract_tar(
                     self.filepath, self.folder, silent=self.silent, nodes_export_subfolder=NODES_EXPORT_SUBFOLDER
                 )
+                self._archive_format = 'tar'
             elif zipfile.is_zipfile(self.filepath):
                 extract_zip(
                     self.filepath, self.folder, silent=self.silent, nodes_export_subfolder=NODES_EXPORT_SUBFOLDER
@@ -100,6 +118,75 @@ class Archive:
 
         self._unpacked = True
 
+    @ensure_unpacked
+    @ensure_within_context
+    def repack(self, output_filepath=None, overwrite=None):
+        """Repack the archive.
+
+        Set new filepath name for repacked archive (if requested), write current data and meta_data dictionaries
+        to folder.
+
+        :param output_filepath: the filename
+        :type output_filepath: str
+        :param overwrite: whether or not to overwrite output_filepath, if it already exists
+        :type overwrite: bool
+        """
+        import six
+
+        if overwrite is None:
+            overwrite = self.overwrite
+
+        # Try to create an output_filepath automatically (based on time and date), if none has been specified
+        if not output_filepath and not self.output_filepath:
+            self._output_filepath = self._new_output_filename(overwrite)
+        elif output_filepath and isinstance(output_filepath, six.string_types):
+            self._output_filepath = output_filepath
+
+        if os.path.exists(self.output_filepath) and not overwrite:
+            raise InvalidArchiveOperation('output file for repacking already exists')
+
+        self._write_json_file(FILENAME_DATA, self.data)
+        self._write_json_file(FILENAME_METADATA, self.meta_data)
+
+        if self.archive_format == 'tar':
+            with tarfile.open(self.output_filepath, 'w:gz', format=tarfile.PAX_FORMAT, dereference=True) as out_file:
+                out_file.add(self.folder.abspath, arcname='')
+        elif self.archive_format == 'zip':
+            with zipfile.ZipFile(
+                self.output_filepath, mode='w', compression=zipfile.ZIP_DEFLATED, allowZip64=True
+            ) as out_file:
+                for dirpath, dirnames, filenames in os.walk(self.folder.abspath):
+                    relpath = os.path.relpath(dirpath, self.folder.abspath)
+                    for filename in dirnames + filenames:
+                        real_src = os.path.join(dirpath, filename)
+                        real_dest = os.path.join(relpath, filename)
+                        out_file.write(real_src, real_dest)
+        else:
+            raise InvalidArchiveOperation('archive_format must be set prior to exit, when Archive should be kept')
+
+    def _new_output_filename(self, overwrite):
+        """Create and return new filename based on self.filepath to repack into.
+
+        :param overwrite: whether or not to overwrite existing file, if necessary.
+        :type overwrite: bool
+        """
+        from aiida.common import timezone
+
+        filepath_split = os.path.basename(self.filepath).split('.')
+        unique_name = timezone.localtime(timezone.now()).strftime('%Y%m%d-%H%M%S')
+        new_filename = '.'.join([
+            '{}_migrated-{}'.format('.'.join(filepath_split[:-1]), unique_name), filepath_split[-1]
+        ])
+        i = 0
+        while os.path.exists(new_filename) and not overwrite:
+            i += 1
+            basename = new_filename.split('.')
+            new_filename = '.'.join([basename[0] + '_{}'.format(i), basename[1]])
+            if i == 100:
+                raise InvalidArchiveOperation('an output file for repacking cannot be created')
+
+        return new_filename
+
     @property
     def filepath(self):
         """Return the filepath of the archive
@@ -109,17 +196,54 @@ class Archive:
         return self._filepath
 
     @property
+    def output_filepath(self):
+        """Return the filepath of where the archive should be repacked
+
+        :return: the archive output filepath
+        """
+        return self._output_filepath
+
+    @property
+    def overwrite(self):
+        """Return whether repacking should be overwrite a possible existing file."""
+        return self._overwrite
+
+    @property
     def silent(self):
         """Return whether unpacking should be done silently."""
         return self._silent
 
+    @silent.setter
+    def silent(self, value=True):
+        """Set silent."""
+        if not isinstance(value, bool):
+            raise TypeError('silent must be a boolean')
+        self._silent = value
+
     @property
     def folder(self):
-        """Return the sandbox folder
+        """Return the folder
 
-        :return: sandbox folder :class:`aiida.common.folders.SandboxFolder`
+        :return: folder
+        :rtype: :py:class:`~aiida.common.folders.SandboxFolder`, :py:class:`~aiida.common.folders.Folder`
         """
         return self._folder
+
+    @property
+    @ensure_unpacked
+    def archive_format(self):
+        """Return the archive format
+
+        :return: format of filepath
+        :rtype: str
+        """
+        return self._archive_format
+
+    @property
+    @ensure_within_context
+    def keep(self):
+        """Return whether to keep the archive upon exit."""
+        return self._keep
 
     @property
     @ensure_within_context
@@ -173,8 +297,8 @@ class Archive:
 
         :return: a dictionary with basic details
         """
-        export_data = self.data.get('export_data', {})
-        links_data = self.data.get('links_uuid', {})
+        export_data = self.read_data('export_data')
+        links_data = self.read_data('links_uuid')
 
         computers = export_data.get('Computer', {})
         groups = export_data.get('Group', {})
@@ -198,7 +322,7 @@ class Archive:
 
         :return: version number
         """
-        return self.meta_data['aiida_version']
+        return self.read_meta_data('aiida_version')
 
     @property
     @ensure_within_context
@@ -207,7 +331,7 @@ class Archive:
 
         :return: version number
         """
-        return self.meta_data['export_version']
+        return self.read_meta_data('export_version')
 
     @property
     @ensure_within_context
@@ -216,10 +340,7 @@ class Archive:
 
         :return: list of conversion notifications
         """
-        try:
-            return self.meta_data['conversion_info']
-        except KeyError:
-            return None
+        return self.read_meta_data('conversion_info')
 
     @ensure_within_context
     @ensure_unpacked
@@ -228,12 +349,103 @@ class Archive:
 
         :param filename: the filename relative to the sandbox folder
         :return: a dictionary with the loaded JSON content
+
+        :raises ~aiida.tools.importexport.common.exceptions.CorruptArchive: if there was an error reading the JSON file
         """
         try:
             with io.open(self.folder.get_abs_path(filename), 'r', encoding='utf8') as fhandle:
                 return json.load(fhandle)
         except OSError as error:
             raise CorruptArchive('Error reading {}: {}'.format(filename, error))
+
+    @ensure_within_context
+    @ensure_unpacked
+    def _read_json_file_content(self, json_filename, key):
+        """Return value in JSON file
+
+        :param json_filename: Valid archive JSON file name.
+        :type json_filename: str
+        :param key: Key matching the value to be returned.
+        :type key: str
+
+        :return: Value of key in JSON file
+        :rtype: dict, str, list
+
+        :raises ~aiida.tools.importexport.common.exceptions.CorruptArchive: if the key cannot be found in JSON file
+        """
+        if json_filename == FILENAME_DATA:
+            json_file = self.data
+            mandatory_keys = self.MANDATORY_DATA_KEYS
+        elif json_filename == FILENAME_METADATA:
+            json_file = self.meta_data
+            mandatory_keys = self.MANDATORY_METADATA_KEYS
+        else:
+            raise CorruptArchive('{} is not a valid archive JSON file'.format(json_file))
+
+        if key in json_file:
+            return json_file[key]
+        if key not in mandatory_keys:
+            return {}
+        # else
+        raise CorruptArchive('{} is missing the mandatory key "{}"'.format(json_filename, key))
+
+    @ensure_within_context
+    def read_data(self, key):
+        """Return value in data.json
+
+        :param key: Key matching the value to be returned
+        :type key: str
+        """
+        return self._read_json_file_content(FILENAME_DATA, key)
+
+    @ensure_within_context
+    def read_meta_data(self, key):
+        """Return value in metadata.json
+
+        :param key: Key matching the value to be returned
+        :type key: str
+        """
+        return self._read_json_file_content(FILENAME_METADATA, key)
+
+    @ensure_within_context
+    @ensure_unpacked
+    def _write_json_file(self, filename, data):
+        """Write the contents of a dictionary to a JSON file in the unpacked archive.
+
+        :param filename: the filename relative to the sandbox folder
+        :type filename: str
+        :param data: the data to be written to a JSON file
+        :type data: dict
+
+        :raises ~aiida.tools.importexport.common.exceptions.CorruptArchive: if there was an error writing the JSON file
+        """
+        try:
+            with io.open(self.folder.get_abs_path(filename), 'wb') as fhandle:
+                json.dump(data, fhandle)
+
+            self._keep = True
+        except OSError as error:
+            raise CorruptArchive('Error writing {}: {}'.format(filename, error))
+
+    @ensure_within_context
+    def _redirect_archive_folder(self):
+        """Return new Folder, pointing to path, which will not erase path upon exit.
+
+        Erase SandboxFolder, if it was instantiated (it shouldn't have been).
+        Redirect self.folder to point at self.filepath, since this is should be a valid unpacked archive.
+        Before this, however, do a superficial check of the folder's contents.
+        """
+        from aiida.common.folders import Folder
+
+        if self.folder and isinstance(self.folder, SandboxFolder):
+            self.folder.erase()
+
+        # Make sure necessary top-level files and folder exists in the filepath
+        for required_file_or_folder in JSON_FILES + [NODES_EXPORT_SUBFOLDER]:
+            if not os.path.exists(os.path.join(self.filepath, required_file_or_folder)):
+                raise CorruptArchive('required file or folder `{}` is not included'.format(required_file_or_folder))
+
+        self._folder = Folder(self.filepath)
 
 
 def extract_zip(infile, folder, nodes_export_subfolder=None, silent=False):
@@ -257,8 +469,6 @@ def extract_zip(infile, folder, nodes_export_subfolder=None, silent=False):
         incorrect formats
     """
     # pylint: disable=fixme
-    json_files = [FILENAME_DATA, FILENAME_METADATA]
-
     if not silent:
         print('READING DATA AND METADATA...')
 
@@ -274,7 +484,7 @@ def extract_zip(infile, folder, nodes_export_subfolder=None, silent=False):
             if not handle.infolist():
                 raise CorruptArchive('no files detected')
 
-            for json_file in json_files:
+            for json_file in JSON_FILES:
                 try:
                     handle.extract(path=folder.abspath, member=json_file)
                 except KeyError:
@@ -315,8 +525,6 @@ def extract_tar(infile, folder, nodes_export_subfolder=None, silent=False):
         incorrect formats
     """
     # pylint: disable=fixme
-    json_files = [FILENAME_DATA, FILENAME_METADATA]
-
     if not silent:
         print('READING DATA AND METADATA...')
 
@@ -329,7 +537,7 @@ def extract_tar(infile, folder, nodes_export_subfolder=None, silent=False):
     try:
         with tarfile.open(infile, 'r:*', format=tarfile.PAX_FORMAT) as handle:
 
-            for json_file in json_files:
+            for json_file in JSON_FILES:
                 try:
                     handle.extract(path=folder.abspath, member=handle.getmember(json_file))
                 except KeyError:
@@ -356,29 +564,3 @@ def extract_tar(infile, folder, nodes_export_subfolder=None, silent=False):
                 handle.extract(path=folder.abspath, member=member)
     except tarfile.ReadError:
         raise ValueError('The input file format for import is not valid (not a compressed tar file)')
-
-
-def extract_tree(infile, folder):
-    """Prepare to import nodes from plain file system tree by copying in the given sandbox folder.
-
-    .. note:: the contents of the unpacked archive directory are copied into the sandbox folder, because the files will
-        anyway hav to be copied to the repository at some point. By copying the contents of the source directory now
-        and continuing operation only on the sandbox folder, we do not risk to modify the source files accidentally.
-        During import then, the node files from the sandbox can be moved to the repository, so they won't have to be
-        copied again in any case.
-
-    :param infile: absolute filepath point to the unpacked archive directory
-    :type infile: str
-
-    :param folder: a temporary folder to which the archive contents are copied
-    :type folder: :py:class:`~aiida.common.folders.SandboxFolder`
-    """
-    json_files = [FILENAME_DATA, FILENAME_METADATA]
-
-    # Make sure necessary JSON files exist
-    for json_file in json_files:
-        if not os.path.exists(os.path.join(infile, json_file)):
-            raise CorruptArchive('required file `{}` is not included'.format(json_file))
-
-    folder.replace_with_folder(infile, move=False, overwrite=True)
-    return folder

--- a/aiida/tools/importexport/common/exceptions.py
+++ b/aiida/tools/importexport/common/exceptions.py
@@ -17,8 +17,9 @@ from aiida.common.exceptions import AiidaException
 
 __all__ = (
     'ExportImportException', 'ArchiveExportError', 'ArchiveImportError', 'IncompatibleArchiveVersionError',
-    'InvalidArchiveOperation', 'CorruptArchive', 'ExportValidationError', 'ImportUniquenessError',
-    'ImportValidationError', 'ArchiveMigrationError', 'MigrationValidationError', 'DanglingLinkError'
+    'CorruptArchive', 'InvalidArchiveOperation', 'ArchiveOperationError', 'ExportValidationError',
+    'ImportUniquenessError', 'ImportValidationError', 'ArchiveMigrationError', 'MigrationValidationError',
+    'DanglingLinkError'
 )
 
 
@@ -38,12 +39,17 @@ class IncompatibleArchiveVersionError(ExportImportException):
     """Raised when trying to import an export archive with an incompatible schema version."""
 
 
+class CorruptArchive(ExportImportException):
+    """Raised when an operation is applied to a corrupt export archive, e.g. missing files or invalid formats."""
+
+
 class InvalidArchiveOperation(ExportImportException):
     """Invalid operation in the class :py:class`~aiida.tools.importexport.common.archive.Archive`"""
 
 
-class CorruptArchive(ExportImportException):
-    """Raised when an operation is applied to a corrupt export archive, e.g. missing files or invalid formats."""
+class ArchiveOperationError(InvalidArchiveOperation):
+    """Operation error (e.g., OSError or IOError)
+    in the class :py:class`~aiida.tools.importexport.common.archive.Archive`"""
 
 
 class ExportValidationError(ArchiveExportError):

--- a/aiida/tools/importexport/common/exceptions.py
+++ b/aiida/tools/importexport/common/exceptions.py
@@ -16,9 +16,9 @@ Note: In order to not override the built-in `ImportError`, both `ImportError` an
 from aiida.common.exceptions import AiidaException
 
 __all__ = (
-    'ExportImportException', 'ArchiveExportError', 'ArchiveImportError', 'CorruptArchive',
-    'IncompatibleArchiveVersionError', 'ExportValidationError', 'ImportUniquenessError', 'ImportValidationError',
-    'ArchiveMigrationError', 'MigrationValidationError', 'DanglingLinkError'
+    'ExportImportException', 'ArchiveExportError', 'ArchiveImportError', 'IncompatibleArchiveVersionError',
+    'InvalidArchiveOperation', 'CorruptArchive', 'ExportValidationError', 'ImportUniquenessError',
+    'ImportValidationError', 'ArchiveMigrationError', 'MigrationValidationError', 'DanglingLinkError'
 )
 
 
@@ -34,12 +34,16 @@ class ArchiveImportError(ExportImportException):
     """Base class for all AiiDA import exceptions."""
 
 
-class CorruptArchive(ExportImportException):
-    """Raised when an operation is applied to a corrupt export archive, e.g. missing files or invalid formats."""
-
-
 class IncompatibleArchiveVersionError(ExportImportException):
     """Raised when trying to import an export archive with an incompatible schema version."""
+
+
+class InvalidArchiveOperation(ExportImportException):
+    """Invalid operation in the class :py:class`~aiida.tools.importexport.common.archive.Archive`"""
+
+
+class CorruptArchive(ExportImportException):
+    """Raised when an operation is applied to a corrupt export archive, e.g. missing files or invalid formats."""
 
 
 class ExportValidationError(ArchiveExportError):

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -120,7 +120,7 @@ def import_data_dj(
     # The sandbox has to remain open until the end
     with SandboxFolder() as folder:
         if os.path.isdir(in_path):
-            extract_tree(in_path, folder)
+            folder = extract_tree(in_path)
         else:
             if tarfile.is_tarfile(in_path):
                 extract_tar(in_path, folder, silent=silent, nodes_export_subfolder=NODES_EXPORT_SUBFOLDER)
@@ -392,8 +392,13 @@ def import_data_dj(
                             )
                         destdir = RepositoryFolder(section=Repository._section_name, uuid=import_entry_uuid)
                         # Replace the folder, possibly destroying existing previous folders, and move the files
-                        # (faster if we are on the same filesystem, and in any case the source is a SandboxFolder)
-                        destdir.replace_with_folder(subfolder.abspath, move=True, overwrite=True)
+                        # (faster if we are on the same filesystem, and in any case the source is a SandboxFolder
+                        # - for extract_tar and extract_zip).
+                        # If extract_tree, do not move, i.e. do not destroy the source.
+                        if issubclass(subfolder.__class__, SandboxFolder):
+                            destdir.replace_with_folder(subfolder.abspath, move=True, overwrite=True)
+                        else:
+                            destdir.replace_with_folder(subfolder.abspath, move=False, overwrite=True)
 
                         # For DbNodes, we also have to store its attributes
                         if not silent:

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -126,7 +126,7 @@ def import_data_sqla(
     # The sandbox has to remain open until the end
     with SandboxFolder() as folder:
         if os.path.isdir(in_path):
-            extract_tree(in_path, folder)
+            folder = extract_tree(in_path)
         else:
             if tarfile.is_tarfile(in_path):
                 extract_tar(in_path, folder, silent=silent, nodes_export_subfolder=NODES_EXPORT_SUBFOLDER)
@@ -473,8 +473,13 @@ def import_data_sqla(
                             )
                         destdir = RepositoryFolder(section=Repository._section_name, uuid=import_entry_uuid)
                         # Replace the folder, possibly destroying existing previous folders, and move the files
-                        # (faster if we are on the same filesystem, and in any case the source is a SandboxFolder)
-                        destdir.replace_with_folder(subfolder.abspath, move=True, overwrite=True)
+                        # (faster if we are on the same filesystem, and in any case the source is a SandboxFolder
+                        # - for extract_tar and extract_zip)
+                        # If extract_tree, do not move, i.e. do not destroy the source.
+                        if issubclass(subfolder.__class__, SandboxFolder):
+                            destdir.replace_with_folder(subfolder.abspath, move=True, overwrite=True)
+                        else:
+                            destdir.replace_with_folder(subfolder.abspath, move=False, overwrite=True)
 
                         # For Nodes, we also have to store Attributes!
                         # Get attributes from import file

--- a/aiida/tools/importexport/migration/__init__.py
+++ b/aiida/tools/importexport/migration/__init__.py
@@ -42,7 +42,7 @@ def migrate_recursively(archive):
     :param archive: The export archive to be migrated.
     :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
     """
-    from aiida.tools.importexport import EXPORT_VERSION as newest_version
+    from aiida.tools.importexport.common.config import EXPORT_VERSION as newest_version
 
     old_version = archive.version_format
 
@@ -82,19 +82,17 @@ def migrate_archive(source, output=None, overwrite=False, silent=False):
     :rtype: dict
     """
     import os
-    from aiida.tools.importexport import Archive
+    from aiida.tools.importexport.common.archive import Archive
 
     if output and os.path.exists(output) and not overwrite:
         raise exceptions.MigrationValidationError('The output file already exists')
 
     try:
-        with Archive(
-            source, output_filepath=output, overwrite=overwrite, silent=silent, sandbox_in_repo=False
-        ) as archive:
+        with Archive(source, silent=silent) as archive:
             old_version = archive.version_format
             new_version = migrate_recursively(archive)
 
-            archive.repack()
+            archive.repack(output_filepath=output, overwrite=overwrite)
     except Exception as why:
         raise exceptions.ArchiveMigrationError(why)
 

--- a/aiida/tools/importexport/migration/utils.py
+++ b/aiida/tools/importexport/migration/utils.py
@@ -9,31 +9,23 @@
 ###########################################################################
 """Utility functions for migration of export-files."""
 
-from aiida.tools.importexport.common import exceptions
 
+def verify_archive_version(archive_version, version):
+    """Utility function to verify that the archive has the correct version number.
 
-def verify_metadata_version(metadata, version=None):
-    """Utility function to verify that the metadata has the correct version number.
-
-    If no version number is passed, it will just extract the version number and return it.
-
-    :param metadata: the content of an export archive metadata.json file
-    :param version: string version number that the metadata is expected to have
+    :param archive_version: the version from an export archive metadata.json file
+    :type archive_version: str
+    :param version: version number that the archive is expected to have
+    :type version: str
     """
-    try:
-        metadata_version = metadata['export_version']
-    except KeyError:
-        raise exceptions.ArchiveMigrationError("metadata is missing the 'export_version' key")
+    from aiida.tools.importexport.common.exceptions import MigrationValidationError
 
-    if version is None:
-        return metadata_version
-
-    if metadata_version != version:
-        raise exceptions.MigrationValidationError(
-            'expected export file with version {} but found version {}'.format(version, metadata_version)
+    if not isinstance(archive_version, str) or not isinstance(version, str):
+        raise MigrationValidationError('Only strings are accepted for "verify_archive_version"')
+    if archive_version != version:
+        raise MigrationValidationError(
+            'expected export file with version {} but found version {}'.format(version, archive_version)
         )
-
-    return None
 
 
 def update_metadata(metadata, version):
@@ -50,7 +42,6 @@ def update_metadata(metadata, version):
     conversion_message = 'Converted from version {} to {} with AiiDA v{}'.format(old_version, version, get_version())
     conversion_info.append(conversion_message)
 
-    metadata['aiida_version'] = get_version()
     metadata['export_version'] = version
     metadata['conversion_info'] = conversion_info
 

--- a/aiida/tools/importexport/migration/v01_to_v02.py
+++ b/aiida/tools/importexport/migration/v01_to_v02.py
@@ -10,16 +10,16 @@
 """Migration from v0.1 to v0.2, used by `verdi export migrate` command."""
 # pylint: disable=unused-argument
 
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata
 
 
-def migrate_v1_to_v2(metadata, data, *args):
-    """
-    Migration of export files from v0.1 to v0.2, which means generalizing the
-    field names with respect to the database backend
+def migrate_v1_to_v2(archive):
+    """Migration of export files from v0.1 to v0.2
 
-    :param metadata: the content of an export archive metadata.json file
-    :param data: the content of an export archive data.json file
+    Which means generalizing the field names with respect to the database backend.
+
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
     """
     old_version = '0.1'
     new_version = '0.2'
@@ -27,7 +27,10 @@ def migrate_v1_to_v2(metadata, data, *args):
     old_start = 'aiida.djsite'
     new_start = 'aiida.backends.djsite'
 
-    verify_metadata_version(metadata, old_version)
+    metadata = archive.meta_data
+    data = archive.data
+
+    verify_archive_version(archive.version_format, old_version)
     update_metadata(metadata, new_version)
 
     def get_new_string(old_string):

--- a/aiida/tools/importexport/migration/v02_to_v03.py
+++ b/aiida/tools/importexport/migration/v02_to_v03.py
@@ -13,17 +13,17 @@
 import enum
 
 from aiida.tools.importexport.common.exceptions import DanglingLinkError
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata
 
 
-def migrate_v2_to_v3(metadata, data, *args):
-    """
-    Migration of export files from v0.2 to v0.3, which means adding the link
-    types to the link entries and making the entity key names backend agnostic
+def migrate_v2_to_v3(archive):
+    """Migration of export files from v0.2 to v0.3
+
+    Which means adding the link types to the link entries and making the entity key names backend agnostic
     by effectively removing the prefix 'aiida.backends.djsite.db.models'
 
-    :param data: the content of an export archive data.json file
-    :param metadata: the content of an export archive metadata.json file
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
     """
 
     old_version = '0.2'
@@ -56,7 +56,10 @@ def migrate_v2_to_v3(metadata, data, *args):
         'aiida.backends.djsite.db.models.DbAttribute': 'Attribute'
     }
 
-    verify_metadata_version(metadata, old_version)
+    metadata = archive.meta_data
+    data = archive.data
+
+    verify_archive_version(archive.version_format, old_version)
     update_metadata(metadata, new_version)
 
     # Create a mapping from node uuid to node type

--- a/aiida/tools/importexport/migration/v03_to_v04.py
+++ b/aiida/tools/importexport/migration/v03_to_v04.py
@@ -30,7 +30,7 @@ import os
 import numpy as np
 
 from aiida.cmdline.utils import echo
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata, remove_fields
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata, remove_fields
 
 
 def migration_base_data_plugin_type_string(data):
@@ -431,18 +431,23 @@ def add_extras(data):
     data.update({'node_extras': node_extras, 'node_extras_conversion': node_extras_conversion})
 
 
-def migrate_v3_to_v4(metadata, data, folder, *args):  # pylint: disable=unused-argument
-    """
-    Migration of export files from v0.3 to v0.4
+def migrate_v3_to_v4(archive):
+    """Migration of export files from v0.3 to v0.4
 
     Note concerning migration 0032 - REV. 1.0.32:
     Remove legacy workflow tables: DbWorkflow, DbWorkflowData, DbWorkflowStep
     These were (according to Antimo Marrazzo) never exported.
+
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
     """
     old_version = '0.3'
     new_version = '0.4'
 
-    verify_metadata_version(metadata, old_version)
+    metadata = archive.meta_data
+    data = archive.data
+
+    verify_archive_version(archive.version_format, old_version)
     update_metadata(metadata, new_version)
 
     # Apply migrations in correct sequential order
@@ -456,7 +461,7 @@ def migrate_v3_to_v4(metadata, data, folder, *args):  # pylint: disable=unused-a
     migration_dbgroup_type_string_change_content(data)
     migration_calc_job_option_attribute_keys(data)
     migration_move_data_within_node_module(data)
-    migration_trajectory_symbols_to_attribute(data, folder)
+    migration_trajectory_symbols_to_attribute(data, archive.folder)
     migration_remove_node_prefix(data)
     migration_rename_parameter_data_to_dict(data)
     migration_dbnode_type_to_dbnode_node_type(metadata, data)

--- a/aiida/tools/importexport/migration/v04_to_v05.py
+++ b/aiida/tools/importexport/migration/v04_to_v05.py
@@ -25,7 +25,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 """
 # pylint: disable=invalid-name
 
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata, remove_fields
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata, remove_fields
 
 
 def migration_drop_node_columns_nodeversion_public(metadata, data):
@@ -48,16 +48,21 @@ def migration_drop_computer_transport_params(metadata, data):
     remove_fields(metadata, data, [entity], [field])
 
 
-def migrate_v4_to_v5(metadata, data, *args):  # pylint: disable=unused-argument
-    """
-    Migration of export files from v0.4 to v0.5
+def migrate_v4_to_v5(archive):
+    """Migration of export files from v0.4 to v0.5
 
-    This is from migration 0034 (drop_node_columns_nodeversion_public) and onwards
+    This is from migration 0034 (drop_node_columns_nodeversion_public) and onwards.
+
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
     """
     old_version = '0.4'
     new_version = '0.5'
 
-    verify_metadata_version(metadata, old_version)
+    metadata = archive.meta_data
+    data = archive.data
+
+    verify_archive_version(archive.version_format, old_version)
     update_metadata(metadata, new_version)
 
     # Apply migrations

--- a/aiida/tools/importexport/migration/v05_to_v06.py
+++ b/aiida/tools/importexport/migration/v05_to_v06.py
@@ -25,7 +25,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 """
 # pylint: disable=invalid-name
 
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata
 
 
 def migrate_deserialized_datetime(data, conversion):
@@ -131,13 +131,19 @@ def migration_migrate_legacy_job_calculation_data(data):
             values['process_label'] = 'Legacy JobCalculation'
 
 
-def migrate_v5_to_v6(metadata, data, *args):  # pylint: disable=unused-argument
-    """Migration of export files from v0.5 to v0.6"""
+def migrate_v5_to_v6(archive):
+    """Migration of export files from v0.5 to v0.6
+
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
+    """
     old_version = '0.5'
     new_version = '0.6'
 
-    verify_metadata_version(metadata, old_version)
-    update_metadata(metadata, new_version)
+    data = archive.data
+
+    verify_archive_version(archive.version_format, old_version)
+    update_metadata(archive.meta_data, new_version)
 
     # Apply migrations
     migration_serialize_datetime_objects(data)

--- a/aiida/tools/importexport/migration/v06_to_v07.py
+++ b/aiida/tools/importexport/migration/v06_to_v07.py
@@ -25,7 +25,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 """
 # pylint: disable=invalid-name
 
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata
 
 
 def migration_data_migration_legacy_process_attributes(data):
@@ -112,14 +112,20 @@ def remove_attribute_link_metadata(metadata):
             metadata[dictionary].pop(entity, None)
 
 
-def migrate_v6_to_v7(metadata, data, *args):  # pylint: disable=unused-argument
-    """Migration of export files from v0.6 to v0.7"""
+def migrate_v6_to_v7(archive):
+    """Migration of export files from v0.6 to v0.7
+
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
+    """
     old_version = '0.6'
     new_version = '0.7'
 
-    verify_metadata_version(metadata, old_version)
+    metadata = archive.meta_data
+
+    verify_archive_version(archive.version_format, old_version)
     update_metadata(metadata, new_version)
 
     # Apply migrations
-    migration_data_migration_legacy_process_attributes(data)
+    migration_data_migration_legacy_process_attributes(archive.data)
     remove_attribute_link_metadata(metadata)

--- a/aiida/tools/importexport/migration/v07_to_v08.py
+++ b/aiida/tools/importexport/migration/v07_to_v08.py
@@ -25,7 +25,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 """
 # pylint: disable=invalid-name
 
-from aiida.tools.importexport.migration.utils import verify_metadata_version, update_metadata
+from aiida.tools.importexport.migration.utils import verify_archive_version, update_metadata
 
 
 def migration_default_link_label(data):
@@ -38,12 +38,19 @@ def migration_default_link_label(data):
             link['label'] = 'result'
 
 
-def migrate_v7_to_v8(metadata, data, *args):  # pylint: disable=unused-argument
-    """Migration of export files from v0.7 to v0.8."""
+def migrate_v7_to_v8(archive):
+    """Migration of export files from v0.7 to v0.8.
+
+    :param archive: The export archive to be migrated.
+    :type archive: :py:class:`~aiida.tools.importexport.common.archive.Archive`
+    """
     old_version = '0.7'
     new_version = '0.8'
 
-    verify_metadata_version(metadata, old_version)
+    data = archive.data
+    metadata = archive.meta_data
+
+    verify_archive_version(archive.version_format, old_version)
     update_metadata(metadata, new_version)
 
     # Apply migrations


### PR DESCRIPTION
Fixes #3199 
Fixes #3193 (since `Archive` is now utilized)

The function `extract_tree` now returns a `Folder` object, pointing to
the archive folder, which should not automatically erase the folder
after import.

The difference between the functions `extract_zip`, `extract_tar` and `extract_tree` now, is that `extract_zip` and `extract_tar` unpacks the compressed files to a `SandboxFolder` under `.aiida/repository/<AiiDA user>/sandbox` (or similar), and then uses the files from there to whatever purpose and finally erases the extracted files (and folders) again.

`extract_tree` will instead return a `Folder` object (parent class of `SandboxFolder`), which points to the "original" folder/tree - the source.
This can potentially create some problems, since one can use `extract_tree` to get a `Folder` object and then use the `erase` method to remove the only known instance of the data.
This may be remedied by copying the contents of the specified path for `extract_tree` to a temporary `SandboxFolder` (as is essentially done when unpacking the zip or tar files) and then exclusively operate on the `SandboxFolder`. The problem, however, with this is the extra space this will take up for large archives/folders/trees. Therefore, I have chosen the solution of pointing to the "original" folder/tree, making sure `erase` is not called upon `__exit__`. The caveat being that I could have missed a specific call to `erase` somewhere, however, this does not seem to be the case - according to the tests :)

**Update**
`extract_tree` is now `get_tree` and all extraction functions have had their uses cut down to a single place; the `Archive` class. This class will henceforth be used in import/export to deal with export archives. I believe this was also @sphuber's original intent for this class(?)

*To do*
~- [ ] Thoroughly introduce `Archive` to the export function~ No need.
- [x] Update migrations to rely on `Archive`
- [x] Move some code from `verdi export migrate` to the `aiida.tools.importexport.migration` module
- [x] Update all tests to use either `Archive` or the extraction functions directly, where it may be needed
- [x] Consider updating test utility functions to use `Archive`