### PR TITLE
Move auto import group outside django transaction

### DIFF
--- a/aiida/backends/tests/tools/importexport/orm/test_groups.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_groups.py
@@ -215,5 +215,29 @@ class TestGroups(AiidaTestCase):
         )
         imported_group = load_group(builder.all()[0][0])
         self.assertEqual(imported_group.uuid, group_uuid)
+        self.assertEqual(
+            imported_group.count(),
+            len(node_uuids),
+            msg='{} Nodes were found in the automatic import group, instead there should have been exactly {} '
+            'Nodes'.format(imported_group.count(), len(node_uuids))
+        )
+        for node in imported_group.nodes:
+            self.assertIn(node.uuid, node_uuids)
+
+        # Import again, using a new Group, and make sure the automatic import Group also captures "existing" Nodes
+        group_label = 'existing_import'
+        group = orm.Group(label=group_label)
+        group_uuid = group.uuid
+
+        import_data(filename, group=group, silent=True)
+
+        imported_group = load_group(label=group_label)
+        self.assertEqual(imported_group.uuid, group_uuid)
+        self.assertEqual(
+            imported_group.count(),
+            len(node_uuids),
+            msg='{} Nodes were found in the automatic import group, instead there should have been exactly {} '
+            'Nodes'.format(imported_group.count(), len(node_uuids))
+        )
         for node in imported_group.nodes:
             self.assertIn(node.uuid, node_uuids)

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -665,6 +665,7 @@ def import_data_sqla(
 
             ######################################################
             # Put everything in a specific group
+            ######################################################
             existing = existing_entries.get(NODE_ENTITY_NAME, {})
             existing_pk = [foreign_ids_reverse_mappings[NODE_ENTITY_NAME][v['uuid']] for v in six.itervalues(existing)]
             new = new_entries.get(NODE_ENTITY_NAME, {})


### PR DESCRIPTION
Fixes #3245 

The creation of the automatic import group for the Django backend did
not include newly created/imported Nodes.
By moving this (final) action outside the `with transaction.atomic()`
block, all Nodes are correctly included.

This was not caught by the tests, because while the node UUIDs that
should be present in the Group were checked, the Group.nodes generator
was used. If there are no Nodes in the group, it simply yields nothing,
i.e. nothing essentially fails. Now the Group.count() function is used
to make sure there is the correct number of Nodes in the Group.