### PR TITLE
Docs: update the "Developing plugin system" section

### DIFF
--- a/docs/source/developer_guide/core/plugin_system.rst
+++ b/docs/source/developer_guide/core/plugin_system.rst
@@ -1,8 +1,7 @@
-Developing The Plugin System
+Developing the plugin system
 ============================
 
-.. note:: this page is intended for people wanting to contribute to
-   the plugin system in ``aiida-core`` and is not needed for people who just want to contribute a plugin.
+.. note:: this page is intended for people wanting to contribute to the plugin system in ``aiida-core`` and is not needed for people who just want to contribute a plugin.
 
 Design Principles
 +++++++++++++++++
@@ -11,11 +10,11 @@ Design Principles
 
 2. Avoid schema changes whenever reasonably possible;
 
-3. Finding and loading plugins must be as fast as the plugin allows, especially for command-line ("cli") commands. In other words, directly importing a plugin class should not be noticeably faster than using the plugin loader/factory;
+3. Finding and loading plugins must be as fast as the plugin allows, especially for command line interface (CLI) commands. In other words, directly importing a plugin class should not be noticeably faster than using the plugin loader/factory;
 
 4. Implement as a drop-in replacement, provide backwards compatibility at first, think about changing interfaces if/when the old system is dropped;
 
-5. plugin management should be as user friendly from ipython as from the cli.
+5. Plugin management should be as user friendly from ipython as from the CLI.
 
 Mini-Spec
 +++++++++
@@ -40,13 +39,17 @@ Terms
    A name given to each area extensible via plugins, one of
 
    * calculations
+   * cmdline.computer.configure
+   * cmdline.data
    * data
    * parsers
    * schedulers
    * transports
-   * workflows
+   * tools.calculations
+   * tools.data.orbitals
    * tools.dbexporters
    * tools.dbimporters
+   * workflows
 
    Each category maps to an entry point group called::
 
@@ -55,14 +58,13 @@ Terms
 Interfaces
 ----------
 
-Pluginloader (aiida/plugins/entry_point.py)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Pluginloader
+^^^^^^^^^^^^
+The plugin loading functionality is defined in :py:mod:`aiida.plugins.entry_point` and relies on the `reentry PyPI package <https://github.com/dropd/reentry>`_ to find and load entry points.
+The ``reentry`` package is part of the build requirements of ``aiida-core`` as defined in the ``pyproject.toml`` file.
+This enables the scanning for existing plugins when AiiDA is installed.
+If for some reason ``reentry`` is uninstalled or is not found, the plugin system will fall back on ``pkg_resources`` from setuptools, which is slower.
 
-The plugin loader relies on the `reentry PyPI package <https://github.com/dropd/reentry>`_ to find and load entry points. ``reentry`` has been added to setup_requires for AiiDA in order to enable scanning for existing plugins when AiiDA is installed. If for some reason ``reentry`` is uninstalled or is not found, the plugin system will fall back on ``pkg_resources`` from setuptools, which is slower.
-
-The API docs are found at the following link: :py:mod:`aiida.plugins.entry_point`.
-
-Registry Tools (aiida/plugins)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+Registry Tools
+^^^^^^^^^^^^^^
 See the API documentation in :py:mod:`aiida.plugins`.


### PR DESCRIPTION
Fixes #3179 

Note that the very last part of the section references the "registry tools" in the `aiida.plugins` module. What this refers to specifically are the `entry.py`, `registry.py` and `info.py` modules. These were apparently originally designed by @DropD to directly interact with the AiiDA registry from the CLI or shell. Note however, that this is dead code as none of it is actually used or tested. I would therefore be in favor of removing the code. When the time arrives where we need a custom plugin manager we can always implement what is needed