### PR TITLE
Always show Comment mode

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_import.py
+++ b/aiida/backends/tests/cmdline/commands/test_import.py
@@ -149,20 +149,15 @@ class TestVerdiImport(AiidaTestCase):
         self.assertFalse(group.is_empty, msg='The Group should not be empty.')
 
     def test_comment_mode(self):
-        """Test comment mode flag works as intended"""
+        """Test toggling comment mode flag"""
         archives = [get_archive_file(self.newest_archive, filepath=self.archive_path)]
 
-        options = ['--comment-mode', 'newest'] + archives
-        result = self.cli_runner.invoke(cmd_import.cmd_import, options)
-        self.assertIsNone(result.exception, result.output)
-        self.assertIn('Comment mode: newest', result.output)
-        self.assertEqual(result.exit_code, 0, result.output)
-
-        options = ['--comment-mode', 'overwrite'] + archives
-        result = self.cli_runner.invoke(cmd_import.cmd_import, options)
-        self.assertIsNone(result.exception, result.output)
-        self.assertIn('Comment mode: overwrite', result.output)
-        self.assertEqual(result.exit_code, 0, result.output)
+        for mode in {'newest', 'overwrite'}:
+            options = ['--comment-mode', mode] + archives
+            result = self.cli_runner.invoke(cmd_import.cmd_import, options)
+            self.assertIsNone(result.exception, result.output)
+            self.assertIn('Comment mode: {}'.format(mode), result.output)
+            self.assertEqual(result.exit_code, 0, result.output)
 
     def test_import_old_local_archives(self):
         """ Test import of old local archives

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -288,10 +288,9 @@ def import_data_dj(
                     else:
                         new_entries[model_name] = data['export_data'][model_name].copy()
 
-            # Show Comment mode if not silent and Comments exist in existing_entries
+            # Show Comment mode if not silent
             if not silent:
-                if COMMENT_ENTITY_NAME in existing_entries:
-                    print('Comment mode: {}'.format(comment_mode))
+                print('Comment mode: {}'.format(comment_mode))
 
             # I import data from the given model
             for model_name in model_order:

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -380,10 +380,9 @@ def import_data_sqla(
                         # Why the copy:
                         new_entries[entity_name] = data['export_data'][entity_name].copy()
 
-            # Show Comment mode if not silent and Comments exist in existing_entries
+            # Show Comment mode if not silent
             if not silent:
-                if COMMENT_ENTITY_NAME in existing_entries:
-                    print('Comment mode: {}'.format(comment_mode))
+                print('Comment mode: {}'.format(comment_mode))
 
             # I import data from the given model
             for entity_sig in entity_sig_order:


### PR DESCRIPTION
It is only relevant to show what the Comment mode is for imports, when
importing a Comment that already exists in the database (i.e. the UUIDs
are the same).

In order to properly test the comment mode flags for `verdi import`, an
archive with a Comment is needed.