### PR TITLE
Add `--all` option to `verdi process play/pause`

### DIFF
--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -386,6 +386,12 @@ TIMEOUT = OverridableOption(
     help='Time in seconds to wait for a response before timing out.'
 )
 
+WAIT = OverridableOption(
+    '--wait/--no-wait',
+    default=False,
+    help='Wait for the action to be completed otherwise return as soon as it is scheduled.'
+)
+
 FORMULA_MODE = OverridableOption(
     '-f',
     '--formula-mode',
@@ -400,7 +406,7 @@ TRAJECTORY_INDEX = OverridableOption(
     'trajectory_index',
     type=click.INT,
     default=None,
-    help='Specific step of the Trajecotry to select.'
+    help='Specific step of the Trajectory to select.'
 )
 
 WITH_ELEMENTS = OverridableOption(


### PR DESCRIPTION
Fixes #2904

For the `play` command, passing this option will play all paused
processes unless specific processes are passed as arguments. Likewise,
for the `pause` command all "active" processes will be paused, meaning
any process with state `CREATED`, `RUNNING` or `WAITING`.