### PR TITLE
Fix for pymatgen dependency (monty) with Py2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install --upgrade pip wheel setuptools coveralls
     - pip install "numpy==1.16.4"  # see https://github.com/materialsproject/pymatgen/issues/1520
+    - pip install "monty==2.0.4"  # see https://github.com/materialsvirtuallab/monty/issues/49
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -37,6 +37,7 @@ itsdangerous==1.1.0
 kiwipy[rmq]==0.5.1
 marshmallow-sqlalchemy==0.16.0
 mock==2.0.0
+monty==2.0.4
 numpy==1.16.4
 paramiko==2.6.0
 passlib==1.7.1

--- a/setup.json
+++ b/setup.json
@@ -86,6 +86,7 @@
     ],
     "atomic_tools": [
       "spglib==1.12.2.post0",
+      "monty==2.0.4",
       "pymatgen<=2018.12.12",
       "ase==3.17.0",
       "PyMySQL==0.9.3",


### PR DESCRIPTION
Fixes #3263

Tests on Travis fails for Py2.7 due to the monty "sub"-dependency in the
pymatgen-2018.12.12 package.
The issue seems to be with monty-2.0.5, so the version for `aiida-core`
will be fixed to monty-2.0.4.