### PR TITLE
update instructions for generating ssh keys

### DIFF
--- a/docs/source/get_started/computers.rst
+++ b/docs/source/get_started/computers.rst
@@ -38,7 +38,10 @@ login from your user to the cluster. To do so type first (only if you do not
 already have some keys in your local ``~/.ssh`` directory - i.e. files like
 ``id_rsa.pub``)::
 
-    ssh-keygen -t rsa
+    ssh-keygen -t rsa -b 4096 -m PEM
+
+.. note:: The ``-m PEM`` flag is necessary in newer versions of OpenSSL that switched to a different key format by default.
+   As of 2019-08, the paramiko library used by AiiDA `only supports the PEM format <https://github.com/paramiko/paramiko/issues/340>`_.
 
 Then copy your keys to the remote computer (in ~/.ssh/authorized_keys) with::
 


### PR DESCRIPTION
closes #3279 

AiiDA relies on paramiko for SSH connections, which - so far - only
works with SSH keys in the older "PEM" format.

Recently, the type of key generated on MacOS with
```
ssh-keygen -t rsa
```
changed from PEM to openssh, and the
[corresponding keys no longer work with paramiko](https://github.com/paramiko/paramiko/issues/340#issuecomment-492448662)
(what is doubly confusing is that key will work just fine if you use
`ssh` directly).

Changing the line in the AiiDA documentation from
```
ssh-keygen -t rsa
```

to
```
ssh-keygen -t rsa -b 4096 -m PEM
```
solves the issue.