### PR TITLE
Allow to construct `SinglefileData` nodes from binary files

### DIFF
--- a/aiida/backends/tests/orm/data/test_singlefile.py
+++ b/aiida/backends/tests/orm/data/test_singlefile.py
@@ -107,3 +107,29 @@ class TestSinglefileData(AiidaTestCase):
 
         self.assertEqual(content_stored, content_original)
         self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])
+
+    def test_binary_file(self):
+        """Test that the constructor accepts binary files."""
+        byte_array = [120, 3, 255, 0, 100]
+        content_binary = bytearray(byte_array)
+
+        with tempfile.NamedTemporaryFile(mode='wb+') as handle:
+            basename = os.path.basename(handle.name)
+            handle.write(bytearray(content_binary))
+            handle.flush()
+            handle.seek(0)
+            node = SinglefileData(handle.name)
+
+        with node.open(mode='rb') as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_binary)
+        self.assertEqual(node.list_object_names(), [basename])
+
+        node.store()
+
+        with node.open(mode='rb') as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_binary)
+        self.assertEqual(node.list_object_names(), [basename])

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -99,7 +99,7 @@ class SinglefileData(Data):
         if is_filelike:
             self.put_object_from_filelike(file, key, mode='wb')
         else:
-            self.put_object_from_file(file, key)
+            self.put_object_from_file(file, key, mode='wb')
 
         # Delete any other existing objects (minus the current `key` which was already removed from the list)
         for existing_key in existing_object_names:

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -179,13 +179,14 @@ class Repository(object):
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
+        # pylint: disable=unused-argument
         if not force:
             self.validate_mutability()
 
         self.validate_object_key(key)
 
-        with io.open(path) as handle:
-            self.put_object_from_filelike(handle, key, mode=mode, encoding=encoding)
+        with io.open(path, mode='rb') as handle:
+            self.put_object_from_filelike(handle, key, mode='wb')
 
     def put_object_from_filelike(self, handle, key, mode='w', encoding='utf8', force=False):
         """Store a new object under `key` with contents of filelike object `handle`.


### PR DESCRIPTION
Fixes #3237 

The `SinglefileData.set_file` method was opening the target file in
non-binary mode with default utf-8 encoding with no way for the user to
override it through the constructor. This would fail when a binary file
was passed. Since the purpose of this operation is just to copy the file
wholesale to the repository this should simply be done in binary mode to
copy the bytes over.