### PR TITLE
Deprecate `mode` and `encoding` of `Repository.put_object_from_file`

### DIFF
--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -99,7 +99,7 @@ class SinglefileData(Data):
         if is_filelike:
             self.put_object_from_filelike(file, key, mode='wb')
         else:
-            self.put_object_from_file(file, key, mode='wb')
+            self.put_object_from_file(file, key)
 
         # Delete any other existing objects (minus the current `key` which was already removed from the list)
         for existing_key in existing_object_names:

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -665,7 +665,7 @@ class Node(Entity):
         """
         self._repository.put_object_from_tree(path, key, contents_only, force)
 
-    def put_object_from_file(self, path, key, mode='w', encoding='utf8', force=False):
+    def put_object_from_file(self, path, key, mode=None, encoding=None, force=False):
         """Store a new object under `key` with contents of the file located at `path` on this file system.
 
         .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
@@ -674,10 +674,28 @@ class Node(Entity):
         :param path: absolute path of file whose contents to copy to the repository
         :param key: fully qualified identifier for the object within the repository
         :param mode: the file mode with which the object will be written
+            Deprecated: will be removed in `v2.0.0`
         :param encoding: the file encoding with which the object will be written
+            Deprecated: will be removed in `v2.0.0`
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
+        # pylint: disable=no-member
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning
+
+        # Note that the defaults of `mode` and `encoding` had to be change to `None` from `w` and `utf-8` resptively, in
+        # order to detect when they were being passed such that the deprecation warning can be emitted. The defaults did
+        # not make sense and so ignoring them is justified, since the side-effect of this function, a file being copied,
+        # will continue working the same.
+        if mode is not None:
+            warnings.warn('the `mode` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning)
+
+        if encoding is not None:
+            warnings.warn(
+                'the `encoding` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning
+            )
+
         self._repository.put_object_from_file(path, key, mode, encoding, force)
 
     def put_object_from_filelike(self, handle, key, mode='w', encoding='utf8', force=False):

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -166,7 +166,7 @@ class Repository(object):
         else:
             folder.insert_path(path)
 
-    def put_object_from_file(self, path, key, mode='w', encoding='utf8', force=False):
+    def put_object_from_file(self, path, key, mode=None, encoding=None, force=False):
         """Store a new object under `key` with contents of the file located at `path` on this file system.
 
         .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
@@ -175,18 +175,35 @@ class Repository(object):
         :param path: absolute path of file whose contents to copy to the repository
         :param key: fully qualified identifier for the object within the repository
         :param mode: the file mode with which the object will be written
+            Deprecated: will be removed in `v2.0.0`
         :param encoding: the file encoding with which the object will be written
+            Deprecated: will be removed in `v2.0.0`
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument,no-member
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning
+
+        # Note that the defaults of `mode` and `encoding` had to be change to `None` from `w` and `utf-8` resptively, in
+        # order to detect when they were being passed such that the deprecation warning can be emitted. The defaults did
+        # not make sense and so ignoring them is justified, since the side-effect of this function, a file being copied,
+        # will continue working the same.
+        if mode is not None:
+            warnings.warn('the `mode` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning)
+
+        if encoding is not None:
+            warnings.warn(
+                'the `encoding` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning
+            )
+
         if not force:
             self.validate_mutability()
 
         self.validate_object_key(key)
 
         with io.open(path, mode='rb') as handle:
-            self.put_object_from_filelike(handle, key, mode='wb')
+            self.put_object_from_filelike(handle, key, mode='wb', encoding=None)
 
     def put_object_from_filelike(self, handle, key, mode='w', encoding='utf8', force=False):
         """Store a new object under `key` with contents of filelike object `handle`.


### PR DESCRIPTION
Fixes #3286 

When copying a file to the repository from a filepath, it does not make
sense to be able to specify the `mode` and `encoding` in which the
target file handle should be opened. It should simply copy over the
bytes and therefore always open in binary mode.

To be able to detect if the arguments are being used, we have to change
the defaults to `None` in order to be able to emit the deprecation
warning. This is justified because despite changing the defaults the
intended side-effect of the method, copying over a file, will be
unchanged in its behavior.