### PR TITLE
Remove obsolete `CalcJob.get_hash`

### DIFF
--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -129,10 +129,6 @@ class CalcJobNode(CalculationNode):
         ]
         return objects
 
-    def get_hash(self, ignore_errors=True, ignored_folder_content=('raw_input',), **kwargs):  # pylint: disable=arguments-differ
-        return super(CalcJobNode, self
-                    ).get_hash(ignore_errors=ignore_errors, ignored_folder_content=ignored_folder_content, **kwargs)
-
     def get_builder_restart(self):
         """Return a `ProcessBuilder` that is ready to relaunch the same `CalcJob` that created this node.
 


### PR DESCRIPTION
Fixes #3312 

This overridden method was necessary originally to add the contents of
the repository to the exclude list when computing the hash. However,
recently in commit 6d4f1ecd8388500c3a0a73767cd32ecc25c25956 this was
added to the base functionality so the overridden behavior is now
identical allowing the method to be removed.