### PR TITLE
Also export empty repository folders (for zip)

### DIFF
--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -140,9 +140,14 @@ class ZipFolder(object):
         if os.path.isdir(src):
             for dirpath, dirnames, filenames in os.walk(src):
                 relpath = os.path.relpath(dirpath, src)
-                for fname in dirnames + filenames:
-                    real_src = os.path.join(dirpath, fname)
-                    real_dest = os.path.join(base_filename, relpath, fname)
+                if not dirnames and not filenames:
+                    real_src = dirpath
+                    real_dest = os.path.join(base_filename, relpath)
                     self._zipfile.write(real_src, real_dest)
+                else:
+                    for fname in dirnames + filenames:
+                        real_src = os.path.join(dirpath, fname)
+                        real_dest = os.path.join(base_filename, relpath, fname)
+                        self._zipfile.write(real_src, real_dest)
         else:
             self._zipfile.write(src, base_filename)


### PR DESCRIPTION
Fixes #3321 

Blocked by PR #3242, since this fixes the issue of the `extract_tree` function, which the new test makes use of.

Edit: The actual fix is not blocked, only the test. I have skipped the new test until PR #3242 has been merged/issue #3199 has been fixed.
It should now be good-to-go.