### PR TITLE
bump pgtest version

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -42,7 +42,7 @@ numpy==1.16.4
 paramiko==2.6.0
 passlib==1.7.1
 pg8000<1.13.0
-pgtest==1.2.0
+pgtest==1.3.1
 pika==1.0.0
 plumpy==0.14.2
 psutil==5.5.1

--- a/setup.json
+++ b/setup.json
@@ -99,7 +99,7 @@
     ],
     "testing": [
       "unittest2==1.1.0; python_version<'3.5'",
-      "pgtest==1.2.0",
+      "pgtest==1.3.1",
       "pg8000<1.13.0",
       "sqlalchemy-diff==0.1.3",
       "coverage==4.5.2",


### PR DESCRIPTION
pgtest <=1.3.0 does not work with postgresql 10 on ubuntu 18.04
https://github.com/jamesnunn/pgtest/issues/9
this is fixed on pgtest 1.3.1