### PR TITLE
Fix the identifier format of the caching configuration file

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -359,7 +359,7 @@ def main():
     else:
         # Launch the same calculations but with caching enabled -- these should be FINISHED immediately
         cached_calcs = []
-        with enable_caching(node_class=CalcJobNode):
+        with enable_caching(identifier='aiida.calculations:templatereplacer'):
             for counter in range(1, number_calculations + 1):
                 inputval = counter
                 calc, expected_result = run_calculation(code=code, counter=counter, inputval=inputval)

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import copy
 import importlib
+import warnings
 import six
 
 from aiida.common import exceptions
@@ -22,6 +23,7 @@ from aiida.common.escaping import sql_string_match
 from aiida.common.hashing import make_hash, _HASH_EXTRA_KEY
 from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
+from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.manage.manager import get_manager
 from aiida.orm.utils.links import LinkManager, LinkTriple
 from aiida.orm.utils.repository import Repository
@@ -680,19 +682,15 @@ class Node(Entity):
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
-        # pylint: disable=no-member
-        import warnings
-        from aiida.common.warnings import AiidaDeprecationWarning
-
         # Note that the defaults of `mode` and `encoding` had to be change to `None` from `w` and `utf-8` resptively, in
         # order to detect when they were being passed such that the deprecation warning can be emitted. The defaults did
         # not make sense and so ignoring them is justified, since the side-effect of this function, a file being copied,
         # will continue working the same.
         if mode is not None:
-            warnings.warn('the `mode` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning)
+            warnings.warn('the `mode` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
 
         if encoding is not None:
-            warnings.warn(
+            warnings.warn(  # pylint: disable=no-member
                 'the `encoding` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning
             )
 
@@ -970,6 +968,11 @@ class Node(Entity):
 
         :parameter with_transaction: if False, do not use a transaction because the caller will already have opened one.
         """
+        if use_cache is not None:
+            warnings.warn(  # pylint: disable=no-member
+                'the `use_cache` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning
+            )
+
         if self.is_stored:
             raise exceptions.ModificationNotAllowed('Node<{}> is already stored'.format(self.id))
 
@@ -979,9 +982,9 @@ class Node(Entity):
 
         for link_triple in self._incoming_cache:
             if not link_triple.node.is_stored:
-                link_triple.node.store(with_transaction=with_transaction, use_cache=use_cache)
+                link_triple.node.store(with_transaction=with_transaction)
 
-        return self.store(with_transaction, use_cache=use_cache)
+        return self.store(with_transaction)
 
     def store(self, with_transaction=True, use_cache=None):
         """Store the node in the database while saving its attributes and repository directory.
@@ -997,6 +1000,11 @@ class Node(Entity):
         # pylint: disable=arguments-differ
         from aiida.manage.caching import get_use_cache
 
+        if use_cache is not None:
+            warnings.warn(  # pylint: disable=no-member
+                'the `use_cache` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning
+            )
+
         if not self._storable:
             raise exceptions.StoringNotAllowed(self._unstorable_message)
 
@@ -1007,9 +1015,8 @@ class Node(Entity):
             # Verify that parents are already stored. Raises if this is not the case.
             self.verify_are_parents_stored()
 
-            # Get default for use_cache if it's not set explicitly.
-            if use_cache is None:
-                use_cache = get_use_cache(type(self))
+            # Determine whether the cache should be used for the process type of this node.
+            use_cache = get_use_cache(identifier=self.process_type)
 
             # Clean the values on the backend node *before* computing the hash in `_get_same_node`. This will allow
             # us to set `clean=False` if we are storing normally, since the values will already have been cleaned

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -300,10 +300,8 @@ def is_valid_entry_point_string(entry_point_string):
     """
     try:
         group, name = entry_point_string.split(ENTRY_POINT_STRING_SEPARATOR)
-    except ValueError:
+    except (TypeError, ValueError):
+        # Either `entry_point_string` is not a string or it does not contain the separator
         return False
 
-    if group in entry_point_group_to_module_path_map:
-        return True
-    else:
-        return False
+    return group in entry_point_group_to_module_path_map

--- a/docs/source/working_with_aiida/caching.rst
+++ b/docs/source/working_with_aiida/caching.rst
@@ -11,7 +11,8 @@ There are numerous reasons why you may need to re-run calculations you’ve alre
 Since AiiDA stores the full provenance of each calculation, it can detect whether a calculation has been run before and reuse its outputs without wasting computational resources.
 This is what we mean by **caching** in AiiDA.
 
-Caching is **not enabled by default**. In order to enable caching for your AiiDA profile (here called ``aiida2``), place the following ``cache_config.yml`` file in your ``.aiida`` configuration folder:
+Caching is **not enabled by default**.
+In order to enable caching for your AiiDA profile (here called ``aiida2``), place the following ``cache_config.yml`` file in your ``.aiida`` configuration folder:
 
 .. code:: yaml
 
@@ -21,8 +22,7 @@ Caching is **not enabled by default**. In order to enable caching for your AiiDA
 From this point onwards, when you launch a new calculation, AiiDA will compare its hash (depending both on the type of calculation and its inputs, see :ref:`caching_matches`) against other calculations already present in your database.
 If another calculation with the same hash is found, AiiDA will reuse its results without repeating the actual calculation.
 
-In order to ensure that the provenance graph with and without caching is the same,
-AiiDA creates both a new calculation node and a copy of the output data nodes as shown in :numref:`fig_caching`.
+In order to ensure that the provenance graph with and without caching is the same, AiiDA creates both a new calculation node and a copy of the output data nodes as shown in :numref:`fig_caching`.
 
 .. _fig_caching:
 .. figure:: include/images/caching.png
@@ -46,14 +46,14 @@ How are nodes hashed?
 ---------------------
 
 *Hashing* is turned on by default, i.e. all nodes in AiiDA are hashed (see also :ref:`devel_controlling_hashing`).
-The hash of a Data node is computed from:
+The hash of a ``Data`` node is computed from:
 
 * all attributes of the node, except the ``_updatable_attributes`` and ``_hash_ignored_attributes``
 * the ``__version__`` of the package which defined the node class
 * the content of the repository folder of the node
 * the UUID of the computer, if the node is associated with one
 
-The hash of a :class:`~aiida.orm.ProcessNode` includes, on top of this, the hashes of any of its input ``Data`` nodes.
+The hash of a :class:`~aiida.orm.ProcessNode` includes, on top of this, the hashes of all of its input ``Data`` nodes.
 
 Once a node is stored in the database, its hash is stored in the ``_aiida_hash`` extra, and this extra is used to find matching nodes.
 If a node of the same class with the same hash already exists in the database, this is considered a cache match.
@@ -101,7 +101,7 @@ Besides an on/off switch per profile, the ``.aiida/cache_config.yml`` provides c
       disabled:
         - aiida.calculations:templatereplacer
 
-In this example, caching is disabled by default, but explicitly enabled for calculaions of the ``PwCalculation`` class, identified by the ``aiida.calculations:quantumespresso.pw`` entry point.
+In this example, caching is disabled by default, but explicitly enabled for calculaions of the ``PwCalculation`` class, identified by the ``aiida.calculations:quantumespresso.pw`` entry point string.
 It also shows how to disable caching for particular calculations (which has no effect here due to the profile-wide default).
 
 Instance level
@@ -111,15 +111,15 @@ Even when caching is turned off for a given calculation type, you can enable it 
 
 .. code:: python
 
-    from aiida.manage.caching import enable_caching
     from aiida.engine import run
-    from aiida.orm import CalcJobNode
-    with enable_caching(entry_point='aiida.calculations:templatereplacer'):
+    from aiida.manage.caching import enable_caching
+    with enable_caching(identifier='aiida.calculations:templatereplacer'):
        run(...)
 
-.. note::
+.. warning::
 
-   This works only with :py:class:`~aiida.engine.run`, not with :py:class:`~aiida.engine.submit`.
+    This affects only the current python interpreter and won't change the behavior of the daemon workers.
+    This means that this technique is only useful when using :py:class:`~aiida.engine.run`, and **not** with :py:class:`~aiida.engine.submit`.
 
 If you suspect a node is being reused in error (e.g. during development), you can also manually *prevent* a specific node from being reused:
 


### PR DESCRIPTION
Fixes #2990 

The old caching configuration file implementation expected the module
path of node sub classes that should be either enabled or disabled for
caching, for example:

    `aiida.orm.node.calculation.job.TemplatereplacerCalculation`

The old caching implementation in the `Node.store` method would
then compare these directives to the node type of the current node being
stored to determine whether it should be considered for caching. This
method broke after the separation of the "process" and "node" concepts.
Since calculation job classes, for example, are now no longer a sub
class of `Node`, but of `Process`, the corresponding node that will be
created will all be `CalcJobNode` instances, regardless of the exact
process sub class. That particular bit of information is stored as its
entry point string in the `process_type` column of the node. For example:

    `aiida.calculations:templatereplacer`

This entry point string is now also the identifier that determines the
caching behavior and should be used in the configuration file.