### PR TITLE
Use iterators for Django migration of `DbLog` entries

### DIFF
--- a/aiida/backends/djsite/db/migrations/0024_dblog_update.py
+++ b/aiida/backends/djsite/db/migrations/0024_dblog_update.py
@@ -140,7 +140,8 @@ def set_new_uuid(apps, _):
     Set new UUIDs for all logs
     """
     DbLog = apps.get_model('db', 'DbLog')
-    for log in DbLog.objects.all():
+    query_set = DbLog.objects.all()
+    for log in query_set.iterator():
         log.uuid = get_new_uuid()
         log.save(update_fields=['uuid'])
 
@@ -254,7 +255,8 @@ def clean_dblog_metadata(apps, _):
     import json
 
     DbLog = apps.get_model('db', 'DbLog')
-    for log in DbLog.objects.all():
+    query_set = DbLog.objects.all()
+    for log in query_set.iterator():
         met = json.loads(log.metadata)
         if 'objpk' in met:
             del met['objpk']
@@ -271,7 +273,8 @@ def enrich_dblog_metadata(apps, _):
     import json
 
     DbLog = apps.get_model('db', 'DbLog')
-    for log in DbLog.objects.all():
+    query_set = DbLog.objects.all()
+    for log in query_set.iterator():
         met = json.loads(log.metadata)
         if 'objpk' not in met:
             met['objpk'] = log.objpk

--- a/aiida/backends/djsite/db/migrations/0032_remove_legacy_workflows.py
+++ b/aiida/backends/djsite/db/migrations/0032_remove_legacy_workflows.py
@@ -65,7 +65,7 @@ def export_workflow_data(apps, _):
     }
 
     with NamedTemporaryFile(
-        prefix='legacy-workflows', suffix='.json', dir='.', delete=delete_on_close, mode='w+'
+        prefix='legacy-workflows', suffix='.json', dir='.', delete=delete_on_close, mode='wb'
     ) as handle:
         filename = handle.name
         json.dump(data, handle)


### PR DESCRIPTION
Fixes #3328 

In migration `0024`, all existing `DbLog` had to be updated and the
implementation used `DbLog.objects.all()`. This loads all entities into
memory causing problems for big databases, with machines running out of
memory and grinding to a halt. Changing to use iterators solves the
problem.