### PR TITLE
Add process description to `verdi plugin list <GROUP> <ENTRY_POINT>`

### DIFF
--- a/aiida/backends/tests/cmdline/utils/test_common.py
+++ b/aiida/backends/tests/cmdline/utils/test_common.py
@@ -76,3 +76,30 @@ class TestCommonUtilities(AiidaTestCase):
         node.logger.warning(warning)
 
         self.assertIn(warning, get_process_function_report(node))
+
+    def test_print_process_info(self):
+        """Test the `print_process_info` method."""
+        from aiida.cmdline.utils.common import print_process_info
+        from aiida.common.utils import Capturing
+        from aiida.engine import Process
+
+        class TestProcessWithoutDocstring(Process):
+            # pylint: disable=missing-docstring
+
+            @classmethod
+            def define(cls, spec):
+                super(TestProcessWithoutDocstring, cls).define(spec)
+                spec.input('some_input')
+
+        class TestProcessWithDocstring(Process):
+            """Some docstring."""
+
+            @classmethod
+            def define(cls, spec):
+                super(TestProcessWithDocstring, cls).define(spec)
+                spec.input('some_input')
+
+        # We are just checking that the command does not except
+        with Capturing():
+            print_process_info(TestProcessWithoutDocstring)
+            print_process_info(TestProcessWithDocstring)

--- a/aiida/cmdline/commands/cmd_plugin.py
+++ b/aiida/cmdline/commands/cmd_plugin.py
@@ -31,7 +31,7 @@ def verdi_plugin():
 def plugin_list(entry_point_group, entry_point):
     """Display a list of all available plugins."""
     from aiida.common import EntryPointError
-    from aiida.cmdline.utils.common import print_process_spec
+    from aiida.cmdline.utils.common import print_process_info
     from aiida.engine import Process
     from aiida.plugins.entry_point import get_entry_point_names, load_entry_point
 
@@ -52,7 +52,7 @@ def plugin_list(entry_point_group, entry_point):
         else:
             try:
                 if issubclass(plugin, Process):
-                    print_process_spec(plugin.spec())
+                    print_process_info(plugin)
                 else:
                     echo.echo(str(plugin.get_description()))
             except (AttributeError, TypeError):

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -375,6 +375,27 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
     return '\n'.join(report)
 
 
+def print_process_info(process):
+    """Print detailed information about a process class and its process specification.
+
+    :param process: a :py:class:`~aiida.engine.processes.process.Process` class
+    """
+    docstring = process.__doc__
+
+    if docstring is not None:
+        docstring = docstring.strip().split('\n')
+
+    if not docstring:
+        docstring = ['No description available']
+
+    click.secho('Description:\n', fg='red', bold=True)
+    for line in docstring:
+        click.echo('\t' + line.lstrip())
+    click.echo()
+
+    print_process_spec(process.spec())
+
+
 def print_process_spec(process_spec):
     """Print the process spec in a human-readable formatted way.
 
@@ -410,7 +431,7 @@ def print_process_spec(process_spec):
     max_width_type = max([len(entry[2]) for entry in inputs + outputs]) + 2
 
     if process_spec.inputs:
-        click.secho('Inputs', fg='red', bold=True)
+        click.secho('Inputs:', fg='red', bold=True)
     for entry in inputs:
         if entry[1] == 'required':
             click.secho(template.format(*entry, width_name=max_width_name, width_type=max_width_type), bold=True)
@@ -418,7 +439,7 @@ def print_process_spec(process_spec):
             click.secho(template.format(*entry, width_name=max_width_name, width_type=max_width_type))
 
     if process_spec.outputs:
-        click.secho('Outputs', fg='red', bold=True)
+        click.secho('Outputs:', fg='red', bold=True)
     for entry in outputs:
         if entry[1] == 'required':
             click.secho(template.format(*entry, width_name=max_width_name, width_type=max_width_type), bold=True)
@@ -426,7 +447,7 @@ def print_process_spec(process_spec):
             click.secho(template.format(*entry, width_name=max_width_name, width_type=max_width_type))
 
     if process_spec.exit_codes:
-        click.secho('Exit codes', fg='red', bold=True)
+        click.secho('Exit codes:', fg='red', bold=True)
     for exit_code in sorted(process_spec.exit_codes.values(), key=lambda exit_code: exit_code.status):
         message = exit_code.message.capitalize()
         click.secho('{:>{width_name}d}:  {}'.format(exit_code.status, message, width_name=max_width_name))


### PR DESCRIPTION
Fixes #3340 

This adds a new section `Description` to the output of `verdi plugin list`
when passing an explicit entry point corresponding to a process class,
the value of which will be based on the docstring. If no docstring is
defined it will display `No description available`.