### PR TITLE
Catch exceptions raised by `aiida.engine.daemon.runner.start_daemon`

### DIFF
--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -63,7 +63,7 @@ def start(foreground, number):
 
     try:
         currenv = get_env_with_venv_bin()
-        subprocess.check_output(command, env=currenv, stderr=subprocess.STDOUT)
+        subprocess.check_output(command, env=currenv, stderr=subprocess.STDOUT)  # pylint: disable=unexpected-keyword-arg
     except subprocess.CalledProcessError as exception:
         click.secho('FAILED', fg='red', bold=True)
         echo.echo_critical(exception.output)
@@ -262,6 +262,10 @@ def start_circus(foreground, number):
             'virtualenv': client.virtualenv,
             'copy_env': True,
             'stdout_stream': {
+                'class': 'FileStream',
+                'filename': client.daemon_log_file,
+            },
+            'stderr_stream': {
                 'class': 'FileStream',
                 'filename': client.daemon_log_file,
             },

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi

--- a/aiida/engine/daemon/runner.py
+++ b/aiida/engine/daemon/runner.py
@@ -23,9 +23,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def start_daemon():
-    """
-    Start a daemon runner for the currently configured profile
-    """
+    """Start a daemon runner for the currently configured profile."""
     daemon_client = get_daemon_client()
     configure_logging(daemon=True, daemon_log_file=daemon_client.daemon_log_file)
 


### PR DESCRIPTION
Fixes #3333 

Exceptions in this call, performed by the Circus daemon when launching a
new daemon worker, were not being caught. This problem would then go
unnoticed as Circus would silently keep reviving the daemon process as
soon as it died due to the uncaught exception. The exception would not
make its way into the daemon log either, so unless one would notice that
the daemon runner pid was changing constantly, it would seem like the
daemon had a worker running even when it was not really. By catching the
exception and echoing it to stdout, it will now show up in the daemon
log file.