### PR TITLE
Pin version requirement of `astroid==2.2.5`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -109,6 +109,8 @@
       "aiida-export-migration-tests==0.7.0"
     ],
     "dev_precommit": [
+      "astroid==1.6.6; python_version<'3.0'",
+      "astroid==2.2.5; python_version>='3.0'",
       "pre-commit==1.17.0",
       "yapf==0.28.0",
       "prospector==1.1.7",


### PR DESCRIPTION
The recently released `astroid==2.3.0` breaks `prospector`.