### PR TITLE
Allow passing directory path in `FolderData` constructor

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -118,6 +118,7 @@ DB_TEST_LIST = {
         'orm.comments': ['aiida.backends.tests.orm.test_comments'],
         'orm.computers': ['aiida.backends.tests.orm.test_computers'],
         'orm.data.dict': ['aiida.backends.tests.orm.data.test_dict'],
+        'orm.data.folder': ['aiida.backends.tests.orm.data.test_folder'],
         'orm.data.kpoints': ['aiida.backends.tests.orm.data.test_kpoints'],
         'orm.data.orbital': ['aiida.backends.tests.orm.data.test_orbital'],
         'orm.data.remote': ['aiida.backends.tests.orm.data.test_remote'],

--- a/aiida/backends/tests/orm/data/test_folder.py
+++ b/aiida/backends/tests/orm/data/test_folder.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the `FolderData` class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import io
+import os
+import shutil
+import tempfile
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm import FolderData
+
+
+class TestFolderData(AiidaTestCase):
+    """Test for the `FolderData` class."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestFolderData, cls).setUpClass(*args, **kwargs)
+        cls.tempdir = tempfile.mkdtemp()
+        cls.tree = {
+            'a.txt': u'Content of file A\nWith some newlines',
+            'b.txt': u'Content of file B without newline',
+        }
+
+        for filename, content in cls.tree.items():
+            with io.open(os.path.join(cls.tempdir, filename), 'w', encoding='utf8') as handle:
+                handle.write(content)
+
+    @classmethod
+    def tearDownClass(cls, *args, **kwargs):
+        shutil.rmtree(cls.tempdir)
+
+    def test_constructor_tree(self):
+        """Test the `tree` constructor keyword."""
+        node = FolderData(tree=self.tempdir)
+        self.assertEqual(sorted(node.list_object_names()), sorted(self.tree.keys()))

--- a/aiida/orm/nodes/data/folder.py
+++ b/aiida/orm/nodes/data/folder.py
@@ -19,3 +19,22 @@ __all__ = ('FolderData',)
 
 class FolderData(Data):
     """`Data` sub class to represent a folder on a file system."""
+
+    def __init__(self, **kwargs):
+        """Construct a new `FolderData` to which any files and folders can be added.
+
+        To add files to a new node use the various repository methods:
+
+            folder = FolderData()
+            folder.put_object_from_tree('/absolute/path/to/directory')
+            folder.put_object_from_filepath('/absolute/path/to/file.txt')
+            folder.put_object_from_filelike(filelike_object)
+
+        Alternatively, in order to simply wrap a directory, the `path` keyword can be used in the constructor:
+
+            folder = FolderData(tree='/absolute/path/to/directory')
+        """
+        tree = kwargs.pop('tree', None)
+        super(FolderData, self).__init__(**kwargs)
+        if tree:
+            self.put_object_from_tree(tree)

--- a/aiida/orm/nodes/data/folder.py
+++ b/aiida/orm/nodes/data/folder.py
@@ -23,16 +23,19 @@ class FolderData(Data):
     def __init__(self, **kwargs):
         """Construct a new `FolderData` to which any files and folders can be added.
 
-        To add files to a new node use the various repository methods:
+        Use the `tree` keyword to simply wrap a directory:
+
+            folder = FolderData(tree='/absolute/path/to/directory')
+
+        Alternatively, one can construct the node first and then use the various repository methods to add objects:
 
             folder = FolderData()
             folder.put_object_from_tree('/absolute/path/to/directory')
             folder.put_object_from_filepath('/absolute/path/to/file.txt')
             folder.put_object_from_filelike(filelike_object)
 
-        Alternatively, in order to simply wrap a directory, the `path` keyword can be used in the constructor:
-
-            folder = FolderData(tree='/absolute/path/to/directory')
+        :param tree: absolute path to a folder to wrap
+        :type tree: str
         """
         tree = kwargs.pop('tree', None)
         super(FolderData, self).__init__(**kwargs)


### PR DESCRIPTION
Fixes #3357 

This will initialize the node and copy over the tree pointed to by the
`tree` keyword argument into the node's repository.