### PR TITLE
Enable auto-completion for `IdentifierParamType`

### DIFF
--- a/aiida/cmdline/params/types/computer.py
+++ b/aiida/cmdline/params/types/computer.py
@@ -13,7 +13,10 @@ Module for the custom click param type computer
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from click.types import StringParamType
+
+from ...utils import decorators
 from .identifier import IdentifierParamType
 
 
@@ -34,6 +37,14 @@ class ComputerParamType(IdentifierParamType):
         """
         from aiida.orm.utils.loaders import ComputerEntityLoader
         return ComputerEntityLoader
+
+    @decorators.with_dbenv()
+    def complete(self, ctx, incomplete):  # pylint: disable=unused-argument
+        """Return possible completions based on an incomplete value.
+
+        :returns: list of tuples of valid entry points (matching incomplete) and a description
+        """
+        return [(option, '') for option, in self.orm_class_loader.get_options(incomplete, project='name')]
 
 
 class ShebangParamType(StringParamType):


### PR DESCRIPTION
Fixes #3361 

The `OrmEntityLoader` class is extended to allow specifying a query
operator in the `get_query_builder` method. This allows the introduction
of the `get_options` method, which unlike `load_entity` will not try to
load one specific entity, but provide a list of possibilities for a
given identifier. This in turn allows the CLI `IdentifierParamType` to
enable auto-completion. Here we only enable it for `LABEL` identifiers
and do not try to infer the identifier type. Finally, the new
functionality is hooked up for the `ComputerParamType`.