### PR TITLE
Pin docs dependency requirement `prompt-toolkit==1.0.16`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -45,6 +45,7 @@ pg8000<1.13.0
 pgtest==1.3.1
 pika==1.0.0
 plumpy==0.14.2
+prompt-toolkit==1.0.16
 psutil==5.5.1
 psycopg2-binary==2.8
 pyblake2==1.1.2; python_version<'3.6'

--- a/setup.json
+++ b/setup.json
@@ -83,6 +83,7 @@
       "docutils==0.14",
       "Jinja2==2.10.1",
       "MarkupSafe==1.1.1",
+      "prompt-toolkit==1.0.16",
       "sphinx-rtd-theme==0.4.3",
       "sphinxcontrib-contentui==0.2.2"
     ],


### PR DESCRIPTION
Fixes #3378 

The just released `1.0.17` breaks the ipython package.