### PR TITLE
Unpin dependency requirement for `prompt-toolkit`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -45,7 +45,6 @@ pg8000<1.13.0
 pgtest==1.3.1
 pika==1.0.0
 plumpy==0.14.2
-prompt-toolkit==1.0.16
 psutil==5.5.1
 psycopg2-binary==2.8
 pyblake2==1.1.2; python_version<'3.6'

--- a/setup.json
+++ b/setup.json
@@ -83,7 +83,6 @@
       "docutils==0.14",
       "Jinja2==2.10.1",
       "MarkupSafe==1.1.1",
-      "prompt-toolkit==1.0.16",
       "sphinx-rtd-theme==0.4.3",
       "sphinxcontrib-contentui==0.2.2"
     ],


### PR DESCRIPTION
New release `1.0.18` fixes the problem with `1.0.17`.