### PR TITLE
Add `export_parameters` to metadata.json in export archives

### DIFF
--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -147,7 +147,7 @@ def export_tree(
 
     all_fields_info, unique_identifiers = get_all_fields_info()
 
-    entities_starting_set = defaultdict(list)
+    entities_starting_set = defaultdict(set)
 
     # The set that contains the nodes ids of the nodes that should be exported
     given_data_entry_ids = set()
@@ -166,17 +166,17 @@ def export_tree(
         # Now a load the backend-independent name into entry_entity_name, e.g. Node!
         # entry_entity_name = schema_to_entity_names(entry_class_string)
         if issubclass(entry.__class__, orm.Group):
-            entities_starting_set[GROUP_ENTITY_NAME].append(entry.uuid)
+            entities_starting_set[GROUP_ENTITY_NAME].add(entry.uuid)
             given_group_entry_ids.add(entry.id)
             given_groups.add(entry)
         elif issubclass(entry.__class__, orm.Node):
-            entities_starting_set[NODE_ENTITY_NAME].append(entry.uuid)
+            entities_starting_set[NODE_ENTITY_NAME].add(entry.uuid)
             if issubclass(entry.__class__, orm.Data):
                 given_data_entry_ids.add(entry.pk)
             elif issubclass(entry.__class__, orm.ProcessNode):
                 given_calculation_entry_ids.add(entry.pk)
         elif issubclass(entry.__class__, orm.Computer):
-            entities_starting_set[COMPUTER_ENTITY_NAME].append(entry.uuid)
+            entities_starting_set[COMPUTER_ENTITY_NAME].add(entry.uuid)
             given_computer_entry_ids.add(entry.pk)
         else:
             raise exceptions.ArchiveExportError(
@@ -186,11 +186,14 @@ def export_tree(
     # Add all the nodes contained within the specified groups
     for group in given_groups:
         for entry in group.nodes:
-            entities_starting_set[NODE_ENTITY_NAME].append(entry.uuid)
+            entities_starting_set[NODE_ENTITY_NAME].add(entry.uuid)
             if issubclass(entry.__class__, orm.Data):
                 given_data_entry_ids.add(entry.pk)
             elif issubclass(entry.__class__, orm.ProcessNode):
                 given_calculation_entry_ids.add(entry.pk)
+
+    for entity, entity_set in entities_starting_set.items():
+        entities_starting_set[entity] = list(entity_set)
 
     # We will iteratively explore the AiiDA graph to find further nodes that
     # should also be exported.

--- a/aiida/tools/importexport/dbexport/utils.py
+++ b/aiida/tools/importexport/dbexport/utils.py
@@ -102,7 +102,7 @@ def fill_in_query(partial_query, originating_entity_str, current_entity_str, tag
         fill_in_query(partial_query, current_entity_str, ref_model_name, new_tag_suffixes)
 
 
-def check_licences(node_licenses, allowed_licenses, forbidden_licenses):
+def check_licenses(node_licenses, allowed_licenses, forbidden_licenses):
     """Check licenses"""
     from aiida.common.exceptions import LicensingException
     from inspect import isfunction
@@ -384,7 +384,7 @@ def retrieve_linked_nodes(process_nodes, data_nodes, **kwargs):  # pylint: disab
     :param call_calc_backward: Follow CALL_CALC links in the backward direction (recursively).
     :param call_work_backward: Follow CALL_WORK links in the backward direction (recursively).
 
-    :return: Set of retrieved Nodes and list of links information.
+    :return: Set of retrieved Nodes, list of links information, and updated dict of LINK_FLAGS.
 
     :raises `~aiida.tools.importexport.common.exceptions.ExportValidationError`: if wrong or too many kwargs are given.
     """
@@ -579,4 +579,4 @@ def retrieve_linked_nodes(process_nodes, data_nodes, **kwargs):  # pylint: disab
                 process_nodes.update(found_nodes - retrieved_nodes)
                 links_uuid_dict.update(links_uuids)
 
-    return retrieved_nodes, list(links_uuid_dict.values())
+    return retrieved_nodes, list(links_uuid_dict.values()), follow_links_rules

--- a/aiida/tools/importexport/dbexport/utils.py
+++ b/aiida/tools/importexport/dbexport/utils.py
@@ -573,4 +573,4 @@ def retrieve_linked_nodes(process_nodes, data_nodes, **kwargs):  # pylint: disab
                 process_nodes.update(found_nodes - retrieved_nodes)
                 links_uuid_dict.update(links_uuids)
 
-    return retrieved_nodes, list(links_uuid_dict.values()), follow_links_rules
+    return retrieved_nodes, list(links_uuid_dict.values()), traversal_rules

--- a/docs/source/import_export/main.rst
+++ b/docs/source/import_export/main.rst
@@ -63,7 +63,7 @@ Let's have a look at the contents of ``metadata.json``:
       "export_version": "0.7",
       "aiida_version": "1.0.0",
       "export_parameters": {
-        "link_follow_rules": {
+        "graph_traversal_rules": {
           "input_calc_forward": false,
           "input_calc_backward": true,
           "create_forward": true,
@@ -77,12 +77,8 @@ Let's have a look at the contents of ``metadata.json``:
           "call_work_forward": true,
           "call_work_backward": false
         },
-        "original_entities": {
+        "entities_starting_set": {
           "Node": ["1024e35e-166b-4104-95f6-c1706df4ce15"]
-        },
-        "license_info": {
-          "allowed_licenses": null,
-          "forbidden_licenses": "Function valid_licenses was used to check for forbidden licenses"
         },
         "include_comments": true,
         "include_logs": false

--- a/docs/source/import_export/main.rst
+++ b/docs/source/import_export/main.rst
@@ -60,8 +60,33 @@ Let's have a look at the contents of ``metadata.json``:
 .. code-block:: json
 
     {
-      "export_version": "0.6",
+      "export_version": "0.7",
       "aiida_version": "1.0.0",
+      "export_parameters": {
+        "link_follow_rules": {
+          "input_calc_forward': False,
+          "input_calc_backward': True,
+          "create_forward': True,
+          "create_backward': True,
+          "return_forward': True,
+          "return_backward': False,
+          "input_work_forward': False,
+          "input_work_backward': True,
+          "call_calc_forward': True,
+          "call_calc_backward': False,
+          "call_work_forward': True,
+          "call_work_backward': False
+        },
+        "original_entities": {
+          "Node": ["1024e35e-166b-4104-95f6-c1706df4ce15"]
+        },
+        "license_info": {
+          "allowed_licenses": None,
+          "forbidden_licenses": "Function valid_licenses was used to check for forbidden licenses"
+        },
+        "include_comments": True,
+        "include_logs": False
+      },
       "unique_identifiers": {
         "Computer": "uuid",
         "Group": "uuid",
@@ -186,10 +211,10 @@ A sample of the ``data.json`` file follows:
     {
       "links_uuid": [
         {
-          "output": "c208c9da-23b4-4c32-8f99-f9141ab28363",
-          "label": "parent_calc_folder",
-          "input": "eaaa114d-3d5b-42eb-a269-cf0e7a3a935d",
-          "type": "inputlink"
+          "output": "1024e35e-166b-4104-95f6-c1706df4ce15",
+          "label": "parameters",
+          "input": "628ba258-ccc1-47bf-bab7-8aee64b563ea",
+          "type": "input_calc"
         }
       ],
       "export_data": {
@@ -248,7 +273,7 @@ A sample of the ``data.json`` file follows:
             "ctime": "2016-08-21T11:56:05.501162",
             "mtime": "2016-08-21T11:56:05.501697",
             "content": "vc-relax calculation with cold smearing",
-            "dbnode": 5921143,
+            "dbnode": 20063,
             "user": 2
           }
         }
@@ -295,13 +320,16 @@ A sample of the ``data.json`` file follows:
             "default_mpiprocs_per_machine": 8
           },
           "remote_workdir": "/scratch/aiida/aiida_run/10/24/e35e-166b-4104-95f6-c1706df4ce15",
-          "state": "FINISHED",
+          "process_state": "finished",
           "max_wallclock_seconds": 900,
           "retrieve_singlefile_list": [],
-          "scheduler_lastchecktime": "2015-10-02T20:30:36.481951",
-          "job_id": "13489"
-        },
-        "6480111": {}
+          "scheduler_lastchecktime": "2015-10-02T20:30:36.481951+00:00",
+          "job_id": "13489",
+          "exit_status": 0,
+          "process_status": null,
+          "process_label": "vc-relax",
+          "sealed": true
+        }
       },
       "node_extras": {
         "5921143": {},

--- a/docs/source/import_export/main.rst
+++ b/docs/source/import_export/main.rst
@@ -64,28 +64,28 @@ Let's have a look at the contents of ``metadata.json``:
       "aiida_version": "1.0.0",
       "export_parameters": {
         "link_follow_rules": {
-          "input_calc_forward': False,
-          "input_calc_backward': True,
-          "create_forward': True,
-          "create_backward': True,
-          "return_forward': True,
-          "return_backward': False,
-          "input_work_forward': False,
-          "input_work_backward': True,
-          "call_calc_forward': True,
-          "call_calc_backward': False,
-          "call_work_forward': True,
-          "call_work_backward': False
+          "input_calc_forward": false,
+          "input_calc_backward": true,
+          "create_forward": true,
+          "create_backward": true,
+          "return_forward": true,
+          "return_backward": false,
+          "input_work_forward": false,
+          "input_work_backward": true,
+          "call_calc_forward": true,
+          "call_calc_backward": false,
+          "call_work_forward": true,
+          "call_work_backward": false
         },
         "original_entities": {
           "Node": ["1024e35e-166b-4104-95f6-c1706df4ce15"]
         },
         "license_info": {
-          "allowed_licenses": None,
+          "allowed_licenses": null,
           "forbidden_licenses": "Function valid_licenses was used to check for forbidden licenses"
         },
-        "include_comments": True,
-        "include_logs": False
+        "include_comments": true,
+        "include_logs": false
       },
       "unique_identifiers": {
         "Computer": "uuid",


### PR DESCRIPTION
Closes #3360 

Current "data structure":
```jsonc
{
  "export_parameters": {
    "link_follow_rules": {
      // Updated dict from config.LINK_FLAGS
    },
    "original_entities": {
      "Node": [
        // UUIDs of originally chosen Nodes that should be exported
      ],
      // Possibly also "Computer": [] and "Group": [].
      // "Node": [] May also be left out, if no Nodes were specified to be exported.
    },
    "licence_info": {
      "allowed_licenses": null, // or a list or, if the parameter was a function, a string, naming the function that was used
      "forbidden_licenses": null // same as for "allowed_licenses"
    },
    "include_comments": true, // reflects the boolean parameter of the same name
    "include_logs": true // reflects the boolean parameter of the same name
  }
}
```


Example, which is also added to the docs:
```jsonc
{
  "export_parameters": {
    "link_follow_rules": {
      "input_calc_forward': False,
      "input_calc_backward': True,
      "create_forward': True,
      "create_backward': True,
      "return_forward': True,
      "return_backward': False,
      "input_work_forward': False,
      "input_work_backward': True,
      "call_calc_forward': True,
      "call_calc_backward': False,
      "call_work_forward': True,
      "call_work_backward': False
    },
    "original_entities": {
      "Node": ["1024e35e-166b-4104-95f6-c1706df4ce15"]
    },
    "license_info": {
      "allowed_licenses": None,
      "forbidden_licenses": "Function valid_licenses was used to check for forbidden licenses"
    },
    "include_comments": True,
    "include_logs": False
  },
  // ...
}  
```