### PR TITLE
Prune input mapping of `ProcessBuilder` before creating `Process`

### DIFF
--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -31,7 +31,7 @@ class ProcessBuilderNamespace(collections.MutableMapping):
     """
 
     def __init__(self, port_namespace):
-        """Dynamically construct the get and set properties for the ports of the given port namespace
+        """Dynamically construct the get and set properties for the ports of the given port namespace.
 
         For each port in the given port namespace a get and set property will be constructed dynamically
         and added to the ProcessBuilderNamespace. The docstring for these properties will be defined
@@ -72,7 +72,7 @@ class ProcessBuilderNamespace(collections.MutableMapping):
             setattr(self.__class__, name, getter)
 
     def __setattr__(self, attr, value):
-        """Set an input value for the given port `attr`.
+        """Assign the given value to the port with key `attr`.
 
         .. note:: Any attributes without a leading underscore being set correspond to inputs and should hence be
             validated with respect to the corresponding input port from the process spec
@@ -147,6 +147,39 @@ class ProcessBuilderNamespace(collections.MutableMapping):
                 self[key].update(value)
             else:
                 self.__setattr__(key, value)
+
+    def _inputs(self, prune=False):
+        """Return the entire mapping of inputs specified for this builder.
+
+        :param prune: boolean, when True, will prune nested namespaces that contain no actual values whatsoever
+        :return: mapping of inputs ports and their input values.
+        """
+        if prune:
+            return self._prune(dict(self))
+
+        return dict(self)
+
+    def _prune(self, value):
+        """Prune a nested mapping from all mappings that are completely empty.
+
+        .. note:: a nested mapping that is completely empty means it contains at most other empty mappings. Other null
+            values, such as `None` or empty lists, should not be pruned.
+
+        :param value: a nested mapping of port values
+        :return: the same mapping but without any nested namespace that is completely empty.
+        """
+        from aiida.orm import Node
+
+        if isinstance(value, collections.Mapping) and not isinstance(value, Node):
+            result = {}
+            for key, sub_value in value.items():
+                pruned = self._prune(sub_value)
+                # If `pruned` is an "empty'ish" mapping and not an instance of `Node`, skip it, otherwise keep it.
+                if not (isinstance(pruned, collections.Mapping) and not pruned and not isinstance(pruned, Node)):
+                    result[key] = pruned
+            return result
+
+        return value
 
 
 class ProcessBuilder(ProcessBuilderNamespace):

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -52,7 +52,7 @@ def instantiate_process(runner, process, *args, **inputs):
     if isinstance(process, ProcessBuilder):
         builder = process
         process_class = builder.process_class
-        inputs.update(**builder)
+        inputs.update(**builder._inputs(prune=True))  # pylint: disable=protected-access
     elif issubclass(process, Process):
         process_class = process
     else:


### PR DESCRIPTION
Fixes #3377 

The validation of a `ProcessSpec` will trigger for a port as soon as a
value has been passed. For a port namespace this is also the case, even
if it contains no actual values. This was a problem when launching a
process from a `ProcessBuilder`. If it contained an optional namespace,
it would always pass at least an empty dictionary for said port, even if
the user did not specify any specific input within it. This would then
always trigger the validation which would fail. This limitation made the
concept of optional port namespaces fundamentally incompatible with the
`ProcessBuilder`. Here we add a method to "prune" the input mapping of a
builder before it is being passed to the process constructor. This will
remove any portnamespace that is completely empty, meaning it contains
no other values other than other empty dictionaries (namespaces).