### PR TITLE
Add test on Travis to check the loading time of `verdi`

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update \
     dvipng \
     dvidvi \
     graphviz \
+    bc \
+    time \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean all
 

--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -18,6 +18,9 @@ case "$TEST_TYPE" in
         ;;
     tests)
 
+        # Test the loading time of `verdi` to ensure the database environment is not loaded
+        "${CI_DIR}/test_verdi_load_time.sh"
+
         # Add the .ci folder to the python path so workchains within it can be found by the daemon
         export PYTHONPATH="${PYTHONPATH}:${CI_DIR}"
 

--- a/.ci/test_verdi_load_time.sh
+++ b/.ci/test_verdi_load_time.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# Test the loading time of `verdi`. This is and attempt to catch changes to the imports in `aiida.cmdline` that will
+# indirectly load the `aiida.orm` module which will trigger loading of the backend environment. This slows down `verdi`
+# significantly, making tab-completion unusable.
+VERDI=`which verdi`
+
+# Typically, the loading time of `verdi` should be around ~0.2 seconds. When loading the database environment this
+# tends to go towards ~0.8 seconds. Since these timings are obviously machine and environment dependent, typically these
+# types of tests are fragile. But with a load limit of more than twice the ideal loading time, if exceeded, should give
+# a reasonably sure indication that the loading of `verdi` is unacceptably slowed down.
+LOAD_LIMIT=0.4
+MAX_NUMBER_ATTEMPTS=5
+
+iteration=0
+
+while true; do
+
+    iteration=$((iteration+1))
+    load_time=$(/usr/bin/time -q -f "%e" $VERDI 2>&1 > /dev/null)
+
+    if (( $(echo "$load_time < $LOAD_LIMIT" | bc -l) )); then
+        echo "SUCCESS: loading time $load_time at iteration $iteration below $load_limit"
+        break
+    else
+        echo "WARNING: loading time $load_time at iteration $iteration above $load_limit"
+
+        if [ $iteration -eq $MAX_NUMBER_ATTEMPTS ]; then
+            echo "ERROR: loading time exceeded the load limit $iteration consecutive times."
+            echo "ERROR: please check that 'aiida.cmdline' does not import 'aiida.orm' at module level, even indirectly"
+            echo "ERROR: also, the database backend environment should not be loaded."
+            exit 2
+        fi
+    fi
+
+done

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import sys
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -58,6 +59,31 @@ def get_valid_test_paths():
     return valid_test_paths
 
 
+@verdi_devel.command('check-load-time')
+def devel_check_load_time():
+    """Check for common indicators that slowdown `verdi`.
+
+    Check for environment properties that negatively affect the responsiveness of the `verdi` command line interface.
+    Known pathways that increase load time:
+
+        * the database environment is loaded when it doesn't need to be
+        * the `aiida.orm` module is imported when it doesn't need to be
+
+    If either of these conditions are true, the command will raise a critical error
+    """
+    from aiida.manage.manager import get_manager
+
+    manager = get_manager()
+
+    if manager.backend_loaded:
+        echo.echo_critical('potential `verdi` speed problem: database backend is loaded.')
+
+    if 'aiida.orm' in sys.modules:
+        echo.echo_critical('potential `verdi` speed problem: `aiida.orm` module is imported.')
+
+    echo.echo_success('no issues detected')
+
+
 @verdi_devel.command('run_daemon')
 @decorators.with_dbenv()
 def devel_run_daemon():
@@ -73,7 +99,6 @@ def devel_run_daemon():
 def devel_tests(paths, verbose):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """Run the unittest suite or parts of it."""
     import os
-    import sys
     import unittest
 
     import aiida

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -121,6 +121,14 @@ class Manager(object):
 
         return self._backend
 
+    @property
+    def backend_loaded(self):
+        """Return whether a database backend has been loaded.
+
+        :return: boolean, True if database backend is currently loaded, False otherwise
+        """
+        return self._backend is not None
+
     def get_backend(self):
         """
         Get the database backend

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -370,8 +370,9 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      run_daemon  Run a daemon instance in the current interpreter.
-      tests       Run the unittest suite or parts of it.
+      check-load-time  Check for common indicators that slowdown `verdi`.
+      run_daemon       Run a daemon instance in the current interpreter.
+      tests            Run the unittest suite or parts of it.
 
 
 .. _verdi_export:


### PR DESCRIPTION
Fixes #3391 

The loading time of `verdi` needs to be kept to a minimum in order to
keep it snappy and tab-completion from workable. This means that the
database environment should not be loaded until it is absolutely
necessary and only within the function body of commands. This means that
`aiida.orm` cannot be imported in the top level of any `aiida.cmdline`
file, as that will_ trigger the loading of the database environment.
However, since this is not easy to spot, this happens all the time,
breaking `verdi` essentially.

We add a test to the Travis build that will use `time` to measure the
loading time and if it exceeds the given limit, it will fail the test.
The limit is set rather loosely, because we do not want numerical noise
to fail this test. The typical mistake causing the loading time to
increase, should largely exceed the limit so should always be caught.