### PR TITLE
Centralize definition of graph traversal rule toggleability and default

### DIFF
--- a/aiida/backends/tests/tools/importexport/orm/test_links.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_links.py
@@ -373,19 +373,14 @@ class TestLinks(AiidaTestCase):
     @staticmethod
     def prepare_link_flags_export(nodes_to_export, test_data):
         """Helper function"""
-        from aiida.tools.importexport.common.config import LINK_FLAGS
-        rules = {}
-        togglable_link_rules = {
-            'input_calc_forward', 'create_backward', 'return_backward', 'input_work_forward', 'call_calc_backward',
-            'call_work_backward'
-        }
-        for rule in LINK_FLAGS:
-            if rule in togglable_link_rules:
-                rules[rule] = LINK_FLAGS[rule]
+        from aiida.common.links import GraphTraversalRules
+
+        export_rules = GraphTraversalRules.EXPORT.value
+        traversal_rules = {name: rule.default for name, rule in export_rules.items() if rule.toggleable}
 
         for export_file, rule_changes, expected_nodes in test_data.values():
-            rules.update(rule_changes)
-            export(nodes_to_export[0], outfile=export_file, silent=True, **rules)
+            traversal_rules.update(rule_changes)
+            export(nodes_to_export[0], outfile=export_file, silent=True, **traversal_rules)
 
             for node_type in nodes_to_export[1]:
                 if node_type in expected_nodes:

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -24,7 +24,7 @@ from aiida.cmdline.params import arguments
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators
 from aiida.cmdline.utils import echo
-from aiida.tools.importexport import LINK_FLAGS
+from aiida.common.links import GraphTraversalRules
 
 
 @verdi.group('export')
@@ -70,42 +70,7 @@ def inspect(archive, version, data, meta_data):
 @options.NODES()
 @options.ARCHIVE_FORMAT()
 @options.FORCE(help='overwrite output file if it already exists')
-@click.option(
-    '--input-calc-forward/--no-input-calc-forward',
-    default=LINK_FLAGS['input_calc_forward'],
-    show_default=True,
-    help='Follow forward INPUT_CALC links (recursively) when calculating the node set to export.'
-)
-@click.option(
-    '--input-work-forward/--no-input-work-forward',
-    default=LINK_FLAGS['input_work_forward'],
-    show_default=True,
-    help='Follow forward INPUT_WORK links (recursively) when calculating the node set to export.'
-)
-@click.option(
-    '--create-backward/--no-create-backward',
-    default=LINK_FLAGS['create_backward'],
-    show_default=True,
-    help='Follow reverse CREATE links (recursively) when calculating the node set to export.'
-)
-@click.option(
-    '--return-backward/--no-return-backward',
-    default=LINK_FLAGS['return_backward'],
-    show_default=True,
-    help='Follow reverse RETURN links (recursively) when calculating the node set to export.'
-)
-@click.option(
-    '--call-calc-backward/--no-call-calc-backward',
-    default=LINK_FLAGS['call_calc_backward'],
-    show_default=True,
-    help='Follow reverse CALL_CALC links (recursively) when calculating the node set to export.'
-)
-@click.option(
-    '--call-work-backward/--no-call-work-backward',
-    default=LINK_FLAGS['call_work_backward'],
-    show_default=True,
-    help='Follow reverse CALL_WORK links (recursively) when calculating the node set to export.'
-)
+@options.graph_traversal_rules(GraphTraversalRules.EXPORT.value)
 @click.option(
     '--include-logs/--exclude-logs',
     default=True,

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -22,9 +22,9 @@ from .overridable import OverridableOption
 from .config import ConfigFileOption
 
 __all__ = (
-    'PROFILE', 'CALCULATION', 'CALCULATIONS', 'CODE', 'CODES', 'COMPUTER', 'COMPUTERS', 'DATUM', 'DATA', 'GROUP',
-    'GROUPS', 'NODE', 'NODES', 'FORCE', 'SILENT', 'VISUALIZATION_FORMAT', 'INPUT_FORMAT', 'EXPORT_FORMAT',
-    'ARCHIVE_FORMAT', 'NON_INTERACTIVE', 'DRY_RUN', 'USER_EMAIL', 'USER_FIRST_NAME', 'USER_LAST_NAME',
+    'graph_traversal_rules', 'PROFILE', 'CALCULATION', 'CALCULATIONS', 'CODE', 'CODES', 'COMPUTER', 'COMPUTERS',
+    'DATUM', 'DATA', 'GROUP', 'GROUPS', 'NODE', 'NODES', 'FORCE', 'SILENT', 'VISUALIZATION_FORMAT', 'INPUT_FORMAT',
+    'EXPORT_FORMAT', 'ARCHIVE_FORMAT', 'NON_INTERACTIVE', 'DRY_RUN', 'USER_EMAIL', 'USER_FIRST_NAME', 'USER_LAST_NAME',
     'USER_INSTITUTION', 'BACKEND', 'DB_HOST', 'DB_PORT', 'DB_USERNAME', 'DB_PASSWORD', 'DB_NAME', 'REPOSITORY_PATH',
     'PROFILE_ONLY_CONFIG', 'PROFILE_SET_DEFAULT', 'PREPEND_TEXT', 'APPEND_TEXT', 'LABEL', 'DESCRIPTION', 'INPUT_PLUGIN',
     'CALC_JOB_STATE', 'PROCESS_STATE', 'EXIT_STATUS', 'FAILED', 'LIMIT', 'PROJECT', 'ORDER_BY', 'PAST_DAYS',
@@ -54,6 +54,23 @@ def active_process_states():
         ProcessState.WAITING.value,
         ProcessState.RUNNING.value,
     ])
+
+
+def graph_traversal_rules(rules):
+    """Apply the graph traversal rule options to the command."""
+
+    def decorator(command):
+        """Only apply to traversal rules if they are toggleable."""
+        for name, traversal_rule in sorted(rules.items(), reverse=True):
+            if traversal_rule.toggleable:
+                option_name = name.replace('_', '-')
+                option_label = '--{option_name}/--no-{option_name}'.format(option_name=option_name)
+                help_string = 'Toggle the {} graph traversal rule used in computing the complete node set.'.format(name)
+                click.option(option_label, default=traversal_rule.default, show_default=True, help=help_string)(command)
+
+        return command
+
+    return decorator
 
 
 PROFILE = OverridableOption(

--- a/aiida/common/links.py
+++ b/aiida/common/links.py
@@ -7,17 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Module to define valid link types."""
+"""Module with utilities and data structures pertaining to links between nodes in the provenance graph."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from collections import namedtuple
 from enum import Enum
+
 import six
 
 from .lang import isidentifier, type_check
 
-__all__ = ('LinkType', 'validate_link_label')
+__all__ = ('GraphTraversalRule', 'GraphTraversalRules', 'LinkType', 'validate_link_label')
 
 
 class LinkType(Enum):
@@ -29,6 +31,55 @@ class LinkType(Enum):
     INPUT_WORK = 'input_work'
     CALL_CALC = 'call_calc'
     CALL_WORK = 'call_work'
+
+
+GraphTraversalRule = namedtuple('GraphTraversalRule', ['link_type', 'direction', 'toggleable', 'default'])
+"""A namedtuple that defines a graph traversal rule.
+
+When starting from a certain sub set of nodes, the graph traversal rules specify which links should be followed to
+add adjacent nodes to finally arrive at a set of nodes that represent a valid and consistent sub graph.
+
+:param link_type: the `LinkType` that the rule applies to
+:param direction: whether the link type should be followed backwards or forwards
+:param toggleable: boolean to indicate whether the rule can be changed from the default value. If this is `False` it
+    means the default value can never be changed as it will result in an inconsistent graph.
+:param default: boolean, the default value of the rule, if `True` means that the link type for the given direction
+    should be followed.
+"""
+
+
+class GraphTraversalRules(Enum):
+    """Graph traversal rules when deleting or exporting nodes."""
+
+    DELETE = {
+        'input_calc_forward': GraphTraversalRule(LinkType.INPUT_CALC, 'forward', False, True),
+        'input_calc_backward': GraphTraversalRule(LinkType.INPUT_CALC, 'backward', False, False),
+        'create_forward': GraphTraversalRule(LinkType.CREATE, 'forward', True, True),
+        'create_backward': GraphTraversalRule(LinkType.CREATE, 'backward', False, True),
+        'return_forward': GraphTraversalRule(LinkType.RETURN, 'forward', False, False),
+        'return_backward': GraphTraversalRule(LinkType.RETURN, 'backward', False, True),
+        'input_work_forward': GraphTraversalRule(LinkType.INPUT_WORK, 'forward', False, True),
+        'input_work_backward': GraphTraversalRule(LinkType.INPUT_WORK, 'backward', False, False),
+        'call_calc_forward': GraphTraversalRule(LinkType.CALL_CALC, 'forward', True, False),
+        'call_calc_backward': GraphTraversalRule(LinkType.CALL_CALC, 'backward', False, True),
+        'call_work_forward': GraphTraversalRule(LinkType.CALL_WORK, 'forward', True, False),
+        'call_work_backward': GraphTraversalRule(LinkType.CALL_WORK, 'backward', False, True)
+    }
+
+    EXPORT = {
+        'input_calc_forward': GraphTraversalRule(LinkType.INPUT_CALC, 'forward', True, False),
+        'input_calc_backward': GraphTraversalRule(LinkType.INPUT_CALC, 'backward', False, True),
+        'create_forward': GraphTraversalRule(LinkType.CREATE, 'forward', False, True),
+        'create_backward': GraphTraversalRule(LinkType.CREATE, 'backward', True, True),
+        'return_forward': GraphTraversalRule(LinkType.RETURN, 'forward', False, True),
+        'return_backward': GraphTraversalRule(LinkType.RETURN, 'backward', True, False),
+        'input_work_forward': GraphTraversalRule(LinkType.INPUT_WORK, 'forward', True, False),
+        'input_work_backward': GraphTraversalRule(LinkType.INPUT_WORK, 'backward', False, True),
+        'call_calc_forward': GraphTraversalRule(LinkType.CALL_CALC, 'forward', False, True),
+        'call_calc_backward': GraphTraversalRule(LinkType.CALL_CALC, 'backward', True, False),
+        'call_work_forward': GraphTraversalRule(LinkType.CALL_WORK, 'forward', False, True),
+        'call_work_backward': GraphTraversalRule(LinkType.CALL_WORK, 'backward', True, False)
+    }
 
 
 def validate_link_label(link_label):

--- a/aiida/tools/importexport/common/config.py
+++ b/aiida/tools/importexport/common/config.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 
 from aiida.orm import Computer, Group, GroupTypeString, Node, User, Log, Comment
 
-__all__ = ('EXPORT_VERSION', 'LINK_FLAGS')
+__all__ = ('EXPORT_VERSION',)
 
 # Current export version
 EXPORT_VERSION = '0.7'
@@ -25,23 +25,6 @@ DUPL_SUFFIX = ' (Imported #{})'
 
 # The name of the subfolder in which the node files are stored
 NODES_EXPORT_SUBFOLDER = 'nodes'
-
-# Default rules for following Links, when creating the graph of Nodes to export
-# Structure: key: <LinkType>_<direction-to-follow>, value: <Follow?>
-LINK_FLAGS = {
-    'input_calc_forward': False,  # Togglable
-    'input_calc_backward': True,
-    'create_forward': True,
-    'create_backward': True,  # Togglable
-    'return_forward': True,
-    'return_backward': False,  # Togglable
-    'input_work_forward': False,  # Togglable
-    'input_work_backward': True,
-    'call_calc_forward': True,
-    'call_calc_backward': False,  # Togglable
-    'call_work_forward': True,
-    'call_work_backward': False  # Togglable
-}
 
 # Giving names to the various entities. Attributes and links are not AiiDA
 # entities but we will refer to them as entities in the file (to simplify

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -77,23 +77,8 @@ def export_zip(what, outfile='testzip', overwrite=False, silent=False, use_compr
         Default: True, *include* logs in export.
     :type include_logs: bool
 
-    :param input_calc_forward: Follow forward INPUT_CALC links (recursively) when calculating the node set to export.
-    :type input_calc_forward: bool
-
-    :param create_backward: Follow reversed CREATE links (recursively) when calculating the node set to export.
-    :type create_backward: bool
-
-    :param return_backward: Follow reversed RETURN links (recursively) when calculating the node set to export.
-    :type return_backward: bool
-
-    :param input_work_forward: Follow forward INPUT_WORK links (recursively) when calculating the node set to export.
-    :type input_work_forward: bool
-
-    :param call_calc_backward: Follow reversed CALL_CALC links (recursively) when calculating the node set to export.
-    :type call_calc_backward: bool
-
-    :param call_work_backward: Follow reversed CALL_WORK links (recursively) when calculating the node set to export.
-    :type call_work_backward: bool
+    :param kwargs: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
+        are toggleable and what the defaults are.
 
     :raises `~aiida.tools.importexport.common.exceptions.ArchiveExportError`: if there are any internal errors when
         exporting.
@@ -148,23 +133,8 @@ def export_tree(
         Default: True, *include* logs in export.
     :type include_logs: bool
 
-    :param input_calc_forward: Follow forward INPUT_CALC links (recursively) when calculating the node set to export.
-    :type input_calc_forward: bool
-
-    :param create_backward: Follow reversed CREATE links (recursively) when calculating the node set to export.
-    :type create_backward: bool
-
-    :param return_backward: Follow reversed RETURN links (recursively) when calculating the node set to export.
-    :type return_backward: bool
-
-    :param input_work_forward: Follow forward INPUT_WORK links (recursively) when calculating the node set to export.
-    :type input_work_forward: bool
-
-    :param call_calc_backward: Follow reversed CALL_CALC links (recursively) when calculating the node set to export.
-    :type call_calc_backward: bool
-
-    :param call_work_backward: Follow reversed CALL_WORK links (recursively) when calculating the node set to export.
-    :type call_work_backward: bool
+    :param kwargs: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
+        are toggleable and what the defaults are.
 
     :raises `~aiida.tools.importexport.common.exceptions.ArchiveExportError`: if there are any internal errors when
         exporting.
@@ -506,23 +476,8 @@ def export(what, outfile='export_data.aiida.tar.gz', overwrite=False, silent=Fal
         Default: True, *include* logs in export.
     :type include_logs: bool
 
-    :param input_calc_forward: Follow forward INPUT_CALC links (recursively) when calculating the node set to export.
-    :type input_calc_forward: bool
-
-    :param create_backward: Follow reversed CREATE links (recursively) when calculating the node set to export.
-    :type create_backward: bool
-
-    :param return_backward: Follow reversed RETURN links (recursively) when calculating the node set to export.
-    :type return_backward: bool
-
-    :param input_work_forward: Follow forward INPUT_WORK links (recursively) when calculating the node set to export.
-    :type input_work_forward: bool
-
-    :param call_calc_backward: Follow reversed CALL_CALC links (recursively) when calculating the node set to export.
-    :type call_calc_backward: bool
-
-    :param call_work_backward: Follow reversed CALL_WORK links (recursively) when calculating the node set to export.
-    :type call_work_backward: bool
+    :param kwargs: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
+        are toggleable and what the defaults are.
 
     :raises `~aiida.tools.importexport.common.exceptions.ArchiveExportError`: if there are any internal errors when
         exporting.


### PR DESCRIPTION
Fixes #3393 and resolves `verdi` loading speed issue

The available graph traversal rules are identical for node export and
deletion. Only the toggleability and defaults differs for each of the
two scenarios. To prevent mistakes, we centralize their definition in
one location. Two dictionaries in `aiida.common.links` provide a mapping
of each traversal rule onto a named tuple that records the default value
and toggleability.

This notation allows for dynamic code, for example, the command line
options that toggle the rules are now generated dynamically for the
`verdi export create` and `verdi node delete` commands.

In addition, the old `LINK_FLAG` data structure was defined in the
`aiida.tools.importexport` module which indirectly causeed `verdi` to
slow down. The dictionary was needed to generate the command options
and by importing it, indirectly the `aiida.orm` module was imported.