### PR TITLE
Allow arbitrarily nested `key` in `Node.put_object_from_filelike`

### DIFF
--- a/aiida/backends/tests/orm/utils/test_repository.py
+++ b/aiida/backends/tests/orm/utils/test_repository.py
@@ -29,6 +29,9 @@ class TestRepository(AiidaTestCase):
         self.tempdir = tempfile.mkdtemp()
         self.tree = {
             'subdir': {
+                'nested': {
+                    'deep.txt': u'Content does not matter',
+                },
                 'a.txt': u'Content of file A\nWith some newlines',
                 'b.txt': u'Content of file B without newline',
             },
@@ -71,6 +74,15 @@ class TestRepository(AiidaTestCase):
     def test_put_object_from_filelike(self):
         """Test the `put_object_from_filelike` method."""
         key = os.path.join('subdir', 'a.txt')
+        filepath = os.path.join(self.tempdir, key)
+        content = self.get_file_content(key)
+
+        with io.open(filepath, 'r') as handle:
+            node = Node()
+            node.put_object_from_filelike(handle, key)
+            self.assertEqual(node.get_object_content(key), content)
+
+        key = os.path.join('subdir', 'nested', 'deep.txt')
         filepath = os.path.join(self.tempdir, key)
         content = self.get_file_content(key)
 

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -225,7 +225,7 @@ class Repository(object):
 
         folder = self._get_base_folder()
 
-        if os.sep in key:
+        while os.sep in key:
             basepath, key = key.split(os.sep, 1)
             folder = folder.get_subfolder(basepath, create=True)
 


### PR DESCRIPTION
Fixes #3397 

The key was already checked for a path separator in which case the
corresponding base directory was created first, if it did not yet exist,
except any further nesting was not checked for. This change will ensure
that any non-existing sub directories will be created first.