### PR TITLE
Move `CalcJob` input `computer` from `options` to `metadata`

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -93,6 +93,25 @@ class TestCalcJob(AiidaTestCase):
         with self.assertRaises(TypeError):
             launch.run(SimpleCalcJob, code=self.code, metadata={'options': orm.Dict(dict={'a': 1})})
 
+    def test_computer(self):
+        """Test passing an explicit `computer` in the `metadata`."""
+        inputs = {
+            'code': self.code,
+            'x': orm.Int(1),
+            'y': orm.Int(2),
+            'metadata': {
+                'computer': self.code.computer,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'num_mpiprocs_per_machine': 1
+                    },
+                }
+            }
+        }
+
+        ArithmeticAddCalculation(inputs=inputs)
+
     def test_invalid_parser_name(self):
         """Passing an invalid parser name should already stop during input validation."""
         inputs = {

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -50,9 +50,11 @@ class CalcJob(Process):
     def define(cls, spec):
         # yapf: disable
         super(CalcJob, cls).define(spec)
-        spec.input('code', valid_type=orm.Code, help='The Code to use for this job.')
+        spec.input('code', valid_type=orm.Code, help='The `Code` to use for this job.')
         spec.input('metadata.dry_run', valid_type=bool, default=False,
-            help='When set to True will prepare the calculation job for submission but not actually launch it.')
+            help='When set to `True` will prepare the calculation job for submission but not actually launch it.')
+        spec.input('metadata.computer', valid_type=orm.Computer, required=False,
+            help='When using a "local" code, set the computer on which the calculation should be run.')
         spec.input_namespace('{}.{}'.format(spec.metadata_key, spec.options_key), required=False)
         spec.input('metadata.options.input_filename', valid_type=six.string_types, required=False,
             help='Filename to which the input for the code that is to be run will be written.')
@@ -79,8 +81,6 @@ class CalcJob(Process):
             help='Set the account to use in for the queue on the remote computer')
         spec.input('metadata.options.qos', valid_type=six.string_types, required=False,
             help='Set the quality of service to use in for the queue on the remote computer')
-        spec.input('metadata.options.computer', valid_type=orm.Computer, required=False,
-            help='Set the computer to be used by the calculation')
         spec.input('metadata.options.withmpi', valid_type=bool, default=False,
             help='Set the calculation to use mpi',)
         spec.input('metadata.options.mpirun_extra_params', valid_type=(list, tuple), default=[],

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -654,6 +654,8 @@ class Process(plumpy.Process):
                 self.node.label = metadata
             elif name == 'description':
                 self.node.description = metadata
+            elif name == 'computer':
+                self.node.computer = metadata
             elif name == 'options':
                 for option_name, option_value in metadata.items():
                     self.node.set_option(option_name, option_value)


### PR DESCRIPTION
Fixes #3396 

All options are stored as attributes on the `CalcJobNode` but the
`computer` input will have a `Computer` instance as type and needs to be
stored as a property. It therefore makes more sense to be passed as a
metadata like the `label` and `description`.