### PR TITLE
Move and improve `CalcJob` input validation to process spec

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -12,6 +12,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import copy
+import unittest
+
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
@@ -28,7 +31,20 @@ class TestCalcJob(AiidaTestCase):
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super(TestCalcJob, cls).setUpClass(*args, **kwargs)
-        cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
+        cls.remote_code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
+        cls.local_code = orm.Code(local_executable='true', files=['/bin/true']).store()
+        cls.inputs = {
+            'x': orm.Int(1),
+            'y': orm.Int(2),
+            'metadata': {
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'num_mpiprocs_per_machine': 1
+                    },
+                }
+            }
+        }
 
     def setUp(self):
         super(TestCalcJob, self).setUp()
@@ -91,43 +107,83 @@ class TestCalcJob(AiidaTestCase):
 
         # The `metadata.options` input expects a plain dict and not a node `Dict`
         with self.assertRaises(TypeError):
-            launch.run(SimpleCalcJob, code=self.code, metadata={'options': orm.Dict(dict={'a': 1})})
+            launch.run(SimpleCalcJob, code=self.remote_code, metadata={'options': orm.Dict(dict={'a': 1})})
 
-    def test_computer(self):
-        """Test passing an explicit `computer` in the `metadata`."""
-        inputs = {
-            'code': self.code,
-            'x': orm.Int(1),
-            'y': orm.Int(2),
-            'metadata': {
-                'computer': self.code.computer,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'num_mpiprocs_per_machine': 1
-                    },
-                }
-            }
-        }
+    def test_remote_code_set_computer_implicit(self):
+        """Test launching a `CalcJob` with a remote code *with* explicitly defining a computer.
 
-        ArithmeticAddCalculation(inputs=inputs)
+        This should work, because the `computer` should be retrieved from the `code` and automatically set for the
+        process by the engine itself.
+        """
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.remote_code
+
+        process = ArithmeticAddCalculation(inputs=inputs)
+        self.assertTrue(process.node.is_stored)
+        self.assertEqual(process.node.computer.uuid, self.remote_code.computer.uuid)
+
+    @unittest.skip('Reenable when #3412 is addressed.')
+    def test_remote_code_unstored_computer(self):
+        """Test launching a `CalcJob` with an unstored computer which should raise."""
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.remote_code
+        inputs['metadata']['computer'] = orm.Computer('different', 'localhost', 'desc', 'local', 'direct')
+
+        with self.assertRaises(exceptions.InputValidationError):
+            ArithmeticAddCalculation(inputs=inputs)
+
+    def test_remote_code_set_computer_explicit(self):
+        """Test launching a `CalcJob` with a remote code *with* explicitly defining a computer.
+
+        This should work as long as the explicitly defined computer is the same as the one configured for the `code`
+        input. If this is not the case, it should raise.
+        """
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.remote_code
+
+        # Setting explicitly a computer that is not the same as that of the `code` should raise
+        with self.assertRaises(exceptions.InputValidationError):
+            inputs['metadata']['computer'] = orm.Computer('different', 'localhost', 'desc', 'local', 'direct').store()
+            process = ArithmeticAddCalculation(inputs=inputs)
+
+        # Setting the same computer as that of the `code` effectively accomplishes nothing but should be fine
+        inputs['metadata']['computer'] = self.remote_code.computer
+        process = ArithmeticAddCalculation(inputs=inputs)
+        self.assertTrue(process.node.is_stored)
+        self.assertEqual(process.node.computer.uuid, self.remote_code.computer.uuid)
+
+    def test_local_code_set_computer(self):
+        """Test launching a `CalcJob` with a local code *with* explicitly defining a computer, which should work."""
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.local_code
+        inputs['metadata']['computer'] = self.computer
+
+        process = ArithmeticAddCalculation(inputs=inputs)
+        self.assertTrue(process.node.is_stored)
+        self.assertEqual(process.node.computer.uuid, self.computer.uuid)  # pylint: disable=no-member
+
+    def test_local_code_no_computer(self):
+        """Test launching a `CalcJob` with a local code *without* explicitly defining a computer, which should raise."""
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.local_code
+
+        with self.assertRaises(exceptions.InputValidationError):
+            ArithmeticAddCalculation(inputs=inputs)
 
     def test_invalid_parser_name(self):
         """Passing an invalid parser name should already stop during input validation."""
-        inputs = {
-            'code': self.code,
-            'x': orm.Int(1),
-            'y': orm.Int(2),
-            'metadata': {
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'num_mpiprocs_per_machine': 1
-                    },
-                    'parser_name': 'invalid_parser'
-                }
-            }
-        }
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.remote_code
+        inputs['metadata']['options']['parser_name'] = 'invalid_parser'
 
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaises(exceptions.InputValidationError):
+            ArithmeticAddCalculation(inputs=inputs)
+
+    def test_invalid_resources(self):
+        """Passing invalid resources should already stop during input validation."""
+        inputs = copy.deepcopy(self.inputs)
+        inputs['code'] = self.remote_code
+        inputs['metadata']['options']['resources'].pop('num_machines')
+
+        with self.assertRaises(exceptions.InputValidationError):
             ArithmeticAddCalculation(inputs=inputs)

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -31,8 +31,7 @@ class ProcessBuilderNamespace(collections.MutableMapping):
     """
 
     def __init__(self, port_namespace):
-        """
-        Dynamically construct the get and set properties for the ports of the given port namespace
+        """Dynamically construct the get and set properties for the ports of the given port namespace
 
         For each port in the given port namespace a get and set property will be constructed dynamically
         and added to the ProcessBuilderNamespace. The docstring for these properties will be defined
@@ -73,9 +72,10 @@ class ProcessBuilderNamespace(collections.MutableMapping):
             setattr(self.__class__, name, getter)
 
     def __setattr__(self, attr, value):
-        """
-        Any attributes without a leading underscore being set correspond to inputs and should hence
-        be validated with respect to the corresponding input port from the process spec
+        """Set an input value for the given port `attr`.
+
+        .. note:: Any attributes without a leading underscore being set correspond to inputs and should hence be
+            validated with respect to the corresponding input port from the process spec
 
         :param attr: attribute
         :type attr: str
@@ -153,9 +153,13 @@ class ProcessBuilder(ProcessBuilderNamespace):
     """A process builder that helps setting up the inputs for creating a new process."""
 
     def __init__(self, process_class):
+        """Construct a `ProcessBuilder` instance for the given `Process` class.
+
+        :param process_class: the `Process` subclass
+        """
         self._process_class = process_class
         self._process_spec = self._process_class.spec()
-        super(ProcessBuilder, self).__init__(port_namespace=self._process_spec.inputs)
+        super(ProcessBuilder, self).__init__(self._process_spec.inputs)
 
     @property
     def process_class(self):

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -282,7 +282,6 @@ class Code(Data):
             if not self.get_local_executable():
                 raise ValidationError('You have to set which file is the local executable '
                                       'using the set_exec_filename() method')
-                # c[1] is True if the element is a file
             if self.get_local_executable() not in self.list_object_names():
                 raise ValidationError("The local executable '{}' is not in the list of "
                                       'files of this code'.format(self.get_local_executable()))
@@ -453,28 +452,29 @@ class Code(Data):
             return self.get_remote_exec_path()
 
     def get_builder(self):
-        """
-        Create and return a new ProcessBuilder for the default Calculation
-        plugin, as obtained by the self.get_input_plugin_name() method.
+        """Create and return a new `ProcessBuilder` for the `CalcJob` class of the plugin configured for this code.
 
-        :note: it also sets the ``builder.code`` value.
+        The configured calculation plugin class is defined by the `get_input_plugin_name` method.
 
+        .. note:: it also sets the ``builder.code`` value.
+
+        :return: a `ProcessBuilder` instance with the `code` input already populated with ourselves
         :raise aiida.common.EntryPointError: if the specified plugin does not exist.
         :raise ValueError: if no default plugin was specified.
-
-        :return:
         """
         from aiida.plugins import CalculationFactory
+
         plugin_name = self.get_input_plugin_name()
+
         if plugin_name is None:
-            raise ValueError('You did not specify a default input plugin for this code')
+            raise ValueError('no default calculation input plugin specified for this code')
+
         try:
-            C = CalculationFactory(plugin_name)
+            process_class = CalculationFactory(plugin_name)
         except EntryPointError:
             raise EntryPointError('the calculation entry point `{}` could not be loaded'.format(plugin_name))
 
-        builder = C.get_builder()
-        # Setup the code already
+        builder = process_class.get_builder()
         builder.code = self
 
         return builder

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -146,43 +146,6 @@ class CalcJobNode(CalculationNode):
 
         return builder
 
-    def _validate(self):
-        """
-        Verify if all the input nodes are present and valid.
-
-        :raise: ValidationError: if invalid parameters are found.
-        """
-        super(CalcJobNode, self)._validate()
-
-        if self.computer is None:
-            raise exceptions.ValidationError('no computer was specified')
-
-        try:
-            parser_class = self.get_parser_class()
-        except exceptions.EntryPointError as exception:
-            raise exceptions.ValidationError('invalid parser specified: {}'.format(exception))
-
-        try:
-            # Since a parser is not required to be set, so `get_parser_class` will return `None` in that case
-            if parser_class is not None:
-                parser_class(self)
-        except TypeError as exception:
-            raise exceptions.ValidationError('invalid parser specified: {}'.format(exception))
-
-        resources = self.get_option('resources')
-        scheduler = self.computer.get_scheduler()  # pylint: disable=no-member
-        def_cpus_machine = self.computer.get_default_mpiprocs_per_machine()  # pylint: disable=no-member
-
-        if def_cpus_machine is not None:
-            resources['default_mpiprocs_per_machine'] = def_cpus_machine
-
-        try:
-            scheduler.create_job_resource(**resources)
-        except (TypeError, ValueError) as exc:
-            raise exceptions.ValidationError(
-                'Invalid resources for the scheduler of the specified computer: {}'.format(exc)
-            )
-
     @property
     def _raw_input_folder(self):
         """


### PR DESCRIPTION
Fixes #3395 

Compound input validation for the `CalcJob` was mostly implemented on
the node level in `CalcJobNode._validate`. This has been moved to a
validator on the input portnamespace of the `CalcJob` in order to catch
inputs problems as soon as possible. It implements existing validation:

 * A `Computer` has been defined
 * The parser class, if specified, can be successfully loaded
 * The specified resources are valid and sufficient for the scheduler

In addition, the validation on the `Computer` has been improved. It now
checks that if it is specified both directly in the `metadata` as well
as indirectly through the `Code` input (in the case of a remote code)
that it concerns the same computer.