### PR TITLE
Ensure `Data` export methods return correct type

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -117,6 +117,7 @@ DB_TEST_LIST = {
         'orm.authinfos': ['aiida.backends.tests.orm.test_authinfos'],
         'orm.comments': ['aiida.backends.tests.orm.test_comments'],
         'orm.computers': ['aiida.backends.tests.orm.test_computers'],
+        'orm.data.data': ['aiida.backends.tests.orm.data.test_data'],
         'orm.data.dict': ['aiida.backends.tests.orm.data.test_dict'],
         'orm.data.folder': ['aiida.backends.tests.orm.data.test_folder'],
         'orm.data.kpoints': ['aiida.backends.tests.orm.data.test_kpoints'],

--- a/aiida/backends/tests/fixtures/data/Si.cif
+++ b/aiida/backends/tests/fixtures/data/Si.cif
@@ -1,0 +1,258 @@
+#------------------------------------------------------------------------------
+#$Date: 2018-09-27 07:13:35 +0300 (Thu, 27 Sep 2018) $
+#$Revision: 211196 $
+#$URL: file:///home/coder/svn-repositories/cod/cif/1/52/66/1526655.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/
+#
+# All data on this site have been placed in the public domain by the
+# contributors.
+#
+data_1526655
+loop_
+_publ_author_name
+'Kitano, A.'
+'Shintani, A.'
+'Yonemura, M.'
+'Moriguchi, K.'
+'Yamanaka, S.'
+'Fukuoka, H.'
+'Munetoh, S.'
+'Takata, M.'
+'Nishibori, E.'
+'Sakata, M.'
+_publ_section_title
+;
+ Structural properties and thermodynamic stability of Ba-doped silicon
+ type-I clathrates synthesized under high pressure
+;
+_journal_name_full
+'Physical Review, Serie 3. B - Condensed Matter (18,1978-)'
+_journal_page_first              0452061
+_journal_page_last               0452069
+_journal_volume                  64
+_journal_year                    2001
+_chemical_formula_sum            Si
+_space_group_IT_number           227
+_symmetry_space_group_name_Hall  'F 4d 2 3 -1d'
+_symmetry_space_group_name_H-M   'F d -3 m :1'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_formula_units_Z            8
+_cell_length_a                   5.381
+_cell_length_b                   5.381
+_cell_length_c                   5.381
+_cell_volume                     155.808
+_citation_journal_id_ASTM        PRBMDO
+_cod_data_source_file            Kitano_PRBMDO_2001_1900.cif
+_cod_data_source_block           Si1
+_cod_original_cell_volume        155.8077
+_cod_original_sg_symbol_Hall     '-F 4vw 2vw 3 (x+1/8,y+1/8,z+1/8)'
+_cod_original_formula_sum        Si1
+_cod_database_code               1526655
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+-y+1/4,x+1/4,z+1/4
+-x,-y+1/2,z+1/2
+y+3/4,-x+1/4,z+3/4
+x,-y+1/2,-z+1/2
+y+3/4,x+1/4,-z+3/4
+-x,y,-z
+-y+1/4,-x+1/4,-z+1/4
+z,x,y
+-x+1/4,z+1/4,y+1/4
+-z,-x+1/2,y+1/2
+x+3/4,-z+1/4,y+3/4
+z,-x+1/2,-y+1/2
+x+3/4,z+1/4,-y+3/4
+-z,x,-y
+-x+1/4,-z+1/4,-y+1/4
+y,z,x
+y+1/2,-z,-x+1/2
+z+1/4,y+3/4,-x+3/4
+-y+1/2,z+1/2,-x
+-z+1/4,-y+3/4,-x+3/4
+-y+1/2,-z+1/2,x
+z+1/4,-y+1/4,x+1/4
+-z+3/4,y+1/4,x+3/4
+-x+1/4,-y+1/4,-z+1/4
+y,-x,-z
+x+1/4,y-1/4,-z-1/4
+-y-1/2,x,-z-1/2
+-x+1/4,y-1/4,z-1/4
+-y-1/2,-x,z-1/2
+x+1/4,-y+1/4,z+1/4
+y,x,z
+-z+1/4,-x+1/4,-y+1/4
+x,-z,-y
+z+1/4,x-1/4,-y-1/4
+-x-1/2,z,-y-1/2
+-z+1/4,x-1/4,y-1/4
+-x-1/2,-z,y-1/2
+z+1/4,-x+1/4,y+1/4
+x,z,y
+-y+1/4,-z+1/4,-x+1/4
+-y-1/4,z+1/4,x-1/4
+-z,-y-1/2,x-1/2
+y-1/4,-z-1/4,x+1/4
+z,y-1/2,x-1/2
+y-1/4,z-1/4,-x+1/4
+-z,y,-x
+z-1/2,-y,-x-1/2
+x,y+1/2,z+1/2
+-y+1/4,x+3/4,z+3/4
+-x,-y+1,z+1
+y+3/4,-x+3/4,z+5/4
+x,-y+1,-z+1
+y+3/4,x+3/4,-z+5/4
+-x,y+1/2,-z+1/2
+-y+1/4,-x+3/4,-z+3/4
+z,x+1/2,y+1/2
+-x+1/4,z+3/4,y+3/4
+-z,-x+1,y+1
+x+3/4,-z+3/4,y+5/4
+z,-x+1,-y+1
+x+3/4,z+3/4,-y+5/4
+-z,x+1/2,-y+1/2
+-x+1/4,-z+3/4,-y+3/4
+y,z+1/2,x+1/2
+y+1/2,-z+1/2,-x+1
+z+1/4,y+5/4,-x+5/4
+-y+1/2,z+1,-x+1/2
+-z+1/4,-y+5/4,-x+5/4
+-y+1/2,-z+1,x+1/2
+z+1/4,-y+3/4,x+3/4
+-z+3/4,y+3/4,x+5/4
+-x+1/4,-y+3/4,-z+3/4
+y,-x+1/2,-z+1/2
+x+1/4,y+1/4,-z+1/4
+-y-1/2,x+1/2,-z
+-x+1/4,y+1/4,z+1/4
+-y-1/2,-x+1/2,z
+x+1/4,-y+3/4,z+3/4
+y,x+1/2,z+1/2
+-z+1/4,-x+3/4,-y+3/4
+x,-z+1/2,-y+1/2
+z+1/4,x+1/4,-y+1/4
+-x-1/2,z+1/2,-y
+-z+1/4,x+1/4,y+1/4
+-x-1/2,-z+1/2,y
+z+1/4,-x+3/4,y+3/4
+x,z+1/2,y+1/2
+-y+1/4,-z+3/4,-x+3/4
+-y-1/4,z+3/4,x+1/4
+-z,-y,x
+y-1/4,-z+1/4,x+3/4
+z,y,x
+y-1/4,z+1/4,-x+3/4
+-z,y+1/2,-x+1/2
+z-1/2,-y+1/2,-x
+x+1/2,y,z+1/2
+-y+3/4,x+1/4,z+3/4
+-x+1/2,-y+1/2,z+1
+y+5/4,-x+1/4,z+5/4
+x+1/2,-y+1/2,-z+1
+y+5/4,x+1/4,-z+5/4
+-x+1/2,y,-z+1/2
+-y+3/4,-x+1/4,-z+3/4
+z+1/2,x,y+1/2
+-x+3/4,z+1/4,y+3/4
+-z+1/2,-x+1/2,y+1
+x+5/4,-z+1/4,y+5/4
+z+1/2,-x+1/2,-y+1
+x+5/4,z+1/4,-y+5/4
+-z+1/2,x,-y+1/2
+-x+3/4,-z+1/4,-y+3/4
+y+1/2,z,x+1/2
+y+1,-z,-x+1
+z+3/4,y+3/4,-x+5/4
+-y+1,z+1/2,-x+1/2
+-z+3/4,-y+3/4,-x+5/4
+-y+1,-z+1/2,x+1/2
+z+3/4,-y+1/4,x+3/4
+-z+5/4,y+1/4,x+5/4
+-x+3/4,-y+1/4,-z+3/4
+y+1/2,-x,-z+1/2
+x+3/4,y-1/4,-z+1/4
+-y,x,-z
+-x+3/4,y-1/4,z+1/4
+-y,-x,z
+x+3/4,-y+1/4,z+3/4
+y+1/2,x,z+1/2
+-z+3/4,-x+1/4,-y+3/4
+x+1/2,-z,-y+1/2
+z+3/4,x-1/4,-y+1/4
+-x,z,-y
+-z+3/4,x-1/4,y+1/4
+-x,-z,y
+z+3/4,-x+1/4,y+3/4
+x+1/2,z,y+1/2
+-y+3/4,-z+1/4,-x+3/4
+-y+1/4,z+1/4,x+1/4
+-z+1/2,-y-1/2,x
+y+1/4,-z-1/4,x+3/4
+z+1/2,y-1/2,x
+y+1/4,z-1/4,-x+3/4
+-z+1/2,y,-x+1/2
+z,-y,-x
+x+1/2,y+1/2,z
+-y+3/4,x+3/4,z+1/4
+-x+1/2,-y+1,z+1/2
+y+5/4,-x+3/4,z+3/4
+x+1/2,-y+1,-z+1/2
+y+5/4,x+3/4,-z+3/4
+-x+1/2,y+1/2,-z
+-y+3/4,-x+3/4,-z+1/4
+z+1/2,x+1/2,y
+-x+3/4,z+3/4,y+1/4
+-z+1/2,-x+1,y+1/2
+x+5/4,-z+3/4,y+3/4
+z+1/2,-x+1,-y+1/2
+x+5/4,z+3/4,-y+3/4
+-z+1/2,x+1/2,-y
+-x+3/4,-z+3/4,-y+1/4
+y+1/2,z+1/2,x
+y+1,-z+1/2,-x+1/2
+z+3/4,y+5/4,-x+3/4
+-y+1,z+1,-x
+-z+3/4,-y+5/4,-x+3/4
+-y+1,-z+1,x
+z+3/4,-y+3/4,x+1/4
+-z+5/4,y+3/4,x+3/4
+-x+3/4,-y+3/4,-z+1/4
+y+1/2,-x+1/2,-z
+x+3/4,y+1/4,-z-1/4
+-y,x+1/2,-z-1/2
+-x+3/4,y+1/4,z-1/4
+-y,-x+1/2,z-1/2
+x+3/4,-y+3/4,z+1/4
+y+1/2,x+1/2,z
+-z+3/4,-x+3/4,-y+1/4
+x+1/2,-z+1/2,-y
+z+3/4,x+1/4,-y-1/4
+-x,z+1/2,-y-1/2
+-z+3/4,x+1/4,y-1/4
+-x,-z+1/2,y-1/2
+z+3/4,-x+3/4,y+1/4
+x+1/2,z+1/2,y
+-y+3/4,-z+3/4,-x+1/4
+-y+1/4,z+3/4,x-1/4
+-z+1/2,-y,x-1/2
+y+1/4,-z+1/4,x+1/4
+z+1/2,y,x-1/2
+y+1/4,z+1/4,-x+1/4
+-z+1/2,y+1/2,-x
+z,-y+1/2,-x-1/2
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_U_iso_or_equiv
+Si1 Si 0 0 0 1 0.0

--- a/aiida/backends/tests/orm/data/test_data.py
+++ b/aiida/backends/tests/orm/data/test_data.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the `Data` base class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+import numpy
+
+from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
+
+
+class TestData(AiidaTestCase):
+    """Test for the `Data` base class."""
+
+    @staticmethod
+    def generate_class_instance(data_class):
+        """Generate a dummy `Data` instance for the given sub class."""
+        dirpath_fixtures = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'fixtures'))
+        if data_class is orm.CifData:
+            instance = data_class(file=os.path.join(dirpath_fixtures, 'data', 'Si.cif'))
+            return instance
+
+        if data_class is orm.StructureData:
+            instance = orm.CifData(file=os.path.join(dirpath_fixtures, 'data', 'Si.cif')).get_structure()
+            return instance
+
+        if data_class is orm.BandsData:
+            kpoints = orm.KpointsData()
+            kpoints.set_cell([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+            kpoints.set_kpoints([[0., 0., 0.], [0.1, 0.1, 0.1]])
+            instance = data_class()
+            instance.set_kpointsdata(kpoints)
+            instance.set_bands([[1.0, 2.0], [3.0, 4.0]])
+            return instance
+
+        if data_class is orm.TrajectoryData:
+            instance = data_class()
+            stepids = numpy.array([60])
+            times = stepids * 0.01
+            cells = numpy.array([[[3., 0., 0.], [0., 3., 0.], [0., 0., 3.]]])
+            positions = numpy.array([[[0., 0., 0.]]])
+            instance.set_trajectory(stepids=stepids, cells=cells, symbols=['H'], positions=positions, times=times)
+            return instance
+
+        raise RuntimeError(
+            'no instance generator implemented for class `{}`. If you have added a `_prepare_*` method '
+            'for this data class, add a generator of a dummy instance here'.format(data_class)
+        )
+
+    def test_data_exporters(self):
+        """Verify that the return value of the export methods of all `Data` sub classes have the correct type.
+
+        It should be a tuple where the first should be a byte string and the second a dictionary.
+        """
+        from aiida.plugins.entry_point import get_entry_points
+
+        for entry_point in get_entry_points('aiida.data'):
+
+            data_class = entry_point.load()
+            export_formats = data_class.get_export_formats()
+
+            if not export_formats:
+                continue
+
+            instance = self.generate_class_instance(data_class)
+
+            for fileformat in export_formats:
+                content, dictionary = instance._exportcontent(fileformat)  # pylint: disable=protected-access
+                self.assertIsInstance(content, bytes)
+                self.assertIsInstance(dictionary, dict)

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -61,13 +61,13 @@ def _show_jmol(exec_name, trajectory_list, **kwargs):
     import subprocess
 
     # pylint: disable=protected-access
-    with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+    with tempfile.NamedTemporaryFile(mode='w+b') as handle:
         for trajectory in trajectory_list:
-            tmpf.write(trajectory._exportcontent('cif', **kwargs)[0])
-        tmpf.flush()
+            handle.write(trajectory._exportcontent('cif', **kwargs)[0])
+        handle.flush()
 
         try:
-            subprocess.check_output([exec_name, tmpf.name])
+            subprocess.check_output([exec_name, handle.name])
         except subprocess.CalledProcessError:
             # The program died: just print a message
             echo.echo_info('the call to {} ended with an error.'.format(exec_name))
@@ -93,7 +93,7 @@ def _show_xcrysden(exec_name, object_list, **kwargs):
     obj = object_list[0]
 
     # pylint: disable=protected-access
-    with tempfile.NamedTemporaryFile(mode='w+', suffix='.xsf') as tmpf:
+    with tempfile.NamedTemporaryFile(mode='w+b', suffix='.xsf') as tmpf:
         tmpf.write(obj._exportcontent('xsf', **kwargs)[0])
         tmpf.flush()
 
@@ -154,7 +154,7 @@ def _show_vesta(exec_name, structure_list):
     import subprocess
 
     # pylint: disable=protected-access
-    with tempfile.NamedTemporaryFile(mode='w+', suffix='.cif') as tmpf:
+    with tempfile.NamedTemporaryFile(mode='w+b', suffix='.cif') as tmpf:
         for structure in structure_list:
             tmpf.write(structure._exportcontent('cif')[0])
         tmpf.flush()
@@ -186,7 +186,7 @@ def _show_vmd(exec_name, structure_list):
     structure = structure_list[0]
 
     # pylint: disable=protected-access
-    with tempfile.NamedTemporaryFile(mode='w+', suffix='.xsf') as tmpf:
+    with tempfile.NamedTemporaryFile(mode='w+b', suffix='.xsf') as tmpf:
         tmpf.write(structure._exportcontent('xsf')[0])
         tmpf.flush()
 
@@ -224,7 +224,7 @@ def _show_xmgrace(exec_name, list_bands):
             'agr', setnumber_offset=current_band_number, color_number=(iband + 1 % max_num_agr_colors)
         )
         # write a tempfile
-        tempf = tempfile.NamedTemporaryFile('w+', suffix='.agr')
+        tempf = tempfile.NamedTemporaryFile('w+b', suffix='.agr')
         tempf.write(text)
         tempf.flush()
         list_files.append(tempf)

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -684,7 +684,7 @@ class BandsData(KpointsData):
             return_text.append('')
             return_text.append('')
 
-        return ('\n'.join(return_text)).encode('utf-8'), {}
+        return '\n'.join(return_text).encode('utf-8'), {}
 
     def _matplotlib_get_dict(self,
                              main_file_name='',
@@ -964,7 +964,7 @@ class BandsData(KpointsData):
         script.append(u'plot "{}" with l lc rgb "#000000"'.format(os.path.basename(dat_filename).replace('"', '\"')))
 
         script_data = u'\n'.join(script) + u'\n'
-        extra_files = {dat_filename: raw_data.encode('utf-8')}
+        extra_files = {dat_filename: raw_data}
 
         return script_data.encode('utf-8'), extra_files
 

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -732,22 +732,18 @@ class CifData(SinglefileData):
 
         return result['structure']
 
-    # pylint: disable=unused-argument
-    def _prepare_cif(self, main_file_name=''):
-        """
-        Return CIF string of CifData object.
+    def _prepare_cif(self, **kwargs):  # pylint: disable=unused-argument
+        """Return CIF string of CifData object.
 
-        If parsed values are present, a CIF string is created
-        and written to file.
-        If no parsed values are present, the CIF string is read
-        from file.
+        If parsed values are present, a CIF string is created and written to file. If no parsed values are present, the
+        CIF string is read from file.
         """
         if self._values and not self.is_stored:
             # Note: this overwrites the CIF file!
             self.set_values(self._values)
 
-        with self.open() as handle:
-            return handle.read().encode('utf-8'), {}
+        with self.open(mode='rb') as handle:
+            return handle.read(), {}
 
     def _get_object_ase(self):
         """

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -178,7 +178,10 @@ class Data(Node):
                     'No formats are implemented yet.'.format(fileformat, self.__class__.__name__)
                 )
 
-        return func(main_file_name=main_file_name, **kwargs)
+        string, dictionary = func(main_file_name=main_file_name, **kwargs)
+        assert isinstance(string, bytes), 'export function `{}` did not return the content as a byte string.'
+
+        return string, dictionary
 
     @override
     def export(self, path, fileformat=None, overwrite=False, **kwargs):

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -1058,7 +1058,7 @@ class StructureData(Data):
 
         return_dict = {'s': [cell_json], 'm': [{'a': atoms_json}], 'units': '&Aring;'}
 
-        return json.dumps(return_dict), {}
+        return json.dumps(return_dict).encode('utf-8'), {}
 
     def _prepare_xyz(self, main_file_name=''):
         """


### PR DESCRIPTION
Fixes #2756 and fixes #3277 

Sub classes of `Data` can implement methods that export their content in
a certain format. The `Data.export` function will call through to these
sub class specific methods and expects the returned content to be a
byte string. This was not always the case and so caused exceptions. A
test is added that checks the type of the returned tuple for the `Data`
sub classes that currently have export functionality.

The `verdi data * show/export` commands that serve as a CLI endpoint for
this export functionality will have to make sure that if they need to
write the returned export content to file, that they open the target in
binary mode. This was not the case for all formats and is now fixed.