### PR TITLE
Use correct session to reset database in SqlAlchemy unit tests

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import copy
-import unittest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
@@ -122,7 +121,6 @@ class TestCalcJob(AiidaTestCase):
         self.assertTrue(process.node.is_stored)
         self.assertEqual(process.node.computer.uuid, self.remote_code.computer.uuid)
 
-    @unittest.skip('Reenable when #3412 is addressed.')
     def test_remote_code_unstored_computer(self):
         """Test launching a `CalcJob` with an unstored computer which should raise."""
         inputs = copy.deepcopy(self.inputs)


### PR DESCRIPTION
Fixes #3412 

The method that reset the contents of the database after each set of
unit tests for the SqlAlchemy backend was retrieving a session that
would be disconnected from the current test session. This would cause
then leave orphaned ORM instances in the main session that no longer
corresponded to actual database instances resulting in exceptions like
`ObjectDeleteError`. Going through the backend to retrieve a transaction
will ensure that the session is nested in the main test session.