### PR TITLE
Migration safenet for running daemons

### DIFF
--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -30,6 +30,11 @@ def verdi_database():
 def database_migrate(force):
     """Migrate the database to the latest schema version."""
     from aiida.manage.manager import get_manager
+    from aiida.engine.daemon.client import get_daemon_client
+
+    client = get_daemon_client()
+    if client.is_daemon_running:
+        echo.echo_critical('Migration aborted, the daemon for the profile is still running.')
 
     manager = get_manager()
     profile = manager.get_profile()


### PR DESCRIPTION
The command `verdi migrate` will now check if the daemon is running and it will not continue if it is.
Not really sure if there is a way to include tests for this (is there a way to start/stop the daemon from python code?).

EDIT: this would close #3414