### PR TITLE
Use empty tuple as default for `follow_links` in `NodeTreePrinter`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -21,6 +21,7 @@ from click.testing import CliRunner
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_node
+from aiida.common.utils import Capturing
 
 
 def get_result_lines(result):
@@ -59,10 +60,19 @@ class TestVerdiNode(AiidaTestCase):
 
     def test_node_tree(self):
         """Test `verdi node tree`"""
-        node = orm.Data().store()
-        options = [str(node.pk)]
+        options = [str(self.node.pk)]
         result = self.cli_runner.invoke(cmd_node.tree, options)
         self.assertClickResultNoException(result)
+
+    def test_node_tree_printer(self):
+        """Test the `NodeTreePrinter` utility."""
+        from aiida.cmdline.commands.cmd_node import NodeTreePrinter
+
+        with Capturing():
+            NodeTreePrinter.print_node_tree(self.node, max_depth=1)
+
+        with Capturing():
+            NodeTreePrinter.print_node_tree(self.node, max_depth=1, follow_links=())
 
     def test_node_attributes(self):
         """Test verdi node attributes"""

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -240,7 +240,7 @@ class NodeTreePrinter(object):
     """Utility functions for printing node trees."""
 
     @classmethod
-    def print_node_tree(cls, node, max_depth, follow_links=None):
+    def print_node_tree(cls, node, max_depth, follow_links=()):
         """Top-level function for printing node tree."""
         from ete3 import Tree
         from aiida.cmdline.utils.common import get_node_summary
@@ -256,13 +256,12 @@ class NodeTreePrinter(object):
         return link_triple.node.ctime
 
     @classmethod
-    def _build_tree(cls, node, show_pk=True, max_depth=None, follow_links=None, depth=0):
+    def _build_tree(cls, node, show_pk=True, max_depth=None, follow_links=(), depth=0):
         """Return string with tree."""
         if max_depth is not None and depth > max_depth:
             return None
 
         children = []
-        # pylint: disable=unused-variable
         for entry in sorted(node.get_outgoing(link_type=follow_links).all(), key=cls._ctime):
             child_str = cls._build_tree(
                 entry.node, show_pk, follow_links=follow_links, max_depth=max_depth, depth=depth + 1


### PR DESCRIPTION
Fixes #2970 

The value is passed to `get_outgoing` and `None` will raise a `TypeError`