### PR TITLE
Allow passing `retrieved_temporary_folder` to `Parser.parse_from_node`

### DIFF
--- a/aiida/backends/tests/parsers/test_parser.py
+++ b/aiida/backends/tests/parsers/test_parser.py
@@ -109,9 +109,12 @@ class TestParser(AiidaTestCase):
         retrieved.store()
         retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
-        result, node = ArithmeticAddParser.parse_from_node(node)
+        result, calcfunction = ArithmeticAddParser.parse_from_node(node)
 
         self.assertIsInstance(result['sum'], orm.Int)
         self.assertEqual(result['sum'].value, summed)
-        self.assertIsInstance(node, orm.CalcFunctionNode)
-        self.assertEqual(node.exit_status, 0)
+        self.assertIsInstance(calcfunction, orm.CalcFunctionNode)
+        self.assertEqual(calcfunction.exit_status, 0)
+
+        # Verify that the `retrieved_temporary_folder` keyword can be passed, there is no validation though
+        result, calcfunction = ArithmeticAddParser.parse_from_node(node, retrieved_temporary_folder='/some/path')

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -110,7 +110,7 @@ class Parser(object):
         return result
 
     @classmethod
-    def parse_from_node(cls, node, store_provenance=True):
+    def parse_from_node(cls, node, store_provenance=True, retrieved_temporary_folder=None):
         """Parse the outputs directly from the `CalcJobNode`.
 
         If `store_provenance` is set to False, a `CalcFunctionNode` will still be generated, but it will not be stored.
@@ -123,6 +123,7 @@ class Parser(object):
 
         :param node: a `CalcJobNode` instance
         :param store_provenance: bool, if True will store the parsing as a `CalcFunctionNode` in the provenance
+        :param retrieved_temporary_folder: absolute path to folder with contents of `retrieved_temporary_list`
         :return: a tuple of the parsed results and the `CalcFunctionNode` representing the process of parsing
         """
         parser = cls(node=node)
@@ -141,6 +142,9 @@ class Parser(object):
             :param kwargs: keyword arguments that are passed to `Parser.parse` after it has been constructed
             """
             from aiida.engine import Process
+
+            if retrieved_temporary_folder is not None:
+                kwargs['retrieved_temporary_folder'] = retrieved_temporary_folder
 
             exit_code = parser.parse(**kwargs)
             outputs = parser.outputs


### PR DESCRIPTION
Fixes #3061 

A `CalcJob` class can specify a `retrieve_temporary_list`, the files
of which will be retrieved in a separate temporary folder that is then
passed by the daemon to the `Parser.parse` function in the keyword
arguments as `retrieved_temporary_folder`. To allow one to pass the
same temporary folder through the `Parser.parse_from_node` wrapper, the
`retrieved_temporary_folder` keyword is added to the signature.