### PR TITLE
Make `Repository.get_object` raise if key does not exist

### DIFF
--- a/aiida/backends/tests/orm/utils/test_repository.py
+++ b/aiida/backends/tests/orm/utils/test_repository.py
@@ -19,6 +19,7 @@ import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm import Node
+from aiida.orm.utils.repository import File, FileType
 
 
 class TestRepository(AiidaTestCase):
@@ -70,6 +71,30 @@ class TestRepository(AiidaTestCase):
             content = content[part]
 
         return content
+
+    def test_list_object_names(self):
+        """Test the `list_object_names` method."""
+        node = Node()
+        node.put_object_from_tree(self.tempdir, '')
+
+        self.assertEqual(sorted(node.list_object_names()), ['c.txt', 'subdir'])
+        self.assertEqual(sorted(node.list_object_names('subdir')), ['a.txt', 'b.txt', 'nested'])
+
+    def test_get_object(self):
+        """Test the `get_object` method."""
+        node = Node()
+        node.put_object_from_tree(self.tempdir, '')
+
+        self.assertEqual(node.get_object('c.txt'), File('c.txt', FileType.FILE))
+        self.assertEqual(node.get_object('subdir'), File('subdir', FileType.DIRECTORY))
+        self.assertEqual(node.get_object('subdir/a.txt'), File('a.txt', FileType.FILE))
+        self.assertEqual(node.get_object('subdir/nested'), File('nested', FileType.DIRECTORY))
+
+        with self.assertRaises(IOError):
+            node.get_object('subdir/not_existant')
+
+        with self.assertRaises(IOError):
+            node.get_object('subdir/not_existant.dat')
 
     def test_put_object_from_filelike(self):
         """Test the `put_object_from_filelike` method."""

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -108,6 +108,7 @@ class Repository(object):
 
         :param key: fully qualified identifier for the object within the repository
         :return: a `File` named tuple representing the object located at key
+        :raises IOError: if no object with the given key exists
         """
         self.validate_object_key(key)
 
@@ -121,10 +122,15 @@ class Repository(object):
         if directory:
             folder = folder.get_subfolder(directory)
 
-        if os.path.isdir(os.path.join(folder.abspath, filename)):
+        filepath = os.path.join(folder.abspath, filename)
+
+        if os.path.isdir(filepath):
             return File(filename, FileType.DIRECTORY)
 
-        return File(filename, FileType.FILE)
+        if os.path.isfile(filepath):
+            return File(filename, FileType.FILE)
+
+        raise IOError('object {} does not exist'.format(key))
 
     def get_object_content(self, key, mode='r'):
         """Return the content of a object identified by key.


### PR DESCRIPTION
Fixes #3451 

The method was always returning a `File` instance, even if the
corresponding object does not even exist within the repository.