### PR TITLE
Fix the `is_process_function` attribute of process functions

### DIFF
--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -121,6 +121,11 @@ class TestProcessFunction(AiidaTestCase):
         super(TestProcessFunction, self).tearDown()
         self.assertIsNone(Process.current())
 
+    def test_properties(self):
+        """Test that the `is_process_function` attributes is set."""
+        self.assertEqual(self.function_return_input.is_process_function, True)
+        self.assertEqual(self.function_return_true.is_process_function, True)
+
     def test_plugin_version(self):
         """Test the version attributes of a process function."""
         from aiida import __version__ as version_core

--- a/aiida/backends/tests/engine/test_utils.py
+++ b/aiida/backends/tests/engine/test_utils.py
@@ -16,7 +16,8 @@ from tornado.gen import coroutine
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.engine.utils import exponential_backoff_retry
+from aiida.engine import calcfunction, workfunction
+from aiida.engine.utils import exponential_backoff_retry, is_process_function
 
 ITERATION = 0
 MAX_ITERATIONS = 3
@@ -64,3 +65,21 @@ class TestExponentialBackoffRetry(AiidaTestCase):
         max_attempts = MAX_ITERATIONS - 1
         with self.assertRaises(RuntimeError):
             loop.run_sync(lambda: exponential_backoff_retry(coro, initial_interval=0.1, max_attempts=max_attempts))
+
+    def test_is_process_function(self):
+        """Test the `is_process_function` utility."""
+
+        def normal_function():
+            pass
+
+        @calcfunction
+        def calc_function():
+            pass
+
+        @workfunction
+        def work_function():
+            pass
+
+        self.assertEqual(is_process_function(normal_function), False)
+        self.assertEqual(is_process_function(calc_function), True)
+        self.assertEqual(is_process_function(work_function), True)

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -105,11 +105,6 @@ def process_function(node_class):
     :type node_class: :class:`aiida.orm.ProcessNode`
     """
 
-    @staticmethod
-    @property
-    def is_process_function():
-        return True
-
     def decorator(function):
         """
         Turn the decorated function into a FunctionProcess.
@@ -200,7 +195,7 @@ def process_function(node_class):
         decorated_function.run = decorated_function
         decorated_function.run_get_pk = run_get_pk
         decorated_function.run_get_node = run_get_node
-        decorated_function.is_process_function = is_process_function
+        decorated_function.is_process_function = True
 
         return decorated_function
 

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -203,7 +203,7 @@ def is_process_function(function):
     :returns: True if the function is a wrapped process function, False otherwise
     """
     try:
-        return function.is_process_function
+        return function.is_process_function is True
     except AttributeError:
         return False
 


### PR DESCRIPTION
Fixes #3453 

The `is_process_function` attribute was set to a property that would
always return `True`, except the way it was implemented calling it on a
decorated function would just return the property object and not the
value it should return. This bug went unnoticed even in the utility
`aiida.engine.utils.is_process_function` which would return the property
of a wrapped function, which since that is considered "truthy" would
still have the desired effect, but for the wrong reasons. There is no
need to have this be a property, so instead we simply set it as an
attribute. The utility will now return a value that also explicitly
checks for the `True` boolean value.