### PR TITLE
Emit a warning when a node instance is set as input port default

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -148,12 +148,12 @@ class CalcJob(Process):
             help='Set the quality of service to use in for the queue on the remote computer')
         spec.input('metadata.options.withmpi', valid_type=bool, default=False,
             help='Set the calculation to use mpi',)
-        spec.input('metadata.options.mpirun_extra_params', valid_type=(list, tuple), default=[],
+        spec.input('metadata.options.mpirun_extra_params', valid_type=(list, tuple), default=lambda: [],
             help='Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '
                  'computer.mpirun_command. Example: mpirun -np 8 extra_params[0] extra_params[1] ... exec.x',)
         spec.input('metadata.options.import_sys_environment', valid_type=bool, default=True,
             help='If set to true, the submission script will load the system environment variables',)
-        spec.input('metadata.options.environment_variables', valid_type=dict, default={},
+        spec.input('metadata.options.environment_variables', valid_type=dict, default=lambda: {},
             help='Set a dictionary of custom environment variables for this calculation',)
         spec.input('metadata.options.priority', valid_type=str, required=False,
             help='Set the priority of the job to be queued')

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -317,7 +317,7 @@ class TestProcess(AiidaTestCase):
             @classmethod
             def define(cls, spec):
                 super().define(spec)
-                spec.input('add_outputs', valid_type=orm.Bool, default=orm.Bool(False))
+                spec.input('add_outputs', valid_type=orm.Bool, default=lambda: orm.Bool(False))
                 spec.output_namespace('integer.namespace', valid_type=orm.Int, dynamic=True)
                 spec.output('required_string', valid_type=orm.Str, required=True)
 

--- a/tests/engine/test_process_builder.py
+++ b/tests/engine/test_process_builder.py
@@ -31,7 +31,7 @@ class ExampleWorkChain(WorkChain):
         spec.input('name.spaced', valid_type=orm.Int, help='Namespaced port')
         spec.input('name_spaced', valid_type=orm.Str, help='Not actually a namespaced port')
         spec.input('boolean', valid_type=orm.Bool, help='A pointless boolean')
-        spec.input('default', valid_type=orm.Int, default=orm.Int(DEFAULT_INT).store())
+        spec.input('default', valid_type=orm.Int, default=lambda: orm.Int(DEFAULT_INT).store())
 
 
 class LazyProcessNamespace(Process):

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -52,7 +52,7 @@ class TestProcessFunction(AiidaTestCase):
             return data_a
 
         @workfunction
-        def function_args_with_default(data_a=orm.Int(DEFAULT_INT)):
+        def function_args_with_default(data_a=lambda: orm.Int(DEFAULT_INT)):
             return data_a
 
         @calcfunction
@@ -72,12 +72,12 @@ class TestProcessFunction(AiidaTestCase):
             return result
 
         @workfunction
-        def function_args_and_default(data_a, data_b=orm.Int(DEFAULT_INT)):
+        def function_args_and_default(data_a, data_b=lambda: orm.Int(DEFAULT_INT)):
             return {'data_a': data_a, 'data_b': data_b}
 
         @workfunction
         def function_defaults(
-            data_a=orm.Int(DEFAULT_INT), metadata={
+            data_a=lambda: orm.Int(DEFAULT_INT), metadata={
                 'label': DEFAULT_LABEL,
                 'description': DEFAULT_DESCRIPTION
             }

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -131,8 +131,8 @@ class TestQueryBuilder(AiidaTestCase):
             def define(cls, spec):
                 super().define(spec)
                 spec.input('success', valid_type=orm.Bool)
-                spec.input('through_return', valid_type=orm.Bool, default=orm.Bool(False))
-                spec.input('through_exit_code', valid_type=orm.Bool, default=orm.Bool(False))
+                spec.input('through_return', valid_type=orm.Bool, default=lambda: orm.Bool(False))
+                spec.input('through_exit_code', valid_type=orm.Bool, default=lambda: orm.Bool(False))
                 spec.exit_code(cls.EXIT_STATUS, 'EXIT_STATUS', cls.EXIT_MESSAGE)
                 spec.outline(if_(cls.should_return_out_of_outline)(return_(cls.EXIT_STATUS)), cls.failure, cls.success)
                 spec.output(cls.OUTPUT_LABEL, required=False)


### PR DESCRIPTION
Fixes #2515 and fixes #3143 

Using mutable objects as defaults for `InputPorts` can lead to
unexpected result and should be discouraged. We override the `InputPort`
constructor to check the type of the default, if specified and emit a
warning if it is not a lambda, i.e. a callable or an immutable type. The
check for immutability is not well-defined in python so we check whether
the default has a type within a set of known immutable types. This means
that there can be obscure immutable types that trigger a false positive
but since all we do is print a `UserWarning` this is acceptable.

The `CalcJob` implementation had to be adapted to conform with the new
requirements as the `mpirun_extra_params` and `environment_variables`
metadata options were using mutable types for their default. The
defaults have been changed to the `list` and `dict` base types which
when not instantiated act like callables and therefore respect the
rules.