### PR TITLE
CifData: ignore missing scan_type attribute

### DIFF
--- a/aiida/orm/implementation/django/nodes.py
+++ b/aiida/orm/implementation/django/nodes.py
@@ -176,7 +176,7 @@ class DjangoNode(entities.DjangoModelEntity[models.DbNode], BackendNode):
 
         :param key: name of the attribute
         :return: the value of the attribute
-        :raises AttributeError: if the attribute does not exist and no default is specified
+        :raises AttributeError: if the attribute does not exist
         """
         try:
             return self._dbmodel.attributes[key]
@@ -321,7 +321,7 @@ class DjangoNode(entities.DjangoModelEntity[models.DbNode], BackendNode):
 
         :param key: name of the extra
         :return: the value of the extra
-        :raises AttributeError: if the extra does not exist and no default is specified
+        :raises AttributeError: if the extra does not exist
         """
         try:
             return self._dbmodel.extras[key]
@@ -484,7 +484,7 @@ class DjangoNode(entities.DjangoModelEntity[models.DbNode], BackendNode):
         self._dbmodel.attributes = clean_value(self._dbmodel.attributes)
         self._dbmodel.extras = clean_value(self._dbmodel.extras)
 
-    def store(self, links=None, with_transaction=True, clean=True):
+    def store(self, links=None, with_transaction=True, clean=True):  # pylint: disable=arguments-differ
         """Store the node in the database.
 
         :param links: optional links to add before storing

--- a/aiida/orm/implementation/nodes.py
+++ b/aiida/orm/implementation/nodes.py
@@ -176,7 +176,7 @@ class BackendNode(backends.BackendEntity):
 
         :param key: name of the attribute
         :return: the value of the attribute
-        :raises AttributeError: if the attribute does not exist and no default is specified
+        :raises AttributeError: if the attribute does not exist
         """
 
     @abc.abstractmethod
@@ -283,7 +283,7 @@ class BackendNode(backends.BackendEntity):
 
         :param key: name of the extra
         :return: the value of the extra
-        :raises AttributeError: if the extra does not exist and no default is specified
+        :raises AttributeError: if the extra does not exist
         """
 
     @abc.abstractmethod

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -178,7 +178,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
 
         :param key: name of the attribute
         :return: the value of the attribute
-        :raises AttributeError: if the attribute does not exist and no default is specified
+        :raises AttributeError: if the attribute does not exist
         """
         try:
             return self._dbmodel.attributes[key]
@@ -326,7 +326,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
 
         :param key: name of the extra
         :return: the value of the extra
-        :raises AttributeError: if the extra does not exist and no default is specified
+        :raises AttributeError: if the extra does not exist
         """
         try:
             return self._dbmodel.extras[key]
@@ -496,7 +496,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         self._dbmodel.attributes = clean_value(self._dbmodel.attributes)
         self._dbmodel.extras = clean_value(self._dbmodel.extras)
 
-    def store(self, links=None, with_transaction=True, clean=True):
+    def store(self, links=None, with_transaction=True, clean=True):  # pylint: disable=arguments-differ
         """Store the node in the database.
 
         :param links: optional links to add before storing

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -235,15 +235,16 @@ class CifData(SinglefileData):
         first, the values are updated from the physical CIF file.
     """
     # pylint: disable=abstract-method, too-many-public-methods
-    _set_incompatibilities = [('ase', 'file'), ('ase', 'values'), ('file', 'values')]
-    _scan_types = ('standard', 'flex')
-    _parse_policies = ('eager', 'lazy')
+    _SET_INCOMPATIBILITIES = [('ase', 'file'), ('ase', 'values'), ('file', 'values')]
+    _SCAN_TYPES = ('standard', 'flex')
+    _SCAN_TYPE_DEFAULT = 'standard'
+    _PARSE_POLICIES = ('eager', 'lazy')
+    _PARSE_POLICY_DEFAULT = 'eager'
+
     _values = None
     _ase = None
 
-    def __init__(
-        self, ase=None, file=None, values=None, source=None, scan_type='standard', parse_policy='eager', **kwargs
-    ):
+    def __init__(self, ase=None, file=None, values=None, source=None, scan_type=None, parse_policy=None, **kwargs):
         # pylint: disable=too-many-arguments, redefined-builtin
 
         args = {
@@ -252,13 +253,13 @@ class CifData(SinglefileData):
             'values': values,
         }
 
-        for left, right in self._set_incompatibilities:
+        for left, right in CifData._SET_INCOMPATIBILITIES:
             if args[left] is not None and args[right] is not None:
                 raise ValueError('cannot pass {} and {} at the same time'.format(left, right))
 
         super(CifData, self).__init__(file, **kwargs)
-        self.set_scan_type(scan_type)
-        self.set_parse_policy(parse_policy)
+        self.set_scan_type(scan_type or CifData._SCAN_TYPE_DEFAULT)
+        self.set_parse_policy(parse_policy or CifData._PARSE_POLICY_DEFAULT)
 
         if source is not None:
             self.set_source(source)
@@ -411,7 +412,7 @@ class CifData(SinglefileData):
             from CifFile import CifBlock  # pylint: disable=no-name-in-module
 
             with self.open() as handle:
-                c = CifFile.ReadCif(handle, scantype=self.get_attribute('scan_type', 'standard'))  # pylint: disable=no-member
+                c = CifFile.ReadCif(handle, scantype=self.get_attribute('scan_type', CifData._SCAN_TYPE_DEFAULT))  # pylint: disable=no-member
             for k, v in c.items():
                 c.dictionary[k] = CifBlock(v)
             self._values = c
@@ -494,7 +495,7 @@ class CifData(SinglefileData):
 
         :param scan_type: Either 'standard' or 'flex' (see _scan_types)
         """
-        if scan_type in self._scan_types:
+        if scan_type in CifData._SCAN_TYPES:
             self.set_attribute('scan_type', scan_type)
         else:
             raise ValueError('Got unknown scan_type {}'.format(scan_type))
@@ -506,7 +507,7 @@ class CifData(SinglefileData):
         :param parse_policy: Either 'eager' (parse CIF file on set_file)
             or 'lazy' (defer parsing until needed)
         """
-        if parse_policy in self._parse_policies:
+        if parse_policy in CifData._PARSE_POLICIES:
             self.set_attribute('parse_policy', parse_policy)
         else:
             raise ValueError('Got unknown parse_policy {}'.format(parse_policy))

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -411,7 +411,7 @@ class CifData(SinglefileData):
             from CifFile import CifBlock  # pylint: disable=no-name-in-module
 
             with self.open() as handle:
-                c = CifFile.ReadCif(handle, scantype=self.get_attribute('scan_type'))  # pylint: disable=no-member
+                c = CifFile.ReadCif(handle, scantype=self.get_attribute('scan_type', 'standard'))  # pylint: disable=no-member
             for k, v in c.items():
                 c.dictionary[k] = CifBlock(v)
             self._values = c

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -986,7 +986,7 @@ class Node(Entity):
 
         return self.store(with_transaction)
 
-    def store(self, with_transaction=True, use_cache=None):
+    def store(self, with_transaction=True, use_cache=None):  # pylint: disable=arguments-differ
         """Store the node in the database while saving its attributes and repository directory.
 
         After being called attributes cannot be changed anymore! Instead, extras can be changed only AFTER calling
@@ -997,7 +997,6 @@ class Node(Entity):
 
         :parameter with_transaction: if False, do not use a transaction because the caller will already have opened one.
         """
-        # pylint: disable=arguments-differ
         from aiida.manage.caching import get_use_cache
 
         if use_cache is not None:


### PR DESCRIPTION
fix #3463 

the scan_type attribute was introduced at some point and old CifData
nodes do not contain it.
This change fixes the class such that it should continue to work even if
the scan_type attribute is not set.