### PR TITLE
Add database data migration to seal unsealed processes

### DIFF
--- a/aiida/backends/djsite/db/migrations/0041_seal_unsealed_processes.py
+++ b/aiida/backends/djsite/db/migrations/0041_seal_unsealed_processes.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,too-few-public-methods
+"""Seal any process nodes that have not yet been sealed but should.
+
+This should have been accomplished by the last step in the previous migration, but because the WHERE clause was
+incorrect, not all nodes that should have been targeted were included. The problem is with the statement:
+
+    attributes->>'process_state' NOT IN ('created', 'running', 'waiting')
+
+The problem here is that this will yield `False` if the attribute `process_state` does not even exist. This will be the
+case for legacy calculations like `InlineCalculation` nodes. Their node type was already migrated in `0020` but most of
+them will be unsealed.
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.41'
+DOWN_REVISION = '1.0.40'
+
+
+class Migration(migrations.Migration):
+    """Data migration for legacy process attributes."""
+
+    dependencies = [
+        ('db', '0040_data_migration_legacy_process_attributes'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=r"""
+                UPDATE db_dbnode
+                SET attributes = jsonb_set(attributes, '{"sealed"}', to_jsonb(True))
+                WHERE
+                    node_type LIKE 'process.%' AND
+                    NOT attributes ? 'sealed' AND
+                    NOT (
+                        attributes ? 'process_state' AND
+                        attributes->>'process_state' IN ('created', 'running', 'waiting')
+                    );
+                -- Set `sealed=True` for process nodes that do not yet have a `sealed` attribute AND are not in an active state
+                -- It is important to check that `process_state` exists at all before doing the IN check.
+                """,
+            reverse_sql=''
+        ),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -23,7 +23,7 @@ class DeserializationException(AiidaException):
     pass
 
 
-LATEST_MIGRATION = '0040_data_migration_legacy_process_attributes'
+LATEST_MIGRATION = '0041_seal_unsealed_processes'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/aiida/backends/djsite/db/subtests/migrations/test_migrations_0041_seal_unsealed_processes.py
+++ b/aiida/backends/djsite/db/subtests/migrations/test_migrations_0041_seal_unsealed_processes.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=import-error,no-name-in-module,invalid-name
+"""Tests for the migrations of legacy process attributes."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from aiida.backends.djsite.db.subtests.migrations.test_migrations_common import TestMigrations
+
+
+class TestSealUnsealedProcessesMigration(TestMigrations):
+    """Test the migration that performs a data migration of legacy `JobCalcState`."""
+
+    migrate_from = '0040_data_migration_legacy_process_attributes'
+    migrate_to = '0041_seal_unsealed_processes'
+
+    def setUpBeforeMigration(self):
+        node_process = self.DbNode(
+            node_type='process.calculation.calcjob.CalcJobNode.',
+            user_id=self.default_user.id,
+            attributes={
+                'process_state': 'finished',
+                'sealed': True,
+            }
+        )
+        node_process.save()
+        self.node_process_id = node_process.id
+
+        # This is an "active" modern process, due to its `process_state` and should *not* receive the `sealed` attribute
+        node_process_active = self.DbNode(
+            node_type='process.calculation.calcjob.CalcJobNode.',
+            user_id=self.default_user.id,
+            attributes={
+                'process_state': 'created',
+            }
+        )
+        node_process_active.save()
+        self.node_process_active_id = node_process_active.id
+
+        # This is a legacy process that does not even have a `process_state`
+        node_process_legacy = self.DbNode(
+            node_type='process.calculation.calcfunction.CalcFunctionNode.', user_id=self.default_user.id, attributes={}
+        )
+        node_process_legacy.save()
+        self.node_process_legacy_id = node_process_legacy.id
+
+        # Note that `Data` nodes should not have these attributes in real databases but the migration explicitly
+        # excludes data nodes, which is what this test is verifying, by checking they are not deleted
+        node_data = self.DbNode(
+            node_type='data.dict.Dict.',
+            user_id=self.default_user.id,
+        )
+        node_data.save()
+        self.node_data_id = node_data.id
+
+    def test_data_migrated(self):
+        """Verify that the correct attributes are removed."""
+        node_process = self.load_node(self.node_process_id)
+        self.assertEqual(node_process.attributes['sealed'], True)
+
+        node_process_active = self.load_node(self.node_process_active_id)
+        self.assertNotIn('sealed', node_process_active.attributes)
+
+        node_process_legacy = self.load_node(self.node_process_legacy_id)
+        self.assertEqual(node_process_legacy.attributes['sealed'], True)
+
+        node_data = self.load_node(self.node_data_id)
+        self.assertNotIn('sealed', node_data.attributes)

--- a/aiida/backends/sqlalchemy/migrations/versions/7b38a9e783e7_seal_unsealed_processes.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/7b38a9e783e7_seal_unsealed_processes.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,no-member
+"""Seal any process nodes that have not yet been sealed but should.
+
+This should have been accomplished by the last step in the previous migration, but because the WHERE clause was
+incorrect, not all nodes that should have been targeted were included. The problem is with the statement:
+
+    attributes->>'process_state' NOT IN ('created', 'running', 'waiting')
+
+The problem here is that this will yield `False` if the attribute `process_state` does not even exist. This will be the
+case for legacy calculations like `InlineCalculation` nodes. Their node type was already migrated in `0020` but most of
+them will be unsealed.
+
+Revision ID: 7b38a9e783e7
+Revises: e734dd5e50d7
+Create Date: 2019-10-28 13:22:56.224234
+
+"""
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '7b38a9e783e7'
+down_revision = 'e734dd5e50d7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Migrations for the upgrade."""
+    conn = op.get_bind()
+
+    statement = text(
+        """
+        UPDATE db_dbnode
+        SET attributes = jsonb_set(attributes, '{"sealed"}', to_jsonb(True))
+        WHERE
+            node_type LIKE 'process.%' AND
+            NOT attributes ? 'sealed' AND
+            NOT (
+                attributes ? 'process_state' AND
+                attributes->>'process_state' IN ('created', 'running', 'waiting')
+            );
+        -- Set `sealed=True` for process nodes that do not yet have a `sealed` attribute AND are not in an active state
+        -- It is important to check that `process_state` exists at all before doing the IN check.
+        """
+    )
+    conn.execute(statement)
+
+
+def downgrade():
+    """Migrations for the downgrade."""

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -26,6 +26,7 @@ DB_TEST_LIST = {
             'aiida.backends.djsite.db.subtests.migrations.test_migrations_0037_attributes_extras_settings_json',
             'aiida.backends.djsite.db.subtests.migrations.test_migrations_0038_data_migration_legacy_job_calculations',
             'aiida.backends.djsite.db.subtests.migrations.test_migrations_0040_data_migration_legacy_process_attributes',
+            'aiida.backends.djsite.db.subtests.migrations.test_migrations_0041_seal_unsealed_processes',
         ],
     },
     BACKEND_SQLA: {


### PR DESCRIPTION
Fixes #3468 

This should have been taken care of by the previous migration named
`0040_data_migration_legacy_process_attributes`, however, the query was
incorrect and would skip processes that did not have a `sealed` attribute
nor a `process_state` attribute, which is the case for certain legacy
calculations like `InlineCalculation`. The fix is that in the `where`
clause first check for the presence of the `process_state` attribute
before performing the check that its value does not correspond to an
active state.