### PR TITLE
Accept arguments to aiida_profile

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -61,7 +61,7 @@ def clear_database(aiida_profile):  # pylint: disable=redefined-outer-name
     """
     yield
     # after the test function has completed, reset the database
-    aiida_profile.reset_db()
+    aiida_profile().reset_db()
 
 
 @pytest.fixture(scope='function')

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -23,18 +23,27 @@ from __future__ import print_function
 import tempfile
 import shutil
 import pytest
+from aiida.common.extendeddicts import AttributeDict
 from aiida.manage.tests import test_manager, get_test_backend_name, get_test_profile_name
 
 
 @pytest.fixture(scope='session', autouse=True)
-def aiida_profile():
+def aiida_profile(request):
     """Set up AiiDA test profile for the duration of the tests.
 
     Note: scope='session' limits this fixture to run once per session. Thanks to ``autouse=True``, you don't actually
      need to depend on it explicitly - it will activate as soon as you import it in your ``conftest.py``.
     """
     # create new TestManager instance
-    with test_manager(backend=get_test_backend_name(), profile_name=get_test_profile_name()) as test_mgr:
+    try:
+        test_arguments = request.param
+    except AttributeError:
+        test_arguments = AttributeDict()
+    if 'backend' not in test_arguments:
+        test_arguments.backend = get_test_backend_name()
+    if 'profile_name' not in test_arguments:
+        test_arguments.profile_name = get_test_profile_name()
+    with test_manager(**test_arguments) as test_mgr:
         yield test_mgr
     # here, the TestManager instance has already been destroyed
 

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -23,28 +23,35 @@ from __future__ import print_function
 import tempfile
 import shutil
 import pytest
-from aiida.common.extendeddicts import AttributeDict
+
 from aiida.manage.tests import test_manager, get_test_backend_name, get_test_profile_name
 
 
 @pytest.fixture(scope='session', autouse=True)
-def aiida_profile(request):
+def aiida_profile():
     """Set up AiiDA test profile for the duration of the tests.
 
     Note: scope='session' limits this fixture to run once per session. Thanks to ``autouse=True``, you don't actually
      need to depend on it explicitly - it will activate as soon as you import it in your ``conftest.py``.
     """
+
     # create new TestManager instance
-    try:
-        test_arguments = request.param
-    except AttributeError:
-        test_arguments = AttributeDict()
-    if 'backend' not in test_arguments:
-        test_arguments.backend = get_test_backend_name()
-    if 'profile_name' not in test_arguments:
-        test_arguments.profile_name = get_test_profile_name()
-    with test_manager(**test_arguments) as test_mgr:
-        yield test_mgr
+
+    def execute(test_arguments=None):
+        if test_arguments is not None:
+            if not isinstance(test_arguments, dict):
+                raise ValueError('The passed test arguments should be passed as a dictionary.')
+        else:
+            test_arguments = {}
+
+        if 'backend' not in test_arguments:
+            test_arguments['backend'] = get_test_backend_name()
+        if 'profile_name' not in test_arguments:
+            test_arguments['profile_name'] = get_test_profile_name()
+        with test_manager(**test_arguments) as test_mgr:
+            return test_mgr
+
+    yield execute
     # here, the TestManager instance has already been destroyed
 
 


### PR DESCRIPTION
An initial solution to how to pass arguments to the recently introduced `aiida_profile`. The problem with this approach is that we on the plugin side relies on fixtures, which typically use the `aiida_profile` fixture as well. Since there is no way, using this approach to pass arguments from one fixture to another (say if we want to set `pg_ctl` in the `pgtest` argument to `aiida_profile`).

We would thus severely limit the usability of fixtures on the plugin side.