### PR TITLE
Prepare the reset of the database schema

### DIFF
--- a/aiida/backends/djsite/db/migrations/0042_prepare_schema_reset.py
+++ b/aiida/backends/djsite/db/migrations/0042_prepare_schema_reset.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,too-few-public-methods
+"""Prepare the schema reset."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.42'
+DOWN_REVISION = '1.0.41'
+
+
+class Migration(migrations.Migration):
+    """Prepare the schema reset."""
+
+    dependencies = [
+        ('db', '0041_seal_unsealed_processes'),
+    ]
+
+    # The following statement is trying to perform an UPSERT, i.e. an UPDATE of a given key or if it doesn't exist fall
+    # back to an INSERT. This problem is notoriously difficult to solve as explained in great detail in this article:
+    # https://www.depesz.com/2012/06/10/why-is-upsert-so-complicated/ Postgres 9.5 provides an offical UPSERT method
+    # through the `ON CONFLICT` keyword, but since we also support 9.4 we cannot use it here. The snippet used below
+    # taken from the provided link, is not safe for concurrent operations, but since our migrations always run in an
+    # isolated way, we do not suffer from those problems and can safely use it.
+    operations = [
+        migrations.RunSQL(
+            sql=r"""
+                INSERT INTO db_dbsetting (key, val, description, time)
+                SELECT 'schema_generation', '"1"', 'Database schema generation', NOW()
+                WHERE NOT EXISTS (SELECT * FROM db_dbsetting WHERE key = 'schema_generation');
+                """,
+            reverse_sql=''
+        ),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -23,7 +23,7 @@ class DeserializationException(AiidaException):
     pass
 
 
-LATEST_MIGRATION = '0041_seal_unsealed_processes'
+LATEST_MIGRATION = '0042_prepare_schema_reset'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/aiida/backends/sqlalchemy/migrations/versions/91b573400be5_prepare_schema_reset.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/91b573400be5_prepare_schema_reset.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,no-member
+"""Prepare schema reset.
+
+Revision ID: 91b573400be5
+Revises: 7b38a9e783e7
+Create Date: 2019-07-25 14:58:39.866822
+
+"""
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '91b573400be5'
+down_revision = '7b38a9e783e7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Migrations for the upgrade."""
+    conn = op.get_bind()
+
+    # The following statement is trying to perform an UPSERT, i.e. an UPDATE of a given key or if it doesn't exist fall
+    # back to an INSERT. This problem is notoriously difficult to solve as explained in great detail in this article:
+    # https://www.depesz.com/2012/06/10/why-is-upsert-so-complicated/ Postgres 9.5 provides an offical UPSERT method
+    # through the `ON CONFLICT` keyword, but since we also support 9.4 we cannot use it here. The snippet used below
+    # taken from the provided link, is not safe for concurrent operations, but since our migrations always run in an
+    # isolated way, we do not suffer from those problems and can safely use it.
+    statement = text(
+        """
+        INSERT INTO db_dbsetting (key, val, description)
+        SELECT 'schema_generation', '"1"', 'Database schema generation'
+        WHERE NOT EXISTS (SELECT * FROM db_dbsetting WHERE key = 'schema_generation');
+        """
+    )
+    conn.execute(statement)
+
+
+def downgrade():
+    """Migrations for the downgrade."""


### PR DESCRIPTION
Fixes #3218 

Since the original databsae schema a lot changes have been applied, for
which migrations have been added to the codebase to automatically update
existing databases. However, these migrations require keeping old code
around just to keep them working as well as the for unittests, adding
significant overhead in test run time and development cost. For the
upcoming release of `aiida-core==1.0.0` we intend to "reset" the
database schema so the current migrations can be removed. To do this, we
add a final migration that will mark the point at which the reset can
take place. For convenience we add a setting `schema_generation` which
indicates the current schema generation, which for the `0.*` versions of
`aiida-core` is set to generation `1`.