### PR TITLE
Fixing the `--print-groups` option of `verdi node show`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -74,6 +74,34 @@ class TestVerdiNode(AiidaTestCase):
         with Capturing():
             NodeTreePrinter.print_node_tree(self.node, max_depth=1, follow_links=())
 
+    def test_node_show(self):
+        """Test `verdi node show`"""
+        node = orm.Data().store()
+        node.label = 'SOMELABEL'
+        options = [str(node.pk)]
+        result = self.cli_runner.invoke(cmd_node.node_show, options)
+        self.assertClickResultNoException(result)
+
+        # Let's check some content in the output. At least the UUID and the label should be in there
+        self.assertIn(node.label, result.output)
+        self.assertIn(node.uuid, result.output)
+
+        ## Let's now test the '--print-groups' option
+        options.append('--print-groups')
+        result = self.cli_runner.invoke(cmd_node.node_show, options)
+        self.assertClickResultNoException(result)
+        # I don't check the list of groups - it might be in an autogroup
+
+        # Let's create a group and put the node in there
+        group_name = 'SOMEGROUPNAME'
+        group = orm.Group(group_name).store()
+        group.add_nodes(node)
+
+        result = self.cli_runner.invoke(cmd_node.node_show, options)
+        self.assertClickResultNoException(result)
+        # Now the group should be in there
+        self.assertIn(group_name, result.output)
+
     def test_node_attributes(self):
         """Test verdi node attributes"""
         options = [str(self.node.uuid)]

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -154,17 +154,19 @@ def node_show(nodes, print_groups):
             # pylint: disable=invalid-name
             qb = QueryBuilder()
             qb.append(Node, tag='node', filters={'id': {'==': node.pk}})
-            qb.append(Group, tag='groups', with_node='node', project=['id', 'name'])
+            qb.append(Group, tag='groups', with_node='node', project=['id', 'label', 'type_string'])
 
             echo.echo('#### GROUPS:')
 
             if qb.count() == 0:
-                echo.echo('No groups found containing node {}'.format(node.pk))
+                echo.echo('Node {} does not belong to any group'.format(node.pk))
             else:
+                echo.echo('Node {} belongs to the following groups:'.format(node.pk))
                 res = qb.iterdict()
-                for gr in res:
-                    gr_specs = '{} {}'.format(gr['groups']['name'], gr['groups']['id'])
-                    echo.echo(gr_specs)
+                table = [(gr['groups']['id'], gr['groups']['label'], gr['groups']['type_string']) for gr in res]
+                table.sort()
+
+                echo.echo(tabulate.tabulate(table, headers=['PK', 'Label', 'Group type']))
 
 
 def echo_node_dict(nodes, keys, fmt, identifier, raw, use_attrs=True):


### PR DESCRIPTION
Also adding tests for `verdi node show` in general, and
for the `--print-groups` option in particular.

Fixes #3493