### PR TITLE
Backport database schema generation check

### DIFF
--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import os
 import django
 
-from aiida.backends.utils import validate_attribute_key, SettingsManager, Setting
+from aiida.backends.utils import validate_attribute_key, SettingsManager, Setting, validate_schema_generation
 from aiida.common import NotExistent
 
 SCHEMA_VERSION_DB_KEY = 'db|schemaversion'
@@ -121,6 +121,7 @@ _aiida_autouser_cache = None  # pylint: disable=invalid-name
 
 def migrate_database():
     """Migrate the database to the latest schema version."""
+    validate_schema_generation()
     from django.core.management import call_command
     call_command('migrate')
 
@@ -150,6 +151,8 @@ def check_schema_version(profile_name):
     # Do not do anything if the table does not exist yet
     if 'db_dbsetting' not in connection.introspection.table_names():
         return
+
+    validate_schema_generation()
 
     code_schema_version = aiida.backends.djsite.db.models.SCHEMA_VERSION
     db_schema_version = get_db_schema_version()

--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from aiida.backends import sqlalchemy as sa
 from aiida.backends.sqlalchemy import get_scoped_session
-from aiida.backends.utils import validate_attribute_key, SettingsManager, Setting
+from aiida.backends.utils import validate_attribute_key, SettingsManager, Setting, validate_schema_generation
 from aiida.common import NotExistent
 
 
@@ -347,6 +347,7 @@ def migrate_database(alembic_cfg=None):
 
     :param config: alembic configuration to use, will use default if not provided
     """
+    validate_schema_generation()
     from aiida.backends import sqlalchemy as sa
 
     if alembic_cfg is None:
@@ -367,6 +368,8 @@ def check_schema_version(profile_name):
     from aiida.common.exceptions import ConfigurationError
 
     alembic_cfg = get_alembic_conf()
+
+    validate_schema_generation()
 
     # Getting the version of the code and the database, reusing the existing engine (initialized by AiiDA)
     with sa.ENGINE.begin() as connection:


### PR DESCRIPTION
Fixes #3496 

This check will be implemented in the code after the schema has been
reset, but to make sure that people with a database schema generation
that is newer than the current one, cannot trigger the database, we
backport the check here. Note that this will only affect the release of
`v1.0.0 which will include this commit. Older versions will just attempt
the migration, which will fail and except. So at least it should not
touch and corrupt the database.