### PR TITLE
add `filename` argument to `SinglefileData` constructor

### DIFF
--- a/aiida/backends/tests/orm/data/test_singlefile.py
+++ b/aiida/backends/tests/orm/data/test_singlefile.py
@@ -108,6 +108,34 @@ class TestSinglefileData(AiidaTestCase):
         self.assertEqual(content_stored, content_original)
         self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])
 
+    def test_construct_with_filename(self):
+        """Test constructing an instance, providing a filename."""
+        content_original = u'some testing text\nwith a newline'
+        filename = 'myfile.txt'
+
+        # test creating from string
+        with io.BytesIO(content_original.encode('utf-8')) as handle:
+            node = SinglefileData(file=handle, filename=filename)
+
+        with node.open() as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_original)
+        self.assertEqual(node.list_object_names(), [filename])
+
+        # test creating from file
+        with tempfile.NamedTemporaryFile(mode='wb+') as handle:
+            handle.write(content_original.encode('utf-8'))
+            handle.flush()
+            handle.seek(0)
+            node = SinglefileData(file=handle, filename=filename)
+
+        with node.open() as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_original)
+        self.assertEqual(node.list_object_names(), [filename])
+
     def test_binary_file(self):
         """Test that the constructor accepts binary files."""
         byte_array = [120, 3, 255, 0, 100]

--- a/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""`verdi data singlefile` command."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.cmdline.commands.cmd_data import verdi_data
+from aiida.cmdline.params import arguments, types
+from aiida.cmdline.utils import decorators, echo
+
+
+@verdi_data.group('singlefile')
+def singlefile():
+    """Work with SinglefileData nodes."""
+
+
+@singlefile.command('content')
+@arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:singlefile',)))
+@decorators.with_dbenv()
+def singlefile_content(data):
+    """Show the content of the file."""
+    for node in data:
+        try:
+            echo.echo(node.get_content())
+        except IOError as exception:
+            echo.echo_warning('could not read the content for SinglefileData<{}>: {}'.format(node.pk, str(exception)))

--- a/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
@@ -23,12 +23,11 @@ def singlefile():
 
 
 @singlefile.command('content')
-@arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:singlefile',)))
+@arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:singlefile',)))
 @decorators.with_dbenv()
-def singlefile_content(data):
+def singlefile_content(datum):
     """Show the content of the file."""
-    for node in data:
-        try:
-            echo.echo(node.get_content())
-        except IOError as exception:
-            echo.echo_warning('could not read the content for SinglefileData<{}>: {}'.format(node.pk, str(exception)))
+    try:
+        echo.echo(datum.get_content())
+    except (IOError, OSError) as exception:
+        echo.echo_critical('could not read the content for SinglefileData<{}>: {}'.format(datum.pk, str(exception)))

--- a/aiida/common/lang.py
+++ b/aiida/common/lang.py
@@ -21,7 +21,7 @@ import six
 # Note that there is a difference between the PY2 and PY3 implementations as the latter allows unicode characters
 # We also need to discriminate between the getargspec versus getfullargspec
 if six.PY2:
-    from inspect import getargspec as get_arg_spec
+    from inspect import getargspec as get_arg_spec  # pylint: disable=deprecated-method
 
     def isidentifier(identifier):
         """Return whether the given string is a valid python identifier.

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import functools
 import logging
 import signal
-import inspect
 
 from six.moves import zip  # pylint: disable=unused-import
 from six import PY2
@@ -235,16 +234,16 @@ class FunctionProcess(Process):
         :rtype: :class:`FunctionProcess`
         """
         from aiida import orm
-        from aiida.orm import ProcessNode
+        from aiida.common.lang import get_arg_spec
         from aiida.orm.utils.mixins import FunctionCalculationMixin
 
-        if not issubclass(node_class, ProcessNode) or not issubclass(node_class, FunctionCalculationMixin):
+        if not issubclass(node_class, orm.ProcessNode) or not issubclass(node_class, FunctionCalculationMixin):
             raise TypeError('the node_class should be a sub class of `ProcessNode` and `FunctionCalculationMixin`')
 
         if PY2:
-            args, varargs, keywords, defaults = inspect.getargspec(func)  # pylint: disable=deprecated-method
+            args, varargs, keywords, defaults = get_arg_spec(func)  # pylint: disable=deprecated-method
         else:
-            args, varargs, keywords, defaults, _, _, _ = inspect.getfullargspec(func)  # pylint: disable=no-member
+            args, varargs, keywords, defaults, _, _, _ = get_arg_spec(func)  # pylint: disable=deprecated-method
         nargs = len(args)
         ndefaults = len(defaults) if defaults else 0
         first_default_pos = nargs - ndefaults

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -464,15 +464,19 @@ class CifData(SinglefileData):
 
         return super(CifData, self).store(*args, **kwargs)
 
-    def set_file(self, file):
+    def set_file(self, file, filename=None):
         """
         Set the file.
 
         If the source is set and the MD5 checksum of new file
         is different from the source, the source has to be deleted.
+
+       :param file: filepath or filelike object of the CIF file to store.
+            Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
+        :param filename: specify filename to use (defaults to name of provided file).
         """
         # pylint: disable=redefined-builtin
-        super(CifData, self).set_file(file)
+        super(CifData, self).set_file(file, filename=filename)
         md5sum = self.generate_md5()
         if isinstance(self.source, dict) and \
                 self.source.get('source_md5', None) is not None and \

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -471,7 +471,7 @@ class CifData(SinglefileData):
         If the source is set and the MD5 checksum of new file
         is different from the source, the source has to be deleted.
 
-       :param file: filepath or filelike object of the CIF file to store.
+        :param file: filepath or filelike object of the CIF file to store.
             Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
         :param filename: specify filename to use (defaults to name of provided file).
         """

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -244,7 +244,21 @@ class CifData(SinglefileData):
     _values = None
     _ase = None
 
-    def __init__(self, ase=None, file=None, values=None, source=None, scan_type=None, parse_policy=None, **kwargs):
+    def __init__(
+        self, ase=None, file=None, filename=None, values=None, source=None, scan_type=None, parse_policy=None, **kwargs
+    ):
+        """Construct a new instance and set the contents to that of the file.
+
+        :param file: an absolute filepath or filelike object for CIF.
+            Hint: Pass io.BytesIO(b"my string") to construct the SinglefileData directly from a string.
+        :param filename: specify filename to use (defaults to name of provided file).
+        :param ase: ASE Atoms object to construct the CifData instance from.
+        :param values: PyCifRW CifFile object to construct the CifData instance from.
+        :param source:
+        :param scan_type: scan type string for parsing with PyCIFRW ('standard' or 'flex'). See CifFile.ReadCif
+        :param parse_policy: 'eager' (parse CIF file on set_file) or 'lazy' (defer parsing until needed)
+        """
+
         # pylint: disable=too-many-arguments, redefined-builtin
 
         args = {
@@ -257,7 +271,7 @@ class CifData(SinglefileData):
             if args[left] is not None and args[right] is not None:
                 raise ValueError('cannot pass {} and {} at the same time'.format(left, right))
 
-        super(CifData, self).__init__(file, **kwargs)
+        super(CifData, self).__init__(file, filename=filename, **kwargs)
         self.set_scan_type(scan_type or CifData._SCAN_TYPE_DEFAULT)
         self.set_parse_policy(parse_policy or CifData._PARSE_POLICY_DEFAULT)
 

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -25,20 +25,15 @@ __all__ = ('Data',)
 
 class Data(Node):
     """
-    This class is base class for all data objects.
+    The base class for all Data nodes.
 
-    Specifications of the Data class:
-    AiiDA Data objects are subclasses of Node and should have
-
-    Multiple inheritance must be supported, i.e. Data should have methods for
-    querying and be able to inherit other library objects such as ASE for
+    AiiDA Data classes are subclasses of Node and must support multiple inheritance,
+    i.e. Data nodes should have methods for querying and must be able to inherit other library objects such as ASE for
     structures.
 
     Architecture note:
-    The code plugin is responsible for converting a raw data object produced by
-    code to AiiDA standard object format. The data object then validates itself
-    according to its method. This is done independently in order to allow
-    cross-validation of plugins.
+    Calculation plugins are responsible for converting raw output data from simulation codes to Data nodes.
+    Data nodes are responsible for validating their content (see _validate method).
     """
     _source_attributes = ['db_name', 'db_uri', 'uri', 'id', 'version', 'extras', 'source_md5', 'description', 'license']
 

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -27,9 +27,7 @@ class Data(Node):
     """
     The base class for all Data nodes.
 
-    AiiDA Data classes are subclasses of Node and must support multiple inheritance,
-    i.e. Data nodes should have methods for querying and must be able to inherit other library objects such as ASE for
-    structures.
+    AiiDA Data classes are subclasses of Node and must support multiple inheritance.
 
     Architecture note:
     Calculation plugins are responsible for converting raw output data from simulation codes to Data nodes.

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -29,7 +29,8 @@ class SinglefileData(Data):
     def __init__(self, file, **kwargs):
         """Construct a new instance and set the contents to that of the file.
 
-        :param file: an absolute filepath or filelike object whose contents to copy
+        :param file: an absolute filepath or filelike object whose contents to copy.
+            Hint: Pass io.BytesIO(b"my string") to construct the SinglefileData directly from a string.
         """
         # pylint: disable=redefined-builtin
         super(SinglefileData, self).__init__(**kwargs)
@@ -68,7 +69,7 @@ class SinglefileData(Data):
         """Store the content of the file in the node's repository, deleting any other existing objects.
 
         :param file: an absolute filepath or filelike object whose contents to copy
-            Hint: Pass io.StringIO("my string") to construct the file directly from a string.
+            Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
         """
         # pylint: disable=redefined-builtin
 

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -12,10 +12,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import warnings
 import os
 import six
 
 from aiida.common import exceptions
+from aiida.common.warnings import AiidaDeprecationWarning
+from aiida.common.lang import get_arg_spec
 from .data import Data
 
 __all__ = ('SinglefileData',)
@@ -35,9 +38,17 @@ class SinglefileData(Data):
         """
         # pylint: disable=redefined-builtin
         super(SinglefileData, self).__init__(**kwargs)
+
+        # 'filename' argument was added to 'set_file' after 1.0.0.
+        if 'filename' not in get_arg_spec(self.set_file)[0]:  # pylint: disable=deprecated-method
+            warnings.warn(  # pylint: disable=no-member
+                "Method '{}.set_file' does not support the 'filename' argument. ".format(type(self).__name__) +
+                'This will raise an exception in AiiDA 2.0.', AiidaDeprecationWarning
+            )
+
         if file is not None:
             if filename is None:
-                # for backwards compatibility don't assume that set_file has a 'filename' argument
+                # don't assume that set_file has a 'filename' argument (remove guard in 2.0.0)
                 self.set_file(file)
             else:
                 self.set_file(file, filename=filename)

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -26,16 +26,21 @@ class SinglefileData(Data):
 
     DEFAULT_FILENAME = 'file.txt'
 
-    def __init__(self, file, **kwargs):
+    def __init__(self, file, filename=None, **kwargs):
         """Construct a new instance and set the contents to that of the file.
 
         :param file: an absolute filepath or filelike object whose contents to copy.
             Hint: Pass io.BytesIO(b"my string") to construct the SinglefileData directly from a string.
+        :param filename: specify filename to use (defaults to name of provided file).
         """
         # pylint: disable=redefined-builtin
         super(SinglefileData, self).__init__(**kwargs)
         if file is not None:
-            self.set_file(file)
+            if filename is None:
+                # for backwards compatibility don't assume that set_file has a 'filename' argument
+                self.set_file(file)
+            else:
+                self.set_file(file, filename=filename)
 
     @property
     def filename(self):
@@ -65,11 +70,12 @@ class SinglefileData(Data):
         with self.open() as handle:
             return handle.read()
 
-    def set_file(self, file):
+    def set_file(self, file, filename=None):
         """Store the content of the file in the node's repository, deleting any other existing objects.
 
         :param file: an absolute filepath or filelike object whose contents to copy
             Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
+        :param filename: specify filename to use (defaults to name of provided file).
         """
         # pylint: disable=redefined-builtin
 
@@ -88,6 +94,8 @@ class SinglefileData(Data):
                 key = os.path.basename(file.name)
             except AttributeError:
                 key = self.DEFAULT_FILENAME
+
+        key = filename or key
 
         existing_object_names = self.list_object_names()
 

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -268,10 +268,12 @@ def parse_upf(fname, check_filename=True):
 class UpfData(SinglefileData):
     """`Data` sub class to represent a pseudopotential single file in UPF format."""
 
-    def __init__(self, file=None, source=None, **kwargs):
+    def __init__(self, file=None, filename=None, source=None, **kwargs):
         """Create UpfData instance from pseudopotential file.
 
           :param file: filepath or filelike object of the UPF potential file to store.
+            Hint: Pass io.BytesIO(b"my string") to construct directly from a string.
+          :param filename: specify filename to use (defaults to name of provided file).
           :param source: Dictionary with information on source of the potential (see ".source" property).
           """
         # pylint: disable=redefined-builtin

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -269,6 +269,11 @@ class UpfData(SinglefileData):
     """`Data` sub class to represent a pseudopotential single file in UPF format."""
 
     def __init__(self, file=None, source=None, **kwargs):
+        """Create UpfData instance from pseudopotential file.
+
+          :param file: filepath or filelike object of the UPF potential file to store.
+          :param source: Dictionary with information on source of the potential (see ".source" property).
+          """
         # pylint: disable=redefined-builtin
         super(UpfData, self).__init__(file, **kwargs)
         if source is not None:
@@ -356,10 +361,12 @@ class UpfData(SinglefileData):
         builder.append(cls, filters={'attributes.md5': {'==': md5}})
         return [upf for upf, in builder.all()]
 
-    def set_file(self, file):
+    def set_file(self, file, filename=None):
         """Store the file in the repository and parse it to set the `element` and `md5` attributes.
 
         :param file: filepath or filelike object of the UPF potential file to store.
+            Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
+        :param filename: specify filename to use (defaults to name of provided file).
         """
         # pylint: disable=redefined-builtin
         from aiida.common.exceptions import ParsingError
@@ -377,7 +384,7 @@ class UpfData(SinglefileData):
         except KeyError:
             raise ParsingError("No 'element' parsed in the UPF file {}; unable to store".format(self.filename))
 
-        super(UpfData, self).set_file(file)
+        super(UpfData, self).set_file(file, filename=filename)
 
         self.set_attribute('element', str(element))
         self.set_attribute('md5', md5sum)

--- a/setup.json
+++ b/setup.json
@@ -152,6 +152,7 @@
       "cif = aiida.cmdline.commands.cmd_data.cmd_cif:cif",
       "dict = aiida.cmdline.commands.cmd_data.cmd_dict:dictionary",
       "remote = aiida.cmdline.commands.cmd_data.cmd_remote:remote",
+      "singlefile = aiida.cmdline.commands.cmd_data.cmd_singlefile:singlefile",
       "structure = aiida.cmdline.commands.cmd_data.cmd_structure:structure",
       "trajectory = aiida.cmdline.commands.cmd_data.cmd_trajectory:trajectory",
       "upf = aiida.cmdline.commands.cmd_data.cmd_upf:upf"


### PR DESCRIPTION
fix #3520 

 * The documentation of how to create a `SinglefileData` from a string was incorrect, and missing from the constructor (first commit).
 * While it is possible to create a SinglefileData directly from a string, it was not possible to define the filename. Fixed in second commit.
 * there was no way to get the content of a Singlefiledata on the cli. fixed in 3rd commit.

