### PR TITLE
Patching export for unicode issue

### DIFF
--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -674,7 +674,7 @@ def export_tree(
     }
 
     # N.B. We're really calling zipfolder.open (if exporting a zipfile)
-    with folder.open('data.json', mode='w') as fhandle:
+    with folder.open('data.json', mode='w', encoding='utf-8') as fhandle:
         # fhandle.write(json.dumps(data, cls=UUIDEncoder))
         fhandle.write(json.dumps(data))
 
@@ -695,7 +695,7 @@ def export_tree(
         }
     }
 
-    with folder.open('metadata.json', 'w') as fhandle:
+    with folder.open('metadata.json', 'w', encoding='utf-8') as fhandle:
         fhandle.write(json.dumps(metadata))
 
     EXPORT_LOGGER.debug('ADDING REPOSITORY FILES TO EXPORT ARCHIVE...')

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -673,10 +673,9 @@ def export_tree(
         'groups_uuid': groups_uuid
     }
 
-    # N.B. We're really calling zipfolder.open (if exporting a zipfile)
-    with folder.open('data.json', mode='w', encoding='utf-8') as fhandle:
-        # fhandle.write(json.dumps(data, cls=UUIDEncoder))
-        fhandle.write(json.dumps(data))
+    # NOTE: We're really calling zipfolder.open (if exporting a zipfile)
+    with folder.open('data.json', mode='w') as fhandle:
+        fhandle.write(json.dumps(data))  # json.dumps will always return a str
 
     # Turn sets into lists to be able to export them as JSON metadata.
     for entity, entity_set in entities_starting_set.items():
@@ -695,8 +694,8 @@ def export_tree(
         }
     }
 
-    with folder.open('metadata.json', 'w', encoding='utf-8') as fhandle:
-        fhandle.write(json.dumps(metadata))
+    with folder.open('metadata.json', 'w') as fhandle:
+        fhandle.write(json.dumps(metadata))  # json.dumps will always return a str
 
     EXPORT_LOGGER.debug('ADDING REPOSITORY FILES TO EXPORT ARCHIVE...')
 

--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -16,10 +16,11 @@ import zipfile
 
 class MyWritingZipFile:
 
-    def __init__(self, zip_file, fname):
+    def __init__(self, zip_file, fname, encoding):
         self._zipfile = zip_file
         self._fname = fname
         self._buffer = None
+        self._encoding = encoding
 
     def open(self):
         if self._buffer is not None:
@@ -27,7 +28,10 @@ class MyWritingZipFile:
         self._buffer = io.StringIO()
 
     def write(self, data):
-        self._buffer.write(data)
+        if self._encoding:
+            self._buffer.write(str(data.encode(self._encoding)))
+        else:
+            self._buffer.write(data)
 
     def close(self):
         self._buffer.seek(0)
@@ -94,9 +98,12 @@ class ZipFolder:
     def pwd(self):
         return self._pwd
 
-    def open(self, fname, mode='r'):
+    def open(self, fname, mode='r', encoding='utf8'):
+        if 'b' in mode:
+            encoding = None
+
         if mode == 'w':
-            return MyWritingZipFile(zip_file=self._zipfile, fname=self._get_internal_path(fname))
+            return MyWritingZipFile(zip_file=self._zipfile, fname=self._get_internal_path(fname), encoding=encoding)
         # else
         return self._zipfile.open(self._get_internal_path(fname), mode)
 

--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -25,12 +25,16 @@ class MyWritingZipFile:
     def open(self):
         if self._buffer is not None:
             raise IOError('Cannot open again!')
-        self._buffer = io.StringIO()
+        self._buffer = io.BytesIO()
 
     def write(self, data):
         if self._encoding:
-            self._buffer.write(str(data.encode(self._encoding)))
+            if not isinstance(data, str):
+                raise TypeError('data must be a str when opening in non-bytes mode')
+            self._buffer.write(data.encode(self._encoding))
         else:
+            if not isinstance(data, bytes):
+                raise TypeError('data must be a bytes when opening in bytes mode')
             self._buffer.write(data)
 
     def close(self):
@@ -98,11 +102,11 @@ class ZipFolder:
     def pwd(self):
         return self._pwd
 
-    def open(self, fname, mode='r', encoding='utf8'):
+    def open(self, fname, mode='r', encoding='utf-8'):
         if 'b' in mode:
             encoding = None
 
-        if mode == 'w':
+        if 'w' in mode:
             return MyWritingZipFile(zip_file=self._zipfile, fname=self._get_internal_path(fname), encoding=encoding)
         # else
         return self._zipfile.open(self._get_internal_path(fname), mode)

--- a/tests/tools/importexport/dbexport/test_zip.py
+++ b/tests/tools/importexport/dbexport/test_zip.py
@@ -1,0 +1,47 @@
+"""Tests for aiida.tools.importexport.dbexport.zip"""
+import os
+
+import pytest
+
+from aiida.common import json
+from aiida.tools.importexport.dbexport.zip import ZipFolder
+
+
+def test_writing_bytes(temp_dir):
+    """Verify exporting a Node with a bytes object in the repo is possible"""
+    zip_file = os.path.join(temp_dir, 'test.zip')
+    filename = 'data{}.json'
+
+    data: str = 'aà'
+    bytes_data: bytes = data.encode('utf-8')
+    json_data: str = json.dumps(bytes_data)  # Will always return a string
+    json_bytes_data: bytes = json_data.encode('utf-8')
+
+    with ZipFolder(zip_file, mode='w') as folder:
+        with folder.open(filename.format(0), mode='w') as fhandle:
+            fhandle.write(data)
+
+        with folder.open(filename.format(1), mode='wb') as fhandle:
+            fhandle.write(bytes_data)
+
+        with folder.open(filename.format(2), mode='w') as fhandle:
+            fhandle.write(json_data)
+
+        with folder.open(filename.format(3), mode='wb') as fhandle:
+            fhandle.write(json_bytes_data)
+
+        with pytest.raises(TypeError, match='data must be a bytes'):
+            with folder.open(filename.format(4), mode='wb') as fhandle:
+                fhandle.write(data)
+
+        with pytest.raises(TypeError, match='data must be a str'):
+            with folder.open(filename.format(5), mode='w') as fhandle:
+                fhandle.write(bytes_data)
+
+        with pytest.raises(TypeError, match='data must be a bytes'):
+            with folder.open(filename.format(6), mode='wb') as fhandle:
+                fhandle.write(json_data)
+
+        with pytest.raises(TypeError, match='data must be a str'):
+            with folder.open(filename.format(7), mode='w') as fhandle:
+                fhandle.write(json_bytes_data)

--- a/tests/tools/importexport/dbexport/test_zip.py
+++ b/tests/tools/importexport/dbexport/test_zip.py
@@ -12,10 +12,10 @@ def test_writing_bytes(temp_dir):
     zip_file = os.path.join(temp_dir, 'test.zip')
     filename = 'data{}.json'
 
-    data: str = 'aà'
-    bytes_data: bytes = data.encode('utf-8')
-    json_data: str = json.dumps(bytes_data)  # Will always return a string
-    json_bytes_data: bytes = json_data.encode('utf-8')
+    data = 'aà'
+    bytes_data = data.encode('utf-8')
+    json_data = json.dumps(bytes_data)  # Will always return a string
+    json_bytes_data = json_data.encode('utf-8')
 
     with ZipFolder(zip_file, mode='w') as folder:
         with folder.open(filename.format(0), mode='w') as fhandle:

--- a/tests/tools/importexport/test_specific_import.py
+++ b/tests/tools/importexport/test_specific_import.py
@@ -13,8 +13,6 @@ import os
 import shutil
 import tempfile
 
-import unittest
-
 import numpy as np
 
 from aiida import orm
@@ -268,7 +266,6 @@ class TestSpecificImport(AiidaTestCase):
             'Unable to find the repository folder for Node with UUID={}'.format(node_uuid), str(exc.exception)
         )
 
-    @unittest.skip('Reenable when issue #3199 is solve (PR #3242): Fix `extract_tree`')
     @with_temp_dir
     def test_empty_repo_folder_export(self, temp_dir):
         """Check a Node's empty repository folder is exported properly"""


### PR DESCRIPTION
Fixes #3492

This PR attemps to accommodate the issue described in #3492 by adding encoding info when opening the json files for writing during export and further adding some encoding info in our own `ZipFolder`.

@AntimoMarrazzo, could you possibly try and export using this branch and see if it fixes your usecase?