### PR TITLE
Create backup of configuration file before migrating

### DIFF
--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -18,7 +18,6 @@ import shutil
 
 from aiida.common import json
 
-from .migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
 from .options import get_option, parse_option, NO_DEFAULT
 from .profile import Profile
 from .settings import DEFAULT_UMASK, DEFAULT_CONFIG_INDENT_SIZE
@@ -36,6 +35,52 @@ class Config(object):  # pylint: disable=too-many-public-methods
     KEY_PROFILES = 'profiles'
     KEY_OPTIONS = 'options'
 
+    @classmethod
+    def from_file(cls, filepath):
+        """Instantiate a configuration object from the contents of a given file.
+
+        :param filepath: the absolute path to the configuration file
+        :return: `Config` instance
+        """
+        from aiida.cmdline.utils import echo
+        from .migrations import check_and_migrate_config, config_needs_migrating
+
+        with io.open(filepath, 'r', encoding='utf8') as handle:
+            config = json.load(handle)
+
+        # If the configuration file needs to be migrated, first create a specific backup so it can easily be reverted
+        if config_needs_migrating(config):
+            echo.echo_warning('current configuration file `{}` is outdated and will be migrated'.format(filepath))
+            filepath_backup = cls._backup(filepath)
+            echo.echo_warning('original backed up to `{}`'.format(filepath_backup))
+
+        config = check_and_migrate_config(config)
+
+        return Config(filepath, config)
+
+    @classmethod
+    def _backup(cls, filepath):
+        """Create a backup of the configuration file with the given filepath.
+
+        :param filepath: absolute path to the configuration file to backup
+        :return: the absolute path of the created backup
+        """
+        from aiida.common import timezone
+
+        filepath_backup = None
+
+        # Keep generating a new backup filename based on the current time until it does not exist
+        while not filepath_backup or os.path.isfile(filepath_backup):
+            filepath_backup = '{}.{}'.format(filepath, timezone.now().strftime('%Y%m%d-%H%M%S.%f'))
+
+        try:
+            umask = os.umask(DEFAULT_UMASK)
+            shutil.copy(filepath, filepath_backup)
+        finally:
+            os.umask(umask)
+
+        return filepath_backup
+
     def __init__(self, filepath, config):
         """Instantiate a configuration object from a configuration dictionary and its filepath.
 
@@ -44,6 +89,8 @@ class Config(object):  # pylint: disable=too-many-public-methods
         :param filepath: the absolute filepath of the configuration file
         :param config: the content of the configuration file in dictionary form
         """
+        from .migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
+
         version = config.get(self.KEY_VERSION, {})
         current_version = version.get(self.KEY_VERSION_CURRENT, CURRENT_CONFIG_VERSION)
         compatible_version = version.get(self.KEY_VERSION_OLDEST_COMPATIBLE, OLDEST_COMPATIBLE_CONFIG_VERSION)
@@ -91,10 +138,9 @@ class Config(object):  # pylint: disable=too-many-public-methods
         :param message: a string message to echo with describing the infraction
         """
         from aiida.cmdline.utils import echo
-        filepath = self._filepath + '.bak'
-        self._backup(filepath)
+        filepath_backup = self._backup(self.filepath)
         echo.echo_warning(message)
-        echo.echo_warning('backup of the original config file written to: `{}`'.format(filepath))
+        echo.echo_warning('backup of the original config file written to: `{}`'.format(filepath_backup))
 
     @property
     def dictionary(self):
@@ -321,7 +367,8 @@ class Config(object):  # pylint: disable=too-many-public-methods
 
     def store(self):
         """Write the current config to file."""
-        self._backup()
+        if os.path.isfile(self.filepath):
+            self._backup(self.filepath)
 
         umask = os.umask(DEFAULT_UMASK)
 
@@ -332,18 +379,3 @@ class Config(object):  # pylint: disable=too-many-public-methods
             os.umask(umask)
 
         return self
-
-    def _backup(self, filepath=None):
-        """Create a backup of the current config as it exists on disk."""
-        if not os.path.isfile(self.filepath):
-            return
-
-        umask = os.umask(DEFAULT_UMASK)
-
-        if filepath is None:
-            filepath = self.filepath + '~'
-
-        try:
-            shutil.copy(self.filepath, filepath)
-        finally:
-            os.umask(umask)

--- a/aiida/manage/configuration/migrations/utils.py
+++ b/aiida/manage/configuration/migrations/utils.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from aiida.common import exceptions
 from .migrations import _MIGRATION_LOOKUP, CURRENT_CONFIG_VERSION
 
-__all__ = ('check_and_migrate_config',)
+__all__ = ('check_and_migrate_config', 'config_needs_migrating', 'get_current_version')
 
 
 def check_and_migrate_config(config):
@@ -37,7 +37,7 @@ def config_needs_migrating(config):
     in the code, the config cannot be used and so the function will raise.
 
     :return: True if the configuration has an older version and needs to be migrated, False otherwise
-    :raises ConfigurationVersionError: if the oldest compatible version of the config is higher than the current.
+    :raises aiida.common.ConfigurationVersionError: if the config's oldest compatible version is higher than the current
     """
     current_version = get_current_version(config)
     oldest_compatible_version = get_oldest_compatible_version(config)


### PR DESCRIPTION
Fixes #3510 

This allows users to revert in case of problems with the migration or if
the migration happens by accident. Since the migration is done
automatically without prompt and is not reversible, having a backup is
crucial if users checkout a version of the code by accident.

P.S.: tests not included.