### PR TITLE
Add `python_requires` to `setup.json`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -6,6 +6,7 @@
   "author": "The AiiDA team",
   "author_email": "developers@aiida.net",
   "include_package_data": true,
+  "python_requires": ">=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
   "classifiers": [
     "Framework :: AiiDA",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Fixes #3573 

This will allow `pip>=9.0` to install a version of the package that is
compatible with the current python runtime.

This needs to go in `v1.0.1` before we drop python 2 for `v1.1.0`