### PR TITLE
raise when unable to detect name of local timezone

### DIFF
--- a/aiida/backends/djsite/settings.py
+++ b/aiida/backends/djsite/settings.py
@@ -68,7 +68,9 @@ MANAGERS = ADMINS
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
-# Local time zone for this installation. Always choose the system timezone
+# Local time zone for this installation. Always choose the system timezone.
+# Note: This causes django to set the 'TZ' environment variable, which is read by tzlocal from then onwards.
+# See https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-TIME_ZONE
 TIME_ZONE = get_current_timezone().zone
 
 SITE_ID = 1

--- a/aiida/backends/tests/common/test_timezone.py
+++ b/aiida/backends/tests/common/test_timezone.py
@@ -23,9 +23,14 @@ class TimezoneTest(unittest.TestCase):
     """Tests for the timezone utility module."""
 
     def test_timezone_now(self):
-        """Test timezone.now function."""
+        """Test timezone.now function.
+
+        Check that the time returned by AiiDA's timezone.now() function is compatible
+        with attaching a timezone to a "naive" time stamp using timezone.make_aware().
+        """
         delta = datetime.timedelta(minutes=1)
         ref = timezone.now()
+
         from_tz = timezone.make_aware(datetime.datetime.fromtimestamp(time.time()))
         self.assertLessEqual(from_tz, ref + delta)
         self.assertGreaterEqual(from_tz, ref - delta)

--- a/aiida/common/timezone.py
+++ b/aiida/common/timezone.py
@@ -22,7 +22,14 @@ def get_current_timezone():
     :return: current timezone
     """
     from tzlocal import get_localzone
-    return get_localzone()
+    local = get_localzone()
+
+    if local.zone == 'local':
+        raise ValueError(
+            "Unable to detect name of local time zone. Please set 'TZ' environment variable, e.g."
+            " to 'Europe/Zurich'"
+        )
+    return local
 
 
 def now():
@@ -70,8 +77,10 @@ def make_aware(value, timezone=None, is_dst=None):
 
     if is_aware(value):
         raise ValueError('make_aware expects a naive datetime, got %s' % value)
+
     # This may be wrong around DST changes!
-    return value.replace(tzinfo=timezone)
+    # See http://pytz.sourceforge.net/#localized-times-and-date-arithmetic
+    return timezone.localize(value)
 
 
 def localtime(value, timezone=None):

--- a/aiida/manage/backup/backup_base.py
+++ b/aiida/manage/backup/backup_base.py
@@ -21,7 +21,6 @@ import logging
 from abc import abstractmethod, ABCMeta
 import six
 from dateutil.parser import parse
-from pytz import timezone as ptimezone
 
 from aiida.common import json
 from aiida.common import timezone as dtimezone
@@ -136,11 +135,11 @@ class AbstractBackup(object):
             try:
                 self._oldest_object_bk = parse(backup_variables.get(self.OLDEST_OBJECT_BK_KEY))
                 if self._oldest_object_bk.tzinfo is None:
-                    curr_timezone = str(dtimezone.get_current_timezone())
-                    self._oldest_object_bk = ptimezone(curr_timezone).localize(self._oldest_object_bk)
+                    curr_timezone = dtimezone.get_current_timezone()
+                    self._oldest_object_bk = dtimezone.get_current_timezone().localize(self._oldest_object_bk)
                     self._logger.info(
                         'No timezone defined in the oldest modification date timestamp. Setting current timezone (%s).',
-                        curr_timezone
+                        curr_timezone.zone
                     )
             # If it is not parsable...
             except ValueError:
@@ -168,13 +167,13 @@ class AbstractBackup(object):
                 self._end_date_of_backup = parse(backup_variables.get(self.END_DATE_OF_BACKUP_KEY))
 
                 if self._end_date_of_backup.tzinfo is None:
-                    curr_timezone = str(dtimezone.get_current_timezone())
+                    curr_timezone = dtimezone.get_current_timezone()
                     self._end_date_of_backup = \
-                        ptimezone(curr_timezone).localize(
+                        curr_timezone.localize(
                             self._end_date_of_backup)
                     self._logger.info(
                         'No timezone defined in the end date of backup timestamp. Setting current timezone (%s).',
-                        curr_timezone
+                        curr_timezone.zone
                     )
 
                 self._internal_end_date_of_backup = self._end_date_of_backup


### PR DESCRIPTION
fix #3563 

When tzlocal is unable to detect the name of the local timezone, it
labels it as 'local', which is not understood by django.
When this happens, ask the user to set the desired timezone using the TZ
environment variable.

Todo: Open new issue to consider giving users the option to specify the desired timezone in the AiiDA profile.