### PR TITLE
Improve the backup mechanism of the configuration file

### DIFF
--- a/aiida/backends/tests/utils/configuration.py
+++ b/aiida/backends/tests/utils/configuration.py
@@ -54,6 +54,7 @@ def temporary_config_instance():
     current_profile_name = None
     temporary_config_directory = None
 
+    from aiida.common.utils import Capturing
     from aiida.manage import configuration
     from aiida.manage.configuration import settings, load_profile, reset_profile
 
@@ -75,7 +76,11 @@ def temporary_config_instance():
 
         # Create the instance base directory structure, the config file and a dummy profile
         create_instance_directories()
-        configuration.CONFIG = configuration.load_config(create=True)
+
+        # The constructor of `Config` called by `load_config` will print warning messages about migrating it
+        with Capturing():
+            configuration.CONFIG = configuration.load_config(create=True)
+
         profile = create_mock_profile(name=profile_name, repository_dirpath=temporary_config_directory)
 
         # Add the created profile and set it as the default

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -80,7 +80,6 @@ def load_config(create=False):
     :rtype: :class:`~aiida.manage.configuration.config.Config`
     :raises aiida.common.MissingConfigurationError: if the configuration file could not be found and create=False
     """
-    import io
     import os
     from aiida.common import exceptions
     from .config import Config
@@ -115,12 +114,6 @@ def load_config(create=False):
 
     if not os.path.isfile(filepath) and not create:
         raise exceptions.MissingConfigurationError('configuration file {} does not exist'.format(filepath))
-
-    # If it doesn't exist, just create the file
-    if not os.path.isfile(filepath):
-        from aiida.common import json
-        with io.open(filepath, 'ab') as handle:
-            json.dump({}, handle)
 
     try:
         config = Config.from_file(filepath)

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -119,7 +119,6 @@ def load_config(create=False):
         config = Config.from_file(filepath)
     except ValueError:
         raise exceptions.ConfigurationError('configuration file {} contains invalid JSON'.format(filepath))
-    config.store()
 
     return config
 


### PR DESCRIPTION
Fixes #3580 

The `Config` class was creating a new backup each time `store` was
called, which also happens if nothing really changed to the configuration
content. With the recently introduced change that backup files are now
made unique through a timestamp, this led to a lot of backups being
created that were essentially clones.

To improve this, the `Config.store` method now only writes the file to
disk if the contents in memory have changed. This is done by comparing
the checksum of the on disk file and that memory contents as written to
a temporary file. If the check sums differ a backup is created of the
existing file and the new contents written to the temporary file are
copied to the actual configuration file location. This latter new
approach also guarantees that the backup is always created before
overwriting the original one.