### PR TITLE
config migration: handle edge case

### DIFF
--- a/aiida/manage/configuration/migrations/migrations.py
+++ b/aiida/manage/configuration/migrations/migrations.py
@@ -63,15 +63,17 @@ def _1_add_profile_uuid(config):
 def _2_simplify_default_profiles(config):
     """
     The concept of a different 'process' for a profile has been removed and as such the
-    default profiles key in the configuration no longer needs a value per process ('verdi', 'daemon')
-    We remove the dictionary 'default_profiles' and replace it with a simple value 'default_profile'
+    default profiles key in the configuration no longer needs a value per process ('verdi', 'daemon').
+    We remove the dictionary 'default_profiles' and replace it with a simple value 'default_profile'.
     """
     from aiida.manage.configuration import PROFILE
 
     default_profiles = config.pop('default_profiles', None)
 
-    if default_profiles:
+    if default_profiles and 'daemon' in default_profiles:
         config['default_profile'] = default_profiles['daemon']
+    elif default_profiles and 'verdi' in default_profiles:
+        config['default_profile'] = default_profiles['verdi']
     elif PROFILE is not None:
         config['default_profile'] = PROFILE.name
 


### PR DESCRIPTION
fix #3583

handle edge case in config file migration if 'daemon' key is missing in
'default_profiles'