### PR TITLE
Set default for the `safe_interval` option of `verdi computer configure`

### DIFF
--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -111,10 +111,14 @@ def create_option(name, spec):
     if spec.pop('switch', False):
         option_name = '--{name}/--no-{name}'.format(name=name_dashed)
     kwargs = {}
-    if 'default' not in spec:
+
+    if 'default' in spec:
+        kwargs['show_default'] = True
+    else:
         kwargs['contextual_default'] = interactive_default(
             'ssh', name, also_noninteractive=spec.pop('non_interactive_default', False)
         )
+
     kwargs['cls'] = InteractiveOption
     kwargs.update(spec)
     if existing_option:

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -55,21 +55,16 @@ class LocalTransport(Transport):
     # where the remote computer will rate limit the number of connections.
     _DEFAULT_SAFE_OPEN_INTERVAL = 0.0
 
-    def __init__(self, **kwargs):
-        super(LocalTransport, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(LocalTransport, self).__init__(*args, **kwargs)
         # The `_internal_dir` will emulate the concept of working directory, as the real current working directory is
         # not to be changed to prevent bug-prone situations
-        self._is_open = False
         self._internal_dir = None
 
         # Just to avoid errors
         self._machine = kwargs.pop('machine', None)
         if self._machine and self._machine != 'localhost':
             self.logger.debug('machine was passed, but it is not localhost')
-        self._safe_open_interval = kwargs.pop('safe_interval', self._DEFAULT_SAFE_OPEN_INTERVAL)
-
-        if kwargs:
-            raise ValueError('the following keywords are not recognized: {}'.format(kwargs))
 
     def open(self):
         """

--- a/aiida/transports/plugins/test_local.py
+++ b/aiida/transports/plugins/test_local.py
@@ -43,10 +43,6 @@ class TestBasicConnection(unittest.TestCase):
             t = LocalTransport()
             t.listdir()
 
-    def test_invalid_param(self):
-        with self.assertRaises(ValueError):
-            LocalTransport(unrequired_var='something')
-
     def test_basic(self):
         with LocalTransport():
             pass

--- a/aiida/transports/plugins/test_ssh.py
+++ b/aiida/transports/plugins/test_ssh.py
@@ -41,10 +41,6 @@ class TestBasicConnection(unittest.TestCase):
             t = SshTransport(machine='localhost')
             t.listdir()
 
-    def test_invalid_param(self):
-        with self.assertRaises(ValueError):
-            SshTransport(machine='localhost', invalid_param=True)
-
     def test_auto_add_policy(self):
         with SshTransport(machine='localhost', timeout=30, load_system_host_keys=True, key_policy='AutoAddPolicy'):
             pass


### PR DESCRIPTION
Fixes #2880 

The `safe_interval` is a common option for all `Transport` types but its
default value is class dependent. Since it is a common option it was
defined in the `Transport` base class, but since it is defined as a
class attribute, the default cannot be set yet. Keeping this design, the
only option to insert the class specific default is in `auth_options`
the class property that returns the options for the CLI. By adding the
default here, `verdi computer configure local localhost -n` will now
work without prompting for its only option `safe_interval` as it will
simply use the default.