### PR TITLE
Fix false positive for `verdi database integrity detect-invalid-links`

### DIFF
--- a/aiida/manage/database/integrity/sql/links.py
+++ b/aiida/manage/database/integrity/sql/links.py
@@ -23,7 +23,7 @@ SELECT_CALCULATIONS_WITH_OUTGOING_CALL = """
     JOIN db_dblink AS link ON node_in.id = link.input_id
     JOIN db_dbnode AS node_out ON node_out.id = link.output_id
     WHERE node_in.node_type LIKE 'process.calculation%'
-    AND link.type = 'call_calc' OR link.type = 'call_work';
+    AND (link.type = 'call_calc' OR link.type = 'call_work');
     """
 
 SELECT_CALCULATIONS_WITH_OUTGOING_RETURN = """


### PR DESCRIPTION
Fixes #3539 

The query `SELECT_CALCULATIONS_WITH_OUTGOING_CALL` defined in the module
`aiida.manage.database.integrity.sql.links` contained an error causing
the command to return false positives. The problem was not detected by
the tests because they operated on an empty database and only checked
for true positives. A basic graph is added to now detect the false ones.