### PR TITLE
tone down/remove user warnings

### DIFF
--- a/aiida/backends/djsite/db/migrations/0039_reset_hash.py
+++ b/aiida/backends/djsite/db/migrations/0039_reset_hash.py
@@ -16,7 +16,7 @@ Invalidating node hash - User should rehash nodes for caching
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
-from aiida.cmdline.utils.echo import echo_warning
+from aiida.cmdline.utils import echo
 
 REVISION = '1.0.39'
 DOWN_REVISION = '1.0.38'
@@ -26,7 +26,9 @@ _HASH_EXTRA_KEY = '_aiida_hash'
 
 
 def notify_user(apps, schema_editor):  # pylint: disable=unused-argument
-    echo_warning('Invalidating all the hashes of all the nodes. Please run verdi rehash', bold=True)
+    DbNode = apps.get_model('db', 'DbNode')
+    if DbNode.objects.count():
+        echo.echo_warning('Invalidating the hashes of all nodes. Please run "verdi rehash".', bold=True)
 
 
 class Migration(migrations.Migration):

--- a/aiida/backends/sqlalchemy/migrations/versions/e797afa09270_reset_hash.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e797afa09270_reset_hash.py
@@ -20,7 +20,7 @@ from alembic import op
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from sqlalchemy.sql import text
-from aiida.cmdline.utils.echo import echo_warning
+from aiida.cmdline.utils import echo
 
 # revision identifiers, used by Alembic.
 revision = 'e797afa09270'
@@ -32,21 +32,24 @@ depends_on = None
 _HASH_EXTRA_KEY = '_aiida_hash'
 
 
-def upgrade():
-    """drop the hashes when upgrading"""
-    conn = op.get_bind()
+def drop_hashes(conn):  # pylint: disable=unused-argument
+    """Drop hashes of nodes.
 
-    # Invalidate all the hashes & inform the user
-    echo_warning('Invalidating all the hashes of all the nodes. Please run verdi rehash', bold=True)
+    Print warning only if the DB actually contains nodes.
+    """
+    n_nodes = conn.execute(text("""SELECT count(*) FROM db_dbnode;""")).fetchall()[0][0]
+    if n_nodes > 0:
+        echo.echo_warning('Invalidating the hashes of all nodes. Please run "verdi rehash".', bold=True)
+
     statement = text("""UPDATE db_dbnode SET extras = extras #- '{""" + _HASH_EXTRA_KEY + """}'::text[];""")
     conn.execute(statement)
+
+
+def upgrade():
+    """drop the hashes when upgrading"""
+    drop_hashes(op.get_bind())
 
 
 def downgrade():
     """drop the hashes also when downgrading"""
-    conn = op.get_bind()
-
-    # Invalidate all the hashes & inform the user
-    echo_warning('Invalidating all the hashes of all the nodes. Please run verdi rehash', bold=True)
-    statement = text("""UPDATE db_dbnode SET extras = extras #- '{""" + _HASH_EXTRA_KEY + """}'::text[];""")
-    conn.execute(statement)
+    drop_hashes(op.get_bind())

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -686,8 +686,6 @@ def import_data_dj(
                 print('NO NODES TO IMPORT, SO NO GROUP CREATED, IF IT DID NOT ALREADY EXIST')
 
     if not silent:
-        print('*** WARNING: MISSING EXISTING UUID CHECKS!!')
-        print('*** WARNING: TODO: UPDATE IMPORT_DATA WITH DEFAULT VALUES! (e.g. calc status, user pwd, ...)')
         print('DONE.')
 
     return ret_dict

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -697,8 +697,6 @@ def import_data_sqla(
             raise
 
     if not silent:
-        print('*** WARNING: MISSING EXISTING UUID CHECKS!!')
-        print('*** WARNING: TODO: UPDATE IMPORT_DATA WITH DEFAULT VALUES! (e.g. calc status, user pwd, ...)')
         print('DONE.')
 
     return ret_dict


### PR DESCRIPTION
 * Warning about "node rehash": Every new AiiDA user is told to
   run "verdi rehash". Mention that this is only needed for existing
   data, and reduce from "warning" to "info"

 * Warnings printed at the end of `verdi import`:
   These are warnings for developers, not for users.
   Happy to open issues for those if anyone has any idea what they refer to.
