### PR TITLE
fix error message when repo not found

### DIFF
--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -43,7 +43,7 @@ def get_repository_folder(subfolder=None):
         repository_path = get_profile().repository_path
 
         if not os.path.isdir(repository_path):
-            raise ImportError
+            raise NotADirectoryError(repository_path)
         if subfolder is None:
             retval = os.path.abspath(repository_path)
         elif subfolder == 'sandbox':


### PR DESCRIPTION
discovered with @asle85 

When the repository folder was not found, AiiDA was throwing an
ImportError without any additional information.
Replacing with NotADirectoryError + path to directory