### PR TITLE
fix verdi import from URL

### DIFF
--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -9,7 +9,7 @@
 ###########################################################################
 """Click parameter types for paths."""
 import os
-import urllib
+import requests
 
 import click
 
@@ -68,8 +68,8 @@ class ImportPath(click.Path):
         url = value
 
         try:
-            urllib.request.urlopen(url, data=None, timeout=self.timeout_seconds)
-        except (urllib.error.URLError, urllib.error.HTTPError, timeout):
+            requests.get(url, timeout=self.timeout_seconds)
+        except (requests.exceptions.InvalidURL, requests.exceptions.HTTPError, timeout):
             self.fail(
                 '{0} "{1}" could not be reached within {2} s.\n'
                 'It may be neither a valid {3} nor a valid URL.'.format(

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -37,6 +37,7 @@ python-memcached~=1.59
 pytz~=2019.3
 pyyaml~=3.13
 reentry~=1.3
+requests~=2.21
 seekpath~=1.9,>=1.9.3
 simplejson~=3.16
 spglib~=1.14

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
 - pytz~=2019.3
 - pyyaml~=3.13
 - reentry~=1.3
+- requests~=2.21
 - simplejson~=3.16
 - sqlalchemy-utils~=0.34.2
 - sqlalchemy~=1.3,>=1.3.10

--- a/setup.json
+++ b/setup.json
@@ -43,6 +43,7 @@
     "pytz~=2019.3",
     "pyyaml~=3.13",
     "reentry~=1.3",
+    "requests~=2.21",
     "simplejson~=3.16",
     "sqlalchemy-utils~=0.34.2",
     "sqlalchemy~=1.3,>=1.3.10",


### PR DESCRIPTION
fix #3610 

verdi import from URL was broken since dropping python2.7 support and
the change in url libraries. Using requests now.