### PR TITLE
Allow for the 'file' parameter in SinglefileData.set_file to be a pathlib.Path.

### DIFF
--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -11,6 +11,7 @@
 import inspect
 import os
 import warnings
+import pathlib
 
 from aiida.common import exceptions
 from aiida.common.warnings import AiidaDeprecationWarning
@@ -102,7 +103,7 @@ class SinglefileData(Data):
         """
         # pylint: disable=redefined-builtin
 
-        if isinstance(file, str):
+        if isinstance(file, (str, pathlib.Path)):
             is_filelike = False
 
             key = os.path.basename(file)

--- a/tests/orm/data/test_singlefile.py
+++ b/tests/orm/data/test_singlefile.py
@@ -11,6 +11,7 @@
 
 import os
 import tempfile
+import pathlib
 import io
 
 from aiida.backends.testbase import AiidaTestCase
@@ -104,6 +105,31 @@ class TestSinglefileData(AiidaTestCase):
 
         self.assertEqual(content_stored, content_original)
         self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])
+
+    def test_construct_with_path(self):
+        """Test constructing an instance from a pathlib.Path."""
+        content_original = 'please report to the ministry of silly walks'
+
+        with tempfile.NamedTemporaryFile(mode='w+') as handle:
+            filepath = pathlib.Path(handle.name).resolve()
+            filename = filepath.name
+            handle.write(content_original)
+            handle.flush()
+            node = SinglefileData(file=filepath)
+
+        with node.open() as handle:
+            content_written = handle.read()
+
+        self.assertEqual(node.list_object_names(), [filename])
+        self.assertEqual(content_written, content_original)
+
+        node.store()
+
+        with node.open() as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_original)
+        self.assertEqual(node.list_object_names(), [filename])
 
     def test_construct_with_filename(self):
         """Test constructing an instance, providing a filename."""

--- a/tests/orm/data/test_singlefile.py
+++ b/tests/orm/data/test_singlefile.py
@@ -10,177 +10,195 @@
 """Tests for the `SinglefileData` class."""
 
 import os
+import io
 import tempfile
 import pathlib
-import io
 
-from aiida.backends.testbase import AiidaTestCase
+import pytest
+
 from aiida.orm import SinglefileData, load_node
 
 
-class TestSinglefileData(AiidaTestCase):
-    """Tests for the `SinglefileData` class."""
+@pytest.fixture
+def check_singlefile_content():
+    """Fixture to check the content of a SinglefileData.
 
-    def test_reload_singlefile_data(self):
-        """Test writing and reloading a `SinglefileData` instance."""
-        content_original = 'some text ABCDE'
+    Checks the content of a SinglefileData node against the given
+    reference content and filename.
+    """
 
-        with tempfile.NamedTemporaryFile(mode='w+') as handle:
-            filepath = handle.name
-            basename = os.path.basename(filepath)
-            handle.write(content_original)
-            handle.flush()
-            node = SinglefileData(file=filepath)
+    def inner(node, content_reference, filename, open_mode='r'):
+        with node.open(mode=open_mode) as handle:
+            assert handle.read() == content_reference
 
-        uuid = node.uuid
+        assert node.list_object_names() == [filename]
 
-        with node.open() as handle:
-            content_written = handle.read()
+    return inner
 
-        self.assertEqual(node.list_object_names(), [basename])
-        self.assertEqual(content_written, content_original)
 
+@pytest.fixture
+def check_singlefile_content_with_store(check_singlefile_content):  # pylint: disable=redefined-outer-name
+    """Fixture to check the content of a SinglefileData before and after .store().
+
+    Checks the content of a SinglefileData node against the given reference
+    content and filename twice, before and after calling .store().
+    """
+
+    def inner(node, content_reference, filename, open_mode='r'):
+        check_singlefile_content(
+            node=node,
+            content_reference=content_reference,
+            filename=filename,
+            open_mode=open_mode,
+        )
         node.store()
+        check_singlefile_content(
+            node=node,
+            content_reference=content_reference,
+            filename=filename,
+            open_mode=open_mode,
+        )
 
-        with node.open() as handle:
-            content_stored = handle.read()
+    return inner
 
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [basename])
 
-        node_loaded = load_node(uuid)
-        self.assertTrue(isinstance(node_loaded, SinglefileData))
+def test_reload_singlefile_data(
+    clear_database_before_test,  # pylint: disable=unused-argument
+    check_singlefile_content_with_store,  # pylint: disable=redefined-outer-name
+    check_singlefile_content  # pylint: disable=redefined-outer-name
+):
+    """Test writing and reloading a `SinglefileData` instance."""
+    content_original = 'some text ABCDE'
 
-        with node.open() as handle:
-            content_loaded = handle.read()
+    with tempfile.NamedTemporaryFile(mode='w+') as handle:
+        filepath = handle.name
+        basename = os.path.basename(filepath)
+        handle.write(content_original)
+        handle.flush()
+        node = SinglefileData(file=filepath)
 
-        self.assertEqual(content_loaded, content_original)
-        self.assertEqual(node_loaded.list_object_names(), [basename])
+    check_singlefile_content_with_store(
+        node=node,
+        content_reference=content_original,
+        filename=basename,
+    )
 
-        with node_loaded.open() as handle:
-            self.assertEqual(handle.read(), content_original)
+    node_loaded = load_node(node.uuid)
+    assert isinstance(node_loaded, SinglefileData)
 
-    def test_construct_from_filelike(self):
-        """Test constructing an instance from filelike instead of filepath."""
-        content_original = 'some testing text\nwith a newline'
+    check_singlefile_content(
+        node=node,
+        content_reference=content_original,
+        filename=basename,
+    )
+    check_singlefile_content(
+        node=node_loaded,
+        content_reference=content_original,
+        filename=basename,
+    )
 
-        with tempfile.NamedTemporaryFile(mode='wb+') as handle:
-            basename = os.path.basename(handle.name)
-            handle.write(content_original.encode('utf-8'))
-            handle.flush()
-            handle.seek(0)
-            node = SinglefileData(file=handle)
 
-        with node.open() as handle:
-            content_stored = handle.read()
+def test_construct_from_filelike(
+    clear_database_before_test,  # pylint: disable=unused-argument
+    check_singlefile_content_with_store  # pylint: disable=redefined-outer-name
+):
+    """Test constructing an instance from filelike instead of filepath."""
+    content_original = 'some testing text\nwith a newline'
 
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [basename])
+    with tempfile.NamedTemporaryFile(mode='wb+') as handle:
+        basename = os.path.basename(handle.name)
+        handle.write(content_original.encode('utf-8'))
+        handle.flush()
+        handle.seek(0)
+        node = SinglefileData(file=handle)
 
-        node.store()
+    check_singlefile_content_with_store(
+        node=node,
+        content_reference=content_original,
+        filename=basename,
+    )
 
-        with node.open() as handle:
-            content_stored = handle.read()
 
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [basename])
+def test_construct_from_string(
+    clear_database_before_test,  # pylint: disable=unused-argument
+    check_singlefile_content_with_store  # pylint: disable=redefined-outer-name
+):
+    """Test constructing an instance from a string."""
+    content_original = 'some testing text\nwith a newline'
 
-    def test_construct_from_string(self):
-        """Test constructing an instance from a string."""
-        content_original = 'some testing text\nwith a newline'
+    with io.BytesIO(content_original.encode('utf-8')) as handle:
+        node = SinglefileData(file=handle)
 
-        with io.BytesIO(content_original.encode('utf-8')) as handle:
-            node = SinglefileData(file=handle)
+    check_singlefile_content_with_store(
+        node=node,
+        content_reference=content_original,
+        filename=SinglefileData.DEFAULT_FILENAME,
+    )
 
-        with node.open() as handle:
-            content_stored = handle.read()
 
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])
+def test_construct_with_path(
+    clear_database_before_test,  # pylint: disable=unused-argument
+    check_singlefile_content_with_store  # pylint: disable=redefined-outer-name
+):
+    """Test constructing an instance from a pathlib.Path."""
+    content_original = 'please report to the ministry of silly walks'
 
-        node.store()
+    with tempfile.NamedTemporaryFile(mode='w+') as handle:
+        filepath = pathlib.Path(handle.name).resolve()
+        filename = filepath.name
+        handle.write(content_original)
+        handle.flush()
+        node = SinglefileData(file=filepath)
 
-        with node.open() as handle:
-            content_stored = handle.read()
+    check_singlefile_content_with_store(
+        node=node,
+        content_reference=content_original,
+        filename=filename,
+    )
 
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])
 
-    def test_construct_with_path(self):
-        """Test constructing an instance from a pathlib.Path."""
-        content_original = 'please report to the ministry of silly walks'
+def test_construct_with_filename(
+    clear_database_before_test,  # pylint: disable=unused-argument
+    check_singlefile_content  # pylint: disable=redefined-outer-name
+):
+    """Test constructing an instance, providing a filename."""
+    content_original = 'some testing text\nwith a newline'
+    filename = 'myfile.txt'
 
-        with tempfile.NamedTemporaryFile(mode='w+') as handle:
-            filepath = pathlib.Path(handle.name).resolve()
-            filename = filepath.name
-            handle.write(content_original)
-            handle.flush()
-            node = SinglefileData(file=filepath)
+    # test creating from string
+    with io.BytesIO(content_original.encode('utf-8')) as handle:
+        node = SinglefileData(file=handle, filename=filename)
 
-        with node.open() as handle:
-            content_written = handle.read()
+    check_singlefile_content(node=node, content_reference=content_original, filename=filename)
 
-        self.assertEqual(node.list_object_names(), [filename])
-        self.assertEqual(content_written, content_original)
+    # test creating from file
+    with tempfile.NamedTemporaryFile(mode='wb+') as handle:
+        handle.write(content_original.encode('utf-8'))
+        handle.flush()
+        handle.seek(0)
+        node = SinglefileData(file=handle, filename=filename)
 
-        node.store()
+    check_singlefile_content(node=node, content_reference=content_original, filename=filename)
 
-        with node.open() as handle:
-            content_stored = handle.read()
 
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [filename])
+def test_binary_file(
+    clear_database_before_test,  # pylint: disable=unused-argument
+    check_singlefile_content_with_store  # pylint: disable=redefined-outer-name
+):
+    """Test that the constructor accepts binary files."""
+    byte_array = [120, 3, 255, 0, 100]
+    content_binary = bytearray(byte_array)
 
-    def test_construct_with_filename(self):
-        """Test constructing an instance, providing a filename."""
-        content_original = 'some testing text\nwith a newline'
-        filename = 'myfile.txt'
+    with tempfile.NamedTemporaryFile(mode='wb+') as handle:
+        basename = os.path.basename(handle.name)
+        handle.write(bytearray(content_binary))
+        handle.flush()
+        handle.seek(0)
+        node = SinglefileData(handle.name)
 
-        # test creating from string
-        with io.BytesIO(content_original.encode('utf-8')) as handle:
-            node = SinglefileData(file=handle, filename=filename)
-
-        with node.open() as handle:
-            content_stored = handle.read()
-
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [filename])
-
-        # test creating from file
-        with tempfile.NamedTemporaryFile(mode='wb+') as handle:
-            handle.write(content_original.encode('utf-8'))
-            handle.flush()
-            handle.seek(0)
-            node = SinglefileData(file=handle, filename=filename)
-
-        with node.open() as handle:
-            content_stored = handle.read()
-
-        self.assertEqual(content_stored, content_original)
-        self.assertEqual(node.list_object_names(), [filename])
-
-    def test_binary_file(self):
-        """Test that the constructor accepts binary files."""
-        byte_array = [120, 3, 255, 0, 100]
-        content_binary = bytearray(byte_array)
-
-        with tempfile.NamedTemporaryFile(mode='wb+') as handle:
-            basename = os.path.basename(handle.name)
-            handle.write(bytearray(content_binary))
-            handle.flush()
-            handle.seek(0)
-            node = SinglefileData(handle.name)
-
-        with node.open(mode='rb') as handle:
-            content_stored = handle.read()
-
-        self.assertEqual(content_stored, content_binary)
-        self.assertEqual(node.list_object_names(), [basename])
-
-        node.store()
-
-        with node.open(mode='rb') as handle:
-            content_stored = handle.read()
-
-        self.assertEqual(content_stored, content_binary)
-        self.assertEqual(node.list_object_names(), [basename])
+    check_singlefile_content_with_store(
+        node=node,
+        content_reference=content_binary,
+        filename=basename,
+        open_mode='rb',
+    )


### PR DESCRIPTION
Fixes #4570.

The ``pathlib`` module was introduced in python 3.4 to make path wrangling easier.

The only reason a ``pathlib.Path`` can not currently be used in ``SinglefileData`` is the ``isinstance`` check for ``str`` to determine if the input is a ``filelike`` or a path.