### PR TITLE
Use built-in 'open' instead of 'io.open'.

### DIFF
--- a/aiida/backends/general/migrations/utils.py
+++ b/aiida/backends/general/migrations/utils.py
@@ -12,7 +12,6 @@
 
 import datetime
 import errno
-import io
 import os
 import re
 
@@ -47,7 +46,7 @@ def put_object_from_string(uuid, name, content):
     ensure_repository_folder_created(uuid)
     filepath = os.path.join(get_node_repository_sub_folder(uuid), name)
 
-    with io.open(filepath, 'w', encoding='utf-8') as handle:
+    with open(filepath, 'w', encoding='utf-8') as handle:
         handle.write(content)
 
 
@@ -59,7 +58,7 @@ def get_object_from_repository(uuid, name):
     """
     filepath = os.path.join(get_node_repository_sub_folder(uuid), name)
 
-    with io.open(filepath) as handle:
+    with open(filepath) as handle:
         return handle.read()
 
 
@@ -99,7 +98,7 @@ def store_numpy_array_in_repository(uuid, name, array):
     ensure_repository_folder_created(uuid)
     filepath = get_numpy_array_absolute_path(uuid, name)
 
-    with io.open(filepath, 'wb') as handle:
+    with open(filepath, 'wb') as handle:
         numpy.save(handle, array)
 
 

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -388,7 +388,7 @@ class TestVerdiDataRemote(AiidaTestCase):
         self.r = RemoteData()
         p = tempfile.mkdtemp()
         self.r.set_remote_path(p)
-        with io.open(p + '/file.txt', 'w', encoding='utf8') as fhandle:
+        with open(p + '/file.txt', 'w', encoding='utf8') as fhandle:
             fhandle.write('test string')
         self.r.computer = comp
         self.r.store()

--- a/aiida/backends/tests/common/test_folders.py
+++ b/aiida/backends/tests/common/test_folders.py
@@ -37,9 +37,9 @@ class FoldersTest(unittest.TestCase):
         """Check that there are no exceptions raised when using unicode folders."""
         tmpsource = tempfile.mkdtemp()
         tmpdest = tempfile.mkdtemp()
-        with io.open(os.path.join(tmpsource, 'sąžininga'), 'w', encoding='utf8') as fhandle:
+        with open(os.path.join(tmpsource, 'sąžininga'), 'w', encoding='utf8') as fhandle:
             fhandle.write('test')
-        with io.open(os.path.join(tmpsource, 'žąsis'), 'w', encoding='utf8') as fhandle:
+        with open(os.path.join(tmpsource, 'žąsis'), 'w', encoding='utf8') as fhandle:
             fhandle.write('test')
         folder = Folder(tmpdest)
         folder.insert_path(tmpsource, 'destination')

--- a/aiida/backends/tests/manage/backup/test_backup_setup_script.py
+++ b/aiida/backends/tests/manage/backup/test_backup_setup_script.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Tests for the backup setup script."""
 
-import io
 import os
 import shutil
 import tempfile
@@ -117,7 +116,7 @@ class TestBackupSetupScriptIntegration(AiidaTestCase):
             )
 
             # Check the content of the main backup configuration file
-            with io.open(os.path.join(temp_aiida_folder, 'backup_info.json'), encoding='utf8') as conf_jfile:
+            with open(os.path.join(temp_aiida_folder, 'backup_info.json'), encoding='utf8') as conf_jfile:
                 conf_cont = json.load(conf_jfile)
                 self.assertEqual(conf_cont[AbstractBackup.OLDEST_OBJECT_BK_KEY], '2014-07-18 13:54:53.688484+00:00')
                 self.assertEqual(conf_cont[AbstractBackup.DAYS_TO_BACKUP_KEY], None)

--- a/aiida/backends/tests/manage/configuration/migrations/test_migrations.py
+++ b/aiida/backends/tests/manage/configuration/migrations/test_migrations.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the configuration migration functionality."""
-import io
 import os
 import uuid
 from unittest import TestCase
@@ -28,7 +27,7 @@ class TestConfigMigration(TestCase):
         """Load a configuration file from a fixture."""
         currdir = os.path.dirname(os.path.abspath(__file__))
         filepath = os.path.join(currdir, 'test_samples', filename)
-        with io.open(filepath, 'r', encoding='utf8') as handle:
+        with open(filepath, 'r', encoding='utf8') as handle:
             return json.load(handle)
 
     def setUp(self):

--- a/aiida/backends/tests/orm/data/test_folder.py
+++ b/aiida/backends/tests/orm/data/test_folder.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Tests for the `FolderData` class."""
 
-import io
 import os
 import shutil
 import tempfile
@@ -31,7 +30,7 @@ class TestFolderData(AiidaTestCase):
         }
 
         for filename, content in cls.tree.items():
-            with io.open(os.path.join(cls.tempdir, filename), 'w', encoding='utf8') as handle:
+            with open(os.path.join(cls.tempdir, filename), 'w', encoding='utf8') as handle:
                 handle.write(content)
 
     @classmethod

--- a/aiida/backends/tests/orm/data/test_remote.py
+++ b/aiida/backends/tests/orm/data/test_remote.py
@@ -9,7 +9,6 @@
 ###########################################################################
 
 import errno
-import io
 import os
 import shutil
 import tempfile
@@ -34,7 +33,7 @@ class TestRemoteData(AiidaTestCase):
         self.remote = RemoteData(computer=self.computer)
         self.remote.set_remote_path(self.tmp_path)
 
-        with io.open(os.path.join(self.tmp_path, 'file.txt'), 'w', encoding='utf8') as fhandle:
+        with open(os.path.join(self.tmp_path, 'file.txt'), 'w', encoding='utf8') as fhandle:
             fhandle.write('test string')
 
         self.remote.computer = self.computer

--- a/aiida/backends/tests/orm/utils/test_repository.py
+++ b/aiida/backends/tests/orm/utils/test_repository.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Tests for the `Repository` utility class."""
 
-import io
 import os
 import shutil
 import tempfile
@@ -53,7 +52,7 @@ class TestRepository(AiidaTestCase):
                 os.makedirs(subdir)
                 self.create_file_tree(subdir, value)
             else:
-                with io.open(os.path.join(directory, key), 'w', encoding='utf8') as handle:
+                with open(os.path.join(directory, key), 'w', encoding='utf8') as handle:
                     handle.write(value)
 
     def get_file_content(self, key):
@@ -99,7 +98,7 @@ class TestRepository(AiidaTestCase):
         filepath = os.path.join(self.tempdir, key)
         content = self.get_file_content(key)
 
-        with io.open(filepath, 'r') as handle:
+        with open(filepath, 'r') as handle:
             node = Node()
             node.put_object_from_filelike(handle, key)
             self.assertEqual(node.get_object_content(key), content)
@@ -108,7 +107,7 @@ class TestRepository(AiidaTestCase):
         filepath = os.path.join(self.tempdir, key)
         content = self.get_file_content(key)
 
-        with io.open(filepath, 'r') as handle:
+        with open(filepath, 'r') as handle:
             node = Node()
             node.put_object_from_filelike(handle, key)
             self.assertEqual(node.get_object_content(key), content)

--- a/aiida/backends/tests/test_dataclasses.py
+++ b/aiida/backends/tests/test_dataclasses.py
@@ -3112,7 +3112,7 @@ class TestTrajectoryData(AiidaTestCase):
             files_created = []  # In case there is an exception
             try:
                 files_created = n.export(filename, fileformat=format)
-                with io.open(filename, encoding='utf8') as fhandle:
+                with open(filename, encoding='utf8') as fhandle:
                     filedata = fhandle.read()
             finally:
                 for file in files_created:
@@ -3703,7 +3703,7 @@ class TestBandsData(AiidaTestCase):
             files_created = []  # In case there is an exception
             try:
                 files_created = b.export(filename, fileformat=format)
-                with io.open(filename, encoding='utf8') as fhandle:
+                with open(filename, encoding='utf8') as fhandle:
                     filedata = fhandle.read()
             finally:
                 for file in files_created:

--- a/aiida/backends/tests/test_dbimporters.py
+++ b/aiida/backends/tests/test_dbimporters.py
@@ -10,7 +10,6 @@
 """
 Tests for subclasses of DbImporter, DbSearchResults and DbEntry
 """
-import io
 import unittest
 
 
@@ -264,7 +263,7 @@ class TestNnincDbImporter(AiidaTestCase):
 
         path_root = os.path.split(aiida.__file__)[0]
         path_pseudos = os.path.join(path_root, 'backends', 'tests', 'fixtures', 'pseudos')
-        with io.open(os.path.join(path_pseudos, '{}.UPF'.format(upf)), 'r', encoding='utf8') as f:
+        with open(os.path.join(path_pseudos, '{}.UPF'.format(upf)), 'r', encoding='utf8') as f:
             entry._contents = f.read()
 
         upfnode = entry.get_upf_node()

--- a/aiida/backends/tests/test_nodes.py
+++ b/aiida/backends/tests/test_nodes.py
@@ -577,11 +577,11 @@ class TestNodeBasic(AiidaTestCase):
         os.makedirs(tree_1)
         file_content = 'some text ABCDE'
         file_content_different = 'other values 12345'
-        with io.open(os.path.join(tree_1, 'file1.txt'), 'w', encoding='utf8') as fhandle:
+        with open(os.path.join(tree_1, 'file1.txt'), 'w', encoding='utf8') as fhandle:
             fhandle.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1'))
         os.mkdir(os.path.join(tree_1, 'dir1', 'dir2'))
-        with io.open(os.path.join(tree_1, 'dir1', 'file2.txt'), 'w', encoding='utf8') as fhandle:
+        with open(os.path.join(tree_1, 'dir1', 'file2.txt'), 'w', encoding='utf8') as fhandle:
             fhandle.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1', 'dir2', 'dir3'))
 
@@ -2085,4 +2085,3 @@ class TestNodeDeletion(AiidaTestCase):
         with Capturing():
             delete_nodes((node_list[3].pk,), force=True, create_forward=True)
         self._check_existence(uuids_check_existence, uuids_check_deleted)
-

--- a/aiida/backends/tests/tools/importexport/migration/test_migration.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_migration.py
@@ -65,7 +65,6 @@ class TestExportFileMigration(AiidaTestCase):
 
     def test_migrate_recursively(self):
         """Test function 'migrate_recursively'"""
-        import io
         import tarfile
         import zipfile
 
@@ -88,9 +87,9 @@ class TestExportFileMigration(AiidaTestCase):
                 raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
             try:
-                with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                     data = jsonload(fhandle)
-                with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                     metadata = jsonload(fhandle)
             except IOError:
                 raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))

--- a/aiida/backends/tests/tools/importexport/migration/test_v03_to_v04.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v03_to_v04.py
@@ -10,7 +10,6 @@
 """Test export file migration from export version 0.3 to 0.4"""
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
-import io
 import tarfile
 import zipfile
 
@@ -57,9 +56,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                 raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
             try:
-                with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                     data_v3 = jsonload(fhandle)
-                with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                     metadata_v3 = jsonload(fhandle)
             except IOError:
                 raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
@@ -110,9 +109,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                 raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
             try:
-                with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                     data = jsonload(fhandle)
-                with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                     metadata = jsonload(fhandle)
             except IOError:
                 raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
@@ -317,9 +316,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                 raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
             try:
-                with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                     data_v3 = jsonload(fhandle)
-                with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                     metadata_v3 = jsonload(fhandle)
             except IOError:
                 raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
@@ -455,9 +454,9 @@ class TestMigrateV03toV04(AiidaTestCase):
                 raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
             try:
-                with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                     data = jsonload(fhandle)
-                with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                     metadata = jsonload(fhandle)
             except IOError:
                 raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))

--- a/aiida/backends/tests/tools/importexport/migration/test_v04_to_v05.py
+++ b/aiida/backends/tests/tools/importexport/migration/test_v04_to_v05.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Test export file migration from export version 0.4 to 0.5"""
 
-import io
 import tarfile
 import zipfile
 
@@ -56,9 +55,9 @@ class TestMigrateV04toV05(AiidaTestCase):
                 raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
             try:
-                with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                     data_v4 = jsonload(fhandle)
-                with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                     metadata_v4 = jsonload(fhandle)
             except IOError:
                 raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))

--- a/aiida/backends/tests/tools/importexport/orm/test_links.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_links.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """orm links tests for the export and import routines"""
 
-import io
 import os
 import tarfile
 
@@ -52,7 +51,7 @@ class TestLinks(AiidaTestCase):
         with tarfile.open(filename, 'r:gz', format=tarfile.PAX_FORMAT) as tar:
             tar.extractall(unpack.abspath)
 
-        with io.open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+        with open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
             data = json.load(fhandle)
         data['links_uuid'].append({
             'output': struct.uuid,
@@ -62,7 +61,7 @@ class TestLinks(AiidaTestCase):
             'type': LinkType.CREATE.value
         })
 
-        with io.open(unpack.get_abs_path('data.json'), 'wb') as fhandle:
+        with open(unpack.get_abs_path('data.json'), 'wb') as fhandle:
             json.dump(data, fhandle)
 
         with tarfile.open(filename, 'w:gz', format=tarfile.PAX_FORMAT) as tar:
@@ -634,7 +633,7 @@ class TestLinks(AiidaTestCase):
         with tarfile.open(filename, 'r:gz', format=tarfile.PAX_FORMAT) as tar:
             tar.extractall(unpack.abspath)
 
-        with io.open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+        with open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
             data = json.load(fhandle)
         data['links_uuid'].append({
             'output': calc.uuid,
@@ -643,7 +642,7 @@ class TestLinks(AiidaTestCase):
             'type': LinkType.INPUT_CALC.value
         })
 
-        with io.open(unpack.get_abs_path('data.json'), 'wb') as fhandle:
+        with open(unpack.get_abs_path('data.json'), 'wb') as fhandle:
             json.dump(data, fhandle)
 
         with tarfile.open(filename, 'w:gz', format=tarfile.PAX_FORMAT) as tar:

--- a/aiida/backends/tests/tools/importexport/test_simple.py
+++ b/aiida/backends/tests/tools/importexport/test_simple.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Simple tests for the export and import routines"""
 
-import io
 import os
 import shutil
 import tarfile
@@ -111,11 +110,11 @@ class TestSimple(AiidaTestCase):
             with tarfile.open(filename, 'r:gz', format=tarfile.PAX_FORMAT) as tar:
                 tar.extractall(unpack_tmp_folder)
 
-            with io.open(os.path.join(unpack_tmp_folder, 'metadata.json'), 'r', encoding='utf8') as fhandle:
+            with open(os.path.join(unpack_tmp_folder, 'metadata.json'), 'r', encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
             metadata['export_version'] = 0.0
 
-            with io.open(os.path.join(unpack_tmp_folder, 'metadata.json'), 'wb') as fhandle:
+            with open(os.path.join(unpack_tmp_folder, 'metadata.json'), 'wb') as fhandle:
                 json.dump(metadata, fhandle)
 
             with tarfile.open(filename, 'w:gz', format=tarfile.PAX_FORMAT) as tar:

--- a/aiida/backends/tests/utils/archives.py
+++ b/aiida/backends/tests/utils/archives.py
@@ -10,7 +10,6 @@
 """Test utility to import, inspect, or migrate AiiDA export archives."""
 
 import os
-import io
 import tarfile
 import zipfile
 
@@ -104,9 +103,9 @@ def get_json_files(archive, silent=True, filepath=None, external_module=None):
             raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
         try:
-            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                 data = json.load(fhandle)
-            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
         except IOError:
             raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
@@ -135,9 +134,9 @@ def migrate_archive(input_file, output_file, silent=True):
             raise ValueError('invalid file format, expected either a zip archive or gzipped tarball')
 
         try:
-            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                 data = json.load(fhandle)
-            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
         except IOError:
             raise NotExistent('export archive does not contain the required file {}'.format(fhandle.filename))
@@ -146,10 +145,10 @@ def migrate_archive(input_file, output_file, silent=True):
         migrate_recursively(metadata, data, folder)
 
         # Write json files
-        with io.open(folder.get_abs_path('data.json'), 'wb') as fhandle:
+        with open(folder.get_abs_path('data.json'), 'wb') as fhandle:
             json.dump(data, fhandle, indent=4)
 
-        with io.open(folder.get_abs_path('metadata.json'), 'wb') as fhandle:
+        with open(folder.get_abs_path('metadata.json'), 'wb') as fhandle:
             json.dump(metadata, fhandle, indent=4)
 
         # Pack archive

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -10,7 +10,6 @@
 # pylint: disable=invalid-name,too-many-statements,too-many-branches
 """`verdi computer` command."""
 
-import io
 from functools import partial
 
 import click
@@ -162,7 +161,7 @@ def _computer_create_temp_file(transport, scheduler, authinfo):  # pylint: disab
 
     try:
         transport.getfile(remote_file_path, destfile)
-        with io.open(destfile, encoding='utf8') as dfile:
+        with open(destfile, encoding='utf8') as dfile:
             read_string = dfile.read()
 
         if read_string != file_content:

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi data remote` command."""
-import io
 import stat
 
 import click
@@ -69,7 +68,7 @@ def remote_cat(datum, path):
         with tempfile.NamedTemporaryFile(delete=False) as tmpf:
             tmpf.close()
             datum.getfile(path, tmpf.name)
-            with io.open(tmpf.name, encoding='utf8') as fhandle:
+            with open(tmpf.name, encoding='utf8') as fhandle:
                 sys.stdout.write(fhandle.read())
     except IOError as err:
         echo.echo_critical('{}: {}'.format(err.errno, str(err)))

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -9,8 +9,6 @@
 ###########################################################################
 """`verdi data structure` command."""
 
-import io
-
 import click
 
 from aiida.cmdline.commands.cmd_data import verdi_data
@@ -193,7 +191,7 @@ def import_aiida_xyz(filename, vacuum_factor, vacuum_addition, pbc, dry_run):
     """
     from aiida.orm import StructureData
 
-    with io.open(filename, encoding='utf8') as fobj:
+    with open(filename, encoding='utf8') as fobj:
         xyz_txt = fobj.read()
     new_structure = StructureData()
 

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """`verdi data upf` command."""
 
-import io
 import os
 import click
 
@@ -117,7 +116,7 @@ def upf_exportfamily(folder, group):
     for node in group.nodes:
         dest_path = os.path.join(folder, node.filename)
         if not os.path.isfile(dest_path):
-            with io.open(dest_path, 'w', encoding='utf8') as handle:
+            with open(dest_path, 'w', encoding='utf8') as handle:
                 handle.write(node.get_content())
         else:
             echo.echo_warning('File {} is already present in the destination folder'.format(node.filename))

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -10,7 +10,6 @@
 # pylint: disable=too-many-arguments,import-error,too-many-locals
 """`verdi export` command."""
 
-import io
 import os
 
 import click
@@ -171,9 +170,9 @@ def migrate(input_file, output_file, force, silent, archive_format):
             echo.echo_critical('invalid file format, expected either a zip archive or gzipped tarball')
 
         try:
-            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                 data = json.load(fhandle)
-            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
         except IOError:
             echo.echo_critical('export archive does not contain the required file {}'.format(fhandle.filename))
@@ -181,10 +180,10 @@ def migrate(input_file, output_file, force, silent, archive_format):
         old_version = migration.verify_metadata_version(metadata)
         new_version = migration.migrate_recursively(metadata, data, folder)
 
-        with io.open(folder.get_abs_path('data.json'), 'wb') as fhandle:
+        with open(folder.get_abs_path('data.json'), 'wb') as fhandle:
             json.dump(data, fhandle, indent=4)
 
-        with io.open(folder.get_abs_path('metadata.json'), 'wb') as fhandle:
+        with open(folder.get_abs_path('metadata.json'), 'wb') as fhandle:
             json.dump(metadata, fhandle)
 
         if archive_format in ['zip', 'zip-uncompressed']:

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -96,7 +96,7 @@ def run(scriptname, varargs, group, group_name, exclude, excludesubclasses, incl
     handle = None
 
     try:
-        # Here we use a standard open and not io.open, as exec will later fail if passed a unicode type string.
+        # Here we use a standard open and not open, as exec will later fail if passed a unicode type string.
         handle = open(scriptname, 'r')
     except IOError:
         echo.echo_critical("Unable to load file '{}'".format(scriptname))

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """The verdi shell command"""
 
-import io
 import os
 import click
 
@@ -74,7 +73,7 @@ def shell(plain, no_startup, interface):
                 if not os.path.isfile(pythonrc):
                     continue
                 try:
-                    with io.open(pythonrc, encoding='utf8') as handle:
+                    with open(pythonrc, encoding='utf8') as handle:
                         exec(compile(handle.read(), pythonrc, 'exec'), imported_objects)  # pylint: disable=exec-used
                 except NameError:
                     pass

--- a/aiida/common/files.py
+++ b/aiida/common/files.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Utility functions to operate on filesystem files."""
 import hashlib
-import io
 
 
 def md5_from_filelike(filelike, block_size_factor=128):
@@ -40,7 +39,7 @@ def md5_file(filepath, block_size_factor=128):
     :raises: No checks are done on the file, so if it doesn't exists it may
         raise IOError.
     """
-    with io.open(filepath, 'rb', encoding=None) as handle:
+    with open(filepath, 'rb', encoding=None) as handle:
         return md5_from_filelike(handle, block_size_factor=block_size_factor)
 
 
@@ -60,7 +59,7 @@ def sha1_file(filename, block_size_factor=128):
         raise IOError.
     """
     sha1 = hashlib.sha1()
-    with io.open(filename, 'rb', encoding=None) as fhandle:
+    with open(filename, 'rb', encoding=None) as fhandle:
         # I read 128 bytes at a time until it returns the empty string b''
         for chunk in iter(lambda: fhandle.read(block_size_factor * sha1.block_size), b''):
             sha1.update(chunk)

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -10,7 +10,6 @@
 """Utility functions to operate on filesystem folders."""
 import errno
 import fnmatch
-import io
 import os
 import shutil
 import tempfile
@@ -229,7 +228,7 @@ class Folder:
         if 'b' in mode:
             encoding = None
 
-        with io.open(filepath, mode=mode, encoding=encoding) as handle:
+        with open(filepath, mode=mode, encoding=encoding) as handle:
             shutil.copyfileobj(filelike, handle)
 
         os.chmod(filepath, self.mode_file)
@@ -289,7 +288,7 @@ class Folder:
         if 'b' in mode:
             encoding = None
 
-        return io.open(self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding)
+        return open(self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding)
 
     @property
     def abspath(self):

--- a/aiida/common/json.py
+++ b/aiida/common/json.py
@@ -11,7 +11,7 @@
 Abstracts JSON usage to ensure compatibility with Python2 and Python3.
 
 Use this module prefentially over standard json to ensure compatibility.
-Also note the conventions for using io.open for dump and dumps.
+
 """
 
 import simplejson
@@ -20,7 +20,7 @@ import simplejson
 def dump(data, fhandle, **kwargs):
     """
     Write JSON encoded 'data' to a file-like object, fhandle
-    In Py2/3, use io.open(filename, 'wb') to write.
+    Use open(filename, 'wb') to write.
     The utf8write object is used to ensure that the resulting serialised data is
     encoding as UTF8.
     Any strings with non-ASCII characters need to be unicode strings.
@@ -39,7 +39,7 @@ def dumps(data, **kwargs):
     unlike the standard library json, rather than being dependant on the input.
     We use also ensure_ascii=False to write unicode characters specifically
     as this improves the readability of the json and reduces the file size.
-    When writing to file, use io.open(filename, 'w', encoding='utf8')
+    When writing to file, use open(filename, 'w', encoding='utf8')
     """
     return simplejson.dumps(data, ensure_ascii=False, encoding='utf8', **kwargs)
 
@@ -48,7 +48,7 @@ def load(fhandle, **kwargs):
     """
     Deserialise a JSON file.
 
-    For Py2/Py3 compatibility, io.open(filename, 'r', encoding='utf8') should be used.
+    For encoding consistency, open(filename, 'r', encoding='utf8') should be used.
 
     :raises ValueError: if no valid JSON object could be decoded
     """

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -12,7 +12,6 @@ Controls the daemon
 """
 
 import enum
-import io
 import os
 import shutil
 import socket
@@ -149,13 +148,13 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
         """
         if self.is_daemon_running:
             try:
-                with io.open(self.circus_port_file, 'r', encoding='utf8') as fhandle:
+                with open(self.circus_port_file, 'r', encoding='utf8') as fhandle:
                     return int(fhandle.read().strip())
             except (ValueError, IOError):
                 raise RuntimeError('daemon is running so port file should have been there but could not read it')
         else:
             port = self.get_available_port()
-            with io.open(self.circus_port_file, 'w', encoding='utf8') as fhandle:
+            with open(self.circus_port_file, 'w', encoding='utf8') as fhandle:
                 fhandle.write(str(port))
 
             return port
@@ -178,7 +177,7 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
         """
         if self.is_daemon_running:
             try:
-                return io.open(self.circus_socket_file, 'r', encoding='utf8').read().strip()
+                return open(self.circus_socket_file, 'r', encoding='utf8').read().strip()
             except (ValueError, IOError):
                 raise RuntimeError('daemon is running so sockets file should have been there but could not read it')
         else:
@@ -188,7 +187,7 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
                 return self._SOCKET_DIRECTORY
 
             socket_dir_path = tempfile.mkdtemp()
-            with io.open(self.circus_socket_file, 'w', encoding='utf8') as fhandle:
+            with open(self.circus_socket_file, 'w', encoding='utf8') as fhandle:
                 fhandle.write(str(socket_dir_path))
 
             self._SOCKET_DIRECTORY = socket_dir_path
@@ -202,7 +201,7 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
         """
         if os.path.isfile(self.circus_pid_file):
             try:
-                return int(io.open(self.circus_pid_file, 'r', encoding='utf8').read().strip())
+                return int(open(self.circus_pid_file, 'r', encoding='utf8').read().strip())
             except (ValueError, IOError):
                 return None
         else:

--- a/aiida/manage/backup/backup_base.py
+++ b/aiida/manage/backup/backup_base.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Base abstract Backup class for all backends."""
 import datetime
-import io
 import os
 import logging
 import shutil
@@ -88,7 +87,7 @@ class AbstractBackup(ABC):
         """
         backup_variables = None
 
-        with io.open(backup_info_file_name, 'r', encoding='utf8') as backup_info_file:
+        with open(backup_info_file_name, 'r', encoding='utf8') as backup_info_file:
             try:
                 backup_variables = json.load(backup_info_file)
             except ValueError:
@@ -223,7 +222,7 @@ class AbstractBackup(ABC):
         given filename.
         """
         backup_variables = self._dictionarize_backup_info()
-        with io.open(backup_info_file_name, 'wb') as backup_info_file:
+        with open(backup_info_file_name, 'wb') as backup_info_file:
             json.dump(backup_variables, backup_info_file)
 
     def _find_files_to_backup(self):

--- a/aiida/manage/backup/backup_setup.py
+++ b/aiida/manage/backup/backup_setup.py
@@ -10,7 +10,6 @@
 """Class to backup an AiiDA instance profile."""
 
 import datetime
-import io
 import logging
 import os
 import shutil
@@ -201,7 +200,7 @@ class BackupSetup:
             # Ask questions to properly setup the backup variables
             backup_variables = self.construct_backup_variables(file_backup_folder_abs)
 
-            with io.open(final_conf_filepath, 'wb') as backup_info_file:
+            with open(final_conf_filepath, 'wb') as backup_info_file:
                 json.dump(backup_variables, backup_info_file)
         # If the backup parameters are configured manually
         else:
@@ -239,7 +238,7 @@ backup_inst.run()
         script_path = os.path.join(conf_backup_folder_abs, self._script_filename)
 
         # Write the contents to the script
-        with io.open(script_path, 'w', encoding='utf8') as script_file:
+        with open(script_path, 'w', encoding='utf8') as script_file:
             script_file.write(script_content)
 
         # Set the right permissions

--- a/aiida/manage/caching.py
+++ b/aiida/manage/caching.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Definition of caching mechanism and configuration for calculations."""
 
-import io
 import os
 import copy
 import warnings
@@ -55,7 +54,7 @@ def _get_config(config_file):
         exceptions.ConfigurationError('no profile has been loaded')
 
     try:
-        with io.open(config_file, 'r', encoding='utf8') as handle:
+        with open(config_file, 'r', encoding='utf8') as handle:
             config = yaml.load(handle)[profile.name]
     except (OSError, IOError, KeyError):
         # No config file, or no config for this profile

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Module that defines the configuration file of an AiiDA instance and functions to create and load it."""
 
-import io
 import os
 import shutil
 
@@ -44,7 +43,7 @@ class Config:  # pylint: disable=too-many-public-methods
         from .migrations import check_and_migrate_config, config_needs_migrating
 
         try:
-            with io.open(filepath, 'r', encoding='utf8') as handle:
+            with open(filepath, 'r', encoding='utf8') as handle:
                 config = json.load(handle)
         except (IOError, OSError):
             config = Config(filepath, check_and_migrate_config({}))
@@ -376,7 +375,7 @@ class Config:  # pylint: disable=too-many-public-methods
 
         # If the filepath of this configuration does not yet exist, simply write it.
         if not os.path.isfile(self.filepath):
-            with io.open(self.filepath, 'wb') as handle:
+            with open(self.filepath, 'wb') as handle:
                 self._write(handle)
             return self
 

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -12,7 +12,6 @@ This module defines the classes related to band structures or dispersions
 in a Brillouin zone, and how to operate on them.
 """
 
-import io
 from string import Template
 
 import numpy
@@ -1009,7 +1008,7 @@ class BandsData(KpointsData):
         if not os.path.exists(filename):
             raise RuntimeError('Unable to generate the PDF...')
 
-        with io.open(filename, 'rb', encoding=None) as f:
+        with open(filename, 'rb', encoding=None) as f:
             imgdata = f.read()
         os.remove(filename)
 
@@ -1059,7 +1058,7 @@ class BandsData(KpointsData):
         if not os.path.exists(filename):
             raise RuntimeError('Unable to generate the PNG...')
 
-        with io.open(filename, 'rb', encoding=None) as f:
+        with open(filename, 'rb', encoding=None) as f:
             imgdata = f.read()
         os.remove(filename)
 
@@ -1643,7 +1642,7 @@ print_comment = False
 matplotlib_import_data_inline_template = Template('''all_data_str = r"""$all_data_json"""
 ''')
 
-matplotlib_import_data_fromfile_template = Template('''with io.open("$json_fname", encoding='utf8') as f:
+matplotlib_import_data_fromfile_template = Template('''with open("$json_fname", encoding='utf8') as f:
     all_data_str = f.read()
 ''')
 

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 
-import io
 import os
 
 from aiida.common.exceptions import ValidationError, EntryPointError, InputValidationError
@@ -92,7 +91,7 @@ class Code(Data):
 
         for filename in files:
             if os.path.isfile(filename):
-                with io.open(filename, 'rb') as handle:
+                with open(filename, 'rb') as handle:
                     self.put_object_from_filelike(handle, os.path.split(filename)[1], 'wb', encoding=None)
 
     def __str__(self):

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -9,8 +9,6 @@
 ###########################################################################
 """Module with `Node` sub class `Data` to be used as a base class for data structures."""
 
-import io
-
 from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.common.lang import override
@@ -220,10 +218,10 @@ class Data(Node):
 
         for additional_fname, additional_fcontent in extra_files.items():
             retlist.append(additional_fname)
-            with io.open(additional_fname, 'wb', encoding=None) as fhandle:
+            with open(additional_fname, 'wb', encoding=None) as fhandle:
                 fhandle.write(additional_fcontent)  # This is up to each specific plugin
         retlist.append(path)
-        with io.open(path, 'wb', encoding=None) as fhandle:
+        with open(path, 'wb', encoding=None) as fhandle:
             fhandle.write(filetext)
 
         return retlist
@@ -293,7 +291,7 @@ class Data(Node):
         """
         if fileformat is None:
             fileformat = fname.split('.')[-1]
-        with io.open(fname, 'r', encoding='utf8') as fhandle:  # reads in cwd, if fname is not absolute
+        with open(fname, 'r', encoding='utf8') as fhandle:  # reads in cwd, if fname is not absolute
             self.importstring(fhandle.read(), fileformat)
 
     def _get_importers(self):

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Module of `Data` sub class to represent a pseudopotential single file in UPF format and related utilities."""
 
-import io
 import json
 import re
 
@@ -210,7 +209,7 @@ def parse_upf(fname, check_filename=True):
         upf_contents = fname.read()
         fname = fname.name
     except AttributeError:
-        with io.open(fname, encoding='utf8') as handle:
+        with open(fname, encoding='utf8') as handle:
             upf_contents = handle.read()
 
     match = REGEX_UPF_VERSION.search(upf_contents)

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -10,7 +10,6 @@
 """Mixin classes for ORM classes."""
 
 import inspect
-import io
 
 from aiida.common import exceptions
 from aiida.common.lang import override
@@ -56,7 +55,7 @@ class FunctionCalculationMixin:
 
         try:
             source_file_path = inspect.getsourcefile(func)
-            with io.open(source_file_path, 'rb') as handle:
+            with open(source_file_path, 'rb') as handle:
                 self.put_object_from_filelike(handle, self.FUNCTION_SOURCE_FILE_PATH, mode='wb', encoding=None)
         except (IOError, OSError):
             pass

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -11,7 +11,6 @@
 
 import collections
 import enum
-import io
 import os
 
 from aiida.common import exceptions
@@ -98,7 +97,7 @@ class Repository:
         :param key: fully qualified identifier for the object within the repository
         :param mode: the mode under which to open the handle
         """
-        return io.open(self._get_base_folder().get_abs_path(key), mode=mode)
+        return open(self._get_base_folder().get_abs_path(key), mode=mode)
 
     def get_object(self, key):
         """Return the object identified by key.
@@ -205,7 +204,7 @@ class Repository:
 
         self.validate_object_key(key)
 
-        with io.open(path, mode='rb') as handle:
+        with open(path, mode='rb') as handle:
             self.put_object_from_filelike(handle, key, mode='wb', encoding=None)
 
     def put_object_from_filelike(self, handle, key, mode='w', encoding='utf8', force=False):

--- a/aiida/parsers/plugins/templatereplacer/doubler.py
+++ b/aiida/parsers/plugins/templatereplacer/doubler.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 
-import io
 import os
 
 from aiida.common import exceptions
@@ -62,7 +61,7 @@ class TemplatereplacerDoublerParser(Parser):
                         retrieved_file, retrieved_temporary_folder))
                     return self.exit_codes.ERROR_READING_TEMPORARY_RETRIEVED_FILE
 
-                with io.open(file_path, 'r', encoding='utf8') as handle:
+                with open(file_path, 'r', encoding='utf8') as handle:
                     parsed_value = handle.read().strip()
 
                 # We always strip the content of the file from whitespace to simplify testing for expected output

--- a/aiida/tools/importexport/common/archive.py
+++ b/aiida/tools/importexport/common/archive.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """Utility functions and classes to interact with AiiDA export archives."""
 
-import io
 import os
 import sys
 import tarfile
@@ -215,7 +214,7 @@ class Archive:
         :param filename: the filename relative to the sandbox folder
         :return: a dictionary with the loaded JSON content
         """
-        with io.open(self.folder.get_abs_path(filename), 'r', encoding='utf8') as fhandle:
+        with open(self.folder.get_abs_path(filename), 'r', encoding='utf8') as fhandle:
             return json.load(fhandle)
 
 

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -11,7 +11,6 @@
 """ Django-specific import of AiiDA entities """
 
 from distutils.version import StrictVersion
-import io
 import os
 import tarfile
 import zipfile
@@ -139,10 +138,10 @@ def import_data_dj(
         if not folder.get_content_list():
             raise exceptions.CorruptArchive('The provided file/folder ({}) is empty'.format(in_path))
         try:
-            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
 
-            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
                 data = json.load(fhandle)
         except IOError as error:
             raise exceptions.CorruptArchive(

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -11,7 +11,6 @@
 """ SQLAlchemy-specific import of AiiDA entities """
 
 from distutils.version import StrictVersion
-import io
 import os
 import tarfile
 import zipfile
@@ -141,10 +140,10 @@ def import_data_sqla(
         if not folder.get_content_list():
             raise exceptions.CorruptArchive('The provided file/folder ({}) is empty'.format(in_path))
         try:
-            with io.open(folder.get_abs_path('metadata.json'), encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('metadata.json'), encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
 
-            with io.open(folder.get_abs_path('data.json'), encoding='utf8') as fhandle:
+            with open(folder.get_abs_path('data.json'), encoding='utf8') as fhandle:
                 data = json.load(fhandle)
         except IOError as error:
             raise exceptions.CorruptArchive(

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -28,7 +28,7 @@ def parse_sshconfig(computername):
     import paramiko
     config = paramiko.SSHConfig()
     try:
-        config.parse(io.open(os.path.expanduser('~/.ssh/config'), encoding='utf8'))
+        config.parse(open(os.path.expanduser('~/.ssh/config'), encoding='utf8'))
     except IOError:
         # No file found, so empty configuration
         pass

--- a/aiida/transports/plugins/test_all_plugins.py
+++ b/aiida/transports/plugins/test_all_plugins.py
@@ -205,7 +205,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             # create file
             local_file_name = 'file.txt'
             text = 'Viva Verdi\n'
-            with io.open(os.path.join(t.getcwd(), local_file_name), 'w', encoding='utf8') as fhandle:
+            with open(os.path.join(t.getcwd(), local_file_name), 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
             # remove it
             t.rmtree(local_file_name)
@@ -568,7 +568,7 @@ class TestPutGetFile(unittest.TestCase):
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
             text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+            with open(local_file_name, 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
 
             # here use full path in src and dst
@@ -618,7 +618,7 @@ class TestPutGetFile(unittest.TestCase):
             remote_file_name = 'file_remote.txt'
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
-            fhandle = io.open(local_file_name, 'w', encoding='utf8')
+            fhandle = open(local_file_name, 'w', encoding='utf8')
             fhandle.close()
 
             # partial_file_name is not an abs path
@@ -682,7 +682,7 @@ class TestPutGetFile(unittest.TestCase):
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
             text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+            with open(local_file_name, 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
 
             # localpath is an empty string
@@ -770,7 +770,7 @@ class TestPutGetTree(unittest.TestCase):
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
             text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+            with open(local_file_name, 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
 
             # here use full path in src and dst
@@ -835,7 +835,7 @@ class TestPutGetTree(unittest.TestCase):
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
             text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+            with open(local_file_name, 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
 
             t.put(local_subfolder, remote_subfolder)
@@ -891,7 +891,7 @@ class TestPutGetTree(unittest.TestCase):
             file_3 = os.path.join(local_base_dir, 'c.txt')
             text = 'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with io.open(filename, 'w', encoding='utf8') as fhandle:
+                with open(filename, 'w', encoding='utf8') as fhandle:
                     fhandle.write(text)
 
             # first test the copy. Copy of two files matching patterns, into a folder
@@ -964,7 +964,7 @@ class TestPutGetTree(unittest.TestCase):
             file_3 = os.path.join(local_base_dir, 'c.txt')
             text = 'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with io.open(filename, 'w', encoding='utf8') as fhandle:
+                with open(filename, 'w', encoding='utf8') as fhandle:
                     fhandle.write(text)
 
             # first test put. Copy of two files matching patterns, into a folder
@@ -993,7 +993,7 @@ class TestPutGetTree(unittest.TestCase):
             with self.assertRaises(OSError):
                 t.put(os.path.join(local_base_dir, '*.txt'), 'prova')
             # copy of folder into file
-            with io.open(os.path.join(local_dir, directory, 'existing.txt'), 'w', encoding='utf8') as fhandle:
+            with open(os.path.join(local_dir, directory, 'existing.txt'), 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
             with self.assertRaises(OSError):
                 t.put(os.path.join(local_base_dir), 'existing.txt')
@@ -1044,7 +1044,7 @@ class TestPutGetTree(unittest.TestCase):
             file_3 = os.path.join(local_base_dir, 'c.txt')
             text = 'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with io.open(filename, 'w', encoding='utf8') as fhandle:
+                with open(filename, 'w', encoding='utf8') as fhandle:
                     fhandle.write(text)
 
             # first test put. Copy of two files matching patterns, into a folder
@@ -1075,7 +1075,7 @@ class TestPutGetTree(unittest.TestCase):
             with self.assertRaises(OSError):
                 t.get(os.path.join('local', '*.txt'), os.path.join(local_destination, 'prova'))
             # copy of folder into file
-            with io.open(os.path.join(local_destination, 'existing.txt'), 'w', encoding='utf8') as fhandle:
+            with open(os.path.join(local_destination, 'existing.txt'), 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
             with self.assertRaises(OSError):
                 t.get('local', os.path.join(local_destination, 'existing.txt'))
@@ -1124,7 +1124,7 @@ class TestPutGetTree(unittest.TestCase):
             t.chdir(directory)
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
-            fhandle = io.open(local_file_name, 'w', encoding='utf8')
+            fhandle = open(local_file_name, 'w', encoding='utf8')
             fhandle.close()
 
             # 'tmp1' is not an abs path
@@ -1200,7 +1200,7 @@ class TestPutGetTree(unittest.TestCase):
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
             text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+            with open(local_file_name, 'w', encoding='utf8') as fhandle:
                 fhandle.write(text)
 
             # localpath is an empty string

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@
 # pylint: disable=wrong-import-order
 """Setup script for aiida-core package."""
 import json
-import io
 import os
 
 from utils import fastentrypoints  # pylint: disable=unused-import
@@ -19,7 +18,7 @@ from setuptools import setup, find_packages
 if __name__ == '__main__':
     THIS_FOLDER = os.path.split(os.path.abspath(__file__))[0]
 
-    with io.open(os.path.join(THIS_FOLDER, 'setup.json'), 'r') as info:
+    with open(os.path.join(THIS_FOLDER, 'setup.json'), 'r') as info:
         SETUP_JSON = json.load(info)
 
     SETUP_JSON['extras_require']['testing'] = set(
@@ -38,7 +37,7 @@ if __name__ == '__main__':
 
     setup(
         packages=find_packages(),
-        long_description=io.open(os.path.join(THIS_FOLDER, 'README.md')).read(),
+        long_description=open(os.path.join(THIS_FOLDER, 'README.md')).read(),
         long_description_content_type='text/markdown',
         **SETUP_JSON
     )

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -18,7 +18,6 @@ Validates consistency of setup.json and
 
 """
 
-import io
 import os
 import sys
 import json
@@ -36,7 +35,7 @@ FILEPATH_TOML = os.path.join(ROOT_DIR, FILENAME_TOML)
 
 def get_setup_json():
     """Return the `setup.json` as a python dictionary """
-    with io.open(FILEPATH_SETUP_JSON, 'r') as fil:
+    with open(FILEPATH_SETUP_JSON, 'r') as fil:
         return json.load(fil, object_pairs_hook=OrderedDict)
 
 
@@ -63,7 +62,7 @@ def dump_setup_json(data):
 
     :param data: the dictionary to write to the `setup.json`
     """
-    with io.open(FILEPATH_SETUP_JSON, 'w') as handle:
+    with open(FILEPATH_SETUP_JSON, 'w') as handle:
         # Write with indentation of two spaces and explicitly define separators to not have spaces at end of lines
         return json.dump(data, handle, indent=2, separators=(',', ': '))
 
@@ -119,7 +118,7 @@ def replace_block_in_file(filepath, block_start_marker, block_end_marker, block)
     :param block_end_marker: string marking the end of the block
     :param block: list of lines representing the new block that should be inserted after old block is removed
     """
-    with io.open(filepath) as handle:
+    with open(filepath) as handle:
         lines = handle.readlines()
 
     try:
@@ -129,7 +128,7 @@ def replace_block_in_file(filepath, block_start_marker, block_end_marker, block)
 
     lines = replace_line_block(lines, block, index_start, index_end)
 
-    with io.open(filepath, 'w') as handle:
+    with open(filepath, 'w') as handle:
         for line in lines:
             handle.write(line)
 
@@ -244,7 +243,7 @@ def validate_pyproject():
         sys.exit(1)
 
     try:
-        with io.open(FILEPATH_TOML, 'r') as handle:
+        with open(FILEPATH_TOML, 'r') as handle:
             toml_string = handle.read()
     except IOError as exception:
         click.echo('Could not read the required file: {}'.format(FILEPATH_TOML), err=True)
@@ -309,7 +308,7 @@ def update_environment_yml():
 
     environment_filename = 'environment.yml'
     file_path = os.path.join(ROOT_DIR, environment_filename)
-    with io.open(file_path, 'w') as env_file:
+    with open(file_path, 'w') as env_file:
         env_file.write('# Usage: conda env create -n myenvname -f environment.yml python=3.6\n')
         yaml.safe_dump(
             environment, env_file, explicit_start=True, default_flow_style=False, encoding='utf-8', allow_unicode=True


### PR DESCRIPTION
The ``io.open`` was previously used for py2/py3 compatibility. In Python3, ``io.open`` is simply an alias for the ``open`` built-in, so there is no reason not to use the more standard ``open`` instead.