### PR TITLE
add 'node_type' to list of immutable model fields

### DIFF
--- a/aiida/orm/implementation/django/utils.py
+++ b/aiida/orm/implementation/django/utils.py
@@ -15,7 +15,7 @@ from django.db.models.fields import FieldDoesNotExist
 
 from aiida.common import exceptions
 
-IMMUTABLE_MODEL_FIELDS = {'id', 'pk', 'uuid'}
+IMMUTABLE_MODEL_FIELDS = {'id', 'pk', 'uuid', 'node_type'}
 
 
 class ModelWrapper:

--- a/aiida/orm/implementation/sqlalchemy/utils.py
+++ b/aiida/orm/implementation/sqlalchemy/utils.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.common import exceptions
 
-IMMUTABLE_MODEL_FIELDS = {'id', 'pk', 'uuid'}
+IMMUTABLE_MODEL_FIELDS = {'id', 'pk', 'uuid', 'node_type'}
 
 
 class ModelWrapper:


### PR DESCRIPTION
Fixes #1700 

In the conversion from a backend entity to an ORM entity, the
`node_type` attribute of the ModelWrapper is requested, which triggered
a database query.
This meant that a QueryBuilder returning N nodes actually caused 1+N
queries to the database instead of 1 (with obvious performance hits).

By making 'node_type' explicitly immutable (changing the type of a node
should not be allowed), requesting it no longer triggers a database
query.

Note: Currently, the `IMMUTABLE_MODEL_FIELDS` is a global list, which is applied to all models.
As @muhrin mentioned, we might want to add an `immutable_fields` property to the `model`s so that they can define their own immutable fields. Happy to open an issue for this.