### PR TITLE
Update the Dockerfile for Jenkins to run python 3.7

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,14 +1,18 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER AiiDA Team <info@aiida.net>
+
+# This is necessary such that the setup of `tzlocal` is non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG uid=1000
 ARG gid=1000
 
-## Set correct locale
-## For something more complex, as reported by https://hub.docker.com/_/ubuntu/
-## and taken from postgres:
+# Set correct locale
+# For something more complex, as reported by https://hub.docker.com/_/ubuntu/
+# and taken from postgres:
 # make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+# The `software-properties-common` is necessary to get the command `add-apt-repository`
+RUN apt-get update && apt-get install -y locales software-properties-common && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
@@ -22,21 +26,21 @@ RUN update-locale LANG=en_US.utf8
 # jenkins will replace it with 'cat')
 #CMD ["/bin/true"]
 
+RUN add-apt-repository ppa:deadsnakes/ppa
+
 # install required software
 RUN apt-get update \
     && apt-get -y install \
     git \
     vim \
     openssh-client \
-    postgresql-client-9.5 \
-    postgresql-9.5 \
-    postgresql-server-dev-9.5 \
-    python2.7 \
+    postgresql-client-10 \
+    postgresql-10 \
+    postgresql-server-dev-10 \
     && apt-get -y install \
-    python-pip \
+    python3.7 python3.7-dev \
+    python3-pip \
     ipython \
-    python2.7-dev \
-    && apt-get -y install \
     texlive-base \
     texlive-generic-recommended \
     texlive-fonts-recommended \
@@ -53,8 +57,8 @@ RUN apt-get update \
 
 # Disable password requests for requests coming from localhost
 # Of course insecure, but ok for testing
-RUN cp /etc/postgresql/9.5/main/pg_hba.conf /etc/postgresql/9.5/main/pg_hba.conf~ && \
-    perl -npe 's/^([^#]*)md5$/$1trust/' /etc/postgresql/9.5/main/pg_hba.conf~ > /etc/postgresql/9.5/main/pg_hba.conf
+RUN cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/10/main/pg_hba.conf~ && \
+    perl -npe 's/^([^#]*)md5$/$1trust/' /etc/postgresql/10/main/pg_hba.conf~ > /etc/postgresql/10/main/pg_hba.conf
 
 # install sudo otherwise tests for quicksetup fail,
 # see #1382. I think this part should be removed in the
@@ -80,7 +84,7 @@ RUN updatedb
 
 # update pip and setuptools to get a relatively-recent version
 # This can be updated in the future
-RUN pip install pip==18.1 setuptools==40.6.2
+RUN pip3 install pip==19.2.3 setuptools==42.0.2
 
 # Put the doubler script
 COPY doubler.sh /usr/local/bin/

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -76,7 +76,6 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh 'pip install -U pip==18.1'
                 sh 'pip install --user .[all]'
                 // To be able to do ssh localhost
                 sh 'ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa'

--- a/.ci/test_rpn.sh
+++ b/.ci/test_rpn.sh
@@ -23,10 +23,10 @@ VERDI=$(which verdi)
 
 if [ -n "$EXPRESSIONS" ]; then
     for expression in "${EXPRESSIONS[@]}"; do
-        coverage run -a $VERDI -p ${AIIDA_TEST_BACKEND} run "${CLI_SCRIPT}" -X $CODE -C -F -d -t $TIMEOUT "$expression"
+        $VERDI -p ${AIIDA_TEST_BACKEND} run "${CLI_SCRIPT}" -X $CODE -C -F -d -t $TIMEOUT "$expression"
     done
 else
     for i in $(seq 1 $NUMBER_WORKCHAINS); do
-        coverage run -a $VERDI -p ${AIIDA_TEST_BACKEND} run "${CLI_SCRIPT}" -X $CODE -C -F -d -t $TIMEOUT
+        $VERDI -p ${AIIDA_TEST_BACKEND} run "${CLI_SCRIPT}" -X $CODE -C -F -d -t $TIMEOUT
     done
 fi


### PR DESCRIPTION
Fixes #3601 

Really only had to update python to use python 3, but also took the time
to update some other requirements while we were at it:

 * Update the base image to Ubuntu 18.04
 * Update PostgreSQL to version 10
 * Update python to 3.7
 * Update pip and setuptools

Co-authored-by: Giovanni Pizzi <gio.piz@gmail.com>