### PR TITLE
Cache entrypoints in group

### DIFF
--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -10,6 +10,7 @@
 
 import enum
 import traceback
+import functools
 
 try:
     from reentry.default_manager import PluginManager
@@ -185,7 +186,6 @@ def load_entry_point_from_string(entry_point_string):
     group, name = parse_entry_point_string(entry_point_string)
     return load_entry_point(group, name)
 
-
 def load_entry_point(group, name):
     """
     Load the class registered under the entry point for a given name and group
@@ -234,6 +234,7 @@ def get_entry_point_names(group, sort=True):
     return entry_point_names
 
 
+@functools.lru_cache(maxsize=None)
 def get_entry_points(group):
     """
     Return a list of all the entry points within a specific group
@@ -243,7 +244,7 @@ def get_entry_points(group):
     """
     return [ep for ep in ENTRYPOINT_MANAGER.iter_entry_points(group=group)]
 
-
+@functools.lru_cache(maxsize=None)
 def get_entry_point(group, name):
     """
     Return an entry point with a given name within a specific group


### PR DESCRIPTION
Entry point loading is already cached at the `reentry` level but getting
all entry points within a group can still take significant amount of
time.
This commit introduces a simple cache at the AiiDA level. An alternative
would be to add a cache at the reentry level.

To provide some context: The timings on a query for 300 Dict nodes are
as follows:

 * No cache: ~110 ms
 * Cache: 67ms
 * Cache at `load_node_class` level: 58ms

@muhrin I would say the savings are significant and probably worth reaping. Of course, one could also try to do this at the reentry side...
Let me know. If you think we keep the cache here, I'll add the proper docstrings etc.