### PR TITLE
Timeout a CI job after 30 min. (instead of 360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: aiida-core
 
-on:
-  pull_request:
-  push:
-  - master
-  - develop
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: aiida-core
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  - master
+  - develop
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,15 @@ name: aiida-core
 
 on: [push, pull_request]
 
+env:
+  TIMEOUT_MIN: 30
+
 jobs:
 
   conda:
 
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ env.TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -25,6 +29,7 @@ jobs:
   docs:
 
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ env.TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -53,6 +58,7 @@ jobs:
   pre-commit:
 
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ env.TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -79,6 +85,7 @@ jobs:
   tests:
 
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ env.TIMEOUT_MIN }}
 
     strategy:
       fail-fast: false
@@ -131,6 +138,7 @@ jobs:
   verdi:
 
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ env.TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,12 @@ name: aiida-core
 
 on: [push, pull_request]
 
-env:
-  TIMEOUT_MIN: 30
-
 jobs:
 
   conda:
 
     runs-on: ubuntu-latest
-    timeout-minutes: $TIMEOUT_MIN
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v1
@@ -29,7 +26,7 @@ jobs:
   docs:
 
     runs-on: ubuntu-latest
-    timeout-minutes: $TIMEOUT_MIN
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v1
@@ -58,7 +55,7 @@ jobs:
   pre-commit:
 
     runs-on: ubuntu-latest
-    timeout-minutes: $TIMEOUT_MIN
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v1
@@ -85,7 +82,7 @@ jobs:
   tests:
 
     runs-on: ubuntu-latest
-    timeout-minutes: $TIMEOUT_MIN
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -138,7 +135,7 @@ jobs:
   verdi:
 
     runs-on: ubuntu-latest
-    timeout-minutes: $TIMEOUT_MIN
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   conda:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ TIMEOUT_MIN }}
+    timeout-minutes: $TIMEOUT_MIN
 
     steps:
     - uses: actions/checkout@v1
@@ -29,7 +29,7 @@ jobs:
   docs:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ TIMEOUT_MIN }}
+    timeout-minutes: $TIMEOUT_MIN
 
     steps:
     - uses: actions/checkout@v1
@@ -58,7 +58,7 @@ jobs:
   pre-commit:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ TIMEOUT_MIN }}
+    timeout-minutes: $TIMEOUT_MIN
 
     steps:
     - uses: actions/checkout@v1
@@ -85,7 +85,7 @@ jobs:
   tests:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ TIMEOUT_MIN }}
+    timeout-minutes: $TIMEOUT_MIN
 
     strategy:
       fail-fast: false
@@ -138,7 +138,7 @@ jobs:
   verdi:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ TIMEOUT_MIN }}
+    timeout-minutes: $TIMEOUT_MIN
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   conda:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TIMEOUT_MIN }}
+    timeout-minutes: ${{ TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -29,7 +29,7 @@ jobs:
   docs:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TIMEOUT_MIN }}
+    timeout-minutes: ${{ TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -58,7 +58,7 @@ jobs:
   pre-commit:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TIMEOUT_MIN }}
+    timeout-minutes: ${{ TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -85,7 +85,7 @@ jobs:
   tests:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TIMEOUT_MIN }}
+    timeout-minutes: ${{ TIMEOUT_MIN }}
 
     strategy:
       fail-fast: false
@@ -138,7 +138,7 @@ jobs:
   verdi:
 
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TIMEOUT_MIN }}
+    timeout-minutes: ${{ TIMEOUT_MIN }}
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
FIxes #3626