### PR TITLE
Make sure that datetime conversions ignore `None`

### DIFF
--- a/aiida/common/timezone.py
+++ b/aiida/common/timezone.py
@@ -124,6 +124,8 @@ def datetime_to_isoformat(value):
 
     :param value: a datetime object
     """
+    if value is None:
+        return None
     return value.isoformat()
 
 
@@ -132,4 +134,6 @@ def isoformat_to_datetime(value):
 
     :param value: a ISO format string representation of a datetime object
     """
+    if value is None:
+        return None
     return dateutil.parser.parse(value)


### PR DESCRIPTION
The functions `datetime_to_isoformat` and `isoformat_to_datetime`
assumed to always have a proper type (string or datetime) as input.
However, in some cases, they were called with values that could
be potentially `None`, like this in aiida/engine/utils.py:
```
timezone.isoformat_to_datetime(manager.get(key).value))
```
We are now directly returning `None` if `None` is passed as an
input (and then it's up to the caller to then decide what to do
with the value.

Fixes #3336