### PR TITLE
Fix two issues in `verdi computer configure ssh`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,6 @@
         aiida/backends/tests/test_base_dataclasses.py|
         aiida/backends/tests/cmdline/commands/test_code.py|
         aiida/backends/tests/cmdline/commands/test_comment.py|
-        aiida/backends/tests/cmdline/commands/test_computer.py|
         aiida/backends/tests/cmdline/commands/test_data.py|
         aiida/backends/tests/cmdline/commands/test_export.py|
         aiida/backends/tests/cmdline/commands/test_group.py|
@@ -151,7 +150,6 @@
         aiida/tools/dbimporters/plugins/nninc.py|
         aiida/tools/dbimporters/plugins/oqmd.py|
         aiida/tools/dbimporters/plugins/pcod.py|
-        aiida/transports/plugins/ssh.py|
         aiida/transports/plugins/test_all_plugins.py|
         aiida/transports/plugins/test_local.py|
         aiida/transports/plugins/test_ssh.py|

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -17,12 +17,12 @@ from click.testing import CliRunner
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.cmdline.commands.cmd_computer import computer_disable, computer_enable, computer_setup
+from aiida.cmdline.commands.cmd_computer import computer_setup
 from aiida.cmdline.commands.cmd_computer import computer_show, computer_list, computer_rename, computer_delete
 from aiida.cmdline.commands.cmd_computer import computer_test, computer_configure, computer_duplicate
 
 
-def generate_setup_options_dict(replace_args={}, non_interactive=True):
+def generate_setup_options_dict(replace_args=None, non_interactive=True):
     """
     Return a OrderedDict with the key-value pairs for the command line.
 
@@ -53,8 +53,9 @@ def generate_setup_options_dict(replace_args={}, non_interactive=True):
     valid_noninteractive_options['append-text'] = "env\necho '444'\necho 'third line'"
 
     # I replace kwargs here, so that if they are known, they go at the right order
-    for k in replace_args:
-        valid_noninteractive_options[k] = replace_args[k]
+    if replace_args is not None:
+        for k in replace_args:
+            valid_noninteractive_options[k] = replace_args[k]
 
     return valid_noninteractive_options
 
@@ -79,7 +80,7 @@ def generate_setup_options(ordereddict):
     return options
 
 
-def generate_setup_options_interactive(ordereddict):
+def generate_setup_options_interactive(ordereddict):  # pylint: disable=invalid-name
     """
     Given an (ordered) dict, returns a list of options
 
@@ -91,7 +92,7 @@ def generate_setup_options_interactive(ordereddict):
     :return: a list to be passed as command-line arguments.
     """
     options = []
-    for key, value in ordereddict.items():
+    for value in ordereddict.values():
         if value is None:
             options.append(True)
         else:
@@ -103,17 +104,21 @@ class TestVerdiComputerSetup(AiidaTestCase):
     """Tests for the 'verdi computer setup' command."""
 
     def setUp(self):
+        """Setup the class with a CliRunner."""
         self.cli_runner = CliRunner()
 
     def test_help(self):
+        """Test the help of verdi computer setup."""
         self.cli_runner.invoke(computer_setup, ['--help'], catch_exceptions=False)
 
     def test_reachable(self):
+        """Test if the verdi computer setup is reachable."""
         import subprocess as sp
         output = sp.check_output(['verdi', 'computer', 'setup', '--help'])
         self.assertIn(b'Usage:', output)
 
     def test_interactive(self):
+        """Test verdi computer setup in interactive mode."""
         os.environ['VISUAL'] = 'sleep 1; vim -cwq'
         os.environ['EDITOR'] = 'sleep 1; vim -cwq'
         label = 'interactive_computer'
@@ -143,6 +148,11 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertEqual(new_computer.get_append_text(), '')
 
     def test_mixed(self):
+        """
+        Test verdi computer setup in mixed mode.
+
+        Some parts are given interactively and some non-interactively.
+        """
         os.environ['VISUAL'] = 'sleep 1; vim -cwq'
         os.environ['EDITOR'] = 'sleep 1; vim -cwq'
         label = 'mixed_computer'
@@ -175,8 +185,9 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertEqual(new_computer.get_mpirun_command(), options_dict_full['mpirun-command'].split())
         self.assertEqual(new_computer.get_shebang(), options_dict_full['shebang'])
         self.assertEqual(new_computer.get_workdir(), options_dict_full['work-dir'])
-        self.assertEqual(new_computer.get_default_mpiprocs_per_machine(),
-                         int(options_dict_full['mpiprocs-per-machine']))
+        self.assertEqual(
+            new_computer.get_default_mpiprocs_per_machine(), int(options_dict_full['mpiprocs-per-machine'])
+        )
         # For now I'm not writing anything in them
         self.assertEqual(new_computer.get_prepend_text(), options_dict_full['prepend-text'])
         self.assertEqual(new_computer.get_append_text(), options_dict_full['append-text'])
@@ -210,7 +221,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertIsInstance(result.exception, SystemExit)
         self.assertIn('already exists', result.output)
 
-    def test_noninteractive_optional_default_mpiprocs(self):
+    def test_noninteractive_optional_default_mpiprocs(self):  # pylint: disable=invalid-name
         """
         Check that if is ok not to specify mpiprocs-per-machine
         """
@@ -225,7 +236,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertIsInstance(new_computer, orm.Computer)
         self.assertIsNone(new_computer.get_default_mpiprocs_per_machine())
 
-    def test_noninteractive_optional_default_mpiprocs_2(self):
+    def test_noninteractive_optional_default_mpiprocs_2(self):  # pylint: disable=invalid-name
         """
         Check that if is the specified value is zero, it means unspecified
         """
@@ -240,7 +251,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertIsInstance(new_computer, orm.Computer)
         self.assertIsNone(new_computer.get_default_mpiprocs_per_machine())
 
-    def test_noninteractive_optional_default_mpiprocs_3(self):
+    def test_noninteractive_optional_default_mpiprocs_3(self):  # pylint: disable=invalid-name
         """
         Check that it fails for a negative number of mpiprocs
         """
@@ -320,6 +331,7 @@ scheduler: direct
 
 
 class TestVerdiComputerConfigure(AiidaTestCase):
+    """Test the ``verdi computer configure`` command."""
 
     def setUp(self):
         """Prepare computer builder with common properties."""
@@ -343,10 +355,10 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         self.assertIn('ssh', result.output)
         self.assertIn('local', result.output)
 
-    def test_reachable(self):
+    def test_reachable(self):  # pylint: disable=no-self-use
         """Test reachability of top level and sub commands."""
         import subprocess as sp
-        output = sp.check_output(['verdi', 'computer', 'configure', '--help'])
+        sp.check_output(['verdi', 'computer', 'configure', '--help'])
         sp.check_output(['verdi', 'computer', 'configure', 'local', '--help'])
         sp.check_output(['verdi', 'computer', 'configure', 'ssh', '--help'])
         sp.check_output(['verdi', 'computer', 'configure', 'show', '--help'])
@@ -381,6 +393,7 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         self.assertIn('local', result.output)
 
     def test_local_interactive(self):
+        """Test computer configuration for local transports."""
         self.comp_builder.label = 'test_local_interactive'
         self.comp_builder.transport = 'local'
         comp = self.comp_builder.new()
@@ -411,15 +424,16 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         # I just pass the first four arguments:
         # the username, the port, look_for_keys, and the key_filename
         # This testing also checks that an empty key_filename is ok
-        command_input = (
-            '{remote_username}\n{port}\n{look_for_keys}\n{key_filename}\n'
-        ).format(
-            remote_username=remote_username, port=port,
+        command_input = ('{remote_username}\n{port}\n{look_for_keys}\n{key_filename}\n').format(
+            remote_username=remote_username,
+            port=port,
             look_for_keys='yes' if look_for_keys else 'no',
             key_filename=key_filename
         )
 
-        result = self.cli_runner.invoke(computer_configure, ['ssh', comp.label], input=command_input, catch_exceptions=False)
+        result = self.cli_runner.invoke(
+            computer_configure, ['ssh', comp.label], input=command_input, catch_exceptions=False
+        )
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
         self.assertEqual(new_auth_params['username'], remote_username)
@@ -489,9 +503,10 @@ safe_interval: {interval}
         options = ['ssh', comp.label, '--non-interactive', '--username={}'.format(username), '--safe-interval', '1']
         result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
-        self.assertEqual(orm.AuthInfo.objects.get(
-            dbcomputer_id=comp.id, aiidauser_id=self.user.id).get_auth_params()['username'],
-                         username)
+        self.assertEqual(
+            orm.AuthInfo.objects.get(dbcomputer_id=comp.id, aiidauser_id=self.user.id).get_auth_params()['username'],
+            username
+        )
 
     def test_show(self):
         """Test verdi computer configure show <comp>."""
@@ -505,8 +520,9 @@ safe_interval: {interval}
         result = self.cli_runner.invoke(computer_configure, ['show', comp.label, '--defaults'], catch_exceptions=False)
         self.assertIn('* username', result.output)
 
-        result = self.cli_runner.invoke(computer_configure, ['show', comp.label, '--defaults', '--as-option-string'],
-                                        catch_exceptions=False)
+        result = self.cli_runner.invoke(
+            computer_configure, ['show', comp.label, '--defaults', '--as-option-string'], catch_exceptions=False
+        )
         self.assertIn('--username=', result.output)
 
         config_cmd = ['ssh', comp.label, '--non-interactive']
@@ -514,8 +530,9 @@ safe_interval: {interval}
         result_config = self.cli_runner.invoke(computer_configure, config_cmd, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result_config.output)
 
-        result_cur = self.cli_runner.invoke(computer_configure, ['show', comp.label, '--as-option-string'],
-                                            catch_exceptions=False)
+        result_cur = self.cli_runner.invoke(
+            computer_configure, ['show', comp.label, '--as-option-string'], catch_exceptions=False
+        )
         self.assertIn('--username=', result.output)
         self.assertEqual(result_cur.output, result.output)
 
@@ -537,7 +554,8 @@ class TestVerdiComputerCommands(AiidaTestCase):
             hostname='localhost',
             transport_type='local',
             scheduler_type='direct',
-            workdir='/tmp/aiida')
+            workdir='/tmp/aiida'
+        )
         cls.comp.set_default_mpiprocs_per_machine(1)
         cls.comp.store()
 
@@ -593,8 +611,6 @@ class TestVerdiComputerCommands(AiidaTestCase):
         """
         Test if 'verdi computer show' command works
         """
-        import traceback
-
         # See if we can display info about the test computer.
         result = self.cli_runner.invoke(computer_show, ['comp_cli_test_computer'])
 
@@ -665,8 +681,13 @@ class TestVerdiComputerCommands(AiidaTestCase):
         from aiida.common.exceptions import NotExistent
 
         # Setup a computer to delete during the test
-        comp = orm.Computer(name='computer_for_test_delete', hostname='localhost',
-                            transport_type='local', scheduler_type='direct', workdir='/tmp/aiida').store()
+        orm.Computer(
+            name='computer_for_test_delete',
+            hostname='localhost',
+            transport_type='local',
+            scheduler_type='direct',
+            workdir='/tmp/aiida'
+        ).store()
 
         # See if the command complains about not getting an invalid computer
         options = ['non_existent_computer_name']
@@ -684,12 +705,14 @@ class TestVerdiComputerCommands(AiidaTestCase):
             orm.Computer.objects.get(name='computer_for_test_delete')
 
     def test_computer_duplicate_interactive(self):
+        """Test 'verdi computer duplicate' in interactive mode."""
         os.environ['VISUAL'] = 'sleep 1; vim -cwq'
         os.environ['EDITOR'] = 'sleep 1; vim -cwq'
         label = 'computer_duplicate_interactive'
         user_input = label + '\n\n\n\n\n\n\n\n\nN'
-        result = self.cli_runner.invoke(computer_duplicate, [str(self.comp.pk)], input=user_input,
-                                        catch_exceptions=False)
+        result = self.cli_runner.invoke(
+            computer_duplicate, [str(self.comp.pk)], input=user_input, catch_exceptions=False
+        )
         self.assertIsNone(result.exception, result.output)
 
         new_computer = orm.Computer.objects.get(name=label)
@@ -705,9 +728,12 @@ class TestVerdiComputerCommands(AiidaTestCase):
         self.assertEqual(self.comp.get_append_text(), new_computer.get_append_text())
 
     def test_computer_duplicate_non_interactive(self):
+        """Test if 'verdi computer duplicate' in non-interactive mode."""
         label = 'computer_duplicate_noninteractive'
-        result = self.cli_runner.invoke(computer_duplicate,
-                                        ['--non-interactive', '--label=' + label, str(self.comp.pk)])
+        result = self.cli_runner.invoke(
+            computer_duplicate,
+            ['--non-interactive', '--label=' + label, str(self.comp.pk)]
+        )
         self.assertIsNone(result.exception, result.output)
 
         new_computer = orm.Computer.objects.get(name=label)

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -34,6 +34,22 @@ class AbsolutePathParamType(click.Path):
         return 'ABSOLUTEPATH'
 
 
+class AbsolutePathOrEmptyParamType(AbsolutePathParamType):
+    """
+    The ParamType for identifying absolute Paths, accepting also empty paths.
+    """
+
+    name = 'AbsolutePathEmpty'
+
+    def convert(self, value, param, ctx):
+        if not value:
+            return value
+        return super().convert(value, param, ctx)
+
+    def __repr__(self):
+        return 'ABSOLUTEPATHEMPTY'
+
+
 class ImportPath(click.Path):
     """AiiDA extension of Click's Path-type to include URLs
     An ImportPath can either be a `click.Path`-type or a URL.

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -806,9 +806,7 @@ class LocalTransport(Transport):
         script = ' ; '.join([
             'if [ -d {escaped_remotedir} ]', 'then cd {escaped_remotedir}', 'bash', "else echo ' ** The directory'",
             "echo ' ** {remotedir}'", "echo ' ** seems to have been deleted, I logout...'", 'fi'
-        ]).format(
-            escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir
-        )
+        ]).format(escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir)
         cmd = 'bash -c "{}"'.format(script)
         return cmd
 

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -806,7 +806,9 @@ class LocalTransport(Transport):
         script = ' ; '.join([
             'if [ -d {escaped_remotedir} ]', 'then cd {escaped_remotedir}', 'bash', "else echo ' ** The directory'",
             "echo ' ** {remotedir}'", "echo ' ** seems to have been deleted, I logout...'", 'fi'
-        ]).format(escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir)
+        ]).format(
+            escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir
+        )
         cmd = 'bash -c "{}"'.format(script)
         return cmd
 
@@ -864,10 +866,6 @@ class LocalTransport(Transport):
         Check if path exists
         """
         return os.path.exists(os.path.join(self.curdir, path))
-
-    @classmethod
-    def _get_safe_interval_suggestion_string(cls, computer):
-        return cls._DEFAULT_SAFE_OPEN_INTERVAL
 
 
 CONFIGURE_LOCAL_CMD = transport_cli.create_configure_cmd('local')

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -7,6 +7,8 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Plugin for transport over SSH (and SFTP for file transfer)."""
+# pylint: disable=too-many-lines
 import glob
 import io
 import os
@@ -19,12 +21,18 @@ from aiida.cmdline.params.types.path import AbsolutePathOrEmptyParamType
 from aiida.common.escaping import escape_for_bash
 from ..transport import Transport, TransportInternalError
 
-
 __all__ = ('parse_sshconfig', 'convert_to_bool', 'SshTransport')
 
 
-# TODO : callback functions in paramiko are currently not used much and probably broken
 def parse_sshconfig(computername):
+    """
+    Return the ssh configuration for a given computer name.
+
+    This parses the ``.ssh/config`` file in the home directory and
+    returns the part of configuration of the given computer name.
+
+    :param computername: the computer name for which we want the configuration.
+    """
     import paramiko
     config = paramiko.SSHConfig()
     try:
@@ -37,17 +45,22 @@ def parse_sshconfig(computername):
 
 
 def convert_to_bool(string):
+    """
+    Convert a string passed in the CLI to a valid bool.
+
+    :return: the parsed bool value.
+    :raise ValueError: If the value is not parsable as a bool
+    """
     upstring = str(string).upper()
 
     if upstring in ['Y', 'YES', 'T', 'TRUE']:
         return True
-    elif upstring in ['N', 'NO', 'F', 'FALSE']:
+    if upstring in ['N', 'NO', 'F', 'FALSE']:
         return False
-    else:
-        raise ValueError('Invalid boolean value provided')
+    raise ValueError('Invalid boolean value provided')
 
 
-class SshTransport(Transport):
+class SshTransport(Transport):  # pylint: disable=too-many-public-methods
     """
     Support connection, command execution and data transfer to remote computers via SSH+SFTP.
     """
@@ -55,18 +68,92 @@ class SshTransport(Transport):
     # I disable 'password' and 'pkey' to avoid these data to get logged in the
     # aiida log file.
     _valid_connect_options = [
-        ('username', {'prompt': 'User name', 'help': 'user name for the computer', 'non_interactive_default': True}),
-        ('port', {'option': options.PORT, 'prompt': 'port Nr', 'non_interactive_default': True}),
-        ('look_for_keys', {'switch': True, 'prompt': 'Look for keys', 'help': 'switch automatic key file discovery on / off', 'non_interactive_default': True}),
-        ('key_filename', {'type': AbsolutePathOrEmptyParamType(dir_okay=False, exists=True), 'prompt': 'SSH key file', 'help': 'Manually pass a key file if default path is not set in ssh config', 'non_interactive_default': True}),
-        ('timeout', {'type': int, 'prompt': 'Connection timeout in s', 'help': 'time in seconds to wait for connection before giving up', 'non_interactive_default': True}),
-        ('allow_agent', {'switch': True, 'prompt': 'Allow ssh agent', 'help': 'switch to allow or disallow ssh agent', 'non_interactive_default': True}),
-        ('proxy_command', {'prompt': 'SSH proxy command', 'help': 'SSH proxy command', 'non_interactive_default': True}),  # Managed 'manually' in connect
-        ('compress', {'switch': True, 'prompt': 'Compress file transfers', 'help': 'switch file transfer compression on / off', 'non_interactive_default': True}),
-        ('gss_auth', {'type': bool, 'prompt': 'GSS auth', 'help': 'GSS auth for kerberos', 'non_interactive_default': True}),
-        ('gss_kex', {'type': bool, 'prompt': 'GSS kex', 'help': 'GSS kex for kerberos', 'non_interactive_default': True}),
-        ('gss_deleg_creds', {'type': bool, 'prompt': 'GSS deleg_creds', 'help': 'GSS deleg_creds for kerberos', 'non_interactive_default': True}),
-        ('gss_host', {'prompt': 'GSS host', 'help': 'GSS host for kerberos', 'non_interactive_default': True}),
+        ('username', {
+            'prompt': 'User name',
+            'help': 'user name for the computer',
+            'non_interactive_default': True
+        }),
+        ('port', {
+            'option': options.PORT,
+            'prompt': 'port Nr',
+            'non_interactive_default': True
+        }),
+        (
+            'look_for_keys', {
+                'switch': True,
+                'prompt': 'Look for keys',
+                'help': 'switch automatic key file discovery on / off',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'key_filename', {
+                'type': AbsolutePathOrEmptyParamType(dir_okay=False, exists=True),
+                'prompt': 'SSH key file',
+                'help': 'Manually pass a key file if default path is not set in ssh config',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'timeout', {
+                'type': int,
+                'prompt': 'Connection timeout in s',
+                'help': 'time in seconds to wait for connection before giving up',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'allow_agent', {
+                'switch': True,
+                'prompt': 'Allow ssh agent',
+                'help': 'switch to allow or disallow ssh agent',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'proxy_command', {
+                'prompt': 'SSH proxy command',
+                'help': 'SSH proxy command',
+                'non_interactive_default': True
+            }
+        ),  # Managed 'manually' in connect
+        (
+            'compress', {
+                'switch': True,
+                'prompt': 'Compress file transfers',
+                'help': 'switch file transfer compression on / off',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'gss_auth', {
+                'type': bool,
+                'prompt': 'GSS auth',
+                'help': 'GSS auth for kerberos',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'gss_kex', {
+                'type': bool,
+                'prompt': 'GSS kex',
+                'help': 'GSS kex for kerberos',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'gss_deleg_creds', {
+                'type': bool,
+                'prompt': 'GSS deleg_creds',
+                'help': 'GSS deleg_creds for kerberos',
+                'non_interactive_default': True
+            }
+        ),
+        ('gss_host', {
+            'prompt': 'GSS host',
+            'help': 'GSS host for kerberos',
+            'non_interactive_default': True
+        }),
         # for Kerberos support through python-gssapi
     ]
 
@@ -83,8 +170,22 @@ class SshTransport(Transport):
     # to return a suggestion; it must accept only one parameter, being a Computer
     # instance
     _valid_auth_options = _valid_connect_options + [
-        ('load_system_host_keys', {'switch': True, 'prompt': 'Load system host keys', 'help': 'switch loading system host keys on / off', 'non_interactive_default': True}),
-        ('key_policy', {'type': click.Choice(['RejectPolicy', 'WarningPolicy', 'AutoAddPolicy']), 'prompt': 'Key policy', 'help': 'SSH key policy', 'non_interactive_default': True})
+        (
+            'load_system_host_keys', {
+                'switch': True,
+                'prompt': 'Load system host keys',
+                'help': 'switch loading system host keys on / off',
+                'non_interactive_default': True
+            }
+        ),
+        (
+            'key_policy', {
+                'type': click.Choice(['RejectPolicy', 'WarningPolicy', 'AutoAddPolicy']),
+                'prompt': 'Key policy',
+                'help': 'SSH key policy',
+                'non_interactive_default': True
+            }
+        )
     ]
 
     @classmethod
@@ -183,24 +284,24 @@ class SshTransport(Transport):
                 break
             else:
                 new_pieces.append(piece)
-        return' '.join(new_pieces)
+        return ' '.join(new_pieces)
 
     @classmethod
-    def _get_compress_suggestion_string(cls, computer):
+    def _get_compress_suggestion_string(cls, computer):  # pylint: disable=unused-argument
         """
         Return a suggestion for the specific field.
         """
         return 'True'
 
     @classmethod
-    def _get_load_system_host_keys_suggestion_string(cls, computer):
+    def _get_load_system_host_keys_suggestion_string(cls, computer):  # pylint: disable=unused-argument
         """
         Return a suggestion for the specific field.
         """
         return 'True'
 
     @classmethod
-    def _get_key_policy_suggestion_string(cls, computer):
+    def _get_key_policy_suggestion_string(cls, computer):  # pylint: disable=unused-argument
         """
         Return a suggestion for the specific field.
         """
@@ -238,7 +339,6 @@ class SshTransport(Transport):
         config = parse_sshconfig(computer.hostname)
         return str(config.get('gssapihostname', computer.hostname))
 
-
     def __init__(self, *args, **kwargs):
         """
         Initialize the SshTransport class.
@@ -275,8 +375,10 @@ class SshTransport(Transport):
         elif self._missing_key_policy == 'AutoAddPolicy':
             self._client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         else:
-            raise ValueError('Unknown value of the key policy, allowed values '
-                             'are: RejectPolicy, WarningPolicy, AutoAddPolicy')
+            raise ValueError(
+                'Unknown value of the key policy, allowed values '
+                'are: RejectPolicy, WarningPolicy, AutoAddPolicy'
+            )
 
         self._connect_args = {}
         for k in self._valid_connect_params:
@@ -310,9 +412,10 @@ class SshTransport(Transport):
         try:
             self._client.connect(self._machine, **connection_arguments)
         except Exception as exc:
-            self.logger.error("Error connecting to '{}' through SSH: ".format(self._machine) +
-                              '[{}] {}, '.format(self.__class__.__name__, exc) +
-                              'connect_args were: {}'.format(self._connect_args))
+            self.logger.error(
+                "Error connecting to '{}' through SSH: ".format(self._machine) +
+                '[{}] {}, '.format(self.__class__.__name__, exc) + 'connect_args were: {}'.format(self._connect_args)
+            )
             raise
 
         # Open also a SFTPClient
@@ -383,11 +486,11 @@ class SshTransport(Transport):
         if path is not None:
             try:
                 self.sftp.chdir(path)
-            except SFTPError as e:
+            except SFTPError as exc:
                 # e.args[0] is an error code. For instance,
                 # 20 is 'the object is not a directory'
                 # Here I just re-raise the message as IOError
-                raise IOError(e.args[1])
+                raise IOError(exc.args[1])
 
         # Paramiko already checked that path is a folder, otherwise I would
         # have gotten an exception. Now, I want to check that I have read
@@ -405,7 +508,7 @@ class SshTransport(Transport):
                 self.chdir(old_path)
             raise IOError(str(exc))
 
-    def normalize(self, path):
+    def normalize(self, path='.'):
         """
         Returns the normalized path (removing double slashes, etc...)
         """
@@ -474,15 +577,18 @@ class SshTransport(Transport):
             self.sftp.mkdir(path)
         except IOError as exc:
             if os.path.isabs(path):
-                raise OSError("Error during mkdir of '{}', "
-                              "maybe you don't have the permissions to do it, "
-                              'or the directory already exists? ({})'.format(path, exc))
+                raise OSError(
+                    "Error during mkdir of '{}', "
+                    "maybe you don't have the permissions to do it, "
+                    'or the directory already exists? ({})'.format(path, exc)
+                )
             else:
-                raise OSError("Error during mkdir of '{}' from folder '{}', "
-                              "maybe you don't have the permissions to do it, "
-                              'or the directory already exists? ({})'.format(path, self.getcwd(), exc))
+                raise OSError(
+                    "Error during mkdir of '{}' from folder '{}', "
+                    "maybe you don't have the permissions to do it, "
+                    'or the directory already exists? ({})'.format(path, self.getcwd(), exc)
+                )
 
-    # TODO : implement rmtree
     def rmtree(self, path):
         """
         Remove a file or a directory at path, recursively
@@ -493,8 +599,6 @@ class SshTransport(Transport):
         :raise IOError: if the rm execution failed.
         """
         # Assuming linux rm command!
-
-        # TODO : do we need to avoid the aliases when calling rm_exe='rm'? Call directly /bin/rm?
 
         rm_exe = 'rm'
         rm_flags = '-r -f'
@@ -510,16 +614,25 @@ class SshTransport(Transport):
             if stderr.strip():
                 self.logger.warning('There was nonempty stderr in the rm command: {}'.format(stderr))
             return True
-        else:
-            self.logger.error("Problem executing rm. Exit code: {}, stdout: '{}', "
-                              "stderr: '{}'".format(retval, stdout, stderr))
-            raise IOError('Error while executing rm. Exit code: {}'.format(retval))
+        self.logger.error(
+            "Problem executing rm. Exit code: {}, stdout: '{}', "
+            "stderr: '{}'".format(retval, stdout, stderr)
+        )
+        raise IOError('Error while executing rm. Exit code: {}'.format(retval))
 
     def rmdir(self, path):
         """
         Remove the folder named 'path' if empty.
         """
         self.sftp.rmdir(path)
+
+    def chown(self, path, uid, gid):
+        """
+        Change owner permissions of a file.
+
+        For now, this is not implemented for the SSH transport.
+        """
+        raise NotImplementedError
 
     def isdir(self, path):
         """
@@ -532,12 +645,11 @@ class SshTransport(Transport):
             return False
         try:
             return S_ISDIR(self.sftp.stat(path).st_mode)
-        except IOError as e:
-            if getattr(e, 'errno', None) == 2:
+        except IOError as exc:
+            if getattr(exc, 'errno', None) == 2:
                 # errno=2 means path does not exist: I return False
                 return False
-            else:
-                raise  # Typically if I don't have permissions (errno=13)
+            raise  # Typically if I don't have permissions (errno=13)
 
     def chmod(self, path, mode):
         """
@@ -550,7 +662,8 @@ class SshTransport(Transport):
             raise IOError('Input path is an empty argument.')
         return self.sftp.chmod(path, mode)
 
-    def _os_path_split_asunder(self, path):
+    @staticmethod
+    def _os_path_split_asunder(path):
         """
         Used by makedirs. Takes path (a str)
         and returns a list deconcatenating the path
@@ -560,14 +673,15 @@ class SshTransport(Transport):
             newpath, tail = os.path.split(path)
             if newpath == path:
                 assert not tail
-                if path: parts.append(path)
+                if path:
+                    parts.append(path)
                 break
             parts.append(tail)
             path = newpath
         parts.reverse()
         return parts
 
-    def put(self, localpath, remotepath, callback=None, dereference=True, overwrite=True, ignore_nonexisting=False):
+    def put(self, localpath, remotepath, callback=None, dereference=True, overwrite=True, ignore_nonexisting=False):  # pylint: disable=too-many-arguments,too-many-branches,arguments-differ
         """
         Put a file or a folder from local to remote.
         Redirects to putfile or puttree.
@@ -582,10 +696,6 @@ class SshTransport(Transport):
         :raise ValueError: if local path is invalid
         :raise OSError: if the localpath does not exist
         """
-        # TODO: flag confirm exists since v1.7.7. What is the paramiko
-        # version supported?
-
-        # TODO : add dereference
         if not dereference:
             raise NotImplementedError
 
@@ -610,37 +720,35 @@ class SshTransport(Transport):
                 else:  # the remote path is a directory
                     rename_remote = True
 
-            for s in to_copy_list:
-                if os.path.isfile(s):
+            for file in to_copy_list:
+                if os.path.isfile(file):
                     if rename_remote:  # copying more than one file in one directory
                         # here is the case isfile and more than one file
-                        r = os.path.join(remotepath, os.path.split(s)[1])
-                        self.putfile(s, r, callback, dereference, overwrite)
+                        remotefile = os.path.join(remotepath, os.path.split(file)[1])
+                        self.putfile(file, remotefile, callback, dereference, overwrite)
 
                     elif self.isdir(remotepath):  # one file to copy in '.'
-                        r = os.path.join(remotepath, os.path.split(s)[1])
-                        self.putfile(s, r, callback, dereference, overwrite)
+                        remotefile = os.path.join(remotepath, os.path.split(file)[1])
+                        self.putfile(file, remotefile, callback, dereference, overwrite)
                     else:  # one file to copy on one file
-                        self.putfile(s, remotepath, callback, dereference, overwrite)
+                        self.putfile(file, remotepath, callback, dereference, overwrite)
                 else:
-                    self.puttree(s, remotepath, callback, dereference, overwrite)
+                    self.puttree(file, remotepath, callback, dereference, overwrite)
 
         else:
             if os.path.isdir(localpath):
                 self.puttree(localpath, remotepath, callback, dereference, overwrite)
             elif os.path.isfile(localpath):
                 if self.isdir(remotepath):
-                    r = os.path.join(remotepath, os.path.split(localpath)[1])
-                    self.putfile(localpath, r, callback, dereference, overwrite)
+                    remote = os.path.join(remotepath, os.path.split(localpath)[1])
+                    self.putfile(localpath, remote, callback, dereference, overwrite)
                 else:
                     self.putfile(localpath, remotepath, callback, dereference, overwrite)
             else:
-                if ignore_nonexisting:
-                    pass
-                else:
+                if not ignore_nonexisting:
                     raise OSError('The local path {} does not exist'.format(localpath))
 
-    def putfile(self, localpath, remotepath, callback=None, dereference=True, overwrite=True):
+    def putfile(self, localpath, remotepath, callback=None, dereference=True, overwrite=True):  # pylint: disable=arguments-differ
         """
         Put a file from local to remote.
 
@@ -653,11 +761,8 @@ class SshTransport(Transport):
         :raise OSError: if the localpath does not exist,
                     or unintentionally overwriting
         """
-        # TODO : add dereference
         if not dereference:
             raise NotImplementedError
-
-        # TODO : check what happens if I give in input a directory
 
         if not os.path.isabs(localpath):
             raise ValueError('The localpath must be an absolute path')
@@ -667,9 +772,11 @@ class SshTransport(Transport):
 
         return self.sftp.put(localpath, remotepath, callback=callback)
 
-    def puttree(self, localpath, remotepath, callback=None, dereference=True, overwrite=True):  # by default overwrite
+    def puttree(self, localpath, remotepath, callback=None, dereference=True, overwrite=True):  # pylint: disable=too-many-branches,arguments-differ,unused-argument
         """
         Put a folder recursively from local to remote.
+
+        By default, overwrite.
 
         :param localpath: an (absolute) local path
         :param remotepath: a remote path
@@ -685,7 +792,6 @@ class SshTransport(Transport):
         .. note:: setting dereference equal to True could cause infinite loops.
               see os.walk() documentation
         """
-        # TODO : add dereference
         if not dereference:
             raise NotImplementedError
 
@@ -712,17 +818,15 @@ class SshTransport(Transport):
             remotepath = os.path.join(remotepath, os.path.split(localpath)[1])
             self.mkdir(remotepath)  # create a nested folder
 
-        # TODO, NOTE: we are not using 'onerror' because we checked above that
-        # the folder exists, but it would be better to use it
         for this_source in os.walk(localpath):
             # Get the relative path
             this_basename = os.path.relpath(path=this_source[0], start=localpath)
 
             try:
                 self.sftp.stat(os.path.join(remotepath, this_basename))
-            except IOError as e:
+            except IOError as exc:
                 import errno
-                if e.errno == errno.ENOENT:  # Missing file
+                if exc.errno == errno.ENOENT:  # Missing file
                     self.mkdir(os.path.join(remotepath, this_basename))
                 else:
                     raise
@@ -732,7 +836,7 @@ class SshTransport(Transport):
                 this_remote_file = os.path.join(remotepath, this_basename, this_file)
                 self.putfile(this_local_file, this_remote_file)
 
-    def get(self, remotepath, localpath, callback=None, dereference=True, overwrite=True, ignore_nonexisting=False):
+    def get(self, remotepath, localpath, callback=None, dereference=True, overwrite=True, ignore_nonexisting=False):  # pylint: disable=too-many-branches,arguments-differ,too-many-arguments
         """
         Get a file or folder from remote to local.
         Redirects to getfile or gettree.
@@ -748,7 +852,6 @@ class SshTransport(Transport):
         :raise ValueError: if local path is invalid
         :raise IOError: if the remotepath is not found
         """
-        # TODO : add dereference
         if not dereference:
             raise NotImplementedError
 
@@ -772,24 +875,24 @@ class SshTransport(Transport):
                 else:  # the remote path is a directory
                     rename_local = True
 
-            for s in to_copy_list:
-                if self.isfile(s):
+            for file in to_copy_list:
+                if self.isfile(file):
                     if rename_local:  # copying more than one file in one directory
                         # here is the case isfile and more than one file
-                        r = os.path.join(localpath, os.path.split(s)[1])
-                        self.getfile(s, r, callback, dereference, overwrite)
+                        remote = os.path.join(localpath, os.path.split(file)[1])
+                        self.getfile(file, remote, callback, dereference, overwrite)
                     else:  # one file to copy on one file
-                        self.getfile(s, localpath, callback, dereference, overwrite)
+                        self.getfile(file, localpath, callback, dereference, overwrite)
                 else:
-                    self.gettree(s, localpath, callback, dereference, overwrite)
+                    self.gettree(file, localpath, callback, dereference, overwrite)
 
         else:
             if self.isdir(remotepath):
                 self.gettree(remotepath, localpath, callback, dereference, overwrite)
             elif self.isfile(remotepath):
                 if os.path.isdir(localpath):
-                    r = os.path.join(localpath, os.path.split(remotepath)[1])
-                    self.getfile(remotepath, r, callback, dereference, overwrite)
+                    remote = os.path.join(localpath, os.path.split(remotepath)[1])
+                    self.getfile(remotepath, remote, callback, dereference, overwrite)
                 else:
                     self.getfile(remotepath, localpath, callback, dereference, overwrite)
             else:
@@ -798,7 +901,7 @@ class SshTransport(Transport):
                 else:
                     raise IOError('The remote path {} does not exist'.format(remotepath))
 
-    def getfile(self, remotepath, localpath, callback=None, dereference=True, overwrite=True):
+    def getfile(self, remotepath, localpath, callback=None, dereference=True, overwrite=True):  # pylint: disable=arguments-differ
         """
         Get a file from remote to local.
 
@@ -810,8 +913,6 @@ class SshTransport(Transport):
         :raise ValueError: if local path is invalid
         :raise OSError: if unintentionally overwriting
         """
-        # TODO : add dereference
-
         if not os.path.isabs(localpath):
             raise ValueError('localpath must be an absolute path')
 
@@ -831,7 +932,7 @@ class SshTransport(Transport):
                 pass
             raise
 
-    def gettree(self, remotepath, localpath, callback=None, dereference=True, overwrite=True):
+    def gettree(self, remotepath, localpath, callback=None, dereference=True, overwrite=True):  # pylint: disable=arguments-differ,unused-argument
         """
         Get a folder recursively from remote to local.
 
@@ -847,7 +948,6 @@ class SshTransport(Transport):
         :raise IOError: if the remotepath is not found
         :raise OSError: if unintentionally overwriting
         """
-        # TODO : add dereference
         if not dereference:
             raise NotImplementedError
 
@@ -895,7 +995,7 @@ class SshTransport(Transport):
         aiida_attr = FileAttribute()
         # map the paramiko class into the aiida one
         # note that paramiko object contains more informations than the aiida
-        for key in aiida_attr._valid_fields:
+        for key in aiida_attr._valid_fields:  # pylint: disable=protected-access
             aiida_attr[key] = getattr(paramiko_attr, key)
         return aiida_attr
 
@@ -922,8 +1022,6 @@ class SshTransport(Transport):
         .. note:: setting dereference equal to True could cause infinite loops.
         """
         # In the majority of cases, we should deal with linux cp commands
-        # TODO : do we need to avoid the aliases when calling cp_exe='cp'? Call directly /bin/cp?
-
         cp_flags = '-f'
         if recursive:
             cp_flags += ' -r'
@@ -939,11 +1037,14 @@ class SshTransport(Transport):
         # if in input I give an invalid object raise ValueError
         if not remotesource:
             raise ValueError(
-                'Input to copy() must be a non empty string. ' + 'Found instead %s as remotesource' % remotesource)
+                'Input to copy() must be a non empty string. ' + 'Found instead %s as remotesource' % remotesource
+            )
 
         if not remotedestination:
-            raise ValueError('Input to copy() must be a non empty string. ' +
-                             'Found instead %s as remotedestination' % remotedestination)
+            raise ValueError(
+                'Input to copy() must be a non empty string. ' +
+                'Found instead %s as remotedestination' % remotedestination
+            )
 
         if self.has_magic(remotedestination):
             raise ValueError('Pathname patterns are not allowed in the destination')
@@ -955,47 +1056,50 @@ class SshTransport(Transport):
                 if not self.path_exists(remotedestination) or self.isfile(remotedestination):
                     raise OSError("Can't copy more than one file in the same destination file")
 
-            for s in to_copy_list:
-                self._exec_cp(cp_exe, cp_flags, s, remotedestination)
+            for file in to_copy_list:
+                self._exec_cp(cp_exe, cp_flags, file, remotedestination)
 
         else:
             self._exec_cp(cp_exe, cp_flags, remotesource, remotedestination)
 
     def _exec_cp(self, cp_exe, cp_flags, src, dst):
+        """Execute the ``cp`` command on the remote machine."""
         # to simplify writing the above copy function
         command = '{} {} {} {}'.format(cp_exe, cp_flags, escape_for_bash(src), escape_for_bash(dst))
 
         retval, stdout, stderr = self.exec_command_wait(command)
 
-        # TODO : check and fix below
-
         if retval == 0:
             if stderr.strip():
                 self.logger.warning('There was nonempty stderr in the cp command: {}'.format(stderr))
         else:
-            self.logger.error("Problem executing cp. Exit code: {}, stdout: '{}', "
-                              "stderr: '{}', command: '{}'".format(retval, stdout, stderr, command))
-            raise IOError('Error while executing cp. Exit code: {}, '
-                          "stdout: '{}', stderr: '{}', "
-                          "command: '{}'".format(retval, stdout, stderr, command))
+            self.logger.error(
+                "Problem executing cp. Exit code: {}, stdout: '{}', "
+                "stderr: '{}', command: '{}'".format(retval, stdout, stderr, command)
+            )
+            raise IOError(
+                'Error while executing cp. Exit code: {}, '
+                "stdout: '{}', stderr: '{}', "
+                "command: '{}'".format(retval, stdout, stderr, command)
+            )
 
-    def _local_listdir(self, path, pattern=None):
+    @staticmethod
+    def _local_listdir(path, pattern=None):
         """
         Acts on the local folder, for the rest, same as listdir
         """
         if not pattern:
             return os.listdir(path)
+        import re
+        if path.startswith('/'):  # always this is the case in the local case
+            base_dir = path
         else:
-            import re
-            if path.startswith('/'):  # always this is the case in the local case
-                base_dir = path
-            else:
-                base_dir = os.path.join(os.getcwd(), path)
+            base_dir = os.path.join(os.getcwd(), path)
 
-            filtered_list = glob.glob(os.path.join(base_dir, pattern))
-            if not base_dir.endswith(os.sep):
-                base_dir += os.sep
-            return [re.sub(base_dir, '', i) for i in filtered_list]
+        filtered_list = glob.glob(os.path.join(base_dir, pattern))
+        if not base_dir.endswith(os.sep):
+            base_dir += os.sep
+        return [re.sub(base_dir, '', i) for i in filtered_list]
 
     def listdir(self, path='.', pattern=None):
         """
@@ -1007,17 +1111,16 @@ class SshTransport(Transport):
         """
         if not pattern:
             return self.sftp.listdir(path)
+        import re
+        if path.startswith('/'):
+            base_dir = path
         else:
-            import re
-            if path.startswith('/'):
-                base_dir = path
-            else:
-                base_dir = os.path.join(self.getcwd(), path)
+            base_dir = os.path.join(self.getcwd(), path)
 
-            filtered_list = glob.glob(os.path.join(base_dir, pattern))
-            if not base_dir.endswith('/'):
-                base_dir += '/'
-            return [re.sub(base_dir, '', i) for i in filtered_list]
+        filtered_list = glob.glob(os.path.join(base_dir, pattern))
+        if not base_dir.endswith('/'):
+            base_dir += '/'
+        return [re.sub(base_dir, '', i) for i in filtered_list]
 
     def remove(self, path):
         """
@@ -1025,28 +1128,28 @@ class SshTransport(Transport):
         """
         return self.sftp.remove(path)
 
-    def rename(self, src, dst):
+    def rename(self, oldpath, newpath):
         """
-        Rename a file or folder from src to dst.
+        Rename a file or folder from oldpath to newpath.
 
         :param str oldpath: existing name of the file or folder
         :param str newpath: new name for the file or folder
 
-        :raises IOError: if src/dst is not found
-        :raises ValueError: if src/dst is not a valid string
+        :raises IOError: if oldpath/newpath is not found
+        :raises ValueError: if sroldpathc/newpath is not a valid string
         """
-        if not src:
-            raise ValueError('Source {} is not a valid string'.format(src))
-        if not dst:
-            raise ValueError('Destination {} is not a valid string'.format(dst))
-        if not self.isfile(src):
-            if not self.isdir(src):
-                raise IOError('Source {} does not exist'.format(src))
-        if not self.isfile(dst):
-            if not self.isdir(dst):
-                raise IOError('Destination {} does not exist'.format(dst))
+        if not oldpath:
+            raise ValueError('Source {} is not a valid string'.format(oldpath))
+        if not newpath:
+            raise ValueError('Destination {} is not a valid string'.format(newpath))
+        if not self.isfile(oldpath):
+            if not self.isdir(oldpath):
+                raise IOError('Source {} does not exist'.format(oldpath))
+        if not self.isfile(newpath):
+            if not self.isdir(newpath):
+                raise IOError('Destination {} does not exist'.format(newpath))
 
-        return self.sftp.rename(src, dst)
+        return self.sftp.rename(oldpath, newpath)
 
     def isfile(self, path):
         """
@@ -1059,18 +1162,20 @@ class SshTransport(Transport):
         if not path:
             return False
         try:
-            self.logger.debug("stat for path '{}' ('{}'): {} [{}]".format(path, self.sftp.normalize(path),
-                                                                          self.sftp.stat(path),
-                                                                          self.sftp.stat(path).st_mode))
+            self.logger.debug(
+                "stat for path '{}' ('{}'): {} [{}]".format(
+                    path, self.sftp.normalize(path), self.sftp.stat(path),
+                    self.sftp.stat(path).st_mode
+                )
+            )
             return S_ISREG(self.sftp.stat(path).st_mode)
-        except IOError as e:
-            if getattr(e, 'errno', None) == 2:
+        except IOError as exc:
+            if getattr(exc, 'errno', None) == 2:
                 # errno=2 means path does not exist: I return False
                 return False
-            else:
-                raise  # Typically if I don't have permissions (errno=13)
+            raise  # Typically if I don't have permissions (errno=13)
 
-    def _exec_command_internal(self, command, combine_stderr=False, bufsize=-1):
+    def _exec_command_internal(self, command, combine_stderr=False, bufsize=-1):  # pylint: disable=arguments-differ
         """
         Executes the specified command in bash login shell.
 
@@ -1097,8 +1202,10 @@ class SshTransport(Transport):
 
         if self.getcwd() is not None:
             escaped_folder = escape_for_bash(self.getcwd())
-            command_to_execute = ('cd {escaped_folder} && '
-                                  '{real_command}'.format(escaped_folder=escaped_folder, real_command=command))
+            command_to_execute = (
+                'cd {escaped_folder} && '
+                '{real_command}'.format(escaped_folder=escaped_folder, real_command=command)
+            )
         else:
             command_to_execute = command
 
@@ -1114,7 +1221,7 @@ class SshTransport(Transport):
 
         return stdin, stdout, stderr, channel
 
-    def exec_command_wait(self, command, stdin=None, combine_stderr=False, bufsize=-1):
+    def exec_command_wait(self, command, stdin=None, combine_stderr=False, bufsize=-1):  # pylint: disable=arguments-differ
         """
         Executes the specified command and waits for it to finish.
 
@@ -1128,8 +1235,6 @@ class SshTransport(Transport):
         :return: a tuple with (return_value, stdout, stderr) where stdout and stderr
             are strings.
         """
-        # TODO: To see if like this it works or hangs because of buffer problems.
-
         ssh_stdin, stdout, stderr, channel = self._exec_command_internal(command, combine_stderr, bufsize=bufsize)
 
         if stdin is not None:
@@ -1139,8 +1244,8 @@ class SshTransport(Transport):
                 filelike_stdin = stdin
 
             try:
-                for l in filelike_stdin.readlines():
-                    ssh_stdin.write(l)
+                for line in filelike_stdin.readlines():
+                    ssh_stdin.write(line)
             except AttributeError:
                 raise ValueError('stdin can only be either a string of a file-like object!')
 
@@ -1163,9 +1268,6 @@ class SshTransport(Transport):
         Specific gotocomputer string to connect to a given remote computer via
         ssh and directly go to the calculation folder.
         """
-
-        # TODO: add also ProxyCommand and Timeout support
-
         further_params = []
         if 'username' in self._connect_args:
             further_params.append('-l {}'.format(escape_for_bash(self._connect_args['username'])))
@@ -1177,11 +1279,18 @@ class SshTransport(Transport):
             further_params.append('-i {}'.format(escape_for_bash(self._connect_args['key_filename'])))
 
         further_params_str = ' '.join(further_params)
-        connect_string = """ssh -t {machine} {further_params} "if [ -d {escaped_remotedir} ] ; then cd {escaped_remotedir} ; bash -l ; else echo '  ** The directory' ; echo '  ** {remotedir}' ; echo '  ** seems to have been deleted, I logout...' ; fi" """.format(
-            further_params=further_params_str,
-            machine=self._machine,
-            escaped_remotedir="'{}'".format(remotedir),
-            remotedir=remotedir)
+        # I use triple strings because I both have single and double quotes, but I still want everything in
+        # a single line
+        connect_string = (
+            """ssh -t {machine} {further_params} "if [ -d {escaped_remotedir} ] ;"""
+            """ then cd {escaped_remotedir} ; bash -l ; else echo '  ** The directory' ; """
+            """echo '  ** {remotedir}' ; echo '  ** seems to have been deleted, I logout...' ; fi" """.format(
+                further_params=further_params_str,
+                machine=self._machine,
+                escaped_remotedir="'{}'".format(remotedir),
+                remotedir=remotedir
+            )
+        )
 
         # print connect_string
         return connect_string
@@ -1195,21 +1304,21 @@ class SshTransport(Transport):
         :param remotedestination: remote destination
         """
         # paramiko gives some errors if path is starting with '.'
-        s = os.path.normpath(remotesource)
-        d = os.path.normpath(remotedestination)
+        source = os.path.normpath(remotesource)
+        dest = os.path.normpath(remotedestination)
 
-        if self.has_magic(s):
-            if self.has_magic(d):
+        if self.has_magic(source):
+            if self.has_magic(dest):
                 # if there are patterns in dest, I don't know which name to assign
                 raise ValueError('Remotedestination cannot have patterns')
 
             # find all files matching pattern
-            for this_s in self.glob(s):
+            for this_source in self.glob(source):
                 # create the name of the link: take the last part of the path
-                this_d = os.path.join(remotedestination, os.path.split(this_s)[-1])
-                self.sftp.symlink(this_s, this_d)
+                this_dest = os.path.join(remotedestination, os.path.split(this_source)[-1])
+                self.sftp.symlink(this_source, this_dest)
         else:
-            self.sftp.symlink(s, d)
+            self.sftp.symlink(source, dest)
 
     def path_exists(self, path):
         """
@@ -1218,8 +1327,8 @@ class SshTransport(Transport):
         import errno
         try:
             self.sftp.stat(path)
-        except IOError as e:
-            if e.errno == errno.ENOENT:
+        except IOError as exc:
+            if exc.errno == errno.ENOENT:
                 return False
             raise
         else:

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -15,7 +15,7 @@ from stat import S_ISDIR, S_ISREG
 import click
 
 from aiida.cmdline.params import options
-from aiida.cmdline.params.types.path import AbsolutePathParamType
+from aiida.cmdline.params.types.path import AbsolutePathOrEmptyParamType
 from aiida.common.escaping import escape_for_bash
 from ..transport import Transport, TransportInternalError
 
@@ -58,7 +58,7 @@ class SshTransport(Transport):
         ('username', {'prompt': 'User name', 'help': 'user name for the computer', 'non_interactive_default': True}),
         ('port', {'option': options.PORT, 'prompt': 'port Nr', 'non_interactive_default': True}),
         ('look_for_keys', {'switch': True, 'prompt': 'Look for keys', 'help': 'switch automatic key file discovery on / off', 'non_interactive_default': True}),
-        ('key_filename', {'type': AbsolutePathParamType(dir_okay=False, exists=True), 'prompt': 'SSH key file', 'help': 'Manually pass a key file if default path is not set in ssh config', 'non_interactive_default': True}),
+        ('key_filename', {'type': AbsolutePathOrEmptyParamType(dir_okay=False, exists=True), 'prompt': 'SSH key file', 'help': 'Manually pass a key file if default path is not set in ssh config', 'non_interactive_default': True}),
         ('timeout', {'type': int, 'prompt': 'Connection timeout in s', 'help': 'time in seconds to wait for connection before giving up', 'non_interactive_default': True}),
         ('allow_agent', {'switch': True, 'prompt': 'Allow ssh agent', 'help': 'switch to allow or disallow ssh agent', 'non_interactive_default': True}),
         ('proxy_command', {'prompt': 'SSH proxy command', 'help': 'SSH proxy command', 'non_interactive_default': True}),  # Managed 'manually' in connect
@@ -238,9 +238,6 @@ class SshTransport(Transport):
         config = parse_sshconfig(computer.hostname)
         return str(config.get('gssapihostname', computer.hostname))
 
-    @classmethod
-    def _get_safe_interval_suggestion_string(cls, computer):
-        return cls._DEFAULT_SAFE_OPEN_INTERVAL
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
The interactive SSH was not accepting an empty
ssh key_filename, while this should be acceptable.
I am also adding a test for the interactive setup of
SSH computers.

Moreover, when reconfiguring a computer, the value
of the cooldown time wasn't resued from the authinfo;
instead, the class default was also reused due to some
hardcoding. Code now behaves correctly and is simplified
avoid duplication in base classes and subclasses.

Fixes #3633 and fixes #3634