### PR TITLE
Add hook and exit_code keyword for more nuanced cache validation.

### DIFF
--- a/aiida/engine/processes/exit_code.py
+++ b/aiida/engine/processes/exit_code.py
@@ -15,8 +15,8 @@ from aiida.common.extendeddicts import AttributeDict
 
 __all__ = ('ExitCode', 'ExitCodesNamespace')
 
-ExitCode = namedtuple('ExitCode', 'status message')
-ExitCode.__new__.__defaults__ = (0, None)
+ExitCode = namedtuple('ExitCode', ['status', 'message', 'invalidates_cache'])
+ExitCode.__new__.__defaults__ = (0, None, False)
 """
 A namedtuple to define an exit code for a :class:`~aiida.engine.processes.process.Process`.
 
@@ -29,6 +29,9 @@ corresponding attributes of the node.
 
 :param message: optional message with more details about the failure mode
 :type message: str
+
+:param invalidates_cache: optional flag, indicating that a process should not be used in caching
+:type invalidates_cache: bool
 """
 
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -894,6 +894,22 @@ class Process(plumpy.Process):
             namespace_list.extend(['.'.join(split_ns[:i]) for i in range(1, len(split_ns) + 1)])
         return namespace_list
 
+    @classmethod
+    def is_valid_cache(cls, node):
+        """Check if the given node can be cached from.
+
+        .. warning :: When overriding this method, make sure to call
+            super().is_valid_cache(node) and respect its output. Otherwise,
+            the 'invalidates_cache' keyword on exit codes will not work.
+
+        This method allows extending the behavior of `ProcessNode.is_valid_cache`
+        from `Process` sub-classes, for example in plug-ins.
+        """
+        try:
+            return not cls.spec().exit_codes(node.exit_status).invalidates_cache
+        except ValueError:
+            return True
+
 
 def get_query_string_from_process_type_string(process_type_string):  # pylint: disable=invalid-name
     """

--- a/aiida/engine/processes/process_spec.py
+++ b/aiida/engine/processes/process_spec.py
@@ -48,13 +48,15 @@ class ProcessSpec(plumpy.ProcessSpec):
         """
         return self._exit_codes
 
-    def exit_code(self, status, label, message):
+    def exit_code(self, status, label, message, invalidates_cache=False):
         """
         Add an exit code to the ProcessSpec
 
         :param status: the exit status integer
         :param label: a label by which the exit code can be addressed
         :param message: a more detailed description of the exit code
+        :param invalidates_cache: when set to `True`, a process exiting
+            with this exit code will not be considered for caching
         """
         if not isinstance(status, int):
             raise TypeError('status should be of integer type and not of {}'.format(type(status)))
@@ -68,7 +70,10 @@ class ProcessSpec(plumpy.ProcessSpec):
         if not isinstance(message, str):
             raise TypeError('message should be of basestring type and not of {}'.format(type(message)))
 
-        self._exit_codes[label] = ExitCode(status, message)
+        if not isinstance(invalidates_cache, bool):
+            raise TypeError('invalidates_cache should be of type bool and not of {}'.format(type(invalidates_cache)))
+
+        self._exit_codes[label] = ExitCode(status, message, invalidates_cache=invalidates_cache)
 
 
 class CalcJobProcessSpec(ProcessSpec):

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -479,7 +479,23 @@ class ProcessNode(Sealable, Node):
 
         :returns: True if this process node is valid to be used for caching, False otherwise
         """
-        return super().is_valid_cache and self.is_finished
+        if not (super().is_valid_cache and self.is_finished):
+            return False
+        try:
+            process_class = self.process_class
+        except Exception as exc:  # pylint: disable=broad-except
+            self.logger.warning(
+                "Not considering {} for caching, '{!r}' when accessing its process class.".format(self, exc)
+            )
+            return False
+        # If the process class does not have an 'is_valid_cache'
+        # method, we do not need to perform this check.
+        try:
+            is_valid_cache_func = process_class.is_valid_cache
+        except AttributeError:
+            return True
+
+        return is_valid_cache_func(self)
 
     def _get_objects_to_hash(self):
         """

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -483,13 +483,13 @@ class ProcessNode(Sealable, Node):
             return False
         try:
             process_class = self.process_class
-        except Exception as exc:  # pylint: disable=broad-except
+        except ValueError as exc:
             self.logger.warning(
                 "Not considering {} for caching, '{!r}' when accessing its process class.".format(self, exc)
             )
             return False
-        # If the process class does not have an 'is_valid_cache'
-        # method, we do not need to perform this check.
+        # For process functions, the `process_class` does not have an
+        # is_valid_cache attribute
         try:
             is_valid_cache_func = process_class.is_valid_cache
         except AttributeError:

--- a/docs/source/developer_guide/core/caching.rst
+++ b/docs/source/developer_guide/core/caching.rst
@@ -23,10 +23,18 @@ Below are some methods you can use to control how the hashes of calculation and 
 Controlling caching
 -------------------
 
-There are two methods you can use to disable caching for particular nodes:
+There are several methods you can use to disable caching for particular nodes:
+
+On the level of generic :class:`aiida.orm.nodes.Node`:
 
 * The :meth:`~aiida.orm.nodes.Node.is_valid_cache` property determines whether a particular node can be used as a cache. This is used for example to disable caching from failed calculations.
 * Node classes have a ``_cachable`` attribute, which can be set to ``False`` to completely switch off caching for nodes of that class. This avoids performing queries for the hash altogether.
+
+On the level of :class:`aiida.engine.processes.process.Process` and :class:`aiida.orm.nodes.process.ProcessNode`:
+
+* The :meth:`ProcessNode.is_valid_cache <aiida.orm.nodes.process.ProcessNode.is_valid_cache>` calls :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>`, passing the node itself. This can be used in :class:`~aiida.engine.processes.process.Process` subclasses (e.g. in calculation plugins) to implement custom ways of invalidating the cache.
+* The ``spec.exit_code`` has a keyword argument ``invalidates_cache``. If this is set to ``True``, returning that exit code means the process is no longer considered a valid cache. This is implemented in :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>`.
+
 
 The ``WorkflowNode`` example
 ............................
@@ -48,6 +56,3 @@ When modifying the hashing/caching behaviour of your classes, keep in mind that 
 * False positives, where two different nodes get the same hash by mistake
 
 False negatives are **highly preferrable** because they only increase the runtime of your calculations, while false positives can lead to wrong results.
-
-
-


### PR DESCRIPTION
Fixes #3368.

Adds a method `is_valid_cache` to the `Process` class, which is called with a `ProcessNode` instance as an argument. This method is called by `ProcessNode.is_valid_cache`. It allows implementing
custom behavior in `Process` sub-classes, such as the `CalcJob` classes implemented in plugins.

As a default, the `Process.is_valid_cache` checks whether the exit code returned from the process has a - newly introduced - `invalidates_cache` attribute set to `True`. This is a simple way of marking the as cache invalid for a specific exit code only.

Question: Should all the documentation go into the "Caching: implementation details" section, or do we want to mention the ``spec.exit_code`` option in the "main" caching section?