### PR TITLE
Separate copy and get template

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -147,6 +147,7 @@ DB_TEST_LIST = {
         'restapi.identifiers': ['aiida.backends.tests.restapi.test_identifiers'],
         'restapi': ['aiida.backends.tests.test_restapi'],
         'tools.data.orbital': ['aiida.backends.tests.tools.data.orbital.test_orbitals'],
+        'tools.graph.traversers': ['aiida.backends.tests.tools.graph.test_graph_traversers'],
         'tools.importexport.common.archive': ['aiida.backends.tests.tools.importexport.common.test_archive'],
         'tools.importexport.complex': ['aiida.backends.tests.tools.importexport.test_complex'],
         'tools.importexport.prov_redesign': ['aiida.backends.tests.tools.importexport.test_prov_redesign'],

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -147,6 +147,7 @@ DB_TEST_LIST = {
         'restapi.identifiers': ['aiida.backends.tests.restapi.test_identifiers'],
         'restapi': ['aiida.backends.tests.test_restapi'],
         'tools.data.orbital': ['aiida.backends.tests.tools.data.orbital.test_orbitals'],
+        'tools.graph.age': ['aiida.backends.tests.tools.graph.test_age'],
         'tools.graph.traversers': ['aiida.backends.tests.tools.graph.test_graph_traversers'],
         'tools.importexport.common.archive': ['aiida.backends.tests.tools.importexport.common.test_archive'],
         'tools.importexport.complex': ['aiida.backends.tests.tools.importexport.test_complex'],

--- a/aiida/backends/tests/tools/graph/__init__.py
+++ b/aiida/backends/tests/tools/graph/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################

--- a/aiida/backends/tests/tools/graph/test_age.py
+++ b/aiida/backends/tests/tools/graph/test_age.py
@@ -1,0 +1,456 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=too-many-locals
+"""AGE tests"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+import numpy as np
+from six.moves import range
+from six.moves import zip
+
+from aiida.tools.graph.age_entities import get_basket
+from aiida.tools.graph.age_rules import (UpdateRule, RuleSequence, MODES, RuleSaveWalkers, RuleSetWalkers)
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.links import LinkType
+from aiida.orm import Group, Node, Data, CalculationNode, WorkflowNode, ProcessNode
+from aiida.orm.querybuilder import QueryBuilder
+
+
+def create_tree(max_depth=3, branching=3, starting_cls=Data, draw=False):
+    """
+    Auxiliary function to create a tree with a given depth and a given branching.
+    """
+    if starting_cls not in (Data, CalculationNode):
+        raise TypeError('The starting_cls has to be either Data or Calculation')
+
+    # The number of nodes I will create:
+    number_of_nodes = sum([branching**d for d in range(max_depth)])
+
+    # This is the ancestor of every Node I create later
+    parent = starting_cls().store()
+
+    # This where I save the descendants, by depth (depth is the key).
+    # I'm including original node as a descendant of depth 0.
+    depth_dict = {}
+    depth_dict[0] = set([parent.id])
+
+    # The previous_cls is needed to be able to alternate between Data and Calculations
+    # If previous_cls is Data, add calculations, and vice versa
+    # The previous_ins list stores all the instance created in the previous iteration
+    # The previous_indicies list stores where the ids of previous_ins are
+    # stored in all_instances:
+    previous_cls = starting_cls
+    previous_ins = [parent]
+    previous_indices = [0]
+
+    # all_instances saves all the instances EVER created"
+    all_instances = np.zeros(number_of_nodes, dtype=int)
+    all_instances[0] = parent.id
+    adjacency = np.zeros((number_of_nodes, number_of_nodes), dtype=int)
+
+    # Iterating over the depth of the tree
+    counter = 1
+    for depth in range(1, max_depth):
+        # I'm at new depth, create new set:
+        depth_dict[depth] = set()
+
+        # Here I decide what class to create this level of descendants, and what the
+        # link type is:
+        cls = Data if previous_cls is CalculationNode else CalculationNode
+        ltype = LinkType.CREATE if cls is Data else LinkType.INPUT_CALC
+
+        # The new instances I create are saved in this list:
+        new_ins = []
+        new_indices = []
+
+        # Iterating over previous instances
+        for (pins, pins_idx) in zip(previous_ins, previous_indices):
+            # every previous instances gets a certain number of children:
+            for ioutgoing in range(branching):
+                new = cls()
+                new.add_incoming(pins, link_type=ltype, link_label='link{}'.format(ioutgoing))
+                new.store()
+                #new.add_link_from(pins, link_type=ltype, label='{}'.format(ioutgoing))
+                new_ins.append(new)
+                all_instances[counter] = new.id
+                adjacency[pins_idx, counter] = 1
+                new_indices.append(counter)
+
+                depth_dict[depth].add(new.id)
+                counter += 1
+        # Everything done, loading new instances to previous instances, and previous class
+        # to this class:
+        previous_ins = new_ins
+        previous_indices = new_indices
+        previous_cls = cls
+
+    if draw:
+        print('Function disabled.')
+    #    from aiida.cmdline.utils.ascii_vis import draw_children
+    #    print('\n\n\n The tree created:')
+    #    print(draw_children(parent, dist=max_depth+1))
+    # ~ follow_links_of_type=(LinkType.INPUT_CALC, LinkType.CREATE)))
+    # ~ follow_links_of_type=(LinkType.INPUT, LinkType.CREATE)))
+    #    print('\n\n\n')
+
+    result = {}
+    result['parent'] = parent
+    result['depth_dict'] = depth_dict
+    result['instances'] = all_instances
+    result['adjacency'] = adjacency
+    return result
+
+
+class TestNodes(AiidaTestCase):
+    """Tests for the AGE"""
+    # Hardcoding here how deep I go and the branching at every level
+    # i.e. the number of children per parent Node.
+    DEPTH = 4
+    NUMBER_OF_CHILDREN = 2
+
+    def test_data_provenance(self):
+        """
+        Creating a parent (Data) node.
+        Attaching a sequence of Calculation/Data to create a "provenance".
+        """
+
+        created_dict = create_tree(self.DEPTH, self.NUMBER_OF_CHILDREN)
+        parent = created_dict['parent']
+        desc_dict = created_dict['depth_dict']
+
+        # Created all the nodes, tree.
+        # Now testing whether I find all the descendants
+        # Using the utility function to create the starting entity set:
+        basket0 = get_basket(node_ids=(parent.id,))
+        queryb0 = QueryBuilder().append(Node).append(Node)
+
+        for depth in range(0, self.DEPTH):
+            #print('At depth {}'.format(depth))
+
+            rule = UpdateRule(queryb0, mode=MODES.REPLACE, max_iterations=depth)
+            res = rule.run(basket0.copy())['nodes'].get_keys()
+            #print('   Replace-mode results: {}'.format(', '.join(map(str, sorted(res)))))
+            should_set = desc_dict[depth]
+            self.assertTrue(not (res.difference(should_set) or should_set.difference(res)))
+
+            rule = UpdateRule(queryb0, mode=MODES.APPEND, max_iterations=depth)
+            res = rule.run(basket0.copy())['nodes'].get_keys()
+            #print('   Append-mode  results: {}'.format(', '.join(map(str, sorted(res)))))
+            should_set = set()
+            for this_depth in range(depth + 1):
+                for node_id in desc_dict[this_depth]:
+                    should_set.add(node_id)
+
+            self.assertTrue(not (res.difference(should_set) or should_set.difference(res)))
+
+    def test_cycle(self):
+        """
+        Creating a cycle: A data-instance is both input to and returned by a WorkFlowNode
+        """
+        data_node = Data().store()
+        work_node = WorkflowNode()
+        work_node.add_incoming(data_node, link_type=LinkType.INPUT_WORK, link_label='input_link')
+        work_node.store()
+        data_node.add_incoming(work_node, link_type=LinkType.RETURN, link_label='return_link')
+
+        queryb0 = QueryBuilder().append(Node).append(Node)
+        rule = UpdateRule(queryb0, max_iterations=np.inf)
+        basket0 = get_basket(node_ids=(data_node.id,))
+        res = rule.run(basket0.copy())
+        self.assertEqual(res['nodes'].get_keys(), set([data_node.id, work_node.id]))
+
+    def test_stash(self):
+        """
+        Testing the 'stash' functionality
+        """
+        # This will be tested with a graph that has a calculation (calc_ca) with two
+        # input data nodes (data_i1 and data_i2) and two output data nodes (data_o1
+        # and data_o2), and another calculation (calc_cb) which takes both one of
+        # the inputs and one of the outputs of the first one (data_i2 and data_o2)
+        # as inputs to produce a final output (data_o3).
+
+        calc_ca = CalculationNode()
+
+        data_i1 = Data().store()
+        data_i2 = Data().store()
+        calc_ca.add_incoming(data_i1, link_type=LinkType.INPUT_CALC, link_label='link_ai1')
+        calc_ca.add_incoming(data_i2, link_type=LinkType.INPUT_CALC, link_label='link_ai2')
+        calc_ca.store()
+
+        data_o1 = Data().store()
+        data_o2 = Data().store()
+        data_o1.add_incoming(calc_ca, link_type=LinkType.CREATE, link_label='link_ao1')
+        data_o2.add_incoming(calc_ca, link_type=LinkType.CREATE, link_label='link_ao2')
+
+        dins = set()
+        dins.add(data_i1.id)
+        dins.add(data_i2.id)
+        douts = set()
+        douts.add(data_o1.id)
+        douts.add(data_o2.id)
+
+        calc_cb = CalculationNode()
+        calc_cb.add_incoming(data_i2, link_type=LinkType.INPUT_CALC, link_label='link_bi2')
+        calc_cb.add_incoming(data_o2, link_type=LinkType.INPUT_CALC, link_label='link_bo2')
+        calc_cb.store()
+        data_o3 = Data().store()
+        data_o3.add_incoming(calc_cb, link_type=LinkType.CREATE, link_label='link_bo3')
+
+        # ALso here starting with a set that only contains the starting the calculation:
+        basket0 = get_basket(node_ids=(calc_ca.id,))
+
+        # Creating the rule for getting input nodes:
+        queryb1 = QueryBuilder().append(Node, tag='n').append(Node, with_outgoing='n')
+        rule_in = UpdateRule(queryb1)
+
+        # Creating the rule for getting output nodes
+        queryb2 = QueryBuilder().append(Node, tag='n').append(Node, with_incoming='n')
+        rule_out = UpdateRule(queryb2)
+
+        # I'm testing the input rule. Since I'm updating, I should
+        # have the input and the calculation itself:
+        is_set = rule_in.run(basket0.copy())['nodes'].get_keys()
+        self.assertEqual(is_set, dins.union({calc_ca.id}))
+
+        # Testing the output rule, also here, output + calculation c is expected:
+        is_set = rule_out.run(basket0.copy())['nodes'].get_keys()
+        self.assertEqual(is_set, douts.union({calc_ca.id}))
+
+        # Now I'm  testing the rule sequence.
+        # I first apply the rule to get outputs, than the rule to get inputs
+        rs1 = RuleSequence((rule_out, rule_in))
+        is_set = rs1.run(basket0.copy())['nodes'].get_keys()
+
+        # I expect the union of inputs, outputs, and the calculation:
+        self.assertEqual(is_set, douts.union(dins).union({calc_ca.id}))
+
+        # If the order of the rules is exchanged, I end up of also attaching c2 to the results.
+        # This is because c and c2 share one data-input:
+        rs2 = RuleSequence((rule_in, rule_out))
+        is_set = rs2.run(basket0.copy())['nodes'].get_keys()
+        self.assertEqual(is_set, douts.union(dins).union({calc_ca.id, calc_cb.id}))
+
+        # Testing similar rule, but with the possibility to stash the results:
+        stash = basket0.copy(with_data=False)
+        rsave = RuleSaveWalkers(stash)
+
+        # Checking whether Rule does the right thing i.e If I stash the result,
+        # the active walkers should be an empty set:
+        self.assertEqual(rsave.run(basket0.copy()), basket0.copy(with_data=False))
+
+        # Whereas the stash contains the same data as the starting point:
+        self.assertEqual(stash, basket0)
+        rs2 = RuleSequence((RuleSaveWalkers(stash), rule_in, RuleSetWalkers(stash), rule_out))
+        is_set = rs2.run(basket0.copy())['nodes'].get_keys()
+
+        # NOw I test whether the stash does the right thing,
+        # namely not including c2 in the results:
+        self.assertEqual(is_set, douts.union(dins).union({calc_ca.id}))
+
+    def test_returns_calls(self):
+        """Tests return calls (?)"""
+        create_reversed = False
+        return_reversed = False
+
+        rules = []
+        # linking all processes to input data:
+        queryb0 = QueryBuilder()
+        queryb0.append(Data, tag='predecessor')
+        queryb0.append(
+            ProcessNode,
+            with_incoming='predecessor',
+            edge_filters={'type': {
+                'in': [LinkType.INPUT_CALC.value, LinkType.INPUT_WORK.value]
+            }}
+        )
+        rules.append(UpdateRule(queryb0))
+
+        # CREATE/RETURN(ProcessNode, Data) - Forward
+        queryb0 = QueryBuilder()
+        queryb0.append(ProcessNode, tag='predecessor')
+        queryb0.append(
+            Data,
+            with_incoming='predecessor',
+            edge_filters={'type': {
+                'in': [LinkType.CREATE.value, LinkType.RETURN.value]
+            }}
+        )
+        rules.append(UpdateRule(queryb0))
+
+        # CALL(ProcessNode, ProcessNode) - Forward
+        queryb0 = QueryBuilder()
+        queryb0.append(ProcessNode, tag='predecessor')
+        queryb0.append(
+            ProcessNode,
+            with_incoming='predecessor',
+            edge_filters={'type': {
+                'in': [LinkType.CALL_CALC.value, LinkType.CALL_WORK.value]
+            }}
+        )
+        rules.append(UpdateRule(queryb0))
+
+        # CREATE(ProcessNode, Data) - Reversed
+        if create_reversed:
+            queryb0 = QueryBuilder()
+            queryb0.append(ProcessNode, tag='predecessor', project=['id'])
+            queryb0.append(Data, with_incoming='predecessor', edge_filters={'type': {'in': [LinkType.CREATE.value]}})
+            rules.append(UpdateRule(queryb0))
+
+        # Case 3:
+        # RETURN(ProcessNode, Data) - Reversed
+        if return_reversed:
+            queryb0 = QueryBuilder()
+            queryb0.append(ProcessNode, tag='predecessor')
+            queryb0.append(Data, output_of='predecessor', edge_filters={'type': {'in': [LinkType.RETURN.value]}})
+            rules.append(UpdateRule(queryb0))
+
+        # Test was doing the calculation but not checking the results. Will have to think
+        # how to do that now. Temporal replacement:
+        new_node = Data().store()
+        basket0 = get_basket(node_ids=(new_node.id,))
+
+        ruleseq = RuleSequence(rules, max_iterations=np.inf)
+        resulting_set = ruleseq.run(basket0.copy())
+        expecting_set = resulting_set
+        self.assertEqual(expecting_set, resulting_set)
+
+    def test_groups(self):
+        """
+        Testing whether groups and nodes can be traversed with the Graph explorer:
+        """
+        total_groups = 10
+
+        # I create a certain number of groups and save them in this list:
+        groups = []
+        for idx in range(total_groups):
+            new_group = Group(label='group-{}'.format(idx))
+            new_group.store()
+            groups.append(new_group)
+
+        # Same with nodes: Create 1 node less than I have groups, each node will
+        # be added to the group with the same index and the group of index-1
+        nodes = []
+        for idx in range(1, total_groups):
+            new_node = Data().store()
+            groups[idx].add_nodes(new_node)
+            groups[idx - 1].add_nodes(new_node)
+            nodes.append(new_node)
+
+        # Creating sets for the test:
+        nodes_set = {n.id for n in nodes}
+        groups_set = {g.id for g in groups}
+
+        # Now I want rule that gives me all the data starting from the last node,
+        # with links, belonging to the same group:
+        qb0 = QueryBuilder()
+        qb0.append(Data, tag='d')
+        #qb0.append(Group, with_node='d', tag='g', filters={'type_string':''} )
+        qb0.append(Group, with_node='d', tag='g')
+        # The filter here is there for avoiding problems with autogrouping.
+        # Depending how the test exactly is run, nodes can be put into autogroups.
+        qb0.append(Data, with_group='g')
+
+        initial_node = nodes[-1]
+        expecting_set = nodes_set
+        basket_inp = get_basket(node_ids=(initial_node.id,))
+        tested_rule = UpdateRule(qb0, max_iterations=np.inf)
+        basket_out = tested_rule.run(basket_inp.copy())
+        resulting_set = basket_out['nodes'].get_keys()
+
+        # checking whether this updateRule above really visits all the nodes I created:
+        self.assertEqual(expecting_set, resulting_set)
+
+        # The visits:
+        self.assertEqual(tested_rule.get_visits()['nodes'].get_keys(), resulting_set)
+
+        # I can do the same with 2 rules chained into a RuleSequence:
+        qb1 = QueryBuilder()
+        qb1.append(Node, tag='n')
+        qb1.append(Group, with_node='n')
+        #        qb1.append(Group, with_node='n', filters={'type_string':''})
+
+        qb2 = QueryBuilder()
+        qb2.append(Group, tag='n')
+        qb2.append(Node, with_group='n')
+
+        rule1 = UpdateRule(qb1)
+        rule2 = UpdateRule(qb2)
+        seq = RuleSequence((rule1, rule2), max_iterations=np.inf)
+        res = seq.run(basket_inp.copy())
+        for should_set, is_set in ((nodes_set.copy(), res['nodes'].get_keys()), (groups_set, res['groups'].get_keys())):
+            self.assertEqual(is_set, should_set)
+
+    def test_edges(self):
+        """
+        Testing whether nodes (and nodes) can be traversed with the Graph explorer,
+        with the links being stored
+        """
+
+        # I create a certain number of groups and save them in this list:
+        # (draw was true but changed it until the function is re-stablished)
+        created_dict = create_tree(self.DEPTH, self.NUMBER_OF_CHILDREN, draw=False)
+        instances = created_dict['instances']
+        adjacency = created_dict['adjacency']
+
+        basket0 = get_basket(node_ids=(created_dict['parent'].id,))
+
+        queryb0 = QueryBuilder().append(Node).append(Node)
+
+        rule = UpdateRule(queryb0, mode=MODES.APPEND, max_iterations=self.DEPTH - 1, track_edges=True)
+        res = rule.run(basket0.copy())
+
+        should_set = set()
+        for this_depth in range(self.DEPTH):
+            for node_id in created_dict['depth_dict'][this_depth]:
+                should_set.add(node_id)
+
+        self.assertEqual(res['nodes'].get_keys(), should_set)
+
+        touples_should = set()
+        for i, j in zip(*np.where(adjacency)):
+            touples_should.add((instances[i], instances[j]))
+
+        touples_are = set()
+        for data_touple in res['nodes_nodes'].get_keys():
+            touples_are.add((data_touple[0], data_touple[1]))
+
+        self.assertEqual(touples_are, touples_should)
+
+        rule = UpdateRule(queryb0, mode=MODES.REPLACE, max_iterations=self.DEPTH - 1, track_edges=True)
+        res = rule.run(basket0.copy())
+
+        # Since I apply the replace rule, the last set of links should appear:
+        instances = created_dict['instances']
+        adjacency = created_dict['adjacency']
+
+        touples_should = set()
+        for idx1, pk1 in enumerate(instances):
+            for idx2, pk2 in enumerate(instances):
+                are_adjacent = (adjacency[idx1, idx2] == 1)
+                depth1_ok = pk1 in created_dict['depth_dict'][self.DEPTH - 2]
+                depth2_ok = pk2 in created_dict['depth_dict'][self.DEPTH - 1]
+                if are_adjacent and depth1_ok and depth2_ok:
+                    touples_should.add((pk1, pk2))
+
+        #[
+        #    touples_should.add((pk1, pk2))
+        #    for idx1, pk1 in enumerate(instances)
+        #    for idx2, pk2 in enumerate(instances)
+        #    if adjacency[idx1, idx2] and pk1 in created_dict['depth_dict'][self.DEPTH - 2] and
+        #    pk2 in created_dict['depth_dict'][self.DEPTH - 1]
+        #]
+
+        touples_are = set()
+        for data_touple in res['nodes_nodes'].get_keys():
+            touples_are.add((data_touple[0], data_touple[1]))
+
+        self.assertEqual(touples_are, touples_should)

--- a/aiida/backends/tests/tools/graph/test_age.py
+++ b/aiida/backends/tests/tools/graph/test_age.py
@@ -358,9 +358,9 @@ class TestNodes(AiidaTestCase):
         qb0 = QueryBuilder()
         qb0.append(Data, tag='d')
         #qb0.append(Group, with_node='d', tag='g', filters={'type_string':''} )
-        qb0.append(Group, with_node='d', tag='g')
-        # The filter here is there for avoiding problems with autogrouping.
-        # Depending how the test exactly is run, nodes can be put into autogroups.
+        qb0.append(Group, with_node='d', tag='g', filters={'type_string': 'user'})  # The filter here is
+        # there for avoiding problems with autogrouping. Depending how the test
+        # exactly is run, nodes can be put into autogroups.
         qb0.append(Data, with_group='g')
 
         initial_node = nodes[-1]
@@ -391,7 +391,6 @@ class TestNodes(AiidaTestCase):
         seq = RuleSequence((rule1, rule2), max_iterations=np.inf)
         res = seq.run(basket_inp.copy())
         for should_set, is_set in ((nodes_set.copy(), res['nodes'].get_keys()), (groups_set, res['groups'].get_keys())):
-            print(QueryBuilder().append(Group, filters={'id': {'in': is_set}}).all())
             print(is_set)
             print(should_set)
             self.assertEqual(is_set, should_set)

--- a/aiida/backends/tests/tools/graph/test_age.py
+++ b/aiida/backends/tests/tools/graph/test_age.py
@@ -10,11 +10,7 @@
 # pylint: disable=too-many-locals
 """AGE tests"""
 
-from __future__ import absolute_import
-from __future__ import print_function
 import numpy as np
-from six.moves import range
-from six.moves import zip
 
 from aiida.tools.graph.age_entities import get_basket
 from aiida.tools.graph.age_rules import (UpdateRule, RuleSequence, MODES, RuleSaveWalkers, RuleSetWalkers)
@@ -116,6 +112,11 @@ class TestNodes(AiidaTestCase):
     # i.e. the number of children per parent Node.
     DEPTH = 4
     NUMBER_OF_CHILDREN = 2
+
+    def setUp(self):
+        super().setUp()
+        self.reset_database()
+        print('AMMA RUN THIS THING!')
 
     def test_data_provenance(self):
         """
@@ -328,12 +329,15 @@ class TestNodes(AiidaTestCase):
         Testing whether groups and nodes can be traversed with the Graph explorer:
         """
         total_groups = 10
+        self.reset_database()
+        print('\n\n\n####################')
 
         # I create a certain number of groups and save them in this list:
         groups = []
         for idx in range(total_groups):
             new_group = Group(label='group-{}'.format(idx))
             new_group.store()
+            print('Group {}: ID is {}'.format(idx, new_group.id))
             groups.append(new_group)
 
         # Same with nodes: Create 1 node less than I have groups, each node will
@@ -387,7 +391,13 @@ class TestNodes(AiidaTestCase):
         seq = RuleSequence((rule1, rule2), max_iterations=np.inf)
         res = seq.run(basket_inp.copy())
         for should_set, is_set in ((nodes_set.copy(), res['nodes'].get_keys()), (groups_set, res['groups'].get_keys())):
+            print(is_set)
+            print(should_set)
             self.assertEqual(is_set, should_set)
+
+        print('####################\n\n\n')
+
+        #print('-------\n\n')
 
     def test_edges(self):
         """

--- a/aiida/backends/tests/tools/graph/test_age.py
+++ b/aiida/backends/tests/tools/graph/test_age.py
@@ -236,12 +236,12 @@ class TestNodes(AiidaTestCase):
         self.assertEqual(is_set, douts.union(dins).union({calc_ca.id, calc_cb.id}))
 
         # Testing similar rule, but with the possibility to stash the results:
-        stash = basket0.copy(with_data=False)
+        stash = basket0.get_template()
         rsave = RuleSaveWalkers(stash)
 
         # Checking whether Rule does the right thing i.e If I stash the result,
         # the operational sets should be the original set:
-        self.assertEqual(rsave.run(basket0.copy()), basket0.copy(with_data=True))
+        self.assertEqual(rsave.run(basket0.copy()), basket0.copy())
 
         # Whereas the stash contains the same data as the starting point:
         self.assertEqual(stash, basket0)
@@ -451,3 +451,40 @@ class TestNodes(AiidaTestCase):
             touples_are.add((data_touple[0], data_touple[1]))
 
         self.assertEqual(touples_are, touples_should)
+
+# class TestAiidaEntitySet(AiidaTestCase):
+#     """Tests for AiidaEntitySets"""
+
+#     def setUp(self):
+#         super().setUp()
+#         self.reset_database()
+
+#     def test_class_mismatch(self):
+#         """
+#         Test the case that an AiidaEntitySet is trying to be used in an operation with another class
+#             (e.g. DirectedEdgeSet)
+#         """
+#         pass
+
+#     def test_identifier_mismatch(self):
+#         """
+#         Test the case that the identifier key (e.g. 'id') is different between to AiidaEntitySets
+#         """
+#         pass
+
+#     def test_identifier_type_mismatch(self):
+#         """
+#         Test the case that the variable type of the identifier (e.g. int) is different between AiidaEntitySets
+#         """
+#         pass
+
+#     def test_input_for_set_identifier_mismatch(self):
+#         pass
+
+#     def test_input_for_set_identifier_type_mismatch(self):
+#         pass
+
+#     def test_copy_with_data(self):
+#         pass
+
+

--- a/aiida/backends/tests/tools/graph/test_age.py
+++ b/aiida/backends/tests/tools/graph/test_age.py
@@ -391,6 +391,7 @@ class TestNodes(AiidaTestCase):
         seq = RuleSequence((rule1, rule2), max_iterations=np.inf)
         res = seq.run(basket_inp.copy())
         for should_set, is_set in ((nodes_set.copy(), res['nodes'].get_keys()), (groups_set, res['groups'].get_keys())):
+            print(QueryBuilder().append(Group, filters={'id': {'in': is_set}}).all())
             print(is_set)
             print(should_set)
             self.assertEqual(is_set, should_set)

--- a/aiida/backends/tests/tools/graph/test_age.py
+++ b/aiida/backends/tests/tools/graph/test_age.py
@@ -395,7 +395,6 @@ class TestNodes(AiidaTestCase):
             print(is_set)
             print(should_set)
             self.assertEqual(is_set, should_set)
-
         print('####################\n\n\n')
 
         #print('-------\n\n')

--- a/aiida/backends/tests/tools/graph/test_graph_traversers.py
+++ b/aiida/backends/tests/tools/graph/test_graph_traversers.py
@@ -1,0 +1,417 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=missing-docstring
+# pylint: disable=too-many-locals,too-many-statements
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+#import unittest
+from aiida.backends.testbase import AiidaTestCase
+from aiida.tools.graph.graph_traversers import exhaustive_traverser
+
+
+class TestExhaustiveTraverser(AiidaTestCase):
+
+    @staticmethod
+    def _create_minimal_graph():
+        """
+        Creates a minimal graph which has one parent workflow (W2) that calls
+        a child workflow (W1) which calls a calculation function (C0). There
+        is one input (DI) and one output (DO). It has at least one link of
+        each class:
+
+        * CALL_WORK from W2 to W1.
+        * CALL_CALC from W1 to C0.
+        * INPUT_CALC from DI to C0 and CREATE from C0 to DO.
+        * INPUT_WORK from DI to W1 and RETURN from W1 to DO.
+        * INPUT_WORK from DI to W2 and RETURN from W2 to DO.
+
+        This graph looks like this::
+
+                  input_work     +----+     return
+              +----------------> | W2 | ---------------+
+              |                  +----+                |
+              |                    |                   |
+              |                    | call_work         |
+              |                    |                   |
+              |                    v                   |
+              |     input_work   +----+    return      |
+              |  +-------------> | W1 | ------------+  |
+              |  |               +----+             |  |
+              |  |                 |                |  |
+              |  |                 | call_calc      |  |
+              |  |                 |                |  |
+              |  |                 v                v  v
+            +------+ input_calc  +----+  create   +------+
+            |  DI  | ----------> | C0 | --------> |  DO  |
+            +------+             +----+           +------+
+        """
+        from aiida.common.links import LinkType
+        from aiida import orm
+
+        data_i = orm.Data().store()
+        data_o = orm.Data().store()
+
+        calc_0 = orm.CalculationNode()
+        work_1 = orm.WorkflowNode()
+        work_2 = orm.WorkflowNode()
+
+        calc_0.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc')
+        work_1.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork')
+        work_2.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork')
+        calc_0.add_incoming(work_1, link_type=LinkType.CALL_CALC, link_label='callcalc')
+        work_1.add_incoming(work_2, link_type=LinkType.CALL_WORK, link_label='callwork')
+
+        work_2.store()
+        work_1.store()
+        calc_0.store()
+
+        data_o.add_incoming(calc_0, link_type=LinkType.CREATE, link_label='create0')
+        data_o.add_incoming(work_1, link_type=LinkType.RETURN, link_label='return1')
+        data_o.add_incoming(work_2, link_type=LinkType.RETURN, link_label='return2')
+
+        return data_i, data_o, calc_0, work_1, work_2
+
+    def test_traversal_individually(self):
+        """
+        This will go through all the rules and check one case in graph where it
+        can be applied.
+        """
+        from aiida.common.links import GraphTraversalRules
+
+        # This uses the delete dict because it has the same names as the export dict,
+        # which is all this test needs
+        traverser_rules = {}
+        for name in GraphTraversalRules.DELETE.value:
+            traverser_rules[name] = False
+
+        data_i, data_o, calc_0, work_1, work_2 = self._create_minimal_graph()
+        pkdi = data_i.pk
+        pkdo = data_o.pk
+        pkc0 = calc_0.pk
+        pkw1 = work_1.pk
+        pkw2 = work_2.pk
+
+        test_rule_list = []
+        starting_nodes = []
+        included_nodes = []
+
+        test_rule_list.append('input_calc_forward')
+        starting_nodes.append([pkdi])
+        included_nodes.append([pkc0])
+
+        test_rule_list.append('input_calc_backward')
+        starting_nodes.append([pkc0])
+        included_nodes.append([pkdi])
+
+        test_rule_list.append('create_forward')
+        starting_nodes.append([pkc0])
+        included_nodes.append([pkdo])
+
+        test_rule_list.append('create_backward')
+        starting_nodes.append([pkdo])
+        included_nodes.append([pkc0])
+
+        test_rule_list.append('return_forward')
+        starting_nodes.append([pkw1])
+        included_nodes.append([pkdo])
+
+        test_rule_list.append('return_backward')
+        starting_nodes.append([pkdo])
+        included_nodes.append([pkw1, pkw2])
+
+        test_rule_list.append('input_work_forward')
+        starting_nodes.append([pkdi])
+        included_nodes.append([pkw1, pkw2])
+
+        test_rule_list.append('input_work_backward')
+        starting_nodes.append([pkw1])
+        included_nodes.append([pkdi])
+
+        test_rule_list.append('call_calc_forward')
+        starting_nodes.append([pkw1])
+        included_nodes.append([pkc0])
+
+        test_rule_list.append('call_calc_backward')
+        starting_nodes.append([pkc0])
+        included_nodes.append([pkw1])
+
+        test_rule_list.append('call_work_forward')
+        starting_nodes.append([pkw2])
+        included_nodes.append([pkw1])
+
+        test_rule_list.append('call_work_backward')
+        starting_nodes.append([pkw1])
+        included_nodes.append([pkw2])
+
+        for idx, test_rule in enumerate(test_rule_list):
+            traverser_rules[test_rule] = True
+            obtained_nodes = exhaustive_traverser(starting_nodes[idx], **traverser_rules)
+            expected_nodes = set(starting_nodes[idx] + included_nodes[idx])
+            self.assertEqual(obtained_nodes, expected_nodes)
+            traverser_rules[test_rule] = False
+
+    def test_traversal_full_graph(self):
+        """
+        This will test that the traverser can get the full graph with the minimal traverse
+        required keywords.
+        """
+        from aiida.common.links import GraphTraversalRules
+
+        # This uses the delete dict because it has the same names as the export dict,
+        # which is all this test needs
+        traverser_rules = {}
+        for name in GraphTraversalRules.DELETE.value:
+            traverser_rules[name] = False
+
+        data_i, data_o, calc_0, work_1, work_2 = self._create_minimal_graph()
+        pkdi = data_i.pk
+        pkdo = data_o.pk
+        pkc0 = calc_0.pk
+        pkw1 = work_1.pk
+        pkw2 = work_2.pk
+
+        expected_nodes = set([pkdi, pkdo, pkc0, pkw1, pkw2])
+
+        nodeset_list = []
+
+        nodeset_list.append(
+            ([pkdi], ['input_calc_forward', 'call_calc_backward', 'call_work_backward', 'return_forward'])
+        )
+        nodeset_list.append(([pkdi], ['input_calc_forward', 'create_forward', 'return_backward']))
+        nodeset_list.append(([pkdi], ['input_work_forward', 'call_calc_forward', 'create_forward']))
+
+        nodeset_list.append(
+            ([pkdo], ['create_backward', 'call_calc_backward', 'call_work_backward', 'input_work_backward'])
+        )
+        nodeset_list.append(([pkdo], ['create_backward', 'input_calc_backward', 'input_work_forward']))
+        nodeset_list.append(([pkdo], ['return_backward', 'call_calc_forward', 'input_calc_backward']))
+
+        nodeset_list.append(
+            ([pkc0], ['create_forward', 'call_calc_backward', 'call_work_backward', 'input_calc_backward'])
+        )
+        nodeset_list.append(([pkc0], ['create_forward', 'return_backward', 'input_work_backward']))
+        nodeset_list.append(([pkc0], ['input_calc_backward', 'input_work_forward', 'return_forward']))
+
+        nodeset_list.append(
+            ([pkw1], ['input_work_backward', 'return_forward', 'call_work_backward', 'call_calc_forward'])
+        )
+        nodeset_list.append(
+            ([pkw2], ['input_calc_backward', 'create_forward', 'call_work_forward', 'call_calc_forward'])
+        )
+        nodeset_list.append(([pkw1], ['return_forward', 'create_backward', 'input_calc_backward',
+                                      'input_work_forward']))
+        nodeset_list.append(([pkw1], ['call_calc_forward', 'create_forward', 'return_backward', 'input_calc_backward']))
+
+        for nodes, minimal_set in nodeset_list:
+            for rule in minimal_set:
+                traverser_rules[rule] = True
+            obtained_nodes = exhaustive_traverser(nodes, **traverser_rules)
+            self.assertEqual(obtained_nodes, expected_nodes)
+            for rule in minimal_set:
+                traverser_rules[rule] = False
+
+    @staticmethod
+    def _mini_traverser(node_zero, rule1, rule2, connections):
+        """
+        For testing purposes, limited functionality of the traverser: will take only
+        one node and two rules and obtain all nodes that can be connected to that node
+        through a maximum of two links (if they comply with the two rules provided).
+        The connections must be provided as a dictionary with the following keys:
+
+        - 'node_i': the incoming node.
+        - 'node_o': the outgoing node
+        - 'link_f': the link with the forward direction.
+        - 'link_b': the link with the backward direction.
+        """
+        nodes_found = set([node_zero])
+        for link1 in connections:
+
+            link1_is_go = False
+            zero_is_inp = (node_zero == link1['node_i'])
+            zero_is_out = (node_zero == link1['node_o'])
+            linkf_is_go = link1['rule_f'] in [rule1, rule2]
+            linkb_is_go = link1['rule_b'] in [rule1, rule2]
+
+            if zero_is_inp and linkf_is_go:
+                next_node = link1['node_o']
+                link1_is_go = True
+
+            if zero_is_out and linkb_is_go:
+                next_node = link1['node_i']
+                link1_is_go = True
+
+            if link1_is_go:
+                nodes_found.add(next_node)
+                for link2 in connections:
+                    node_is_inp = (next_node == link2['node_i'])
+                    node_is_out = (next_node == link2['node_o'])
+                    linkf_is_go = link2['rule_f'] in [rule1, rule2]
+                    linkb_is_go = link2['rule_b'] in [rule1, rule2]
+
+                    if node_is_inp and linkf_is_go:
+                        nodes_found.add(link2['node_o'])
+
+                    if node_is_out and linkb_is_go:
+                        nodes_found.add(link2['node_i'])
+
+        return nodes_found
+
+    def test_traversal_concats(self):
+        """
+        This will go through the possible concatenations of rules.
+        """
+        from aiida.common.links import GraphTraversalRules
+
+        # This uses the delete dict because it has the same names as the export dict,
+        # which is all this test needs
+        traverser_rules = {}
+        for name in GraphTraversalRules.DELETE.value:
+            traverser_rules[name] = False
+
+        data_i, data_o, calc_0, work_1, work_2 = self._create_minimal_graph()
+        pkdi = data_i.pk
+        pkdo = data_o.pk
+        pkc0 = calc_0.pk
+        pkw1 = work_1.pk
+        pkw2 = work_2.pk
+
+        node_list = [pkdi, pkdo, pkc0, pkw1, pkw2]
+        connection_links = []
+
+        newlink = {}
+        newlink['node_i'] = pkdi
+        newlink['rule_f'] = 'input_work_forward'
+        newlink['rule_b'] = 'input_work_backward'
+        newlink['node_o'] = pkw2
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkdi
+        newlink['rule_f'] = 'input_work_forward'
+        newlink['rule_b'] = 'input_work_backward'
+        newlink['node_o'] = pkw1
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkdi
+        newlink['rule_f'] = 'input_calc_forward'
+        newlink['rule_b'] = 'input_calc_backward'
+        newlink['node_o'] = pkc0
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkw2
+        newlink['rule_f'] = 'return_forward'
+        newlink['rule_b'] = 'return_backward'
+        newlink['node_o'] = pkdo
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkw1
+        newlink['rule_f'] = 'return_forward'
+        newlink['rule_b'] = 'return_backward'
+        newlink['node_o'] = pkdo
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkc0
+        newlink['rule_f'] = 'create_forward'
+        newlink['rule_b'] = 'create_backward'
+        newlink['node_o'] = pkdo
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkw2
+        newlink['rule_f'] = 'call_work_forward'
+        newlink['rule_b'] = 'call_work_backward'
+        newlink['node_o'] = pkw1
+        connection_links.append(newlink)
+
+        newlink = {}
+        newlink['node_i'] = pkw1
+        newlink['rule_f'] = 'call_calc_forward'
+        newlink['rule_b'] = 'call_calc_backward'
+        newlink['node_o'] = pkc0
+        connection_links.append(newlink)
+
+        for rule1 in GraphTraversalRules.DELETE.value:
+            for rule2 in GraphTraversalRules.DELETE.value:
+                for node_zero in node_list:
+
+                    traverser_rules[rule1] = True
+                    traverser_rules[rule2] = True
+                    expected_nodes = self._mini_traverser(node_zero, rule1, rule2, connection_links)
+                    obtained_nodes = exhaustive_traverser([node_zero], **traverser_rules)
+                    self.assertEqual(obtained_nodes, expected_nodes)
+                    traverser_rules[rule1] = False
+                    traverser_rules[rule2] = False
+
+    def test_traversal_cycle(self):
+        """
+        This will test that cycles don't go into infinite loops by testing a
+        graph with two data nodes data_take and data_drop and a work_select
+        that takes both as input but returns only data_take
+        """
+        from aiida.common.links import GraphTraversalRules
+        from aiida.common.links import LinkType
+        from aiida import orm
+
+        traverser_rules = {}
+        for name in GraphTraversalRules.DELETE.value:
+            traverser_rules[name] = False
+
+        data_take = orm.Data().store()
+        data_drop = orm.Data().store()
+        work_select = orm.WorkflowNode()
+
+        work_select.add_incoming(data_take, link_type=LinkType.INPUT_WORK, link_label='input_take')
+        work_select.add_incoming(data_drop, link_type=LinkType.INPUT_WORK, link_label='input_drop')
+        work_select.store()
+
+        data_take.add_incoming(work_select, link_type=LinkType.RETURN, link_label='return_link')
+
+        data_take = data_take.pk
+        data_drop = data_drop.pk
+        work_select = work_select.pk
+
+        every_node = [data_take, data_drop, work_select]
+
+        for single_node in every_node:
+            expected_nodes = set([single_node])
+            obtained_nodes = exhaustive_traverser([single_node], **traverser_rules)
+            self.assertEqual(obtained_nodes, expected_nodes)
+
+        traverser_rules['input_work_forward'] = True
+        traverser_rules['return_forward'] = True
+        obtained_nodes = exhaustive_traverser([data_drop], **traverser_rules)
+        expected_nodes = set(every_node)
+        self.assertEqual(obtained_nodes, expected_nodes)
+        obtained_nodes = exhaustive_traverser([data_take], **traverser_rules)
+        expected_nodes = set([work_select, data_take])
+        self.assertEqual(obtained_nodes, expected_nodes)
+        obtained_nodes = exhaustive_traverser([work_select], **traverser_rules)
+        self.assertEqual(obtained_nodes, expected_nodes)
+        traverser_rules['input_work_forward'] = False
+        traverser_rules['return_forward'] = False
+
+        traverser_rules['input_work_backward'] = True
+        traverser_rules['return_backward'] = True
+        expected_nodes = set([data_drop])
+        obtained_nodes = exhaustive_traverser([data_drop], **traverser_rules)
+        self.assertEqual(obtained_nodes, expected_nodes)
+        expected_nodes = set(every_node)
+        obtained_nodes = exhaustive_traverser([data_take], **traverser_rules)
+        self.assertEqual(obtained_nodes, expected_nodes)
+        obtained_nodes = exhaustive_traverser([work_select], **traverser_rules)
+        self.assertEqual(obtained_nodes, expected_nodes)
+        traverser_rules['input_work_backward'] = False
+        traverser_rules['return_backward'] = False

--- a/aiida/backends/tests/tools/graph/test_graph_traversers.py
+++ b/aiida/backends/tests/tools/graph/test_graph_traversers.py
@@ -90,7 +90,7 @@ class TestExhaustiveTraverser(AiidaTestCase):
         # This uses the delete dict because it has the same names as the export dict,
         # which is all this test needs
         traverser_rules = {}
-        for name in GraphTraversalRules.DELETE.value:
+        for name in list(GraphTraversalRules.DELETE.value.keys()):
             traverser_rules[name] = False
 
         data_i, data_o, calc_0, work_1, work_2 = self._create_minimal_graph()
@@ -169,7 +169,7 @@ class TestExhaustiveTraverser(AiidaTestCase):
         # This uses the delete dict because it has the same names as the export dict,
         # which is all this test needs
         traverser_rules = {}
-        for name in GraphTraversalRules.DELETE.value:
+        for name in list(GraphTraversalRules.DELETE.value.keys()):
             traverser_rules[name] = False
 
         data_i, data_o, calc_0, work_1, work_2 = self._create_minimal_graph()
@@ -274,7 +274,7 @@ class TestExhaustiveTraverser(AiidaTestCase):
         # This uses the delete dict because it has the same names as the export dict,
         # which is all this test needs
         traverser_rules = {}
-        for name in GraphTraversalRules.DELETE.value:
+        for name in list(GraphTraversalRules.DELETE.value.keys()):
             traverser_rules[name] = False
 
         data_i, data_o, calc_0, work_1, work_2 = self._create_minimal_graph()
@@ -345,11 +345,10 @@ class TestExhaustiveTraverser(AiidaTestCase):
 
         rules_list = GraphTraversalRules.DELETE.value.copy()
 
-        for rule1 in list(rules_list):
+        for rule1 in list(rules_list.keys()):
             rules_list.pop(rule1)
-            for rule2 in rules_list:
+            for rule2 in list(rules_list.keys()):
                 for node_zero in node_list:
-
                     traverser_rules[rule1] = True
                     traverser_rules[rule2] = True
                     expected_nodes = self._mini_traverser(node_zero, rule1, rule2, connection_links)
@@ -369,7 +368,7 @@ class TestExhaustiveTraverser(AiidaTestCase):
         from aiida import orm
 
         traverser_rules = {}
-        for name in GraphTraversalRules.DELETE.value:
+        for name in list(GraphTraversalRules.DELETE.value.keys()):
             traverser_rules[name] = False
 
         data_take = orm.Data().store()
@@ -431,7 +430,7 @@ class TestExhaustiveTraverser(AiidaTestCase):
         # This uses the delete dict because it has the same names as the export dict,
         # which is all this test needs
         traverser_rules = {}
-        for name in GraphTraversalRules.DELETE.value:
+        for name in list(GraphTraversalRules.DELETE.value.keys()):
             traverser_rules[name] = False
 
         test_node = orm.Data().store()

--- a/aiida/tools/graph/__init__.py
+++ b/aiida/tools/graph/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################

--- a/aiida/tools/graph/age_entities.py
+++ b/aiida/tools/graph/age_entities.py
@@ -9,21 +9,15 @@
 ###########################################################################
 # pylint: disable=unnecessary-pass
 """AGE entities"""
-from __future__ import absolute_import
+
 from abc import ABCMeta, abstractmethod
-
-import six
-from six.moves import map
-from six.moves import zip
-
 from aiida.orm import Node, Group
 from aiida.orm.querybuilder import QueryBuilder
 
 VALID_ENTITY_CLASSES = (Node, Group)
 
 
-@six.add_metaclass(ABCMeta)
-class AbstractSetContainer(set):
+class AbstractSetContainer(set, metaclass=ABCMeta):
     """Abstract Set Container"""
 
     @abstractmethod
@@ -50,7 +44,7 @@ class AbstractSetContainer(set):
         pass
 
     def __init__(self):
-        super(AbstractSetContainer, self).__init__()
+        super().__init__()
         self._set = None
         self._additional_identifiers = ()
 
@@ -155,7 +149,7 @@ class AiidaEntitySet(AbstractSetContainer):
         """
         :param aiida_cls: A valid AiiDA ORM class, i.e. Node, Group, Computer
         """
-        super(AiidaEntitySet, self).__init__()
+        super().__init__()
         if not aiida_cls in VALID_ENTITY_CLASSES:
             raise TypeError('aiida_cls has to be among:{}'.format(VALID_ENTITY_CLASSES))
         # Done with checks, saving to attributes:
@@ -258,7 +252,7 @@ class DirectedEdgeSet(AbstractSetContainer):
         """
         :param aiida_cls: A valid AiiDA ORM class, i.e. Node, Group, Computer
         """
-        super(DirectedEdgeSet, self).__init__()
+        super().__init__()
         for aiida_cls in (aiida_cls_to, aiida_cls_from):
             if not aiida_cls in VALID_ENTITY_CLASSES:
                 raise TypeError('aiida_cls has to be among:{}'.format(VALID_ENTITY_CLASSES))

--- a/aiida/tools/graph/age_entities.py
+++ b/aiida/tools/graph/age_entities.py
@@ -17,7 +17,7 @@ from aiida.orm.querybuilder import QueryBuilder
 VALID_ENTITY_CLASSES = (Node, Group)
 
 
-class AbstractSetContainer(set, metaclass=ABCMeta):
+class AbstractSetContainer(metaclass=ABCMeta):
     """Abstract Set Container"""
 
     @abstractmethod

--- a/aiida/tools/graph/age_entities.py
+++ b/aiida/tools/graph/age_entities.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=unnecessary-pass
+"""AGE entities"""
+from __future__ import absolute_import
+from abc import ABCMeta, abstractmethod
+
+import six
+from six.moves import map
+from six.moves import zip
+
+from aiida.orm import Node, Group
+from aiida.orm.querybuilder import QueryBuilder
+
+VALID_ENTITY_CLASSES = (Node, Group)
+
+
+@six.add_metaclass(ABCMeta)
+class AbstractSetContainer(set):
+    """Abstract Set Container"""
+
+    @abstractmethod
+    def _check_self_and_other(self, other):
+        """
+        Utility function. When called, will check whether self and other instance
+        are compatible. Same aiida classes, same identifiers, length of tuples...
+        """
+        pass
+
+    @abstractmethod
+    def _check_input_for_set(self, input_for_set):
+        """
+        When giving me something to the set, this utility function can be used
+        to do the right thing.
+        """
+        pass
+
+    @abstractmethod
+    def copy(self, with_data=False):
+        """
+        Copy
+        """
+        pass
+
+    def __init__(self):
+        super(AbstractSetContainer, self).__init__()
+        self._set = None
+        self._additional_identifiers = ()
+
+    def __len__(self):
+        return len(self._set)
+
+    def __add__(self, other):
+        """
+        Addition of self and another AiidaEntitySet, given by the union of their sets::
+
+            a = Enitity(...)
+            b = Entity(...)
+            c = a+b # new set that contains everything in a and b
+        """
+        self._check_self_and_other(other)
+        new = self.copy(with_data=False)  # , identifier=self.identifier)
+        new.set_key_set_nocheck(self._set.union(other.get_keys()))
+        return new
+
+    def __iadd__(self, other):
+        """
+        Adding inplace::
+
+            a = Entity(...)
+            b = Entity(...)
+            a += b # now a contains also everything that was in b
+        """
+        self._check_self_and_other(other)
+        self.set_key_set_nocheck(self._set.union(other.get_keys()))
+        return self
+
+    def __sub__(self, other):
+        """
+        Subtraction, defined as the set-difference between two entities
+        """
+        self._check_self_and_other(other)
+        new = self.copy(with_data=False)  #, identifier=self.identifier)
+        new.set_key_set_nocheck(self._set.difference(other.get_keys()))
+        return new
+
+    def __isub__(self, other):
+        """
+        subtracting inplace!
+        """
+        self._check_self_and_other(other)
+        self._set = self._set.difference(other.get_keys())
+        return self
+
+    def __repr__(self):
+        return '{{{}}}'.format(','.join(map(str, self._set)))
+
+    def __eq__(self, other):
+        return self._set == other.get_keys()
+
+    def __ne__(self, other):
+        return not self == other
+
+    def set_entities(self, new_entitites):
+        """
+        Replacing my set with the new entities, given by their identifier.
+        """
+        self._set = set(map(self._check_input_for_set, new_entitites))
+
+    def add_entities(self, new_entitites):
+        """
+        Add new entitities to the existing set of self
+        :param new_entities: An iterable of new entities to add.
+        """
+        self._set = self._set.union(list(map(self._check_input_for_set, new_entitites)))
+
+    def get_keys(self):
+        return self._set
+
+    def get_additional_identifiers(self):
+        return self._additional_identifiers
+
+    def set_key_set_nocheck(self, _set):
+        """
+        Use with care! If you know that the new set is valid, call this function.
+        Has the advantage of not checking every entry.
+        """
+        self._set = _set
+
+    def empty(self):
+        """
+        Nulls the set
+        """
+        self._set = set()
+
+
+class AiidaEntitySet(AbstractSetContainer):
+    """
+    Instances of this class reference a subset of entities in a databases
+    via a unique identifier.
+    There are also a few operators defined, for simplicity,
+    to do set-additions (unions) and deletions.
+    The underlying Python-class is **set**, which means that adding an instance
+    again to an AiidaEntitySet will not create a duplicate.
+    """
+
+    def __init__(self, aiida_cls):
+        """
+        :param aiida_cls: A valid AiiDA ORM class, i.e. Node, Group, Computer
+        """
+        super(AiidaEntitySet, self).__init__()
+        if not aiida_cls in VALID_ENTITY_CLASSES:
+            raise TypeError('aiida_cls has to be among:{}'.format(VALID_ENTITY_CLASSES))
+        # Done with checks, saving to attributes:
+        self._aiida_cls = aiida_cls
+        # The _set is the set where keys are set:
+        self._set = set()
+        # The identifier for the key, when I get instance classes it has a type
+        # that I check as well
+        self._identifier = 'id'
+        self._identifier_type = int
+        # For the future: Customize both _identifier and _identifier_type.
+        # (uuid or name (for groups) could also work)
+
+    def _check_self_and_other(self, other):
+        """
+        Utility function. When called, will check whether self and other instance
+        are compatible. Same aiida classes, same identifiers, etc...
+        """
+        if not isinstance(other, AiidaEntitySet):
+            raise TypeError('Other class is not an instance of AiidaEntitySet')
+        if self.aiida_cls != other.aiida_cls:
+            raise TypeError('The two instances do not have the same aiida type!')
+        if self.identifier != other.identifier:
+            raise ValueError('The two instances do not have the same identifier!')
+        if self._identifier_type != other.identifier_type:
+            raise TypeError('The two instances do not have the same identifier type!')
+        return True
+
+    @property
+    def identifier(self):
+        return self._identifier
+
+    @property
+    def identifier_type(self):
+        return self._identifier_type
+
+    @property
+    def aiida_cls(self):
+        return self._aiida_cls
+
+    def _check_input_for_set(self, input_for_set):
+        """
+        When giving me something to the set, this utility function can be used
+        to do the right thing.
+        """
+        if isinstance(input_for_set, self._aiida_cls):
+            return getattr(input_for_set, self._identifier)
+
+        if isinstance(input_for_set, self._identifier_type):
+            return input_for_set
+
+        raise ValueError(
+            '{} is not a valid input\n'
+            'You can either pass an AiiDA instance or a key to an instance that'
+            'matches the identifier you defined ({})'.format(input_for_set, self._identifier_type)
+        )
+
+    def copy(self, with_data=True):
+        """
+        Create a new instance, with the attributes defining being the same.
+        :param bool with_data: Whether to copy also the data.
+        """
+        new = AiidaEntitySet(aiida_cls=self.aiida_cls)  #
+        #  , identifier=self.identifier, identifier_type=self._identifier_type)
+        if with_data:
+            new.set_key_set_nocheck(self._set.copy())
+        return new
+
+    def get_entities(self):
+        """
+        Return the AiiDA entities
+        """
+        for entity, in QueryBuilder().append(
+            self._aiida_cls, project='*', filters={
+                self._identifier: {
+                    'in': self._set
+                }
+            }
+        ).iterall():
+            yield entity
+
+
+class DirectedEdgeSet(AbstractSetContainer):
+    """
+    Instances of this class reference a subset of edges in a databases
+    via the unique identifiers.
+    The underlying Python-class is **set**, which means that adding an instance
+    again to an AiidaEntitySet will not create a duplicate.
+    """
+
+    @property
+    def aiida_cls_to(self):
+        return self._aiida_cls_to
+
+    @property
+    def aiida_cls_from(self):
+        return self._aiida_cls_from
+
+    def __init__(self, aiida_cls_to, aiida_cls_from, additional_identifiers=None):
+        """
+        :param aiida_cls: A valid AiiDA ORM class, i.e. Node, Group, Computer
+        """
+        super(DirectedEdgeSet, self).__init__()
+        for aiida_cls in (aiida_cls_to, aiida_cls_from):
+            if not aiida_cls in VALID_ENTITY_CLASSES:
+                raise TypeError('aiida_cls has to be among:{}'.format(VALID_ENTITY_CLASSES))
+        # Done with checks, saving to attributes:
+        self._aiida_cls_to = aiida_cls_to
+        self._aiida_cls_from = aiida_cls_from
+        # The _set is the set where keys are set:
+        self._set = set()
+
+        # the additional identifiers for the key
+        if additional_identifiers is None:
+            self._additional_identifiers = tuple()
+        elif not isinstance(additional_identifiers, (tuple, list)):
+            raise TypeError('Identifiers need to be a list or tuple')
+        else:
+            self._additional_identifiers = tuple(additional_identifiers)
+
+        # The following attribute defines the edge specification that are enforced and stored,
+        # In addition to the primary keys that are stored anyway.
+        # I.e. for node to node this could be (type, label).
+        self._len_additional_identifiers = len(self._additional_identifiers)
+        self._len_all_identifiers = 2 + self._len_additional_identifiers
+
+    def _check_self_and_other(self, other):
+        """
+        Utility function. When called, will check whether self and other instance
+        are compatible. Same aiida classes, same identifiers, etc...
+        """
+        if not isinstance(other, DirectedEdgeSet):
+            raise TypeError('Other class is not an instance of AiidaEntitySet')
+        if self.aiida_cls_to != other.aiida_cls_to:
+            raise TypeError('The two instances do not have the same aiida type!')
+        if self.aiida_cls_from != other.aiida_cls_from:
+            raise TypeError('The two instances do not have the same aiida type!')
+        if self._additional_identifiers != other.get_additional_identifiers():
+            raise ValueError('The two instances do not have the same identifiers!')
+        return True
+
+    def _check_input_for_set(self, input_for_set):
+        """
+        When giving me something to the set, this utility function can be used
+        to do the right thing.
+        """
+        if isinstance(input_for_set, tuple):
+            if len(input_for_set) != self._len_all_identifiers:
+                raise ValueError(
+                    'The tuple you passed has not the right length {} != {}'.format(
+                        len(tuple), self._len_all_identifiers
+                    )
+                )
+            return input_for_set
+
+        raise TypeError('{} is not a valid input\n' 'It has to be a tuple'.format(input_for_set))
+
+    def copy(self, with_data=True):
+        """
+        Create a new instance, with the attributes defining being the same.
+        :param bool with_data: Whether to copy also the data.
+        """
+        new = DirectedEdgeSet(
+            aiida_cls_to=self.aiida_cls_to,
+            aiida_cls_from=self.aiida_cls_from,
+            additional_identifiers=self._additional_identifiers
+        )  #
+        #  , identifier=self.identifier, identifier_type=self._identifier_type)
+        if with_data:
+            new.set_key_set_nocheck(self._set.copy())
+        return new
+
+
+class Basket():
+    """
+    Basket are a container for several AiidaEntitySet.
+    In the current implementation, they contain a Node "set" and a Group "set".
+    :TODO: Computers and Users!
+    """
+
+    def __init__(self, nodes=None, groups=None, nodes_nodes=None):
+        """
+        :param nodes: An AiidaEntitySet of Node
+        :param groups: An AiidaEntitySet of Group
+        """
+
+        def get_check_set_entity_set(var, keyword, cls):
+            if var is None:
+                return AiidaEntitySet(cls)
+
+            if isinstance(var, AiidaEntitySet):
+                if var.aiida_cls is cls:
+                    return var
+                raise TypeError('{}  has to  have {} as aiida_cls'.format(keyword, cls))
+
+            else:
+                raise TypeError('{} has to be an instance of AiidaEntitySet'.format(keyword))
+
+        def get_check_set_directed_edge_set(var, keyword, cls_from, cls_to, additional_identifiers):
+            if var is None:
+                return DirectedEdgeSet(
+                    aiida_cls_to=cls_to, aiida_cls_from=cls_from, additional_identifiers=additional_identifiers
+                )
+            if isinstance(var, DirectedEdgeSet):
+                if var.aiida_cls_from is not cls_from:
+                    raise TypeError('{} has to  have {} as aiida_cls_from'.format(keyword, cls_from))
+                elif var.aiida_cls_to is not cls_to:
+                    raise TypeError('{} has to  have {} as aiida_cls_to'.format(keyword, cls_to))
+                else:
+                    return var
+            else:
+                raise TypeError('{} has to be an instance of DirectedEdgeSet'.format(keyword))
+
+        nodes = get_check_set_entity_set(nodes, 'nodes', Node)
+        groups = get_check_set_entity_set(groups, 'groups', Group)
+        nodes_nodes = get_check_set_directed_edge_set(
+            nodes_nodes, 'nodes-nodes', Node, Node, additional_identifiers=('label', 'type')
+        )
+
+        # ~ if nodes is None:
+        # ~ nodes = AiidaEntitySet(Node) #, identifier='id', identifier_type=int)
+        # ~ elif isinstance(nodes, AiidaEntitySet):
+        # ~ pass
+        # ~ else:
+
+        # ~ if groups is None:
+        # ~ groups = AiidaEntitySet(Group) #, identifier='id', identifier_type=int)
+        # ~ elif isinstance(groups, AiidaEntitySet):
+        # ~ pass
+        # ~ else:
+        # ~ raise TypeError("groups has to be an instance of AiidaEntitySet")
+        # the Edges:
+        # ~ nodes_nodes = AiidaEdgeSet(Node, Node, additional_identifiers=('type', 'label'))
+        # ~ nodes_groups = AiidaEdgeSet(Node, Group, additional_identifiers=())
+        self._dict = dict(
+            nodes=nodes,
+            groups=groups,
+            nodes_nodes=nodes_nodes,  #nodes_groups=nodes_groups
+        )
+
+    @property
+    def sets(self):
+        return list(zip(*sorted(self.dict.items())))[1]
+
+    @property
+    def dict(self):
+        return self._dict
+
+    @property
+    def nodes(self):
+        return self._dict['nodes']
+
+    @property
+    def groups(self):
+        return self._dict['groups']
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __setitem__(self, key, val):
+        self._dict[key] = val
+
+    def __add__(self, other):
+        new_dict = {}
+        for key in self._dict:
+            new_dict[key] = self._dict[key] + other.dict[key]
+        return Basket(**new_dict)
+
+    def __iadd__(self, other):
+        for key in self._dict:
+            self[key] += other[key]
+        return self
+
+    def __sub__(self, other):
+        new_dict = {}
+        for key in self._dict:
+            new_dict[key] = self[key] - other[key]
+        return Basket(**new_dict)
+
+    def __isub__(self, other):
+        for key in other.dict:
+            self[key] -= other[key]
+        return self
+
+    def __len__(self):
+        return sum([len(s) for s in self.sets])
+
+    def __eq__(self, other):
+        for key in self._dict:
+            if self[key] != other[key]:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):
+        ret_str = ''
+        for key, val in self._dict.items():
+            ret_str += '  ' + key + ': '
+            ret_str += str(val) + '\n'
+        return ret_str
+
+    def empty(self):
+        """
+        Empty every subset from its content
+        """
+        for set_ in self._dict.values():
+            set_.empty()
+
+    def copy(self, with_data=True):
+        new_dict = dict()
+        for key, val in self._dict.items():
+            new_dict[key] = val.copy(with_data=with_data)
+        return Basket(**new_dict)
+
+
+def get_basket(node_ids=None, group_ids=None):
+    """
+    Utility function to get an instance of Basket.
+    :param node_ids: An iterable of node-ids (pks) that are wanted
+    :param group_ids: An iterable group-ids (pks) that are wanted in the set
+
+    Examples::
+        # Will return the collection
+        aiida_entitiy_sets = get_entit_sets(node_ids=(1,2), group_ids=8)
+    """
+
+    node_set = AiidaEntitySet(Node)  #, identifier='id', identifier_type=int)
+    if node_ids:
+        node_set.set_entities(node_ids)
+    group_set = AiidaEntitySet(Group)  #, identifier='id', identifier_type=int)
+    if group_ids:
+        group_set.set_entities(group_ids)
+
+    return Basket(nodes=node_set, groups=group_set)

--- a/aiida/tools/graph/age_entities.py
+++ b/aiida/tools/graph/age_entities.py
@@ -37,9 +37,16 @@ class AbstractSetContainer(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def copy(self, with_data=False):
+    def copy(self):
         """
-        Copy
+        Copy with data
+        """
+        pass
+
+    @abstractmethod
+    def get_template(self):
+        """
+        Get an empty copy with same parameters
         """
         pass
 
@@ -60,7 +67,7 @@ class AbstractSetContainer(metaclass=ABCMeta):
             c = a+b # new set that contains everything in a and b
         """
         self._check_self_and_other(other)
-        new = self.copy(with_data=False)  # , identifier=self.identifier)
+        new = self.get_template() # , identifier=self.identifier)
         new.set_key_set_nocheck(self._set.union(other.get_keys()))
         return new
 
@@ -81,7 +88,7 @@ class AbstractSetContainer(metaclass=ABCMeta):
         Subtraction, defined as the set-difference between two entities
         """
         self._check_self_and_other(other)
-        new = self.copy(with_data=False)  #, identifier=self.identifier)
+        new = self.get_template()  #, identifier=self.identifier)
         new.set_key_set_nocheck(self._set.difference(other.get_keys()))
         return new
 
@@ -207,15 +214,19 @@ class AiidaEntitySet(AbstractSetContainer):
             'matches the identifier you defined ({})'.format(input_for_set, self._identifier_type)
         )
 
-    def copy(self, with_data=True):
+    def get_template(self):
         """
-        Create a new instance, with the attributes defining being the same.
-        :param bool with_data: Whether to copy also the data.
+        Create a new instance with identical parameters (aiida_cls, identity, identity_type, etc.)
         """
-        new = AiidaEntitySet(aiida_cls=self.aiida_cls)  #
-        #  , identifier=self.identifier, identifier_type=self._identifier_type)
-        if with_data:
-            new.set_key_set_nocheck(self._set.copy())
+        new = AiidaEntitySet(aiida_cls=self.aiida_cls)
+        return new
+
+    def copy(self):
+        """
+        Create a new instance, copying all data
+        """
+        new = self.get_template()
+        new.set_key_set_nocheck(self._set.copy())
         return new
 
     def get_entities(self):
@@ -307,19 +318,24 @@ class DirectedEdgeSet(AbstractSetContainer):
 
         raise TypeError('{} is not a valid input\n' 'It has to be a tuple'.format(input_for_set))
 
-    def copy(self, with_data=True):
+    def get_template(self):
         """
-        Create a new instance, with the attributes defining being the same.
-        :param bool with_data: Whether to copy also the data.
+        Create a new instance with identical parameters (aiida_cls_to, etc.)
         """
         new = DirectedEdgeSet(
             aiida_cls_to=self.aiida_cls_to,
             aiida_cls_from=self.aiida_cls_from,
             additional_identifiers=self._additional_identifiers
-        )  #
-        #  , identifier=self.identifier, identifier_type=self._identifier_type)
-        if with_data:
-            new.set_key_set_nocheck(self._set.copy())
+        ) #  , identifier_to=self.identifier_to, identifier_type_to=self._identifier_type_to
+          #  , identifier_from=self.identifier_from, identifier_type_from=self._identifier_type_from)
+        return new
+
+    def copy(self):
+        """
+        Create a new instance, copying all data
+        """
+        new = self.get_template()
+        new.set_key_set_nocheck(self._set.copy())
         return new
 
 
@@ -460,10 +476,16 @@ class Basket():
         for set_ in self._dict.values():
             set_.empty()
 
-    def copy(self, with_data=True):
+    def get_template(self):
         new_dict = dict()
         for key, val in self._dict.items():
-            new_dict[key] = val.copy(with_data=with_data)
+            new_dict[key] = val.get_template()
+        return Basket(**new_dict)
+
+    def copy(self):
+        new_dict = dict()
+        for key, val in self._dict.items():
+            new_dict[key] = val.copy()
         return Basket(**new_dict)
 
 

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -60,7 +60,7 @@ class Operation(metaclass=ABCMeta):
         return self._iterations_done
 
     # ~ def get_walkers(self):
-    # ~ return self._walkers  #.copy(with_data=True)
+    # ~ return self._walkers  #.copy()
 
     # ~ def set_visits(self, entity_set):
     # ~ check_if_basket(entity_set)
@@ -188,12 +188,12 @@ class UpdateRule(Operation):
             self._accumulator_set += operational_set
             # TO-DO: check basket compatibility here, it might crash later!
         else:
-            self._accumulator_set = operational_set.copy(with_data=True)
+            self._accumulator_set = operational_set.copy()
 
         self._init_run(operational_set)
         # The new_results is where I can put the results of the query
         # It starts empty.
-        new_results = operational_set.copy(with_data=False)
+        new_results = operational_set.get_template()
         self._iterations_done = 0
         while (operational_set and self._iterations_done < self._maxiter):
             self._iterations_done += 1
@@ -270,16 +270,16 @@ class RuleSequence(Operation):
             self._accumulator_set += operational_set
             # TO-DO: check basket compatibility here, it might crash later!
         else:
-            self._accumulator_set = operational_set.copy(with_data=True)
+            self._accumulator_set = operational_set.copy()
         if self._visits_set is not None:
             check_if_basket(self._visits_set)
             self._visits_set.empty()
             self._visits_set += operational_set
             # TO-DO: check basket compatibility here, it might crash later!
         else:
-            self._visits_set = operational_set.copy(with_data=True)
+            self._visits_set = operational_set.copy()
 
-        new_results = operational_set.copy(with_data=False)
+        new_results = operational_set.get_template
         self._iterations_done = 0
         while (operational_set and self._iterations_done < self._maxiter):
             self._iterations_done += 1

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -9,12 +9,8 @@
 ###########################################################################
 """AGE rules"""
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-import six
 import numpy as np
 
 from aiida.common.exceptions import InputValidationError
@@ -32,8 +28,7 @@ def check_if_basket(entity_set):
         raise TypeError('You need to set the walkers with an AiidaEntitySet')
 
 
-@six.add_metaclass(ABCMeta)
-class Operation(object):
+class Operation(metaclass=ABCMeta):
     """Operation metaclass"""
 
     def __init__(self, mode, max_iterations, track_edges, track_visits):
@@ -171,7 +166,7 @@ class UpdateRule(Operation):
 
         self._entity_from = get_spec_from_path(queryhelp, 0)
         self._entity_to = get_spec_from_path(queryhelp, -1)
-        super(UpdateRule, self).__init__(mode, max_iterations, track_edges=track_edges, track_visits=track_visits)
+        super().__init__(mode, max_iterations, track_edges=track_edges, track_visits=track_visits)
 
     def _init_run(self, entity_set):
         # pylint: disable=protected-access
@@ -231,7 +226,7 @@ class RuleSaveWalkers(Operation):
 
     def __init__(self, stash):
         self._stash = stash
-        super(RuleSaveWalkers, self).__init__(mode=MODES.REPLACE, max_iterations=1, track_edges=True, track_visits=True)
+        super().__init__(mode=MODES.REPLACE, max_iterations=1, track_edges=True, track_visits=True)
 
     def _load_results(self, target_set, operational_set):
         self._stash += self._walkers
@@ -242,7 +237,7 @@ class RuleSetWalkers(Operation):
 
     def __init__(self, stash):
         self._stash = stash
-        super(RuleSetWalkers, self).__init__(mode=MODES.REPLACE, max_iterations=1, track_edges=True, track_visits=True)
+        super().__init__(mode=MODES.REPLACE, max_iterations=1, track_edges=True, track_visits=True)
 
     def _load_results(self, target_set, operational_set):
         self._walkers.empty()
@@ -258,7 +253,7 @@ class RuleSequence(Operation):
                 print(rule)
                 raise TypeError('rule has to be an instance of Operation-subclass')
         self._rules = rules
-        super(RuleSequence, self).__init__(mode, max_iterations, track_edges=track_edges, track_visits=track_visits)
+        super().__init__(mode, max_iterations, track_edges=track_edges, track_visits=track_visits)
 
     def _load_results(self, target_set, operational_set):  #ex: active_walkers as last arg
         target_set.empty()

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""AGE rules"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from abc import ABCMeta, abstractmethod
+from enum import Enum
+import six
+import numpy as np
+
+from aiida.common.exceptions import InputValidationError
+from aiida.orm.querybuilder import QueryBuilder
+from aiida.tools.graph.age_entities import Basket
+
+
+class MODES(Enum):
+    APPEND = 1
+    REPLACE = 2
+
+
+def check_if_basket(entity_set):
+    if not isinstance(entity_set, Basket):
+        raise TypeError('You need to set the walkers with an AiidaEntitySet')
+
+
+@six.add_metaclass(ABCMeta)
+class Operation(object):
+    """Operation metaclass"""
+
+    def __init__(self, mode, max_iterations, track_edges, track_visits):
+        assert mode in MODES, 'You have to pass an option of {}'.format(MODES)
+        self._mode = mode
+        self.set_max_iterations(max_iterations)
+        self._track_edges = track_edges  # Logical
+        self._track_visits = track_visits  # Logical
+        self._walkers = None
+        self._visits = None
+        self._iterations_done = None
+
+    def _init_run(self, entity_set):
+        pass
+
+    def set_max_iterations(self, max_iterations):
+        """Set max iterations"""
+        if max_iterations is np.inf:
+            pass
+        elif not isinstance(max_iterations, int):
+            raise TypeError('max iterations has to be an integer')
+        self._maxiter = max_iterations
+
+    def set_walkers(self, walkers):
+        check_if_basket(walkers)
+        self._walkers = walkers
+
+    def get_iterations_done(self):
+        return self._iterations_done
+
+    def get_walkers(self):
+        return self._walkers  #.copy(with_data=True)
+
+    def set_visits(self, entity_set):
+        check_if_basket(entity_set)
+        self._visits = entity_set
+
+    def get_visits(self):
+        return self._visits
+
+    @abstractmethod
+    def _load_results(self, target_set, operational_set):
+        pass
+
+    def run(self, walkers=None, visits=None, iterations=None):
+        """run method"""
+
+        if walkers is not None:
+            self.set_walkers(walkers)
+        else:
+            if self._walkers is None:
+                raise RuntimeError('Walkers have not been set for this instance')
+
+        if visits is not None:
+            self.set_visits(visits)
+
+        if self._track_visits and self._visits is None:
+            #raise RuntimeError("Supposed to track visits, but visits have not been "
+            #        "set for this instance")
+            # If nothing is set, I do it here!
+            self.set_visits(self._walkers.copy())
+
+        if iterations is not None:
+            self.set_max_iterations(iterations)
+
+        self._init_run(self._walkers)
+        # The active walkers are all workers where this rule-instance have
+        # not been applied, yet
+        active_walkers = self._walkers.copy()
+        # The new_set is where I can put the results of the query
+        # It starts empty.
+        new_results = self._walkers.copy(with_data=False)
+        # I also need somewhere to store everything I've walked to
+        # with_data is set to True, since the active walkers are of course being visited
+        # even before we start the iterations!
+        visited_this_rule = self._walkers.copy(with_data=True)  # w
+        iterations = 0
+        while (active_walkers and iterations < self._maxiter):
+            iterations += 1
+            # loading results into new_results set:
+            self._load_results(new_results, active_walkers)
+            # It depends on the mode, how I update the walkers
+            # I set the active walkers to all results that have not been visited yet.
+            active_walkers = new_results - visited_this_rule
+            # The visited is augmented:
+            visited_this_rule += active_walkers
+
+        self._iterations_done = iterations
+        if self._mode == MODES.APPEND:
+            self._walkers += visited_this_rule
+        elif self._mode == MODES.REPLACE:
+            self._walkers = active_walkers
+
+        if self._track_visits:
+            self._visits += visited_this_rule
+        return self._walkers
+
+
+class UpdateRule(Operation):
+    """Update Rule"""
+
+    def __init__(self, querybuilder, mode=MODES.APPEND, max_iterations=1, track_edges=False, track_visits=True):
+
+        def get_spec_from_path(queryhelp, idx):
+            if (
+                queryhelp['path'][idx]['entity_type'].startswith('node') or
+                queryhelp['path'][idx]['entity_type'].startswith('data') or
+                queryhelp['path'][idx]['entity_type'].startswith('process') or
+                queryhelp['path'][idx]['entity_type'] == ''
+            ):
+                result = 'nodes'
+            elif queryhelp['path'][idx]['entity_type'] == 'group':
+                result = 'groups'
+            else:
+                raise Exception('not understood entity from ( {} )'.format(queryhelp['path'][idx]['entity_type']))
+            return result
+
+        queryhelp = querybuilder.queryhelp
+        #print('\n\nDICT:')
+        #import pprint
+        #pprint.pprint(queryhelp)
+        #print('---\n')
+        for pathspec in queryhelp['path']:
+            if not pathspec['entity_type']:
+                pathspec['entity_type'] = 'node.Node.'
+        self._querybuilder = QueryBuilder(**queryhelp)
+        queryhelp = self._querybuilder.queryhelp
+        self._first_tag = queryhelp['path'][0]['tag']
+        self._last_tag = queryhelp['path'][-1]['tag']
+
+        # All of these are set in _init_run:
+        self._edge_label = None
+        self._edge_keys = None
+        self._entity_to_identifier = None
+
+        self._entity_from = get_spec_from_path(queryhelp, 0)
+        self._entity_to = get_spec_from_path(queryhelp, -1)
+        super(UpdateRule, self).__init__(mode, max_iterations, track_edges=track_edges, track_visits=track_visits)
+
+    def _init_run(self, entity_set):
+        # pylint: disable=protected-access
+
+        # Removing all other projections in the QueryBuilder instance:
+        for tag in self._querybuilder._projections:
+            self._querybuilder._projections[tag] = []
+
+        # priming querybuilder to add projection on the key I need:
+        self._querybuilder.add_projection(self._last_tag, entity_set[self._entity_to].identifier)
+        self._entity_to_identifier = entity_set[self._entity_to].identifier
+        if self._track_edges:
+            self._querybuilder.add_projection(self._first_tag, entity_set[self._entity_to].identifier)
+            edge_set = entity_set.dict['{}_{}'.format(self._entity_from, self._entity_to)]
+            self._edge_label = '{}--{}'.format(self._first_tag, self._last_tag)
+            self._edge_keys = tuple([(self._first_tag, entity_set[self._entity_from].identifier),
+                                     (self._last_tag, entity_set[self._entity_to].identifier)] +
+                                    [(self._edge_label, identifier)
+                                     for identifier in edge_set.get_additional_identifiers()])
+            try:
+                self._querybuilder.add_projection(self._edge_label, edge_set.get_additional_identifiers())
+            except InputValidationError:
+                raise KeyError(
+                    'The key for the edge is invalid.\n'
+                    'Are the entities really connected, or have you overwritten the edge-tag?'
+                )
+
+    def _load_results(self, target_set, operational_set):
+        """
+        :param target_set: The set to load the results into
+        :param operational_set: Where the results originate from (walkers)
+        """
+        # I check that I have primary keys
+        primkeys = operational_set[self._entity_from].get_keys()
+        # Empty the target set, so that only these results are inside
+        target_set.empty()
+        if primkeys:
+            self._querybuilder.add_filter(
+                self._first_tag, {operational_set[self._entity_from].identifier: {
+                                      'in': primkeys
+                                  }}
+            )
+            qres = self._querybuilder.dict()
+            # These are the new results returned by the query
+            target_set[self._entity_to].add_entities([
+                item[self._last_tag][self._entity_to_identifier] for item in qres
+            ])
+            if self._track_edges:
+                target_set['{}_{}'.format(self._entity_to, self._entity_to)].add_entities([
+                    tuple(item[key1][key2] for (key1, key2) in self._edge_keys) for item in qres
+                ])
+        # Everything is changed in place, no need to return anything
+
+
+class RuleSaveWalkers(Operation):
+    """Rule Save Walkers"""
+
+    def __init__(self, stash):
+        self._stash = stash
+        super(RuleSaveWalkers, self).__init__(mode=MODES.REPLACE, max_iterations=1, track_edges=True, track_visits=True)
+
+    def _load_results(self, target_set, operational_set):
+        self._stash += self._walkers
+
+
+class RuleSetWalkers(Operation):
+    """Rule Set Walkers"""
+
+    def __init__(self, stash):
+        self._stash = stash
+        super(RuleSetWalkers, self).__init__(mode=MODES.REPLACE, max_iterations=1, track_edges=True, track_visits=True)
+
+    def _load_results(self, target_set, operational_set):
+        self._walkers.empty()
+        self._walkers += self._stash
+
+
+class RuleSequence(Operation):
+    """Rule Sequence"""
+
+    def __init__(self, rules, mode=MODES.APPEND, max_iterations=1, track_edges=False, track_visits=True):
+        for rule in rules:
+            if not isinstance(rule, Operation):
+                print(rule)
+                raise TypeError('rule has to be an instance of Operation-subclass')
+        self._rules = rules
+        super(RuleSequence, self).__init__(mode, max_iterations, track_edges=track_edges, track_visits=track_visits)
+
+    def _load_results(self, target_set, operational_set):  #ex: active_walkers as last arg
+        target_set.empty()
+        for _, rule in enumerate(self._rules):
+            # I iterate the operational_set through all the rules:
+            #rule.set_walkers(active_walkers)
+            rule.set_visits(self._visits)
+            rule.set_walkers(self._walkers)
+            target_set += rule.run()

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -41,9 +41,9 @@ def exhaustive_traverser(starting_pks, **kwargs):
         if name not in kwargs:
             raise exceptions.ValidationError('traversal rule {} was not provided'.format(name))
 
-        follow = kwargs.pop(name, rule.default)
+        follow = kwargs.pop(name)
         if not isinstance(follow, bool):
-            raise ValueError('the value of rule {} must be boolean, but it is {}'.format(name, follow))
+            raise ValueError('the value of rule {} must be boolean, but it is: {}'.format(name, follow))
 
         if follow:
             if rule.direction == 'forward':
@@ -56,7 +56,7 @@ def exhaustive_traverser(starting_pks, **kwargs):
                 )
 
     if kwargs:
-        raise exceptions.ValidationError('unrecognized keywords:'.format(**kwargs))
+        raise exceptions.ValidationError('unrecognized keywords: {}'.format(', '.join(kwargs.keys())))
 
     links_backwards = {'type': {'in': follow_backwards}}
     links_forwards = {'type': {'in': follow_forwards}}

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Module for functions to traverse AiiDA graphs."""
+
+from __future__ import absolute_import
+
+
+def exhaustive_traverser(starting_pks, **kwargs):
+    """
+    This function will return the set of all nodes that can be connected
+    to a list of initial nodes through any sequence of specified authorized
+    links and directions.
+
+    :param starting_pks:
+        A list with the (valid) pks of all starting nodes.
+    :param traverse_links:
+        A dictionary asigning a boolean value to each of the graph traversal
+        rules.
+    """
+    from aiida.orm import Node
+    from aiida.orm.querybuilder import QueryBuilder
+    from aiida.common import exceptions
+    from aiida.common.links import GraphTraversalRules
+
+    follow_backwards = []
+    follow_forwards = []
+
+    # Create the dictionary with graph traversal rules to be applied
+    # (This uses the delete dict because it has the same names and directions
+    #  as the export dict, which is all this function needs)
+    for name, rule in GraphTraversalRules.DELETE.value.items():
+
+        # Check that all rules are explicitly provided
+        if name not in kwargs:
+            raise exceptions.ValidationError('traversal rule {} was not provided'.format(name))
+
+        follow = kwargs.pop(name, rule.default)
+        if not isinstance(follow, bool):
+            raise ValueError('the value of rule {} must be boolean, but it is {}'.format(name, follow))
+
+        if follow:
+            if rule.direction == 'forward':
+                follow_forwards.append(rule.link_type.value)
+            elif rule.direction == 'backward':
+                follow_backwards.append(rule.link_type.value)
+            else:
+                raise exceptions.InternalError(
+                    'unrecognized direction `{}` for graph traversal rule'.format(rule.direction)
+                )
+
+    if kwargs:
+        raise exceptions.ValidationError('unrecognized keywords:'.format(**kwargs))
+
+    links_backwards = {'type': {'in': follow_backwards}}
+    links_forwards = {'type': {'in': follow_forwards}}
+
+    operational_set = set(starting_pks)
+    query_nodes = QueryBuilder()
+    query_nodes.append(Node, project=['id'], filters={'id': {'in': operational_set}})
+    existing_pks = {pk[0] for pk in query_nodes.all()}
+    missing_pks = operational_set.difference(existing_pks)
+    if missing_pks:
+        raise exceptions.NotExistent(
+            'The following pks are not in the database and must be pruned before this call: {}'.format(missing_pks)
+        )
+
+    accumulator_set = operational_set.copy()
+    while operational_set:
+        new_pks_set = set()
+
+        if follow_forwards:
+            query_nodes = QueryBuilder()
+            query_nodes.append(Node, filters={'id': {'in': operational_set}}, tag='sources')
+            query_nodes.append(Node, edge_filters=links_forwards, with_incoming='sources', project='id')
+            new_pks_set = new_pks_set.union(set(pk for pk, in query_nodes.iterall()))
+
+        if follow_backwards:
+            query_nodes = QueryBuilder()
+            query_nodes.append(Node, filters={'id': {'in': operational_set}}, tag='sources')
+            query_nodes.append(Node, edge_filters=links_backwards, with_outgoing='sources', project='id')
+            new_pks_set = new_pks_set.union(set(pk for pk, in query_nodes.iterall()))
+
+        operational_set = new_pks_set.difference(accumulator_set)
+        accumulator_set = new_pks_set.union(accumulator_set)
+
+    return accumulator_set

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -78,7 +78,7 @@ def exhaustive_traverser(starting_pks, **kwargs):
     basket = get_basket(node_ids=operational_set)
     rules = []
     if follow_forwards and follow_backwards:
-        stash = basket.copy(with_data=False)
+        stash = basket.get_template()
         rules += [RuleSaveWalkers(stash)]
     if follow_forwards:
         query_outgoing = QueryBuilder()


### PR DESCRIPTION
Various `EntitySet` classes and the `Basket` class have a copy function with the option to copy or not copy data. It seems conceptually more elegant to split this copy function into two functions: one that copies only the template of the class (identifier, identifier type, etc.) with no data called `get_template()` and one that copies the instance with all data called `copy()`.