### PR TITLE
gha: disable faulty repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
         python-version: 3.7
 
     - name: Install system dependencies
+      # remove occasionally problematic repositories we don't use anyway
       run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install texlive-base texlive-generic-recommended texlive-fonts-recommended texlive-latex-base texlive-latex-recommended texlive-latex-extra dvipng dvidvi
 
@@ -67,6 +69,7 @@ jobs:
 
     - name: Install system dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install libkrb5-dev ruby ruby-dev
 
@@ -109,6 +112,7 @@ jobs:
         wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
         echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
         echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install postgresql postgresql-server-dev-all postgresql-client rabbitmq-server graphviz
         sudo systemctl status rabbitmq-server.service


### PR DESCRIPTION
It seems that the virtual environments contain Microsoft repositories
for .NET (and other tools) which can be broken at times:
https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/m-p/41122

Disable them since we don't use packages from there for now.