### PR TITLE
Migrating configuration options to AuthInfo and redesigning the interface

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -26,7 +26,7 @@ verdi -p $AIIDA_TEST_BACKEND daemon incr 4
 
 verdi -p $AIIDA_TEST_BACKEND computer setup --non-interactive --label=localhost --hostname=localhost --transport=local \
     --scheduler=direct --mpiprocs-per-machine=1 --prepend-text="" --append-text=""
-verdi -p $AIIDA_TEST_BACKEND computer configure local localhost --non-interactive --safe-interval=0
+verdi -p $AIIDA_TEST_BACKEND computer configure local localhost --non-interactive --safe-open-interval=0
 
 # Configure the 'add' code inside localhost
 verdi -p $AIIDA_TEST_BACKEND code setup -n -L add \

--- a/.github/config/localhost-config.yaml
+++ b/.github/config/localhost-config.yaml
@@ -1,2 +1,2 @@
 ---
-safe_interval: 0
+safe_open_interval: 0

--- a/aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py
+++ b/aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py
@@ -770,8 +770,8 @@ class TestTextFieldToJSONFieldMigration(TestMigrations):  # pylint: disable=too-
         self.computer = self.DbComputer(**self.computer_kwargs)
         self.computer.save()
 
-        self.auth_info_auth_params = {'safe_interval': 2}
-        self.auth_info_metadata = {'safe_interval': 2}
+        self.auth_info_auth_params = {'safe_open_interval': 2}
+        self.auth_info_metadata = {'safe_open_interval': 2}
         self.auth_info_kwargs = {
             'aiidauser_id': self.default_user.pk,
             'dbcomputer': self.computer,

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -377,7 +377,7 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         comp = self.comp_builder.new()
         comp.store()
 
-        options = ['local', comp.label, '--non-interactive', '--safe-interval', '0']
+        options = ['local', comp.label, '--non-interactive', '--safe-open-interval', '0']
         result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
 
@@ -453,7 +453,7 @@ class TestVerdiComputerConfigure(AiidaTestCase):
 
         with tempfile.NamedTemporaryFile('w') as handle:
             handle.write("""---
-safe_interval: {interval}
+safe_open_interval: {interval}
 """.format(interval=interval))
             handle.flush()
 
@@ -461,7 +461,7 @@ safe_interval: {interval}
             result = self.cli_runner.invoke(computer_configure, options)
 
         self.assertClickResultNoException(result)
-        self.assertEqual(computer.get_configuration()['safe_interval'], interval)
+        self.assertEqual(computer.get_configuration()['safe_open_interval'], interval)
 
     def test_ssh_ni_empty(self):
         """
@@ -477,7 +477,7 @@ safe_interval: {interval}
         comp = self.comp_builder.new()
         comp.store()
 
-        options = ['ssh', comp.label, '--non-interactive', '--safe-interval', '1']
+        options = ['ssh', comp.label, '--non-interactive', '--safe-open-interval', '1']
         result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
 
@@ -500,7 +500,9 @@ safe_interval: {interval}
         comp.store()
 
         username = 'TEST'
-        options = ['ssh', comp.label, '--non-interactive', '--username={}'.format(username), '--safe-interval', '1']
+        options = [
+            'ssh', comp.label, '--non-interactive', '--username={}'.format(username), '--safe-open-interval', '1'
+        ]
         result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
         self.assertEqual(

--- a/aiida/backends/tests/engine/test_manager.py
+++ b/aiida/backends/tests/engine/test_manager.py
@@ -65,7 +65,7 @@ class TestJobsList(AiidaTestCase):
 
     def test_get_minimum_update_interval(self):
         """Test the `JobsList.get_minimum_update_interval` method."""
-        minimum_poll_interval = self.auth_info.computer.get_minimum_job_poll_interval()
+        minimum_poll_interval = self.auth_info.get_minimum_job_poll_interval()
         self.assertEqual(self.jobs_list.get_minimum_update_interval(), minimum_poll_interval)
 
     def test_last_updated(self):

--- a/aiida/backends/tests/engine/test_transport.py
+++ b/aiida/backends/tests/engine/test_transport.py
@@ -108,7 +108,7 @@ class TestTransportQueue(AiidaTestCase):
         finally:
             self.authinfo.get_transport().__class__.open = original
 
-    def test_safe_interval(self):
+    def test_safe_open_interval(self):
         """Verify that the safe interval for a given in transport is respected by the transport queue."""
 
         # Temporarily set the safe open interval for the default transport to a finite value
@@ -131,7 +131,7 @@ class TestTransportQueue(AiidaTestCase):
                     trans = yield request
                     time_current = time.time()
                     time_elapsed = time_current - time_start
-                    time_minimum = trans.get_safe_open_interval() * (iteration + 1)
+                    time_minimum = self.authinfo.get_safe_open_interval() * (iteration + 1)
                     self.assertTrue(time_elapsed > time_minimum, 'transport safe interval was violated')
 
             for i in range(5):

--- a/aiida/backends/tests/orm/test_authinfos.py
+++ b/aiida/backends/tests/orm/test_authinfos.py
@@ -26,7 +26,7 @@ class TestAuthinfo(AiidaTestCase):
 
     def test_set_auth_params(self):
         """Test the auth_params setter."""
-        auth_params = {'safe_interval': 100}
+        auth_params = {'safe_open_interval': 100}
 
         self.auth_info.set_auth_params(auth_params)
         self.assertEqual(self.auth_info.get_auth_params(), auth_params)

--- a/aiida/engine/processes/calcjobs/manager.py
+++ b/aiida/engine/processes/calcjobs/manager.py
@@ -72,7 +72,7 @@ class JobsList:
         :return: the minimum interval
         :rtype: float
         """
-        return self._authinfo.computer.get_minimum_job_poll_interval()
+        return self._authinfo.get_minimum_job_poll_interval()
 
     @property
     def last_updated(self):

--- a/aiida/engine/transports.py
+++ b/aiida/engine/transports.py
@@ -77,7 +77,7 @@ class TransportQueue:
             self._transport_requests[authinfo.id] = transport_request
 
             transport = authinfo.get_transport()
-            safe_open_interval = transport.get_safe_open_interval()
+            safe_open_interval = authinfo.get_safe_open_interval()
 
             def do_open():
                 """ Actually open the transport """

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -133,7 +133,6 @@ class BaseResource(Resource):
         :param page: page no, used for pagination
         :return: http response
         """
-
         ## Decode url parts
         path = unquote(request.path)
         query_string = unquote(request.query_string.decode('utf-8'))

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -14,10 +14,8 @@ from functools import partial
 import click
 
 from aiida.cmdline.params import options, arguments
-from aiida.cmdline.params.options.interactive import InteractiveOption
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.cmdline.utils import echo
-from aiida.common.exceptions import NotExistent
 from aiida.manage.manager import get_manager
 
 TRANSPORT_PARAMS = []
@@ -68,64 +66,20 @@ def transport_option_default(name, computer):
     default = None
     if suggester:
         default = suggester(computer)
-    else:
-        default = transport_cls.auth_options[name].get('default')
     return default
 
 
-def interactive_default(transport_type, key, also_noninteractive=False):
-    """Create a contextual_default value callback for an auth_param key."""
-
-    @with_dbenv()
-    def get_default(ctx):
-        """Determine the default value from the context."""
-        from aiida import orm
-
-        user = ctx.params['user'] or orm.User.objects.get_default()
-        computer = ctx.params['computer']
-        try:
-            authinfo = orm.AuthInfo.objects.get(dbcomputer_id=computer.id, aiidauser_id=user.id)
-        except NotExistent:
-            authinfo = orm.AuthInfo(computer=computer, user=user)
-        non_interactive = ctx.params['non_interactive']
-        old_authparams = authinfo.get_auth_params()
-        if not also_noninteractive and non_interactive:
-            raise click.MissingParameter()
-        suggestion = old_authparams.get(key)
-        suggestion = suggestion or transport_option_default(key, computer)
-        return suggestion
-
-    return get_default
-
-
-def create_option(name, spec):
-    """Create a click option from a name and partial specs as used in transport auth_options."""
-    from copy import deepcopy
-    spec = deepcopy(spec)
-    name_dashed = name.replace('_', '-')
-    option_name = '--{}'.format(name_dashed)
-    existing_option = spec.pop('option', None)
-    if spec.pop('switch', False):
-        option_name = '--{name}/--no-{name}'.format(name=name_dashed)
-    kwargs = {}
-
-    if 'default' in spec:
-        kwargs['show_default'] = True
-    else:
-        kwargs['contextual_default'] = interactive_default(
-            'ssh', name, also_noninteractive=spec.pop('non_interactive_default', False)
-        )
-
-    kwargs['cls'] = InteractiveOption
-    kwargs.update(spec)
-    if existing_option:
-        return existing_option(**kwargs)
-    return click.option(option_name, **kwargs)
-
-
 def list_transport_options(transport_type):
+    """Create and list all click CLI option classes.
+
+    These are created by reading the appropriate tranport auth_options."""
     from aiida.plugins import TransportFactory
-    options_list = [create_option(*item) for item in TransportFactory(transport_type).auth_options.items()]
+    from aiida.cmdline.commands.cmd_computer import create_option, VALID_OPTION_ORIGINS
+
+    options_list = [
+        create_option(key, option, originates_from=VALID_OPTION_ORIGINS.TRANSPORT)
+        for key, option in TransportFactory(transport_type).auth_options.items()
+    ]
     return options_list
 
 
@@ -133,7 +87,7 @@ def transport_options(transport_type):
     """Decorate a command with all options for a computer configure subcommand for transport_type."""
 
     def apply_options(func):
-        """Decorate the command functionn with the appropriate options for the transport type."""
+        """Decorate the command function with the appropriate options for the transport type."""
         options_list = list_transport_options(transport_type)
         options_list.reverse()
         func = arguments.COMPUTER(callback=partial(match_comp_transport, transport_type=transport_type))(func)
@@ -147,7 +101,7 @@ def transport_options(transport_type):
     return apply_options
 
 
-def create_configure_cmd(transport_type):
+def create_configure_cmd_transport_only(transport_type):  # pylint: disable=invalid-name
     """Create verdi computer configure subcommand for a transport type."""
     help_text = """Configure COMPUTER for {} transport.""".format(transport_type)
 

--- a/aiida/transports/common.py
+++ b/aiida/transports/common.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Module defining the properties of additional metadata to be stored in the authinfo."""
+
+
+def validate_positive_number(ctx, param, value):  # pylint: disable=unused-argument
+    """Validate that the number passed to this parameter is a positive number.
+
+    :param ctx: the `click.Context`
+    :param param: the parameter
+    :param value: the value passed for the parameter
+    :raises `click.BadParameter`: if the value is not a positive number
+    """
+    if not isinstance(value, (int, float)) or value < 0:
+        from click import BadParameter
+        raise BadParameter('{} is not a valid positive number'.format(value))
+
+
+PROPERTY_SCHEDULER_POLL_INTERVAL = 'scheduler_poll_interval'  # pylint: disable=invalid-name
+PROPERTY_SAFE_OPEN_INTERVAL = 'safe_open_interval'  # pylint: disable=invalid-name
+
+# These are directly piped to Click
+# These are defined hee so that these can be imported also without importing
+# aiida.orm, needed for Click.
+# Note that if you add a new COMMON_AUTHINFO_OPTION, its default MUST BE defined
+# in the `get_default_for_metadata_field` inside the AuthInfo class
+# (it is there because it can use information from the instance, e.g. to use
+# transport-dependent defaults)
+COMMON_AUTHINFO_OPTIONS = [
+    (
+        PROPERTY_SAFE_OPEN_INTERVAL, {
+            'type': float,
+            'prompt': 'Connection safe interval (s)',
+            'help': 'Minimum time interval in seconds between consecutive connection openings',
+            'callback': validate_positive_number,
+            'non_interactive_default': True
+        }
+    ),
+    (
+        PROPERTY_SCHEDULER_POLL_INTERVAL, {
+            'type': float,
+            'prompt': 'Queue poll interval (s)',
+            'help': 'Minimum time interval in seconds between consecutive pollings of the job scheduler queue status',
+            'callback': validate_positive_number,
+            'non_interactive_default': True
+        }
+    ),
+]

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -866,4 +866,4 @@ class LocalTransport(Transport):
         return os.path.exists(os.path.join(self.curdir, path))
 
 
-CONFIGURE_LOCAL_CMD = transport_cli.create_configure_cmd('local')
+CONFIGURE_LOCAL_CMD = transport_cli.create_configure_cmd_transport_only('local')

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -19,6 +19,8 @@ import click
 from aiida.cmdline.params import options
 from aiida.cmdline.params.types.path import AbsolutePathOrEmptyParamType
 from aiida.common.escaping import escape_for_bash
+from aiida.transports import cli as transport_cli
+
 from ..transport import Transport, TransportInternalError
 
 __all__ = ('parse_sshconfig', 'convert_to_bool', 'SshTransport')
@@ -1333,3 +1335,6 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
             raise
         else:
             return True
+
+
+CONFIGURE_SSH_CMD = transport_cli.create_configure_cmd_transport_only('ssh')

--- a/docs/source/get_started/computers.rst
+++ b/docs/source/get_started/computers.rst
@@ -382,16 +382,11 @@ on a remote machine until the job poll interval has elapsed since the last updat
 Because of this the maximum possible time before a job update could be the sum of
 the two intervals, however this is unlikely to happen in practice.
 
-The transport open interval is currently hardcoded by the transport plugin;
-typically for SSH it's longer than for local transport.
+Both the transport open interval and the minimum job poll interval are stored
+in the ``AuthInfo`` object and can be set when running ``verdi computer configure``.
 
-The job poll interval can be set programmatically on the corresponding ``Computer``
-object in verdi shell::
-
-    load_computer('localhost').set_minimum_job_poll_interval(30.0)
-
-
-would set the transport interval on a computer called 'localhost' to 30 seconds.
+If you want to change these parameters, run ``verdi computer configure`` again
+on your computer.
 
 .. note:: All of these intervals apply *per worker*, meaning that a daemon with
    multiple workers will not necessarily, overall, respect these limits.

--- a/docs/source/working_with_aiida/troubleshooting.rst
+++ b/docs/source/working_with_aiida/troubleshooting.rst
@@ -100,18 +100,14 @@ Here are a few things you can do in order to keep AiiDA running smoothly:
        ``verdi computer configure ssh <COMPUTER_NAME>`` and changing the value
        of the *Connection cooldown time* or, alternatively, by running::
 
-         verdi computer configure ssh --non-interactive --safe-interval <SECONDS> <COMPUTER_NAME>
+         verdi computer configure ssh --non-interactive --safe-open-interval <SECONDS> <COMPUTER_NAME>
      - In addition to the connection cooldown time described above, AiiDA also
        avoids running too often the command to get the list of jobs in the queue
        (``squeue``, ``qstat``, ...), as this can also impact the
        performance of the scheduler. For a given computer, you can increase
-       how many seconds must pass between requests. First load the
-       computer in a shell with ``computer = load_computer(<COMPUTER_NAME>)``.
-       You can check the current value in seconds (by default, 10) with
-       ``computer.get_minimum_job_poll_interval()``.
-       You can then set it to a higher value using::
-
-         computer.set_minimum_job_poll_interval(<NEW_VALUE_SECONDS>)
+       how many seconds must pass between requests. You can change the current value
+       in seconds (by default, 10) similarly as above, via
+       ``verdi computer configure ssh <COMPUTER_NAME>``.
 
 Various tips & tricks
 =====================


### PR DESCRIPTION
I am creating this PR mainly as a discussion place for the design.

This work originally started to fix #3630 (and #3541). However, while working on it, I found a number of design issues that might benefit for a general redesign.

This code shouldn't be merged yet - it starts some moving around, but after further discussions with @muhrin and @sphuber we might want to change properly the current interaction between transport/AuthInfo/scheduler/... classes (and click).

Here are some points after the discussion - once we agree, we can start doing the actual work applying these decisions.

Design issues:
- `AuthInfo` it's actually a `ComputerConfig` object. We don't necessarily need to rename it, but we should think to it that way (all the configuration for a given computer and aiida user pair).
- It contains a set of properties that can be queried by name. This includes generic things, like the safe open interval and the scheduler poll interval, plus one special property being the `auth_params`, that are just piped through to the transport to generate a new instance.
- The transport should *not* know about the generic properties. Now done in the class by the following code:
  ```
  _common_auth_options = [(		
        'safe_interval', {		
            'type': float,		
            'prompt': 'Connection cooldown time (s)',		
            'help': 'Minimum time interval in seconds between consecutive connection openings',		
            'callback': validate_positive_number		
        }		
    )]
  ```
  Moreover, these properties are sent to the `__init__` of the transport, and then just set in an internal variable to then return it back when asked. Since there is no functionality, these variables should never go or be known to the Transport (the transport just knows how to open a transport, the caller is in charge of knowing how often this can be done).
- These settings above (and the same for the transport-specific ones), anyway, should not be click-specific but we should have our own schema and then a way to convert them to a given UI (e.g. click) - what we need is essentially a type (and a validator), a short and a long help string, and a function to get the default
- We still need to merge the authinfo-generic keys and the auth_params (transport-specific) settings in the CLI for `verdi computer configure xxx`
- we should try to simplify the automatic generation of click commands for `verdi computer configure xxx`.
- Moreover, for the entry points, we will remove the entry point `aiida.cmdline.computer.configure` and generate also those from the `aiida.transports` entry point (this was already partially happening).
- We should not have (like I'm originally doing in this WIP code change) the `_common_auth_options` floating around, but we should have an object that knows about this schema (in a non-click-specific way). Ideally this should be in AuthInfo. The problem is, however, that this means that at import time we need to import `aiida.orm` (to get the AuthInfo and generate the click decorators to `verdi computer configure xxx`) and this is slow. We need to decide if we want to solve the speed issue first, and use the `AuthInfo` object as the main class coordinating all this, or have another class (e.g. `aiida.common.computerconfig.ComputerConfig`) that does not know about the backend. `AuthInfo` would just wrap it and provide a "proxy" for the relevant methods, but the logic will be mostly in this internal class, from which the CLI can get the schema information (currently `_common_auth_options`) without loading `aiida.orm`.
- Note: Should this `ComputerConfig` know about the user and the computer? If so, then it should know about them without needing to go to the orm/DB, otherwise it defeats its purpose. Maybe it just needs to contain the content. However, it needs to know at least the TransportClass it is bound to (maybe in the future also the scheduler?)

Other issues:
- fix the tests, make sure that everywhere where we were using the safe-interval (or setting it for efficiency in testing) this is now properly honoured
- update documentation
- Choose properly the names of options. Since this might be the most important user-facing change, let's pick names we're happy with and:
  - let's provide a data migration
  - let's make sure the old ones still work, deprecated
