### PR TITLE
Make command line deprecation warnings visible with test profile

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_comment.py
+++ b/aiida/backends/tests/cmdline/commands/test_comment.py
@@ -24,12 +24,6 @@ class TestVerdiCommentCommand(AiidaTestCase):
         self.cli_runner = CliRunner()
         self.node = orm.Data().store()
 
-    def test_comment_show_simple(self):
-        """Test simply calling the show command (without data to show)."""
-        result = self.cli_runner.invoke(cmd_comment.show, [], catch_exceptions=False)
-        self.assertEqual(result.output, '')
-        self.assertEqual(result.exit_code, 0)
-
     def test_comment_show(self):
         """Test showing an existing comment."""
         self.node.add_comment(COMMENT)

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -74,13 +74,13 @@ def devel_validate_plugins():
 @verdi_devel.command('tests')
 @click.argument('paths', nargs=-1, type=TestModuleParamType(), required=False)
 @options.VERBOSE(help='Print the class and function name for each test.')
-@decorators.deprecated_command("This command will be removed in aiida-core v2.0.0. Please run 'pytest' instead.")
+@decorators.deprecated_command("This command has been removed in aiida-core v1.1.0. Please run 'pytest' instead.")
 @decorators.with_dbenv()
 def devel_tests(paths, verbose):  # pylint: disable=unused-argument
     """Run the unittest suite or parts of it.
 
     .. deprecated:: 1.1.0
-        Will be removed in `v2.0.0`.
+        Entry point will be completely removed in `v2.0.0`.
     """
 
 

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -183,15 +183,11 @@ def deprecated_command(message):
     def wrapper(wrapped, _, args, kwargs):
         """Echo a deprecation warning before doing anything else."""
         from aiida.cmdline.utils import templates
-        from aiida.manage.configuration import get_config
         from textwrap import wrap
 
-        profile = get_config().current_profile
-
-        if not profile.is_test_profile:
-            template = templates.env.get_template('deprecated.tpl')
-            width = 80
-            echo.echo(template.render(msg=wrap(message, width - 4), width=width))
+        template = templates.env.get_template('deprecated.tpl')
+        width = 80
+        echo.echo(template.render(msg=wrap(message, width - 4), width=width))
 
         return wrapped(*args, **kwargs)
 


### PR DESCRIPTION
The `deprecated_command` decorator was only printing the warning if the
profile was not a test profile. With `verdi devel tests` being
deprecated, typically run with a test profile, the warning was being
swallowed.