### PR TITLE
pytest follow-up

### DIFF
--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -3,6 +3,8 @@ set -ev
 
 # Make sure the folder containing the workchains is in the python path before the daemon is started
 export PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}/.ci"
+# show timings of tests
+export PYTEST_ADDOPTS=" --durations=0"
 
 verdi daemon start 4
 verdi -p test_${AIIDA_TEST_BACKEND} run .ci/test_daemon.py

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -32,9 +32,6 @@ from aiida.orm import Group, ArrayData, BandsData, KpointsData, CifData, Dict, R
 class TestVerdiDataExportable:
     """Test exportable data objects."""
 
-    def __init__(self):
-        pass
-
     NODE_ID_STR = 'node_id'
     EMPTY_GROUP_ID_STR = 'empty_group_id'
     EMPTY_GROUP_NAME_STR = 'empty_group'
@@ -87,7 +84,7 @@ class TestVerdiDataExportable:
                 # Try to export it again. It should fail because the
                 # file exists
                 res = self.cli_runner.invoke(export_cmd, options, catch_exceptions=False)
-                self.assertNotEquals(res.exit_code, 0, 'The command should fail because the file already exists')
+                self.assertNotEqual(res.exit_code, 0, 'The command should fail because the file already exists')
 
                 # Now we force the export of the file and it should overwrite
                 # existing files
@@ -103,9 +100,6 @@ class TestVerdiDataExportable:
 
 class TestVerdiDataListable:
     """Test listable data objects."""
-
-    def __init__(self):
-        pass
 
     NODE_ID_STR = 'node_id'
     EMPTY_GROUP_ID_STR = 'empty_group_id'

--- a/aiida/backends/tests/common/test_extendeddicts.py
+++ b/aiida/backends/tests/common/test_extendeddicts.py
@@ -19,14 +19,14 @@ from aiida.common import exceptions
 from aiida.common import extendeddicts
 
 
-class TestFFADExample(extendeddicts.FixedFieldsAttributeDict):
+class FFADExample(extendeddicts.FixedFieldsAttributeDict):
     """
     An example class that accepts only the 'alpha', 'beta' and 'gamma' keys/attributes.
     """
     _valid_fields = ('alpha', 'beta', 'gamma')
 
 
-class TestDFADExample(extendeddicts.DefaultFieldsAttributeDict):
+class DFADExample(extendeddicts.DefaultFieldsAttributeDict):
     """
     An example class that has 'alpha', 'beta' and 'gamma' as default keys.
     """
@@ -270,7 +270,7 @@ class TestFFAD(unittest.TestCase):
 
     def test_insertion(self):
         """Test insertion."""
-        dictionary = TestFFADExample()
+        dictionary = FFADExample()
         dictionary['alpha'] = 1
         dictionary.beta = 2
         # Not a valid key.
@@ -281,14 +281,14 @@ class TestFFAD(unittest.TestCase):
 
     def test_insertion_on_init(self):
         """Test insertion in constructor."""
-        TestFFADExample({'alpha': 1, 'beta': 2})
+        FFADExample({'alpha': 1, 'beta': 2})
         with self.assertRaises(KeyError):
             # 'delta' is not a valid key
-            TestFFADExample({'alpha': 1, 'delta': 2})
+            FFADExample({'alpha': 1, 'delta': 2})
 
     def test_pickle(self):
         """Note: pickle works here because self._valid_fields is defined at the class level!"""
-        dictionary_01 = TestFFADExample({'alpha': 1, 'beta': 2})
+        dictionary_01 = FFADExample({'alpha': 1, 'beta': 2})
         dictionary_02 = pickle.loads(pickle.dumps(dictionary_01))
         dictionary_02.gamma = 3
         with self.assertRaises(KeyError):
@@ -299,7 +299,7 @@ class TestFFAD(unittest.TestCase):
         I test that the get_valid_fields() is working as a class method,
         so I don't need to instantiate the class to get the list.
         """
-        self.assertEqual(set(TestFFADExample.get_valid_fields()), set(['alpha', 'beta', 'gamma']))
+        self.assertEqual(set(FFADExample.get_valid_fields()), set(['alpha', 'beta', 'gamma']))
 
 
 class TestDFAD(unittest.TestCase):
@@ -307,7 +307,7 @@ class TestDFAD(unittest.TestCase):
 
     def test_insertion_and_retrieval(self):
         """Test insertion and retrieval."""
-        dictionary = TestDFADExample()
+        dictionary = DFADExample()
         dictionary['alpha'] = 1
         dictionary.beta = 2
         dictionary['delta'] = 3
@@ -319,7 +319,7 @@ class TestDFAD(unittest.TestCase):
 
     def test_keylist_method(self):
         """Test keylist retrieval."""
-        dictionary = TestDFADExample()
+        dictionary = DFADExample()
         dictionary['alpha'] = 1
         dictionary.beta = 2
         dictionary['delta'] = 3
@@ -336,11 +336,11 @@ class TestDFAD(unittest.TestCase):
         I test that the get_default_fields() is working as a class method,
         so I don't need to instantiate the class to get the list.
         """
-        self.assertEqual(set(TestDFADExample.get_default_fields()), set(['alpha', 'beta', 'gamma']))
+        self.assertEqual(set(DFADExample.get_default_fields()), set(['alpha', 'beta', 'gamma']))
 
     def test_validation(self):
         """Test validation."""
-        dictionary = TestDFADExample()
+        dictionary = DFADExample()
 
         # Should be ok to have an empty 'alpha' attribute
         dictionary.validate()

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -192,48 +192,48 @@ class TestExitStatus(AiidaTestCase):
 
     def test_failing_workchain_through_integer(self):
         result, node = launch.run.get_node(PotentialFailureWorkChain, success=Bool(False))
-        self.assertEquals(node.exit_status, PotentialFailureWorkChain.EXIT_STATUS)
-        self.assertEquals(node.exit_message, None)
-        self.assertEquals(node.is_finished, True)
-        self.assertEquals(node.is_finished_ok, False)
-        self.assertEquals(node.is_failed, True)
+        self.assertEqual(node.exit_status, PotentialFailureWorkChain.EXIT_STATUS)
+        self.assertEqual(node.exit_message, None)
+        self.assertEqual(node.is_finished, True)
+        self.assertEqual(node.is_finished_ok, False)
+        self.assertEqual(node.is_failed, True)
         self.assertNotIn(PotentialFailureWorkChain.OUTPUT_LABEL, node.get_outgoing().all_link_labels())
 
     def test_failing_workchain_through_exit_code(self):
         result, node = launch.run.get_node(PotentialFailureWorkChain, success=Bool(False), through_exit_code=Bool(True))
-        self.assertEquals(node.exit_status, PotentialFailureWorkChain.EXIT_STATUS)
-        self.assertEquals(node.exit_message, PotentialFailureWorkChain.EXIT_MESSAGE)
-        self.assertEquals(node.is_finished, True)
-        self.assertEquals(node.is_finished_ok, False)
-        self.assertEquals(node.is_failed, True)
+        self.assertEqual(node.exit_status, PotentialFailureWorkChain.EXIT_STATUS)
+        self.assertEqual(node.exit_message, PotentialFailureWorkChain.EXIT_MESSAGE)
+        self.assertEqual(node.is_finished, True)
+        self.assertEqual(node.is_finished_ok, False)
+        self.assertEqual(node.is_failed, True)
         self.assertNotIn(PotentialFailureWorkChain.OUTPUT_LABEL, node.get_outgoing().all_link_labels())
 
     def test_successful_workchain_through_integer(self):
         result, node = launch.run.get_node(PotentialFailureWorkChain, success=Bool(True))
-        self.assertEquals(node.exit_status, 0)
-        self.assertEquals(node.is_finished, True)
-        self.assertEquals(node.is_finished_ok, True)
-        self.assertEquals(node.is_failed, False)
+        self.assertEqual(node.exit_status, 0)
+        self.assertEqual(node.is_finished, True)
+        self.assertEqual(node.is_finished_ok, True)
+        self.assertEqual(node.is_failed, False)
         self.assertIn(PotentialFailureWorkChain.OUTPUT_LABEL, node.get_outgoing().all_link_labels())
-        self.assertEquals(node.get_outgoing().get_node_by_label(PotentialFailureWorkChain.OUTPUT_LABEL),
+        self.assertEqual(node.get_outgoing().get_node_by_label(PotentialFailureWorkChain.OUTPUT_LABEL),
                           PotentialFailureWorkChain.OUTPUT_VALUE)
 
     def test_successful_workchain_through_exit_code(self):
         result, node = launch.run.get_node(PotentialFailureWorkChain, success=Bool(True), through_exit_code=Bool(True))
-        self.assertEquals(node.exit_status, 0)
-        self.assertEquals(node.is_finished, True)
-        self.assertEquals(node.is_finished_ok, True)
-        self.assertEquals(node.is_failed, False)
+        self.assertEqual(node.exit_status, 0)
+        self.assertEqual(node.is_finished, True)
+        self.assertEqual(node.is_finished_ok, True)
+        self.assertEqual(node.is_failed, False)
         self.assertIn(PotentialFailureWorkChain.OUTPUT_LABEL, node.get_outgoing().all_link_labels())
-        self.assertEquals(node.get_outgoing().get_node_by_label(PotentialFailureWorkChain.OUTPUT_LABEL),
+        self.assertEqual(node.get_outgoing().get_node_by_label(PotentialFailureWorkChain.OUTPUT_LABEL),
                           PotentialFailureWorkChain.OUTPUT_VALUE)
 
     def test_return_out_of_outline(self):
         result, node = launch.run.get_node(PotentialFailureWorkChain, success=Bool(True), through_return=Bool(True))
-        self.assertEquals(node.exit_status, PotentialFailureWorkChain.EXIT_STATUS)
-        self.assertEquals(node.is_finished, True)
-        self.assertEquals(node.is_finished_ok, False)
-        self.assertEquals(node.is_failed, True)
+        self.assertEqual(node.exit_status, PotentialFailureWorkChain.EXIT_STATUS)
+        self.assertEqual(node.is_finished, True)
+        self.assertEqual(node.is_finished_ok, False)
+        self.assertEqual(node.is_failed, True)
         self.assertNotIn(PotentialFailureWorkChain.OUTPUT_LABEL, node.get_outgoing().all_link_labels())
 
 
@@ -438,15 +438,15 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(r1=self.submit(ReturnA), r2=self.submit(ReturnB))
 
             def s2(self):
-                test_case.assertEquals(self.ctx.r1.outputs.res, A)
-                test_case.assertEquals(self.ctx.r2.outputs.res, B)
+                test_case.assertEqual(self.ctx.r1.outputs.res, A)
+                test_case.assertEqual(self.ctx.r2.outputs.res, B)
 
                 # Try overwriting r1
                 return ToContext(r1=self.submit(ReturnB))
 
             def s3(self):
-                test_case.assertEquals(self.ctx.r1.outputs.res, B)
-                test_case.assertEquals(self.ctx.r2.outputs.res, B)
+                test_case.assertEqual(self.ctx.r1.outputs.res, B)
+                test_case.assertEqual(self.ctx.r2.outputs.res, B)
 
         run_and_check_success(Wf)
 
@@ -754,8 +754,8 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(result_b=self.submit(SimpleWc))
 
             def result(self):
-                test_case.assertEquals(self.ctx.result_a.outputs.result, val)
-                test_case.assertEquals(self.ctx.result_b.outputs.result, val)
+                test_case.assertEqual(self.ctx.result_a.outputs.result, val)
+                test_case.assertEqual(self.ctx.result_b.outputs.result, val)
 
         run_and_check_success(Workchain)
 
@@ -823,21 +823,21 @@ class TestWorkchain(AiidaTestCase):
         wc = ExitCodeWorkChain()
 
         # The exit code can be gotten by calling it with the status or label, as well as using attribute dereferencing
-        self.assertEquals(wc.exit_codes(status).status, status)
-        self.assertEquals(wc.exit_codes(label).status, status)
-        self.assertEquals(wc.exit_codes.SOME_EXIT_CODE.status, status)
+        self.assertEqual(wc.exit_codes(status).status, status)
+        self.assertEqual(wc.exit_codes(label).status, status)
+        self.assertEqual(wc.exit_codes.SOME_EXIT_CODE.status, status)
 
         with self.assertRaises(AttributeError):
             wc.exit_codes.NON_EXISTENT_ERROR
 
-        self.assertEquals(ExitCodeWorkChain.exit_codes.SOME_EXIT_CODE.status, status)
-        self.assertEquals(ExitCodeWorkChain.exit_codes.SOME_EXIT_CODE.message, message)
+        self.assertEqual(ExitCodeWorkChain.exit_codes.SOME_EXIT_CODE.status, status)
+        self.assertEqual(ExitCodeWorkChain.exit_codes.SOME_EXIT_CODE.message, message)
 
-        self.assertEquals(ExitCodeWorkChain.exit_codes['SOME_EXIT_CODE'].status, status)
-        self.assertEquals(ExitCodeWorkChain.exit_codes['SOME_EXIT_CODE'].message, message)
+        self.assertEqual(ExitCodeWorkChain.exit_codes['SOME_EXIT_CODE'].status, status)
+        self.assertEqual(ExitCodeWorkChain.exit_codes['SOME_EXIT_CODE'].message, message)
 
-        self.assertEquals(ExitCodeWorkChain.exit_codes[label].status, status)
-        self.assertEquals(ExitCodeWorkChain.exit_codes[label].message, message)
+        self.assertEqual(ExitCodeWorkChain.exit_codes[label].status, status)
+        self.assertEqual(ExitCodeWorkChain.exit_codes[label].message, message)
 
     def _run_with_checkpoints(self, wf_class, inputs=None):
         if inputs is None:
@@ -893,9 +893,9 @@ class TestWorkChainAbort(AiidaTestCase):
         runner.schedule(process)
         runner.loop.run_sync(lambda: run_async())
 
-        self.assertEquals(process.node.is_finished_ok, False)
-        self.assertEquals(process.node.is_excepted, True)
-        self.assertEquals(process.node.is_killed, False)
+        self.assertEqual(process.node.is_finished_ok, False)
+        self.assertEqual(process.node.is_excepted, True)
+        self.assertEqual(process.node.is_killed, False)
 
     def test_simple_kill_through_process(self):
         """
@@ -919,9 +919,9 @@ class TestWorkChainAbort(AiidaTestCase):
         runner.schedule(process)
         runner.loop.run_sync(lambda: run_async())
 
-        self.assertEquals(process.node.is_finished_ok, False)
-        self.assertEquals(process.node.is_excepted, False)
-        self.assertEquals(process.node.is_killed, True)
+        self.assertEqual(process.node.is_finished_ok, False)
+        self.assertEqual(process.node.is_excepted, False)
+        self.assertEqual(process.node.is_killed, True)
 
 
 class TestWorkChainAbortChildren(AiidaTestCase):
@@ -981,9 +981,9 @@ class TestWorkChainAbortChildren(AiidaTestCase):
             with self.assertRaises(RuntimeError):
                 launch.run(process)
 
-        self.assertEquals(process.node.is_finished_ok, False)
-        self.assertEquals(process.node.is_excepted, True)
-        self.assertEquals(process.node.is_killed, False)
+        self.assertEqual(process.node.is_finished_ok, False)
+        self.assertEqual(process.node.is_excepted, True)
+        self.assertEqual(process.node.is_killed, False)
 
     def test_simple_kill_through_process(self):
         """
@@ -1006,13 +1006,13 @@ class TestWorkChainAbortChildren(AiidaTestCase):
         runner.loop.run_sync(lambda: run_async())
 
         child = process.node.get_outgoing(link_type=LinkType.CALL_WORK).first().node
-        self.assertEquals(child.is_finished_ok, False)
-        self.assertEquals(child.is_excepted, False)
-        self.assertEquals(child.is_killed, True)
+        self.assertEqual(child.is_finished_ok, False)
+        self.assertEqual(child.is_excepted, False)
+        self.assertEqual(child.is_killed, True)
 
-        self.assertEquals(process.node.is_finished_ok, False)
-        self.assertEquals(process.node.is_excepted, False)
-        self.assertEquals(process.node.is_killed, True)
+        self.assertEqual(process.node.is_finished_ok, False)
+        self.assertEqual(process.node.is_excepted, False)
+        self.assertEqual(process.node.is_killed, True)
 
 
 class TestImmutableInputWorkchain(AiidaTestCase):
@@ -1060,7 +1060,7 @@ class TestImmutableInputWorkchain(AiidaTestCase):
                 test_class.assertIn('a', self.inputs)
                 test_class.assertIn('b', self.inputs)
                 test_class.assertNotIn('c', self.inputs)
-                test_class.assertEquals(self.inputs['a'].value, 1)
+                test_class.assertEqual(self.inputs['a'].value, 1)
 
         run_and_check_success(Wf, a=Int(1), b=Int(2))
 
@@ -1095,7 +1095,7 @@ class TestImmutableInputWorkchain(AiidaTestCase):
                 test_class.assertIn('one', self.inputs.subspace)
                 test_class.assertIn('two', self.inputs.subspace)
                 test_class.assertNotIn('four', self.inputs.subspace)
-                test_class.assertEquals(self.inputs.subspace['one'].value, 1)
+                test_class.assertEqual(self.inputs.subspace['one'].value, 1)
 
         run_and_check_success(Wf, subspace={'one': Int(1), 'two': Int(2)})
 
@@ -1260,7 +1260,7 @@ class TestWorkChainExpose(AiidaTestCase):
                 }
             },
         )
-        self.assertEquals(
+        self.assertEqual(
             res, {
                 'a': Float(2.2),
                 'sub_1': {
@@ -1293,7 +1293,7 @@ class TestWorkChainExpose(AiidaTestCase):
                         }
                     },
                 )))
-        self.assertEquals(
+        self.assertEqual(
             res, {
                 'sub': {
                     'sub': {
@@ -1425,5 +1425,5 @@ class TestDefaultUniqueness(AiidaTestCase):
         # Trying to load one of the inputs through the UUID should fail,
         # as both `child_one.a` and `child_two.a` should have the same UUID.
         node = load_node(uuid=node.get_incoming().get_node_by_label('child_one__a').uuid)
-        self.assertEquals(
+        self.assertEqual(
             len(uuids), len(nodes), 'Only {} unique UUIDS for {} input nodes'.format(len(uuids), len(nodes)))

--- a/aiida/backends/tests/test_nodes.py
+++ b/aiida/backends/tests/test_nodes.py
@@ -132,7 +132,7 @@ class TestNodeHashing(AiidaTestCase):
         hash1 = node.get_hash()
         node.set_process_state('finished')
         hash2 = node.get_hash()
-        self.assertNotEquals(hash1, None)
+        self.assertNotEqual(hash1, None)
         self.assertEqual(hash1, hash2)
 
 
@@ -495,7 +495,7 @@ class TestNodeBasic(AiidaTestCase):
             self.assertEqual(fhandle.read(), file_content)
 
         b = a.clone()
-        self.assertNotEquals(a.uuid, b.uuid)
+        self.assertNotEqual(a.uuid, b.uuid)
 
         # Check that the content is there
         self.assertEqual(set(b.list_object_names()), set(['file1.txt', 'file2.txt']))
@@ -603,7 +603,7 @@ class TestNodeBasic(AiidaTestCase):
 
         # clone into a new node
         b = a.clone()
-        self.assertNotEquals(a.uuid, b.uuid)
+        self.assertNotEqual(a.uuid, b.uuid)
 
         # Check that the content is there
         self.assertEqual(set(b.list_object_names('.')), set(['tree_1']))

--- a/aiida/backends/tests/test_nodes.py
+++ b/aiida/backends/tests/test_nodes.py
@@ -100,8 +100,8 @@ class TestNodeHashing(AiidaTestCase):
         # Check that the query doesn't fail
         qb.all()
         # And that the results are correct
-        self.assertEquals(qb.count(), 1)
-        self.assertEquals(qb.first()[0], n.id)
+        self.assertEqual(qb.count(), 1)
+        self.assertEqual(qb.first()[0], n.id)
 
     @staticmethod
     def create_folderdata_with_empty_file():
@@ -133,7 +133,7 @@ class TestNodeHashing(AiidaTestCase):
         node.set_process_state('finished')
         hash2 = node.get_hash()
         self.assertNotEquals(hash1, None)
-        self.assertEquals(hash1, hash2)
+        self.assertEqual(hash1, hash2)
 
 
 class TestTransitiveNoLoops(AiidaTestCase):
@@ -211,25 +211,25 @@ class TestQueryWithAiidaObjects(AiidaTestCase):
         results = [_ for [_] in qb.all()]
         # a3, a4 should not be found because they are not CalcJobNodes.
         # a6, a7 should not be found because they have not the attribute set.
-        self.assertEquals(set([i.pk for i in results]), set([a1.pk]))
+        self.assertEqual(set([i.pk for i in results]), set([a1.pk]))
 
         # Same query, but by the generic Node class
         qb = orm.QueryBuilder()
         qb.append(orm.Node, filters={'extras': {'has_key': extra_name}})
         results = [_ for [_] in qb.all()]
-        self.assertEquals(set([i.pk for i in results]), set([a1.pk, a3.pk, a4.pk]))
+        self.assertEqual(set([i.pk for i in results]), set([a1.pk, a3.pk, a4.pk]))
 
         # Same query, but by the Data class
         qb = orm.QueryBuilder()
         qb.append(orm.Data, filters={'extras': {'has_key': extra_name}})
         results = [_ for [_] in qb.all()]
-        self.assertEquals(set([i.pk for i in results]), set([a3.pk, a4.pk]))
+        self.assertEqual(set([i.pk for i in results]), set([a3.pk, a4.pk]))
 
         # Same query, but by the Dict subclass
         qb = orm.QueryBuilder()
         qb.append(orm.Dict, filters={'extras': {'has_key': extra_name}})
         results = [_ for [_] in qb.all()]
-        self.assertEquals(set([i.pk for i in results]), set([a4.pk]))
+        self.assertEqual(set([i.pk for i in results]), set([a4.pk]))
 
 
 class TestNodeBasic(AiidaTestCase):
@@ -308,14 +308,14 @@ class TestNodeBasic(AiidaTestCase):
         a.set_attribute('k9', None)
 
         # Now I check if I can retrieve them, before the storage
-        self.assertEquals(self.boolval, a.get_attribute('k1'))
-        self.assertEquals(self.intval, a.get_attribute('k2'))
-        self.assertEquals(self.floatval, a.get_attribute('k3'))
-        self.assertEquals(self.stringval, a.get_attribute('k4'))
-        self.assertEquals(self.dictval, a.get_attribute('k5'))
-        self.assertEquals(self.listval, a.get_attribute('k6'))
-        self.assertEquals(self.emptydict, a.get_attribute('k7'))
-        self.assertEquals(self.emptylist, a.get_attribute('k8'))
+        self.assertEqual(self.boolval, a.get_attribute('k1'))
+        self.assertEqual(self.intval, a.get_attribute('k2'))
+        self.assertEqual(self.floatval, a.get_attribute('k3'))
+        self.assertEqual(self.stringval, a.get_attribute('k4'))
+        self.assertEqual(self.dictval, a.get_attribute('k5'))
+        self.assertEqual(self.listval, a.get_attribute('k6'))
+        self.assertEqual(self.emptydict, a.get_attribute('k7'))
+        self.assertEqual(self.emptylist, a.get_attribute('k8'))
         self.assertIsNone(a.get_attribute('k9'))
 
         # And now I try to delete the keys
@@ -370,7 +370,7 @@ class TestNodeBasic(AiidaTestCase):
         }
 
         # Now I check if I can retrieve them, before the storage
-        self.assertEquals(a.attributes, target_attrs)
+        self.assertEqual(a.attributes, target_attrs)
 
         # And now I try to delete the keys
         a.delete_attribute('k1')
@@ -383,7 +383,7 @@ class TestNodeBasic(AiidaTestCase):
         a.delete_attribute('k8')
         a.delete_attribute('k9')
 
-        self.assertEquals(a.attributes, {})
+        self.assertEqual(a.attributes, {})
 
     def test_get_attrs_after_storing(self):
         a = orm.Data()
@@ -412,7 +412,7 @@ class TestNodeBasic(AiidaTestCase):
         }
 
         # Now I check if I can retrieve them, before the storage
-        self.assertEquals(a.attributes, target_attrs)
+        self.assertEqual(a.attributes, target_attrs)
 
     def test_store_object(self):
         """Trying to set objects as attributes should fail, because they are not json-serializable."""
@@ -457,9 +457,9 @@ class TestNodeBasic(AiidaTestCase):
         b_expected_attributes['new'] = 'cvb'
 
         # I check before storing that the attributes are ok
-        self.assertEquals(b.attributes, b_expected_attributes)
+        self.assertEqual(b.attributes, b_expected_attributes)
         # Note that during copy, I do not copy the extras!
-        self.assertEquals({k: v for k, v in b.extras.items()}, {})
+        self.assertEqual({k: v for k, v in b.extras.items()}, {})
 
         # I store now
         b.store()
@@ -468,11 +468,11 @@ class TestNodeBasic(AiidaTestCase):
         b_expected_extras = {'meta': 'textofext', '_aiida_hash': AnyValue()}
 
         # Now I check that the attributes of the original node have not changed
-        self.assertEquals({k: v for k, v in a.attributes.items()}, attrs_to_set)
+        self.assertEqual({k: v for k, v in a.attributes.items()}, attrs_to_set)
 
         # I check then on the 'b' copy
-        self.assertEquals({k: v for k, v in b.attributes.items()}, b_expected_attributes)
-        self.assertEquals({k: v for k, v in b.extras.items()}, b_expected_extras)
+        self.assertEqual({k: v for k, v in b.attributes.items()}, b_expected_attributes)
+        self.assertEqual({k: v for k, v in b.extras.items()}, b_expected_extras)
 
     def test_files(self):
         import tempfile
@@ -488,21 +488,21 @@ class TestNodeBasic(AiidaTestCase):
             a.put_object_from_file(handle.name, 'file1.txt')
             a.put_object_from_file(handle.name, 'file2.txt')
 
-        self.assertEquals(set(a.list_object_names()), set(['file1.txt', 'file2.txt']))
+        self.assertEqual(set(a.list_object_names()), set(['file1.txt', 'file2.txt']))
         with a.open('file1.txt') as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         with a.open('file2.txt') as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
 
         b = a.clone()
         self.assertNotEquals(a.uuid, b.uuid)
 
         # Check that the content is there
-        self.assertEquals(set(b.list_object_names()), set(['file1.txt', 'file2.txt']))
+        self.assertEqual(set(b.list_object_names()), set(['file1.txt', 'file2.txt']))
         with b.open('file1.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
         with b.open('file2.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
 
         # I overwrite a file and create a new one in the clone only
         with tempfile.NamedTemporaryFile(mode='w+') as handle:
@@ -512,18 +512,18 @@ class TestNodeBasic(AiidaTestCase):
             b.put_object_from_file(handle.name, 'file3.txt')
 
         # I check the new content, and that the old one has not changed
-        self.assertEquals(set(a.list_object_names()), set(['file1.txt', 'file2.txt']))
+        self.assertEqual(set(a.list_object_names()), set(['file1.txt', 'file2.txt']))
         with a.open('file1.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
         with a.open('file2.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
-        self.assertEquals(set(b.list_object_names()), set(['file1.txt', 'file2.txt', 'file3.txt']))
+            self.assertEqual(handle.read(), file_content)
+        self.assertEqual(set(b.list_object_names()), set(['file1.txt', 'file2.txt', 'file3.txt']))
         with b.open('file1.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
         with b.open('file2.txt') as handle:
-            self.assertEquals(handle.read(), file_content_different)
+            self.assertEqual(handle.read(), file_content_different)
         with b.open('file3.txt') as handle:
-            self.assertEquals(handle.read(), file_content_different)
+            self.assertEqual(handle.read(), file_content_different)
 
         # This should in principle change the location of the files,
         # so I recheck
@@ -538,19 +538,19 @@ class TestNodeBasic(AiidaTestCase):
             c.put_object_from_file(handle.name, 'file1.txt')
             c.put_object_from_file(handle.name, 'file4.txt')
 
-        self.assertEquals(set(a.list_object_names()), set(['file1.txt', 'file2.txt']))
+        self.assertEqual(set(a.list_object_names()), set(['file1.txt', 'file2.txt']))
         with a.open('file1.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
         with a.open('file2.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
 
-        self.assertEquals(set(c.list_object_names()), set(['file1.txt', 'file2.txt', 'file4.txt']))
+        self.assertEqual(set(c.list_object_names()), set(['file1.txt', 'file2.txt', 'file4.txt']))
         with c.open('file1.txt') as handle:
-            self.assertEquals(handle.read(), file_content_different)
+            self.assertEqual(handle.read(), file_content_different)
         with c.open('file2.txt') as handle:
-            self.assertEquals(handle.read(), file_content)
+            self.assertEqual(handle.read(), file_content)
         with c.open('file4.txt') as handle:
-            self.assertEquals(handle.read(), file_content_different)
+            self.assertEqual(handle.read(), file_content_different)
 
     def test_folders(self):
         """
@@ -589,13 +589,13 @@ class TestNodeBasic(AiidaTestCase):
         a.put_object_from_tree(tree_1, 'tree_1')
 
         # verify if the node has the structure I expect
-        self.assertEquals(set(a.list_object_names()), set(['tree_1']))
-        self.assertEquals(set(a.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(set(a.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        self.assertEqual(set(a.list_object_names()), set(['tree_1']))
+        self.assertEqual(set(a.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEqual(set(a.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with a.open(os.path.join('tree_1', 'file1.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         with a.open(os.path.join('tree_1', 'dir1', 'file2.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
 
         # try to exit from the folder
         with self.assertRaises(ValueError):
@@ -606,13 +606,13 @@ class TestNodeBasic(AiidaTestCase):
         self.assertNotEquals(a.uuid, b.uuid)
 
         # Check that the content is there
-        self.assertEquals(set(b.list_object_names('.')), set(['tree_1']))
-        self.assertEquals(set(b.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(set(b.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        self.assertEqual(set(b.list_object_names('.')), set(['tree_1']))
+        self.assertEqual(set(b.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEqual(set(b.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with b.open(os.path.join('tree_1', 'file1.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         with b.open(os.path.join('tree_1', 'dir1', 'file2.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
 
         # I overwrite a file and create a new one in the copy only
         dir3 = os.path.join(directory, 'dir3')
@@ -627,21 +627,21 @@ class TestNodeBasic(AiidaTestCase):
         b.put_object_from_filelike(stream, 'file3.txt')
 
         # I check the new content, and that the old one has not changed old
-        self.assertEquals(set(a.list_object_names('.')), set(['tree_1']))
-        self.assertEquals(set(a.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(set(a.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        self.assertEqual(set(a.list_object_names('.')), set(['tree_1']))
+        self.assertEqual(set(a.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEqual(set(a.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with a.open(os.path.join('tree_1', 'file1.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         with a.open(os.path.join('tree_1', 'dir1', 'file2.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         # new
-        self.assertEquals(set(b.list_object_names('.')), set(['tree_1', 'file3.txt']))
-        self.assertEquals(set(b.list_object_names('tree_1')), set(['file1.txt', 'dir1', 'dir3']))
-        self.assertEquals(set(b.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        self.assertEqual(set(b.list_object_names('.')), set(['tree_1', 'file3.txt']))
+        self.assertEqual(set(b.list_object_names('tree_1')), set(['file1.txt', 'dir1', 'dir3']))
+        self.assertEqual(set(b.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with b.open(os.path.join('tree_1', 'file1.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         with b.open(os.path.join('tree_1', 'dir1', 'file2.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
 
         # This should in principle change the location of the files, so I recheck
         a.store()
@@ -656,22 +656,22 @@ class TestNodeBasic(AiidaTestCase):
         c.delete_object(os.path.join('tree_1', 'dir1', 'dir2'))
 
         # check old
-        self.assertEquals(set(a.list_object_names('.')), set(['tree_1']))
-        self.assertEquals(set(a.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(set(a.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        self.assertEqual(set(a.list_object_names('.')), set(['tree_1']))
+        self.assertEqual(set(a.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEqual(set(a.list_object_names(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with a.open(os.path.join('tree_1', 'file1.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
         with a.open(os.path.join('tree_1', 'dir1', 'file2.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
 
         # check new
-        self.assertEquals(set(c.list_object_names('.')), set(['tree_1']))
-        self.assertEquals(set(c.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(set(c.list_object_names(os.path.join('tree_1', 'dir1'))), set(['file2.txt', 'file4.txt']))
+        self.assertEqual(set(c.list_object_names('.')), set(['tree_1']))
+        self.assertEqual(set(c.list_object_names('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEqual(set(c.list_object_names(os.path.join('tree_1', 'dir1'))), set(['file2.txt', 'file4.txt']))
         with c.open(os.path.join('tree_1', 'file1.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content_different)
+            self.assertEqual(fhandle.read(), file_content_different)
         with c.open(os.path.join('tree_1', 'dir1', 'file2.txt')) as fhandle:
-            self.assertEquals(fhandle.read(), file_content)
+            self.assertEqual(fhandle.read(), file_content)
 
         # garbage cleaning
         shutil.rmtree(directory)
@@ -690,12 +690,12 @@ class TestNodeBasic(AiidaTestCase):
 
         # Now I check if I can retrieve them, before the storage
         self.assertIsNone(a.get_attribute('none'))
-        self.assertEquals(self.boolval, a.get_attribute('bool'))
-        self.assertEquals(self.intval, a.get_attribute('integer'))
-        self.assertEquals(self.floatval, a.get_attribute('float'))
-        self.assertEquals(self.stringval, a.get_attribute('string'))
-        self.assertEquals(self.dictval, a.get_attribute('dict'))
-        self.assertEquals(self.listval, a.get_attribute('list'))
+        self.assertEqual(self.boolval, a.get_attribute('bool'))
+        self.assertEqual(self.intval, a.get_attribute('integer'))
+        self.assertEqual(self.floatval, a.get_attribute('float'))
+        self.assertEqual(self.stringval, a.get_attribute('string'))
+        self.assertEqual(self.dictval, a.get_attribute('dict'))
+        self.assertEqual(self.listval, a.get_attribute('list'))
 
     def test_attr_with_reload(self):
         a = orm.Data()
@@ -711,12 +711,12 @@ class TestNodeBasic(AiidaTestCase):
 
         b = orm.load_node(uuid=a.uuid)
         self.assertIsNone(a.get_attribute('none'))
-        self.assertEquals(self.boolval, b.get_attribute('bool'))
-        self.assertEquals(self.intval, b.get_attribute('integer'))
-        self.assertEquals(self.floatval, b.get_attribute('float'))
-        self.assertEquals(self.stringval, b.get_attribute('string'))
-        self.assertEquals(self.dictval, b.get_attribute('dict'))
-        self.assertEquals(self.listval, b.get_attribute('list'))
+        self.assertEqual(self.boolval, b.get_attribute('bool'))
+        self.assertEqual(self.intval, b.get_attribute('integer'))
+        self.assertEqual(self.floatval, b.get_attribute('float'))
+        self.assertEqual(self.stringval, b.get_attribute('string'))
+        self.assertEqual(self.dictval, b.get_attribute('dict'))
+        self.assertEqual(self.listval, b.get_attribute('list'))
 
     def test_extra_with_reload(self):
         a = orm.Data()
@@ -729,42 +729,42 @@ class TestNodeBasic(AiidaTestCase):
         a.set_extra('list', self.listval)
 
         # Check before storing
-        self.assertEquals(self.boolval, a.get_extra('bool'))
-        self.assertEquals(self.intval, a.get_extra('integer'))
-        self.assertEquals(self.floatval, a.get_extra('float'))
-        self.assertEquals(self.stringval, a.get_extra('string'))
-        self.assertEquals(self.dictval, a.get_extra('dict'))
-        self.assertEquals(self.listval, a.get_extra('list'))
+        self.assertEqual(self.boolval, a.get_extra('bool'))
+        self.assertEqual(self.intval, a.get_extra('integer'))
+        self.assertEqual(self.floatval, a.get_extra('float'))
+        self.assertEqual(self.stringval, a.get_extra('string'))
+        self.assertEqual(self.dictval, a.get_extra('dict'))
+        self.assertEqual(self.listval, a.get_extra('list'))
 
         a.store()
 
         # Check after storing
-        self.assertEquals(self.boolval, a.get_extra('bool'))
-        self.assertEquals(self.intval, a.get_extra('integer'))
-        self.assertEquals(self.floatval, a.get_extra('float'))
-        self.assertEquals(self.stringval, a.get_extra('string'))
-        self.assertEquals(self.dictval, a.get_extra('dict'))
-        self.assertEquals(self.listval, a.get_extra('list'))
+        self.assertEqual(self.boolval, a.get_extra('bool'))
+        self.assertEqual(self.intval, a.get_extra('integer'))
+        self.assertEqual(self.floatval, a.get_extra('float'))
+        self.assertEqual(self.stringval, a.get_extra('string'))
+        self.assertEqual(self.dictval, a.get_extra('dict'))
+        self.assertEqual(self.listval, a.get_extra('list'))
 
         b = orm.load_node(uuid=a.uuid)
         self.assertIsNone(a.get_extra('none'))
-        self.assertEquals(self.boolval, b.get_extra('bool'))
-        self.assertEquals(self.intval, b.get_extra('integer'))
-        self.assertEquals(self.floatval, b.get_extra('float'))
-        self.assertEquals(self.stringval, b.get_extra('string'))
-        self.assertEquals(self.dictval, b.get_extra('dict'))
-        self.assertEquals(self.listval, b.get_extra('list'))
+        self.assertEqual(self.boolval, b.get_extra('bool'))
+        self.assertEqual(self.intval, b.get_extra('integer'))
+        self.assertEqual(self.floatval, b.get_extra('float'))
+        self.assertEqual(self.stringval, b.get_extra('string'))
+        self.assertEqual(self.dictval, b.get_extra('dict'))
+        self.assertEqual(self.listval, b.get_extra('list'))
 
     def test_get_extras_with_default(self):
         a = orm.Data()
         a.store()
         a.set_extra('a', 'b')
 
-        self.assertEquals(a.get_extra('a'), 'b')
+        self.assertEqual(a.get_extra('a'), 'b')
         with self.assertRaises(AttributeError):
             a.get_extra('c')
 
-        self.assertEquals(a.get_extra('c', 'def'), 'def')
+        self.assertEqual(a.get_extra('c', 'def'), 'def')
 
     def test_attr_and_extras_multikey(self):
         """
@@ -807,12 +807,12 @@ class TestNodeBasic(AiidaTestCase):
 
         all_extras = dict(_aiida_hash=AnyValue(), **extras_to_set)
 
-        self.assertEquals(set(list(a.attributes.keys())), set(attrs_to_set.keys()))
-        self.assertEquals(set(list(a.extras.keys())), set(all_extras.keys()))
+        self.assertEqual(set(list(a.attributes.keys())), set(attrs_to_set.keys()))
+        self.assertEqual(set(list(a.extras.keys())), set(all_extras.keys()))
 
-        self.assertEquals(a.attributes, attrs_to_set)
+        self.assertEqual(a.attributes, attrs_to_set)
 
-        self.assertEquals(a.extras, all_extras)
+        self.assertEqual(a.extras, all_extras)
 
     def test_delete_extras(self):
         """
@@ -836,7 +836,7 @@ class TestNodeBasic(AiidaTestCase):
         for k, v in extras_to_set.items():
             a.set_extra(k, v)
 
-        self.assertEquals({k: v for k, v in a.extras.items()}, all_extras)
+        self.assertEqual({k: v for k, v in a.extras.items()}, all_extras)
 
         # I pregenerate it, it cannot change during iteration
         list_keys = list(extras_to_set.keys())
@@ -845,7 +845,7 @@ class TestNodeBasic(AiidaTestCase):
             # performed correctly
             a.delete_extra(k)
             del all_extras[k]
-            self.assertEquals({k: v for k, v in a.extras.items()}, all_extras)
+            self.assertEqual({k: v for k, v in a.extras.items()}, all_extras)
 
     def test_replace_extras_1(self):
         """
@@ -888,7 +888,7 @@ class TestNodeBasic(AiidaTestCase):
         for k, v in extras_to_set.items():
             a.set_extra(k, v)
 
-        self.assertEquals(a.extras, all_extras)
+        self.assertEqual(a.extras, all_extras)
 
         for k, v in new_extras.items():
             # I delete one by one the keys and check if the operation is
@@ -898,7 +898,7 @@ class TestNodeBasic(AiidaTestCase):
         # I update extras_to_set with the new entries, and do the comparison
         # again
         all_extras.update(new_extras)
-        self.assertEquals(a.extras, all_extras)
+        self.assertEqual(a.extras, all_extras)
 
     def test_basetype_as_attr(self):
         """
@@ -987,7 +987,7 @@ class TestNodeBasic(AiidaTestCase):
             a.add_comment('text', user=user)
 
         a.store()
-        self.assertEquals(a.get_comments(), [])
+        self.assertEqual(a.get_comments(), [])
 
         before = timezone.now() - timedelta(seconds=1)
         a.add_comment('text', user=user)
@@ -1005,7 +1005,7 @@ class TestNodeBasic(AiidaTestCase):
             self.assertTrue(time > before)
             self.assertTrue(time < after)
 
-        self.assertEquals([(i.user.email, i.content) for i in comments], [
+        self.assertEqual([(i.user.email, i.content) for i in comments], [
             (self.user_email, 'text'),
             (self.user_email, 'text2'),
         ])
@@ -1029,15 +1029,15 @@ class TestNodeBasic(AiidaTestCase):
 
         # Test that the code1 can be loaded correctly with its label
         q_code_1 = orm.Code.get_from_string(code1.label)
-        self.assertEquals(q_code_1.id, code1.id)
-        self.assertEquals(q_code_1.label, code1.label)
-        self.assertEquals(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
+        self.assertEqual(q_code_1.id, code1.id)
+        self.assertEqual(q_code_1.label, code1.label)
+        self.assertEqual(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
 
         # Test that the code2 can be loaded correctly with its label
         q_code_2 = orm.Code.get_from_string(code2.label + '@' + self.computer.get_name())
-        self.assertEquals(q_code_2.id, code2.id)
-        self.assertEquals(q_code_2.label, code2.label)
-        self.assertEquals(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
+        self.assertEqual(q_code_2.id, code2.id)
+        self.assertEqual(q_code_2.label, code2.label)
+        self.assertEqual(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Calling get_from_string for a non string type raises exception
         with self.assertRaises(InputValidationError):
@@ -1076,27 +1076,27 @@ class TestNodeBasic(AiidaTestCase):
 
         # Test that the code1 can be loaded correctly with its label only
         q_code_1 = orm.Code.get(label=code1.label)
-        self.assertEquals(q_code_1.id, code1.id)
-        self.assertEquals(q_code_1.label, code1.label)
-        self.assertEquals(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
+        self.assertEqual(q_code_1.id, code1.id)
+        self.assertEqual(q_code_1.label, code1.label)
+        self.assertEqual(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
 
         # Test that the code1 can be loaded correctly with its id/pk
         q_code_1 = orm.Code.get(code1.id)
-        self.assertEquals(q_code_1.id, code1.id)
-        self.assertEquals(q_code_1.label, code1.label)
-        self.assertEquals(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
+        self.assertEqual(q_code_1.id, code1.id)
+        self.assertEqual(q_code_1.label, code1.label)
+        self.assertEqual(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
 
         # Test that the code2 can be loaded correctly with its label and computername
         q_code_2 = orm.Code.get(label=code2.label, machinename=self.computer.get_name())
-        self.assertEquals(q_code_2.id, code2.id)
-        self.assertEquals(q_code_2.label, code2.label)
-        self.assertEquals(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
+        self.assertEqual(q_code_2.id, code2.id)
+        self.assertEqual(q_code_2.label, code2.label)
+        self.assertEqual(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Test that the code2 can be loaded correctly with its id/pk
         q_code_2 = orm.Code.get(code2.id)
-        self.assertEquals(q_code_2.id, code2.id)
-        self.assertEquals(q_code_2.label, code2.label)
-        self.assertEquals(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
+        self.assertEqual(q_code_2.id, code2.id)
+        self.assertEqual(q_code_2.label, code2.label)
+        self.assertEqual(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Test that the lookup of a nonexistent code works as expected
         with self.assertRaises(NotExistent):
@@ -1123,9 +1123,9 @@ class TestNodeBasic(AiidaTestCase):
         # Code.get(pk_label_duplicate) should return code1, as the pk takes
         # precedence
         q_code_4 = orm.Code.get(code4.label)
-        self.assertEquals(q_code_4.id, code1.id)
-        self.assertEquals(q_code_4.label, code1.label)
-        self.assertEquals(q_code_4.get_remote_exec_path(), code1.get_remote_exec_path())
+        self.assertEqual(q_code_4.id, code1.id)
+        self.assertEqual(q_code_4.label, code1.label)
+        self.assertEqual(q_code_4.get_remote_exec_path(), code1.get_remote_exec_path())
 
     def test_code_description(self):
         """
@@ -1140,10 +1140,10 @@ class TestNodeBasic(AiidaTestCase):
         code.store()
 
         q_code1 = orm.Code.get(label=code.label)
-        self.assertEquals(code.description, str(q_code1.description))
+        self.assertEqual(code.description, str(q_code1.description))
 
         q_code2 = orm.Code.get(code.id)
-        self.assertEquals(code.description, str(q_code2.description))
+        self.assertEqual(code.description, str(q_code2.description))
 
     def test_list_for_plugin(self):
         """
@@ -1396,22 +1396,22 @@ class TestSubNodesAndLinks(AiidaTestCase):
         n3.store_all()
 
         n2_in_links = [(n.link_label, n.node.uuid) for n in n2.get_incoming()]
-        self.assertEquals(sorted(n2_in_links), sorted([
+        self.assertEqual(sorted(n2_in_links), sorted([
             ('l1', n1.uuid),
         ]))
         n3_in_links = [(n.link_label, n.node.uuid) for n in n3.get_incoming()]
-        self.assertEquals(sorted(n3_in_links), sorted([
+        self.assertEqual(sorted(n3_in_links), sorted([
             ('l2', n2.uuid),
             ('l3', n1.uuid),
         ]))
 
         n1_out_links = [(entry.link_label, entry.node.pk) for entry in n1.get_outgoing()]
-        self.assertEquals(sorted(n1_out_links), sorted([
+        self.assertEqual(sorted(n1_out_links), sorted([
             ('l1', n2.pk),
             ('l3', n3.pk),
         ]))
         n2_out_links = [(entry.link_label, entry.node.pk) for entry in n2.get_outgoing()]
-        self.assertEquals(sorted(n2_out_links), sorted([('l2', n3.pk)]))
+        self.assertEqual(sorted(n2_out_links), sorted([('l2', n3.pk)]))
 
     def test_multiple_create_links(self):
         """
@@ -1488,7 +1488,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
         calculation_inputs = calc.get_incoming().all()
 
         # This calculation has two data inputs
-        self.assertEquals(len(calculation_inputs), 2)
+        self.assertEqual(len(calculation_inputs), 2)
 
     def test_check_single_calc_source(self):
         """
@@ -1537,19 +1537,19 @@ class TestSubNodesAndLinks(AiidaTestCase):
         node_return.add_incoming(node_origin, link_type=LinkType.RETURN, link_label='return2')
 
         # All incoming and outgoing
-        self.assertEquals(len(node_origin.get_incoming().all()), 2)
-        self.assertEquals(len(node_origin.get_outgoing().all()), 3)
+        self.assertEqual(len(node_origin.get_incoming().all()), 2)
+        self.assertEqual(len(node_origin.get_outgoing().all()), 3)
 
         # Link specific incoming
-        self.assertEquals(len(node_origin.get_incoming(link_type=LinkType.CALL_WORK).all()), 1)
-        self.assertEquals(len(node_origin2.get_incoming(link_type=LinkType.CALL_WORK).all()), 1)
-        self.assertEquals(len(node_origin.get_incoming(link_type=LinkType.INPUT_WORK).all()), 1)
-        self.assertEquals(len(node_origin.get_incoming(link_label_filter='in_ut%').all()), 1)
-        self.assertEquals(len(node_origin.get_incoming(node_class=orm.Node).all()), 2)
+        self.assertEqual(len(node_origin.get_incoming(link_type=LinkType.CALL_WORK).all()), 1)
+        self.assertEqual(len(node_origin2.get_incoming(link_type=LinkType.CALL_WORK).all()), 1)
+        self.assertEqual(len(node_origin.get_incoming(link_type=LinkType.INPUT_WORK).all()), 1)
+        self.assertEqual(len(node_origin.get_incoming(link_label_filter='in_ut%').all()), 1)
+        self.assertEqual(len(node_origin.get_incoming(node_class=orm.Node).all()), 2)
 
         # Link specific outgoing
-        self.assertEquals(len(node_origin.get_outgoing(link_type=LinkType.CALL_WORK).all()), 1)
-        self.assertEquals(len(node_origin.get_outgoing(link_type=LinkType.RETURN).all()), 2)
+        self.assertEqual(len(node_origin.get_outgoing(link_type=LinkType.CALL_WORK).all()), 1)
+        self.assertEqual(len(node_origin.get_outgoing(link_type=LinkType.RETURN).all()), 2)
 
 
 class AnyValue:

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -530,7 +530,7 @@ def get_formula(symbol_list, mode='hill', separator=''):
         raise ValueError('Mode should be hill, hill_compact, group, ' 'reduce, count or count_compact')
 
     if mode in ['hill_compact', 'count_compact']:
-        from fractions import gcd
+        from math import gcd
         the_gcd = reduce(gcd, [e[0] for e in the_symbol_list])
         the_symbol_list = [[e[0] // the_gcd, e[1]] for e in the_symbol_list]
 

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -74,7 +74,7 @@ def run_api(flask_app, flask_api, **kwargs):
     # If the user selects the profiling option, then we need
     # to do a little extra setup
     if wsgi_profile:
-        from werkzeug.contrib.profiler import ProfilerMiddleware
+        from werkzeug.middleware.profiler import ProfilerMiddleware
 
         app.config['PROFILE'] = True
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -58,7 +58,7 @@ class NodeTranslator(BaseTranslator):
 
         # Inspect the subclasses of NodeTranslator, to avoid hard-coding
         # (should resemble the following tree)
-        """
+        r"""
                                               /- CodeTranslator
                                              /
                                             /- KpointsTranslator

--- a/aiida/schedulers/plugins/test_lsf.py
+++ b/aiida/schedulers/plugins/test_lsf.py
@@ -59,14 +59,14 @@ class TestParserBjobs(unittest.TestCase):
         # The parameters are hard coded in the text to parse
         job_on_cluster = 7
         job_parsed = len(job_list)
-        self.assertEquals(job_parsed, job_on_cluster)
+        self.assertEqual(job_parsed, job_on_cluster)
 
         job_queued = 2
         job_queue_name = ['8nm', 'test']
         job_queued_parsed = len([j for j in job_list if j.job_state and j.job_state == JobState.QUEUED])
         job_queue_name_parsed = [j.queue_name for j in job_list if j.job_state and j.job_state == JobState.QUEUED]
-        self.assertEquals(job_queued, job_queued_parsed)
-        self.assertEquals(job_queue_name, job_queue_name_parsed)
+        self.assertEqual(job_queued, job_queued_parsed)
+        self.assertEqual(job_queue_name, job_queue_name_parsed)
 
         job_done = 2
         job_done_title = ['aiida-1033269', 'test']
@@ -74,18 +74,18 @@ class TestParserBjobs(unittest.TestCase):
         job_done_parsed = len([j for j in job_list if j.job_state and j.job_state == JobState.DONE])
         job_done_title_parsed = [j.title for j in job_list if j.job_state and j.job_state == JobState.DONE]
         job_done_annotation_parsed = [j.annotation for j in job_list if j.job_state and j.job_state == JobState.DONE]
-        self.assertEquals(job_done, job_done_parsed)
-        self.assertEquals(job_done_title, job_done_title_parsed)
-        self.assertEquals(job_done_annotation, job_done_annotation_parsed)
+        self.assertEqual(job_done, job_done_parsed)
+        self.assertEqual(job_done_title, job_done_title_parsed)
+        self.assertEqual(job_done_annotation, job_done_annotation_parsed)
 
         job_running = 3
         job_running_parsed = len([j for j in job_list if j.job_state \
                                   and j.job_state == JobState.RUNNING])
-        self.assertEquals(job_running, job_running_parsed)
+        self.assertEqual(job_running, job_running_parsed)
 
         running_users = ['inewton', 'inewton', 'dbowie']
         parsed_running_users = [j.job_owner for j in job_list if j.job_state and j.job_state == JobState.RUNNING]
-        self.assertEquals(running_users, parsed_running_users)
+        self.assertEqual(running_users, parsed_running_users)
 
         running_jobs = ['764254593', '764255172', '764245175']
         num_machines = [1, 1, 1]
@@ -95,15 +95,15 @@ class TestParserBjobs(unittest.TestCase):
         parsed_allocated_machines = [
             j.allocated_machines_raw for j in job_list if j.job_state and j.job_state == JobState.RUNNING
         ]
-        self.assertEquals(running_jobs, parsed_running_jobs)
-        self.assertEquals(num_machines, parsed_num_machines)
-        self.assertEquals(allocated_machines, parsed_allocated_machines)
+        self.assertEqual(running_jobs, parsed_running_jobs)
+        self.assertEqual(num_machines, parsed_num_machines)
+        self.assertEqual(allocated_machines, parsed_allocated_machines)
 
-        self.assertEquals([j.requested_wallclock_time_seconds for j in job_list if j.job_id == '764254593'][0], 60)
-        self.assertEquals([j.wallclock_time_seconds for j in job_list if j.job_id == '764255172'][0], 9)
-        self.assertEquals([j.wallclock_time_seconds for j in job_list if j.job_id == '764245175'][0], 4785)
+        self.assertEqual([j.requested_wallclock_time_seconds for j in job_list if j.job_id == '764254593'][0], 60)
+        self.assertEqual([j.wallclock_time_seconds for j in job_list if j.job_id == '764255172'][0], 9)
+        self.assertEqual([j.wallclock_time_seconds for j in job_list if j.job_id == '764245175'][0], 4785)
         current_year = datetime.datetime.now().year
-        self.assertEquals([j.submission_time for j in job_list if j.job_id == '764245175'][0],
+        self.assertEqual([j.submission_time for j in job_list if j.job_id == '764245175'][0],
                           datetime.datetime(current_year, 12, 31, 23, 40))
 
         # Important to enable again logs!
@@ -170,7 +170,7 @@ class TestParserSubmit(unittest.TestCase):
         stdout = SUBMIT_STDOUT_TO_TEST
         stderr = ''
 
-        self.assertEquals(scheduler._parse_submit_output(retval, stdout, stderr), '764254593')
+        self.assertEqual(scheduler._parse_submit_output(retval, stdout, stderr), '764254593')
 
 
 class TestParserBkill(unittest.TestCase):

--- a/aiida/schedulers/plugins/test_pbspro.py
+++ b/aiida/schedulers/plugins/test_pbspro.py
@@ -773,32 +773,32 @@ class TestParserQstat(unittest.TestCase):
         # The parameters are hard coded in the text to parse
         job_on_cluster = 6
         job_parsed = len(job_list)
-        self.assertEquals(job_parsed, job_on_cluster)
+        self.assertEqual(job_parsed, job_on_cluster)
 
         job_running = 2
         job_running_parsed = len([j for j in job_list if j.job_state \
                                   and j.job_state == JobState.RUNNING])
-        self.assertEquals(job_running, job_running_parsed)
+        self.assertEqual(job_running, job_running_parsed)
 
         job_held = 2
         job_held_parsed = len([j for j in job_list if j.job_state \
                                and j.job_state == JobState.QUEUED_HELD])
-        self.assertEquals(job_held, job_held_parsed)
+        self.assertEqual(job_held, job_held_parsed)
 
         job_queued = 2
         job_queued_parsed = len([j for j in job_list if j.job_state \
                                  and j.job_state == JobState.QUEUED])
-        self.assertEquals(job_queued, job_queued_parsed)
+        self.assertEqual(job_queued, job_queued_parsed)
 
         running_users = ['user02', 'user3']
         parsed_running_users = [j.job_owner for j in job_list if j.job_state \
                                 and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_users), set(parsed_running_users))
+        self.assertEqual(set(running_users), set(parsed_running_users))
 
         running_jobs = ['69301.mycluster', '74164.mycluster']
         parsed_running_jobs = [j.job_id for j in job_list if j.job_state \
                                and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_jobs), set(parsed_running_jobs))
+        self.assertEqual(set(running_jobs), set(parsed_running_jobs))
 
         for j in job_list:
             if j.allocated_machines:
@@ -828,32 +828,32 @@ class TestParserQstat(unittest.TestCase):
         # The parameters are hard coded in the text to parse
         job_on_cluster = 10
         job_parsed = len(job_list)
-        self.assertEquals(job_parsed, job_on_cluster)
+        self.assertEqual(job_parsed, job_on_cluster)
 
         job_running = 2
         job_running_parsed = len([j for j in job_list if j.job_state \
                                   and j.job_state == JobState.RUNNING])
-        self.assertEquals(job_running, job_running_parsed)
+        self.assertEqual(job_running, job_running_parsed)
 
         job_held = 1
         job_held_parsed = len([j for j in job_list if j.job_state \
                                and j.job_state == JobState.QUEUED_HELD])
-        self.assertEquals(job_held, job_held_parsed)
+        self.assertEqual(job_held, job_held_parsed)
 
         job_queued = 5
         job_queued_parsed = len([j for j in job_list if j.job_state \
                                  and j.job_state == JobState.QUEUED])
-        self.assertEquals(job_queued, job_queued_parsed)
+        self.assertEqual(job_queued, job_queued_parsed)
 
         running_users = ['somebody', 'user_556491']
         parsed_running_users = [j.job_owner for j in job_list if j.job_state \
                                 and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_users), set(parsed_running_users))
+        self.assertEqual(set(running_users), set(parsed_running_users))
 
         running_jobs = ['555716', '556491']
         parsed_running_jobs = [j.job_id for j in job_list if j.job_state \
                                and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_jobs), set(parsed_running_jobs))
+        self.assertEqual(set(running_jobs), set(parsed_running_jobs))
 
         for j in job_list:
             if j.allocated_machines:
@@ -953,7 +953,7 @@ class TestSubmitScript(unittest.TestCase):
             submit_script_text = scheduler.get_submit_script(job_tmpl)
 
             # This tests if the implementation correctly chooses the default:
-            self.assertEquals(submit_script_text.split('\n')[0], expected_first_line)
+            self.assertEqual(submit_script_text.split('\n')[0], expected_first_line)
 
     def test_submit_script_with_num_cores_per_machine(self):
         """

--- a/aiida/schedulers/plugins/test_sge.py
+++ b/aiida/schedulers/plugins/test_sge.py
@@ -236,45 +236,45 @@ class TestCommand(unittest.TestCase):
         # Is job_list parsed correctly?:
         job_on_cluster = 3
         job_parsed = len(job_list)
-        self.assertEquals(job_parsed, job_on_cluster)
+        self.assertEqual(job_parsed, job_on_cluster)
 
         # Check if different job states are realized:
         job_running = 1
         job_running_parsed = len([j for j in job_list if j.job_state \
                                   and j.job_state == JobState.RUNNING])
-        self.assertEquals(job_running, job_running_parsed)
+        self.assertEqual(job_running, job_running_parsed)
 
         job_held = 1
         job_held_parsed = len([j for j in job_list if j.job_state \
                                and j.job_state == JobState.QUEUED_HELD])
-        self.assertEquals(job_held, job_held_parsed)
+        self.assertEqual(job_held, job_held_parsed)
 
         job_queued = 1
         job_queued_parsed = len([j for j in job_list if j.job_state \
                                  and j.job_state == JobState.QUEUED])
-        self.assertEquals(job_queued, job_queued_parsed)
+        self.assertEqual(job_queued, job_queued_parsed)
 
         # check if job id is recognized:
         running_jobs = ['1212299']
         parsed_running_jobs = [j.job_id for j in job_list if j.job_state \
                                and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_jobs), set(parsed_running_jobs))
+        self.assertEqual(set(running_jobs), set(parsed_running_jobs))
 
         dispatch_time = [self._parse_time_string('2013-06-18T12:08:23')]
         parsed_dispatch_time = [j.dispatch_time for j in job_list if j.dispatch_time]
-        self.assertEquals(set(dispatch_time), set(parsed_dispatch_time))
+        self.assertEqual(set(dispatch_time), set(parsed_dispatch_time))
 
         submission_times = [
             self._parse_time_string('2013-06-18T12:00:57'),
             self._parse_time_string('2013-06-18T12:09:47')
         ]
         parsed_submission_times = [j.submission_time for j in job_list if j.submission_time]
-        self.assertEquals(set(submission_times), set(parsed_submission_times))
+        self.assertEqual(set(submission_times), set(parsed_submission_times))
 
         running_jobs = [test_raw_data]
         parsed_running_jobs = [j.raw_data for j in job_list if j.job_state \
                                and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_jobs), set(parsed_running_jobs))
+        self.assertEqual(set(running_jobs), set(parsed_running_jobs))
 
         # job_list_raise=sge._parse_joblist_output(retval, \
         #                                         text_qstat_ext_urg_xml_test_raise, stderr)

--- a/aiida/schedulers/plugins/test_sge.py
+++ b/aiida/schedulers/plugins/test_sge.py
@@ -220,7 +220,7 @@ class TestCommand(unittest.TestCase):
 
         # TEST 2:
         logging.disable(logging.ERROR)
-        with self.assertRaisesRegexp(SchedulerError, '^Error during submission, retval=1'):
+        with self.assertRaisesRegex(SchedulerError, '^Error during submission, retval=1'):
             sge_parse_submit_output = sge._parse_submit_output(1, '', '')
         logging.disable(logging.NOTSET)
 

--- a/aiida/schedulers/plugins/test_torque.py
+++ b/aiida/schedulers/plugins/test_torque.py
@@ -773,32 +773,32 @@ class TestParserQstat(unittest.TestCase):
         # The parameters are hard coded in the text to parse
         job_on_cluster = 6
         job_parsed = len(job_list)
-        self.assertEquals(job_parsed, job_on_cluster)
+        self.assertEqual(job_parsed, job_on_cluster)
 
         job_running = 2
         job_running_parsed = len([j for j in job_list if j.job_state \
                                   and j.job_state == JobState.RUNNING])
-        self.assertEquals(job_running, job_running_parsed)
+        self.assertEqual(job_running, job_running_parsed)
 
         job_held = 2
         job_held_parsed = len([j for j in job_list if j.job_state \
                                and j.job_state == JobState.QUEUED_HELD])
-        self.assertEquals(job_held, job_held_parsed)
+        self.assertEqual(job_held, job_held_parsed)
 
         job_queued = 2
         job_queued_parsed = len([j for j in job_list if j.job_state \
                                  and j.job_state == JobState.QUEUED])
-        self.assertEquals(job_queued, job_queued_parsed)
+        self.assertEqual(job_queued, job_queued_parsed)
 
         running_users = ['user02', 'user3']
         parsed_running_users = [j.job_owner for j in job_list if j.job_state \
                                 and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_users), set(parsed_running_users))
+        self.assertEqual(set(running_users), set(parsed_running_users))
 
         running_jobs = ['69301.mycluster', '74164.mycluster']
         parsed_running_jobs = [j.job_id for j in job_list if j.job_state \
                                and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_jobs), set(parsed_running_jobs))
+        self.assertEqual(set(running_jobs), set(parsed_running_jobs))
 
         for j in job_list:
             if j.allocated_machines:
@@ -828,32 +828,32 @@ class TestParserQstat(unittest.TestCase):
         # The parameters are hard coded in the text to parse
         job_on_cluster = 10
         job_parsed = len(job_list)
-        self.assertEquals(job_parsed, job_on_cluster)
+        self.assertEqual(job_parsed, job_on_cluster)
 
         job_running = 2
         job_running_parsed = len([j for j in job_list if j.job_state \
                                   and j.job_state == JobState.RUNNING])
-        self.assertEquals(job_running, job_running_parsed)
+        self.assertEqual(job_running, job_running_parsed)
 
         job_held = 1
         job_held_parsed = len([j for j in job_list if j.job_state \
                                and j.job_state == JobState.QUEUED_HELD])
-        self.assertEquals(job_held, job_held_parsed)
+        self.assertEqual(job_held, job_held_parsed)
 
         job_queued = 5
         job_queued_parsed = len([j for j in job_list if j.job_state \
                                  and j.job_state == JobState.QUEUED])
-        self.assertEquals(job_queued, job_queued_parsed)
+        self.assertEqual(job_queued, job_queued_parsed)
 
         running_users = ['somebody', 'user_556491']
         parsed_running_users = [j.job_owner for j in job_list if j.job_state \
                                 and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_users), set(parsed_running_users))
+        self.assertEqual(set(running_users), set(parsed_running_users))
 
         running_jobs = ['555716', '556491']
         parsed_running_jobs = [j.job_id for j in job_list if j.job_state \
                                and j.job_state == JobState.RUNNING]
-        self.assertEquals(set(running_jobs), set(parsed_running_jobs))
+        self.assertEqual(set(running_jobs), set(parsed_running_jobs))
 
         for j in job_list:
             if j.allocated_machines:

--- a/aiida/tools/dbimporters/plugins/icsd.py
+++ b/aiida/tools/dbimporters/plugins/icsd.py
@@ -157,7 +157,7 @@ class IcsdDbImporter(DbImporter):
         # or at the end of the formula expression (no space after).
         # Be aware that one needs to check that space/beginning of line before and ideally also space/end of line
         # after, because I found that capitalization of the element name is not enforced in these queries.
-        return ' AND '.join("SUM_FORM REGEXP '(^|\ ){}[0-9\.]+($|\ )'".format(e) for e in values)
+        return ' AND '.join(r'SUM_FORM REGEXP \'(^|\ ){}[0-9\.]+($|\ )\''.format(e) for e in values)
 
     def _double_clause(self, key, alias, values, precision):
         """

--- a/aiida/tools/dbimporters/plugins/mpod.py
+++ b/aiida/tools/dbimporters/plugins/mpod.py
@@ -94,7 +94,7 @@ class MpodDbImporter(DbImporter):
         results = None
         for query in query_statements:
             response = urllib.request.urlopen(query).read()
-            this_results = re.findall('/datafiles/(\d+)\.mpod', response)
+            this_results = re.findall(r'/datafiles/(\d+)\.mpod', response)
             if results is None:
                 results = this_results
             else:

--- a/aiida/tools/dbimporters/plugins/nninc.py
+++ b/aiida/tools/dbimporters/plugins/nninc.py
@@ -74,7 +74,7 @@ class NnincDbImporter(DbImporter):
 
         query = self.query_get(**kwargs)
         response = urllib.request.urlopen(query).read()
-        results = re.findall("psp_files/([^']+)\.UPF", response)
+        results = re.findall(r'psp_files/([^\']+)\.UPF', response)
 
         elements = kwargs.get('element', None)
         if elements and not isinstance(elements, list):

--- a/aiida/tools/dbimporters/plugins/oqmd.py
+++ b/aiida/tools/dbimporters/plugins/oqmd.py
@@ -60,13 +60,13 @@ class OqmdDbImporter(DbImporter):
 
         query_statement = self.query_get(**kwargs)
         response = urllib.request.urlopen(query_statement).read()
-        entries = re.findall('(/materials/entry/\d+)', response)
+        entries = re.findall(r'(/materials/entry/\d+)', response)
 
         results = []
         for entry in entries:
             response = urllib.request.urlopen('{}{}'.format(self._query_url,
                                                      entry)).read()
-            structures = re.findall('/materials/export/conventional/cif/(\d+)',
+            structures = re.findall(r'/materials/export/conventional/cif/(\d+)',
                                     response)
             for struct in structures:
                 results.append({'id': struct})

--- a/aiida/transports/plugins/test_all_plugins.py
+++ b/aiida/transports/plugins/test_all_plugins.py
@@ -142,7 +142,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             directory = 'temp_dir_test'
             t.chdir(location)
 
-            self.assertEquals(location, t.getcwd())
+            self.assertEqual(location, t.getcwd())
             while t.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
@@ -185,7 +185,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             directory = 'temp_dir_test'
             t.chdir(location)
 
-            self.assertEquals(location, t.getcwd())
+            self.assertEqual(location, t.getcwd())
             while t.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
@@ -232,7 +232,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             directory = 'temp_dir_test'
             trans.chdir(location)
 
-            self.assertEquals(location, trans.getcwd())
+            self.assertEqual(location, trans.getcwd())
             while trans.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
@@ -291,7 +291,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             directory = 'temp_dir_test'
             trans.chdir(location)
 
-            self.assertEquals(location, trans.getcwd())
+            self.assertEqual(location, trans.getcwd())
             while trans.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
@@ -342,7 +342,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             directory = 'temp_dir_test'
             t.chdir(location)
 
-            self.assertEquals(location, t.getcwd())
+            self.assertEqual(location, t.getcwd())
             while t.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
@@ -416,13 +416,13 @@ class TestDirectoryManipulation(unittest.TestCase):
             t.chmod(directory, 0o777)
 
             # test if the security bits have changed
-            self.assertEquals(t.get_mode(directory), 0o777)
+            self.assertEqual(t.get_mode(directory), 0o777)
 
             # change permissions
             t.chmod(directory, 0o511)
 
             # test if the security bits have changed
-            self.assertEquals(t.get_mode(directory), 0o511)
+            self.assertEqual(t.get_mode(directory), 0o511)
 
             # TODO : bug in paramiko. When changing the directory to very low \
             # I cannot set it back to higher permissions
@@ -473,7 +473,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             t.chmod(directory, 0)
 
             # test if the security bits have changed
-            self.assertEquals(t.get_mode(directory), 0)
+            self.assertEqual(t.get_mode(directory), 0)
 
             old_cwd = t.getcwd()
 
@@ -482,7 +482,7 @@ class TestDirectoryManipulation(unittest.TestCase):
 
             new_cwd = t.getcwd()
 
-            self.assertEquals(old_cwd, new_cwd)
+            self.assertEqual(old_cwd, new_cwd)
 
             # TODO : the test leaves a directory even if it is successful
             #        The bug is in paramiko. After lowering the permissions,
@@ -533,7 +533,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             new_dir = t.normalize(os.path.join('/', 'tmp'))
             t.chdir(new_dir)
             t.chdir('')
-            self.assertEquals(new_dir, t.getcwd())
+            self.assertEqual(new_dir, t.getcwd())
 
 
 class TestPutGetFile(unittest.TestCase):
@@ -896,17 +896,17 @@ class TestPutGetTree(unittest.TestCase):
 
             # first test the copy. Copy of two files matching patterns, into a folder
             t.copy(os.path.join('local', '*.txt'), '.')
-            self.assertEquals(set(['a.txt', 'c.txt', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['a.txt', 'c.txt', 'local']), set(t.listdir('.')))
             t.remove('a.txt')
             t.remove('c.txt')
             # second test copy. Copy of two folders
             t.copy('local', 'prova')
-            self.assertEquals(set(['prova', 'local']), set(t.listdir('.')))
-            self.assertEquals(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir('prova')))
+            self.assertEqual(set(['prova', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir('prova')))
             t.rmtree('prova')
             # third test copy. Can copy one file into a new file
             t.copy(os.path.join('local', '*.tmp'), 'prova')
-            self.assertEquals(set(['prova', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['prova', 'local']), set(t.listdir('.')))
             t.remove('prova')
             # fourth test copy: can't copy more than one file on the same file,
             # i.e., the destination should be a folder
@@ -915,7 +915,7 @@ class TestPutGetTree(unittest.TestCase):
             # fifth test, copying one file into a folder
             t.mkdir('prova')
             t.copy(os.path.join('local', 'a.txt'), 'prova')
-            self.assertEquals(set(t.listdir('prova')), set(['a.txt']))
+            self.assertEqual(set(t.listdir('prova')), set(['a.txt']))
             t.rmtree('prova')
             # sixth test, copying one file into a file
             t.copy(os.path.join('local', 'a.txt'), 'prova')
@@ -926,8 +926,8 @@ class TestPutGetTree(unittest.TestCase):
             #tests performed locally on a Mac may result in a failure.
             t.mkdir('prova')
             t.copy('local', 'prova')
-            self.assertEquals(set(['local']), set(t.listdir('prova')))
-            self.assertEquals(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir(os.path.join('prova', 'local'))))
+            self.assertEqual(set(['local']), set(t.listdir('prova')))
+            self.assertEqual(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir(os.path.join('prova', 'local'))))
             t.rmtree('prova')
             # exit
             t.chdir('..')
@@ -969,24 +969,24 @@ class TestPutGetTree(unittest.TestCase):
 
             # first test put. Copy of two files matching patterns, into a folder
             t.put(os.path.join(local_base_dir, '*.txt'), '.')
-            self.assertEquals(set(['a.txt', 'c.txt', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['a.txt', 'c.txt', 'local']), set(t.listdir('.')))
             t.remove('a.txt')
             t.remove('c.txt')
             # second. Copy of folder into a non existing folder
             t.put(local_base_dir, 'prova')
-            self.assertEquals(set(['prova', 'local']), set(t.listdir('.')))
-            self.assertEquals(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir('prova')))
+            self.assertEqual(set(['prova', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir('prova')))
             t.rmtree('prova')
             # third. copy of folder into an existing folder
             t.mkdir('prova')
             t.put(local_base_dir, 'prova')
-            self.assertEquals(set(['prova', 'local']), set(t.listdir('.')))
-            self.assertEquals(set(['local']), set(t.listdir('prova')))
-            self.assertEquals(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir(os.path.join('prova', 'local'))))
+            self.assertEqual(set(['prova', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['local']), set(t.listdir('prova')))
+            self.assertEqual(set(['a.txt', 'b.tmp', 'c.txt']), set(t.listdir(os.path.join('prova', 'local'))))
             t.rmtree('prova')
             # third test copy. Can copy one file into a new file
             t.put(os.path.join(local_base_dir, '*.tmp'), 'prova')
-            self.assertEquals(set(['prova', 'local']), set(t.listdir('.')))
+            self.assertEqual(set(['prova', 'local']), set(t.listdir('.')))
             t.remove('prova')
             # fourth test copy: can't copy more than one file on the same file,
             # i.e., the destination should be a folder
@@ -1001,7 +1001,7 @@ class TestPutGetTree(unittest.TestCase):
             # fifth test, copying one file into a folder
             t.mkdir('prova')
             t.put(os.path.join(local_base_dir, 'a.txt'), 'prova')
-            self.assertEquals(set(t.listdir('prova')), set(['a.txt']))
+            self.assertEqual(set(t.listdir('prova')), set(['a.txt']))
             t.rmtree('prova')
             # sixth test, copying one file into a file
             t.put(os.path.join(local_base_dir, 'a.txt'), 'prova')
@@ -1049,26 +1049,26 @@ class TestPutGetTree(unittest.TestCase):
 
             # first test put. Copy of two files matching patterns, into a folder
             t.get(os.path.join('local', '*.txt'), local_destination)
-            self.assertEquals(set(['a.txt', 'c.txt', 'local']), set(os.listdir(local_destination)))
+            self.assertEqual(set(['a.txt', 'c.txt', 'local']), set(os.listdir(local_destination)))
             os.remove(os.path.join(local_destination, 'a.txt'))
             os.remove(os.path.join(local_destination, 'c.txt'))
             # second. Copy of folder into a non existing folder
             t.get('local', os.path.join(local_destination, 'prova'))
-            self.assertEquals(set(['prova', 'local']), set(os.listdir(local_destination)))
-            self.assertEquals(
+            self.assertEqual(set(['prova', 'local']), set(os.listdir(local_destination)))
+            self.assertEqual(
                 set(['a.txt', 'b.tmp', 'c.txt']), set(os.listdir(os.path.join(local_destination, 'prova'))))
             shutil.rmtree(os.path.join(local_destination, 'prova'))
             # third. copy of folder into an existing folder
             os.mkdir(os.path.join(local_destination, 'prova'))
             t.get('local', os.path.join(local_destination, 'prova'))
-            self.assertEquals(set(['prova', 'local']), set(os.listdir(local_destination)))
-            self.assertEquals(set(['local']), set(os.listdir(os.path.join(local_destination, 'prova'))))
-            self.assertEquals(
+            self.assertEqual(set(['prova', 'local']), set(os.listdir(local_destination)))
+            self.assertEqual(set(['local']), set(os.listdir(os.path.join(local_destination, 'prova'))))
+            self.assertEqual(
                 set(['a.txt', 'b.tmp', 'c.txt']), set(os.listdir(os.path.join(local_destination, 'prova', 'local'))))
             shutil.rmtree(os.path.join(local_destination, 'prova'))
             # third test copy. Can copy one file into a new file
             t.get(os.path.join('local', '*.tmp'), os.path.join(local_destination, 'prova'))
-            self.assertEquals(set(['prova', 'local']), set(os.listdir(local_destination)))
+            self.assertEqual(set(['prova', 'local']), set(os.listdir(local_destination)))
             os.remove(os.path.join(local_destination, 'prova'))
             # fourth test copy: can't copy more than one file on the same file,
             # i.e., the destination should be a folder
@@ -1083,7 +1083,7 @@ class TestPutGetTree(unittest.TestCase):
             # fifth test, copying one file into a folder
             os.mkdir(os.path.join(local_destination, 'prova'))
             t.get(os.path.join('local', 'a.txt'), os.path.join(local_destination, 'prova'))
-            self.assertEquals(set(os.listdir(os.path.join(local_destination, 'prova'))), set(['a.txt']))
+            self.assertEqual(set(os.listdir(os.path.join(local_destination, 'prova'))), set(['a.txt']))
             shutil.rmtree(os.path.join(local_destination, 'prova'))
             # sixth test, copying one file into a file
             t.get(os.path.join('local', 'a.txt'), os.path.join(local_destination, 'prova'))
@@ -1279,12 +1279,12 @@ class TestExecuteCommandWait(unittest.TestCase):
             self.assertTrue(t.isdir(subfolder))
             t.chdir(subfolder)
 
-            self.assertEquals(subfolder_fullpath, t.getcwd())
+            self.assertEqual(subfolder_fullpath, t.getcwd())
             retcode, stdout, stderr = t.exec_command_wait('pwd')
-            self.assertEquals(retcode, 0)
+            self.assertEqual(retcode, 0)
             # I have to strip it because 'pwd' returns a trailing \n
-            self.assertEquals(stdout.strip(), subfolder_fullpath)
-            self.assertEquals(stderr, '')
+            self.assertEqual(stdout.strip(), subfolder_fullpath)
+            self.assertEqual(stderr, '')
 
             if delete_at_end:
                 t.chdir(location)
@@ -1295,18 +1295,18 @@ class TestExecuteCommandWait(unittest.TestCase):
         test_string = str('some_test String')
         with custom_transport as t:
             retcode, stdout, stderr = t.exec_command_wait('cat', stdin=test_string)
-            self.assertEquals(retcode, 0)
-            self.assertEquals(stdout, test_string)
-            self.assertEquals(stderr, '')
+            self.assertEqual(retcode, 0)
+            self.assertEqual(stdout, test_string)
+            self.assertEqual(stderr, '')
 
     @run_for_all_plugins
     def test_exec_with_stdin_unicode(self, custom_transport):
         test_string = 'some_test String'
         with custom_transport as t:
             retcode, stdout, stderr = t.exec_command_wait('cat', stdin=test_string)
-            self.assertEquals(retcode, 0)
-            self.assertEquals(stdout, test_string)
-            self.assertEquals(stderr, '')
+            self.assertEqual(retcode, 0)
+            self.assertEqual(stdout, test_string)
+            self.assertEqual(stderr, '')
 
     @run_for_all_plugins
     def test_exec_with_stdin_filelike(self, custom_transport):
@@ -1315,9 +1315,9 @@ class TestExecuteCommandWait(unittest.TestCase):
         stdin = io.StringIO(test_string)
         with custom_transport as t:
             retcode, stdout, stderr = t.exec_command_wait('cat', stdin=stdin)
-            self.assertEquals(retcode, 0)
-            self.assertEquals(stdout, test_string)
-            self.assertEquals(stderr, '')
+            self.assertEqual(retcode, 0)
+            self.assertEqual(stdout, test_string)
+            self.assertEqual(stderr, '')
 
     @run_for_all_plugins
     def test_exec_with_wrong_stdin(self, custom_transport):

--- a/aiida/transports/plugins/test_local.py
+++ b/aiida/transports/plugins/test_local.py
@@ -25,7 +25,7 @@ class TestGeneric(unittest.TestCase):
         import getpass
 
         with LocalTransport() as t:
-            self.assertEquals(t.whoami(), getpass.getuser())
+            self.assertEqual(t.whoami(), getpass.getuser())
 
 
 class TestBasicConnection(unittest.TestCase):

--- a/docs/source/developer_guide/plugins/basics.rst
+++ b/docs/source/developer_guide/plugins/basics.rst
@@ -66,7 +66,6 @@ What a plugin can do
   - db importers
   - db exporters
   - subcommands to some ``verdi`` commands
-  - tests to be run using ``verdi devel tests``
 
   This typically involves subclassing the respective base class AiiDA provides for that purpose.
 * Install separate commandline and/or GUI executables

--- a/docs/source/developer_guide/plugins/plugin_tests.rst
+++ b/docs/source/developer_guide/plugins/plugin_tests.rst
@@ -215,8 +215,4 @@ Thus, the conversion to ``pytest`` can look as follows:
 
 For more details on running ``unittest`` cases through pytest, see the `pytest documentation`_.
 
-.. note::
-  This modification will break the compatibility with aiida-core's testing framework and the ``verdi devel tests`` interface.
-  If you were using this interface, do not forget to remove the corresponding entry points from your ``setup.json``.
-
 .. _pytest documentation: https://docs.pytest.org/en/latest/unittest.html

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,9 @@
 [pytest]
 testpaths = aiida
+filterwarnings =
+    ignore::DeprecationWarning:babel:
+    ignore::DeprecationWarning:django:
+    ignore::DeprecationWarning:frozendict:
+    ignore::DeprecationWarning:sqlalchemy:
+    ignore::DeprecationWarning:yaml:
+    ignore::DeprecationWarning:pymatgen:

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ filterwarnings =
     ignore::DeprecationWarning:sqlalchemy:
     ignore::DeprecationWarning:yaml:
     ignore::DeprecationWarning:pymatgen:
+    ignore::DeprecationWarning:jsonbackend:


### PR DESCRIPTION
starts to address #3659 

 * Updates docs for pytest.
 * Brings pytest warnings [from 423](https://github.com/aiidateam/aiida-core/runs/349411377#step:9:1697) [down to 31](https://github.com/aiidateam/aiida-core/pull/3674/checks?check_run_id=349781026#step:9:1827):
   * fix usage of deprecated unittest api
   * fix tests skipped because of `__init__` constructor
   * fix classes incorrectly identified as tests
   * fix deprecated usage of external modules
   * fix incorrect escape sequences in regular expressions
   * ignore unnecessary warnings from external packages
     **Note:** this could be made more flexible (e.g. narrowing down filters), since such warnings can sometimes be useful, e.g. if we are using a deprecated API of the package (say, django). Most of the time, it is the external package that is using some deprecated API.
 * adds [individual test timings](https://github.com/aiidateam/aiida-core/pull/3674/checks?check_run_id=349781026#step:9:323)

Note: These are the slowest tests, all of which would be good to speed up
```
  Run test suite15m 15s
0.48s call     aiida/backends/tests/engine/test_process_function.py::TestProcessFunction::test_function_default_label
-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================ slowest test durations ============================
22.95s call     aiida/backends/tests/tools/importexport/orm/test_links.py::TestLinks::test_high_level_workflow_links
10.74s call     aiida/backends/tests/tools/importexport/orm/test_links.py::TestLinks::test_complex_workflow_graph_export_sets
8.51s call     aiida/backends/tests/tools/importexport/orm/test_links.py::TestLinks::test_link_flags
8.01s call     aiida/backends/tests/test_nodes.py::TestNodeDeletion::test_delete_cases
5.95s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestDuplicateNodeUuidMigration::test_deduplicated_uuids
5.60s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestUuidMigration::test_uuid_untouched
5.52s call     aiida/backends/tests/engine/test_rmq.py::TestProcessControl::test_launch_with_inputs
5.44s call     aiida/backends/tests/engine/test_rmq.py::TestProcessControl::test_exception_process
5.38s call     aiida/backends/tests/engine/test_rmq.py::TestProcessControl::test_submit_simple
5.37s call     aiida/backends/tests/engine/test_futures.py::TestWf::test_calculation_future_broadcasts
4.31s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestCalcAttributeKeysMigration::test_attribute_key_changes
4.22s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestDbLogMigrationBackward::test_objpk_objname
4.19s call     aiida/cmdline/utils/test_multiline.py::TestMultilineInput::test_edit_comment
4.08s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestGroupRenamingMigration::test_group_string_update
4.05s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestDbLogMigrationRecordCleaning::test_dblog_unique_uuids
4.04s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestDbLogMigrationRecordCleaning::test_dblog_calculation_node
4.03s call     aiida/backends/djsite/db/subtests/migrations/test_migrations_many.py::TestDbLogMigrationRecordCleaning::test_dblog_correct_export_of_logs
4.01s call     aiida/backends/djsite/db/subtests/migrations/test_migration
```