### PR TITLE
Skip documenting the outline if it is None

### DIFF
--- a/aiida/sphinxext/process.py
+++ b/aiida/sphinxext/process.py
@@ -116,7 +116,8 @@ class AiidaProcessDirective(Directive):
 
         if hasattr(self.process_spec, 'get_outline'):
             outline = self.process_spec.get_outline()
-            content += self.build_outline_doctree(outline=outline)
+            if outline is not None:
+                content += self.build_outline_doctree(outline=outline)
         return content
 
     def build_doctree(self, title, port_namespace):

--- a/aiida/sphinxext/tests/demo_workchain.py
+++ b/aiida/sphinxext/tests/demo_workchain.py
@@ -62,5 +62,17 @@ class DemoWorkChain(WorkChain):  # pylint: disable=abstract-method
         pass
 
 
+class EmptyOutlineWorkChain(WorkChain):  # pylint: disable=abstract-method
+    """
+    Here we check that the directive works even if the outline is empty.
+    """
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        spec.input('x', valid_type=Float, help='First input argument.')
+
+
 class NormalClass:  # pylint: disable=too-few-public-methods
     """This is here to check that we didn't break the regular autoclass."""

--- a/aiida/sphinxext/tests/reference_results/workchain.xml
+++ b/aiida/sphinxext/tests/reference_results/workchain.xml
@@ -57,6 +57,17 @@ while(some_check)
 finalize</literal_block></paragraph>
             </desc_content>
         </desc>
+        <paragraph>The following workchain checks that the directive works also when no outline is specified:</paragraph>
+        <desc desctype="class" domain="py" noindex="False" objtype="class">
+            <desc_signature first="False" fullname="WorkChain"><desc_annotation xml:space="preserve">workchain</desc_annotation><desc_addname xml:space="preserve">demo_workchain.</desc_addname><desc_name xml:space="preserve">EmptyOutlineWorkChain</desc_name></desc_signature>
+            <desc_content>
+                <paragraph>
+                        Here we check that the directive works even if the outline is empty.
+                        </paragraph>
+                <paragraph><strong>Inputs:</strong><bullet_list bullet="*"><list_item><literal_strong>metadata</literal_strong>, <emphasis>Namespace</emphasis><details opened="False"><summary>Namespace Ports</summary><bullet_list bullet="*"><list_item><literal_strong>call_link_label</literal_strong>, <emphasis>str</emphasis>, optional, <emphasis>non_db</emphasis> – The label to use for the <title_reference>CALL</title_reference> link if the process is called by another process.</list_item><list_item><literal_strong>description</literal_strong>, <emphasis>str</emphasis>, optional, <emphasis>non_db</emphasis> – Description to set on the process node.</list_item><list_item><literal_strong>label</literal_strong>, <emphasis>str</emphasis>, optional, <emphasis>non_db</emphasis> – Label to set on the process node.</list_item><list_item><literal_strong>store_provenance</literal_strong>, <emphasis>bool</emphasis>, optional, <emphasis>non_db</emphasis> – If set to <title_reference>False</title_reference> provenance will not be stored in the database.</list_item></bullet_list></details></list_item><list_item><literal_strong>x</literal_strong>, <emphasis>Float</emphasis>, required – First input argument.</list_item></bullet_list></paragraph>
+                <paragraph><strong>Outputs:</strong><paragraph>None defined.</paragraph></paragraph>
+            </desc_content>
+        </desc>
         <paragraph>The command is also hooked into <literal>sphinx.ext.autodoc</literal>, so AiiDA processes will be properly documented using <literal>.. automodule::</literal> as well.</paragraph>
         <target ids="module-demo_workchain" ismod="True"></target>
         <index entries="['single',\ 'demo_workchain\ (module)',\ 'module-demo_workchain',\ '',\ None]"></index>
@@ -66,6 +77,13 @@ finalize</literal_block></paragraph>
             <desc_signature class="" first="False" fullname="DemoWorkChain" ids="demo_workchain.DemoWorkChain" module="demo_workchain" names="demo_workchain.DemoWorkChain"><desc_annotation xml:space="preserve">class </desc_annotation><desc_addname xml:space="preserve">demo_workchain.</desc_addname><desc_name xml:space="preserve">DemoWorkChain</desc_name><desc_parameterlist xml:space="preserve"><desc_parameter xml:space="preserve">inputs=None</desc_parameter><desc_parameter xml:space="preserve">logger=None</desc_parameter><desc_parameter xml:space="preserve">runner=None</desc_parameter><desc_parameter xml:space="preserve">enable_persistence=True</desc_parameter></desc_parameterlist></desc_signature>
             <desc_content>
                 <paragraph>A demo workchain to show how the workchain auto-documentation works.</paragraph>
+            </desc_content>
+        </desc>
+        <index entries="['single',\ 'EmptyOutlineWorkChain\ (class\ in\ demo_workchain)',\ 'demo_workchain.EmptyOutlineWorkChain',\ '',\ None]"></index>
+        <desc desctype="class" domain="py" noindex="False" objtype="class">
+            <desc_signature class="" first="False" fullname="EmptyOutlineWorkChain" ids="demo_workchain.EmptyOutlineWorkChain" module="demo_workchain" names="demo_workchain.EmptyOutlineWorkChain"><desc_annotation xml:space="preserve">class </desc_annotation><desc_addname xml:space="preserve">demo_workchain.</desc_addname><desc_name xml:space="preserve">EmptyOutlineWorkChain</desc_name><desc_parameterlist xml:space="preserve"><desc_parameter xml:space="preserve">inputs=None</desc_parameter><desc_parameter xml:space="preserve">logger=None</desc_parameter><desc_parameter xml:space="preserve">runner=None</desc_parameter><desc_parameter xml:space="preserve">enable_persistence=True</desc_parameter></desc_parameterlist></desc_signature>
+            <desc_content>
+                <paragraph>Here we check that the directive works even if the outline is empty.</paragraph>
             </desc_content>
         </desc>
         <index entries="['single',\ 'NormalClass\ (class\ in\ demo_workchain)',\ 'demo_workchain.NormalClass',\ '',\ None]"></index>

--- a/aiida/sphinxext/tests/workchain_source/index.rst
+++ b/aiida/sphinxext/tests/workchain_source/index.rst
@@ -24,6 +24,11 @@ The namespaces can be set to expand by default, using the ``:expand-namespaces:`
     :module: demo_workchain
     :expand-namespaces:
 
+The following workchain checks that the directive works also when no outline is specified:
+
+.. aiida-workchain:: EmptyOutlineWorkChain
+    :module: demo_workchain
+
 The command is also hooked into ``sphinx.ext.autodoc``, so AiiDA processes will be properly documented using ``.. automodule::`` as well.
 
 .. automodule:: demo_workchain


### PR DESCRIPTION
If no outline is created in the `define` method, `get_outline` will return `None`. Previously, this led to an error in the sphinx directive. This is fixed by explicitly checking for `None`.

This error occurred in an 'abstract base' workchain that does not implement an outline itself, but is still documented.