### PR TITLE
Update `prospector` to the latest version `v1.2.0`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation,no-else-raise
+disable=bad-continuation,locally-disabled,useless-suppression,django-not-available,bad-option-value,logging-format-interpolation,no-else-raise,import-outside-toplevel
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -9,12 +9,11 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module that contains the db migrations."""
-
 from django.core.exceptions import ObjectDoesNotExist
-from aiida.common.exceptions import AiidaException, DbContentError
 
 from aiida.backends.manager import SCHEMA_VERSION_KEY, SCHEMA_VERSION_DESCRIPTION
 from aiida.backends.manager import SCHEMA_GENERATION_KEY, SCHEMA_GENERATION_DESCRIPTION
+from aiida.common.exceptions import AiidaException, DbContentError
 
 
 class DeserializationException(AiidaException):
@@ -92,8 +91,6 @@ def current_schema_version():
 
 def _deserialize_basic_type(mainitem):
     """Deserialize the basic python data types."""
-    from aiida.common.timezone import (is_naive, make_aware, get_current_timezone)
-
     if mainitem['datatype'] == 'none':
         return None
     if mainitem['datatype'] == 'bool':

--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -224,9 +224,9 @@ class TestVerdiCalculation(AiidaTestCase):
         for job in calculations:
             if job[0].uuid == self.arithmetic_job.uuid:
                 continue
-            else:
-                add_job = job[0]
-                return
+
+            add_job = job[0]
+            return
 
         # Make sure add_job does not specify options 'input_filename' and 'output_filename'
         self.assertIsNone(

--- a/aiida/backends/tests/manage/backup/test_backup_setup_script.py
+++ b/aiida/backends/tests/manage/backup/test_backup_setup_script.py
@@ -105,7 +105,7 @@ class TestBackupSetupScriptIntegration(AiidaTestCase):
                 backup_setup.BackupSetup().run()
 
             # Get the backup configuration files & dirs
-            backup_conf_records = [f for f in os.listdir(temp_aiida_folder)]
+            backup_conf_records = os.listdir(temp_aiida_folder)
             # Check if all files & dirs are there
             self.assertTrue(
                 backup_conf_records is not None and len(backup_conf_records) == 4 and

--- a/aiida/backends/tests/tools/importexport/orm/test_links.py
+++ b/aiida/backends/tests/tools/importexport/orm/test_links.py
@@ -301,7 +301,7 @@ class TestLinks(AiidaTestCase):
                 export_target_uuids, imported_node_uuids,
                 'Problem in comparison of export node: ' + export_node_str + '\n' + 'Expected set: ' +
                 str(export_target_uuids) + '\n' + 'Imported set: ' + str(imported_node_uuids) + '\n' + 'Difference: ' +
-                str([_ for _ in export_target_uuids.symmetric_difference(imported_node_uuids)])
+                str(export_target_uuids.symmetric_difference(imported_node_uuids))
             )
 
     @with_temp_dir

--- a/aiida/backends/tests/tools/importexport/test_complex.py
+++ b/aiida/backends/tests/tools/importexport/test_complex.py
@@ -200,7 +200,7 @@ class TestComplex(AiidaTestCase):
             group = orm.Group.get(label=grouplabel)
             # exporting based on all members of the group
             # this also checks if group memberships are preserved!
-            export([group] + [n for n in group.nodes], outfile=filename, silent=True)
+            export([group] + list(group.nodes), outfile=filename, silent=True)
             # cleaning the DB!
             self.clean_db()
             self.create_user()

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -291,7 +291,6 @@ def start_circus(foreground, number):
 
     while should_restart:
         try:
-            arbiter = arbiter
             future = arbiter.start()
             should_restart = False
             if check_future_exception_and_log(future) is None:

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -212,11 +212,11 @@ class InteractiveOption(ConditionalOption):
                 # dispatch - e.g. show help
                 self._ctrl[value]()
                 continue
-            else:
-                # try to convert, if unsuccessful continue prompting
-                successful, value = self.safely_convert(value, param, ctx)
-                if successful:
-                    return value
+
+            # try to convert, if unsuccessful continue prompting
+            successful, value = self.safely_convert(value, param, ctx)
+            if successful:
+                return value
 
     def after_callback(self, ctx, param, value):
         """If a callback was registered on init, call it and return it's value."""

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -275,7 +275,7 @@ def _(folder, **kwargs):
                     yield digest
                 yield _END_DIGEST
 
-    return [_single_digest('folder')] + [d for d in folder_digests(folder)]
+    return [_single_digest('folder')] + list(folder_digests(folder))
 
 
 def float_to_text(value, sig):

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -642,7 +642,8 @@ class Process(plumpy.Process):
         for name, metadata in self.metadata.items():
             if name in ['store_provenance', 'dry_run', 'call_link_label']:
                 continue
-            elif name == 'label':
+
+            if name == 'label':
                 self.node.label = metadata
             elif name == 'description':
                 self.node.description = metadata

--- a/aiida/orm/implementation/django/querybuilder.py
+++ b/aiida/orm/implementation/django/querybuilder.py
@@ -365,7 +365,7 @@ class DjangoQueryBuilder(BackendQueryBuilder):
         """
         entity = self.get_column(column_name, alias)[attrpath]
         if cast is None:
-            entity = entity
+            pass
         elif cast == 'f':
             entity = entity.astext.cast(Float)
         elif cast == 'i':

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -30,8 +30,8 @@ class BackendGroup(backends.BackendEntity):
         :return: the name of the group as a string
         """
 
-    @abc.abstractproperty
     @label.setter
+    @abc.abstractmethod
     def label(self, name):
         """
         Attempt to change the name of the group instance. If the group is already stored
@@ -140,7 +140,7 @@ class BackendGroup(backends.BackendEntity):
         the number of nodes in the group using len().
         """
 
-    @abc.abstractproperty
+    @abc.abstractmethod
     def count(self):
         """Return the number of entities in this group.
 

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -35,7 +35,7 @@ class BackendQueryBuilder:
         self.inner_to_outer_schema = dict()
         self.outer_to_inner_schema = dict()
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def Node(self):
         """
         Decorated as a property, returns the implementation for DbNode.
@@ -43,49 +43,49 @@ class BackendQueryBuilder:
         a corresponding dummy-model  must be written.
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def Link(self):
         """
         A property, decorated with @property. Returns the implementation for the DbLink
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def Computer(self):
         """
         A property, decorated with @property. Returns the implementation for the Computer
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def User(self):
         """
         A property, decorated with @property. Returns the implementation for the User
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def Group(self):
         """
         A property, decorated with @property. Returns the implementation for the Group
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def AuthInfo(self):
         """
         A property, decorated with @property. Returns the implementation for the AuthInfo
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def Comment(self):
         """
         A property, decorated with @property. Returns the implementation for the Comment
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def Log(self):
         """
         A property, decorated with @property. Returns the implementation for the Log
         """
 
-    @abc.abstractmethod
+    @abc.abstractproperty
     def table_groups_nodes(self):
         """
         A property, decorated with @property. Returns the implementation for the many-to-many

--- a/aiida/orm/implementation/sqlalchemy/querybuilder.py
+++ b/aiida/orm/implementation/sqlalchemy/querybuilder.py
@@ -380,7 +380,7 @@ class SqlaQueryBuilder(BackendQueryBuilder):
         """
         entity = self.get_column(column_name, alias)[attrpath]
         if cast is None:
-            entity = entity
+            pass
         elif cast == 'f':
             entity = entity.astext.cast(Float)
         elif cast == 'i':

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -583,7 +583,8 @@ class SlurmScheduler(Scheduler):
             this_job.queue_name = thisjob_dict['partition']
 
             try:
-                this_job.requested_wallclock_time_seconds = (self._convert_time(thisjob_dict['time_limit']))  # pylint: disable=invalid-name
+                walltime = (self._convert_time(thisjob_dict['time_limit']))
+                this_job.requested_wallclock_time_seconds = walltime  # pylint: disable=invalid-name
             except ValueError:
                 self.logger.warning('Error parsing the time limit for job id {}'.format(this_job.job_id))
 

--- a/aiida/schedulers/plugins/test_slurm.py
+++ b/aiida/schedulers/plugins/test_slurm.py
@@ -73,7 +73,7 @@ class TestParserSqueue(unittest.TestCase):
         parsed_running_jobs = [j.job_id for j in job_list if j.job_state and j.job_state == JobState.RUNNING]
         self.assertEqual(set(JOBS_RUNNING), set(parsed_running_jobs))
 
-        self.assertEqual(job_dict['863553'].requested_wallclock_time_seconds, 30 * 60)
+        self.assertEqual(job_dict['863553'].requested_wallclock_time_seconds, 30 * 60)  # pylint: disable=invalid-name
         self.assertEqual(job_dict['863553'].wallclock_time_seconds, 29 * 60 + 29)
         self.assertEqual(job_dict['863553'].dispatch_time, datetime.datetime(2013, 5, 23, 11, 44, 11))
         self.assertEqual(job_dict['863553'].submission_time, datetime.datetime(2013, 5, 23, 10, 42, 11))
@@ -85,7 +85,7 @@ class TestParserSqueue(unittest.TestCase):
 
         self.assertEqual(job_dict['861352'].title, 'Pressure_PBEsol_0')
 
-        self.assertEqual(job_dict['863554'].requested_wallclock_time_seconds, None)  # not set
+        self.assertEqual(job_dict['863554'].requested_wallclock_time_seconds, None)  # pylint: disable=invalid-name
 
         # allocated_machines is not implemented in this version of the plugin
         #        for j in job_list:

--- a/aiida/sphinxext/tests/conftest.py
+++ b/aiida/sphinxext/tests/conftest.py
@@ -44,7 +44,7 @@ def build_sphinx(build_dir):  # pylint: disable=redefined-outer-name
         doctree_dir = os.path.join(build_dir, 'doctrees')
         out_dir = os.path.join(build_dir, builder)
 
-        completed_proc = subprocess.run(
+        completed_proc = subprocess.run(  # pylint: disable=subprocess-run-check
             [sys.executable, '-m', 'sphinx', '-b', builder, '-d', doctree_dir, source_dir, out_dir],
             # add demo_workchain.py to the PYTHONPATH
             cwd=os.path.join(source_dir, os.pardir),

--- a/aiida/tools/dbimporters/plugins/materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/materialsproject.py
@@ -81,7 +81,6 @@ class MaterialsProjectImporter(DbImporter):
         """
         return self._properties
 
-    @property
     def get_supported_keywords(self):
         """
         Returns the list of all supported query keywords

--- a/aiida/tools/importexport/dbexport/utils.py
+++ b/aiida/tools/importexport/dbexport/utils.py
@@ -412,9 +412,9 @@ def retrieve_linked_nodes(process_nodes, data_nodes, **kwargs):  # pylint: disab
             # If it is already visited continue to the next node
             if current_node_pk in retrieved_nodes:
                 continue
+
             # Otherwise say that it is a node to be exported
-            else:
-                retrieved_nodes.add(current_node_pk)
+            retrieved_nodes.add(current_node_pk)
 
             # INPUT_CALC(Data, CalculationNode) - Backward
             if traversal_rules['input_calc_backward']:
@@ -518,9 +518,9 @@ def retrieve_linked_nodes(process_nodes, data_nodes, **kwargs):  # pylint: disab
             # If it is already visited continue to the next node
             if current_node_pk in retrieved_nodes:
                 continue
+
             # Otherwise say that it is a node to be exported
-            else:
-                retrieved_nodes.add(current_node_pk)
+            retrieved_nodes.add(current_node_pk)
 
             # INPUT_CALC(Data, CalculationNode) - Forward
             if traversal_rules['input_calc_forward']:

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -530,13 +530,10 @@ def import_data_dj(
                 except KeyError:
                     if ignore_unknown_nodes:
                         continue
-                    else:
-                        raise exceptions.ImportValidationError(
-                            'Trying to create a link with one or both unknown nodes, stopping (in_uuid={}, '
-                            'out_uuid={}, label={}, type={})'.format(
-                                link['input'], link['output'], link['label'], link['type']
-                            )
-                        )
+                    raise exceptions.ImportValidationError(
+                        'Trying to create a link with one or both unknown nodes, stopping (in_uuid={}, out_uuid={}, '
+                        'label={}, type={})'.format(link['input'], link['output'], link['label'], link['type'])
+                    )
 
                 # Check if link already exists, skip if it does
                 # This is equivalent to an existing triple link (i.e. unique_triple from below)

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -591,13 +591,10 @@ def import_data_sqla(
                 except KeyError:
                     if ignore_unknown_nodes:
                         continue
-                    else:
-                        raise exceptions.ImportValidationError(
-                            'Trying to create a link with one or both unknown nodes, stopping (in_uuid={}, '
-                            'out_uuid={}, label={}, type={})'.format(
-                                link['input'], link['output'], link['label'], link['type']
-                            )
-                        )
+                    raise exceptions.ImportValidationError(
+                        'Trying to create a link with one or both unknown nodes, stopping (in_uuid={}, out_uuid={}, '
+                        'label={}, type={})'.format(link['input'], link['output'], link['label'], link['type'])
+                    )
 
                 # Since backend specific Links (DbLink) are not validated upon creation, we will now validate them.
                 source = QueryBuilder().append(Node, filters={'id': in_id}, project='*').first()[0]

--- a/aiida/tools/importexport/migration/v06_to_v07.py
+++ b/aiida/tools/importexport/migration/v06_to_v07.py
@@ -73,10 +73,10 @@ def migration_data_migration_legacy_process_attributes(data):
                     uuid_pk = data['export_data']['Node'][node_pk].get('uuid', node_pk)
                     illegal_cases.append([uuid_pk, process_state])
                     continue  # No reason to do more now
-                else:
-                    # Either the ProcessNode is in a non-active state or its 'process_state' hasn't been set.
-                    # In both cases we claim the ProcessNode 'sealed' and make it importable.
-                    content['sealed'] = True
+
+                # Either the ProcessNode is in a non-active state or its 'process_state' hasn't been set.
+                # In both cases we claim the ProcessNode 'sealed' and make it importable.
+                content['sealed'] = True
 
                 # Remove attributes
                 for attr in attrs_to_remove:

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -52,9 +52,7 @@ def configure_computer_main(computer, user, **kwargs):
 
 def common_params(command_func):
     """Decorate a command function with common click parameters for all transport plugins."""
-    params = [i for i in TRANSPORT_PARAMS]
-    params.reverse()
-    for param in params:
+    for param in TRANSPORT_PARAMS.copy().reverse():
         command_func = param(command_func)
     return command_func
 

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -282,8 +282,9 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
                 # If there is a piece with > to readdress stderr or stdout,
                 # skip from here on (anything else can only be readdressing)
                 break
-            else:
-                new_pieces.append(piece)
+
+            new_pieces.append(piece)
+
         return ' '.join(new_pieces)
 
     @classmethod

--- a/setup.json
+++ b/setup.json
@@ -93,10 +93,10 @@
       "sqlalchemy-diff~=0.1.3"
     ],
     "dev_precommit": [
-      "astroid==2.2.5",
+      "astroid==2.3.3",
       "pre-commit==1.18.3",
-      "prospector==1.1.7",
-      "pylint==2.3.1",
+      "prospector==1.2.0",
+      "pylint==2.4.4",
       "toml~=0.10.0",
       "yapf==0.28.0"
     ],


### PR DESCRIPTION
Fixes #3688 

This comes with new requirement of `pylint==2.4.4` which comes with a
few new warnings that have been addressed in the code base:

 * no-else-break
 * no-else-continue
 * self-assigning-variable
 * property-with-parameters
 * invalid-overridden-method
 * unnecessary-comprehension

One additional new warning has been added to the ignore list

 * import-outside-toplevel

PEP8 recommends to only have imports at the toplevel of a module and not
in function or class definitions. However, the changes required would be
significant and so we leave that for another time.