### PR TITLE
Ensure correct types for `QueryBuilder().dict()` with multiple projections

### DIFF
--- a/aiida/backends/tests/orm/test_querybuilder.py
+++ b/aiida/backends/tests/orm/test_querybuilder.py
@@ -363,6 +363,21 @@ class TestQueryBuilder(AiidaTestCase):
         self.assertTrue(id(query1) != id(query2))
         self.assertTrue(id(query2) == id(query3))
 
+    def test_dict_multiple_projections(self):
+        """Test that the `.dict()` accumulator with multiple projections returns the correct types."""
+        node = orm.Data().store()
+        builder = orm.QueryBuilder().append(orm.Data, project=['*', 'id'])
+        results = builder.dict()
+
+        self.assertIsInstance(results, list)
+        self.assertTrue(all(isinstance(value, dict) for value in results))
+
+        dictionary = list(results[0].values())[0]  # `results` should have the form [{'Data_1': {'*': Node, 'id': 1}}]
+
+        self.assertIsInstance(dictionary['*'], orm.Data)
+        self.assertEqual(dictionary['*'].pk, node.pk)
+        self.assertEqual(dictionary['id'], node.pk)
+
     def test_operators_eq_lt_gt(self):
         nodes = [orm.Data() for _ in range(8)]
 

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -18,7 +18,6 @@ an interface classes which enforces the implementation of its defined methods.
 An instance of one of the implementation classes becomes a member of the :func:`QueryBuilder` instance
 when instantiated by the user.
 """
-
 # Checking for correct input with the inspect module
 from inspect import isclass as inspect_isclass
 import copy


### PR DESCRIPTION
Fixes #3679 

The returned results by the backend implementation of `QueryBuilder` are
passed through `get_aiida_entity_res` to convert backend instances to
front end class instances. However, in the `iterdict` accumulator this
was not accounting for mappings and sequences. This would cause problems
when multiple projections were used, such as `project=['*', 'id']`. The
'*' notation will cause the entire node instance to be loaded, however
due to the fact that it was inside a dictionary in the response it would
not be converted.