### PR TITLE
`CalcJob`: do not pause when exception thrown in the `presubmit`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -99,10 +99,10 @@ argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming hint for attribute names
-attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+attr-name-hint=(([a-z][a-z0-9_]{2,32})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct attribute names
-attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+attr-rgx=(([a-z][a-z0-9_]{2,32})|(_[a-z0-9_]*))$
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -31,6 +31,7 @@ pygments~=2.5
 pymatgen>=2019.7.2
 pymysql~=0.9.3
 pyparsing~=2.4
+pytest-timeout~=1.3
 pytest~=5.3
 python-dateutil~=2.8
 python-memcached~=1.59

--- a/setup.json
+++ b/setup.json
@@ -90,6 +90,7 @@
       "pg8000~=1.13",
       "pgtest~=1.3,>=1.3.1",
       "pytest~=5.3",
+      "pytest-timeout~=1.3",
       "sqlalchemy-diff~=0.1.3"
     ],
     "dev_precommit": [


### PR DESCRIPTION
Fixes #3687 

The `presubmit` call of the `CalcJob` has recently been moved to the
`aiida.engine.processes.calcjobs.tasks.task_upload_job` which is wrapped
in the exponential backoff mechanism. The latter was introduced to
recover from transient problems such as connection problems during the
actual upload to a remote machine. However it should not catch exception
from the `presubmit` call which are not actually transient and thus not
automatically recoverable. In this case the process should simply
except.

Here we test this by mocking the presubmit to raise an exception and
check that it is bubbled up and the process does not end up in a paused
state. To prevent the test from blocking in the case the process gets
put in the paused state erroneously, we put a timeout on the test for
which we need the `pytest-timeout` plugin.