### PR TITLE
Update dependeny requirement `circus~=0.16.0`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -3,7 +3,7 @@ aiida-export-migration-tests==0.8.0
 aldjemy~=0.9.1
 alembic~=1.2
 ase~=3.18
-circus~=0.15.0
+circus~=0.16.1
 click-completion~=0.5.1
 click-config-file~=0.5.0
 click-spinner~=0.1.8
@@ -15,7 +15,7 @@ flask-cors~=3.0
 flask-restful~=0.3.7
 flask~=1.1
 graphviz~=0.13
-ipython>=4.0,<6.0
+ipython~=7.0
 jinja2~=2.10
 kiwipy[rmq]~=0.5.1
 numpy~=1.17,<1.18

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
 - aldjemy~=0.9.1
 - alembic~=1.2
-- circus~=0.15.0
+- circus~=0.16.1
 - click-completion~=0.5.1
 - click-config-file~=0.5.0
 - click-spinner~=0.1.8
@@ -16,7 +16,7 @@ dependencies:
 - django~=2.2
 - ete3~=3.1
 - python-graphviz~=0.13
-- ipython>=4.0,<6.0
+- ipython~=7.0
 - jinja2~=2.10
 - kiwipy[rmq]~=0.5.1
 - numpy~=1.17,<1.18

--- a/setup.json
+++ b/setup.json
@@ -21,7 +21,7 @@
   "install_requires": [
     "aldjemy~=0.9.1",
     "alembic~=1.2",
-    "circus~=0.15.0",
+    "circus~=0.16.1",
     "click-completion~=0.5.1",
     "click-config-file~=0.5.0",
     "click-spinner~=0.1.8",
@@ -29,7 +29,7 @@
     "django~=2.2",
     "ete3~=3.1",
     "graphviz~=0.13",
-    "ipython>=4.0,<6.0",
+    "ipython~=7.0",
     "jinja2~=2.10",
     "kiwipy[rmq]~=0.5.1",
     "numpy~=1.17,<1.18",


### PR DESCRIPTION
Fixes #3559 

This new release of `circus` makes it compatible with `pyzmq>=17`. This
in turn allows us to unpin the `ipython` requirement which required
these versions of `pyzmq`. Note that implicitly the upper limit is
`7.10` for `ipython` because there python 3.5 support is dropped which
we support for another 9 months.