### PR TITLE
Add imports from urllib to dbimporters

### DIFF
--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -220,9 +220,10 @@ class DbEntry:
         Returns raw contents of a file as string.
         """
         if self._contents is None:
+            from urllib.request import urlopen
             from hashlib import md5
 
-            self._contents = urllib.request.urlopen(self.source['uri']).read().decode('utf-8')
+            self._contents = urlopen(self.source['uri']).read().decode('utf-8')
             self.source['source_md5'] = md5(self._contents.encode('utf-8')).hexdigest()
         return self._contents
 

--- a/aiida/tools/dbimporters/plugins/icsd.py
+++ b/aiida/tools/dbimporters/plugins/icsd.py
@@ -406,7 +406,7 @@ class IcsdDbImporter(DbImporter):
         :param kwargs: A list of ``keyword = [values]`` pairs
         :return: IcsdSearchResults
         """
-
+        from urllib.parse import urlencode
         self.actual_args = {
             'action': 'Search',
             'nb_rows': '100',  # max is 100
@@ -428,7 +428,7 @@ class IcsdDbImporter(DbImporter):
             except KeyError as exc:
                 raise TypeError("ICSDImporter got an unexpected keyword argument '{}'".format(exc.args[0]))
 
-        url_values = urllib.parse.urlencode(self.actual_args)
+        url_values = urlencode(self.actual_args)
         query_url = self.db_parameters['urladd'] + url_values
 
         return IcsdSearchResults(query=query_url, db_parameters=self.db_parameters)
@@ -590,11 +590,12 @@ class IcsdSearchResults(DbSearchResults):
 
         else:
             from bs4 import BeautifulSoup
+            from urllib.request import urlopen
             import re
 
-            self.html = urllib.request.urlopen(self.db_parameters['server'] +
-                                               self.db_parameters['db'] + '/' +
-                                               self.query.format(str(self.page))).read()
+            self.html = urlopen(self.db_parameters['server'] +
+                                self.db_parameters['db'] + '/' +
+                                self.query.format(str(self.page))).read()
 
             self.soup = BeautifulSoup(self.html)
 

--- a/aiida/tools/dbimporters/plugins/mpod.py
+++ b/aiida/tools/dbimporters/plugins/mpod.py
@@ -88,12 +88,13 @@ class MpodDbImporter(DbImporter):
         :return: an instance of
             :py:class:`aiida.tools.dbimporters.plugins.mpod.MpodSearchResults`.
         """
+        from urllib.request import urlopen
         import re
 
         query_statements = self.query_get(**kwargs)
         results = None
         for query in query_statements:
-            response = urllib.request.urlopen(query).read()
+            response = urlopen(query).read()
             this_results = re.findall(r'/datafiles/(\d+)\.mpod', response)
             if results is None:
                 results = this_results

--- a/aiida/tools/dbimporters/plugins/nninc.py
+++ b/aiida/tools/dbimporters/plugins/nninc.py
@@ -70,10 +70,11 @@ class NnincDbImporter(DbImporter):
         :return: an instance of
             :py:class:`aiida.tools.dbimporters.plugins.nninc.NnincSearchResults`.
         """
+        from urllib.request import urlopen
         import re
 
         query = self.query_get(**kwargs)
-        response = urllib.request.urlopen(query).read()
+        response = urlopen(query).read()
         results = re.findall(r'psp_files/([^\']+)\.UPF', response)
 
         elements = kwargs.get('element', None)

--- a/aiida/tools/dbimporters/plugins/oqmd.py
+++ b/aiida/tools/dbimporters/plugins/oqmd.py
@@ -56,15 +56,16 @@ class OqmdDbImporter(DbImporter):
         :return: an instance of
             :py:class:`aiida.tools.dbimporters.plugins.oqmd.OqmdSearchResults`.
         """
+        from urllib.request import urlopen
         import re
 
         query_statement = self.query_get(**kwargs)
-        response = urllib.request.urlopen(query_statement).read()
+        response = urlopen(query_statement).read()
         entries = re.findall(r'(/materials/entry/\d+)', response)
 
         results = []
         for entry in entries:
-            response = urllib.request.urlopen('{}{}'.format(self._query_url,
+            response = urlopen('{}{}'.format(self._query_url,
                                                      entry)).read()
             structures = re.findall(r'/materials/export/conventional/cif/(\d+)',
                                     response)


### PR DESCRIPTION
Some query functions of the dbimporters used urlopen and urlencode without importing urllib.request and urllib.parse.

closes #3698