### PR TITLE
Add 'py:class set' to docs nitpick-exceptions

### DIFF
--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -19,9 +19,8 @@ def get_nodes_delete(starting_pks, get_links=False, **kwargs):
     to a list of initial nodes through any sequence of specified authorized
     links and directions for deletion.
 
-    :type starting_pks: list or tuple
-    :param starting_pks:
-        Contains the (valid) pks of the starting nodes (also accepts sets).
+    :type starting_pks: list or tuple or set
+    :param starting_pks: Contains the (valid) pks of the starting nodes.
 
     :param bool get_links:
         Pass True to also return the links between all nodes (found + initial).
@@ -55,9 +54,8 @@ def get_nodes_export(starting_pks, get_links=False, **kwargs):
     links and directions for export. This will also return the links and
     the traversal rules parsed.
 
-    :type starting_pks: list or tuple
-    :param starting_pks:
-        Contains the (valid) pks of the starting nodes (also accepts sets).
+    :type starting_pks: list or tuple or set
+    :param starting_pks: Contains the (valid) pks of the starting nodes.
 
     :param bool get_links:
         Pass True to also return the links between all nodes (found + initial).
@@ -166,8 +164,8 @@ def traverse_graph(starting_pks, max_iterations=None, get_links=False, links_for
     to a list of initial nodes through any sequence of specified links.
     Optionally, it may also return the links that connect these nodes.
 
-    :type starting_pks: list or tuple
-    :param starting_pks: The set of (valid) pks for the starting nodes (also accepts sets).
+    :type starting_pks: list or tuple or set
+    :param starting_pks: Contains the (valid) pks of the starting nodes.
 
     :type max_iterations: int or None
     :param max_iterations:

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -93,6 +93,7 @@ py:class  builtins.int
 py:class  builtins.object
 py:class  builtins.str
 py:class  builtins.dict
+py:class  set
 
 # python builtin objects
 py:obj basestring


### PR DESCRIPTION
There was an error when trying to add the intrinsic 'set' to the list of posible :types: accepted by a parameter in the docstring. This is apparently a problem sphynx compatibility with pythons base documentation, so the only current solution is adding an exception for it.