### PR TITLE
add non-zero exit code for verdi daemon status

### DIFF
--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -98,7 +98,7 @@ def status(all_profiles):
         daemons_running.append(client.is_daemon_running)
 
     if not all(daemons_running):
-        sys.exit(1)
+        sys.exit(3)
 
 
 @verdi_daemon.command()

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -12,6 +12,7 @@
 import os
 import subprocess
 import time
+import sys
 
 import click
 from click_spinner import spinner
@@ -86,6 +87,7 @@ def status(all_profiles):
     else:
         profiles = [config.current_profile]
 
+    daemons_running = []
     for profile in profiles:
         client = get_daemon_client(profile.name)
         delete_stale_pid_file(client)
@@ -93,6 +95,10 @@ def status(all_profiles):
         click.secho('{}'.format(profile.name), bold=True)
         result = get_daemon_status(client)
         echo.echo(result)
+        daemons_running.append(client.is_daemon_running)
+
+    if not all(daemons_running):
+        sys.exit(1)
 
 
 @verdi_daemon.command()

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -75,9 +75,12 @@ def start(foreground, number):
 
 
 @verdi_daemon.command()
-@click.option('--all', 'all_profiles', is_flag=True, help='Show all daemons.')
+@click.option('--all', 'all_profiles', is_flag=True, help='Show status of all daemons.')
 def status(all_profiles):
-    """Print the status of the current daemon or all daemons."""
+    """Print the status of the current daemon or all daemons.
+
+    Returns exit code 0 if all requested daemons are running, else exit code 3.
+    """
     from aiida.engine.daemon.client import get_daemon_client
 
     config = get_config()

--- a/tests/cmdline/utils/test_daemon.py
+++ b/tests/cmdline/utils/test_daemon.py
@@ -96,6 +96,7 @@ def test_daemon_not_running():
     """Test `get_daemon_status` output when the daemon is not running."""
     client = get_daemon_client()
     assert 'The daemon is not running' in get_daemon_status(client)
+    assert not client.is_daemon_running
 
 
 @patch.object(DaemonClient, 'is_daemon_running', lambda: True)
@@ -120,6 +121,7 @@ Active workers [1]:
  4990    0.231        0  2019-12-17 12:27:38
 Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers"""
     assert get_daemon_status(client) == literal
+    assert client.is_daemon_running
 
 
 @patch.object(DaemonClient, 'is_daemon_running', lambda: True)


### PR DESCRIPTION
fixes #3728

`verdi daemon status` was always returning exit code 0, which makes it
difficult to use the command programmatically (e.g. in ansible).
It now returns exit code 1 if the daemon of any of the requested
profiles is not running.