### PR TITLE
Docs: ensure RTD style is set when building locally

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,7 +120,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+# html_theme = 'default'
 
 # Enable labeling for figures
 numfig = True


### PR DESCRIPTION
Fixes #3733 

The definition of the stylesheet to that of ReadTheDocs when building
locally was recently moved to the top of the `docs/source/conf.py` file.
However, the default statement, defining the default theme, now was
executed afterwards, overriding the custom configuration. Simply
commenting it out restores the correct behavior.