### PR TITLE
Improve `restapi.common.identifiers.get_node_namespace` efficiency

### DIFF
--- a/aiida/restapi/common/identifiers.py
+++ b/aiida/restapi/common/identifiers.py
@@ -342,7 +342,7 @@ def get_node_namespace():
     from aiida import orm
     from aiida.plugins.entry_point import is_valid_entry_point_string, parse_entry_point_string
 
-    builder = orm.QueryBuilder().append(orm.Node, project=['node_type', 'process_type'])
+    builder = orm.QueryBuilder().append(orm.Node, project=['node_type', 'process_type']).distinct()
     unique_types = {(node_type, process_type if process_type else '') for node_type, process_type in builder.all()}
 
     # First we create a flat list of all "leaf" node types.


### PR DESCRIPTION
Fixes #3736 

This function serves to build a full hierarchical namespace of all
existing node types in the database. It is used by the REST API to
populate the side bar accordion with all the available node types, which
facilitates easy filtering. However, for big databases this function is
very slow. The main cost is the query for node/process type tuples:

    QueryBuilder().append(Node, project=['node_type', 'process_type'])

The function really only needs the unique tuples, which is currently
done in python. This can be done straight on the SQL level by using:

    builder.distinct()

This prevents having to load the tuples for all nodes, which saves a lot
of computing time for big databases. By adding the `distinct` clause,
the query for a database of approximately 3 million nodes, was reduced
by a factor of 10, from 50 to roughly 5 seconds.