### PR TITLE
Various changes to the docker infrastructure:

### DIFF
--- a/.docker/my_init.d/configure-aiida.sh
+++ b/.docker/my_init.d/configure-aiida.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -em
 
-su -c /opt/configure-aiida.sh $SYSTEM_USER
+su -c /opt/configure-aiida.sh ${SYSTEM_USER}

--- a/.docker/opt/configure-aiida.sh
+++ b/.docker/opt/configure-aiida.sh
@@ -25,17 +25,17 @@ unset __conda_setup
 reentry scan
 
 # Setup AiiDA autocompletion.
-grep _VERDI_COMPLETE /home/$SYSTEM_USER/.bashrc &> /dev/null || echo 'eval "$(_VERDI_COMPLETE=source verdi)"' >> /home/$SYSTEM_USER/.bashrc
+grep _VERDI_COMPLETE /home/${SYSTEM_USER}/.bashrc &> /dev/null || echo 'eval "$(_VERDI_COMPLETE=source verdi)"' >> /home/${SYSTEM_USER}/.bashrc
 
 # Check if user requested to set up AiiDA profile (and if it exists already)
-if [[ $SETUP_DEFAULT_PROFILE == true ]] && ! verdi profile show $PROFILE_NAME &> /dev/null; then
+if [[ ${SETUP_DEFAULT_PROFILE} == true ]] && ! verdi profile show ${PROFILE_NAME} &> /dev/null; then
     NEED_SETUP_PROFILE=true;
 else
     NEED_SETUP_PROFILE=false;
 fi
 
 # Setup AiiDA profile if needed.
-if [[ $NEED_SETUP_PROFILE == true ]]; then
+if [[ ${NEED_SETUP_PROFILE} == true ]]; then
 
     # Create AiiDA profile.
     verdi quicksetup                           \
@@ -49,24 +49,27 @@ if [[ $NEED_SETUP_PROFILE == true ]]; then
 
     # Setup and configure local computer.
     computer_name=localhost
-    verdi computer show $computer_name || verdi computer setup \
-        --non-interactive                                      \
-        --label "${computer_name}"                             \
-        --description "this computer"                          \
-        --hostname "${computer_name}"                          \
-        --transport local                                      \
-        --scheduler direct                                     \
-        --work-dir /home/aiida/aiida_run/                      \
-        --mpirun-command "mpirun -np {tot_num_mpiprocs}"       \
-        --mpiprocs-per-machine 1 &&                            \
-    verdi computer configure local "${computer_name}"          \
-        --non-interactive                                      \
+    verdi computer show ${computer_name} || verdi computer setup   \
+        --non-interactive                                          \
+        --label "${computer_name}"                                 \
+        --description "this computer"                              \
+        --hostname "${computer_name}"                              \
+        --transport local                                          \
+        --scheduler direct                                         \
+        --work-dir /home/aiida/aiida_run/                          \
+        --mpirun-command "mpirun -np {tot_num_mpiprocs}"           \
+        --mpiprocs-per-machine 1 &&                                \
+    verdi computer configure local "${computer_name}"              \
+        --non-interactive                                          \
         --safe-interval 0.0
 fi
 
 
 # Show the default profile
 verdi profile show || echo "The default profile is not set."
+
+# Make sure that the daemon is not running, otherwise the migration will abort.
+verdi daemon stop
 
 # Migration will run for the default profile.
 verdi database migrate --force || echo "Database migration failed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,4 @@ jobs:
         docker logs $DOCKERID
         docker exec --tty --user aiida $DOCKERID /bin/bash -l -c 'verdi profile show default'
         docker exec --tty --user aiida $DOCKERID /bin/bash -l -c 'verdi computer show localhost'
+        docker exec --tty --user aiida $DOCKERID /bin/bash -l -c 'verdi daemon status'

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV AIIDADB_BACKEND django
 
 # Copy and install AiiDA
 COPY . aiida-core
-RUN pip install ./aiida-core
+RUN pip install ./aiida-core[atomic_tools]
 
 # Configure aiida for the user
 COPY .docker/opt/configure-aiida.sh /opt/configure-aiida.sh


### PR DESCRIPTION
* Surround variable names with curly brackets.
* Dockerfile: install aiida with atomic_tools extra (needed to operate cif
files for example).
* Stop daemon before performing database migration. This might be
useful if the container wasn't shut down properly and, at startup,
aiida daemon is considered to be in running state.