### PR TITLE
select python version for conda CI test

### DIFF
--- a/.github/workflows/conda.sh
+++ b/.github/workflows/conda.sh
@@ -7,10 +7,6 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 
-# Workaround for https://github.com/conda/conda/issues/9337
-pip uninstall -y setuptools
-conda install setuptools
-
 conda update -q conda
 conda info -a
 conda env create -f environment.yml -n test-environment

--- a/.github/workflows/conda.sh
+++ b/.github/workflows/conda.sh
@@ -13,4 +13,4 @@ conda install setuptools
 
 conda update -q conda
 conda info -a
-conda env create -f environment.yml -n test-environment python=$PYTHON_VERSION
+conda env create -f environment.yml -n test-environment

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-# Usage: conda env create -n myenvname -f environment.yml python=3.6
+# Usage: conda env create -n myenvname -f environment.yml
 ---
 name: aiida
 channels:
@@ -6,6 +6,7 @@ channels:
 - conda-forge
 - etetoolkit
 dependencies:
+- python==3.7
 - aldjemy~=0.9.1
 - alembic~=1.2
 - circus~=0.16.1

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 - etetoolkit
 dependencies:
-- python==3.6
+- python~=3.7
 - aldjemy~=0.9.1
 - alembic~=1.2
 - circus~=0.16.1

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 - etetoolkit
 dependencies:
-- python==3.7
+- python==3.6
 - aldjemy~=0.9.1
 - alembic~=1.2
 - circus~=0.16.1

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -291,7 +291,7 @@ def update_environment_yml():
     # python version cannot be overriden from outside environment.yml
     # (even if it is not specified at all in environment.yml)
     # https://github.com/conda/conda/issues/9506
-    conda_requires = ['python==3.6']
+    conda_requires = ['python~=3.7']
     for req in install_requires:
         # skip packages required for specific python versions
         # (environment.yml aims at the latest python version)

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -288,7 +288,10 @@ def update_environment_yml():
     replacements = {'psycopg2-binary': 'psycopg2', 'graphviz': 'python-graphviz'}
     install_requires = get_setup_json()['install_requires']
 
-    conda_requires = []
+    # python version cannot be overriden from outside environment.yml
+    # (even if it is not specified at all in environment.yml)
+    # https://github.com/conda/conda/issues/9506
+    conda_requires = ['python==3.7']
     for req in install_requires:
         # skip packages required for specific python versions
         # (environment.yml aims at the latest python version)
@@ -309,7 +312,7 @@ def update_environment_yml():
     environment_filename = 'environment.yml'
     file_path = os.path.join(ROOT_DIR, environment_filename)
     with open(file_path, 'w') as env_file:
-        env_file.write('# Usage: conda env create -n myenvname -f environment.yml python=3.6\n')
+        env_file.write('# Usage: conda env create -n myenvname -f environment.yml\n')
         yaml.safe_dump(
             environment, env_file, explicit_start=True, default_flow_style=False, encoding='utf-8', allow_unicode=True
         )

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -291,7 +291,7 @@ def update_environment_yml():
     # python version cannot be overriden from outside environment.yml
     # (even if it is not specified at all in environment.yml)
     # https://github.com/conda/conda/issues/9506
-    conda_requires = ['python==3.7']
+    conda_requires = ['python==3.6']
     for req in install_requires:
         # skip packages required for specific python versions
         # (environment.yml aims at the latest python version)


### PR DESCRIPTION
fixes #3757 

It turns out that when creating a conda environment from an
`environment.yml` file, it is not possible to specify or override the
python version of the environment from the command line.

I.e. it turns out that

   conda env create -f environment.yml -n test-environment python=3.7

actually sets up a python 3.6 environment.

Until this functionality becomes available, I suggest we explicitly set
the python version it in the `environment.yml` file.