### PR TITLE
force string type into str before escaping

### DIFF
--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -98,7 +98,6 @@ def get_regex_pattern_from_sql(sql_pattern):
         :param tokens_to_apply: the list of tokens still to process (in order: the first will be processed first)
         :return: a tokenized and escaped string for regex
         """
-        string = str(string)
         if tokens_to_apply:
             # We still have tokens to process
             # find the first occurrence of the first token passed in the list
@@ -142,5 +141,4 @@ def sql_string_match(string, pattern):
     :param pattern: the SQL pattern
     :return: True if the string matches, False otherwise
     """
-    string = str(string)
     return bool(re.match(get_regex_pattern_from_sql(pattern), string))

--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -35,6 +35,7 @@ def escape_for_bash(str_to_escape):
     within triple quotes to make it work, getting finally: the complicated
     string found below.
     """
+    str_to_escape = str(str_to_escape)
     if str_to_escape is None:
         return ''
 
@@ -62,6 +63,7 @@ def escape_for_sql_like(string):
     - ``_`` -> match exactly one character
 
     """
+    string = str(string)
     return string.replace('%', '\\%').replace('_', '\\_')
 
 
@@ -96,6 +98,7 @@ def get_regex_pattern_from_sql(sql_pattern):
         :param tokens_to_apply: the list of tokens still to process (in order: the first will be processed first)
         :return: a tokenized and escaped string for regex
         """
+        string = str(string)
         if tokens_to_apply:
             # We still have tokens to process
             # find the first occurrence of the first token passed in the list
@@ -139,4 +142,5 @@ def sql_string_match(string, pattern):
     :param pattern: the SQL pattern
     :return: True if the string matches, False otherwise
     """
+    string = str(string)
     return bool(re.match(get_regex_pattern_from_sql(pattern), string))

--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -63,7 +63,6 @@ def escape_for_sql_like(string):
     - ``_`` -> match exactly one character
 
     """
-    string = str(string)
     return string.replace('%', '\\%').replace('_', '\\_')
 
 


### PR DESCRIPTION
It is very easy for a user to pass integers as arguments when a string is expected. In the current version, an exception that would be very cryptic to novel users occurs. Forcing a string type should be a harmless way of avoiding this error. 

The returned error is 
```
  File "/home/daniel/Src/aiida-core/aiida/engine/processes/calcjobs/tasks.py", line 78, in do_upload
    calc_info, script_filename = process.presubmit(folder)
  File "/home/daniel/Src/aiida-core/aiida/engine/processes/calcjobs/calcjob.py", line 467, in presubmit
    script_content = scheduler.get_submit_script(job_tmpl)
  File "/home/daniel/Src/aiida-core/aiida/schedulers/scheduler.py", line 156, in get_submit_script
    script_lines.append(self._get_run_line(job_tmpl.codes_info, job_tmpl.codes_run_mode))
  File "/home/daniel/Src/aiida-core/aiida/schedulers/scheduler.py", line 227, in _get_run_line
    command_to_exec_list.append(escape_for_bash(arg))
  File "/home/daniel/Src/aiida-core/aiida/common/escaping.py", line 41, in escape_for_bash
    escaped_quotes = str_to_escape.replace("'", """'"'"'""")
AttributeError: 'int' object has no attribute 'replace'
```