### PR TITLE
Fix bugs in _store_from_cache and repository.erase

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1090,6 +1090,7 @@ class Node(Entity, metaclass=AbstractNodeMeta):
             if key != Sealable.SEALED_KEY:
                 self.set_attribute(key, value)
 
+        self._repository.erase()
         self.put_object_from_tree(cache_node._repository._get_base_folder().abspath)  # pylint: disable=protected-access
 
         self._store(with_transaction=with_transaction, clean=False)

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1090,6 +1090,10 @@ class Node(Entity, metaclass=AbstractNodeMeta):
             if key != Sealable.SEALED_KEY:
                 self.set_attribute(key, value)
 
+        # The erase() removes the current content of the sandbox folder.
+        # If this was not done, the content of the sandbox folder could
+        # become mangled when copying over the content of the cache
+        # source repository folder.
         self._repository.erase()
         self.put_object_from_tree(cache_node._repository._get_base_folder().abspath)  # pylint: disable=protected-access
 

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -262,7 +262,7 @@ class Repository:
         if not force:
             self.validate_mutability()
 
-        self._repo_folder.erase()
+        self._get_base_folder().erase()
 
     def store(self):
         """Store the contents of the sandbox folder into the repository folder."""

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -733,14 +733,13 @@ class TestNodeLinks(AiidaTestCase):
             _ = workflow.outputs.some_label
 
 
-def test_store_from_cache(aiida_profile):  # pylint: disable=unused-argument
+# Clearing the DB is needed because other parts of the tests (not using
+# the fixture infrastructure) delete the User.
+def test_store_from_cache(clear_database_before_test):  # pylint: disable=unused-argument
     """
     Regression test for storing a Node with (nested) repository
     content with caching.
     """
-    # This is needed because other parts of the tests (not using the
-    # fixture infrastructure) delete the User.
-    aiida_profile.reset_db()
     data = Data()
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = os.path.join(tmpdir, 'directory')

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -738,6 +738,9 @@ def test_store_from_cache(aiida_profile):  # pylint: disable=unused-argument
     Regression test for storing a Node with (nested) repository
     content with caching.
     """
+    # This is needed because other parts of the tests (not using the
+    # fixture infrastructure) delete the User.
+    aiida_profile.reset_db()
     data = Data()
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = os.path.join(tmpdir, 'directory')

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -733,7 +733,7 @@ class TestNodeLinks(AiidaTestCase):
             _ = workflow.outputs.some_label
 
 
-def test_store_from_cache():
+def test_store_from_cache(aiida_profile):  # pylint: disable=unused-argument
     """
     Regression test for storing a Node with (nested) repository
     content with caching.

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -11,11 +11,13 @@
 """Tests for the Node ORM class."""
 
 import os
+import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions, LinkType
 from aiida.orm import Data, Node, User, CalculationNode, WorkflowNode, load_node
 from aiida.orm.utils.links import LinkTriple
+from aiida.manage.caching import enable_caching
 
 
 class TestNode(AiidaTestCase):
@@ -729,3 +731,22 @@ class TestNodeLinks(AiidaTestCase):
         self.assertEqual(workflow.outputs.result_b.pk, output2.pk)
         with self.assertRaises(exceptions.NotExistent):
             _ = workflow.outputs.some_label
+
+
+def test_store_from_cache():
+    """
+    Regression test for storing a Node with (nested) repository
+    content with caching.
+    """
+    data = Data()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = os.path.join(tmpdir, 'directory')
+        os.makedirs(dir_path)
+        with open(os.path.join(dir_path, 'file'), 'w') as file:
+            file.write('content')
+        data.put_object_from_tree(tmpdir)
+
+    data.store()
+    with enable_caching():
+        clone = data.clone().store()
+    assert data.get_hash() == clone.get_hash()

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -749,4 +749,5 @@ def test_store_from_cache():
     data.store()
     with enable_caching():
         clone = data.clone().store()
+    assert clone.get_cache_source() == data.uuid
     assert data.get_hash() == clone.get_hash()

--- a/tests/orm/utils/test_repository.py
+++ b/tests/orm/utils/test_repository.py
@@ -181,7 +181,7 @@ class TestRepository(AiidaTestCase):
     def test_erase_stored_raise(self):
         """
         Test that trying to erase the repository content of a stored
-        Data node without the force flag raises
+        Data node without the force flag raises.
         """
         node = Data()
         node.put_object_from_tree(self.tempdir, '')

--- a/tests/orm/utils/test_repository.py
+++ b/tests/orm/utils/test_repository.py
@@ -16,6 +16,7 @@ import tempfile
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm import Node, Data
 from aiida.orm.utils.repository import File, FileType
+from aiida.common.exceptions import ModificationNotAllowed
 
 
 class TestRepository(AiidaTestCase):
@@ -189,4 +190,4 @@ class TestRepository(AiidaTestCase):
         self.assertEqual(sorted(node.list_object_names()), ['c.txt', 'subdir'])
         self.assertEqual(sorted(node.list_object_names('subdir')), ['a.txt', 'b.txt', 'nested'])
 
-        node._repository.erase()  # pylint: disable=protected-access
+        self.assertRaises(ModificationNotAllowed, node._repository.erase)  # pylint: disable=protected-access

--- a/tests/orm/utils/test_repository.py
+++ b/tests/orm/utils/test_repository.py
@@ -14,7 +14,7 @@ import shutil
 import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm import Node
+from aiida.orm import Node, Data
 from aiida.orm.utils.repository import File, FileType
 
 
@@ -147,3 +147,46 @@ class TestRepository(AiidaTestCase):
         key = os.path.join(basepath, 'subdir', 'a.txt')
         content = self.get_file_content(os.path.join('subdir', 'a.txt'))
         self.assertEqual(node.get_object_content(key), content)
+
+    def test_erase_unstored(self):
+        """
+        Test that _repository.erase removes the content of an unstored
+        node.
+        """
+        node = Node()
+        node.put_object_from_tree(self.tempdir, '')
+
+        self.assertEqual(sorted(node.list_object_names()), ['c.txt', 'subdir'])
+        self.assertEqual(sorted(node.list_object_names('subdir')), ['a.txt', 'b.txt', 'nested'])
+
+        node._repository.erase()  # pylint: disable=protected-access
+        self.assertEqual(node.list_object_names(), [])
+
+    def test_erase_stored_force(self):
+        """
+        Test that _repository.erase removes the content of an stored
+        Data node when passing force=True.
+        """
+        node = Data()
+        node.put_object_from_tree(self.tempdir, '')
+        node.store()
+
+        self.assertEqual(sorted(node.list_object_names()), ['c.txt', 'subdir'])
+        self.assertEqual(sorted(node.list_object_names('subdir')), ['a.txt', 'b.txt', 'nested'])
+
+        node._repository.erase(force=True)  # pylint: disable=protected-access
+        self.assertEqual(node.list_object_names(), [])
+
+    def test_erase_stored_raise(self):
+        """
+        Test that trying to erase the repository content of a stored
+        Data node without the force flag raises
+        """
+        node = Data()
+        node.put_object_from_tree(self.tempdir, '')
+        node.store()
+
+        self.assertEqual(sorted(node.list_object_names()), ['c.txt', 'subdir'])
+        self.assertEqual(sorted(node.list_object_names('subdir')), ['a.txt', 'b.txt', 'nested'])
+
+        node._repository.erase()  # pylint: disable=protected-access


### PR DESCRIPTION
The `_store_from_cache` needed to erase the content of its sandbox folder before copying over the content of the cache source. Currently, the existing contents are mixed with with the contents
to be copied in.
In fixing this, we discovered an issue in repository.erase, where an unstored node would try erasing the (inexistent) folder in the permanent repository, instead of the SandboxFolder.

Fixed in collaboration with @sphuber, so this should be reviewed by someone else.