### PR TITLE
Fix CI postgres issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: harmon758/postgresql-action@v1
+    - uses: CasperWA/postgresql-action@v1.2
       with:
-        postgresql version: '11'
+        postgresql version: '10'
         postgresql db: test_${{ matrix.backend }}
-        postgresql user: 'postgres'
+        postgresql user: postgres
         postgresql password: ''
+        postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
@@ -115,7 +116,7 @@ jobs:
         echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install postgresql postgresql-server-dev-all postgresql-client rabbitmq-server graphviz
+        sudo apt install postgresql-10 rabbitmq-server graphviz
         sudo systemctl status rabbitmq-server.service
 
     - name: Install python dependencies

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -52,4 +52,4 @@ tabulate~=0.8.5
 tornado<5.0
 tzlocal~=2.0
 upf_to_json~=0.9.2
-wrapt~=1.11
+wrapt~=1.11.1

--- a/environment.yml
+++ b/environment.yml
@@ -37,4 +37,4 @@ dependencies:
 - tornado<5.0
 - tzlocal~=2.0
 - upf_to_json~=0.9.2
-- wrapt~=1.11
+- wrapt~=1.11.1

--- a/setup.json
+++ b/setup.json
@@ -51,7 +51,7 @@
     "tornado<5.0",
     "tzlocal~=2.0",
     "upf_to_json~=0.9.2",
-    "wrapt~=1.11"
+    "wrapt~=1.11.1"
   ],
   "extras_require": {
     "ssh_kerberos": [


### PR DESCRIPTION
Fixes #3763 

I have a working branch.

Forking the original postgresql-action from @Harmon758 (actually from other forks of his, since he is non-responsive for the maintenance of the action), I have updated the action with other forks' contributions as well as some of my own.
Most importantly is one for setting the auth-method when starting `initdb` (see [here](https://hub.docker.com/_/postgres), search for `POSTGRES_INITDB_ARGS`).

I have tested that it works if set to `trust` - which, obviously, it should. But I found that it then also doesn't matter if there is any inconsistencies between the db passwords set for a profile and the actual db password - which, again, makes sense.

Currently, I am testing with the auth-method set to `password` instead.
Edit: This does not seem to work (unless one sets a password, I guess).
So the question is now, do you want to have it set to `trust` so that it all runs, but then we're not sure if some security measures are tested correctly? Or should I try and find a more "secure" auth-method, where it also runs (this may take a lot more time)?

Also, this sets the `wrapt` dependency to `~=1.11.1`