### PR TITLE
`BaseRestartWorkChain`: require process handlers to be instance methods

### DIFF
--- a/.ci/workchains.py
+++ b/.ci/workchains.py
@@ -9,7 +9,7 @@
 ###########################################################################
 from aiida.common import AttributeDict
 from aiida.engine import calcfunction, workfunction, WorkChain, ToContext, append_, while_, ExitCode
-from aiida.engine import BaseRestartWorkChain, register_process_handler, ProcessHandlerReport
+from aiida.engine import BaseRestartWorkChain, process_handler, ProcessHandlerReport
 from aiida.engine.persistence import ObjectLoader
 from aiida.orm import Int, List, Str
 from aiida.plugins import CalculationFactory
@@ -48,26 +48,23 @@ class ArithmeticAddBaseWorkChain(BaseRestartWorkChain):
         super().setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(ArithmeticAddCalculation, 'add'))
 
+    @process_handler(priority=500)
+    def sanity_check_not_too_big(self, node):
+        """My puny brain cannot deal with numbers that I cannot count on my hand."""
+        if node.is_finished_ok and node.outputs.sum > 10:
+            return ProcessHandlerReport(True, self.exit_codes.ERROR_TOO_BIG)
 
-@register_process_handler(ArithmeticAddBaseWorkChain, priority=500)
-def sanity_check_not_too_big(self, node):
-    """My puny brain cannot deal with numbers that I cannot count on my hand."""
-    if node.is_finished_ok and node.outputs.sum > 10:
-        return ProcessHandlerReport(True, self.exit_codes.ERROR_TOO_BIG)
+    @process_handler(priority=450, exit_codes=ExitCode(1000, 'Unicorn encountered'))
+    def a_magic_unicorn_appeared(self, node):
+        """As we all know unicorns do not exist so we should never have to deal with it."""
+        raise RuntimeError('this handler should never even have been called')
 
-
-@register_process_handler(ArithmeticAddBaseWorkChain, priority=450, exit_codes=ExitCode(1000, 'Unicorn encountered'))
-def a_magic_unicorn_appeared(self, node):
-    """As we all know unicorns do not exist so we should never have to deal with it."""
-    raise RuntimeError('this handler should never even have been called')
-
-
-@register_process_handler(ArithmeticAddBaseWorkChain, priority=400, exit_codes=ArithmeticAddCalculation.exit_codes.ERROR_NEGATIVE_NUMBER)
-def error_negative_sum(self, node):
-    """What even is a negative number, how can I have minus three melons?!."""
-    self.ctx.inputs.x = Int(abs(node.inputs.x.value))
-    self.ctx.inputs.y = Int(abs(node.inputs.y.value))
-    return ProcessHandlerReport(True)
+    @process_handler(priority=400, exit_codes=ArithmeticAddCalculation.exit_codes.ERROR_NEGATIVE_NUMBER)
+    def error_negative_sum(self, node):
+        """What even is a negative number, how can I have minus three melons?!."""
+        self.ctx.inputs.x = Int(abs(node.inputs.x.value))
+        self.ctx.inputs.y = Int(abs(node.inputs.y.value))
+        return ProcessHandlerReport(True)
 
 
 class NestedWorkChain(WorkChain):

--- a/aiida/engine/processes/workchains/utils.py
+++ b/aiida/engine/processes/workchains/utils.py
@@ -9,27 +9,13 @@
 ###########################################################################
 """Utilities for `WorkChain` implementations."""
 from collections import namedtuple
-from functools import wraps
+from functools import partial
+from inspect import getfullargspec
+from wrapt import decorator
 
 from ..exit_code import ExitCode
 
-__all__ = ('ProcessHandler', 'ProcessHandlerReport', 'register_process_handler')
-
-ProcessHandler = namedtuple('ProcessHandler', 'method priority exit_codes')
-ProcessHandler.__new__.__defaults__ = (None, 0, None)
-"""A namedtuple to define a process handler for a :class:`aiida.engine.BaseRestartWorkChain`.
-
-The `method` element refers to a function decorated by the `register_process_handler` that has turned it into a bound
-method of the target `WorkChain` class. The method takes an instance of a :class:`~aiida.orm.ProcessNode` as its sole
-argument. The method can return an optional `ProcessHandlerReport` to signal whether other handlers still need to be
-considered or whether the work chain should be terminated immediately. The priority determines in which order the
-handler methods are executed, with the higher priority being executed first.
-
-:param method: the decorated process handling function turned into a bound work chain class method
-:param priority: integer denoting the process handler's priority
-:param exit_codes: single or list of `ExitCode` instances. A handler that defines this should only be called for a given
-    completed process if its exit status is a member of `exit_codes`.
-"""
+__all__ = ('ProcessHandlerReport', 'process_handler')
 
 ProcessHandlerReport = namedtuple('ProcessHandlerReport', 'do_break exit_code')
 ProcessHandlerReport.__new__.__defaults__ = (False, ExitCode())
@@ -49,16 +35,12 @@ returning a non-zero exit code from any work chain step will instruct the engine
 """
 
 
-def register_process_handler(cls, *, priority=None, exit_codes=None):
-    """Decorator to register a function as a handler for a :class:`~aiida.engine.BaseRestartWorkChain`.
+def process_handler(wrapped=None, *, priority=None, exit_codes=None):
+    """Decorator to register a :class:`~aiida.engine.BaseRestartWorkChain` instance method as a process handler.
 
-    The function expects two arguments, a work chain class and a priortity. The decorator will add the function as a
-    class method to the work chain class and add an :class:`~aiida.engine.ProcessHandler` tuple to the `__handlers`
-    private attribute of the work chain. During the `inspect_process` outline method, the work chain will retrieve all
-    the registered handlers through the :meth:`~aiida.engine.BaseRestartWorkChain._handlers` property and loop over them
-    sorted with respect to their priority in reverse. If the work chain class defines the
-    :attr:`~aiida.engine.BaseRestartWorkChain._verbose` attribute and is set to `True`, a report message will be fired
-    when the process handler is executed.
+    The decorator will validate the `priority` and `exit_codes` optional keyword arguments and then add itself as an
+    attribute to the `wrapped` instance method. This is used in the `inspect_process` to return all instance methods of
+    the class that have been decorated by this function and therefore are considered to be process handlers.
 
     Requirements on the function signature of process handling functions. The function to which the decorator is applied
     needs to take two arguments:
@@ -79,6 +61,9 @@ def register_process_handler(cls, *, priority=None, exit_codes=None):
         code set on the `node` does not appear in the `exit_codes`. This is useful to have a handler called only when
         the process failed with a specific exit code.
     """
+    if wrapped is None:
+        return partial(process_handler, priority=priority, exit_codes=exit_codes)
+
     if priority is None:
         priority = 0
 
@@ -91,41 +76,40 @@ def register_process_handler(cls, *, priority=None, exit_codes=None):
     if exit_codes and any([not isinstance(exit_code, ExitCode) for exit_code in exit_codes]):
         raise TypeError('`exit_codes` should be an instance of `ExitCode` or list thereof.')
 
-    def process_handler_decorator(handler):
-        """Decorate a function to dynamically register a handler to a `WorkChain` class."""
+    handler_args = getfullargspec(wrapped)[0]
 
-        @wraps(handler)
-        def process_handler(self, node):
-            """Wrap handler to add a log to the report if the handler is called and verbosity is turned on."""
-            verbose = hasattr(cls, '_verbose') and cls._verbose  # pylint: disable=protected-access
+    if len(handler_args) != 2:
+        raise TypeError('process handler `{}` has invalid signature: should be (self, node)'.format(wrapped.__name__))
 
-            if exit_codes and node.exit_status not in [exit_code.status for exit_code in exit_codes]:
-                if verbose:
-                    self.report('skipped {} because of exit code filter'.format(handler.__name__))
-                return None
+    wrapped.decorator = process_handler
+    wrapped.priority = priority if priority else 0
 
-            if verbose:
-                self.report('({}){}'.format(priority, handler.__name__))
+    @decorator
+    def wrapper(wrapped, instance, args, kwargs):
 
-            result = handler(self, node)
+        # When the handler will be called by the `BaseRestartWorkChain` it will pass the node as the only argument
+        node = args[0]
 
-            # If a handler report is returned, attach the handler's name to node's attributes
-            if isinstance(result, ProcessHandlerReport):
-                try:
-                    called_process_handlers = self.node.get_extra('called_process_handlers', [])
-                    current_process = called_process_handlers[-1]
-                except IndexError:
-                    # The extra was never initialized, so we skip this functionality
-                    pass
-                else:
-                    # Append the name of the handler to the last list in `called_process_handlers` and save it
-                    current_process.append(handler.__name__)
-                    self.node.set_extra('called_process_handlers', called_process_handlers)
+        if exit_codes and node.exit_status not in [exit_code.status for exit_code in exit_codes]:
+            result = None
+        else:
+            result = wrapped(*args, **kwargs)
 
-            return result
+        # Append the name and return value of the current process handler to the `considered_handlers` extra.
+        try:
+            considered_handlers = instance.node.get_extra(instance._considered_handlers_extra, [])  # pylint: disable=protected-access
+            current_process = considered_handlers[-1]
+        except IndexError:
+            # The extra was never initialized, so we skip this functionality
+            pass
+        else:
+            # Append the name of the handler to the last list in `considered_handlers` and save it
+            serialized = result
+            if isinstance(serialized, ProcessHandlerReport):
+                serialized = {'do_break': serialized.do_break, 'exit_status': serialized.exit_code.status}
+            current_process.append((wrapped.__name__, serialized))
+            instance.node.set_extra(instance._considered_handlers_extra, considered_handlers)  # pylint: disable=protected-access
 
-        cls.register_handler(handler.__name__, ProcessHandler(process_handler, priority, exit_codes))
+        return result
 
-        return process_handler
-
-    return process_handler_decorator
+    return wrapper(wrapped)  # pylint: disable=no-value-for-parameter

--- a/tests/engine/processes/workchains/test_utils.py
+++ b/tests/engine/processes/workchains/test_utils.py
@@ -7,12 +7,12 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=no-self-use,unused-argument,unused-variable
+# pylint: disable=no-self-use,unused-argument,unused-variable,function-redefined,missing-class-docstring,missing-function-docstring
 """Tests for `aiida.engine.processes.workchains.utils` module."""
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import ExitCode, ProcessState
 from aiida.engine.processes.workchains.restart import BaseRestartWorkChain
-from aiida.engine.processes.workchains.utils import register_process_handler, ProcessHandlerReport
+from aiida.engine.processes.workchains.utils import process_handler, ProcessHandlerReport
 from aiida.orm import ProcessNode
 from aiida.plugins import CalculationFactory
 
@@ -20,27 +20,33 @@ ArithmeticAddCalculation = CalculationFactory('arithmetic.add')
 
 
 class TestRegisterProcessHandler(AiidaTestCase):
-    """Tests for the `register_process_handler` decorator."""
+    """Tests for the `process_handler` decorator."""
 
     def test_priority_keyword_only(self):
         """The `priority` should be keyword only."""
         with self.assertRaises(TypeError):
 
-            @register_process_handler(BaseRestartWorkChain, 400)  # pylint: disable=too-many-function-args
+            class SomeWorkChain(BaseRestartWorkChain):
+
+                @process_handler(400)  # pylint: disable=too-many-function-args
+                def _(self, node):
+                    pass
+
+        class SomeWorkChain(BaseRestartWorkChain):
+
+            @process_handler(priority=400)
             def _(self, node):
                 pass
-
-        @register_process_handler(BaseRestartWorkChain, priority=400)
-        def _(self, node):
-            pass
 
     def test_priority_type(self):
         """The `priority` should be an integer."""
         with self.assertRaises(TypeError):
 
-            @register_process_handler(BaseRestartWorkChain, priority='400')
-            def _(self, node):
-                pass
+            class SomeWorkChain(BaseRestartWorkChain):
+
+                @process_handler(priority='400')
+                def _(self, node):
+                    pass
 
     def test_priority(self):
         """Test that the handlers are called in order of their `priority`."""
@@ -50,36 +56,36 @@ class TestRegisterProcessHandler(AiidaTestCase):
 
             _process_class = ArithmeticAddCalculation
 
-        # Register some handlers that should be called in order of 4 -> 3 -> 2 -> 1 but are on purpose registered in a
-        # different order. When called, they should add their name to `handlers_called` attribute of the node. This can
-        # then be checked after invoking `inspect_process` to ensure they were called in the right order
-        @register_process_handler(ArithmeticAddBaseWorkChain, priority=100)
-        def handler_01(self, node):
-            handlers_called = node.get_attribute(attribute_key, default=[])
-            handlers_called.append('handler_01')
-            node.set_attribute(attribute_key, handlers_called)
-            return ProcessHandlerReport(False, ExitCode(100))
+            # Register some handlers that should be called in order of 4 -> 3 -> 2 -> 1 but are on purpose registered in
+            # a different order. When called, they should add their name to `handlers_called` attribute of the node.
+            # This can then be checked after invoking `inspect_process` to ensure they were called in the right order
+            @process_handler(priority=100)
+            def handler_01(self, node):
+                handlers_called = node.get_attribute(attribute_key, default=[])
+                handlers_called.append('handler_01')
+                node.set_attribute(attribute_key, handlers_called)
+                return ProcessHandlerReport(False, ExitCode(100))
 
-        @register_process_handler(ArithmeticAddBaseWorkChain, priority=300)
-        def handler_03(self, node):
-            handlers_called = node.get_attribute(attribute_key, default=[])
-            handlers_called.append('handler_03')
-            node.set_attribute(attribute_key, handlers_called)
-            return ProcessHandlerReport(False, ExitCode(300))
+            @process_handler(priority=300)
+            def handler_03(self, node):
+                handlers_called = node.get_attribute(attribute_key, default=[])
+                handlers_called.append('handler_03')
+                node.set_attribute(attribute_key, handlers_called)
+                return ProcessHandlerReport(False, ExitCode(300))
 
-        @register_process_handler(ArithmeticAddBaseWorkChain, priority=200)
-        def handler_02(self, node):
-            handlers_called = node.get_attribute(attribute_key, default=[])
-            handlers_called.append('handler_02')
-            node.set_attribute(attribute_key, handlers_called)
-            return ProcessHandlerReport(False, ExitCode(200))
+            @process_handler(priority=200)
+            def handler_02(self, node):
+                handlers_called = node.get_attribute(attribute_key, default=[])
+                handlers_called.append('handler_02')
+                node.set_attribute(attribute_key, handlers_called)
+                return ProcessHandlerReport(False, ExitCode(200))
 
-        @register_process_handler(ArithmeticAddBaseWorkChain, priority=400)
-        def handler_04(self, node):
-            handlers_called = node.get_attribute(attribute_key, default=[])
-            handlers_called.append('handler_04')
-            node.set_attribute(attribute_key, handlers_called)
-            return ProcessHandlerReport(False, ExitCode(400))
+            @process_handler(priority=400)
+            def handler_04(self, node):
+                handlers_called = node.get_attribute(attribute_key, default=[])
+                handlers_called.append('handler_04')
+                node.set_attribute(attribute_key, handlers_called)
+                return ProcessHandlerReport(False, ExitCode(400))
 
         child = ProcessNode()
         child.set_process_state(ProcessState.FINISHED)
@@ -97,13 +103,17 @@ class TestRegisterProcessHandler(AiidaTestCase):
         """The `exit_codes` should be keyword only."""
         with self.assertRaises(TypeError):
 
-            @register_process_handler(BaseRestartWorkChain, ExitCode())  # pylint: disable=too-many-function-args
+            class SomeWorkChain(BaseRestartWorkChain):
+
+                @process_handler(ExitCode())  # pylint: disable=too-many-function-args
+                def _(self, node):
+                    pass
+
+        class SomeWorkChain(BaseRestartWorkChain):
+
+            @process_handler(exit_codes=ExitCode())
             def _(self, node):
                 pass
-
-        @register_process_handler(BaseRestartWorkChain, exit_codes=ExitCode())
-        def _(self, node):
-            pass
 
     def test_exit_codes_type(self):
         """The `exit_codes` should be single or list of `ExitCode` instances."""
@@ -117,24 +127,26 @@ class TestRegisterProcessHandler(AiidaTestCase):
         with self.assertRaises(TypeError):
             for incorrect_type in incorrect_types:
 
-                @register_process_handler(BaseRestartWorkChain, exit_codes=incorrect_type)
-                def _(self, node):
-                    pass
+                class SomeWorkChain(BaseRestartWorkChain):
 
-        @register_process_handler(BaseRestartWorkChain, exit_codes=ExitCode(400, 'Some exit code'))
-        def _(self, node):
-            pass
+                    @process_handler(exit_codes=incorrect_type)
+                    def _(self, node):
+                        pass
 
-        @register_process_handler(BaseRestartWorkChain, exit_codes=[ExitCode(400, 'a'), ExitCode(401, 'b')])
-        def _(self, node):
-            pass
+        class SomeWorkChain(BaseRestartWorkChain):
+
+            @process_handler(exit_codes=ExitCode(400, 'Some exit code'))
+            def _(self, node):
+                pass
+
+        class SomeWorkChain(BaseRestartWorkChain):
+
+            @process_handler(exit_codes=[ExitCode(400, 'a'), ExitCode(401, 'b')])
+            def _(self, node):
+                pass
 
     def test_exit_codes_filter(self):
         """Test that the `exit_codes` argument properly filters, returning `None` if the `node` has different status."""
-
-        class ArithmeticAddBaseWorkChain(BaseRestartWorkChain):
-
-            _process_class = ArithmeticAddCalculation
 
         exit_code_filter = ExitCode(400)
 
@@ -146,17 +158,21 @@ class TestRegisterProcessHandler(AiidaTestCase):
         node_skip = ProcessNode()
         node_skip.set_exit_status(200)  # Some other exit status
 
-        @register_process_handler(ArithmeticAddBaseWorkChain, exit_codes=exit_code_filter)
-        def _(self, node):
-            return ProcessHandlerReport()
+        class ArithmeticAddBaseWorkChain(BaseRestartWorkChain):
+
+            _process_class = ArithmeticAddCalculation
+
+            @process_handler(exit_codes=exit_code_filter)
+            def _(self, node):
+                return ProcessHandlerReport()
 
         # Create dummy process instance
         process = ArithmeticAddBaseWorkChain()
 
         # Loop over all handlers, which should be just the one, and call it with the two different nodes
-        for handler in process._handlers:  # pylint: disable=protected-access
+        for handler in process._handlers():  # pylint: disable=protected-access
             # The `node_match` should match the `exit_codes` filter and so return a report instance
-            assert isinstance(handler.method(process, node_match), ProcessHandlerReport)
+            assert isinstance(handler(node_match), ProcessHandlerReport)
 
             # The `node_skip` has a wrong exit status and so should get skipped, returning `None`
-            assert handler.method(process, node_skip) is None
+            assert handler(node_skip) is None


### PR DESCRIPTION
Fixes #3780 

The original implementation of the `register_process_handler` allowed an
unbound method to be bound to a subclass of `BaseRestartWorkChain`
outside of its scope. Since this also makes it possible to attach these
process handlers from outside of the module of the work chain, this will
run the risk of the loss of provenance. Here we rename the decorator to
`process_handler` and it can only be applied to instance methods. This
forces the handlers to be defined in the same module as the work chain
to which they apply.