### PR TITLE
Add fixtures to clear the database before or after tests

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -37,12 +37,29 @@ def aiida_profile():
 
 
 @pytest.fixture(scope='function')
-def clear_database(aiida_profile):  # pylint: disable=redefined-outer-name
+def clear_database(clear_database_after_test):  # pylint: disable=redefined-outer-name,unused-argument
+    """Alias for 'clear_database_after_test'.
+
+    Clears the database after each test. Use of the explicit
+    'clear_database_after_test' is preferred.
+    """
+
+
+@pytest.fixture(scope='function')
+def clear_database_after_test(aiida_profile):  # pylint: disable=redefined-outer-name
     """Clear the database after each test.
     """
     yield
     # after the test function has completed, reset the database
     aiida_profile.reset_db()
+
+
+@pytest.fixture(scope='function')
+def clear_database_before_test(aiida_profile):  # pylint: disable=redefined-outer-name
+    """Clear the database before each test.
+    """
+    aiida_profile.reset_db()
+    yield
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
The current 'clear_database' fixture clears the DB after the test has run. Since clearing it before the tests is also a common use case, this adds a 'clear_database_before_test' fixture. For naming consistency, we rename 'clear_database' to 'clear_database_after_test', and turn 'clear_database' into an
alias for that function for backwards compatibility.