### PR TITLE
pyproject: add build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry~=1.3"]
+requires = ["setuptools>=40.8.0", "wheel", "reentry~=1.3"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
if there is a `build-system` section, it should also define
the backend, otherwise a PEP517-based build will fail:

    python -m pep517.build --source --binary --out-dir dist/ .