### PR TITLE
Avoid deadlocks when retrieving stdout/stderr via SSH

### DIFF
--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -759,27 +759,45 @@ class LocalTransport(Transport):
 
         return proc.stdin, proc.stdout, proc.stderr, proc
 
-    def exec_command_wait(self, command, **kwargs):
+    def exec_command_wait_bytes(self, command, stdin=None, **kwargs):
         """
         Executes the specified command and waits for it to finish.
 
         :param command: the command to execute
 
         :return: a tuple with (return_value, stdout, stderr) where stdout and
-                 stderr are strings.
+                 stderr are bytes.
         """
-        stdin = kwargs.get('stdin')
         local_stdin, _, _, local_proc = self._exec_command_internal(command)
 
         if stdin is not None:
+            # Implicitly assume that the desired encoding is 'utf-8' if I receive a string.
+            # Also, if I get a StringIO, I jsut read it all in memory and put it into a BytesIO.
+            # Clearly not memory effective - in this case do not use a StringIO, but pass directly a BytesIO
+            # that will be read line by line, if you have a huge stdin and care about memory usage.
             if isinstance(stdin, str):
-                filelike_stdin = io.StringIO(stdin)
+                filelike_stdin = io.BytesIO(stdin.encode('utf-8'))
+            elif isinstance(stdin, bytes):
+                filelike_stdin = io.BytesIO(stdin)
+            elif isinstance(stdin, io.TextIOBase):
+
+                def line_encoder(iterator, encoding='utf-8'):
+                    """Encode the iterator item by item (i.e., line by line).
+
+                    This only wraps iterating over it and not all other methods, but it's enough for its
+                    use below."""
+                    for line in iterator:
+                        yield line.encode(encoding)
+
+                filelike_stdin = line_encoder(stdin)
             else:
+                if not isinstance(stdin, io.BufferedIOBase):
+                    raise ValueError('You can only pass strings, bytes, BytesIO or StringIO objects')
                 filelike_stdin = stdin
 
             try:
-                for line in filelike_stdin.readlines():
-                    local_stdin.write(line.encode('utf-8'))  # the Popen.stdin/out/err are byte streams
+                for line in filelike_stdin:
+                    local_stdin.write(line)  # the Popen.stdin/out/err are byte streams
             except AttributeError:
                 raise ValueError('stdin can only be either a string or a file-like object!')
         else:
@@ -790,7 +808,7 @@ class LocalTransport(Transport):
 
         retval = local_proc.returncode
 
-        return retval, output_text.decode('utf-8'), stderr_text.decode('utf-8')
+        return retval, output_text, stderr_text
 
     def gotocomputer_command(self, remotedir):
         """

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -765,14 +765,14 @@ class LocalTransport(Transport):
 
         :param command: the command to execute
 
-        :return: a tuple with (return_value, stdout, stderr) where stdout and
-                 stderr are bytes.
+        :return: a tuple with (return_value, stdout, stderr) where stdout and stderr
+            are both bytes and the return_value is an int.
         """
         local_stdin, _, _, local_proc = self._exec_command_internal(command)
 
         if stdin is not None:
             # Implicitly assume that the desired encoding is 'utf-8' if I receive a string.
-            # Also, if I get a StringIO, I jsut read it all in memory and put it into a BytesIO.
+            # Also, if I get a StringIO, I just read it all in memory and put it into a BytesIO.
             # Clearly not memory effective - in this case do not use a StringIO, but pass directly a BytesIO
             # that will be read line by line, if you have a huge stdin and care about memory usage.
             if isinstance(stdin, str):
@@ -790,10 +790,10 @@ class LocalTransport(Transport):
                         yield line.encode(encoding)
 
                 filelike_stdin = line_encoder(stdin)
-            else:
-                if not isinstance(stdin, io.BufferedIOBase):
-                    raise ValueError('You can only pass strings, bytes, BytesIO or StringIO objects')
+            elif isinstance(stdin, io.BufferedIOBase):
                 filelike_stdin = stdin
+            else:
+                raise ValueError('You can only pass strings, bytes, BytesIO or StringIO objects')
 
             try:
                 for line in filelike_stdin:

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -398,18 +398,44 @@ class Transport(abc.ABC):
         """
         raise NotImplementedError
 
-    def exec_command_wait(self, command, **kwargs):
+    def exec_command_wait_bytes(self, command, stdin=None, **kwargs):
         """
         Execute the command on the shell, waits for it to finish,
-        and return the retcode, the stdout and the stderr.
+        and return the retcode, the stdout and the stderr as bytes.
 
-        Enforce the execution to be run from the pwd (as given by
-        self.getcwd), if this is not None.
+        Enforce the execution to be run from the pwd (as given by self.getcwd), if this is not None.
+
+        The command implementation can have some additional plugin-specific kwargs.
 
         :param str command: execute the command given as a string
-        :return: a list: the retcode (int), stdout (str) and stderr (str).
+        :param stdin: (optional,default=None) can be a string or a file-like object.
+        :return: a tuple: the retcode (int), stdout (bytes) and stderr (bytes).
         """
         raise NotImplementedError
+
+    def exec_command_wait(self, command, stdin=None, encoding='utf-8', **kwargs):
+        """
+        Executes the specified command and waits for it to finish.
+
+        :note: this function also decodes the bytes received into a string with the specified encoding,
+            which is set to be ``utf-8`` by default (for backward-compatibility with earlier versions) of
+            AiiDA.
+            Use this method only if you are sure that you are getting a properly encoded string; otherwise,
+            use the ``exec_command_wait_bytes`` method that returns the undecoded byte stream.
+
+        :note: additional kwargs are passed to the ``exec_command_wait_bytes`` function, that might use them
+            depending on the plugin.
+
+        :param command: the command to execute
+        :param stdin: (optional,default=None) can be a string or a file-like object.
+        :param encoding: the encoding to use to decode the byte stream received from the remote command execution.
+
+        :return: a tuple with (return_value, stdout, stderr) where stdout and stderr are both strings, decoded
+            with the specified encoding.
+        """
+        retval, stdout_bytes, stderr_bytes = self.exec_command_wait_bytes(command=command, stdin=stdin, **kwargs)
+        # Return the decoded strings
+        return (retval, stdout_bytes.decode(encoding), stderr_bytes.decode(encoding))
 
     def get(self, remotepath, localpath, *args, **kwargs):
         """
@@ -689,6 +715,8 @@ class Transport(abc.ABC):
         """
 
         command = 'whoami'
+        # Assuming here that the username is either ASCII or UTF-8 encoded
+        # This should be true essentially always
         retval, username, stderr = self.exec_command_wait(command)
         if retval == 0:
             if stderr.strip():

--- a/docs/source/topics/transport_template.py
+++ b/docs/source/topics/transport_template.py
@@ -58,13 +58,14 @@ class NewTransport(Transport):
         :raise IOError: if one of src or dst does not exist
         """
 
-    def exec_command_wait(self, command, **kwargs):
+    def exec_command_wait_bytes(self, command, stdin=None, **kwargs):
         """Execute the command on the shell, wait for it to finish and return the retcode, the stdout and the stderr.
 
         Enforce the execution to be run from the pwd (as given by ``self.getcwd``), if this is not None.
 
         :param str command: execute the command given as a string
-        :return: a tuple: the retcode (int), stdout (str) and stderr (str).
+        :param stdin: (optional,default=None) can be a string or a file-like object.
+        :return: a tuple: the retcode (int), stdout (bytes) and stderr (bytes).
         """
 
     def get_attribute(self, path):

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -1281,6 +1281,103 @@ class TestExecuteCommandWait(unittest.TestCase):
             with self.assertRaises(ValueError):
                 transport.exec_command_wait('cat', stdin=1)
 
+    @run_for_all_plugins
+    def test_transfer_big_stdout(self, custom_transport):  # pylint: disable=too-many-locals
+        """Test the transfer of a large amount of data on stdout."""
+        import os
+        import random
+        import string
+        import tempfile
+
+        # Create a "big" file of > 2MB (10MB here; in general, larger than the buffer size)
+        min_file_size_bytes = 5 * 1024 * 1024
+        # The file content will be a sequence of these lines, until the size
+        # is > MIN_FILE_SIZE_BYTES
+        file_line = 'This is a Unicødê štring\n'
+        fname = 'test.dat'
+        script_fname = 'script.py'
+
+        # I create a large content of the file (as a string)
+        file_line_binary = file_line.encode('utf8')
+        line_repetitions = (min_file_size_bytes // len(file_line_binary) + 1)
+        fcontent = (file_line_binary * line_repetitions).decode('utf8')
+
+        with custom_transport as trans:
+            # We cannot use tempfile.mkdtemp because we're on a remote folder
+            location = trans.normalize(os.path.join('/', 'tmp'))
+            directory = 'temp_dir_test_transfer_big_stdout'
+            trans.chdir(location)
+
+            self.assertEqual(location, trans.getcwd())
+            while trans.isdir(directory):
+                # I append a random letter/number until it is unique
+                directory += random.choice(string.ascii_uppercase + string.digits)
+            trans.mkdir(directory)
+            trans.chdir(directory)
+
+            with tempfile.NamedTemporaryFile(mode='wb') as tmpf:
+                tmpf.write(fcontent.encode('utf8'))
+                tmpf.flush()
+
+                # I put a file with specific content there at the right file name
+                trans.putfile(tmpf.name, fname)
+
+            python_code = r"""import sys
+
+# disable buffering is only allowed in binary
+#stdout = open(sys.stdout.fileno(), mode="wb", buffering=0)
+#stderr = open(sys.stderr.fileno(), mode="wb", buffering=0)
+# Use these lines instead if you want to use buffering
+# I am leaving these in as most programs typically are buffered
+stdout = open(sys.stdout.fileno(), mode="wb")
+stderr = open(sys.stderr.fileno(), mode="wb")
+
+line = '''{}'''.encode('utf-8')
+
+for i in range({}):
+    stdout.write(line)
+    stderr.write(line)
+""".format(file_line, line_repetitions)
+
+            with tempfile.NamedTemporaryFile(mode='w') as tmpf:
+                tmpf.write(python_code)
+                tmpf.flush()
+
+                # I put a file with specific content there at the right file name
+                trans.putfile(tmpf.name, script_fname)
+
+            # I get its content via the stdout; emulate also network slowness (note I cat twice)
+            retcode, stdout, stderr = trans.exec_command_wait(f'cat {fname} ; sleep 1 ; cat {fname}')
+            self.assertEqual(stderr, '')
+            self.assertEqual(stdout, fcontent + fcontent)
+            self.assertEqual(retcode, 0)
+
+            # I get its content via the stderr; emulate also network slowness (note I cat twice)
+            retcode, stdout, stderr = trans.exec_command_wait(f'cat {fname} >&2 ; sleep 1 ; cat {fname} >&2')
+            self.assertEqual(stderr, fcontent + fcontent)
+            self.assertEqual(stdout, '')
+            self.assertEqual(retcode, 0)
+
+            # This time, I cat one one on each of the two streams intermittently, to check
+            # that this does not hang.
+
+            # Initially I was using a command like
+            #        'i=0; while [ "$i" -lt {} ] ; do let i=i+1; echo -n "{}" ; echo -n "{}" >&2 ; done'.format(
+            #        line_repetitions, file_line, file_line))
+            # However this is pretty slow (and using 'cat' of a file containing only one line is even slower)
+
+            retcode, stdout, stderr = trans.exec_command_wait(f'python3 {script_fname}')
+
+            self.assertEqual(stderr, fcontent)
+            self.assertEqual(stdout, fcontent)
+            self.assertEqual(retcode, 0)
+
+            # Clean-up
+            trans.remove(fname)
+            trans.remove(script_fname)
+            trans.chdir('..')
+            trans.rmdir(directory)
+
 
 class TestDirectScheduler(unittest.TestCase):
     """


### PR DESCRIPTION
Fixes #1525

The simple shift of the line `retval = channel.recv_exit_status()`
below `stdout.read()` and `stderr.read()`, while partially improving
the situation, is not enough (see discussion in #1525).
This instead reads in chunks both stdout and stderr, alternating between them.
Tests (added) show that this does not hang anymore for large files.