### PR TITLE
Remove conda activattion from configure-aiida.sh script.

### DIFF
--- a/.docker/opt/configure-aiida.sh
+++ b/.docker/opt/configure-aiida.sh
@@ -8,20 +8,7 @@ set -x
 # Environment.
 export SHELL=/bin/bash
 
-# Activate conda.
-__conda_setup="$('/opt/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then
-        . "/opt/conda/etc/profile.d/conda.sh"
-    else
-        export PATH="/opt/conda/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-
-# Very important to run after conda activation, otherwise AiiDA won't work.
+# Update the list of installed aiida plugins.
 reentry scan
 
 # Setup AiiDA autocompletion.


### PR DESCRIPTION
This is now done globally by the base container: https://github.com/aiidateam/aiida-prerequisites/pull/13