### PR TITLE
`QueryBuilder`: add support for `datetime.date` objects in filters

### DIFF
--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -24,6 +24,16 @@ class TestQueryBuilder(AiidaTestCase):
         self.clean_db()
         self.insert_data()
 
+    def test_date_filters_support(self):
+        """Verify that `datetime.date` is supported in filters."""
+        from datetime import datetime, date, timedelta
+
+        orm.Data(ctime=datetime.now() - timedelta(days=3)).store()
+        orm.Data(ctime=datetime.now() - timedelta(days=1)).store()
+
+        builder = orm.QueryBuilder().append(orm.Node, filters={'ctime': {'>': date.today() - timedelta(days=1)}})
+        self.assertEqual(builder.count(), 1)
+
     def test_ormclass_type_classification(self):
         """
         This tests the classifications of the QueryBuilder


### PR DESCRIPTION
Fixes #3794 

Each query is hashed for efficiency reasons, such that repeated queries
can be taken from a cache. This requires the builder instance and all
its attributes to be hashable. The filters can reference `datetime.date`
objects to express date and time conditions, but these were not
supported by the hashing implementation, unlike `datetime.datetime`
objects. Here we update the `aiida.common.hashing.make_hash` single
dispatch to also support `datetime.date` objects.