### PR TITLE
Disable caching for data

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -85,7 +85,7 @@ class Node(Entity, metaclass=AbstractNodeMeta):
     _hash_ignored_attributes = tuple()
 
     # Flag that determines whether the class can be cached.
-    _cachable = True
+    _cachable = False
 
     # Base path within the repository where to put objects by default
     _repository_base_path = 'path'

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -46,9 +46,6 @@ class ProcessNode(Sealable, Node):
     # The link_type might not be correct while the object is being created.
     _hash_ignored_inputs = ['CALL_CALC', 'CALL_WORK']
 
-    # Specific sub classes should be marked as cacheable when appropriate
-    _cachable = False
-
     _unstorable_message = 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
     def __str__(self):

--- a/aiida/orm/nodes/process/workflow/workchain.py
+++ b/aiida/orm/nodes/process/workflow/workchain.py
@@ -19,8 +19,6 @@ __all__ = ('WorkChainNode',)
 class WorkChainNode(WorkflowNode):
     """ORM class for all nodes representing the execution of a WorkChain."""
 
-    _cachable = False
-
     STEPPER_STATE_INFO_KEY = 'stepper_state_info'
 
     @classproperty

--- a/docs/source/developer_guide/core/caching.rst
+++ b/docs/source/developer_guide/core/caching.rst
@@ -42,7 +42,7 @@ The ``WorkflowNode`` example
 As discussed in the :ref:`user guide <caching_limitations>`, nodes which can have ``RETURN`` links cannot be cached.
 This is enforced on two levels:
 
-* The ``_cachable`` property is set to ``False`` in the :class:`~aiida.orm.nodes.process.ProcessNode`, and only re-enabled in :class:`~aiida.orm.nodes.process.calculation.calcjob.CalcJobNode` and :class:`~aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode`.
+* The ``_cachable`` property is set to ``False`` in the :class:`~aiida.orm.nodes.Node`, and only re-enabled in :class:`~aiida.orm.nodes.process.calculation.calculation.CalculationNode` (which affects CalcJobs and calcfunctions).
   This means that a :class:`~aiida.orm.nodes.process.workflow.workflow.WorkflowNode` will not be cached.
 * The ``_store_from_cache`` method, which is used to "clone" an existing node, will raise an error if the existing node has any ``RETURN`` links.
   This extra safe-guard prevents cases where a user might incorrectly override the ``_cachable`` property on a ``WorkflowNode`` subclass.

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -17,7 +17,6 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions, LinkType
 from aiida.orm import Data, Node, User, CalculationNode, WorkflowNode, load_node
 from aiida.orm.utils.links import LinkTriple
-from aiida.manage.caching import enable_caching
 
 
 class TestNode(AiidaTestCase):
@@ -749,7 +748,9 @@ def test_store_from_cache(clear_database_before_test):  # pylint: disable=unused
         data.put_object_from_tree(tmpdir)
 
     data.store()
-    with enable_caching():
-        clone = data.clone().store()
+
+    clone = data.clone()
+    clone._store_from_cache(data, with_transaction=False)  # pylint: disable=protected-access
+
     assert clone.get_cache_source() == data.uuid
     assert data.get_hash() == clone.get_hash()

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -750,7 +750,8 @@ def test_store_from_cache(clear_database_before_test):  # pylint: disable=unused
     data.store()
 
     clone = data.clone()
-    clone._store_from_cache(data, with_transaction=False)  # pylint: disable=protected-access
+    clone._store_from_cache(data, with_transaction=True)  # pylint: disable=protected-access
 
+    assert clone.is_stored
     assert clone.get_cache_source() == data.uuid
     assert data.get_hash() == clone.get_hash()


### PR DESCRIPTION
Fixes #3802.

Change the default for the ``_cachable`` class attribute to ``False`` in the ``Node`` class. This means it will be enabled only in the ``CalculationNode`` sub-classes.