### PR TITLE
remove deprecation warning from get_description

### DIFF
--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -160,9 +160,6 @@ class Code(Data):
         """Return a string description of this Code instance.
 
         :return: string description of this Code instance
-
-        .. deprecated:: 1.2.0
-            Will be removed in `v2.0.0`. Use `.description` property instead
         """
         return '{}'.format(self.description)
 


### PR DESCRIPTION
fix #3818 

The `description` property is understood to return the value stored in
the description column, while `get_description` may be a compound of
various columns/attributes.

Reverting incorrect deprecation of get_description for the Code class.