### PR TITLE
add append and prepend to aiida_local_code_factory

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -133,13 +133,15 @@ def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-oute
     :rtype: object
     """
 
-    def get_code(entry_point, executable, computer=aiida_localhost):
+    def get_code(entry_point, executable, computer=aiida_localhost, append=None, prepend=None):
         """Get local code.
         Sets up code for given entry point on given computer.
 
         :param entry_point: Entry point of calculation plugin
         :param executable: name of executable; will be searched for in local system PATH.
         :param computer: (local) AiiDA computer
+        :param append: Append text for code setup
+        :param append: Prepend text for code setup
         :return: The code node
         :rtype: :py:class:`aiida.orm.Code`
         """
@@ -158,6 +160,10 @@ def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-oute
             input_plugin_name=entry_point,
             remote_computer_exec=[computer, executable_path],
         )
+        if append is not None:
+            code.set_append_text(append)
+        if prepend is not None:
+            code.set_prepend_text(prepend)
         code.label = executable
         return code.store()
 

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -140,9 +140,9 @@ def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-oute
         :param entry_point: Entry point of calculation plugin
         :param executable: name of executable; will be searched for in local system PATH.
         :param computer: (local) AiiDA computer
-        :param prepend: a string of code that will be put in the scheduler script before the
+        :param prepend_text: a string of code that will be put in the scheduler script before the
             execution of the code.
-        :param append: a string of code that will be put in the scheduler script after the
+        :param append_text: a string of code that will be put in the scheduler script after the
             execution of the code.
         :return: The code node
         :rtype: :py:class:`aiida.orm.Code`

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -133,15 +133,17 @@ def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-oute
     :rtype: object
     """
 
-    def get_code(entry_point, executable, computer=aiida_localhost, append=None, prepend=None):
+    def get_code(entry_point, executable, computer=aiida_localhost, prepend_text=None, append_text=None):
         """Get local code.
         Sets up code for given entry point on given computer.
 
         :param entry_point: Entry point of calculation plugin
         :param executable: name of executable; will be searched for in local system PATH.
         :param computer: (local) AiiDA computer
-        :param append: Append text for code setup
-        :param append: Prepend text for code setup
+        :param prepend: a string of code that will be put in the scheduler script before the
+            execution of the code.
+        :param append: a string of code that will be put in the scheduler script after the
+            execution of the code.
         :return: The code node
         :rtype: :py:class:`aiida.orm.Code`
         """
@@ -160,10 +162,10 @@ def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-oute
             input_plugin_name=entry_point,
             remote_computer_exec=[computer, executable_path],
         )
-        if append is not None:
-            code.set_append_text(append)
-        if prepend is not None:
-            code.set_prepend_text(prepend)
+        if prepend_text is not None:
+            code.set_prepend_text(prepend_text)
+        if append_text is not None:
+            code.set_append_text(append_text)
         code.label = executable
         return code.store()
 


### PR DESCRIPTION
This PR aims to add the ability of adding `append_text` and `prepend_text` to the `aiida_local_code_factory` which is need in writing tests for codes where we need to have these extra fields. 