### PR TITLE
Update coverage upload step and use actions/checkout v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,14 +139,13 @@ jobs:
         .github/workflows/tests.sh
 
     - name: Upload coverage report
-      if: matrix.python-version == 3.5
-      uses: codecov/codecov-action@v1.0.5
+      if: matrix.python-version == 3.5 && github.repository == 'aiidateam/aiida-core'
+      uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         name: aiida-pytests-py3.5-${{ matrix.backend }}
         flags: ${{ matrix.backend }}
         file: ./coverage.xml
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 
   verdi:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -95,7 +95,7 @@ jobs:
         backend: ['django', 'sqlalchemy']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
     - uses: CasperWA/postgresql-action@v1.2
       with:
         postgresql version: '10'
@@ -153,7 +153,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -175,7 +175,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
 
     - name: Install docker
       run: |


### PR DESCRIPTION
Update coverage upload step.

Since it is [now possible](https://community.codecov.io/t/whitelist-github-action-servers-to-upload-without-a-token/491/17) to upload tokenless to codecov (_only_ from public GitHub repositories), we should do this for our PRs.

CI also fails if the coverage upload fails now.

The logic for when the coverage should be uploaded:
- ONLY for tests with Python 3.5
- ~If it's a PR.~
- ~If it's a push commit AND the repository is `aiidateam/aiida-core`.~
- It's a push in or PR against the repository `aiidateam/aiida-core`

Note: I wrongly created the PR #3834 to test the `if` part of when the coverage should be uploaded. It was originally meant to point to my fork - and since I later rebased, it didn't allow me to reopen the PR. So here's a new one :)

**Edit**: Also updated the checkout action to ~v2~ master (~`actions/checkout@v2`~ `actions/checkout@master`). It's more robust and performant than v1, see [here](https://github.com/actions/checkout) for more information.
It was necessary to use `master` instead of `v2`, since otherwise the codecov-action cannot retrieve the PR number, which is needed for uploading coverage.