### PR TITLE
Update verdi_user_guide.rst.

### DIFF
--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -476,9 +476,11 @@ Below is a list with all available subcommands.
                                       addresses. Automatically discovered archive
                                       URLs will be downloadeded and added to
                                       ARCHIVES for importing
+
       -G, --group GROUP               Specify group to which all the import nodes
                                       will be added. If such a group does not
                                       exist, it will be created automatically.
+
       -e, --extras-mode-existing [keep_existing|update_existing|mirror|none|ask]
                                       Specify which extras from the export archive
                                       should be imported for nodes that are
@@ -491,20 +493,25 @@ Below is a list with all available subcommands.
                                       mirror: import all extras and remove any
                                       existing extras that are not present in the
                                       archive. none: do not import any extras.
+
       -n, --extras-mode-new [import|none]
                                       Specify whether to import extras of new
                                       nodes: import: import extras. none: do not
                                       import extras.
+
       --comment-mode [newest|overwrite]
                                       Specify the way to import Comments with
                                       identical UUIDs: newest: Only the newest
                                       Comments (based on mtime)
                                       (default).overwrite: Replace existing
                                       Comments with those from the import file.
+
       --migration / --no-migration    Force migration of export file archives, if
                                       needed.  [default: True]
+
       -n, --non-interactive           Non-interactive mode: never prompt for
                                       input.
+
       --help                          Show this message and exit.
 
 
@@ -615,10 +622,12 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           Non-interactive mode: never prompt for
                                       input.
+
       --profile PROFILE               The name of the new profile.  [required]
       --email TEXT                    Email address that serves as the user name
                                       and a way to identify data created by it.
                                       [required]
+
       --first-name TEXT               First name of the user.  [required]
       --last-name TEXT                Last name of the user.  [required]
       --institution TEXT              Institution of the user.  [required]
@@ -633,13 +642,17 @@ Below is a list with all available subcommands.
       --db-password TEXT              Password to connect to the database.
       --su-db-name TEXT               Name of the template database to connect to
                                       as the database superuser.
+
       --su-db-username TEXT           User name of the database super user.
       --su-db-password TEXT           Password to connect as the database
                                       superuser.
+
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
+
       --config FILE                   Load option values from configuration file
                                       in yaml format.
+
       --help                          Show this message and exit.
 
 
@@ -660,6 +673,7 @@ Below is a list with all available subcommands.
     Options:
       -e, --entry-point PLUGIN  Only include nodes that are class or sub class of
                                 the class identified by this entry point.
+
       -f, --force               Do not ask for confirmation.
       --help                    Show this message and exit.
 
@@ -687,6 +701,7 @@ Below is a list with all available subcommands.
       --debug                 run app in debug mode
       --wsgi-profile          to use WSGI profiler middleware for finding
                               bottlenecks in web application
+
       --hookup / --no-hookup  to hookup app
       --help                  Show this message and exit.
 
@@ -709,8 +724,10 @@ Below is a list with all available subcommands.
       -i, --include TEXT            Include these classes from auto grouping
       -E, --excludesubclasses TEXT  Exclude these classes and their sub classes
                                     from auto grouping
+
       -I, --includesubclasses TEXT  Include these classes and their sub classes
                                     from auto grouping
+
       --help                        Show this message and exit.
 
 
@@ -728,10 +745,12 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           Non-interactive mode: never prompt for
                                       input.
+
       --profile PROFILE               The name of the new profile.  [required]
       --email TEXT                    Email address that serves as the user name
                                       and a way to identify data created by it.
                                       [required]
+
       --first-name TEXT               First name of the user.  [required]
       --last-name TEXT                Last name of the user.  [required]
       --institution TEXT              Institution of the user.  [required]
@@ -744,12 +763,16 @@ Below is a list with all available subcommands.
       --db-name TEXT                  Name of the database to create.  [required]
       --db-username TEXT              Name of the database user to create.
                                       [required]
+
       --db-password TEXT              Password to connect to the database.
                                       [required]
+
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
+
       --config FILE                   Load option values from configuration file
                                       in yaml format.
+
       --help                          Show this message and exit.
 
 
@@ -769,9 +792,11 @@ Below is a list with all available subcommands.
       --no-startup                    When using plain Python, ignore the
                                       PYTHONSTARTUP environment variable and
                                       ~/.pythonrc.py script.
+
       -i, --interface [ipython|bpython]
                                       Specify an interactive interpreter
                                       interface.
+
       --help                          Show this message and exit.
 
 


### PR DESCRIPTION
The latest release of Click (7.1) produces a slightly different
formatting of the CLI help strings.

This patch updates our docs to match that formatting.

This patch fixes the failure of the verdi-autodocs pre-commit hook with
Click version 7.1.