### PR TITLE
Pin the Click version to 7.0.

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -7,7 +7,7 @@ circus~=0.16.1
 click-completion~=0.5.1
 click-config-file~=0.5.0
 click-spinner~=0.1.8
-click~=7.0
+click==7.0
 coverage<5.0
 django~=2.2
 docutils==0.15.2

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - click-completion~=0.5.1
 - click-config-file~=0.5.0
 - click-spinner~=0.1.8
-- click~=7.0
+- click==7.0
 - django~=2.2
 - ete3~=3.1
 - python-graphviz~=0.13

--- a/setup.json
+++ b/setup.json
@@ -26,7 +26,7 @@
     "click-completion~=0.5.1",
     "click-config-file~=0.5.0",
     "click-spinner~=0.1.8",
-    "click~=7.0",
+    "click==7.0",
     "django~=2.2",
     "ete3~=3.1",
     "graphviz~=0.13",


### PR DESCRIPTION
The recent update to Click (7.1) breaks our tests and this CI workflow,
because the help output formatting was slightly changed.

Until we have resolved other issues we should pin the Click version to
7.0.

Because of this incidence, I have added "Click" to the [list of problematic dependencies](https://github.com/aiidateam/aiida-core/wiki/AiiDA-Dependency-Management#problematic-dependencies).