### PR TITLE
Use actions/checkout@v2 (instead of @master)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -76,7 +76,7 @@ jobs:
         python-version: [3.5, 3.8]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: CasperWA/postgresql-action@v1.2
       with:
         postgresql version: '10'
@@ -143,7 +143,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -165,7 +165,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Install docker
       run: |


### PR DESCRIPTION
`master` was used due to `actions/checkout@v2` not working with `codecov/codecov-action@v1`.

An issue was raised at actions/checkout#180