### PR TITLE
Dm/revise update requirements workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,7 @@ jobs:
           If this commit is part of a pull request, you can automatically update the requirements by
           commenting with '/update-requirements'.
 
-          Click [here](https://github.com/aiidateam/aiida-core/wiki/AiiDA-Dependency-Management) for
-          more information.
+          Click [here](https://github.com/aiidateam/aiida-core/wiki/AiiDA-Dependency-Management) for more information.
 
   tests:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,42 @@ jobs:
       run:
         pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
+  check-requirements:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install dm-script dependencies
+      run: pip install packaging==20.3 click~=7.0 pyyaml~=5.1 toml
+
+    - name: Check requirements files
+      run: python ./utils/dependency_management.py check-requirements
+
+    - name: Create commit comment
+      if: failure()
+      uses: peter-evans/commit-comment@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: setup.json
+        body: |
+          It appears that at least one of the environments defined in the requirements files
+          ('requirements/*.txt') is not meeting the dependencies specified in the 'setup.json' file.
+          These files are used for testing, so it is important that they are updated.
+
+          If this commit is part of a pull request, you can automatically update the requirements by
+          commenting with '/update-requirements'.
+
+          Click [here](https://github.com/aiidateam/aiida-core/wiki/AiiDA-Dependency-Management) for
+          more information.
+
   tests:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         body: |
           It appears that at least one of the environments defined in the requirements files
           ('requirements/*.txt') is not meeting the dependencies specified in the 'setup.json' file.
-          These files are used for testing, so it is important that they are updated.
+          These files define the environment for continuous integration tests, so it is important that they are updated.
 
           If this commit is part of a pull request, you can automatically update the requirements by
           commenting with '/update-requirements'.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       run: pip install packaging==20.3 click~=7.0 pyyaml~=5.1 toml
 
     - name: Check requirements files
-      run: python ./utils/dependency_management.py check-requirements
+      run: python ./utils/dependency_management.py check-requirements DEFAULT
 
     - name: Create commit comment
       if: failure()

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: 3.7
 
     - name: Install dm-script dependencies
-      run: pip install click~=7.0 pyyaml~=5.1 toml
+      run: pip install packaging==20.3 click~=7.0 pyyaml~=5.1 toml
 
     - name: Validate
       run: python ./utils/dependency_management.py validate-all

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -1,13 +1,8 @@
 name: update-requirements
 
 on:
-  push:
-    paths:
-      - 'setup.*'
-      - '.github/workflows/update-requirements.yml'
-  pull_request:
-    branches:
-      - master
+  repository_dispatch:
+    types: [update-requirements-command]
 
 jobs:
 

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -23,7 +23,9 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.head_ref }}
     - uses: CasperWA/postgresql-action@v1.2
       with:
         postgresql version: '10'
@@ -88,6 +90,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.head_ref }}
 
       - name: Download requirements.txt files
         uses: actions/download-artifact@v1
@@ -106,7 +110,7 @@ jobs:
         uses: ad-m/github-push-action@v0.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          branch: ${{ github.event.client_payload.head_ref }}
 
       - name: Create Pull Request (since update via push failed)
         if: failure() && github.repository == 'aiidateam/aiida-core'

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -339,8 +339,7 @@ def check_requirements(extras):
     match all the dependencies specified in 'setup.json.
 
     The arguments allow to specify which 'extra' requirements to expect.
-    Use DEFAULT to expect all extra requirements that are to be expected
-    by default.
+    Use 'DEFAULT' to select 'atomic_tools', 'docs', 'notebook', 'rest', and 'testing'.
 
     """
 

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -369,6 +369,8 @@ def check_requirements(extras):
                 '\n'.join(' - ' + str(f) for f in not_installed)
             )
 
+    click.secho("Requirements files appear to be in sync with specifications in 'setup.json'.", fg='green')
+
 
 @cli.command()
 @click.argument('extras', nargs=-1)


### PR DESCRIPTION
This PR adds a command to the dependency_management script to check the requirements files and a step to the CI workflow which will execute that check. In addition to failing the CI checks, a comment will be issued on to the commit itself, that explains what the problem is and how to proceed.

The update-requirements workflow is now only manually triggered. Triggering will be achieved via  a slash-command comment on the PR which is picked up by the aiida-bot.