### PR TITLE
Dm/auto generate all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,6 +110,18 @@
     description: "This hook runs Prospector: https://github.com/landscapeio/prospector"
     entry: prospector
 
+  - id: dm-generate-all
+    name: Update all requirements files
+    entry: python ./utils/dependency_management.py generate-all
+    language: system
+    files: >-
+      (?x)^(
+        setup.py|
+        setup.json|
+        utils/dependency_management.py
+        )$
+    pass_filenames: false
+
   - id: rtd-requirements
     name: Validate docs/requirements_for_rtd.txt
     entry: python ./utils/dependency_management.py validate-rtd-reqs

--- a/setup.json
+++ b/setup.json
@@ -98,6 +98,7 @@
     ],
     "dev_precommit": [
       "astroid==2.3.3",
+      "packaging==20.3",
       "pre-commit==1.18.3",
       "prospector==1.2.0",
       "pylint==2.4.4",


### PR DESCRIPTION
With this patch the "dependent" dependency specification files (`environment.yml` etc.) which are updated by `./util/dependency_management.py generate-all` command, are automatically updated as part of the pre-commit hook; reducing the likelihood of failed CI runs, because of the inconsistency.

Note that this will not affect the "requirements" files and the validation checks as part of the pre-commit hook are not checking those files. They are only checked as part of the CI workflow.