### PR TITLE
Convert argument to str in `aiida.common.escaping.escape_for_bash`

### DIFF
--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -38,6 +38,8 @@ def escape_for_bash(str_to_escape):
     if str_to_escape is None:
         return ''
 
+    str_to_escape = str(str_to_escape)
+
     escaped_quotes = str_to_escape.replace("'", """'"'"'""")
     return "'{}'".format(escaped_quotes)
 

--- a/tests/common/test_escaping.py
+++ b/tests/common/test_escaping.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida.common.escaping`."""
+from aiida.common.escaping import escape_for_bash
+
+
+def test_escape_for_bash():
+    """Tests various inputs for `aiida.common.escaping.escape_for_bash`."""
+    tests = (
+        [None, ''],
+        ['string', "'string'"],
+        ['string with space', "'string with space'"],
+        ["string with a ' single quote", """'string with a '"'"' single quote'"""],
+        [1, "'1'"],
+        [2.0, "'2.0'"],
+    )
+
+    for string_input, string_escaped in tests:
+        assert escape_for_bash(string_input) == string_escaped


### PR DESCRIPTION
Fixes #3872 

Without conversion to string, any non-string type will cause the
function to raise an `AttributeError` since it won't have the method
`str_replace`.

Supersedes #3769 