### PR TITLE
Add python intersphinx mapping

### DIFF
--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -106,7 +106,7 @@ class InteractiveOption(ConditionalOption):
         return None
 
     def _get_default(self, ctx):
-        """provides the functionality of :func:`click.Option.get_default`"""
+        """provides the functionality of :meth:`click.Option.get_default`"""
         if self._contextual_default is not None:
             default = self._contextual_default(ctx)
         else:

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -321,6 +321,9 @@ class Waiting(plumpy.Waiting):
     """The waiting state for the `CalcJob` process."""
 
     def __init__(self, process, done_callback, msg=None, data=None):
+        """
+        :param :class:`~plumpy.base.state_machine.StateMachine` process: The process this state belongs to
+        """
         super().__init__(process, done_callback, msg, data)
         self._task = None
         self._killing = None

--- a/aiida/engine/processes/process_spec.py
+++ b/aiida/engine/processes/process_spec.py
@@ -65,10 +65,10 @@ class ProcessSpec(plumpy.ProcessSpec):
             raise ValueError('status should be a positive integer, received {}'.format(type(status)))
 
         if not isinstance(label, str):
-            raise TypeError('label should be of basestring type and not of {}'.format(type(label)))
+            raise TypeError('label should be of str type and not of {}'.format(type(label)))
 
         if not isinstance(message, str):
-            raise TypeError('message should be of basestring type and not of {}'.format(type(message)))
+            raise TypeError('message should be of str type and not of {}'.format(type(message)))
 
         if not isinstance(invalidates_cache, bool):
             raise TypeError('invalidates_cache should be of type bool and not of {}'.format(type(invalidates_cache)))

--- a/aiida/orm/implementation/logs.py
+++ b/aiida/orm/implementation/logs.py
@@ -45,7 +45,7 @@ class BackendLog(backends.BackendEntity):
         The name of the logger that created this entry
 
         :return: The entry loggername
-        :rtype: basestring
+        :rtype: str
         """
 
     @abc.abstractproperty
@@ -54,7 +54,7 @@ class BackendLog(backends.BackendEntity):
         The name of the log level
 
         :return: The entry log level name
-        :rtype: basestring
+        :rtype: str
         """
 
     @abc.abstractproperty
@@ -72,7 +72,7 @@ class BackendLog(backends.BackendEntity):
         Get the message corresponding to the entry
 
         :return: The entry message
-        :rtype: basestring
+        :rtype: str
         """
 
     @abc.abstractproperty

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -40,7 +40,7 @@ class Log(entities.Entity):
             Helper function to create a log entry from a record created as by the python logging library
 
             :param record: The record created by the logging module
-            :type record: :class:`logging.record`
+            :type record: :class:`logging.LogRecord`
 
             :return: An object implementing the log entry interface
             :rtype: :class:`aiida.orm.logs.Log`
@@ -139,16 +139,16 @@ class Log(entities.Entity):
         :type time: :class:`!datetime.datetime`
 
         :param loggername: name of logger
-        :type loggername: basestring
+        :type loggername: str
 
         :param levelname: name of log level
-        :type levelname: basestring
+        :type levelname: str
 
         :param dbnode_id: id of database node
         :type dbnode_id: int
 
         :param message: log message
-        :type message: basestring
+        :type message: str
 
         :param metadata: metadata
         :type metadata: dict
@@ -194,7 +194,7 @@ class Log(entities.Entity):
         The name of the logger that created this entry
 
         :return: The entry loggername
-        :rtype: basestring
+        :rtype: str
         """
         return self._backend_entity.loggername
 
@@ -204,7 +204,7 @@ class Log(entities.Entity):
         The name of the log level
 
         :return: The entry log level name
-        :rtype: basestring
+        :rtype: str
         """
         return self._backend_entity.levelname
 
@@ -224,7 +224,7 @@ class Log(entities.Entity):
         Get the message corresponding to the entry
 
         :return: The entry message
-        :rtype: basestring
+        :rtype: str
         """
         return self._backend_entity.message
 

--- a/aiida/orm/nodes/data/array/xy.py
+++ b/aiida/orm/nodes/data/array/xy.py
@@ -43,10 +43,10 @@ class XyData(ArrayData):
     def _arrayandname_validator(self, array, name, units):
         """
         Validates that the array is an numpy.ndarray and that the name is
-        of type basestring. Raises InputValidationError if this not the case.
+        of type str. Raises InputValidationError if this not the case.
         """
         if not isinstance(name, str):
-            raise InputValidationError('The name must always be an instance of basestring.')
+            raise InputValidationError('The name must always be a str.')
 
         if not isinstance(array, np.ndarray):
             raise InputValidationError('The input array must always be a numpy array')
@@ -55,7 +55,7 @@ class XyData(ArrayData):
         except ValueError:
             raise InputValidationError('The input array must only contain floats')
         if not isinstance(units, str):
-            raise InputValidationError('The units must always be an instance of basestring.')
+            raise InputValidationError('The units must always be a str.')
 
     def set_x(self, x_array, x_name, x_units):
         """

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,11 @@ needs_sphinx = '1.5.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode', 'IPython.sphinxext.ipython_console_highlighting', 'IPython.sphinxext.ipython_directive', 'sphinxcontrib.contentui', 'aiida.sphinxext']
+extensions = [
+    'sphinx.ext.intersphinx', 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.viewcode', 'sphinx.ext.coverage',
+    'sphinx.ext.imgmath', 'sphinx.ext.ifconfig', 'sphinx.ext.todo', 'IPython.sphinxext.ipython_console_highlighting',
+    'IPython.sphinxext.ipython_directive', 'sphinxcontrib.contentui', 'aiida.sphinxext'
+]
 ipython_mplbackend = ''
 
 todo_include_todos = True
@@ -115,6 +119,14 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+intersphinx_mapping = {
+    'click': ('https://click.palletsprojects.com/', None),
+    'flask': ('http://flask.pocoo.org/docs/latest/', None),
+    'flask_restful': ('https://flask-restful.readthedocs.io/en/latest/', None),
+    'kiwipy': ('https://kiwipy.readthedocs.io/en/latest/', None),
+    'plumpy': ('https://plumpy.readthedocs.io/en/latest/', None),
+    'python': ('https://docs.python.org/3', None),
+}
 
 # -- Options for HTML output ---------------------------------------------------
 
@@ -361,17 +373,8 @@ epub_copyright = copyright
 # Allow duplicate toc entries.
 #epub_tocdup = True
 
-# otherwise, readthedocs.org uses their theme by default, so no need
-# to specify it
-
-
 # Warnings to ignore when using the -n (nitpicky) option
-# We should ignore any python built-in exception, for instance
-nitpick_ignore = [('py:class','Warning'), ('py:class', 'exceptions.Warning')]
-
-for line in open('nitpick-exceptions'):
-    if line.strip() == '' or line.startswith('#'):
-        continue
-    dtype, target = line.split(None, 1)
-    target = target.strip()
-    nitpick_ignore.append((dtype, target))
+with open('nitpick-exceptions', 'r') as handle:
+    nitpick_ignore = [
+        tuple(line.strip().split(None, 1)) for line in handle.readlines() if line.strip() and not line.startswith('#')
+    ]

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -1,243 +1,86 @@
-# built-in python exceptions
-py:exc  ArithmeticError
-py:exc  AssertionError
-py:exc  AttributeError
-py:exc  BaseException
-py:exc  BufferError
-py:exc  DeprecationWarning
-py:exc  EOFError
-py:exc  EnvironmentError
-py:exc  Exception
-py:exc  FloatingPointError
-py:exc  FutureWarning
-py:exc  GeneratorExit
-py:exc  IOError
-py:exc  ImportError
-py:exc  ImportWarning
-py:exc  IndentationError
-py:exc  IndexError
-py:exc  KeyError
-py:exc  KeyboardInterrupt
-py:exc  LookupError
-py:exc  MemoryError
-py:exc  NameError
-py:exc  NotImplementedError
-py:exc  OSError
-py:exc  OverflowError
-py:exc  PendingDeprecationWarning
-py:exc  ReferenceError
-py:exc  RuntimeError
-py:exc  RuntimeWarning
-py:exc  StandardError
-py:exc  StopIteration
-py:exc  SyntaxError
-py:exc  SyntaxWarning
-py:exc  SystemError
-py:exc  SystemExit
-py:exc  TabError
-py:exc  TypeError
-py:exc  UnboundLocalError
-py:exc  UnicodeDecodeError
-py:exc  UnicodeEncodeError
-py:exc  UnicodeError
-py:exc  UnicodeTranslateError
-py:exc  UnicodeWarning
-py:exc  UserWarning
-py:exc  VMSError
-py:exc  ValueError
-py:exc  Warning
-py:exc  WindowsError
-py:exc  ZeroDivisionError
+### python builtins
 
-# python builtins
-py:class  classmethod
-py:class  dict
-py:class  callable
-py:class  filter
-py:class  list
-py:class  object
-py:class  unittest.case.TestCase
-py:class  unittest.runner.TextTestRunner
-py:class  unittest2.case.TestCase
-py:meth   unittest.TestLoader.discover
-py:meth   copy.copy
-py:class  abc.ABC
-py:class  exceptions.Exception
-py:class  exceptions.ValueError
-py:class  exceptions.BaseException
-# repeat for Python 3
-py:class  Exception
-py:class  ValueError
-py:class  BaseException
-py:class  str
-py:class  bytes
-py:class  tuple
-py:class  int
-py:class  float
-py:class  bool
-py:class  basestring
-py:class  None
-py:class  type
-py:class  typing.Final
-# this is required for metaclasses(?)
-py:class  __builtin__.bool
-py:class  __builtin__.float
-py:class  __builtin__.int
-py:class  __builtin__.object
-py:class  __builtin__.str
-py:class  __builtin__.dict
-# ... and the same for Python 3
-py:class  builtins.bool
-py:class  builtins.float
-py:class  builtins.int
-py:class  builtins.object
-py:class  builtins.str
-py:class  builtins.dict
-py:class  set
+# note: there doesn't seem to be a standard way of indicating a callable in python3
+# https://stackoverflow.com/questions/23571253/how-to-define-a-callable-parameter-in-a-python-docstring
+py:class callable
 
-# python builtin objects
-py:obj basestring
-py:obj bool
-py:obj float
-py:obj int
-py:obj str
-py:obj string
-py:obj tuple
-py:obj None
-py:obj bool
+# For some reason, "filter" does not seem to be found
+py:class filter
 
-# python packages
-# Note: These are needed, if they are provided, e.g.
-# as types or rtypes without actually being imported
-py:class  abc.ABCMeta
+py:class unittest.case.TestCase
+py:class unittest.runner.TextTestRunner
 
-py:exc    click.BadParameter
-py:exc    click.UsageError
-py:class  click.ParamType
-py:class  click.core.Group
-py:class  click.core.Option
-py:class  click.Command
-py:class  click.Group
-py:class  click.Option
-py:class  click.types.ParamType
-py:class  click.types.Choice
-py:class  click.types.IntParamType
-py:class  click.types.StringParamType
-py:class  click.types.Path
+# required for metaclasses(?)
+py:class builtins.bool
+py:class builtins.float
+py:class builtins.int
+py:class builtins.object
+py:class builtins.str
+py:class builtins.dict
 
-py:class  concurrent.futures._base.TimeoutError
+### AiiDA
 
-py:class  distutils.version.Version
+# not quite clear why necessary...
+py:class WorkChainSpec
 
-py:class  docutils.parsers.rst.Directive
+### python packages
+# Note: These exceptions are needed if
+# * the objects are referenced e.g. as param/return types types in method docstrings (without intersphinx mapping)
+# * the documentation linked via intersphinx lists the objects at a different (usually lower) import hierarchy
+py:class click.core.Group
+py:class click.core.Option
+py:class click.types.ParamType
+py:class click.types.Choice
+py:class click.types.IntParamType
+py:class click.types.StringParamType
+py:class click.types.Path
+py:meth  click.Option.get_default
 
-py:class  enum.Enum
-py:class  enum.IntEnum
+py:class concurrent.futures._base.TimeoutError
 
-py:class  flask.app.Flask
-py:class  flask.json.JSONEncoder
-py:class  flask_restful.Api
-py:class  flask_restful.Resource
+py:class docutils.parsers.rst.Directive
 
-py:class  frozenset
+py:class frozenset
 
-py:class  logging.Filter
-py:class  logging.Handler
-py:class  logging.record
-py:class  logging.Logger
-py:class  logging.LoggerAdapter
+py:class paramiko.proxy.ProxyCommand
 
-py:class  paramiko.proxy.ProxyCommand
+# These can be removed once they are properly included in the `__all__` in `plumpy`
+py:class plumpy.ports.PortNamespace
+py:class plumpy.utils.AttributesDict
 
-py:class  StateMachine
-py:class  plumpy.futures.Future
-py:class  plumpy.processes.Process
-py:class  plumpy.process_comms.ProcessLauncher
-py:class  plumpy.process_spec.ProcessSpec
-py:class  plumpy.Port
-py:class  plumpy.Process
-py:class  plumpy.Communicator
-py:class  plumpy.RemoteProcessThreadController
-py:class  plumpy.Bundle
-py:class  plumpy.workchains.WorkChainSpec
-py:class  plumpy.WorkChainSpec
-py:class  plumpy.Persister
-py:class  plumpy.persistence.Persister
-py:class  plumpy.PersistenceError
-py:class  plumpy.ports.Port
-py:class  plumpy.ports.InputPort
-py:class  plumpy.ports.OutputPort
-py:class  plumpy.ports.PortNamespace
-py:class  plumpy.utils.AttributesDict
-py:class  plumpy.loaders.DefaultObjectLoader
-py:class  plumpy.ObjectLoader
-py:class  plumpy.process_states.Waiting
-py:class  plumpy.process_comms.RemoteProcessThreadController
-py:exc    plumpy.TaskRejected
-py:meth   plumpy.ProcessSpec.output
-py:meth   plumpy.process_spec.ProcessSpec.expose_inputs
-py:meth   plumpy.process_spec.ProcessSpec.expose_outputs
+py:class topika.Connection
 
-py:class  kiwipy.futures.Future
-py:class  kiwipy.communications.TimeoutError
-py:class  kiwipy.Communicator
-py:class  kiwipy.rmq.communicator.RmqThreadCommunicator
+py:class tornado.ioloop.IOLoop
+py:class tornado.concurrent.Future
 
-py:class  topika.Connection
+py:class IPython.core.magic.Magics
 
-py:class  tornado.ioloop.IOLoop
-py:class  tornado.concurrent.Future
+py:class HTMLParser.HTMLParser
+py:class html.parser.HTMLParser
 
-py:class  IPython.core.magic.Magics
+py:class django.contrib.auth.base_user.AbstractBaseUser
+py:class django.contrib.auth.base_user.BaseUserManager
+py:class django.contrib.auth.models.AbstractBaseUser
+py:class django.contrib.auth.models.BaseUserManager
+py:class django.contrib.auth.models.PermissionsMixin
+py:class django.core.exceptions.MultipleObjectsReturned
+py:class django.core.exceptions.ObjectDoesNotExist
+py:class django.db.models.base.Model
+py:class django.db.models.manager.Manager
+py:class django.db.models.query.QuerySet
+py:class django.db.migrations.migration.Migration
 
-py:class  HTMLParser.HTMLParser
-py:class  html.parser.HTMLParser
+py:class flask.app.Flask
 
-py:class  tuple
+py:class sqlalchemy.ext.declarative.api.Base
+py:class sqlalchemy.ext.declarative.api.Model
+py:class sqlalchemy.sql.functions.FunctionElement
+py:class sqlalchemy.orm.query.Query
+py:class sqlalchemy.orm.util.AliasedClass
+py:class sqlalchemy.orm.session.Session
+py:exc sqlalchemy.orm.exc.MultipleResultsFound
 
-py:class  staticmethod
-
-py:class  django.contrib.auth.base_user.AbstractBaseUser
-py:class  django.contrib.auth.base_user.BaseUserManager
-py:class  django.contrib.auth.models.AbstractBaseUser
-py:class  django.contrib.auth.models.BaseUserManager
-py:class  django.contrib.auth.models.PermissionsMixin
-py:class  django.core.exceptions.MultipleObjectsReturned
-py:class  django.core.exceptions.ObjectDoesNotExist
-py:class  django.db.models.base.Model
-py:class  django.db.models.manager.Manager
-py:class  django.db.models.query.QuerySet
-py:class  django.db.migrations.migration.Migration
-
-py:class  sqlalchemy.ext.declarative.api.Base
-py:class  sqlalchemy.ext.declarative.api.Model
-py:class  sqlalchemy.sql.functions.FunctionElement
-py:class  sqlalchemy.orm.query.Query
-py:class  sqlalchemy.orm.util.AliasedClass
-py:class  sqlalchemy.orm.session.Session
-py:exc    sqlalchemy.orm.exc.MultipleResultsFound
-
-py:class  sphinx.ext.autodoc.ClassDocumenter
-
-py:class  collections.abc.Mapping
-py:class  collections.abc.MutableMapping
-py:class  collections.abc.MutableSequence
-py:class  collections.abc.Iterator
-py:class  collections.abc.Sized
-
-# backend-dependent implementation
-py:class  WorkChainSpec
-py:class  aiida.orm.nodes.Node
-py:meth   aiida.engine.processes.process_spec.ProcessSpec.input
-py:meth   aiida.engine.processes.process_spec.ProcessSpec.output
-py:meth   aiida.engine.processes.process_spec.ProcessSpec.outline
-
-# This comes from ABCMeta
-py:meth   aiida.orm.groups.Group.get_from_string
-
-py:mod    click
-py:class  click.Choice
-py:func   click.Option.get_default
+py:class sphinx.ext.autodoc.ClassDocumenter
 
 py:class yaml.Dumper
 py:class yaml.Loader
@@ -245,21 +88,10 @@ py:class yaml.dumper.Dumper
 py:class yaml.loader.Loader
 py:class yaml.FullLoader
 py:class yaml.loader.FullLoader
-
 py:class uuid.UUID
 
-# typing
-py:class typing.Generic
-py:class typing.TypeVar
-
-# Python 3 complains about this because of orm.Entity.Collection inner class (no idea why)
-py:class Collection
-
-
-# psychopg2
 py:class psycopg2.extensions.cursor
 
-# Aldjemy exceptions
 py:class aldjemy.orm.DbNode
 py:class aldjemy.orm.DbLink
 py:class aldjemy.orm.DbComputer
@@ -270,5 +102,4 @@ py:class aldjemy.orm.DbComment
 py:class aldjemy.orm.DbLog
 py:class aldjemy.orm.DbSetting
 
-# Alembic
 py:class alembic.config.Config

--- a/docs/source/working/calculations.rst
+++ b/docs/source/working/calculations.rst
@@ -115,7 +115,7 @@ Next we should define what outputs we expect the calculation to produce:
 Just as for the inputs, one can specify what node type each output should have.
 By default a defined output will be 'required', which means that if the calculation job terminates and the output has not been attached, the process will be marked as failed.
 To indicate that an output is optional, one can use ``required=False`` in the ``spec.output`` call.
-Note that the process spec, and its :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.input` and :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.output` methods provide a lot more functionality.
+Note that the process spec, and its :py:meth:`~plumpy.ProcessSpec.input` and :py:meth:`~plumpy.ProcessSpec.output` methods provide a lot more functionality.
 Fore more details, please refer to the section on :ref:`process specifications<working_processes_spec>`.
 
 

--- a/docs/source/working/workflows.rst
+++ b/docs/source/working/workflows.rst
@@ -178,8 +178,8 @@ The third and final line is extremely important, as it will call the ``define`` 
 Inputs and outputs
 ------------------
 With those formalities out of the way, you can start defining the interesting properties of the work chain through the ``spec``.
-In the example you can see how the method :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.input` is used to define multiple input ports, which document exactly which inputs the work chain expects.
-Similarly, :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.output` is called to instruct that the work chain will produce an output with the label ``result``.
+In the example you can see how the method :py:meth:`~plumpy.ProcessSpec.input` is used to define multiple input ports, which document exactly which inputs the work chain expects.
+Similarly, :py:meth:`~plumpy.ProcessSpec.output` is called to instruct that the work chain will produce an output with the label ``result``.
 These two port creation methods support a lot more functionality, such as adding help string, validation and more, all of which is documented in detail in the section on :ref:`ports and port namespace<working_processes_ports_portnamespaces>`.
 
 
@@ -189,7 +189,7 @@ Outline
 -------
 The outline is what sets the work chain apart from other processes.
 It is a way of defining the higher-level logic that encodes the workflow that the work chain takes.
-The outline is defined in the ``define`` method through the :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.outline`.
+The outline is defined in the ``define`` method through the :py:meth:`~plumpy.WorkChainSpec.outline`.
 It takes a sequence of instructions that the work chain will execute, each of which is implemented as a method of the work chain class.
 In the simple example above, the outline consists of three simple instructions: ``add``, ``multiply``, ``results``.
 Since these are implemented as instance methods, they are prefixed with ``cls.`` to indicate that they are in fact methods of the work chain class.


### PR DESCRIPTION
Add intersphinx mapping to python standard library documentation, i.e.
things like :py:exc:`ValueError` now link directly there.
This also allows to cut down the "nitpick exceptions" quite
dramatically.

Note: I will rebase this PR after #3875 is merged