### PR TITLE
Prevent nodes without registered entry points from being stored

### DIFF
--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -12,6 +12,7 @@ from abc import ABCMeta
 import logging
 import math
 import numbers
+import warnings
 from collections.abc import Iterable, Mapping
 
 from aiida.common import exceptions
@@ -70,7 +71,14 @@ def load_node_class(type_string):
         entry_point_name = strip_prefix(base_path, 'nodes.')
         return load_entry_point('aiida.node', entry_point_name)
 
-    raise exceptions.EntryPointError('unknown type string {}'.format(type_string))
+    # At this point we really have an anomalous type string. At some point, storing nodes with unresolvable type strings
+    # was allowed, for example by creating a sub class in a shell and then storing an instance. Attempting to load the
+    # node then would fail miserably. This is now no longer allowed, but we need a fallback for existing cases, which
+    # should be rare. We fallback on `Data` and not `Node` because bare node instances are also not storable and so the
+    # logic of the ORM is not well defined for a loaded instance of the base `Node` class.
+    warnings.warn('unknown type string `{}`, falling back onto `Data` class'.format(type_string))  # pylint: disable=no-member
+
+    return Data
 
 
 def get_type_string_from_class(class_module, class_name):
@@ -247,13 +255,9 @@ def clean_value(value):
 
 
 class AbstractNodeMeta(ABCMeta):  # pylint: disable=too-few-public-methods
-    """
-    Some python black magic to set correctly the logger also in subclasses.
-    """
+    """Some python black magic to set correctly the logger also in subclasses."""
 
-    # pylint: disable=arguments-differ,protected-access,too-many-function-args
-
-    def __new__(mcs, name, bases, namespace):
+    def __new__(mcs, name, bases, namespace):  # pylint: disable=arguments-differ,protected-access,too-many-function-args
         newcls = ABCMeta.__new__(mcs, name, bases, namespace)
         newcls._logger = logging.getLogger('{}.{}'.format(namespace['__module__'], name))
 

--- a/tests/orm/utils/test_node.py
+++ b/tests/orm/utils/test_node.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the `Node` utils."""
+import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm import Data
@@ -20,4 +21,9 @@ class TestLoadNodeClass(AiidaTestCase):
     def test_load_node_class_fallback(self):
         """Verify that `load_node_class` will fall back to `Data` class if entry point cannot be loaded."""
         loaded_class = load_node_class('data.some.non.existing.plugin.')
+        self.assertEqual(loaded_class, Data)
+
+        # For really unresolvable type strings, we fall back onto the `Data` class
+        with pytest.warns(UserWarning):
+            loaded_class = load_node_class('__main__.SubData.')
         self.assertEqual(loaded_class, Data)


### PR DESCRIPTION
Fixes #3457

Up until now it was possible to store instances of `Node` subclasses
that do not have a registered entry point. Imagine for example the
definition of a `Data` subclass called `SubClass` in a shell and an
instance being stored. The node type string will be:

  `__main__.SubClass.`

When trying to load this node at a later point in time, the type string
can of course not be resolved to an importable class and the loader
would raise an exception.

The first change is that this exception is now turned into a warning and
the loader falls back onto the `Data` class. Note that we do not use the
`Node` class for this as this base class is also not storable and so the
ORM logic is potentially ill-defined for instances of the base `Node`.

Secondly, we now add a check to `Node.store` to make sure that the class
corresponds to a registered entry point. If this is not the case, the
store method will raise `StoringNotAllowed`.

One unit test was deleted because its implementation was incorrect and
was not actually testing what it was intending to test. Besides intended
functionality is now covered by other tests.