### PR TITLE
Ensure log messages are not duplicated in daemon log file

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -180,6 +180,11 @@ def configure_logging(with_orm=False, daemon=False, daemon_log_file=None):
 
         for logger in config.get('loggers', {}).values():
             logger.setdefault('handlers', []).append(daemon_handler_name)
+            try:
+                # Remove the `console` stdout stream handler to prevent messages being duplicated in the daemon log file
+                logger['handlers'].remove('console')
+            except ValueError:
+                pass
 
     # Add the `DbLogHandler` if `with_orm` is `True`
     if with_orm:


### PR DESCRIPTION
Fixes #3889 

The logging for the daemon was configured with a handler both for
writing to stdout `console` as well as a rotating file handler that
writes directly to the daemon log file. The last one is the intended one
but since the default `console` handler was also kept, its output also
ended up in the daemon log file, duplicating every message.