### PR TITLE
Fix the `RotatingFileHandler` configuration of the daemon logger

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -175,7 +175,8 @@ def configure_logging(with_orm=False, daemon=False, daemon_log_file=None):
             'class': 'logging.handlers.RotatingFileHandler',
             'filename': daemon_log_file,
             'encoding': 'utf8',
-            'maxBytes': 100000,
+            'maxBytes': 10000000,  # 10 MB
+            'backupCount': 10,
         }
 
         for logger in config.get('loggers', {}).values():


### PR DESCRIPTION
Fixes #3557

The logging configuration for the daemon did already include the
definition of a `RotatingFileHandler`, however, the logs were not
actually being rolled over when the maximum size was hit. The problem
was because the argument `backupCount` was not defined. As the python
documentation of the `logging` module states:

  but if either of `maxBytes` or `backupCount` is zero, rollover never
  occurs, so you generally want to set `backupCount` to at least 1,
  and have a non-zero `maxBytes`.

Setting `backupCount` to 10, fixes the problem. The size of each file is
set to 10 MB. This should then keep at most 100 MB of log files for each
profile.