### PR TITLE
Implement functionality to immigrate already completed `CalcJobs`

### DIFF
--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -109,8 +109,9 @@ def submit(process, **inputs):
     process = instantiate_process(runner, process, **inputs)
 
     # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
-    # instead of raising, because in this way the user does not have to change the launcher when testing.
-    if process.metadata.get('dry_run', False):
+    # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
+    # for if `remote_folder` is present in the inputs, which means we are immigrating an already completed calculation.
+    if process.metadata.get('dry_run', False) or 'remote_folder' in inputs:
         _, node = run_get_node(process)
         return node
 

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -116,6 +116,12 @@ class CalcJob(Process):
         super().define(spec)
         spec.inputs.validator = validate_calc_job
         spec.input('code', valid_type=orm.Code, help='The `Code` to use for this job.')
+        spec.input('remote_folder', valid_type=orm.RemoteData, required=False,
+            help='Remote directory containing the results of an already completed calculation job without AiiDA. The '
+                 'inputs should be passed to the `CalcJob` as normal but instead of launching the actual job, the '
+                 'engine will recreate the input files and then proceed straight to the retrieve step where the files '
+                 'of this `RemoteData` will be retrieved as if it had been actually launched through AiiDA. If a '
+                 'parser is defined in the inputs, the results are parsed and attached as output nodes as usual.')
         spec.input('metadata.dry_run', valid_type=bool, default=False,
             help='When set to `True` will prepare the calculation job for submission but not actually launch it.')
         spec.input('metadata.computer', valid_type=orm.Computer, required=False,
@@ -219,20 +225,12 @@ class CalcJob(Process):
         process in the `Wait` state, waiting for the `UPLOAD` transport task to be started.
         """
         if self.inputs.metadata.dry_run:
-            from aiida.common.folders import SubmitTestFolder
-            from aiida.engine.daemon.execmanager import upload_calculation
-            from aiida.transports.plugins.local import LocalTransport
-
-            with LocalTransport() as transport:
-                with SubmitTestFolder() as folder:
-                    calc_info, script_filename = self.presubmit(folder)
-                    transport.chdir(folder.abspath)
-                    upload_calculation(self.node, transport, calc_info, folder, inputs=self.inputs, dry_run=True)
-                    self.node.dry_run_info = {
-                        'folder': folder.abspath,
-                        'script_filename': script_filename
-                    }
+            self._perform_dry_run()
             return plumpy.Stop(None, True)
+
+        if 'remote_folder' in self.inputs:
+            exit_code = self._perform_immigration()
+            return exit_code
 
         # The following conditional is required for the caching to properly work. Even if the source node has a process
         # state of `Finished` the cached process will still enter the running state. The process state will have then
@@ -243,6 +241,50 @@ class CalcJob(Process):
 
         # Launch the upload operation
         return plumpy.Wait(msg='Waiting to upload', data=UPLOAD_COMMAND)
+
+    def _perform_dry_run(self):
+        """Perform a dry run.
+
+        Instead of performing the normal sequence of steps, just the `presubmit` is called, which will call the method
+        `prepare_for_submission` of the plugin to generate the input files based on the inputs. Then the upload action
+        is called, but using a normal local transport that will copy the files to a local sandbox folder. The generated
+        input script and the absolute path to the sandbox folder are stored in the `dry_run_info` attribute of the node
+        of this process.
+        """
+        from aiida.common.folders import SubmitTestFolder
+        from aiida.engine.daemon.execmanager import upload_calculation
+        from aiida.transports.plugins.local import LocalTransport
+
+        with LocalTransport() as transport:
+            with SubmitTestFolder() as folder:
+                calc_info, script_filename = self.presubmit(folder)
+                transport.chdir(folder.abspath)
+                upload_calculation(self.node, transport, calc_info, folder, inputs=self.inputs, dry_run=True)
+                self.node.dry_run_info = {
+                    'folder': folder.abspath,
+                    'script_filename': script_filename
+                }
+
+    def _perform_immigration(self):
+        """Perform the immigration of an already completed calculation.
+
+        The inputs contained a `RemoteData` under the key `remote_folder` signalling that this is not supposed to be run
+        as a normal calculation job, but rather the results are already computed outside of AiiDA and merely need to be
+        imported.
+        """
+        from aiida.common.datastructures import CalcJobState
+        from aiida.common.folders import SandboxFolder
+        from aiida.engine.daemon.execmanager import retrieve_calculation
+        from aiida.transports.plugins.local import LocalTransport
+
+        with LocalTransport() as transport:
+            with SandboxFolder() as folder:
+                with SandboxFolder() as retrieved_temporary_folder:
+                    self.presubmit(folder)
+                    self.node.set_remote_workdir(self.inputs.remote_folder.get_remote_path())
+                    retrieve_calculation(self.node, transport, retrieved_temporary_folder.abspath)
+                    self.node.set_state(CalcJobState.PARSING)
+                    return self.parse(retrieved_temporary_folder.abspath)
 
     def prepare_for_submission(self, folder):
         """Prepare files for submission of calculation."""


### PR DESCRIPTION
Fixes #1892 

When people start using AiiDA they typically already have many
calculation jobs completed without the use of AiiDA and they wish to
import these somehow, such that they can be included in the provenance
graph along with the future calculations they will run through AiiDA.

This concept was originally implemented for the `PwCalculation` in the
`aiida-quantumespresso` plugin and worked, but the approach required a
separate `CalcJob` implementation for each existing `CalcJob` class that
one might want to import.

Here we implement a generic mechanism directly in `aiida-core` that will
allow any `CalcJob` implementation to "immigrate" already completed
jobs. The calculation job is launched just as one would launch a
normal one through AiiDA, except one additional input is passed: a
`RemoteData` instance under the name `remote_folder` that contains the
output files of the completed calculation. The naming is chosen on
purpose to be the same as the `RemoteData` that is normally created by
the engine during a normal calculation job run.

When the engine detects this input, instead of going through the normal
sequence of transport tasks, it simply performs the presubmit and then
goes straight to the "retrieve" step. Here the engine will retrieve the
files from the provided `RemoteData` as if they had just been produced
during an actual run. In this way, the process is executed almost
exactly in the same way as a normal run, except the job itself is not
actually executed.