### PR TITLE
enable loading config.yml files from URL

### DIFF
--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -16,7 +16,7 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
-from aiida.cmdline.params.types import GroupParamType, ImportPath
+from aiida.cmdline.params.types import GroupParamType, UrlPath
 from aiida.cmdline.utils import decorators, echo
 
 EXTRAS_MODE_EXISTING = ['keep_existing', 'update_existing', 'mirror', 'none', 'ask']
@@ -137,7 +137,7 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
 
 
 @verdi.command('import')
-@click.argument('archives', nargs=-1, type=ImportPath(exists=True, readable=True))
+@click.argument('archives', nargs=-1, type=UrlPath(exists=True, readable=True))
 @click.option(
     '-w',
     '--webpages',

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -459,7 +459,11 @@ WITH_ELEMENTS_EXCLUSIVE = OverridableOption(
     help='Only select objects containing only these and no other elements.'
 )
 
-CONFIG_FILE = ConfigFileOption('--config', help='Load option values from configuration file in yaml format.')
+CONFIG_FILE = ConfigFileOption(
+    '--config',
+    type=types.UrlPath(exists=True, readable=True, dir_okay=False),
+    help='Load option values from configuration file in yaml format (local path or URL).'
+)
 
 IDENTIFIER = OverridableOption(
     '-i',

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -21,7 +21,7 @@ from .multiple import MultipleValueParamType
 from .node import NodeParamType
 from .process import ProcessParamType
 from .nonemptystring import NonEmptyStringParamType
-from .path import AbsolutePathParamType, ImportPath
+from .path import AbsolutePathParamType, UrlPath
 from .plugin import PluginParamType
 from .profile import ProfileParamType
 from .user import UserParamType
@@ -32,5 +32,5 @@ __all__ = (
     'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType',
     'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
     'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType',
-    'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType', 'ImportPath'
+    'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType', 'UrlPath'
 )

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -52,20 +52,26 @@ class AbsolutePathOrEmptyParamType(AbsolutePathParamType):
         return 'ABSOLUTEPATHEMPTY'
 
 
-class ImportPath(click.Path):
+class UrlPath(click.Path):
     """AiiDA extension of Click's Path-type to include URLs
-    An ImportPath can either be a `click.Path`-type or a URL.
+    An UrlPath can either be a `click.Path`-type or a URL.
 
-    :param timeout_seconds: Timeout time in seconds that a URL response is expected.
-    :value timeout_seconds: Must be an int in the range [0;60], extrema included.
-      If an int outside the range [0;60] is given, the value will be set to the respective extremum value.
-      If any other type than int is given a TypeError will be raised.
+    :param int timeout_seconds: Maximum timeout accepted for URL response.
+        Must be an integer in the range [0;60].
     """
 
     # pylint: disable=protected-access
 
     def __init__(self, timeout_seconds=URL_TIMEOUT_SECONDS, **kwargs):
         super().__init__(**kwargs)
+
+        try:
+            timeout_seconds = int(timeout_seconds)
+        except ValueError:
+            raise TypeError('timeout_seconds should be an integer but got: {}'.format(type(timeout_seconds)))
+
+        if timeout_seconds < 0 or timeout_seconds > 60:
+            raise ValueError('timeout_seconds needs to be in the range [0;60].')
 
         self.timeout_seconds = timeout_seconds
 
@@ -97,21 +103,3 @@ class ImportPath(click.Path):
             )
 
         return url
-
-    @property
-    def timeout_seconds(self):
-        return self._timeout_seconds
-
-    # pylint: disable=attribute-defined-outside-init
-    @timeout_seconds.setter
-    def timeout_seconds(self, value):
-        try:
-            self._timeout_seconds = int(value)
-        except ValueError:
-            raise TypeError('timeout_seconds should be an integer but got: {}'.format(type(value)))
-
-        if self._timeout_seconds < 0:
-            self._timeout_seconds = 0
-
-        if self._timeout_seconds > 60:
-            self._timeout_seconds = 60

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -639,7 +639,7 @@ Below is a list with all available subcommands.
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
       --config FILE                   Load option values from configuration file
-                                      in yaml format.
+                                      in yaml format (local path or URL).
       --help                          Show this message and exit.
 
 
@@ -752,7 +752,7 @@ Below is a list with all available subcommands.
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
       --config FILE                   Load option values from configuration file
-                                      in yaml format.
+                                      in yaml format (local path or URL).
       --help                          Show this message and exit.
 
 

--- a/tests/cmdline/commands/test_import.py
+++ b/tests/cmdline/commands/test_import.py
@@ -203,11 +203,11 @@ class TestVerdiImport(AiidaTestCase):
 
     def test_import_url_timeout(self):
         """Test a timeout to valid URL is correctly errored"""
-        from aiida.cmdline.params.types import ImportPath
+        from aiida.cmdline.params.types import UrlPath
 
         timeout_url = 'http://www.google.com:81'
 
-        test_timeout_path = ImportPath(exists=True, readable=True, timeout_seconds=0)
+        test_timeout_path = UrlPath(exists=True, readable=True, timeout_seconds=0)
         with self.assertRaises(BadParameter) as cmd_exc:
             test_timeout_path(timeout_url)
 

--- a/tests/cmdline/params/types/test_path.py
+++ b/tests/cmdline/params/types/test_path.py
@@ -10,17 +10,17 @@
 """Tests for Path types"""
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.cmdline.params.types import ImportPath
+from aiida.cmdline.params.types import UrlPath
 
 
 class TestImportPath(AiidaTestCase):
-    """Tests `ImportPath`"""
+    """Tests `UrlPath`"""
 
     def test_default_timeout(self):
         """Test the default timeout_seconds value is correct"""
         from aiida.cmdline.params.types.path import URL_TIMEOUT_SECONDS
 
-        import_path = ImportPath()
+        import_path = UrlPath()
 
         self.assertEqual(import_path.timeout_seconds, URL_TIMEOUT_SECONDS)
 
@@ -30,7 +30,7 @@ class TestImportPath(AiidaTestCase):
         valid_values = [42, '42']
 
         for value in valid_values:
-            import_path = ImportPath(timeout_seconds=value)
+            import_path = UrlPath(timeout_seconds=value)
 
             self.assertEqual(import_path.timeout_seconds, int(value))
 
@@ -38,13 +38,13 @@ class TestImportPath(AiidaTestCase):
         """Test a TypeError is raised when a None value is given for timeout_seconds"""
 
         with self.assertRaises(TypeError):
-            ImportPath(timeout_seconds=None)
+            UrlPath(timeout_seconds=None)
 
     def test_wrong_type_timeout(self):
         """Test a TypeError is raised when wrong type is given for timeout_seconds"""
 
         with self.assertRaises(TypeError):
-            ImportPath(timeout_seconds='test')
+            UrlPath(timeout_seconds='test')
 
     def test_range_timeout(self):
         """Test timeout_seconds defines extrema when out of range
@@ -55,8 +55,8 @@ class TestImportPath(AiidaTestCase):
         lower = range_timeout[0] - 5
         upper = range_timeout[1] + 5
 
-        lower_path = ImportPath(timeout_seconds=lower)
-        upper_path = ImportPath(timeout_seconds=upper)
+        lower_path = UrlPath(timeout_seconds=lower)
+        upper_path = UrlPath(timeout_seconds=upper)
 
         msg_lower = "timeout_seconds should have been corrected to the lower bound: '{}', but instead it is {}".format(
             range_timeout[0], lower_path.timeout_seconds


### PR DESCRIPTION
In the view of the plans of starting online repositories that maintain
yaml configuration files for computers and codes, it becomes very useful
to be able to directly import a configuration file from a URL.