### PR TITLE
Use GitHub Actions services (for PostgreSQL and RabbitMQ)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,18 +139,9 @@ jobs:
 
     - name: Install system dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install postgresql-10 graphviz
-
-    # - name: Install system dependencies
-    #   run: |
-    #     wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-    #     echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-    #     echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-    #     sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-    #     sudo apt update
-    #     sudo apt install postgresql-10 rabbitmq-server graphviz
-    #     sudo systemctl status rabbitmq-server.service
 
     - name: Upgrade pip
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # - uses: CasperWA/postgresql-action@v1.2
-    #   with:
-    #     postgresql version: '10'
-    #     postgresql db: test_${{ matrix.backend }}
-    #     postgresql user: postgres
-    #     postgresql password: ''
-    #     postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,15 +110,29 @@ jobs:
         backend: ['django', 'sqlalchemy']
         python-version: [3.5, 3.8]
 
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_PASSWORD: ''
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v2
-    - uses: CasperWA/postgresql-action@v1.2
-      with:
-        postgresql version: '10'
-        postgresql db: test_${{ matrix.backend }}
-        postgresql user: postgres
-        postgresql password: ''
-        postgresql auth: trust
+    # - uses: CasperWA/postgresql-action@v1.2
+    #   with:
+    #     postgresql version: '10'
+    #     postgresql db: test_${{ matrix.backend }}
+    #     postgresql user: postgres
+    #     postgresql password: ''
+    #     postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         env:
           POSTGRES_DB: test_${{ matrix.backend }}
           POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
 
     steps:
     - uses: actions/checkout@v2
@@ -135,13 +139,18 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-        echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install postgresql-10 rabbitmq-server graphviz
-        sudo systemctl status rabbitmq-server.service
+        sudo apt install postgresql-10 graphviz
+
+    # - name: Install system dependencies
+    #   run: |
+    #     wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
+    #     echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
+    #     echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
+    #     sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+    #     sudo apt update
+    #     sudo apt install postgresql-10 rabbitmq-server graphviz
+    #     sudo systemctl status rabbitmq-server.service
 
     - name: Upgrade pip
       run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -98,15 +98,23 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8]
         backend: ['django', 'sqlalchemy']
 
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v2
-    - uses: CasperWA/postgresql-action@v1.2
-      with:
-        postgresql version: '10'
-        postgresql db: test_${{ matrix.backend }}
-        postgresql user: postgres
-        postgresql password: ''
-        postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -112,6 +112,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
 
     steps:
     - uses: actions/checkout@v2
@@ -123,13 +127,9 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-        echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install postgresql-10 rabbitmq-server graphviz
-        sudo systemctl status rabbitmq-server.service
+        sudo apt install postgresql-10 graphviz
 
     - run: pip install --upgrade pip
 

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -17,17 +17,25 @@ jobs:
         backend: ['django', 'sqlalchemy']
         python-version: [3.5, 3.6, 3.7, 3.8]
 
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.head_ref }}
-    - uses: CasperWA/postgresql-action@v1.2
-      with:
-        postgresql version: '10'
-        postgresql db: test_${{ matrix.backend }}
-        postgresql user: postgres
-        postgresql password: ''
-        postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -31,6 +31,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
 
     steps:
     - uses: actions/checkout@v2
@@ -44,13 +48,9 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-        echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install postgresql-10 rabbitmq-server graphviz
-        sudo systemctl status rabbitmq-server.service
+        sudo apt install postgresql-10 graphviz
 
     - run: pip install --upgrade pip
 


### PR DESCRIPTION
Move over to a more "clean" setup of system services in CI tests, here PostgreSQL and RabbitMQ.

This utilizes [GitHub Actions services](https://help.github.com/en/actions/configuring-and-managing-workflows/using-databases-and-service-containers), specifically integrating the Docker images for PostgreSQL and RabbitMQ.

Hence, some oblique lines in the workflow can be removed under the "Install system dependencies" step(s) as well as the PostgreSQL action.

**Note**: This does _not_ solve the issue of having a PostgreSQL super user with an empty password; the authentication method is kept to `"trust"`, i.e., allowing all connections no matter the database user password.