### PR TITLE
Add support for subclassing in `Groups` to the `QueryBuilder`

### DIFF
--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -49,6 +49,14 @@ __all__ = ('QueryBuilder',)
 
 _LOGGER = logging.getLogger(__name__)
 
+# This global variable is necessary to enable the subclassing functionality for the `Group` entity. The current
+# implementation of the `QueryBuilder` was written with the assumption that only `Node` was subclassable. Support for
+# subclassing was added later for `Group` and is based on its `type_string`, but the current implementation does not
+# allow to extend this support to the `QueryBuilder` in an elegant way. The prefix `group.` needs to be used in various
+# places to make it work, but really the internals of the `QueryBuilder` should be rewritten to in principle support
+# subclassing for any entity type. This workaround should then be able to be removed.
+GROUP_ENTITY_TYPE_PREFIX = 'group.'
+
 
 def get_querybuilder_classifiers_from_cls(cls, qb):
     """
@@ -83,10 +91,10 @@ def get_querybuilder_classifiers_from_cls(cls, qb):
 
     # Groups:
     elif issubclass(cls, qb.Group):
-        classifiers['ormclass_type_string'] = 'group'
+        classifiers['ormclass_type_string'] = GROUP_ENTITY_TYPE_PREFIX + cls._type_string
         ormclass = cls
     elif issubclass(cls, groups.Group):
-        classifiers['ormclass_type_string'] = 'group'
+        classifiers['ormclass_type_string'] = GROUP_ENTITY_TYPE_PREFIX + cls._type_string
         ormclass = qb.Group
 
     # Computers:
@@ -164,7 +172,8 @@ def get_querybuilder_classifiers_from_type(ormclass_type_string, qb):
     classifiers['process_type_string'] = None
     classifiers['ormclass_type_string'] = ormclass_type_string.lower()
 
-    if classifiers['ormclass_type_string'] == 'group':
+    if classifiers['ormclass_type_string'].startswith(GROUP_ENTITY_TYPE_PREFIX):
+        classifiers['ormclass_type_string'] = 'group.core'
         ormclass = qb.Group
     elif classifiers['ormclass_type_string'] == 'computer':
         ormclass = qb.Computer
@@ -179,11 +188,10 @@ def get_querybuilder_classifiers_from_type(ormclass_type_string, qb):
     if ormclass == qb.Node:
         is_valid_node_type_string(classifiers['ormclass_type_string'], raise_on_false=True)
 
-
     return ormclass, classifiers
 
 
-def get_type_filter(classifiers, subclassing):
+def get_node_type_filter(classifiers, subclassing):
     """
     Return filter dictionaries given a set of classifiers.
 
@@ -199,13 +207,14 @@ def get_type_filter(classifiers, subclassing):
     value = classifiers['ormclass_type_string']
 
     if not subclassing:
-        filter = {'==': value}
+        filters = {'==': value}
     else:
         # Note: the query_type_string always ends with a dot. This ensures that "like {str}%" matches *only*
         # the query type string
-        filter = {'like': '{}%'.format(escape_for_sql_like(get_query_type_from_type_string(value)))}
+        filters = {'like': '{}%'.format(escape_for_sql_like(get_query_type_from_type_string(value)))}
 
-    return filter
+    return filters
+
 
 def get_process_type_filter(classifiers, subclassing):
     """
@@ -229,7 +238,7 @@ def get_process_type_filter(classifiers, subclassing):
     value = classifiers['process_type_string']
 
     if not subclassing:
-        filter = {'==': value}
+        filters = {'==': value}
     else:
         if ':' in value:
             # if value is an entry point, do usual subclassing
@@ -237,7 +246,7 @@ def get_process_type_filter(classifiers, subclassing):
             # Note: the process_type_string stored in the database does *not* end in a dot.
             # In order to avoid that querying for class 'Begin' will also find class 'BeginEnd',
             # we need to search separately for equality and 'like'.
-            filter = {'or': [
+            filters = {'or': [
                 {'==': value},
                 {'like': escape_for_sql_like(get_query_string_from_process_type_string(value))},
             ]}
@@ -248,19 +257,46 @@ def get_process_type_filter(classifiers, subclassing):
             # between process classes and node classes
 
             # Note: Improve this when issue #2475 is addressed
-            filter = {'like': '%'}
+            filters = {'like': '%'}
         else:
             warnings.warn("Process type '{}' does not correspond to a registered entry. "
                           'This risks queries to fail once the location of the process class changes. '
                           "Add an entry point for '{}' to remove this warning.".format(value, value),
                           AiidaEntryPointWarning)
-            filter = {'or': [
+            filters = {'or': [
                 {'==': value},
                 {'like': escape_for_sql_like(get_query_string_from_process_type_string(value))},
             ]}
 
+    return filters
 
-    return filter
+
+def get_group_type_filter(classifiers, subclassing):
+    """Return filter dictionaries for `Group.type_string` given a set of classifiers.
+
+    :param classifiers: a dictionary with classifiers (note: does *not* support lists)
+    :param subclassing: if True, allow for subclasses of the ormclass
+
+    :returns: dictionary in QueryBuilder filter language to pass into {'type_string': ... }
+    :rtype: dict
+    """
+    from aiida.common.escaping import escape_for_sql_like
+
+    value = classifiers['ormclass_type_string'].lstrip(GROUP_ENTITY_TYPE_PREFIX)
+
+    if not subclassing:
+        filters = {'==': value}
+    else:
+        # This is a hardcoded solution to the problem that the base class `Group` should match all subclasses, however
+        # its entry point string is `core` and so will only match those subclasses whose entry point also starts with
+        # 'core', however, this is only the case for group subclasses shipped with `aiida-core`. Any plugins from
+        # external packages will never be matched. Making the entry point name of `Group` an empty string is also not
+        # possible so we perform the switch here in code.
+        if value == 'core':
+            value = ''
+        filters = {'like': '{}%'.format(escape_for_sql_like(value))}
+
+    return filters
 
 
 class QueryBuilder:
@@ -692,20 +728,16 @@ class QueryBuilder:
         # FILTERS ######################################
         try:
             self._filters[tag] = {}
-            # So far, only Node and its subclasses need additional filters on column type
-            # (for other classes, the "classifi.
-            # This so far only is necessary for AiidaNodes not for groups.
-            # Now here there is the issue that for everything else,
-            # the query_type_string is either None (e.g. if Group was passed)
-            # or a list of None (if (Group, ) was passed.
-            # Here we have to only call the function _add_type_filter essentially if it makes sense to
-            # For now that is only nodes, and it is hardcoded. In the future (e.g. we subclass group)
-            # this has to be added
+            # Subclassing is currently only implemented for the `Node` and `Group` classes. So for those cases we need
+            # to construct the correct filters corresponding to the provided classes and value of `subclassing`.
             if ormclass == self._impl.Node:
-                self._add_type_filter(tag, classifiers, subclassing)
+                self._add_node_type_filter(tag, classifiers, subclassing)
                 self._add_process_type_filter(tag, classifiers, subclassing)
 
-            # The order has to be first _add_type_filter and then add_filter.
+            elif ormclass == self._impl.Group:
+                self._add_group_type_filter(tag, classifiers, subclassing)
+
+            # The order has to be first _add_node_type_filter and then add_filter.
             # If the user adds a query on the type column, it overwrites what I did
             # if the user specified a filter, add it:
             if filters is not None:
@@ -993,23 +1025,21 @@ class QueryBuilder:
 
         return processed_filters
 
-    def _add_type_filter(self, tagspec, classifiers, subclassing):
+    def _add_node_type_filter(self, tagspec, classifiers, subclassing):
         """
-        Add a filter based on type.
+        Add a filter based on node type.
 
         :param tagspec: The tag, which has to exist already as a key in self._filters
         :param classifiers: a dictionary with classifiers
         :param subclassing: if True, allow for subclasses of the ormclass
         """
-        tag = self._get_tag_from_specification(tagspec)
-
         if isinstance(classifiers, list):
             # If a list was passed to QueryBuilder.append, this propagates to a list in the classifiers
             entity_type_filter = {'or': []}
             for c in classifiers:
-                entity_type_filter['or'].append(get_type_filter(c, subclassing))
+                entity_type_filter['or'].append(get_node_type_filter(c, subclassing))
         else:
-            entity_type_filter = get_type_filter(classifiers, subclassing)
+            entity_type_filter = get_node_type_filter(classifiers, subclassing)
 
         self.add_filter(tagspec, {'node_type': entity_type_filter})
 
@@ -1023,8 +1053,6 @@ class QueryBuilder:
 
         Note: This function handles the case when process_type_string is None.
         """
-        tag = self._get_tag_from_specification(tagspec)
-
         if isinstance(classifiers, list):
             # If a list was passed to QueryBuilder.append, this propagates to a list in the classifiers
             process_type_filter = {'or': []}
@@ -1040,6 +1068,23 @@ class QueryBuilder:
                 process_type_filter = get_process_type_filter(classifiers, subclassing)
                 self.add_filter(tagspec, {'process_type': process_type_filter})
 
+    def _add_group_type_filter(self, tagspec, classifiers, subclassing):
+        """
+        Add a filter based on group type.
+
+        :param tagspec: The tag, which has to exist already as a key in self._filters
+        :param classifiers: a dictionary with classifiers
+        :param subclassing: if True, allow for subclasses of the ormclass
+        """
+        if isinstance(classifiers, list):
+            # If a list was passed to QueryBuilder.append, this propagates to a list in the classifiers
+            type_string_filter = {'or': []}
+            for classifier in classifiers:
+                type_string_filter['or'].append(get_group_type_filter(classifier, subclassing))
+        else:
+            type_string_filter = get_group_type_filter(classifiers, subclassing)
+
+        self.add_filter(tagspec, {'type_string': type_string_filter})
 
     def add_projection(self, tag_spec, projection_spec):
         r"""
@@ -1678,7 +1723,9 @@ class QueryBuilder:
         :param joining_value: the tag of the nodes to be joined
         """
         # Set the calling entity - to allow for the correct join relation to be set
-        if self._path[index]['entity_type'] not in ['computer', 'user', 'group', 'comment', 'log']:
+        if self._path[index]['entity_type'].startswith(GROUP_ENTITY_TYPE_PREFIX):
+            calling_entity = 'group'
+        elif self._path[index]['entity_type'] not in ['computer', 'user', 'comment', 'log']:
             calling_entity = 'node'
         else:
             calling_entity = self._path[index]['entity_type']

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -77,6 +77,8 @@ class QueryRule(Operation, metaclass=ABCMeta):
         super().__init__(max_iterations, track_edges=track_edges)
 
         def get_spec_from_path(queryhelp, idx):
+            from aiida.orm.querybuilder import GROUP_ENTITY_TYPE_PREFIX
+
             if (
                 queryhelp['path'][idx]['entity_type'].startswith('node') or
                 queryhelp['path'][idx]['entity_type'].startswith('data') or
@@ -84,7 +86,7 @@ class QueryRule(Operation, metaclass=ABCMeta):
                 queryhelp['path'][idx]['entity_type'] == ''
             ):
                 result = 'nodes'
-            elif queryhelp['path'][idx]['entity_type'] == 'group':
+            elif queryhelp['path'][idx]['entity_type'].startswith(GROUP_ENTITY_TYPE_PREFIX):
                 result = 'groups'
             else:
                 raise Exception('not understood entity from ( {} )'.format(queryhelp['path'][idx]['entity_type']))

--- a/aiida/tools/groups/paths.py
+++ b/aiida/tools/groups/paths.py
@@ -171,7 +171,7 @@ class GroupPath:
         # type: () -> Optional[self.cls]
         """Return the concrete group associated with this path."""
         try:
-            return self.cls.objects.get(label=self.path)
+            return orm.QueryBuilder().append(self.cls, subclassing=False, filters={'label': self.path}).one()[0]
         except NotExistent:
             return None
 
@@ -188,7 +188,7 @@ class GroupPath:
         """
         query = orm.QueryBuilder()
         filters = {'label': self.path}
-        query.append(self.cls, filters=filters, project='id')
+        query.append(self.cls, subclassing=False, filters=filters, project='id')
         return [r[0] for r in query.all()]
 
     @property
@@ -222,7 +222,7 @@ class GroupPath:
         filters = {}
         if self.path:
             filters['label'] = {'like': self.path + self.delimiter + '%'}
-        query.append(self.cls, filters=filters, project='label')
+        query.append(self.cls, subclassing=False, filters=filters, project='label')
         if query.count() == 0 and self.is_virtual:
             raise NoGroupsInPathError(self)
 
@@ -282,7 +282,7 @@ class GroupPath:
         group_filters = {}
         if self.path:
             group_filters['label'] = {'or': [{'==': self.path}, {'like': self.path + self.delimiter + '%'}]}
-        query.append(self.cls, filters=group_filters, project='label', tag='group')
+        query.append(self.cls, subclassing=False, filters=group_filters, project='label', tag='group')
         query.append(
             orm.Node if node_class is None else node_class,
             with_group='group',

--- a/tests/cmdline/commands/test_group_ls.py
+++ b/tests/cmdline/commands/test_group_ls.py
@@ -28,7 +28,6 @@ def setup_groups(clear_database_before_test):
     yield
 
 
-@pytest.mark.skip('Reenable when subclassing in the query builder is implemented (#3902)')
 def test_with_no_opts(setup_groups):
     """Test ``verdi group path ls``"""
 
@@ -47,7 +46,6 @@ def test_with_no_opts(setup_groups):
     assert result.output == 'a/c/d\na/c/e\n'
 
 
-@pytest.mark.skip('Reenable when subclassing in the query builder is implemented (#3902)')
 def test_recursive(setup_groups):
     """Test ``verdi group path ls --recursive``"""
 
@@ -63,7 +61,6 @@ def test_recursive(setup_groups):
         assert result.output == 'a/c/d\na/c/e\na/c/e/g\n'
 
 
-@pytest.mark.skip('Reenable when subclassing in the query builder is implemented (#3902)')
 @pytest.mark.parametrize('tag', ['-l', '--long'])
 def test_long(setup_groups, tag):
     """Test ``verdi group path ls --long``"""
@@ -109,7 +106,6 @@ def test_long(setup_groups, tag):
     )
 
 
-@pytest.mark.skip('Reenable when subclassing in the query builder is implemented (#3902)')
 @pytest.mark.parametrize('tag', ['--no-virtual'])
 def test_groups_only(setup_groups, tag):
     """Test ``verdi group path ls --no-virtual``"""

--- a/tests/orm/test_autogroups.py
+++ b/tests/orm/test_autogroups.py
@@ -9,7 +9,7 @@
 ###########################################################################
 """Tests for the Autogroup functionality."""
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm import Group, QueryBuilder
+from aiida.orm import AutoGroup, QueryBuilder
 from aiida.orm.autogroup import Autogroup
 
 
@@ -21,16 +21,9 @@ class TestAutogroup(AiidaTestCase):
         label_prefix = 'test_prefix_TestAutogroup'
 
         # Check that there are no groups to begin with
-        queryb = QueryBuilder().append(Group, filters={'type_string': 'auto.run', 'label': label_prefix}, project='*')
+        queryb = QueryBuilder().append(AutoGroup, filters={'label': label_prefix})
         assert not list(queryb.all())
-        queryb = QueryBuilder().append(
-            Group, filters={
-                'type_string': 'auto.run',
-                'label': {
-                    'like': r'{}\_%'.format(label_prefix)
-                }
-            }, project='*'
-        )
+        queryb = QueryBuilder().append(AutoGroup, filters={'label': {'like': r'{}\_%'.format(label_prefix)}})
         assert not list(queryb.all())
 
         # First group (no existing one)
@@ -64,7 +57,7 @@ class TestAutogroup(AiidaTestCase):
         )
 
         # I create a group with a large integer suffix (9)
-        Group(label='{}_9'.format(label_prefix), type_string='auto.run').store()
+        AutoGroup(label='{}_9'.format(label_prefix), type_string='auto.run').store()
         # The next autogroup should become number 10
         autogroup = Autogroup()
         autogroup.set_group_label_prefix(label_prefix)
@@ -76,7 +69,7 @@ class TestAutogroup(AiidaTestCase):
         )
 
         # I create a group with a non-integer suffix (15a), it should be ignored
-        Group(label='{}_15b'.format(label_prefix), type_string='auto.run').store()
+        AutoGroup(label='{}_15b'.format(label_prefix), type_string='auto.run').store()
         # The next autogroup should become number 11
         autogroup = Autogroup()
         autogroup.set_group_label_prefix(label_prefix)
@@ -93,19 +86,12 @@ class TestAutogroup(AiidaTestCase):
         label_prefix = 'new_test_prefix_TestAutogroup'
         # I create a group with the same prefix, but followed by non-underscore
         # characters. These should be ignored in the logic.
-        Group(label='{}xx'.format(label_prefix), type_string='auto.run').store()
+        AutoGroup(label='{}xx'.format(label_prefix), type_string='auto.run').store()
 
         # Check that there are no groups to begin with
-        queryb = QueryBuilder().append(Group, filters={'type_string': 'auto.run', 'label': label_prefix}, project='*')
+        queryb = QueryBuilder().append(AutoGroup, filters={'label': label_prefix})
         assert not list(queryb.all())
-        queryb = QueryBuilder().append(
-            Group, filters={
-                'type_string': 'auto.run',
-                'label': {
-                    'like': r'{}\_%'.format(label_prefix)
-                }
-            }, project='*'
-        )
+        queryb = QueryBuilder().append(AutoGroup, filters={'label': {'like': r'{}\_%'.format(label_prefix)}})
         assert not list(queryb.all())
 
         # First group (no existing one)

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -60,10 +60,10 @@ class TestQueryBuilder(AiidaTestCase):
 
         for _cls, classifiers in (
             qb._get_ormclass(orm.Group, None),
-            qb._get_ormclass(None, 'group'),
-            qb._get_ormclass(None, 'Group'),
+            qb._get_ormclass(None, 'group.core'),
+            qb._get_ormclass(None, 'Group.core'),
         ):
-            self.assertEqual(classifiers['ormclass_type_string'], 'group')
+            self.assertTrue(classifiers['ormclass_type_string'].startswith('group'))
 
         for _cls, classifiers in (
             qb._get_ormclass(orm.User, None),


### PR DESCRIPTION
Fixes #3902

This now allows to search for instances of `Group` and all its
subclasses through the `QueryBuilder` just as implemented for the `Node`
class. The subclassing is based on the `type_string` of the group
instances, which in turn is defined by the entry point name. When
querying for `Group` instances through the `QueryBuilder`:

    QueryBuilder().append(Group).all()

by default subclassing is enabled and should return all instances of a
subclass of `Group` as well. The same goes for subclasses of `Group`
themselves. Imagine a plugin defines the following entry points:

    'plugin.sub = aiida_plugin.groups:SubGroup'
    'plugin.sub.a = aiida_plugin.groups:SubAGroup'
    'plugin.sub.b = aiida_plugin.groups:SubBGroup'

The following query:

    QueryBuilder().append(SubGroup).all()

will return all instances of `SubGroup` but also of `SubAGroup` and
`SubBGroup`. This is because their entry point names both start with the
entry point name `plugin.sub` of the class that is being appended.

Note that in order for all group instances to be returned when querying
for the `Group` base class, a small hack had to be applied in the query
builder code building the filters. Note that the entry point name of
`Group` is `core` and so with the rules described above, the plugin
subclasses would never be matched since their entry point names do not
start with `core`. This is a problem and could be fixed by making the
type string of base group instances an empty string, however, this would
require using an empty string for the `Group` base class which is not
allowed in Python. To still provide the desired behavior, when querying
for `Group` instances the `type_string` filter is set to match anything.