### PR TITLE
Add the `-v/--version` option to `verdi export migrate`

### DIFF
--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -145,17 +145,26 @@ def create(
 @options.ARCHIVE_FORMAT()
 @options.FORCE(help='overwrite output file if it already exists')
 @options.SILENT()
-def migrate(input_file, output_file, force, silent, archive_format):
+@click.option(
+    '-v',
+    '--version',
+    type=click.STRING,
+    required=False,
+    metavar='VERSION',
+    help='Specify an exact archive version to migrate to. By default the most recent version is taken.'
+)
+def migrate(input_file, output_file, force, silent, archive_format, version):
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
-    """
-    Migrate an old export archive file to the most recent format.
-    """
+    """Migrate an export archive to a more recent format version."""
     import tarfile
     import zipfile
 
     from aiida.common import json
     from aiida.common.folders import SandboxFolder
-    from aiida.tools.importexport import migration, extract_zip, extract_tar
+    from aiida.tools.importexport import EXPORT_VERSION, migration, extract_zip, extract_tar, ArchiveMigrationError
+
+    if version is None:
+        version = EXPORT_VERSION
 
     if os.path.exists(output_file) and not force:
         echo.echo_critical('the output file already exists')
@@ -178,7 +187,10 @@ def migrate(input_file, output_file, force, silent, archive_format):
             echo.echo_critical('export archive does not contain the required file {}'.format(fhandle.filename))
 
         old_version = migration.verify_metadata_version(metadata)
-        new_version = migration.migrate_recursively(metadata, data, folder)
+        try:
+            new_version = migration.migrate_recursively(metadata, data, folder, version)
+        except ArchiveMigrationError as exception:
+            echo.echo_critical(exception)
 
         with open(folder.get_abs_path('data.json'), 'wb') as fhandle:
             json.dump(data, fhandle, indent=4)

--- a/aiida/tools/importexport/migration/__init__.py
+++ b/aiida/tools/importexport/migration/__init__.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Migration export files from old export versions to the newest, used by `verdi export migrate` command."""
-
-from aiida.cmdline.utils import echo
-from aiida.tools.importexport.common.exceptions import DanglingLinkError
+from aiida.common.lang import type_check
+from aiida.tools.importexport import EXPORT_VERSION
+from aiida.tools.importexport.common.exceptions import DanglingLinkError, ArchiveMigrationError
 
 from .utils import verify_metadata_version
 from .v01_to_v02 import migrate_v1_to_v2
@@ -34,34 +34,37 @@ MIGRATE_FUNCTIONS = {
 }
 
 
-def migrate_recursively(metadata, data, folder):
-    """
-    Recursive migration of export files from v0.1 to newest version,
+def migrate_recursively(metadata, data, folder, version=EXPORT_VERSION):
+    """Recursive migration of export files from v0.1 to a newer version.
+
     See specific migration functions for detailed descriptions.
 
     :param metadata: the content of an export archive metadata.json file
     :param data: the content of an export archive data.json file
     :param folder: SandboxFolder in which the archive has been unpacked (workdir)
+    :param version: the version to migrate to, by default the current export version
     """
-    from aiida.tools.importexport import EXPORT_VERSION as newest_version
-
     old_version = verify_metadata_version(metadata)
 
+    type_check(version, str)
+
     try:
-        if old_version == newest_version:
-            echo.echo_critical('Your export file is already at the newest export version {}'.format(newest_version))
+        if old_version == version:
+            raise ArchiveMigrationError('Your export file is already at the version {}'.format(version))
+        elif old_version > version:
+            raise ArchiveMigrationError('Backward migrations are not supported')
         elif old_version in MIGRATE_FUNCTIONS:
             MIGRATE_FUNCTIONS[old_version](metadata, data, folder)
         else:
-            echo.echo_critical('Cannot migrate from version {}'.format(old_version))
+            raise ArchiveMigrationError('Cannot migrate from version {}'.format(old_version))
     except ValueError as exception:
-        echo.echo_critical(exception)
+        raise ArchiveMigrationError(exception)
     except DanglingLinkError:
-        echo.echo_critical('Export file is invalid because it contains dangling links')
+        raise ArchiveMigrationError('Export file is invalid because it contains dangling links')
 
     new_version = verify_metadata_version(metadata)
 
-    if new_version < newest_version:
-        new_version = migrate_recursively(metadata, data, folder)
+    if new_version < version:
+        new_version = migrate_recursively(metadata, data, folder, version)
 
     return new_version

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -394,7 +394,7 @@ Below is a list with all available subcommands.
     Commands:
       create   Export subsets of the provenance graph to file for sharing.
       inspect  Inspect contents of an exported archive without importing it.
-      migrate  Migrate an old export archive file to the most recent format.
+      migrate  Migrate an export archive to a more recent format version.
 
 
 .. _verdi_graph:


### PR DESCRIPTION
Fixes #3909 

The default behavior remains the same and if not specified the export
archive will be migrated to the latest version. However, with the flag
any other version can be chosen, as long as it constitutes a forward
migration as backward migrations are not supported.