### PR TITLE
Unpin the `click` dependency

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name,unused-argument
 """
 Collection of pytest fixtures using the TestManager for easy testing of AiiDA plugins.
 
@@ -16,8 +17,8 @@ Collection of pytest fixtures using the TestManager for easy testing of AiiDA pl
  * aiida_local_code_factory
 
 """
-import tempfile
 import shutil
+import tempfile
 import pytest
 
 from aiida.manage.tests import test_manager, get_test_backend_name, get_test_profile_name
@@ -30,14 +31,13 @@ def aiida_profile():
     Note: scope='session' limits this fixture to run once per session. Thanks to ``autouse=True``, you don't actually
      need to depend on it explicitly - it will activate as soon as you import it in your ``conftest.py``.
     """
-    # create new TestManager instance
-    with test_manager(backend=get_test_backend_name(), profile_name=get_test_profile_name()) as test_mgr:
-        yield test_mgr
-    # here, the TestManager instance has already been destroyed
+    with test_manager(backend=get_test_backend_name(), profile_name=get_test_profile_name()) as manager:
+        yield manager
+    # Leaving the context manager will automatically cause the `TestManager` instance to be destroyed
 
 
 @pytest.fixture(scope='function')
-def clear_database(clear_database_after_test):  # pylint: disable=redefined-outer-name,unused-argument
+def clear_database(clear_database_after_test):
     """Alias for 'clear_database_after_test'.
 
     Clears the database after each test. Use of the explicit
@@ -46,18 +46,15 @@ def clear_database(clear_database_after_test):  # pylint: disable=redefined-oute
 
 
 @pytest.fixture(scope='function')
-def clear_database_after_test(aiida_profile):  # pylint: disable=redefined-outer-name
-    """Clear the database after each test.
-    """
+def clear_database_after_test(aiida_profile):
+    """Clear the database after the test."""
     yield
-    # after the test function has completed, reset the database
     aiida_profile.reset_db()
 
 
 @pytest.fixture(scope='function')
-def clear_database_before_test(aiida_profile):  # pylint: disable=redefined-outer-name
-    """Clear the database before each test.
-    """
+def clear_database_before_test(aiida_profile):
+    """Clear the database before the test."""
     aiida_profile.reset_db()
     yield
 
@@ -81,7 +78,7 @@ def temp_dir():
 
 
 @pytest.fixture(scope='function')
-def aiida_localhost(temp_dir):  # pylint: disable=redefined-outer-name
+def aiida_localhost(temp_dir):
     """Get an AiiDA computer for localhost.
 
     Usage::
@@ -118,7 +115,7 @@ def aiida_localhost(temp_dir):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture(scope='function')
-def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-outer-name
+def aiida_local_code_factory(aiida_localhost):
     """Get an AiiDA code on localhost.
 
     Searches in the PATH for a given executable and creates an AiiDA code with provided entry point.
@@ -126,47 +123,56 @@ def aiida_local_code_factory(aiida_localhost):  # pylint: disable=redefined-oute
     Usage::
 
       def test_1(aiida_local_code_factory):
-          code = aiida_local_code_factory('pw.x', 'quantumespresso.pw')
+          code = aiida_local_code_factory('quantumespresso.pw', '/usr/bin/pw.x')
           # use code for testing ...
 
-    :return: A function get_code(executable, entry_point) that returns the Code node.
+    :return: A function get_code(entry_point, executable) that returns the `Code` node.
     :rtype: object
     """
 
-    def get_code(entry_point, executable, computer=aiida_localhost, prepend_text=None, append_text=None):
+    def get_code(entry_point, executable, computer=aiida_localhost, label=None, prepend_text=None, append_text=None):
         """Get local code.
+
         Sets up code for given entry point on given computer.
 
         :param entry_point: Entry point of calculation plugin
         :param executable: name of executable; will be searched for in local system PATH.
         :param computer: (local) AiiDA computer
-        :param prepend_text: a string of code that will be put in the scheduler script before the
-            execution of the code.
-        :param append_text: a string of code that will be put in the scheduler script after the
-            execution of the code.
-        :return: The code node
+        :param prepend_text: a string of code that will be put in the scheduler script before the execution of the code.
+        :param append_text: a string of code that will be put in the scheduler script after the execution of the code.
+        :return: the `Code` either retrieved from the database or created if it did not yet exist.
         :rtype: :py:class:`aiida.orm.Code`
         """
-        from aiida.orm import Code
+        from aiida.common import exceptions
+        from aiida.orm import Code, Computer, QueryBuilder
 
-        codes = Code.objects.find(filters={'label': executable})  # pylint: disable=no-member
-        if codes:
-            return codes[0]
+        if label is None:
+            label = executable
+
+        builder = QueryBuilder().append(Computer, filters={'uuid': computer.uuid}, tag='computer')
+        builder.append(Code, filters={'label': label, 'attributes.input_plugin': entry_point}, with_computer='computer')
+
+        try:
+            code = builder.one()[0]
+        except (exceptions.MultipleObjectsError, exceptions.NotExistent):
+            code = None
+        else:
+            return code
 
         executable_path = shutil.which(executable)
-
         if not executable_path:
             raise ValueError('The executable "{}" was not found in the $PATH.'.format(executable))
 
-        code = Code(
-            input_plugin_name=entry_point,
-            remote_computer_exec=[computer, executable_path],
-        )
+        code = Code(input_plugin_name=entry_point, remote_computer_exec=[computer, executable_path])
+        code.label = label
+        code.description = label
+
         if prepend_text is not None:
             code.set_prepend_text(prepend_text)
+
         if append_text is not None:
             code.set_append_text(append_text)
-        code.label = executable
+
         return code.store()
 
     return get_code

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -7,7 +7,7 @@ circus~=0.16.1
 click-completion~=0.5.1
 click-config-file~=0.5.0
 click-spinner~=0.1.8
-click==7.0
+click~=7.0
 coverage<5.0
 django~=2.2
 docutils==0.15.2

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -477,9 +477,11 @@ Below is a list with all available subcommands.
                                       addresses. Automatically discovered archive
                                       URLs will be downloadeded and added to
                                       ARCHIVES for importing
+
       -G, --group GROUP               Specify group to which all the import nodes
                                       will be added. If such a group does not
                                       exist, it will be created automatically.
+
       -e, --extras-mode-existing [keep_existing|update_existing|mirror|none|ask]
                                       Specify which extras from the export archive
                                       should be imported for nodes that are
@@ -492,20 +494,25 @@ Below is a list with all available subcommands.
                                       mirror: import all extras and remove any
                                       existing extras that are not present in the
                                       archive. none: do not import any extras.
+
       -n, --extras-mode-new [import|none]
                                       Specify whether to import extras of new
                                       nodes: import: import extras. none: do not
                                       import extras.
+
       --comment-mode [newest|overwrite]
                                       Specify the way to import Comments with
                                       identical UUIDs: newest: Only the newest
                                       Comments (based on mtime)
                                       (default).overwrite: Replace existing
                                       Comments with those from the import file.
+
       --migration / --no-migration    Force migration of export file archives, if
                                       needed.  [default: True]
+
       -n, --non-interactive           Non-interactive mode: never prompt for
                                       input.
+
       --help                          Show this message and exit.
 
 
@@ -616,11 +623,13 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           Non-interactive mode: never prompt for
                                       input.
+
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you
                                       generate. The email address is exported
                                       along with the data, when sharing it.
                                       [required]
+
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
@@ -630,18 +639,22 @@ Below is a list with all available subcommands.
                                       Database backend to use.
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
                                       authentication.
+
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.
       --db-username NONEMPTYSTRING    Name of the database user to create.
       --db-password TEXT              Password of the database user.
       --su-db-name TEXT               Name of the template database to connect to
                                       as the database superuser.
+
       --su-db-username TEXT           User name of the database super user.
       --su-db-password TEXT           Password to connect as the database
                                       superuser.
+
       --repository DIRECTORY          Absolute path to the file repository.
       --config FILE                   Load option values from configuration file
                                       in yaml format.
+
       --help                          Show this message and exit.
 
 
@@ -662,6 +675,7 @@ Below is a list with all available subcommands.
     Options:
       -e, --entry-point PLUGIN  Only include nodes that are class or sub class of
                                 the class identified by this entry point.
+
       -f, --force               Do not ask for confirmation.
       --help                    Show this message and exit.
 
@@ -688,6 +702,7 @@ Below is a list with all available subcommands.
       --debug                  Enable debugging
       --wsgi-profile           Whether to enable WSGI profiler middleware for
                                finding bottlenecks
+
       --hookup / --no-hookup   Hookup app to flask server
       --help                   Show this message and exit.
 
@@ -709,13 +724,17 @@ Below is a list with all available subcommands.
                                       Specify the prefix of the label of the auto
                                       group (numbers might be automatically
                                       appended to generate unique names per run).
+
       -n, --group-name TEXT           Specify the name of the auto group
                                       [DEPRECATED, USE --auto-group-label-prefix
                                       instead]. This also enables auto-grouping.
+
       -e, --exclude TEXT              Exclude these classes from auto grouping
                                       (use full entrypoint strings).
+
       -i, --include TEXT              Include these classes from auto grouping
                                       (use full entrypoint strings or "all").
+
       --help                          Show this message and exit.
 
 
@@ -733,11 +752,13 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           Non-interactive mode: never prompt for
                                       input.
+
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you
                                       generate. The email address is exported
                                       along with the data, when sharing it.
                                       [required]
+
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
@@ -747,14 +768,17 @@ Below is a list with all available subcommands.
                                       Database backend to use.
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
                                       authentication.
+
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.  [required]
       --db-username NONEMPTYSTRING    Name of the database user to create.
                                       [required]
+
       --db-password TEXT              Password of the database user.  [required]
       --repository DIRECTORY          Absolute path to the file repository.
       --config FILE                   Load option values from configuration file
                                       in yaml format.
+
       --help                          Show this message and exit.
 
 
@@ -774,9 +798,11 @@ Below is a list with all available subcommands.
       --no-startup                    When using plain Python, ignore the
                                       PYTHONSTARTUP environment variable and
                                       ~/.pythonrc.py script.
+
       -i, --interface [ipython|bpython]
                                       Specify an interactive interpreter
                                       interface.
+
       --help                          Show this message and exit.
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - click-completion~=0.5.1
 - click-config-file~=0.5.0
 - click-spinner~=0.1.8
-- click==7.0
+- click~=7.0
 - django~=2.2
 - ete3~=3.1
 - python-graphviz~=0.13

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,5 @@ filterwarnings =
     ignore::DeprecationWarning:yaml:
     ignore::DeprecationWarning:pymatgen:
     ignore::DeprecationWarning:jsonbackend:
+    ignore::DeprecationWarning:reentry:
+    ignore::DeprecationWarning:pkg_resources:

--- a/setup.json
+++ b/setup.json
@@ -26,7 +26,7 @@
     "click-completion~=0.5.1",
     "click-config-file~=0.5.0",
     "click-spinner~=0.1.8",
-    "click==7.0",
+    "click~=7.0",
     "django~=2.2",
     "ete3~=3.1",
     "graphviz~=0.13",

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -7,10 +7,14 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=unused-argument
 """Tests for the 'verdi code' command."""
 import os
 import subprocess as sp
+from textwrap import dedent
+
 from click.testing import CliRunner
+import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_code import (setup_code, delete, hide, reveal, relabel, code_list, show, code_duplicate)
@@ -24,13 +28,11 @@ class TestVerdiCodeSetup(AiidaTestCase):
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super().setUpClass(*args, **kwargs)
-        orm.Computer(
+        cls.computer = orm.Computer(
             name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
     def setUp(self):
-        self.comp = orm.Computer.objects.get(name='comp')
-
         self.cli_runner = CliRunner()
         self.this_folder = os.path.dirname(__file__)
         self.this_file = os.path.basename(__file__)
@@ -42,46 +44,20 @@ class TestVerdiCodeSetup(AiidaTestCase):
         output = sp.check_output(['verdi', 'code', 'setup', '--help'])
         self.assertIn(b'Usage:', output)
 
-    def test_interactive_remote(self):
-        """Test interactive remote code setup."""
-
-        from aiida.orm import Code
-        os.environ['VISUAL'] = 'sleep 1; vim -cwq'
-        os.environ['EDITOR'] = 'sleep 1; vim -cwq'
-        label = 'interactive_remote'
-        user_input = '\n'.join([label, 'description', 'arithmetic.add', 'yes', self.comp.name, '/remote/abs/path'])
-        result = self.cli_runner.invoke(setup_code, input=user_input)
-        self.assertClickResultNoException(result)
-        self.assertIsInstance(Code.get_from_string('{}@{}'.format(label, self.comp.name)), Code)
-
-    def test_interactive_upload(self):
-        """Test interactive code setup."""
-        from aiida.orm import Code
-        os.environ['VISUAL'] = 'sleep 1; vim -cwq'
-        os.environ['EDITOR'] = 'sleep 1; vim -cwq'
-        label = 'interactive_upload'
-        user_input = '\n'.join([label, 'description', 'arithmetic.add', 'no', self.this_folder, self.this_file])
-        result = self.cli_runner.invoke(setup_code, input=user_input)
-        self.assertIsNone(result.exception, result.output)
-        self.assertIsInstance(Code.get_from_string('{}'.format(label)), Code)
-
     def test_noninteractive_remote(self):
         """Test non-interactive remote code setup."""
-
-        from aiida.orm import Code
         label = 'noninteractive_remote'
         options = [
             '--non-interactive', '--label={}'.format(label), '--description=description',
-            '--input-plugin=arithmetic.add', '--on-computer', '--computer={}'.format(self.comp.name),
+            '--input-plugin=arithmetic.add', '--on-computer', '--computer={}'.format(self.computer.name),
             '--remote-abs-path=/remote/abs/path'
         ]
         result = self.cli_runner.invoke(setup_code, options)
         self.assertClickResultNoException(result)
-        self.assertIsInstance(Code.get_from_string('{}@{}'.format(label, self.comp.name)), Code)
+        self.assertIsInstance(orm.Code.get_from_string('{}@{}'.format(label, self.computer.name)), orm.Code)
 
     def test_noninteractive_upload(self):
         """Test non-interactive code setup."""
-        from aiida.orm import Code
         label = 'noninteractive_upload'
         options = [
             '--non-interactive', '--label={}'.format(label), '--description=description',
@@ -90,23 +66,25 @@ class TestVerdiCodeSetup(AiidaTestCase):
         ]
         result = self.cli_runner.invoke(setup_code, options)
         self.assertClickResultNoException(result)
-        self.assertIsInstance(Code.get_from_string('{}'.format(label)), Code)
+        self.assertIsInstance(orm.Code.get_from_string('{}'.format(label)), orm.Code)
 
     def test_from_config(self):
         """Test setting up a code from a config file"""
-        from aiida.orm import Code
         import tempfile
 
         label = 'noninteractive_config'
 
         with tempfile.NamedTemporaryFile('w') as handle:
             handle.write(
-                """---
-label: {l}
-input_plugin: arithmetic.add
-computer: {c}
-remote_abs_path: /remote/abs/path
-""".format(l=label, c=self.comp.name)
+                dedent(
+                    """
+                    ---
+                    label: {label}
+                    input_plugin: arithmetic.add
+                    computer: {computer}
+                    remote_abs_path: /remote/abs/path
+                    """
+                ).format(label=label, computer=self.computer.name)
             )
             handle.flush()
             result = self.cli_runner.invoke(
@@ -115,17 +93,7 @@ remote_abs_path: /remote/abs/path
             )
 
         self.assertClickResultNoException(result)
-        self.assertIsInstance(Code.get_from_string('{}'.format(label)), Code)
-
-    def test_mixed(self):
-        """Test mixed (interactive/from config) code setup."""
-        from aiida.orm import Code
-        label = 'mixed_remote'
-        options = ['--description=description', '--on-computer', '--remote-abs-path=/remote/abs/path']
-        user_input = '\n'.join([label, 'arithmetic.add', self.comp.name])
-        result = self.cli_runner.invoke(setup_code, options, input=user_input)
-        self.assertClickResultNoException(result)
-        self.assertIsInstance(Code.get_from_string('{}@{}'.format(label, self.comp.name)), Code)
+        self.assertIsInstance(orm.Code.get_from_string('{}'.format(label)), orm.Code)
 
 
 class TestVerdiCodeCommands(AiidaTestCase):
@@ -136,19 +104,17 @@ class TestVerdiCodeCommands(AiidaTestCase):
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super().setUpClass(*args, **kwargs)
-        orm.Computer(
+        cls.computer = orm.Computer(
             name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
     def setUp(self):
-        self.comp = orm.Computer.objects.get(name='comp')
-
         try:
             code = orm.Code.get_from_string('code')
         except NotExistent:
             code = orm.Code(
                 input_plugin_name='arithmetic.add',
-                remote_computer_exec=[self.comp, '/remote/abs/path'],
+                remote_computer_exec=[self.computer, '/remote/abs/path'],
             )
             code.label = 'code'
             code.description = 'desc'
@@ -175,14 +141,12 @@ class TestVerdiCodeCommands(AiidaTestCase):
         """Test force code relabeling."""
         result = self.cli_runner.invoke(relabel, [str(self.code.pk), 'new_code'])
         self.assertIsNone(result.exception, result.output)
-        from aiida.orm import load_node
-        new_code = load_node(self.code.pk)
+        new_code = orm.load_node(self.code.pk)
         self.assertEqual(new_code.label, 'new_code')
 
     def test_relabel_code_full(self):
         self.cli_runner.invoke(relabel, [str(self.code.pk), 'new_code@comp'])
-        from aiida.orm import load_node
-        new_code = load_node(self.code.pk)
+        new_code = orm.load_node(self.code.pk)
         self.assertEqual(new_code.label, 'new_code')
 
     def test_relabel_code_full_bad(self):
@@ -195,24 +159,22 @@ class TestVerdiCodeCommands(AiidaTestCase):
         self.assertIsNone(result.exception, result.output)
 
         with self.assertRaises(NotExistent):
-            from aiida.orm import Code
-            Code.get_from_string('code')
+            orm.Code.get_from_string('code')
 
     def test_code_list(self):
         """Test code list command."""
         # set up second code 'code2'
-        from aiida.orm import Code
         try:
-            code = Code.get_from_string('code2')
+            code = orm.Code.get_from_string('code2')
         except NotExistent:
-            code = Code(
+            code = orm.Code(
                 input_plugin_name='templatereplacer',
-                remote_computer_exec=[self.comp, '/remote/abs/path'],
+                remote_computer_exec=[self.computer, '/remote/abs/path'],
             )
             code.label = 'code2'
             code.store()
 
-        options = ['-A', '-a', '-o', '--input-plugin=arithmetic.add', '--computer={}'.format(self.comp.name)]
+        options = ['-A', '-a', '-o', '--input-plugin=arithmetic.add', '--computer={}'.format(self.computer.name)]
         result = self.cli_runner.invoke(code_list, options)
         self.assertIsNone(result.exception, result.output)
         self.assertTrue(str(self.code.pk) in result.output, 'PK of first code should be included')
@@ -238,39 +200,13 @@ class TestVerdiCodeCommands(AiidaTestCase):
         self.assertIsNone(result.exception, result.output)
         self.assertTrue(str(self.code.pk) in result.output)
 
-    def test_code_duplicate_interactive(self):
-        """Test code duplication interactive."""
-        from aiida.orm import Code
-        os.environ['VISUAL'] = 'sleep 1; vim -cwq'
-        os.environ['EDITOR'] = 'sleep 1; vim -cwq'
-        label = 'code_duplicate_interactive'
-        user_input = label + '\n\n\n\n\n\n'
-        result = self.cli_runner.invoke(code_duplicate, [str(self.code.pk)], input=user_input, catch_exceptions=False)
-        self.assertIsNone(result.exception, result.output)
-
-        new_code = Code.get_from_string(label)
-        self.assertEqual(self.code.description, new_code.description)
-        self.assertEqual(self.code.get_prepend_text(), new_code.get_prepend_text())
-        self.assertEqual(self.code.get_append_text(), new_code.get_append_text())
-
-        # test that providing "!" to description leads to empty description
-        # https://github.com/aiidateam/aiida-core/issues/3770
-        label = 'code_duplicate_interactive2'
-        user_input = label + '\n!\n\n\n\n\n'
-        result = self.cli_runner.invoke(code_duplicate, [str(self.code.pk)], input=user_input, catch_exceptions=False)
-        self.assertIsNone(result.exception, result.output)
-
-        new_code = Code.get_from_string(label)
-        self.assertEqual('', new_code.description)
-
     def test_code_duplicate_non_interactive(self):
         """Test code duplication non-interactive."""
         label = 'code_duplicate_noninteractive'
         result = self.cli_runner.invoke(code_duplicate, ['--non-interactive', '--label=' + label, str(self.code.pk)])
         self.assertIsNone(result.exception, result.output)
 
-        from aiida.orm import Code
-        new_code = Code.get_from_string(label)
+        new_code = orm.Code.get_from_string(label)
         self.assertEqual(self.code.description, new_code.description)
         self.assertEqual(self.code.get_prepend_text(), new_code.get_prepend_text())
         self.assertEqual(self.code.get_append_text(), new_code.get_append_text())
@@ -286,3 +222,68 @@ class TestVerdiCodeNoCodes(AiidaTestCase):
     def test_code_list_no_codes_error_message(self):
         result = self.cli_runner.invoke(code_list)
         self.assertEqual(1, result.output.count('# No codes found matching the specified criteria.'))
+
+
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_interactive_remote(clear_database_before_test, aiida_localhost, non_interactive_editor):
+    """Test interactive remote code setup."""
+    label = 'interactive_remote'
+    user_input = '\n'.join([label, 'description', 'arithmetic.add', 'yes', aiida_localhost.name, '/remote/abs/path'])
+    result = CliRunner().invoke(setup_code, input=user_input)
+    assert result.exception is None
+    assert isinstance(orm.Code.get_from_string('{}@{}'.format(label, aiida_localhost.name)), orm.Code)
+
+
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_interactive_upload(clear_database_before_test, aiida_localhost, non_interactive_editor):
+    """Test interactive code setup."""
+    label = 'interactive_upload'
+    dirname = os.path.dirname(__file__)
+    basename = os.path.basename(__file__)
+    user_input = '\n'.join([label, 'description', 'arithmetic.add', 'no', dirname, basename])
+    result = CliRunner().invoke(setup_code, input=user_input)
+    assert result.exception is None
+    assert isinstance(orm.Code.get_from_string('{}'.format(label)), orm.Code)
+
+
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_mixed(clear_database_before_test, aiida_localhost, non_interactive_editor):
+    """Test mixed (interactive/from config) code setup."""
+    from aiida.orm import Code
+    label = 'mixed_remote'
+    options = ['--description=description', '--on-computer', '--remote-abs-path=/remote/abs/path']
+    user_input = '\n'.join([label, 'arithmetic.add', aiida_localhost.name])
+    result = CliRunner().invoke(setup_code, options, input=user_input)
+    assert result.exception is None
+    assert isinstance(Code.get_from_string('{}@{}'.format(label, aiida_localhost.name)), Code)
+
+
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_code_duplicate_interactive(clear_database_before_test, aiida_local_code_factory, non_interactive_editor):
+    """Test code duplication interactive."""
+    label = 'code_duplicate_interactive'
+    user_input = label + '\n\n\n\n\n\n'
+    code = aiida_local_code_factory('arithmetic.add', '/bin/cat', label='code')
+    result = CliRunner().invoke(code_duplicate, [str(code.pk)], input=user_input)
+    assert result.exception is None, result.exception
+
+    duplicate = orm.Code.get_from_string(label)
+    assert code.description == duplicate.description
+    assert code.get_prepend_text() == duplicate.get_prepend_text()
+    assert code.get_append_text() == duplicate.get_append_text()
+
+
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_code_duplicate_ignore(clear_database_before_test, aiida_local_code_factory, non_interactive_editor):
+    """Providing "!" to description should lead to empty description.
+
+    Regression test for: https://github.com/aiidateam/aiida-core/issues/3770
+    """
+    label = 'code_duplicate_interactive'
+    user_input = label + '\n!\n\n\n\n\n'
+    code = aiida_local_code_factory('arithmetic.add', '/bin/cat', label='code')
+    result = CliRunner().invoke(code_duplicate, [str(code.pk)], input=user_input, catch_exceptions=False)
+    assert result.exception is None, result.exception
+
+    duplicate = orm.Code.get_from_string(label)
+    assert duplicate.description == ''

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -7,13 +7,14 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=unused-argument
 """Tests for the 'verdi computer' command."""
-
 from collections import OrderedDict
 import os
 import tempfile
 
 from click.testing import CliRunner
+import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
@@ -116,36 +117,6 @@ class TestVerdiComputerSetup(AiidaTestCase):
         import subprocess as sp
         output = sp.check_output(['verdi', 'computer', 'setup', '--help'])
         self.assertIn(b'Usage:', output)
-
-    def test_interactive(self):
-        """Test verdi computer setup in interactive mode."""
-        os.environ['VISUAL'] = 'sleep 1; vim -cwq'
-        os.environ['EDITOR'] = 'sleep 1; vim -cwq'
-        label = 'interactive_computer'
-
-        options_dict = generate_setup_options_dict(replace_args={'label': label}, non_interactive=False)
-        # In any case, these would be managed by the visual editor
-        options_dict.pop('prepend-text')
-        options_dict.pop('append-text')
-        user_input = '\n'.join(generate_setup_options_interactive(options_dict))
-
-        result = self.cli_runner.invoke(computer_setup, input=user_input)
-        self.assertIsNone(result.exception, msg='There was an unexpected exception. Output: {}'.format(result.output))
-
-        new_computer = orm.Computer.objects.get(name=label)
-        self.assertIsInstance(new_computer, orm.Computer)
-
-        self.assertEqual(new_computer.description, options_dict['description'])
-        self.assertEqual(new_computer.hostname, options_dict['hostname'])
-        self.assertEqual(new_computer.get_transport_type(), options_dict['transport'])
-        self.assertEqual(new_computer.get_scheduler_type(), options_dict['scheduler'])
-        self.assertEqual(new_computer.get_mpirun_command(), options_dict['mpirun-command'].split())
-        self.assertEqual(new_computer.get_shebang(), options_dict['shebang'])
-        self.assertEqual(new_computer.get_workdir(), options_dict['work-dir'])
-        self.assertEqual(new_computer.get_default_mpiprocs_per_machine(), int(options_dict['mpiprocs-per-machine']))
-        # For now I'm not writing anything in them
-        self.assertEqual(new_computer.get_prepend_text(), '')
-        self.assertEqual(new_computer.get_append_text(), '')
 
     def test_mixed(self):
         """
@@ -749,3 +720,33 @@ class TestVerdiComputerCommands(AiidaTestCase):
         self.assertEqual(self.comp.get_default_mpiprocs_per_machine(), new_computer.get_default_mpiprocs_per_machine())
         self.assertEqual(self.comp.get_prepend_text(), new_computer.get_prepend_text())
         self.assertEqual(self.comp.get_append_text(), new_computer.get_append_text())
+
+
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_interactive(clear_database_before_test, aiida_localhost, non_interactive_editor):
+    """Test verdi computer setup in interactive mode."""
+    label = 'interactive_computer'
+
+    options_dict = generate_setup_options_dict(replace_args={'label': label}, non_interactive=False)
+    # In any case, these would be managed by the visual editor
+    options_dict.pop('prepend-text')
+    options_dict.pop('append-text')
+    user_input = '\n'.join(generate_setup_options_interactive(options_dict))
+
+    result = CliRunner().invoke(computer_setup, input=user_input)
+    assert result.exception is None, 'There was an unexpected exception. Output: {}'.format(result.output)
+
+    new_computer = orm.Computer.objects.get(name=label)
+    assert isinstance(new_computer, orm.Computer)
+
+    assert new_computer.description == options_dict['description']
+    assert new_computer.hostname == options_dict['hostname']
+    assert new_computer.get_transport_type() == options_dict['transport']
+    assert new_computer.get_scheduler_type() == options_dict['scheduler']
+    assert new_computer.get_mpirun_command() == options_dict['mpirun-command'].split()
+    assert new_computer.get_shebang() == options_dict['shebang']
+    assert new_computer.get_workdir() == options_dict['work-dir']
+    assert new_computer.get_default_mpiprocs_per_machine() == int(options_dict['mpiprocs-per-machine'])
+    # For now I'm not writing anything in them
+    assert new_computer.get_prepend_text() == ''
+    assert new_computer.get_append_text() == ''

--- a/tests/cmdline/params/options/test_conditional.py
+++ b/tests/cmdline/params/options/test_conditional.py
@@ -66,7 +66,7 @@ class ConditionalOptionTest(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(cmd, ['--on'])
         self.assertIsNotNone(result.exception)
-        self.assertIn('Error: Missing option "--opt".', result.output)
+        self.assertTrue('Error: Missing option' in result.output and '--opt' in result.output)
 
     def test_flag_off(self):
         """
@@ -89,7 +89,7 @@ class ConditionalOptionTest(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(cmd, ['--on'])
         self.assertIsNotNone(result.exception)
-        self.assertIn('Error: Missing option "--opt".', result.output)
+        self.assertTrue('Error: Missing option' in result.output and '--opt' in result.output)
 
     def setup_multi_non_eager(self):
         """
@@ -139,11 +139,11 @@ class ConditionalOptionTest(unittest.TestCase):
         runner, cmd = self.setup_multi_non_eager()
         result = runner.invoke(cmd, ['--a', '--opt-b=Bla'])
         self.assertIsNotNone(result.exception)
-        self.assertIn('Error: Missing option "--opt-a".', result.output)
+        self.assertTrue('Error: Missing option' in result.output and '--opt-a' in result.output)
 
         result_rev = runner.invoke(cmd, ['--opt-b=Bla', '--a'])
         self.assertIsNotNone(result_rev.exception)
-        self.assertIn('Error: Missing option "--opt-a".', result_rev.output)
+        self.assertTrue('Error: Missing option' in result.output and '--opt-a' in result.output)
 
     def test_ba(self):
         """
@@ -154,11 +154,11 @@ class ConditionalOptionTest(unittest.TestCase):
         runner, cmd = self.setup_multi_non_eager()
         result = runner.invoke(cmd, ['--b', '--opt-a=Bla'])
         self.assertIsNotNone(result.exception)
-        self.assertIn('Error: Missing option "--opt-b".', result.output)
+        self.assertTrue('Error: Missing option' in result.output and '--opt-b' in result.output)
 
         result_rev = runner.invoke(cmd, ['--opt-a=Bla', '--b'])
         self.assertIsNotNone(result_rev.exception)
-        self.assertIn('Error: Missing option "--opt-b".', result_rev.output)
+        self.assertTrue('Error: Missing option' in result.output and '--opt-b' in result.output)
 
     @staticmethod
     def user_callback(_ctx, param, value):
@@ -181,9 +181,8 @@ class ConditionalOptionTest(unittest.TestCase):
         @click.option('--flag', is_flag=True)
         @click.option('--opt-a', required_fn=lambda c: c.params.get('flag'), cls=ConditionalOption, **kwargs)
         def cmd(flag, opt_a):
-            """ A command with a flag and customizable options that dependon it """
+            """A command with a flag and customizable options that depend on it."""
             # pylint: disable=unused-argument
-
             click.echo('{}'.format(opt_a))
 
         return cmd

--- a/tests/cmdline/utils/test_multiline.py
+++ b/tests/cmdline/utils/test_multiline.py
@@ -7,56 +7,53 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=unused-argument
 """Unit tests for editing pre and post bash scripts, comments, etc."""
-import os
-import unittest
-
-from click.testing import CliRunner
+import pytest
 
 from aiida.cmdline.utils.multi_line_input import edit_pre_post, edit_comment
 
+COMMAND = 'sleep 1 ; vim -c "g!/^#=/s/$/Test" -cwq'  # Appends `Test` to every line NOT starting with `#=`
 
-class TestMultilineInput(unittest.TestCase):
-    """Test functions for editing pre and post bash scripts, comments, etc."""
 
-    def setUp(self):
-        ## Sleep 1 is needed because on some filesystems (e.g. some pre 10.13 Mac) the
-        ## filesystem returns the time with a precision of 1 second, and
-        ## click uses the timestamp to decide if the file was re-saved or not.
-        editor_cmd = 'sleep 1 ; vim -c "g!/^#=/s/$/Test" -cwq'  # appends Test to
-        # every line that does NOT start with '#=' characters
-        os.environ['EDITOR'] = editor_cmd
-        os.environ['VISUAL'] = editor_cmd
-        self.runner = CliRunner()
+@pytest.mark.parametrize('non_interactive_editor', (COMMAND,), indirect=True)
+def test_pre_post(non_interactive_editor):
+    result = edit_pre_post(summary={'Param 1': 'Value 1', 'Param 2': 'Value 1'})
+    assert result[0] == 'Test\nTest\nTest'
+    assert result[1] == 'Test\nTest\nTest'
 
-    def test_pre_post(self):
-        result = edit_pre_post(summary={'Param 1': 'Value 1', 'Param 2': 'Value 1'})
-        self.assertEqual(result[0], 'Test\nTest\nTest')
-        self.assertEqual(result[1], 'Test\nTest\nTest')
 
-    def test_edit_pre_post(self):
-        result = edit_pre_post(pre='OldPre', post='OldPost')
-        self.assertEqual(result[0], 'Test\nOldPreTest\nTest')
-        self.assertEqual(result[1], 'Test\nOldPostTest\nTest')
+@pytest.mark.parametrize('non_interactive_editor', (COMMAND,), indirect=True)
+def test_edit_pre_post(non_interactive_editor):
+    result = edit_pre_post(pre='OldPre', post='OldPost')
+    assert result[0] == 'Test\nOldPreTest\nTest'
+    assert result[1] == 'Test\nOldPostTest\nTest'
 
-    def test_edit_pre_post_comment(self):
-        """Test that lines starting with '#=' are ignored and are not ignored
-        if they start with any other character"""
-        result = edit_pre_post(pre='OldPre\n#=Delete me', post='OldPost #=Dont delete me')
-        self.assertEqual(result[0], 'Test\nOldPreTest\nTest')
-        self.assertEqual(result[1], 'Test\nOldPost #=Dont delete meTest\nTest')
 
-    def test_edit_pre_bash_comment(self):
-        """Test that bash comments starting with '#' are NOT deleted"""
-        result = edit_pre_post(pre='OldPre\n# Dont delete me', post='OldPost # Dont delete me')
-        self.assertEqual(result[0], 'Test\nOldPreTest\n# Dont delete meTest\nTest')
-        self.assertEqual(result[1], 'Test\nOldPost # Dont delete meTest\nTest')
+@pytest.mark.parametrize('non_interactive_editor', (COMMAND,), indirect=True)
+def test_edit_pre_post_comment(non_interactive_editor):
+    """Test that lines starting with '#=' are ignored and are not ignored if they start with any other character."""
+    result = edit_pre_post(pre='OldPre\n#=Delete me', post='OldPost #=Dont delete me')
+    assert result[0] == 'Test\nOldPreTest\nTest'
+    assert result[1] == 'Test\nOldPost #=Dont delete meTest\nTest'
 
-    def test_new_comment(self):
-        new_comment = edit_comment()
-        self.assertEqual(new_comment, 'Test')
 
-    def test_edit_comment(self):
-        old_comment = 'OldComment'
-        new_comment = edit_comment(old_cmt=old_comment)
-        self.assertEqual(new_comment, old_comment + 'Test')
+@pytest.mark.parametrize('non_interactive_editor', (COMMAND,), indirect=True)
+def test_edit_pre_bash_comment(non_interactive_editor):
+    """Test that bash comments starting with '#' are NOT deleted."""
+    result = edit_pre_post(pre='OldPre\n# Dont delete me', post='OldPost # Dont delete me')
+    assert result[0] == 'Test\nOldPreTest\n# Dont delete meTest\nTest'
+    assert result[1] == 'Test\nOldPost # Dont delete meTest\nTest'
+
+
+@pytest.mark.parametrize('non_interactive_editor', (COMMAND,), indirect=True)
+def test_new_comment(non_interactive_editor):
+    new_comment = edit_comment()
+    assert new_comment == 'Test'
+
+
+@pytest.mark.parametrize('non_interactive_editor', (COMMAND,), indirect=True)
+def test_edit_comment(non_interactive_editor):
+    old_comment = 'OldComment'
+    new_comment = edit_comment(old_cmt=old_comment)
+    assert new_comment == old_comment + 'Test'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,48 @@
 import pytest  # pylint: disable=unused-import
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
+
+
+@pytest.fixture()
+def non_interactive_editor(request):
+    """Fixture to patch click's `Editor.edit_file`.
+
+    In `click==7.1` the `Editor.edit_file` command was changed to escape the `os.environ['EDITOR']` command. Our tests
+    are currently abusing this variable to define an automated vim command in order to make an interactive command
+    non-interactive, and escaping it makes bash interpret the command and its arguments as a single command instead.
+    Here we patch the method to remove the escaping of the editor command.
+
+    :param request: the command to set for the editor that is to be called
+    """
+    import os
+    from unittest.mock import patch
+    from click._termui_impl import Editor
+
+    os.environ['EDITOR'] = request.param
+    os.environ['VISUAL'] = request.param
+
+    def edit_file(self, filename):
+        import os
+        import subprocess
+        import click
+
+        editor = self.get_editor()
+        if self.env:
+            environ = os.environ.copy()
+            environ.update(self.env)
+        else:
+            environ = None
+        try:
+            process = subprocess.Popen(
+                '{} {}'.format(editor, filename),  # This is the line that we change removing `shlex_quote`
+                env=environ,
+                shell=True,
+            )
+            exit_code = process.wait()
+            if exit_code != 0:
+                raise click.ClickException('{}: Editing failed!'.format(editor))
+        except OSError as exception:
+            raise click.ClickException('{}: Editing failed: {}'.format(editor, exception))
+
+    with patch.object(Editor, 'edit_file', edit_file):
+        yield


### PR DESCRIPTION
Fixes #3838 
Fixes #3810 

The breaking of the tests was caused by two separate commits:

  * 718485be48263056e7036ea9a60ce11b47e2fc26
  * 37d897069f58f7f2a016c14b0620c6d387430b4b

The first one changes the format of the output of a command if a
required option is missing. The double quotes around the option have
been changed to single quotes.

The second commit is more pernicious: the `Editor.edit_file` method was
updated to escape the editor and filename parameters passed to the sub
process call. Our tests were abusing the absence of escaping to pass
arguments to the editor command, in our case `vim`, as to make the
normally interactive command a non-interactive one for testing purposes.
Now that the editor command is escaped, the arguments are understood by
bash to be part of the command which of course then cannot be found and
the test fails. We "fix" this problem by patching the changed method in
`click` to undo the escaping.