### PR TITLE
Various features and fixes related to `Group` subclassing and `Group` in the CLI

### DIFF
--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi group` commands"""
-
 import click
 
 from aiida.common.exceptions import UniquenessError
@@ -179,74 +178,89 @@ def group_show(group, raw, limit, uuid):
 
 
 @verdi_group.command('list')
-@options.ALL_USERS(help='Show groups for all users, rather than only for the current user')
-@click.option(
-    '-u',
-    '--user',
-    'user_email',
-    type=click.STRING,
-    help='Add a filter to show only groups belonging to a specific user'
-)
-@click.option('-a', '--all-types', is_flag=True, default=False, help='Show groups of all types')
+@options.ALL_USERS(help='Show groups for all users, rather than only for the current user.')
+@options.USER(help='Add a filter to show only groups belonging to a specific user')
+@options.ALL(help='Show groups of all types.')
 @click.option(
     '-t',
     '--type',
     'group_type',
-    default='core',
+    default=None,
     help='Show groups of a specific type, instead of user-defined groups. Start with semicolumn if you want to '
-    'specify aiida-internal type'
+    'specify aiida-internal type. [deprecated: use `--type-string` instead. Will be removed in 2.0.0]'
 )
+@options.TYPE_STRING()
 @click.option(
-    '-d', '--with-description', 'with_description', is_flag=True, default=False, help='Show also the group description'
+    '-d',
+    '--with-description',
+    'with_description',
+    is_flag=True,
+    default=False,
+    help='Show also the group description.'
 )
-@click.option('-C', '--count', is_flag=True, default=False, help='Show also the number of nodes in the group')
-@options.PAST_DAYS(help='add a filter to show only groups created in the past N days', default=None)
+@click.option('-C', '--count', is_flag=True, default=False, help='Show also the number of nodes in the group.')
+@options.PAST_DAYS(help='Add a filter to show only groups created in the past N days.', default=None)
 @click.option(
     '-s',
     '--startswith',
     type=click.STRING,
     default=None,
-    help='add a filter to show only groups for which the name begins with STRING'
+    help='Add a filter to show only groups for which the label begins with STRING.'
 )
 @click.option(
     '-e',
     '--endswith',
     type=click.STRING,
     default=None,
-    help='add a filter to show only groups for which the name ends with STRING'
+    help='Add a filter to show only groups for which the label ends with STRING.'
 )
 @click.option(
     '-c',
     '--contains',
     type=click.STRING,
     default=None,
-    help='add a filter to show only groups for which the name contains STRING'
+    help='Add a filter to show only groups for which the label contains STRING.'
 )
 @options.ORDER_BY(type=click.Choice(['id', 'label', 'ctime']), default='id')
 @options.ORDER_DIRECTION()
-@options.NODE(help='Show only the groups that contain the node')
+@options.NODE(help='Show only the groups that contain the node.')
 @with_dbenv()
 def group_list(
-    all_users, user_email, all_types, group_type, with_description, count, past_days, startswith, endswith, contains,
-    order_by, order_dir, node
+    all_users, user, all_entries, group_type, type_string, with_description, count, past_days, startswith, endswith,
+    contains, order_by, order_dir, node
 ):
     """Show a list of existing groups."""
-    # pylint: disable=too-many-branches,too-many-arguments, too-many-locals
+    # pylint: disable=too-many-branches,too-many-arguments,too-many-locals,too-many-statements
     import datetime
-    from aiida.common.escaping import escape_for_sql_like
-    from aiida.common import timezone
-    from aiida.orm import Group
-    from aiida.orm import QueryBuilder
-    from aiida.orm import User
+    import warnings
     from aiida import orm
+    from aiida.common import timezone
+    from aiida.common.escaping import escape_for_sql_like
+    from aiida.common.warnings import AiidaDeprecationWarning
     from tabulate import tabulate
 
-    query = QueryBuilder()
+    builder = orm.QueryBuilder()
     filters = {}
 
-    # Specify group types
-    if not all_types:
-        filters = {'type_string': {'==': group_type}}
+    if group_type is not None:
+        warnings.warn('`--group-type` is deprecated, use `--type-string` instead', AiidaDeprecationWarning)  # pylint: disable=no-member
+
+        if type_string is not None:
+            raise click.BadOptionUsage('group-type', 'cannot use `--group-type` and `--type-string` at the same time.')
+        else:
+            type_string = group_type
+
+    # Have to specify the default for `type_string` here instead of directly in the option otherwise it will always
+    # raise above if the user specifies just the `--group-type` option. Once that option is removed, the default can
+    # be moved to the option itself.
+    if type_string is None:
+        type_string = 'core'
+
+    if not all_entries:
+        if '%' in type_string or '_' in type_string:
+            filters['type_string'] = {'like': type_string}
+        else:
+            filters['type_string'] = type_string
 
     # Creation time
     if past_days:
@@ -261,26 +275,25 @@ def group_list(
     if contains:
         filters['or'].append({'label': {'like': '%{}%'.format(escape_for_sql_like(contains))}})
 
-    query.append(Group, filters=filters, tag='group', project='*')
+    builder.append(orm.Group, filters=filters, tag='group', project='*')
 
     # Query groups that belong to specific user
-    if user_email:
-        user = user_email
+    if user:
+        user_email = user.email
     else:
         # By default: only groups of this user
-        user = orm.User.objects.get_default().email
+        user_email = orm.User.objects.get_default().email
 
     # Query groups that belong to all users
     if not all_users:
-        query.append(User, filters={'email': {'==': user}}, with_group='group')
+        builder.append(orm.User, filters={'email': {'==': user_email}}, with_group='group')
 
     # Query groups that contain a particular node
     if node:
-        from aiida.orm import Node
-        query.append(Node, filters={'id': {'==': node.id}}, with_group='group')
+        builder.append(orm.Node, filters={'id': {'==': node.id}}, with_group='group')
 
-    query.order_by({Group: {order_by: order_dir}})
-    result = query.all()
+    builder.order_by({orm.Group: {order_by: order_dir}})
+    result = builder.all()
 
     projection_lambdas = {
         'pk': lambda group: str(group.pk),
@@ -306,9 +319,13 @@ def group_list(
     for group in result:
         table.append([projection_lambdas[field](group[0]) for field in projection_fields])
 
-    if not all_types:
-        echo.echo_info('If you want to see the groups of all types, please add -a/--all-types option')
-    echo.echo(tabulate(table, headers=projection_header))
+    if not all_entries:
+        echo.echo_info('to show groups of all types, use the `-a/--all` option.')
+
+    if not table:
+        echo.echo_info('no groups found matching the specified criteria.')
+    else:
+        echo.echo(tabulate(table, headers=projection_header))
 
 
 @verdi_group.command('create')
@@ -356,36 +373,34 @@ def verdi_group_path():
 
 @verdi_group_path.command('ls')
 @click.argument('path', type=click.STRING, required=False)
-@click.option('-R', '--recursive', is_flag=True, default=False, help='Recursively list sub-paths encountered')
-@click.option('-l', '--long', 'as_table', is_flag=True, default=False, help='List as a table, with sub-group count')
+@options.TYPE_STRING(default='core', help='Filter to only include groups of this type string.')
+@click.option('-R', '--recursive', is_flag=True, default=False, help='Recursively list sub-paths encountered.')
+@click.option('-l', '--long', 'as_table', is_flag=True, default=False, help='List as a table, with sub-group count.')
 @click.option(
-    '-d', '--with-description', 'with_description', is_flag=True, default=False, help='Show also the group description'
+    '-d',
+    '--with-description',
+    'with_description',
+    is_flag=True,
+    default=False,
+    help='Show also the group description.'
 )
 @click.option(
     '--no-virtual',
     'no_virtual',
     is_flag=True,
     default=False,
-    help='Only show paths that fully correspond to an existing group'
-)
-@click.option(
-    '-t',
-    '--type',
-    'group_type',
-    default='core',
-    help='Show groups of a specific type, instead of user-defined groups. Start with semicolumn if you want to '
-    'specify aiida-internal type'
+    help='Only show paths that fully correspond to an existing group.'
 )
 @click.option('--no-warn', is_flag=True, default=False, help='Do not issue a warning if any paths are invalid.')
 @with_dbenv()
-def group_path_ls(path, recursive, as_table, no_virtual, group_type, with_description, no_warn):
-    # pylint: disable=too-many-arguments
+def group_path_ls(path, type_string, recursive, as_table, no_virtual, with_description, no_warn):
+    # pylint: disable=too-many-arguments,too-many-branches
     """Show a list of existing group paths."""
     from aiida.plugins import GroupFactory
     from aiida.tools.groups.paths import GroupPath, InvalidPath
 
     try:
-        path = GroupPath(path or '', cls=GroupFactory(group_type), warn_invalid_child=not no_warn)
+        path = GroupPath(path or '', cls=GroupFactory(type_string), warn_invalid_child=not no_warn)
     except InvalidPath as err:
         echo.echo_critical(str(err))
 

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -27,10 +27,10 @@ __all__ = (
     'EXPORT_FORMAT', 'ARCHIVE_FORMAT', 'NON_INTERACTIVE', 'DRY_RUN', 'USER_EMAIL', 'USER_FIRST_NAME', 'USER_LAST_NAME',
     'USER_INSTITUTION', 'DB_BACKEND', 'DB_ENGINE', 'DB_HOST', 'DB_PORT', 'DB_USERNAME', 'DB_PASSWORD', 'DB_NAME',
     'REPOSITORY_PATH', 'PROFILE_ONLY_CONFIG', 'PROFILE_SET_DEFAULT', 'PREPEND_TEXT', 'APPEND_TEXT', 'LABEL',
-    'DESCRIPTION', 'INPUT_PLUGIN', 'CALC_JOB_STATE', 'PROCESS_STATE', 'EXIT_STATUS', 'FAILED', 'LIMIT', 'PROJECT',
-    'ORDER_BY', 'PAST_DAYS', 'OLDER_THAN', 'ALL', 'ALL_STATES', 'ALL_USERS', 'GROUP_CLEAR', 'RAW', 'HOSTNAME',
-    'TRANSPORT', 'SCHEDULER', 'USER', 'PORT', 'FREQUENCY', 'VERBOSE', 'TIMEOUT', 'FORMULA_MODE', 'TRAJECTORY_INDEX',
-    'WITH_ELEMENTS', 'WITH_ELEMENTS_EXCLUSIVE'
+    'DESCRIPTION', 'INPUT_PLUGIN', 'CALC_JOB_STATE', 'PROCESS_STATE', 'PROCESS_LABEL', 'TYPE_STRING', 'EXIT_STATUS',
+    'FAILED', 'LIMIT', 'PROJECT', 'ORDER_BY', 'PAST_DAYS', 'OLDER_THAN', 'ALL', 'ALL_STATES', 'ALL_USERS',
+    'GROUP_CLEAR', 'RAW', 'HOSTNAME', 'TRANSPORT', 'SCHEDULER', 'USER', 'PORT', 'FREQUENCY', 'VERBOSE', 'TIMEOUT',
+    'FORMULA_MODE', 'TRAJECTORY_INDEX', 'WITH_ELEMENTS', 'WITH_ELEMENTS_EXCLUSIVE'
 )
 
 TRAVERSAL_RULE_HELP_STRING = {
@@ -331,6 +331,16 @@ PROCESS_LABEL = OverridableOption(
     type=click.STRING,
     required=False,
     help='Only include entries whose process label matches this filter.'
+)
+
+TYPE_STRING = OverridableOption(
+    '-T',
+    '--type-string',
+    'type_string',
+    type=click.STRING,
+    required=False,
+    help='Only include entries whose type string matches this filter. Can include `_` to match a single arbitrary '
+    'character or `%` to match any number of characters.'
 )
 
 EXIT_STATUS = OverridableOption(

--- a/aiida/cmdline/params/types/choice.py
+++ b/aiida/cmdline/params/types/choice.py
@@ -43,7 +43,6 @@ class LazyChoice(click.ParamType):
         """
         if self.__click_choice is None:
             self.__click_choice = click.Choice(self._get_choices())
-            # self._get_choices = None
         return self.__click_choice
 
     @property

--- a/aiida/cmdline/params/types/code.py
+++ b/aiida/cmdline/params/types/code.py
@@ -8,8 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module to define the custom click type for code."""
-
 import click
+
+from aiida.cmdline.utils import decorators
 from .identifier import IdentifierParamType
 
 
@@ -39,6 +40,14 @@ class CodeParamType(IdentifierParamType):
         """
         from aiida.orm.utils.loaders import CodeEntityLoader
         return CodeEntityLoader
+
+    @decorators.with_dbenv()
+    def complete(self, ctx, incomplete):  # pylint: disable=unused-argument
+        """Return possible completions based on an incomplete value.
+
+        :returns: list of tuples of valid entry points (matching incomplete) and a description
+        """
+        return [(option, '') for option, in self.orm_class_loader.get_options(incomplete, project='label')]
 
     def convert(self, value, param, ctx):
         code = super().convert(value, param, ctx)

--- a/aiida/cmdline/params/types/group.py
+++ b/aiida/cmdline/params/types/group.py
@@ -7,12 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Module for custom click param type group
-"""
-
+"""Module for custom click param type group."""
 import click
 
+from aiida.common.lang import type_check
 from aiida.cmdline.utils.decorators import with_dbenv
 
 from .identifier import IdentifierParamType
@@ -23,29 +21,50 @@ class GroupParamType(IdentifierParamType):
 
     name = 'Group'
 
-    def __init__(self, create_if_not_exist=False):
+    def __init__(self, create_if_not_exist=False, sub_classes=('aiida.groups:core',)):
+        """Construct the parameter type.
+
+        The `sub_classes` argument can be used to narrow the set of subclasses of `Group` that should be matched. By
+        default all subclasses of `Group` will be matched, otherwise it is restricted to the subclasses that correspond
+        to the entry point names in the tuple of `sub_classes`.
+
+        To prevent having to load the database environment at import time, the actual loading of the entry points is
+        deferred until the call to `convert` is made. This is to keep the command line autocompletion light and
+        responsive. The entry point strings will be validated, however, to see if they correspond to known entry points.
+
+        :param create_if_not_exist: boolean, if True, will create the group if it does not yet exist. By default the
+            group created will be of class `Group`, unless another subclass is specified through `sub_classes`. Note
+            that in this case, only a single entry point name can be specified
+        :param sub_classes: a tuple of entry point strings from the `aiida.groups` entry point group.
+        """
+        type_check(sub_classes, tuple, allow_none=True)
+
+        if create_if_not_exist and len(sub_classes) > 1:
+            raise ValueError('`sub_classes` can at most contain one entry point if `create_if_not_exist=True`')
+
         self._create_if_not_exist = create_if_not_exist
-        super().__init__()
+        super().__init__(sub_classes=sub_classes)
 
     @property
     def orm_class_loader(self):
-        """
-        Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-        to be used to load the entity for a given identifier
+        """Return the orm entity loader class, which should be a subclass of `OrmEntityLoader`.
 
-        :return: the orm entity loader class for this ParamType
+        This class is supposed to be used to load the entity for a given identifier.
+
+        :return: the orm entity loader class for this `ParamType`
         """
         from aiida.orm.utils.loaders import GroupEntityLoader
         return GroupEntityLoader
 
     @with_dbenv()
     def convert(self, value, param, ctx):
-        from aiida.orm import Group
         try:
             group = super().convert(value, param, ctx)
         except click.BadParameter:
             if self._create_if_not_exist:
-                group = Group(label=value)
+                # The particular subclass to load will be stored in `_sub_classes` as loaded by `convert` of the super.
+                cls = self._sub_classes[0]
+                group = cls(label=value)
             else:
                 raise
 

--- a/aiida/cmdline/params/types/group.py
+++ b/aiida/cmdline/params/types/group.py
@@ -11,7 +11,7 @@
 import click
 
 from aiida.common.lang import type_check
-from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils import decorators
 
 from .identifier import IdentifierParamType
 
@@ -56,7 +56,15 @@ class GroupParamType(IdentifierParamType):
         from aiida.orm.utils.loaders import GroupEntityLoader
         return GroupEntityLoader
 
-    @with_dbenv()
+    @decorators.with_dbenv()
+    def complete(self, ctx, incomplete):  # pylint: disable=unused-argument
+        """Return possible completions based on an incomplete value.
+
+        :returns: list of tuples of valid entry points (matching incomplete) and a description
+        """
+        return [(option, '') for option, in self.orm_class_loader.get_options(incomplete, project='label')]
+
+    @decorators.with_dbenv()
     def convert(self, value, param, ctx):
         try:
             group = super().convert(value, param, ctx)

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -1723,12 +1723,14 @@ class QueryBuilder:
         :param joining_value: the tag of the nodes to be joined
         """
         # Set the calling entity - to allow for the correct join relation to be set
-        if self._path[index]['entity_type'].startswith(GROUP_ENTITY_TYPE_PREFIX):
+        entity_type = self._path[index]['entity_type']
+
+        if isinstance(entity_type, str) and entity_type.startswith(GROUP_ENTITY_TYPE_PREFIX):
             calling_entity = 'group'
-        elif self._path[index]['entity_type'] not in ['computer', 'user', 'comment', 'log']:
+        elif entity_type not in ['computer', 'user', 'comment', 'log']:
             calling_entity = 'node'
         else:
-            calling_entity = self._path[index]['entity_type']
+            calling_entity = entity_type
 
         if joining_keyword == 'direction':
             if joining_value > 0:

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -456,15 +456,19 @@ class CodeEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
+        from aiida.common.escaping import escape_for_sql_like
         from aiida.orm import Computer
 
         try:
-            label, _, machinename = identifier.partition('@')
+            identifier, _, machinename = identifier.partition('@')
         except AttributeError:
             raise ValueError('the identifier needs to be a string')
 
+        if operator == 'like':
+            identifier = escape_for_sql_like(identifier) + '%'
+
         builder = QueryBuilder()
-        builder.append(cls=classes, tag='code', project=project, filters={'label': {'==': label}})
+        builder.append(cls=classes, tag='code', project=project, filters={'label': {operator: identifier}})
 
         if machinename:
             builder.append(Computer, filters={'name': {'==': machinename}}, with_node='code')

--- a/tests/cmdline/params/types/test_code.py
+++ b/tests/cmdline/params/types/test_code.py
@@ -7,109 +7,125 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name,unused-variable,unused-argument
 """Tests for the `CodeParamType`."""
-
 import click
+import pytest
 
-from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params.types import CodeParamType
 from aiida.orm import Code
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 
-class TestCodeParamType(AiidaTestCase):
-    """Tests for the `CodeParamType`."""
+@pytest.fixture
+def parameter_type():
+    """Return an instance of the `CodeParamType`."""
+    return CodeParamType()
 
-    @classmethod
-    def setUpClass(cls, *args, **kwargs):
-        """
-        Create some code to test the CodeParamType parameter type for the command line infrastructure
-        We create an initial code with a random name and then on purpose create two code with a name
-        that matches exactly the ID and UUID, respectively, of the first one. This allows us to test
-        the rules implemented to solve ambiguities that arise when determing the identifier type
-        """
-        super().setUpClass(*args, **kwargs)
 
-        cls.param_base = CodeParamType()
-        cls.param_entry_point = CodeParamType(entry_point='arithmetic.add')
-        cls.entity_01 = Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.entity_02 = Code(remote_computer_exec=(cls.computer, '/bin/true'),
-                             input_plugin_name='arithmetic.add').store()
-        cls.entity_03 = Code(remote_computer_exec=(cls.computer, '/bin/true'),
-                             input_plugin_name='templatereplacer').store()
+@pytest.fixture
+def setup_codes(clear_database_before_test, aiida_localhost):
+    """Create some `Code` instances to test the `CodeParamType` parameter type for the command line infrastructure.
 
-        cls.entity_01.label = 'computer_01'
-        cls.entity_02.label = str(cls.entity_01.pk)
-        cls.entity_03.label = str(cls.entity_01.uuid)
+    We create an initial code with a random name and then on purpose create two code with a name that matches exactly
+    the ID and UUID, respectively, of the first one. This allows us to test the rules implemented to solve ambiguities
+    that arise when determing the identifier type.
+    """
+    entity_01 = Code(remote_computer_exec=(aiida_localhost, '/bin/true')).store()
+    entity_02 = Code(remote_computer_exec=(aiida_localhost, '/bin/true'), input_plugin_name='arithmetic.add').store()
+    entity_03 = Code(remote_computer_exec=(aiida_localhost, '/bin/true'), input_plugin_name='templatereplacer').store()
 
-    def test_get_by_id(self):
-        """
-        Verify that using the ID will retrieve the correct entity
-        """
-        identifier = '{}'.format(self.entity_01.pk)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+    entity_01.label = 'computer_01'
+    entity_02.label = str(entity_01.pk)
+    entity_03.label = str(entity_01.uuid)
 
-    def test_get_by_uuid(self):
-        """
-        Verify that using the UUID will retrieve the correct entity
-        """
-        identifier = '{}'.format(self.entity_01.uuid)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+    return entity_01, entity_02, entity_03
 
-    def test_get_by_label(self):
-        """
-        Verify that using the LABEL will retrieve the correct entity
-        """
-        identifier = '{}'.format(self.entity_01.label)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
 
-    def test_get_by_fullname(self):
-        """
-        Verify that using the LABEL@machinename will retrieve the correct entity
-        """
-        identifier = '{}@{}'.format(self.entity_01.label, self.computer.name)  # pylint: disable=no-member
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+def test_get_by_id(setup_codes, parameter_type):
+    """Verify that using the ID will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_codes
+    identifier = '{}'.format(entity_01.pk)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-    def test_ambiguous_label_pk(self):
-        """
-        Situation: LABEL of entity_02 is exactly equal to ID of entity_01
 
-        Verify that using an ambiguous identifier gives precedence to the ID interpretation
-        Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
-        """
-        identifier = '{}'.format(self.entity_02.label)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+def test_get_by_uuid(setup_codes, parameter_type):
+    """Verify that using the UUID will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_codes
+    identifier = '{}'.format(entity_01.uuid)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_02.uuid)
 
-    def test_ambiguous_label_uuid(self):
-        """
-        Situation: LABEL of entity_03 is exactly equal to UUID of entity_01
+def test_get_by_label(setup_codes, parameter_type):
+    """Verify that using the LABEL will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_codes
+    identifier = '{}'.format(entity_01.label)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-        Verify that using an ambiguous identifier gives precedence to the UUID interpretation
-        Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
-        """
-        identifier = '{}'.format(self.entity_03.label)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
-        result = self.param_base.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_03.uuid)
+def test_get_by_fullname(setup_codes, parameter_type):
+    """Verify that using the LABEL@machinename will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_codes
+    identifier = '{}@{}'.format(entity_01.label, entity_01.computer.name)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-    def test_entry_point_validation(self):
-        """Verify that when an `entry_point` is defined in the constructor, it is respected in the validation."""
-        identifier = '{}'.format(self.entity_02.pk)
-        result = self.param_entry_point.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_02.uuid)
 
-        with self.assertRaises(click.BadParameter):
-            identifier = '{}'.format(self.entity_03.pk)
-            result = self.param_entry_point.convert(identifier, None, None)
+def test_ambiguous_label_pk(setup_codes, parameter_type):
+    """Situation: LABEL of entity_02 is exactly equal to ID of entity_01.
+
+    Verify that using an ambiguous identifier gives precedence to the ID interpretation
+    Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
+    """
+    entity_01, entity_02, entity_03 = setup_codes
+    identifier = '{}'.format(entity_02.label)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
+
+    identifier = '{}{}'.format(entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_02.uuid
+
+
+def test_ambiguous_label_uuid(setup_codes, parameter_type):
+    """Situation: LABEL of entity_03 is exactly equal to UUID of entity_01.
+
+    Verify that using an ambiguous identifier gives precedence to the UUID interpretation
+    Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
+    """
+    entity_01, entity_02, entity_03 = setup_codes
+    identifier = '{}'.format(entity_03.label)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
+
+    identifier = '{}{}'.format(entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_03.uuid
+
+
+def test_entry_point_validation(setup_codes):
+    """Verify that when an `entry_point` is defined in the constructor, it is respected in the validation."""
+    entity_01, entity_02, entity_03 = setup_codes
+    parameter_type = CodeParamType(entry_point='arithmetic.add')
+    identifier = '{}'.format(entity_02.pk)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_02.uuid
+
+    with pytest.raises(click.BadParameter):
+        identifier = '{}'.format(entity_03.pk)
+        result = parameter_type.convert(identifier, None, None)
+
+
+def test_complete(setup_codes, parameter_type, aiida_localhost):
+    """Test the `complete` method that provides auto-complete functionality."""
+    entity_01, entity_02, entity_03 = setup_codes
+    entity_04 = Code(label='xavier', remote_computer_exec=(aiida_localhost, '/bin/true')).store()
+
+    options = [item[0] for item in parameter_type.complete(None, '')]
+    assert sorted(options) == sorted([entity_01.label, entity_02.label, entity_03.label, entity_04.label])
+
+    options = [item[0] for item in parameter_type.complete(None, 'xa')]
+    assert sorted(options) == sorted([entity_04.label])

--- a/tests/cmdline/params/types/test_group.py
+++ b/tests/cmdline/params/types/test_group.py
@@ -7,81 +7,127 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name,unused-variable,unused-argument
 """Tests for the `GroupParamType`."""
-from aiida.backends.testbase import AiidaTestCase
+import click
+import pytest
+
 from aiida.cmdline.params.types import GroupParamType
-from aiida.orm import Group
+from aiida.orm import Group, AutoGroup, ImportGroup
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 
-class TestGroupParamType(AiidaTestCase):
-    """Tests for the `GroupParamType`."""
+@pytest.fixture
+def parameter_type():
+    """Return an instance of the `GroupParamType`."""
+    return GroupParamType()
 
-    @classmethod
-    def setUpClass(cls, *args, **kwargs):
-        """
-        Create some groups to test the GroupParamType parameter type for the command line infrastructure
-        We create an initial group with a random name and then on purpose create two groups with a name
-        that matches exactly the ID and UUID, respectively, of the first one. This allows us to test
-        the rules implemented to solve ambiguities that arise when determing the identifier type
-        """
-        super().setUpClass(*args, **kwargs)
 
-        cls.param = GroupParamType()
-        cls.entity_01 = Group(label='group_01').store()
-        cls.entity_02 = Group(label=str(cls.entity_01.pk)).store()
-        cls.entity_03 = Group(label=str(cls.entity_01.uuid)).store()
+@pytest.fixture
+def setup_groups(clear_database_before_test):
+    """Create some groups to test the `GroupParamType` parameter type for the command line infrastructure.
 
-    def test_get_by_id(self):
-        """
-        Verify that using the ID will retrieve the correct entity
-        """
-        identifier = '{}'.format(self.entity_01.pk)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+    We create an initial group with a random name and then on purpose create two groups with a name that matches exactly
+    the ID and UUID, respectively, of the first one. This allows us to test the rules implemented to solve ambiguities
+    that arise when determing the identifier type.
+    """
+    entity_01 = Group(label='group_01').store()
+    entity_02 = AutoGroup(label=str(entity_01.pk)).store()
+    entity_03 = ImportGroup(label=str(entity_01.uuid)).store()
+    return entity_01, entity_02, entity_03
 
-    def test_get_by_uuid(self):
-        """
-        Verify that using the UUID will retrieve the correct entity
-        """
-        identifier = '{}'.format(self.entity_01.uuid)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
 
-    def test_get_by_label(self):
-        """
-        Verify that using the LABEL will retrieve the correct entity
-        """
-        identifier = '{}'.format(self.entity_01.label)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+def test_get_by_id(setup_groups, parameter_type):
+    """Verify that using the ID will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_groups
+    identifier = '{}'.format(entity_01.pk)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-    def test_ambiguous_label_pk(self):
-        """
-        Situation: LABEL of entity_02 is exactly equal to ID of entity_01
 
-        Verify that using an ambiguous identifier gives precedence to the ID interpretation
-        Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
-        """
-        identifier = '{}'.format(self.entity_02.label)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
+def test_get_by_uuid(setup_groups, parameter_type):
+    """Verify that using the UUID will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_groups
+    identifier = '{}'.format(entity_01.uuid)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_02.uuid)
 
-    def test_ambiguous_label_uuid(self):
-        """
-        Situation: LABEL of entity_03 is exactly equal to UUID of entity_01
+def test_get_by_label(setup_groups, parameter_type):
+    """Verify that using the LABEL will retrieve the correct entity."""
+    entity_01, entity_02, entity_03 = setup_groups
+    identifier = '{}'.format(entity_01.label)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
 
-        Verify that using an ambiguous identifier gives precedence to the UUID interpretation
-        Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
-        """
-        identifier = '{}'.format(self.entity_03.label)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
-        result = self.param.convert(identifier, None, None)
-        self.assertEqual(result.uuid, self.entity_03.uuid)
+def test_ambiguous_label_pk(setup_groups, parameter_type):
+    """Situation: LABEL of entity_02 is exactly equal to ID of entity_01.
+
+    Verify that using an ambiguous identifier gives precedence to the ID interpretation. Appending the special ambiguity
+    breaker character will force the identifier to be treated as a LABEL.
+    """
+    entity_01, entity_02, entity_03 = setup_groups
+    identifier = '{}'.format(entity_02.label)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
+
+    identifier = '{}{}'.format(entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_02.uuid
+
+
+def test_ambiguous_label_uuid(setup_groups, parameter_type):
+    """Situation: LABEL of entity_03 is exactly equal to UUID of entity_01.
+
+    Verify that using an ambiguous identifier gives precedence to the UUID interpretation. Appending the special
+    ambiguity breaker character will force the identifier to be treated as a LABEL.
+    """
+    entity_01, entity_02, entity_03 = setup_groups
+    identifier = '{}'.format(entity_03.label)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_01.uuid
+
+    identifier = '{}{}'.format(entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
+    result = parameter_type.convert(identifier, None, None)
+    assert result.uuid == entity_03.uuid
+
+
+def test_create_if_not_exist(setup_groups):
+    """Test the `create_if_not_exist` constructor argument."""
+    label = 'non-existing-label-01'
+    parameter_type = GroupParamType(create_if_not_exist=True)
+    result = parameter_type.convert(label, None, None)
+    assert isinstance(result, Group)
+
+    label = 'non-existing-label-02'
+    parameter_type = GroupParamType(create_if_not_exist=True, sub_classes=('aiida.groups:core.auto',))
+    result = parameter_type.convert(label, None, None)
+    assert isinstance(result, AutoGroup)
+
+    # Specifying more than one subclass when `create_if_not_exist=True` is not allowed.
+    with pytest.raises(ValueError):
+        GroupParamType(create_if_not_exist=True, sub_classes=('aiida.groups:core.auto', 'aiida.groups:core.import'))
+
+
+@pytest.mark.parametrize(('sub_classes', 'expected'), (
+    (None, (True, True, True)),
+    (('aiida.groups:core.auto',), (False, True, False)),
+    (('aiida.groups:core.auto', 'aiida.groups:core.import'), (False, True, True)),
+))
+def test_sub_classes(setup_groups, sub_classes, expected):
+    """Test the `sub_classes` constructor argument."""
+    entity_01, entity_02, entity_03 = setup_groups
+    parameter_type = GroupParamType(sub_classes=sub_classes)
+
+    results = []
+
+    for group in [entity_01, entity_02, entity_03]:
+        try:
+            parameter_type.convert(str(group.pk), None, None)
+        except click.BadParameter:
+            results.append(False)
+        else:
+            results.append(True)
+
+    assert tuple(results) == expected

--- a/tests/cmdline/params/types/test_group.py
+++ b/tests/cmdline/params/types/test_group.py
@@ -131,3 +131,15 @@ def test_sub_classes(setup_groups, sub_classes, expected):
             results.append(True)
 
     assert tuple(results) == expected
+
+
+def test_complete(setup_groups, parameter_type):
+    """Test the `complete` method that provides auto-complete functionality."""
+    entity_01, entity_02, entity_03 = setup_groups
+    entity_04 = Group(label='xavier').store()
+
+    options = [item[0] for item in parameter_type.complete(None, '')]
+    assert sorted(options) == sorted([entity_01.label, entity_02.label, entity_03.label, entity_04.label])
+
+    options = [item[0] for item in parameter_type.complete(None, 'xa')]
+    assert sorted(options) == sorted([entity_04.label])

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -360,6 +360,25 @@ class TestGroupsSubclasses(AiidaTestCase):
         assert orm.QueryBuilder().append(orm.Group, filters={'type_string': 'custom.group'}).count() == 1
 
     @staticmethod
+    def test_querying_node_subclasses():
+        """Test querying for groups with multiple types for nodes it contains."""
+        group = orm.Group(label='group').store()
+        data_int = orm.Int().store()
+        data_str = orm.Str().store()
+        data_bool = orm.Bool().store()
+
+        group.add_nodes([data_int, data_str, data_bool])
+
+        builder = orm.QueryBuilder().append(orm.Group, tag='group')
+        builder.append((orm.Int, orm.Str), with_group='group', project='id')
+        results = [entry[0] for entry in builder.iterall()]
+
+        assert len(results) == 2
+        assert data_int.pk in results
+        assert data_str.pk in results
+        assert data_bool.pk not in results
+
+    @staticmethod
     def test_query_with_group():
         """Docs."""
         group = orm.Group(label='group').store()


### PR DESCRIPTION
Fixes #3925 

This PR comprises four commits:

1. Fix a bug in `QueryBuilder` that was introduced recently by added `Group` subclassing support
2. Deprecate `--group-type` for `--type-string` which provides querying with subclassing
3. Add support for subclassing to `GroupParamType` CLI type
4. Add auto-complete support for `Code` and `Group` instance options and arguments