### PR TITLE
Remove the equality operator of `ExitCode`

### DIFF
--- a/aiida/engine/processes/exit_code.py
+++ b/aiida/engine/processes/exit_code.py
@@ -48,9 +48,6 @@ class ExitCode(namedtuple('ExitCode', ['status', 'message', 'invalidates_cache']
 
         return ExitCode(self.status, message, self.invalidates_cache)
 
-    def __eq__(self, other):
-        return all(getattr(self, attr) == getattr(other, attr) for attr in ['status', 'message', 'invalidates_cache'])
-
 
 # Set the defaults for the `ExitCode` attributes
 ExitCode.__new__.__defaults__ = (0, None, False)

--- a/tests/engine/processes/text_exit_code.py
+++ b/tests/engine/processes/text_exit_code.py
@@ -33,6 +33,18 @@ def test_exit_code_construct():
     assert exit_code.invalidates_cache == invalidates_cache
 
 
+def test_exit_code_serializability():
+    """Test that an `ExitCode` instance can be serialized and deserialized with `yaml`."""
+    import yaml
+
+    exit_code = ExitCode()
+    serialized = yaml.dump(exit_code)
+    deserialized = yaml.full_load(serialized)
+
+    assert deserialized == exit_code
+    assert isinstance(deserialized, ExitCode)
+
+
 def test_exit_code_equality():
     """Test that the equality operator works properly."""
     exit_code_origin = ExitCode(1, 'message', True)
@@ -41,6 +53,24 @@ def test_exit_code_equality():
 
     assert exit_code_origin == exit_code_clone
     assert exit_code_clone != exit_code_different
+
+    # Check default `ExitCode` also matches normal tuples
+    exit_code = ExitCode()
+    assert exit_code == (0, None, False)
+
+    assert exit_code != {}
+    assert exit_code != []
+    assert exit_code != ()
+    assert exit_code != (0)
+    assert exit_code != (None,)
+    assert exit_code != (0, None)
+    assert exit_code != [0, None, False]
+    assert exit_code != [0, None, False, 'test']
+
+    # `ExitCode` instances should match bare tuples as long as the content is the same
+    exit_code = ExitCode(1, 'message', True)
+    assert exit_code == (1, 'message', True)
+    assert exit_code != ()
 
 
 def test_exit_code_template_message():


### PR DESCRIPTION
Fixes #3939 

The operator implementation assumed that `other` would always be an
instance of `ExitCode` as well and so therefore was guaranteed to
contain the same attributes. However, comparing it to a bare tuple would
also invoke the `ExitCode.__eq__` method and would raise and
`AttributeError` as a result. The desired behavior for the equality
operator is that it returns True for any other tuple of the same length
and content. Since this is exactly what is implemented by the tuple
base type, we do not have to override it at all.