### PR TITLE
Add the `flat` argument to `QueryBuilder.all()` method

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -211,7 +211,7 @@ def process_pause(processes, all_entries, timeout, wait):
     if not processes and all_entries:
         active_states = options.active_process_states()
         builder = QueryBuilder().append(ProcessNode, filters={'attributes.process_state': {'in': active_states}})
-        processes = [entry[0] for entry in builder.all()]
+        processes = builder.all(flat=True)
 
     futures = {}
     for process in processes:
@@ -248,7 +248,7 @@ def process_play(processes, all_entries, timeout, wait):
 
     if not processes and all_entries:
         builder = QueryBuilder().append(ProcessNode, filters={'attributes.paused': True})
-        processes = [entry[0] for entry in builder.all()]
+        processes = builder.all(flat=True)
 
     futures = {}
     for process in processes:

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -334,7 +334,7 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
             with_incoming='workcalculation',
             tag='subworkchains'
         )
-        result = list(itertools.chain(*builder.distinct().all()))
+        result = builder.all(flat=True)
 
         # This will return a single flat list of tuples, where the first element
         # corresponds to the WorkChain pk and the second element is an integer

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -149,7 +149,7 @@ class Collection(typing.Generic[EntityType]):
         :rtype: list
         """
         query = self.query(filters=filters, order_by=order_by, limit=limit)
-        return [_[0] for _ in query.all()]
+        return query.all(flat=True)
 
     def all(self):
         """
@@ -158,7 +158,7 @@ class Collection(typing.Generic[EntityType]):
         :return: A list of all entities
         :rtype: list
         """
-        return [_[0] for _ in self.query().all()]
+        return self.query().all(flat=True)  # pylint: disable=no-member
 
     def count(self, filters=None):
         """Count entities in this collection according to criteria

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -340,21 +340,12 @@ class Group(entities.Entity, metaclass=GroupMeta):
         """
         from aiida.orm import QueryBuilder
 
-        filters = {}
         if 'type_string' in kwargs:
+            message = '`type_string` is deprecated because it is determined automatically'
+            warnings.warn(message)  # pylint: disable=no-member
             type_check(kwargs['type_string'], str)
 
-        query = QueryBuilder()
-        for key, val in kwargs.items():
-            filters[key] = val
-
-        query.append(cls, filters=filters)
-        results = query.all()
-        if len(results) > 1:
-            raise exceptions.MultipleObjectsError("Found {} groups matching criteria '{}'".format(len(results), kwargs))
-        if not results:
-            raise exceptions.NotExistent("No group found matching criteria '{}'".format(kwargs))
-        return results[0][0]
+        return QueryBuilder().append(cls, filters=kwargs).one()[0]
 
     def is_user_defined(self):
         """

--- a/aiida/orm/implementation/django/logs.py
+++ b/aiida/orm/implementation/django/logs.py
@@ -144,8 +144,8 @@ class DjangoLogCollection(BackendLogCollection):
             raise exceptions.ValidationError('filters must not be empty')
 
         # Apply filter and delete found entities
-        builder = QueryBuilder().append(Log, filters=filters, project='id').all()
-        entities_to_delete = [_[0] for _ in builder]
+        builder = QueryBuilder().append(Log, filters=filters, project='id')
+        entities_to_delete = builder.all(flat=True)
         for entity in entities_to_delete:
             self.delete(entity)
 

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -173,8 +173,8 @@ class SqlaCommentCollection(BackendCommentCollection):
             raise exceptions.ValidationError('filters must not be empty')
 
         # Apply filter and delete found entities
-        builder = QueryBuilder().append(Comment, filters=filters, project='id').all()
-        entities_to_delete = [_[0] for _ in builder]
+        builder = QueryBuilder().append(Comment, filters=filters, project='id')
+        entities_to_delete = builder.all(flat=True)
         for entity in entities_to_delete:
             self.delete(entity)
 

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -154,8 +154,8 @@ class SqlaLogCollection(BackendLogCollection):
             raise exceptions.ValidationError('filter must not be empty')
 
         # Apply filter and delete found entities
-        builder = QueryBuilder().append(Log, filters=filters, project='id').all()
-        entities_to_delete = [_[0] for _ in builder]
+        builder = QueryBuilder().append(Log, filters=filters, project='id')
+        entities_to_delete = builder.all(flat=True)
         for entity in entities_to_delete:
             self.delete(entity)
 

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -322,9 +322,9 @@ class CifData(SinglefileData):
             otherwise the CIF file will not be found.
         """
         from aiida.orm.querybuilder import QueryBuilder
-        qb = QueryBuilder()
-        qb.append(cls, filters={'attributes.md5': {'==': md5}})
-        return [_ for [_] in qb.all()]
+        builder = QueryBuilder()
+        builder.append(cls, filters={'attributes.md5': {'==': md5}})
+        return builder.all(flat=True)
 
     @classmethod
     def get_or_create(cls, filename, use_first=False, store_cif=True):

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -173,7 +173,7 @@ class Code(Data):
         :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
             a code
         """
-        from aiida.common.exceptions import (NotExistent, MultipleObjectsError, InputValidationError)
+        from aiida.common.exceptions import NotExistent, MultipleObjectsError
         from aiida.orm.querybuilder import QueryBuilder
         from aiida.orm.computers import Computer
 
@@ -185,7 +185,7 @@ class Code(Data):
         if qb.count() == 0:
             raise NotExistent("'{}' is not a valid code name.".format(label))
         elif qb.count() > 1:
-            codes = [_ for [_] in qb.all()]
+            codes = qb.all(flat=True)
             retstr = ("There are multiple codes with label '{}', having IDs: ".format(label))
             retstr += ', '.join(sorted([str(c.pk) for c in codes])) + '.\n'
             retstr += ('Relabel them (using their ID), or refer to them with their ID.')
@@ -212,7 +212,7 @@ class Code(Data):
         from aiida.orm.utils import load_code
 
         # first check if code pk is provided
-        if (pk):
+        if pk:
             code_int = int(pk)
             try:
                 return load_code(pk=code_int)
@@ -222,7 +222,7 @@ class Code(Data):
                 raise MultipleObjectsError("More than one code in the DB with pk='{}'!".format(pk))
 
         # check if label (and machinename) is provided
-        elif (label != None):
+        elif label is not None:
             return cls.get_code_helper(label, machinename)
 
         else:
@@ -276,7 +276,7 @@ class Code(Data):
         from aiida.orm.querybuilder import QueryBuilder
         qb = QueryBuilder()
         qb.append(cls, filters={'attributes.input_plugin': {'==': plugin}})
-        valid_codes = [_ for [_] in qb.all()]
+        valid_codes = qb.all(flat=True)
 
         if labels:
             return [c.label for c in valid_codes]

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -342,7 +342,7 @@ class UpfData(SinglefileData):
         from aiida.orm.querybuilder import QueryBuilder
         builder = QueryBuilder()
         builder.append(cls, filters={'attributes.md5': {'==': md5}})
-        return [upf for upf, in builder.all()]
+        return builder.all(flat=True)
 
     def set_file(self, file, filename=None):
         """Store the file in the repository and parse it to set the `element` and `md5` attributes.
@@ -380,7 +380,7 @@ class UpfData(SinglefileData):
         query = QueryBuilder()
         query.append(UpfFamily, tag='group', project='label')
         query.append(UpfData, filters={'id': {'==': self.id}}, with_group='group')
-        return [label for label, in query.all()]
+        return query.all(flat=True)
 
     @property
     def element(self):
@@ -484,7 +484,7 @@ class UpfData(SinglefileData):
 
         builder.order_by({UpfFamily: {'id': 'asc'}})
 
-        return [group for group, in builder.all()]
+        return builder.all(flat=True)
 
     # pylint: disable=unused-argument
     def _prepare_json(self, main_file_name=''):

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -2189,21 +2189,24 @@ class QueryBuilder:
 
             yield item
 
-    def all(self, batch_size=None):
-        """
-        Executes the full query with the order of the rows as returned by the backend.
-        the order inside each row is given by the order of the vertices in the path
-        and the order of the projections for each vertice in the path.
+    def all(self, batch_size=None, flat=False):
+        """Executes the full query with the order of the rows as returned by the backend.
 
-        :param int batch_size:
-            The size of the batches to ask the backend to batch results in subcollections.
-            You can optimize the speed of the query by tuning this parameter.
-            Leave the default (*None*) if speed is not critical or if you don't know
-            what you're doing!
+        The order inside each row is given by the order of the vertices in the path and the order of the projections for
+        each vertex in the path.
 
+        :param int batch_size: the size of the batches to ask the backend to batch results in subcollections. You can
+            optimize the speed of the query by tuning this parameter. Leave the default `None` if speed is not critical
+            or if you don't know what you're doing.
+        :param bool flat: return the result as a flat list of projected entities without sub lists.
         :returns: a list of lists of all projected entities.
         """
-        return list(self.iterall(batch_size=batch_size))
+        matches = list(self.iterall(batch_size=batch_size))
+
+        if not flat:
+            return matches
+
+        return [projection for entry in matches for projection in entry]
 
     def dict(self, batch_size=None):
         """

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -224,7 +224,7 @@ def traverse_graph(starting_pks, max_iterations=None, get_links=False, links_for
 
     query_nodes = orm.QueryBuilder()
     query_nodes.append(orm.Node, project=['id'], filters={'id': {'in': operational_set}})
-    existing_pks = {pk[0] for pk in query_nodes.all()}
+    existing_pks = set(query_nodes.all(flat=True))
     missing_pks = operational_set.difference(existing_pks)
     if missing_pks:
         raise exceptions.NotExistent(

--- a/aiida/tools/groups/paths.py
+++ b/aiida/tools/groups/paths.py
@@ -189,7 +189,7 @@ class GroupPath:
         query = orm.QueryBuilder()
         filters = {'label': self.path}
         query.append(self.cls, subclassing=False, filters=filters, project='id')
-        return [r[0] for r in query.all()]
+        return query.all(flat=True)
 
     @property
     def is_virtual(self):

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -256,7 +256,7 @@ def export_tree(
         # Get related log(s) - universal for all nodes
         builder = orm.QueryBuilder()
         builder.append(orm.Log, filters={'dbnode_id': {'in': to_be_exported}}, project='id')
-        res = {_[0] for _ in builder.all()}
+        res = set(builder.all(flat=True))
         given_log_entry_ids.update(res)
 
     # Comments
@@ -264,7 +264,7 @@ def export_tree(
         # Get related log(s) - universal for all nodes
         builder = orm.QueryBuilder()
         builder.append(orm.Comment, filters={'dbnode_id': {'in': to_be_exported}}, project='id')
-        res = {_[0] for _ in builder.all()}
+        res = set(builder.all(flat=True))
         given_comment_entry_ids.update(res)
 
     # Here we get all the columns that we plan to project per entity that we

--- a/aiida/tools/importexport/dbexport/utils.py
+++ b/aiida/tools/importexport/dbexport/utils.py
@@ -263,8 +263,7 @@ def check_process_nodes_sealed(nodes):
         raise exceptions.ExportValidationError('nodes must be either an int or set/list of ints')
 
     filters = {'id': {'in': nodes}, 'attributes.sealed': True}
-    sealed_nodes = QueryBuilder().append(ProcessNode, filters=filters, project=['id']).all()
-    sealed_nodes = {_[0] for _ in sealed_nodes}
+    sealed_nodes = set(QueryBuilder().append(ProcessNode, filters=filters, project=['id']).all(flat=True))
 
     if sealed_nodes != nodes:
         raise exceptions.ExportValidationError(

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -677,7 +677,7 @@ def import_data_dj(
 
             # Add all the nodes to the new group
             # TODO: decide if we want to return the group label
-            nodes = [entry[0] for entry in QueryBuilder().append(Node, filters={'id': {'in': pks_for_group}}).all()]
+            nodes = QueryBuilder().append(Node, filters={'id': {'in': pks_for_group}}).all(flat=True)
             group.add_nodes(nodes)
 
             if not silent:

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -629,6 +629,32 @@ class TestQueryBuilder(AiidaTestCase):
         res2 = {item[1] for item in qb.all()}
         self.assertEqual(res2, {d2.id, d4.id})
 
+    @staticmethod
+    def test_flat():
+        """Test the `flat` keyword for the `QueryBuilder.all()` method."""
+        from itertools import chain
+
+        pks = []
+        uuids = []
+        for _ in range(10):
+            node = orm.Data().store()
+            pks.append(node.pk)
+            uuids.append(node.uuid)
+
+        # Single projected property
+        builder = orm.QueryBuilder().append(orm.Data, project='id').order_by({orm.Data: 'id'})
+        result = builder.all(flat=True)
+        assert isinstance(result, list)
+        assert len(result) == 10
+        assert result == pks
+
+        # Mutltiple projections
+        builder = orm.QueryBuilder().append(orm.Data, project=['id', 'uuid']).order_by({orm.Data: 'id'})
+        result = builder.all(flat=True)
+        assert isinstance(result, list)
+        assert len(result) == 20
+        assert result == list(chain.from_iterable(zip(pks, uuids)))
+
 
 class TestMultipleProjections(AiidaTestCase):
     """Unit tests for the QueryBuilder ORM class."""


### PR DESCRIPTION
This allows to simplify the commonly found form:

    results = [entry[0] for entry in builder.all()]

to the more compact and readable form:

    results = builder.all(flat=True)

The default is set to `flat=False` such that this change is fully
backwards compatible. Occurrences in the code base itself have been
updated as much as possible.