### PR TITLE
Make the job submission script configurable through `CalcJob` options

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -269,13 +269,11 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
         remotedata.store()
 
 
-def submit_calculation(calculation, transport, calc_info, script_filename):
+def submit_calculation(calculation, transport):
     """Submit a previously uploaded `CalcJob` to the scheduler.
 
     :param calculation: the instance of CalcJobNode to submit.
     :param transport: an already opened transport to use to submit the calculation.
-    :param calc_info: the calculation info datastructure returned by `CalcJobNode._presubmit`
-    :param script_filename: the job launch script returned by `CalcJobNode._presubmit`
     :return: the job id as returned by the scheduler `submit_from_script` call
     """
     job_id = calculation.get_job_id()
@@ -291,8 +289,9 @@ def submit_calculation(calculation, transport, calc_info, script_filename):
     scheduler = calculation.computer.get_scheduler()
     scheduler.set_transport(transport)
 
+    submit_script_filename = calculation.get_option('submit_script_filename')
     workdir = calculation.get_remote_workdir()
-    job_id = scheduler.submit_from_script(workdir, script_filename)
+    job_id = scheduler.submit_from_script(workdir, submit_script_filename)
     calculation.set_job_id(job_id)
 
     return job_id

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -122,13 +122,15 @@ class CalcJob(Process):
             help='When using a "local" code, set the computer on which the calculation should be run.')
         spec.input_namespace('{}.{}'.format(spec.metadata_key, spec.options_key), required=False)
         spec.input('metadata.options.input_filename', valid_type=str, required=False,
-            help='Filename to which the input for the code that is to be run will be written.')
+            help='Filename to which the input for the code that is to be run is written.')
         spec.input('metadata.options.output_filename', valid_type=str, required=False,
-            help='Filename to which the content of stdout of the code that is to be run will be written.')
+            help='Filename to which the content of stdout of the code that is to be run is written.')
+        spec.input('metadata.options.submit_script_filename', valid_type=str, default='_aiidasubmit.sh',
+            help='Filename to which the job submission script is written.')
         spec.input('metadata.options.scheduler_stdout', valid_type=str, default='_scheduler-stdout.txt',
-            help='Filename to which the content of stdout of the scheduler will be written.')
+            help='Filename to which the content of stdout of the scheduler is written.')
         spec.input('metadata.options.scheduler_stderr', valid_type=str, default='_scheduler-stderr.txt',
-            help='Filename to which the content of stderr of the scheduler will be written.')
+            help='Filename to which the content of stderr of the scheduler is written.')
         spec.input('metadata.options.resources', valid_type=dict, required=True, validator=validate_resources,
             help='Set the dictionary of resources to be used by the scheduler plugin, like the number of nodes, '
                  'cpus etc. This dictionary is scheduler-plugin dependent. Look at the documentation of the '
@@ -225,12 +227,12 @@ class CalcJob(Process):
 
             with LocalTransport() as transport:
                 with SubmitTestFolder() as folder:
-                    calc_info, script_filename = self.presubmit(folder)
+                    calc_info = self.presubmit(folder)
                     transport.chdir(folder.abspath)
                     upload_calculation(self.node, transport, calc_info, folder, inputs=self.inputs, dry_run=True)
                     self.node.dry_run_info = {
                         'folder': folder.abspath,
-                        'script_filename': script_filename
+                        'script_filename': self.node.get_option('submit_script_filename')
                     }
             return plumpy.Stop(None, True)
 
@@ -463,9 +465,9 @@ class CalcJob(Process):
         if max_memory_kb is not None:
             job_tmpl.max_memory_kb = max_memory_kb
 
-        script_filename = '_aiidasubmit.sh'
+        submit_script_filename = self.node.get_option('submit_script_filename')
         script_content = scheduler.get_submit_script(job_tmpl)
-        folder.create_file_from_filelike(io.StringIO(script_content), script_filename, 'w', encoding='utf8')
+        folder.create_file_from_filelike(io.StringIO(script_content), submit_script_filename, 'w', encoding='utf8')
 
         subfolder = folder.get_subfolder('.aiida', create=True)
         subfolder.create_file_from_filelike(io.StringIO(json.dumps(job_tmpl)), 'job_tmpl.json', 'w', encoding='utf8')
@@ -506,4 +508,4 @@ class CalcJob(Process):
                                           'The destination path of the remote copy '
                                           'is absolute! ({})'.format(this_pk, dest_rel_path))
 
-        return calc_info, script_filename
+        return calc_info

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -60,7 +60,7 @@ def task_upload_job(process, transport_queue, cancellable):
 
     if node.get_state() == CalcJobState.SUBMITTING:
         logger.warning('CalcJob<{}> already marked as SUBMITTING, skipping task_update_job'.format(node.pk))
-        raise Return(True)
+        raise Return
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
     max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
@@ -75,13 +75,13 @@ def task_upload_job(process, transport_queue, cancellable):
             with SandboxFolder() as folder:
                 # Any exception thrown in `presubmit` call is not transient so we circumvent the exponential backoff
                 try:
-                    calc_info, script_filename = process.presubmit(folder)
+                    calc_info = process.presubmit(folder)
                 except Exception as exception:  # pylint: disable=broad-except
                     raise PreSubmitException('exception occurred in presubmit call') from exception
                 else:
                     execmanager.upload_calculation(node, transport, calc_info, folder)
 
-            raise Return((calc_info, script_filename))
+            raise Return
 
     try:
         logger.info('scheduled request to upload CalcJob<{}>'.format(node.pk))
@@ -102,7 +102,7 @@ def task_upload_job(process, transport_queue, cancellable):
 
 
 @coroutine
-def task_submit_job(node, transport_queue, calc_info, script_filename, cancellable):
+def task_submit_job(node, transport_queue, cancellable):
     """Transport task that will attempt to submit a job calculation.
 
     The task will first request a transport from the queue. Once the transport is yielded, the relevant execmanager
@@ -112,8 +112,6 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancellab
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param calc_info: the calculation info datastructure returned by `CalcJobNode._presubmit`
-    :param script_filename: the job launch script returned by `CalcJobNode._presubmit`
     :param cancellable: the cancelled flag that will be queried to determine whether the task was cancelled
     :type cancellable: :class:`aiida.engine.utils.InterruptableFuture`
     :raises: Return if the tasks was successfully completed
@@ -133,7 +131,7 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancellab
     def do_submit():
         with transport_queue.request_transport(authinfo) as request:
             transport = yield cancellable.with_interrupt(request)
-            raise Return(execmanager.submit_calculation(node, transport, calc_info, script_filename))
+            raise Return(execmanager.submit_calculation(node, transport))
 
     try:
         logger.info('scheduled request to submit CalcJob<{}>'.format(node.pk))
@@ -229,7 +227,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
     """
     if node.get_state() == CalcJobState.PARSING:
         logger.warning('CalcJob<{}> already marked as PARSING, skipping task_retrieve_job'.format(node.pk))
-        raise Return(True)
+        raise Return
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
     max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
@@ -269,7 +267,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
     else:
         node.set_state(CalcJobState.PARSING)
         logger.info('retrieving CalcJob<{}> successful'.format(node.pk))
-        raise Return(result)
+        raise Return
 
 
 @coroutine
@@ -338,12 +336,7 @@ class Waiting(plumpy.Waiting):
 
         node = self.process.node
         transport_queue = self.process.runner.transport
-
-        if isinstance(self.data, tuple):
-            command = self.data[0]
-            args = self.data[1:]
-        else:
-            command = self.data
+        command = self.data
 
         process_status = 'Waiting for transport task: {}'.format(command)
 
@@ -351,12 +344,12 @@ class Waiting(plumpy.Waiting):
 
             if command == UPLOAD_COMMAND:
                 node.set_process_status(process_status)
-                calc_info, script_filename = yield self._launch_task(task_upload_job, self.process, transport_queue)
-                raise Return(self.submit(calc_info, script_filename))
+                yield self._launch_task(task_upload_job, self.process, transport_queue)
+                raise Return(self.submit())
 
             elif command == SUBMIT_COMMAND:
                 node.set_process_status(process_status)
-                yield self._launch_task(task_submit_job, node, transport_queue, *args)
+                yield self._launch_task(task_submit_job, node, transport_queue)
                 raise Return(self.update())
 
             elif self.data == UPDATE_COMMAND:
@@ -408,15 +401,15 @@ class Waiting(plumpy.Waiting):
         finally:
             self._task = None
 
-    def upload(self, calc_info, script_filename):
+    def upload(self):
         """Return the `Waiting` state that will `upload` the `CalcJob`."""
         msg = 'Waiting for calculation folder upload'
         return self.create_state(ProcessState.WAITING, None, msg=msg, data=UPLOAD_COMMAND)
 
-    def submit(self, calc_info, script_filename):
+    def submit(self):
         """Return the `Waiting` state that will `submit` the `CalcJob`."""
         msg = 'Waiting for scheduler submission'
-        return self.create_state(ProcessState.WAITING, None, msg=msg, data=(SUBMIT_COMMAND, calc_info, script_filename))
+        return self.create_state(ProcessState.WAITING, None, msg=msg, data=SUBMIT_COMMAND)
 
     def update(self):
         """Return the `Waiting` state that will `update` the `CalcJob`."""


### PR DESCRIPTION
Fixes #3947 

The name of the job submission script was hard coded to `_aiidasubmit.sh`
which not only makes it less flexible but it also required the value to
be passed in a long series of calls from `CalcJob.presubmit` all the way
through the transport tasks to the `submit_calculation` method in the
`aiida.engine.daemon.execmanager` module.

This value is now configurable through `metadata.options.script_filename`
with the default being the same. This allows to remove the value from
the return value of `CalcJob.presubmit` and the call-chain through all
the transport tasks, because `submit_calculation` can now simply
retrieve the correct value directly from the `CalcJobNode`.

This change also fixes a bug in the `task_upload_job` that returned the
wrong value if the idempotency check was hit to see if the method had
already been executed. This can happen if the daemon is stopped before
the next transport task is reached but after the upload has already been
executed. This check prevents it from being executed again by simply
returning. However, it was supposed to return the `calc_info` and
`script_filename` normally returned by the `presubmit` call, but it
would no longer have these variables and so returned `True`. The caller
`Waiting.execute` would expect a tuple and except.