### PR TITLE
Fix exception handling in commands calling `list_repository_contents`

### DIFF
--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -176,8 +176,8 @@ def calcjob_inputls(calcjob, path, color):
 
     try:
         list_repository_contents(calcjob, path, color)
-    except ValueError as exception:
-        echo.echo_critical(exception)
+    except FileNotFoundError:
+        echo.echo_critical('the path `{}` does not exist for the given node'.format(path))
 
 
 @verdi_calcjob.command('outputls')
@@ -203,8 +203,8 @@ def calcjob_outputls(calcjob, path, color):
 
     try:
         list_repository_contents(retrieved, path, color)
-    except ValueError as exception:
-        echo.echo_critical(exception)
+    except FileNotFoundError:
+        echo.echo_critical('the path `{}` does not exist for the given node'.format(path))
 
 
 @verdi_calcjob.command('cleanworkdir')

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -71,7 +71,7 @@ def start(foreground, number):
         subprocess.check_output(command, env=currenv, stderr=subprocess.STDOUT)  # pylint: disable=unexpected-keyword-arg
     except subprocess.CalledProcessError as exception:
         click.secho('FAILED', fg='red', bold=True)
-        echo.echo_critical(exception.output)
+        echo.echo_critical(str(exception))
 
     # We add a small timeout to give the pid-file a chance to be created
     with spinner():

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -190,7 +190,7 @@ def migrate(input_file, output_file, force, silent, archive_format, version):
         try:
             new_version = migration.migrate_recursively(metadata, data, folder, version)
         except ArchiveMigrationError as exception:
-            echo.echo_critical(exception)
+            echo.echo_critical(str(exception))
 
         with open(folder.get_abs_path('data.json'), 'wb') as fhandle:
             json.dump(data, fhandle, indent=4)

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -60,8 +60,8 @@ def repo_ls(node, relative_path, color):
 
     try:
         list_repository_contents(node, relative_path, color)
-    except ValueError as exception:
-        echo.echo_critical(exception)
+    except FileNotFoundError:
+        echo.echo_critical('the path `{}` does not exist for the given node'.format(relative_path))
 
 
 @verdi_node_repo.command('dump')

--- a/aiida/cmdline/utils/repository.py
+++ b/aiida/cmdline/utils/repository.py
@@ -17,6 +17,7 @@ def list_repository_contents(node, path, color):
 
     :param node: the node
     :param path: directory path
+    :raises FileNotFoundError: if the `path` does not exist in the repository of the given node
     """
     from aiida.orm.utils.repository import FileType
 

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -628,6 +628,7 @@ class Node(Entity, metaclass=AbstractNodeMeta):
 
         :param key: fully qualified identifier for the object within the repository
         :return: a list of `File` named tuples representing the objects present in directory with the given key
+        :raises FileNotFoundError: if the `path` does not exist in the repository of this node
         """
         return self._repository.list_objects(key)
 

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -141,6 +141,11 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertIn('calcinfo.json', get_result_lines(result))
         self.assertIn('job_tmpl.json', get_result_lines(result))
 
+        options = [self.arithmetic_job.uuid, 'non-existing-folder']
+        result = self.cli_runner.invoke(command.calcjob_inputls, options)
+        self.assertIsNotNone(result.exception)
+        self.assertIn('does not exist for the given node', result.output)
+
     def test_calcjob_outputls(self):
         """Test verdi calcjob outputls"""
         options = []
@@ -154,6 +159,11 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertIn('_scheduler-stderr.txt', get_result_lines(result))
         self.assertIn('_scheduler-stdout.txt', get_result_lines(result))
         self.assertIn('aiida.out', get_result_lines(result))
+
+        options = [self.arithmetic_job.uuid, 'non-existing-folder']
+        result = self.cli_runner.invoke(command.calcjob_inputls, options)
+        self.assertIsNotNone(result.exception)
+        self.assertIn('does not exist for the given node', result.output)
 
     def test_calcjob_inputcat(self):
         """Test verdi calcjob inputcat"""

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -184,6 +184,18 @@ class TestVerdiNode(AiidaTestCase):
                 result = self.cli_runner.invoke(cmd_node.extras, options)
                 self.assertIsNone(result.exception, result.output)
 
+    def test_node_repo_ls(self):
+        """Test 'verdi node repo ls' command."""
+        options = [str(self.folder_node.pk), 'some/nested/folder']
+        result = self.cli_runner.invoke(cmd_node.repo_ls, options, catch_exceptions=False)
+        self.assertClickResultNoException(result)
+        self.assertIn('filename.txt', result.output)
+
+        options = [str(self.folder_node.pk), 'some/non-existing-folder']
+        result = self.cli_runner.invoke(cmd_node.repo_ls, options, catch_exceptions=False)
+        self.assertIsNotNone(result.exception)
+        self.assertIn('does not exist for the given node', result.output)
+
     def test_node_repo_dump(self):
         """Test 'verdi node repo dump' command."""
 


### PR DESCRIPTION
Fixes #3967 

The commands `verdi node repo ls` and `verdi calcjob inputls/outputls`
were passing the caught exception object straight into the echo call
without casting it to a string first, which would incur another
exception by itself. On top of that, they were catching `ValueError`
exceptions, which, as far as I can tell, would never be thrown. Instead
if the path does not exist a `FileNotFoundError` will be thrown. The
commands now catch this instead and print a useful message. This failure
path of the commands was not tested, so the bug went unnoticed.

The problem of raw exception objects being passed to `echo_critical`
were present in some other commands as well, which have now been fixed.