### PR TITLE
Fix bug in `verdi daemon restart --reset` 

### DIFF
--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -214,7 +214,12 @@ def restart(ctx, reset, no_wait):
 
     if reset:
         ctx.invoke(stop)
-        ctx.invoke(start)
+        # These two lines can be simplified to `ctx.invoke(start)` once issue #950 in `click` is resolved.
+        # Due to that bug, the `callback` of the `number` argument the `start` command is not being called, which is
+        # responsible for settting the default value, which causes `None` to be passed and that triggers an exception.
+        # As a temporary workaround, we fetch the default here manually and pass that in explicitly.
+        number = ctx.obj.config.get_option('daemon.default_workers', ctx.obj.profile.name)
+        ctx.invoke(start, number=number)
     else:
 
         if wait:

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -63,6 +63,29 @@ class TestVerdiDaemon(AiidaTestCase):
         finally:
             self.daemon_client.stop_daemon(wait=True)
 
+    def test_daemon_restart(self):
+        """Test `verdi daemon restart` both with and without `--reset` flag."""
+        try:
+            result = self.cli_runner.invoke(cmd_daemon.start, [])
+            self.assertClickResultNoException(result)
+
+            result = self.cli_runner.invoke(cmd_daemon.restart, [])
+            self.assertClickResultNoException(result)
+
+            result = self.cli_runner.invoke(cmd_daemon.restart, ['--reset'])
+            self.assertClickResultNoException(result)
+
+            daemon_response = self.daemon_client.get_daemon_info()
+            worker_response = self.daemon_client.get_worker_info()
+
+            self.assertIn('status', daemon_response, daemon_response)
+            self.assertEqual(daemon_response['status'], 'ok', daemon_response)
+
+            self.assertIn('info', worker_response, worker_response)
+            self.assertEqual(len(worker_response['info']), 1, worker_response)
+        finally:
+            self.daemon_client.stop_daemon(wait=True)
+
     @pytest.mark.skip(reason='Test fails non-deterministically; see issue #3051.')
     def test_daemon_start_number(self):
         """Test `verdi daemon start` with a specific number of workers."""


### PR DESCRIPTION
Fixes #3960 

The command `verdi daemon restart --reset` was excepting when it was
invoking the `verdi daemon start` command. The reason being that recently
the `number` argument of `verdi daemon start` was changed to not define
a default directly, but to go through a callback. This would then set
the default based on a configuration option for the current profile.

However, due to a bug in `click`, parameter callbacks are not called
when invoking a command through `Context.invoke`, which caused the
`number` argument to be `None` which triggered an exception. Until that
bug is fixed in `click`, which has issue #950, we add a workaround to
manually defining the default value, that would normally have been done
by the argument callback, and explicitly passing it in the invoke call.

**N.B.:** I [opened a PR](https://github.com/pallets/click/pull/1540) that fixes the underlying bug in `click`.