### PR TITLE
Add codecov.yml codecov configuration file

### DIFF
--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -9,9 +9,13 @@ export PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}/.ci"
 # - pytest-cov configuration taken from top-level .coveragerc
 # - coverage is reported as XML and in terminal,
 #   including the numbers/ranges of lines which are not covered
-# - coverage results of multiple tests are collected
+# - coverage results of multiple tests are collected (this is always the case with Codecov)
 # - coverage is reported on files in aiida/
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --durations=50"
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-config=${GITHUB_WORKSPACE}/.coveragerc"
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-report xml"
 export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-append"
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov=aiida"
 
 # daemon tests
 verdi daemon start 4

--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -9,7 +9,7 @@ export PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}/.ci"
 # - pytest-cov configuration taken from top-level .coveragerc
 # - coverage is reported as XML and in terminal,
 #   including the numbers/ranges of lines which are not covered
-# - coverage results of multiple tests are collected (this is always the case with Codecov)
+# - coverage results of multiple tests (within a single GH Actions CI job) are collected
 # - coverage is reported on files in aiida/
 export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --durations=50"
 export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-config=${GITHUB_WORKSPACE}/.coveragerc"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  notify:
+    after_n_builds: 2
+    wait_for_ci: yes
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: up
+  range: "60...90"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,10 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
+  precision: 2  # default, here for transparency
   round: up
-  range: "60...90"
+  range: "70...100"  # default, here for transparency
   status:
     project:
       default:
-        threshold: 1%
+        threshold: 0.02%

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,7 @@ coverage:
   precision: 2
   round: up
   range: "60...90"
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-addopts = --durations=50 --cov-config=.coveragerc --cov-report xml --cov=aiida
 testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning:babel:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= --durations=50 --cov-config=.coveragerc --cov-report xml --cov=aiida
+addopts = --durations=50 --cov-config=.coveragerc --cov-report xml --cov=aiida
 testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning:babel:


### PR DESCRIPTION
Closes #3975 

A Codecov configuration file is added in the package root (`codecov.yml`).
In it, the following is specified:
- Upload _only_ if CI passes (I guess this is only true for the CI jobs that run `pytest` in Python 3.5).
- Add PR comment/status report when two builds have been received, i.e., when the Python 3.5 `pytest` jobs have run for both backends.
  This is to avoid confusion when only one of the CI jobs have finished and the codecov report is suddenly reporting missing lines.
- Use default range for coloration (70-100 %), where coverage will be shaded from red to green in this range, and be solid red and green below and above this range (not relevant), respectively.
- Round percentages up (instead of down).
- Set threshold for failing `codecov/project` CI status to 0.02 % (instead of the default 0 %).
  ~It seems this can not be set as a float (see [details](https://docs.codecov.io/docs/commit-status#threshold)).~