### PR TITLE
enable loading config.yml files from URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,6 +166,7 @@
       (?x)^(
         aiida/cmdline/commands/.*|
         aiida/cmdline/params/.*|
+        aiida/cmdline/params/types/.*|
         utils/validate_consistency.py|
       )$
     pass_filenames: false

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -17,7 +17,7 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
-from aiida.cmdline.params.types import GroupParamType, ImportPath
+from aiida.cmdline.params.types import GroupParamType, PathOrUrl
 from aiida.cmdline.utils import decorators, echo
 
 EXTRAS_MODE_EXISTING = ['keep_existing', 'update_existing', 'mirror', 'none', 'ask']
@@ -186,7 +186,7 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
 
 
 @verdi.command('import')
-@click.argument('archives', nargs=-1, type=ImportPath(exists=True, readable=True))
+@click.argument('archives', nargs=-1, type=PathOrUrl(exists=True, readable=True))
 @click.option(
     '-w',
     '--webpages',

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -497,8 +497,8 @@ WITH_ELEMENTS_EXCLUSIVE = OverridableOption(
 
 CONFIG_FILE = ConfigFileOption(
     '--config',
-    type=click.Path(exists=True, dir_okay=False),
-    help='Load option values from configuration file in yaml format.'
+    type=types.FileOrUrl(),
+    help='Load option values from configuration file in yaml format (local path or URL).'
 )
 
 IDENTIFIER = OverridableOption(

--- a/aiida/cmdline/params/options/config.py
+++ b/aiida/cmdline/params/options/config.py
@@ -18,10 +18,9 @@ import yaml
 from .overridable import OverridableOption
 
 
-def yaml_config_file_provider(file_path, cmd_name):  # pylint: disable=unused-argument
-    """Read yaml config file."""
-    with open(file_path, 'r') as handle:
-        return yaml.safe_load(handle)
+def yaml_config_file_provider(handle, cmd_name):  # pylint: disable=unused-argument
+    """Read yaml config file from file handle."""
+    return yaml.safe_load(handle)
 
 
 class ConfigFileOption(OverridableOption):

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -21,7 +21,7 @@ from .multiple import MultipleValueParamType
 from .node import NodeParamType
 from .process import ProcessParamType
 from .strings import (NonEmptyStringParamType, EmailType, HostnameType, EntryPointType, LabelStringType)
-from .path import AbsolutePathParamType, ImportPath
+from .path import AbsolutePathParamType, PathOrUrl, FileOrUrl
 from .plugin import PluginParamType
 from .profile import ProfileParamType
 from .user import UserParamType
@@ -32,5 +32,6 @@ __all__ = (
     'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType',
     'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
     'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType',
-    'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType', 'ImportPath'
+    'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType', 'PathOrUrl',
+    'FileOrUrl'
 )

--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -15,7 +15,7 @@ from . import exceptions
 __all__ = ('AttributeDict', 'FixedFieldsAttributeDict', 'DefaultFieldsAttributeDict')
 
 
-class AttributeDict(dict):
+class AttributeDict(dict):  # pylint: disable=too-many-instance-attributes
     """
     This class internally stores values in a dictionary, but exposes
     the keys also as attributes, i.e. asking for attrdict.key

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -5,7 +5,7 @@ alembic~=1.2
 ase~=3.18
 circus~=0.16.1
 click-completion~=0.5.1
-click-config-file~=0.5.0
+click-config-file~=0.6.0
 click-spinner~=0.1.8
 click~=7.0
 coverage<5.0

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -34,6 +34,7 @@ py:class click.types.Choice
 py:class click.types.IntParamType
 py:class click.types.StringParamType
 py:class click.types.Path
+py:class click.types.File
 py:meth  click.Option.get_default
 
 py:class concurrent.futures._base.TimeoutError

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -499,8 +499,8 @@ Below is a list with all available subcommands.
                                       superuser.
 
       --repository DIRECTORY          Absolute path to the file repository.
-      --config FILE                   Load option values from configuration file
-                                      in yaml format.
+      --config FILEORURL              Load option values from configuration file
+                                      in yaml format (local path or URL).
 
       --help                          Show this message and exit.
 
@@ -622,8 +622,8 @@ Below is a list with all available subcommands.
 
       --db-password TEXT              Password of the database user.  [required]
       --repository DIRECTORY          Absolute path to the file repository.
-      --config FILE                   Load option values from configuration file
-                                      in yaml format.
+      --config FILEORURL              Load option values from configuration file
+                                      in yaml format (local path or URL).
 
       --help                          Show this message and exit.
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - alembic~=1.2
 - circus~=0.16.1
 - click-completion~=0.5.1
-- click-config-file~=0.5.0
+- click-config-file~=0.6.0
 - click-spinner~=0.1.8
 - click~=7.0
 - django~=2.2

--- a/requirements/requirements-py-3.5.txt
+++ b/requirements/requirements-py-3.5.txt
@@ -15,7 +15,7 @@ chardet==3.0.4
 circus==0.16.1
 Click==7.0
 click-completion==0.5.2
-click-config-file==0.5.0
+click-config-file==0.6.0
 click-spinner==0.1.8
 configobj==5.0.6
 coverage==4.5.4

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -15,7 +15,7 @@ chardet==3.0.4
 circus==0.16.1
 Click==7.0
 click-completion==0.5.2
-click-config-file==0.5.0
+click-config-file==0.6.0
 click-spinner==0.1.8
 configobj==5.0.6
 coverage==4.5.4

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -15,7 +15,7 @@ chardet==3.0.4
 circus==0.16.1
 Click==7.0
 click-completion==0.5.2
-click-config-file==0.5.0
+click-config-file==0.6.0
 click-spinner==0.1.8
 configobj==5.0.6
 coverage==4.5.4

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -15,7 +15,7 @@ chardet==3.0.4
 circus==0.16.1
 Click==7.0
 click-completion==0.5.2
-click-config-file==0.5.0
+click-config-file==0.6.0
 click-spinner==0.1.8
 configobj==5.0.6
 coverage==4.5.4

--- a/setup.json
+++ b/setup.json
@@ -25,7 +25,7 @@
     "alembic~=1.2",
     "circus~=0.16.1",
     "click-completion~=0.5.1",
-    "click-config-file~=0.5.0",
+    "click-config-file~=0.6.0",
     "click-spinner~=0.1.8",
     "click~=7.0",
     "django~=2.2",

--- a/tests/cmdline/commands/test_import.py
+++ b/tests/cmdline/commands/test_import.py
@@ -209,11 +209,11 @@ class TestVerdiImport(AiidaTestCase):
 
     def test_import_url_timeout(self):
         """Test a timeout to valid URL is correctly errored"""
-        from aiida.cmdline.params.types import ImportPath
+        from aiida.cmdline.params.types import PathOrUrl
 
         timeout_url = 'http://www.google.com:81'
 
-        test_timeout_path = ImportPath(exists=True, readable=True, timeout_seconds=0)
+        test_timeout_path = PathOrUrl(exists=True, readable=True, timeout_seconds=0)
         with self.assertRaises(BadParameter) as cmd_exc:
             test_timeout_path(timeout_url)
 
@@ -229,7 +229,7 @@ class TestVerdiImport(AiidaTestCase):
         self.assertIsNotNone(result.exception, result.output)
         self.assertNotEqual(result.exit_code, 0, result.output)
 
-        error_message = 'It may be neither a valid path nor a valid URL.'
+        error_message = 'Is it a valid path or URL?'
         self.assertIn(error_message, result.output, result.exception)
 
     def test_non_interactive_and_migration(self):

--- a/tests/cmdline/params/types/test_path.py
+++ b/tests/cmdline/params/types/test_path.py
@@ -10,60 +10,37 @@
 """Tests for Path types"""
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.cmdline.params.types import ImportPath
+from aiida.cmdline.params.types.path import PathOrUrl, _check_timeout_seconds
 
 
-class TestImportPath(AiidaTestCase):
-    """Tests `ImportPath`"""
+class TestPath(AiidaTestCase):
+    """Tests for `PathOrUrl` and `FileOrUrl`"""
 
     def test_default_timeout(self):
         """Test the default timeout_seconds value is correct"""
         from aiida.cmdline.params.types.path import URL_TIMEOUT_SECONDS
 
-        import_path = ImportPath()
+        import_path = PathOrUrl()
 
         self.assertEqual(import_path.timeout_seconds, URL_TIMEOUT_SECONDS)
 
-    def test_valid_timeout(self):
-        """Test a valid timeout_seconds value"""
+    def test_timeout_checks(self):
+        """Test that timeout check handles different values.
 
+         * valid
+         * none
+         * wrong type
+         * outside range
+        """
         valid_values = [42, '42']
 
         for value in valid_values:
-            import_path = ImportPath(timeout_seconds=value)
+            self.assertEqual(_check_timeout_seconds(value), int(value))
 
-            self.assertEqual(import_path.timeout_seconds, int(value))
+        for invalid in [None, 'test']:
+            with self.assertRaises(TypeError):
+                _check_timeout_seconds(invalid)
 
-    def test_none_timeout(self):
-        """Test a TypeError is raised when a None value is given for timeout_seconds"""
-
-        with self.assertRaises(TypeError):
-            ImportPath(timeout_seconds=None)
-
-    def test_wrong_type_timeout(self):
-        """Test a TypeError is raised when wrong type is given for timeout_seconds"""
-
-        with self.assertRaises(TypeError):
-            ImportPath(timeout_seconds='test')
-
-    def test_range_timeout(self):
-        """Test timeout_seconds defines extrema when out of range
-        Range of timeout_seconds is [0;60], extrema included.
-        """
-
-        range_timeout = [0, 60]
-        lower = range_timeout[0] - 5
-        upper = range_timeout[1] + 5
-
-        lower_path = ImportPath(timeout_seconds=lower)
-        upper_path = ImportPath(timeout_seconds=upper)
-
-        msg_lower = "timeout_seconds should have been corrected to the lower bound: '{}', but instead it is {}".format(
-            range_timeout[0], lower_path.timeout_seconds
-        )
-        self.assertEqual(lower_path.timeout_seconds, range_timeout[0], msg_lower)
-
-        msg_upper = "timeout_seconds should have been corrected to the upper bound: '{}', but instead it is {}".format(
-            range_timeout[1], upper_path.timeout_seconds
-        )
-        self.assertEqual(upper_path.timeout_seconds, range_timeout[1], msg_upper)
+        for invalid in [-5, 65]:
+            with self.assertRaises(ValueError):
+                _check_timeout_seconds(invalid)


### PR DESCRIPTION
In the view of the plans of starting online repositories that maintain
yaml configuration files for computers and codes, it becomes very useful
to be able to directly import a configuration file from a URL.

Todo:
- [x] write a test