### PR TITLE
Docs: add "How to - Configuring your installation"

### DIFF
--- a/docs/source/howto/installation.rst
+++ b/docs/source/howto/installation.rst
@@ -74,7 +74,148 @@ This behavior can be changed using the ``--skip-repository`` and ``--skip-db`` o
 Configuring your installation
 =============================
 
-`#4001`_
+.. _how-to:installation:configure:tab-completion:
+
+Activating tab-completion
+-------------------------
+The ``verdi`` command line interface has many commands and parameters, which can be tab-completed to simplify its use.
+To enable tab-completion, the following shell command should be executed:
+
+.. code:: bash
+
+    $ eval "$(_VERDI_COMPLETE=source verdi)"
+
+Place this command in your shell or virtual environment activation script to automatically enable tab completion when opening a new shell or activating an environment.
+This file is shell specific, but likely one of the following:
+
+    * the startup file of your shell (``.bashrc``, ``.zsh``, ...), if aiida is installed system-wide
+    * the `activation script <https://virtualenv.pypa.io/en/latest/userguide/#activate-script>`_ of your virtual environment
+    * a `startup file <https://conda.io/docs/user-guide/tasks/manage-environments.html#saving-environment-variables>`_ for your conda environment
+
+
+.. important::
+
+    After you have added the line to the start up script, make sure to restart the terminal or source the script for the changes to take effect.
+
+
+.. _how-to:installation:configure:options:
+
+Configuring profile options
+---------------------------
+AiiDA provides various configurational options for profiles, which can be controlled with the :ref:`verdi config<reference:command-line:verdi-config>` command.
+To set a configurational option, simply pass the name of the option and the value to set ``verdi config OPTION_NAME OPTION_VALUE``.
+The available options are tab-completed, so simply type ``verdi config`` and thit <TAB> twice to list them.
+
+For example, if you want to change the default number of workers that are created when you start the daemon, you can run:
+
+.. code:: bash
+
+    $ verdi config daemon.default_workers 5
+    Success: daemon.default_workers set to 5 for profile-one
+
+You can check the currently defined value of any option by simply calling the command without specifying a value, for example:
+
+.. code:: bash
+
+    $ verdi config daemon.default_workers
+    5
+
+If no value is displayed, it means that no value has ever explicitly been set for this particular option and the default will always be used.
+By default any option set through ``verdi config`` will be applied to the current default profile.
+To change the profile you can use the :ref:`profile option<topics:cli:profile>`.
+
+To undo the configuration of a particular option and reset it so the default value is used, you can use the ``--unset`` option:
+
+.. code:: bash
+
+    $ verdi config daemon.default_workers --unset
+    Success: daemon.default_workers unset for profile-one
+
+If you want to set a particular option that should be applied to all profiles, you can use the ``--global`` flag:
+
+.. code:: bash
+
+    $ verdi config daemon.default_workers 5 --global
+    Success: daemon.default_workers set to 5 globally
+
+and just as on a per-profile basis, this can be undone with the ``--unset`` flag:
+
+.. code:: bash
+
+    $ verdi config daemon.default_workers --unset --global
+    Success: daemon.default_workers unset globally
+
+.. important::
+
+    Changes that affect the daemon (e.g. ``logging.aiida_loglevel``) will only take affect after restarting the daemon.
+
+
+.. _how-to:installation:configure:instance-isolation:
+
+Isolating multiple instances
+----------------------------
+An AiiDA instance is defined as the installed source code plus the configuration folder that stores the configuration files with all the configured profiles.
+It is possible to run multiple AiiDA instances on a single machine, simply by isolating the code and configuration in a virtual environment.
+
+To isolate the code, simply create a virtual environment, e.g., with conda or venv, and then follow the instructions for :ref:`installation<intro/install_advanced>` after activation.
+Whenever you activate this particular environment, you will be running the particular version of AiiDA (and all the plugins) that you installed specifically for it.
+
+This is separate from the configuration of AiiDA, which is stored in the configuration directory which is always named ``.aiida`` and by default is stored in the home directory.
+Therefore, the default path of the configuration directory is ``~/.aiida``.
+By default, each AiiDA instance (each installation) will store associated profiles in this folder.
+A best practice is to always separate the profiles together with the code to which they belong.
+The typical approach is to place the configuration folder in the virtual environment itself and have it automatically selected whenever the environment is activated.
+
+The location of the AiiDA configuration folder, can be controlled with the ``AIIDA_PATH`` environment variable.
+This allows us to change the configuration folder automatically, by adding the following lines to the activation script of a virtual environment.
+For example, if the path of your virtual environment is ``/home/user/.virtualenvs/aiida``, add the following line:
+
+.. code:: bash
+
+    $ export AIIDA_PATH='/home/user/.virtualenvs/aiida'
+
+Make sure to reactivate the virtual environment, if it was already active, for the changes to take effect.
+
+.. note::
+
+   For ``conda``, create a directory structure ``etc/conda/activate.d`` in the root folder of your conda environment (e.g. ``/home/user/miniconda/envs/aiida``), and place a file ``aiida-init.sh`` in that folder which exports the ``AIIDA_PATH``.
+
+You can test that everything works by first echoing the environment variable with ``echo $AIIDA_PATH`` to confirm it prints the correct path.
+Finally, you can check that AiiDA know also properly realizes the new location for the configuration folder by calling ``verdi profile list``.
+This should display the current location of the configuration directory:
+
+.. code:: bash
+
+    Info: configuration folder: /home/user/.virtualenvs/aiida/.aiida
+    Critical: configuration file /home/user/.virtualenvs/aiida/.aiida/config.json does not exist
+
+The second line you will only see if you haven't yet setup a profile for this AiiDA instance.
+For information on setting up a profile, refer to :ref:`creating profiles<how-to:installation:profile>`.
+
+Besides a single path, the value of ``AIIDA_PATH`` can also be a colon-separated list of paths.
+AiiDA will go through each of the paths and check whether they contain a configuration directory, i.e., a folder with the name ``.aiida``.
+The first configuration directory that is encountered will be used as the configuration directory.
+If no configuration directory is found, one will be created in the last path that was considered.
+For example, the directory structure in your home folder ``~/`` might look like this::
+
+    .
+    ├── .aiida
+    └── project_a
+        ├── .aiida
+        └── subfolder
+
+If you leave the ``AIIDA_PATH`` variable unset, the default location ``~/.aiida`` will be used.
+However, if you set:
+
+.. code:: bash
+
+    $ export AIIDA_PATH='~/project_a:'
+
+the configuration directory ``~/project_a/.aiida`` will be used.
+
+.. warning::
+
+    If there was no ``.aiida`` directory in ``~/project_a``, AiiDA would have created it for you, so make sure to set the ``AIIDA_PATH`` correctly.
 
 
 .. _how-to:installation:performance:
@@ -110,7 +251,6 @@ Managing multiple users
 
 
 
-.. _#4001: https://github.com/aiidateam/aiida-core/issues/4001
 .. _#4002: https://github.com/aiidateam/aiida-core/issues/4002
 .. _#4003: https://github.com/aiidateam/aiida-core/issues/4003
 .. _#4004: https://github.com/aiidateam/aiida-core/issues/4004

--- a/docs/source/install/configuration.rst
+++ b/docs/source/install/configuration.rst
@@ -3,93 +3,6 @@
 Configure AiiDA
 ===============
 
-.. _tab-completion:
-
-Verdi tab-completion
---------------------
-The ``verdi`` command line interface has many commands and options,
-which can be tab-completed to simplify your life.
-Enable tab-completion with the following shell command::
-
-    eval "$(_VERDI_COMPLETE=source verdi)"
-
-Place this command in your startup file, i.e. one of
-
-* the startup file of your shell (``.bashrc``, ``.zsh``, ...), if aiida is installed system-wide
-* the `activate script <https://virtualenv.pypa.io/en/latest/userguide/#activate-script>`_ of your virtual environment
-* a `startup file <https://conda.io/docs/user-guide/tasks/manage-environments.html#saving-environment-variables>`_ for your conda environment
-
-In order to enable tab completion in your current shell,
-make sure to source the startup file once.
-
-.. note::
-    This line replaces the ``eval "$(verdi completioncommand)"`` line that was used in ``aiida-core<1.0.0``. While this continues to work, support for the old line may be dropped in the future.
-
-
-.. _directory_location:
-
-Isolating AiiDA environments
-----------------------------
-
-By default, the AiiDA configuration is stored in the directory ``~/.aiida``.
-When running AiiDA in multiple virtual environments (using ``virtualenv`` or ``conda``),
-you can ask AiiDA to use a separate ``.aiida`` configuration directory per environment.
-
-1. Create your virtual environment ``aiida2``
-2. Edit the activation script ``~/.virtualenvs/aiida2/bin/activate``
-   and append a line to set the ``AIIDA_PATH`` environment variable::
-
-    export AIIDA_PATH='~/.virtualenvs/aiida2'  # use .aiida configuration in this folder
-    eval "$(_VERDI_COMPLETE=source verdi)"  # e.g. set up tab completion
-
-.. note::
-   For ``conda``,     create a directory structure ``etc/conda/activate.d`` in
-   the root folder of your conda environment (e.g.
-   ``/home/user/miniconda/envs/aiida``), and place a file ``aiida-init.sh`` in
-   that folder which exports the ``AIIDA_PATH``.
-
-3. Deactivate and re-activate the virtual environment
-
-You can test that everything is set up correctly if you can reproduce the following::
-
-    (aiida2)$ echo $AIIDA_PATH
-    >>> ~/.virtualenvs/aiida2
-
-    (aiida2)$ verdi profile list
-    >>> Info: configuration folder: /home/my_username/.virtualenvs/aiida/.aiida2
-    >>> Critical: configuration file /home/my_username/.virtualenvs/aiida/.aiida2/config.json does not exist
-
-Now simply :ref:`create a new AiiDA profile <setup_aiida>` in the ``aiida2`` environment.
-
-``AIIDA_PATH`` Details
-......................
-
-The value of ``AIIDA_PATH`` can be a colon-separated list of paths.
-AiiDA will go through each of the paths and check whether they contain a ``.aiida`` directory.
-The first configuration directory that is encountered will be used.
-If no ``.aiida`` directory is found, one will be created in the last path that was considered.
-
-For example, the directory structure in your home folder ``~/`` might look like this ::
-
-    .
-    ├── .aiida
-    └── project_a
-        ├── .aiida
-        └── subfolder
-
-
-If you leave the ``AIIDA_PATH`` variable unset, the default location ``~/.aiida`` will be used.
-However, if you set ::
-
-    export AIIDA_PATH='~/project_a:'
-
-the configuration directory ``~/project_a/.aiida`` will be used.
-
-.. warning::
-    If there was no ``.aiida`` directory in ``~/project_a``, AiiDA would have created it for you.
-    Thus make sure to set the ``AIIDA_PATH`` correctly.
-
-
 Using AiiDA in Jupyter
 ----------------------
 
@@ -109,8 +22,6 @@ followed by ``Shift-Enter``. If no exception is thrown, you can use AiiDA in Jup
 
 If you want to set the same environment as in a ``verdi shell``,
 add the following code to a ``.py`` file (create one if there isn't any) in ``<home_folder>/.ipython/profile_default/startup/``::
-
-
 
   try:
       import aiida


### PR DESCRIPTION
Fixes #4001

This section describes how multiple instances of AiiDA can be isolated
on the same machine, how tab-completion can be activated and how the
`verdi config` command can be used to configure profile options.

Except for the `verdi config` section, which is completely new, the
other content has been adapted from existing documentation.