### PR TITLE
Update ZipFolder (in importexport module)

### DIFF
--- a/aiida/common/warnings.py
+++ b/aiida/common/warnings.py
@@ -10,7 +10,11 @@
 """Define warnings that can be thrown by AiiDA."""
 
 
-class AiidaDeprecationWarning(Warning):
+class AiidaWarning(Warning):
+    """Generic AiiDA warning."""
+
+
+class AiidaDeprecationWarning(AiidaWarning):
     """
     Class for AiiDA deprecations.
 
@@ -22,13 +26,13 @@ class AiidaDeprecationWarning(Warning):
     """
 
 
-class AiidaEntryPointWarning(Warning):
+class AiidaEntryPointWarning(AiidaWarning):
     """
     Class for warnings concerning AiiDA entry points.
     """
 
 
-class AiidaTestWarning(Warning):
+class AiidaTestWarning(AiidaWarning):
     """
     Class for warnings concerning the AiiDA testing infrastructure.
     """

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -673,10 +673,9 @@ def export_tree(
         'groups_uuid': groups_uuid
     }
 
-    # N.B. We're really calling zipfolder.open (if exporting a zipfile)
+    # NOTE: We're really calling zipfolder.open (if exporting a zipfile)
     with folder.open('data.json', mode='w') as fhandle:
-        # fhandle.write(json.dumps(data, cls=UUIDEncoder))
-        fhandle.write(json.dumps(data))
+        fhandle.write(json.dumps(data))  # json.dumps will always return a str
 
     # Turn sets into lists to be able to export them as JSON metadata.
     for entity, entity_set in entities_starting_set.items():
@@ -696,7 +695,7 @@ def export_tree(
     }
 
     with folder.open('metadata.json', 'w') as fhandle:
-        fhandle.write(json.dumps(metadata))
+        fhandle.write(json.dumps(metadata))  # json.dumps will always return a str
 
     EXPORT_LOGGER.debug('ADDING REPOSITORY FILES TO EXPORT ARCHIVE...')
 

--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -92,15 +92,16 @@ class ZipFolder:
 
         Imitating :py:meth:`aiida.common.folders.Folder.open`.
 
-        Since zipfile.ZipFile.writestr is str/bytes agnostic, we don't care about encoding.
-        NOTE: This means encoding other than UTF-8/Unicode is not supported
-        (since it is not supported by zipfile.ZipFile).
+        Since zipfile.ZipFile.writestr is str/bytes agnostic, we don't care about encoding (or 'b' in mode).
+        NOTE: This means whatever data is passed to
+        :py:meth:`aiida.tools.importexport.dbexport.zip.ZipFileWrapper.write` will be written to this ZipFolder with
+        whatever encoding it may have.
         The encoding parameter is still present to be similar to :py:class:`aiida.common.folders.Folder`.
         """
-        if encoding is not None:
+        if encoding is not None or 'b' in mode:
             warnings.warn(  # pylint: disable=no-member
-                'encoding has no effect for ZipFolder, it will always be "utf-8". '
-                'See zipfile docs for more information.',
+                'encoding or "b" in mode has no effect for ZipFolder, it will always be encoded according to the '
+                'encoding of the data written or read. See zipfile docs for more information.',
                 AiidaWarning
             )
 
@@ -120,7 +121,7 @@ class ZipFolder:
         dest = os.path.normpath(os.path.join(self.path, relpath))
 
         if check_existence:
-            if not os.path.exists(dest):
+            if not self.exists(dest):
                 raise OSError('{} does not exist within the zip-folder {}'.format(relpath, self.path))
 
         return dest

--- a/aiida/tools/importexport/dbexport/zip.py
+++ b/aiida/tools/importexport/dbexport/zip.py
@@ -8,62 +8,55 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Export a zip-file."""
-# pylint: disable=missing-docstring,redefined-builtin
-import io
+# pylint: disable=redefined-builtin
 import os
+import warnings
 import zipfile
 
+from aiida.common.warnings import AiidaWarning
 
-class MyWritingZipFile:
 
-    def __init__(self, zip_file, fname):
+class ZipFileWrapper:
+    """"Wrap" zipfile.ZipFile to make `write` method equal `writestr`"""
+
+    def __init__(self, zip_file, filename):
         self._zipfile = zip_file
-        self._fname = fname
-        self._buffer = None
-
-    def open(self):
-        if self._buffer is not None:
-            raise IOError('Cannot open again!')
-        self._buffer = io.StringIO()
+        self._filename = filename
 
     def write(self, data):
-        self._buffer.write(data)
-
-    def close(self):
-        self._buffer.seek(0)
-        self._zipfile.writestr(self._fname, self._buffer.read())
-        self._buffer = None
+        self._zipfile.writestr(self._filename, data)
 
     def __enter__(self):
-        self.open()
         return self
 
     def __exit__(self, type, value, traceback):
-        self.close()
+        pass
 
 
 class ZipFolder:
-    """
-    To improve: if zipfile is closed, do something
+    """"Wrap" for zipfile.ZipFile in order to act as a ZipFolder.
+
+    This class is supposed to imitate :py:class:`aiida.common.folders.Folder`.
+
+    NOTE: To improve: if zipfile is closed, do something
     (e.g. add explicit open method, rename open to openfile,
     set _zipfile to None, ...)
+
+    :param zipfolder_or_name: either another ZipFolder instance,
+        of which you want to get a subfolder, or a filename to create.
+    :param mode: the file mode; see the zipfile.ZipFile docs for valid
+        strings. Note: can be specified only if zipfolder_or_name is a
+        string (the filename to generate)
+    :param subfolder: the subfolder that specified the "current working
+        directory" in the zip file. If zipfolder_or_name is a ZipFolder,
+        subfolder is a relative path from zipfolder_or_name.path.
+    :param use_compression: either True, to compress files in the Zip, or
+        False if you just want to pack them together without compressing.
+        It is ignored if zipfolder_or_name is a ZipFolder instance.
     """
 
-    def __init__(self, zipfolder_or_fname, mode=None, subfolder='.', use_compression=True, allowZip64=True):
-        """
-        :param zipfolder_or_fname: either another ZipFolder instance,
-          of which you want to get a subfolder, or a filename to create.
-        :param mode: the file mode; see the zipfile.ZipFile docs for valid
-          strings. Note: can be specified only if zipfolder_or_fname is a
-          string (the filename to generate)
-        :param subfolder: the subfolder that specified the "current working
-          directory" in the zip file. If zipfolder_or_fname is a ZipFolder,
-          subfolder is a relative path from zipfolder_or_fname.subfolder
-        :param use_compression: either True, to compress files in the Zip, or
-          False if you just want to pack them together without compressing.
-          It is ignored if zipfolder_or_fname is a ZipFolder isntance.
-        """
-        if isinstance(zipfolder_or_fname, str):
+    def __init__(self, zipfolder_or_name, mode=None, subfolder='.', use_compression=True, allowZip64=True):
+        if isinstance(zipfolder_or_name, str):
             the_mode = mode
             if the_mode is None:
                 the_mode = 'r'
@@ -72,14 +65,14 @@ class ZipFolder:
             else:
                 compression = zipfile.ZIP_STORED
             self._zipfile = zipfile.ZipFile(
-                zipfolder_or_fname, mode=the_mode, compression=compression, allowZip64=allowZip64
+                zipfolder_or_name, mode=the_mode, compression=compression, allowZip64=allowZip64
             )
-            self._pwd = subfolder
+            self._path = subfolder
         else:
             if mode is not None:
                 raise ValueError("Cannot specify 'mode' when passing a ZipFolder")
-            self._zipfile = zipfolder_or_fname._zipfile  # pylint: disable=protected-access
-            self._pwd = os.path.join(zipfolder_or_fname.pwd, subfolder)
+            self._zipfile = zipfolder_or_name._zipfile  # pylint: disable=protected-access
+            self._path = os.path.join(zipfolder_or_name.path, subfolder)
 
     def __enter__(self):
         return self
@@ -91,20 +84,48 @@ class ZipFolder:
         self._zipfile.close()
 
     @property
-    def pwd(self):
-        return self._pwd
+    def path(self):
+        return self._path
 
-    def open(self, fname, mode='r'):
-        if mode == 'w':
-            return MyWritingZipFile(zip_file=self._zipfile, fname=self._get_internal_path(fname))
-        # else
-        return self._zipfile.open(self._get_internal_path(fname), mode)
+    def open(self, name, mode='r', encoding=None, check_existence=False):
+        """Open a file or folder within the current ZipFolder for reading or writing
 
-    def _get_internal_path(self, filename):
-        return os.path.normpath(os.path.join(self.pwd, filename))
+        Imitating :py:meth:`aiida.common.folders.Folder.open`.
 
-    # pylint: disable=unused-argument
-    def get_subfolder(self, subfolder, create=False, reset_limit=False):
+        Since zipfile.ZipFile.writestr is str/bytes agnostic, we don't care about encoding.
+        NOTE: This means encoding other than UTF-8/Unicode is not supported
+        (since it is not supported by zipfile.ZipFile).
+        The encoding parameter is still present to be similar to :py:class:`aiida.common.folders.Folder`.
+        """
+        if encoding is not None:
+            warnings.warn(  # pylint: disable=no-member
+                'encoding has no effect for ZipFolder, it will always be "utf-8". '
+                'See zipfile docs for more information.',
+                AiidaWarning
+            )
+
+        if 'w' in mode:
+            return ZipFileWrapper(zip_file=self._zipfile, filename=self.get_path(name, check_existence=check_existence))
+
+        return self._zipfile.open(self.get_path(name, check_existence=check_existence), mode)
+
+    def get_path(self, relpath, check_existence=False):
+        """Return a normalized path of internal path within ZipFolder
+
+        Similar to :py:meth:`aiida.common.folders.Folder.get_abs_path`.
+        """
+        if os.path.isabs(relpath):
+            raise ValueError('relpath must be a relative path')
+
+        dest = os.path.normpath(os.path.join(self.path, relpath))
+
+        if check_existence:
+            if not os.path.exists(dest):
+                raise OSError('{} does not exist within the zip-folder {}'.format(relpath, self.path))
+
+        return dest
+
+    def get_subfolder(self, subfolder, create=False, reset_limit=False):  # pylint: disable=unused-argument
         # reset_limit: ignored
         # create: ignored, for the time being
         return ZipFolder(self, subfolder=subfolder)
@@ -119,12 +140,22 @@ class ZipFolder:
         return exists
 
     def insert_path(self, src, dest_name=None, overwrite=True):
+        """Copy a file or folder to the ZipFolder.
+
+        Similar functionality to :py:meth:`aiida.common.folders.Folder.insert_path`.
+
+        :param src: the source filename to copy
+        :param dest_name: if None, the same basename of src is used. Otherwise,
+                the destination filename will have this file name.
+        :param overwrite: if ``False``, raises an error on existing destination;
+                otherwise, delete it first.
+        """
         if dest_name is None:
             base_filename = str(os.path.basename(src))
         else:
             base_filename = str(dest_name)
 
-        base_filename = self._get_internal_path(base_filename)
+        base_filename = self.get_path(base_filename)
 
         src = str(src)
 

--- a/tests/tools/importexport/dbexport/test_zip.py
+++ b/tests/tools/importexport/dbexport/test_zip.py
@@ -1,12 +1,16 @@
 """Tests for aiida.tools.importexport.dbexport.zip"""
 import os
+import zipfile
+
+import pytest
 
 from aiida.common import json
+from aiida.common.warnings import AiidaWarning
 from aiida.tools.importexport.dbexport.zip import ZipFolder
 
 
-def test_writing_bytes(temp_dir):
-    """Verify exporting a Node with a bytes object in the repo is possible"""
+def test_writing_text(temp_dir):
+    """Verify writing `str` is possible"""
     zip_file = os.path.join(temp_dir, 'test.zip')
     filename = 'data{}.json'
 
@@ -14,21 +18,82 @@ def test_writing_bytes(temp_dir):
     bytes_data = data.encode('utf-8')
     json_data = json.dumps(bytes_data)  # Will always return a string
 
+    assert data != bytes_data
+    assert isinstance(json_data, str)
+
     with ZipFolder(zip_file, mode='w') as folder:
         with folder.open(filename.format(0), mode='w') as fhandle:
-            fhandle.write(data)
-
-        with folder.open(filename.format(1), mode='wb') as fhandle:
-            fhandle.write(bytes_data)
-
-        with folder.open(filename.format(2), mode='w') as fhandle:
             fhandle.write(json_data)
 
-        with folder.open(filename.format(3), mode='wb') as fhandle:
-            fhandle.write(data)
+        with pytest.warns(AiidaWarning, match='encoding or "b" in mode has no effect for ZipFolder'):
+            with folder.open(filename.format(1), mode='wb') as fhandle:
+                fhandle.write(json_data)
 
-        with folder.open(filename.format(4), mode='w') as fhandle:
+    zipfile.ZipFile(zip_file, mode='r').extractall(path=temp_dir)
+
+    with open(os.path.join(temp_dir, filename.format(0)), mode='r') as fhandle:
+        extracted_data = fhandle.read()
+
+    assert extracted_data == json_data
+
+    with open(os.path.join(temp_dir, filename.format(1)), mode='r') as fhandle:
+        extracted_data = fhandle.read()
+
+    assert extracted_data == json_data
+
+
+def test_writing_utf_bytes(temp_dir):
+    """Verify writing `bytes` in UTF-8 is possible"""
+    zip_file = os.path.join(temp_dir, 'test.zip')
+    filename = 'data{}.json'
+
+    data = 'aà'
+    bytes_data = data.encode('utf-8')
+
+    assert data != bytes_data
+
+    with ZipFolder(zip_file, mode='w') as folder:
+        with pytest.warns(AiidaWarning, match='encoding or "b" in mode has no effect for ZipFolder'):
+            with folder.open(filename.format(0), mode='wb') as fhandle:
+                fhandle.write(bytes_data)
+
+        with folder.open(filename.format(1), mode='w') as fhandle:
             fhandle.write(bytes_data)
 
-        with folder.open(filename.format(5), mode='wb') as fhandle:
-            fhandle.write(json_data)
+    zipfile.ZipFile(zip_file, mode='r').extractall(path=temp_dir)
+
+    with open(os.path.join(temp_dir, filename.format(0)), mode='rb') as fhandle:
+        extracted_data = fhandle.read()
+
+    assert extracted_data == bytes_data
+    assert extracted_data.decode('utf-8') == data
+
+    with open(os.path.join(temp_dir, filename.format(1)), mode='rb') as fhandle:
+        extracted_data = fhandle.read()
+
+    assert extracted_data == bytes_data
+    assert extracted_data.decode('utf-8') == data
+
+
+def test_writing_non_utf_bytes(temp_dir):
+    """Check ZipFolder can handle `bytes` other than UTF-8"""
+    zip_file = os.path.join(temp_dir, 'test.zip')
+    filename = 'data.json'
+
+    data = 'aà'
+    latin_data = data.encode('latin-1')
+    unicode_data = data.encode('utf-8')
+
+    assert latin_data != unicode_data
+
+    with ZipFolder(zip_file, mode='w') as folder:
+        with pytest.warns(AiidaWarning, match='encoding or "b" in mode has no effect for ZipFolder'):
+            with folder.open(filename, mode='wb', encoding='latin-1') as fhandle:
+                fhandle.write(latin_data)
+
+    zipfile.ZipFile(zip_file, mode='r').extractall(path=temp_dir)
+    with open(os.path.join(temp_dir, filename), mode='rb') as fhandle:
+        extracted_data = fhandle.read()
+
+    assert extracted_data == latin_data
+    assert str(extracted_data.decode('latin-1')) == data

--- a/tests/tools/importexport/dbexport/test_zip.py
+++ b/tests/tools/importexport/dbexport/test_zip.py
@@ -1,0 +1,34 @@
+"""Tests for aiida.tools.importexport.dbexport.zip"""
+import os
+
+from aiida.common import json
+from aiida.tools.importexport.dbexport.zip import ZipFolder
+
+
+def test_writing_bytes(temp_dir):
+    """Verify exporting a Node with a bytes object in the repo is possible"""
+    zip_file = os.path.join(temp_dir, 'test.zip')
+    filename = 'data{}.json'
+
+    data = 'aà'
+    bytes_data = data.encode('utf-8')
+    json_data = json.dumps(bytes_data)  # Will always return a string
+
+    with ZipFolder(zip_file, mode='w') as folder:
+        with folder.open(filename.format(0), mode='w') as fhandle:
+            fhandle.write(data)
+
+        with folder.open(filename.format(1), mode='wb') as fhandle:
+            fhandle.write(bytes_data)
+
+        with folder.open(filename.format(2), mode='w') as fhandle:
+            fhandle.write(json_data)
+
+        with folder.open(filename.format(3), mode='wb') as fhandle:
+            fhandle.write(data)
+
+        with folder.open(filename.format(4), mode='w') as fhandle:
+            fhandle.write(bytes_data)
+
+        with folder.open(filename.format(5), mode='wb') as fhandle:
+            fhandle.write(json_data)

--- a/tests/tools/importexport/dbexport/test_zip.py
+++ b/tests/tools/importexport/dbexport/test_zip.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for aiida.tools.importexport.dbexport.zip"""
 import os
 import zipfile


### PR DESCRIPTION
The outcome of the now closed PR #3537.

It streamlines the `aiida.tools.importexport.dbexport.zip` module, renaming and minimizing the `MyWritingZipFile` to it's necessary parts, and further cements the desire for `ZipFolder`'s methods to be similar to those of `aiida.common.folders.Folder`.
I have chosen not to sub-class `Folder` at this point, simply because I would need to override almost all methods, most of which are not needed. However, this is still an opportunity, if desired.

Concerning handling `bytes` vs. `str` for writing, `zipfile.ZipFile.writestr()` doesn't care, it converts a `str` to `bytes` encoded in UTF-8. Thus, opening `ZipFolder` (keeping the parameters from `Folder`) `encoding` has no effect, nor does adding `b` in the `mode` parameter.
If `encoding` is specifically supplied (or 'b' is found in `mode`) when calling `ZipFolder.open()`, a warning is emitted.

Other things in this PR (in separate commits):
- I add a top-level `AiidaWarning`, similar to `AiidaException`.
  All AiiDA-specific `Warning` classes are now sub-classes of this one.
  I needed a general warning for the `open` method.
- Remove skipping a test in `tests.tools.importexport.test_specific_import`, since the related issue was fixed with a previous PR, but never re-introduced.