### PR TITLE
Fix bug in `Code.get_full_text_info`

### DIFF
--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -7,14 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 import os
 
 from aiida.common.exceptions import ValidationError, EntryPointError, InputValidationError
-
 from .data import Data
-
-DEPRECATION_DOCS_URL = 'http://aiida-core.readthedocs.io/en/latest/concepts/processes.html#the-process-builder'
 
 __all__ = ('Code',)
 
@@ -491,9 +487,12 @@ class Code(Data):
         return builder
 
     def get_full_text_info(self, verbose=False):
+        """Return a list of lists with a human-readable detailed information on this code.
+
+        :return: list of lists where each entry consists of two elements: a key and a value
         """
-        Return a (multiline) string with a human-readable detailed information on this computer
-        """
+        from aiida.orm.utils.repository import FileType
+
         result = []
         result.append(['PK', self.pk])
         result.append(['UUID', self.uuid])
@@ -508,11 +507,11 @@ class Code(Data):
             result.append(['Type', 'local'])
             result.append(['Exec name', self.get_execname()])
             result.append(['List of files/folders:', ''])
-            for fname in self.list_object_names():
-                if self._repository._get_folder_pathsubfolder.isdir(fname):
-                    result.append(['directory', fname])
+            for obj in self.list_objects():
+                if obj.type == FileType.DIRECTORY:
+                    result.append(['directory', obj.name])
                 else:
-                    result.append(['file', fname])
+                    result.append(['file', obj.name])
         else:
             result.append(['Type', 'remote'])
             result.append(['Remote machine', self.get_remote_computer().name])
@@ -536,7 +535,6 @@ class Code(Data):
 
     @classmethod
     def setup(cls, **kwargs):
-        # raise NotImplementedError
         from aiida.cmdline.commands.code import CodeInputValidationClass
         code = CodeInputValidationClass().set_and_validate_from_code(kwargs)
 

--- a/tests/orm/data/test_code.py
+++ b/tests/orm/data/test_code.py
@@ -1,0 +1,46 @@
+"""Tests for the `Code` class."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida.orm import Code
+
+
+@pytest.fixture
+def create_codes(tmpdir, aiida_localhost):
+    """Create a local and remote `Code` instance."""
+    filename = 'add.sh'
+    filepath = str(tmpdir / filename)  # Cast the filepath to str as Python 3.5 does not support Path objects for `open`
+
+    with open(filepath, 'w'):
+        pass
+
+    code_local = Code(local_executable=filename, files=[filepath]).store()
+    code_remote = Code(remote_computer_exec=(aiida_localhost, '/bin/true')).store()
+
+    return code_local, code_remote
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_get_full_text_info(create_codes):
+    """Test the `Code.get_full_text_info` method."""
+    for code in create_codes:
+        full_text_info = code.get_full_text_info()
+
+        assert isinstance(full_text_info, list)
+        assert ['PK', code.pk] in full_text_info
+        assert ['UUID', code.uuid] in full_text_info
+        assert ['Label', code.label] in full_text_info
+        assert ['Description', code.description] in full_text_info
+
+        if code.is_local():
+            assert ['Type', 'local'] in full_text_info
+            assert ['Exec name', code.get_execname()] in full_text_info
+            assert ['List of files/folders:', ''] in full_text_info
+        else:
+            assert ['Type', 'remote'] in full_text_info
+            assert ['Remote machine', code.computer.name] in full_text_info
+            assert ['Remote absolute path', code.get_remote_exec_path()] in full_text_info
+
+    for code in create_codes:
+        full_text_info = code.get_full_text_info(verbose=True)
+        assert ['Calculations', 0] in full_text_info


### PR DESCRIPTION
Fixes #4079 

This method was not tested and so it went unnoticed that it was still
using the `_get_folder_pathsubfolder` repository method that has been
removed in `aiida-core==1.0.0`. Direct access to the folder underlying
the node repository is no longer allowed and instead the API should be
used to inspect the available objects, in this case `list_objects`.