### PR TITLE
Ensure `verdi group show --limit` respects limit even in raw mode

### DIFF
--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -166,7 +166,7 @@ def group_show(group, raw, limit, uuid):
             header.append('UUID')
         header.extend(['PK', 'Type', 'Created'])
         echo.echo('# Nodes:')
-        for node in group.nodes:
+        for node in node_iterator:
             row = []
             if uuid:
                 row.append(node.uuid)

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -192,6 +192,14 @@ class TestVerdiGroup(AiidaTestCase):
         self.assertEqual(len(result.output.strip().split('\n')), 1)
         self.assertTrue(str(nodes[0].pk) in result.output or str(nodes[1].pk) in result.output)
 
+        # Repeat test with `limit=1` but without the `--raw` flag as it has a different code path that is affected
+        result = self.cli_runner.invoke(cmd_group.group_show, [label, '--limit', '1'])
+        self.assertClickResultNoException(result)
+
+        # Check that one, and only one pk appears in the output
+        self.assertTrue(str(nodes[0].pk) in result.output or str(nodes[1].pk) in result.output)
+        self.assertTrue(not (str(nodes[0].pk) in result.output and str(nodes[1].pk) in result.output))
+
     def test_description(self):
         """Test `verdi group description` command."""
         description = 'It is a new description'


### PR DESCRIPTION
Fixes #4091 

The code is affected by the `--limit` flag both where the `--raw` flag
is enabled and if it is disabled. However, in the disabled case the
limit was not respected. This was not detected because the unit test
only tested the code path when `--raw` is enabled.