### PR TITLE
Increase the efficiency of the `SqlaGroup.nodes` iterator

### DIFF
--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -146,11 +146,10 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
             def __init__(self, dbnodes, backend):
                 self._backend = backend
                 self._dbnodes = dbnodes
-                self._iter = dbnodes.__iter__()
                 self.generator = self._genfunction()
 
             def _genfunction(self):
-                for node in self._iter:
+                for node in self._dbnodes:
                     yield self._backend.get_backend_entity(node)
 
             def __iter__(self):


### PR DESCRIPTION
Fixes #4090

The iterator was calling `dbnodes.__iter__()` which was violting
the lazy loading of the nodes as they are needed during iteration
leading to a huge load time for big groups even when only a slice
is demanded. For reference, on a group with roughly half a million
nodes, getting a single one through `group.nodes[0]` went from
taking a minute to a few milliseconds.

P.S.: not sure how to test this. Could think of a dedicated performance test on Jenkins, but for a regression I am not sure it is worth effort