### PR TITLE
Move to CircleCI for CI Documentation builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build_docs:
+  docs:
     docker:
       # see: https://circleci.com/docs/2.0/circleci-images/#python
       - image: circleci/python:3.7-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,8 @@ jobs:
           name: Build docs to store
           # nit-picky mode, turn warnings into errors,
           # but do not stop the build on errors (so we can still inspect the doc artifacts)
-          # this needs to re re-instated when doc-revamp merged
-          # command: |
-          #   sphinx-build -b html -nW --keep-going -d docs/_build/doctrees docs/source docs/_build/html
           command: |
             sphinx-build -b html -n --keep-going -d docs/_build/doctrees docs/source docs/_build/html
-          # environment:
-            # READTHEDOCS: 'True'
-            # RUN_APIDOC: 'False'
       - store_artifacts:
           path: docs/_build/html/
           destination: html
@@ -43,4 +37,4 @@ workflows:
   version: 2
   default:
     jobs:
-      - build_docs
+      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Build docs to store
           # nit-picky mode, turn warnings into errors,
-          # but don't stop the build on errors (so we can still inspect the doc artifacts)
+          # but do not stop the build on errors (so we can still inspect the doc artifacts)
           command: |
             sphinx-build -b html -nW --keep-going -d docs/_build/doctrees docs/source docs/_build/html
           # environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,11 @@ jobs:
           name: Build docs to store
           # nit-picky mode, turn warnings into errors,
           # but do not stop the build on errors (so we can still inspect the doc artifacts)
+          # this needs to re re-instated when doc-revamp merged
+          # command: |
+          #   sphinx-build -b html -nW --keep-going -d docs/_build/doctrees docs/source docs/_build/html
           command: |
-            sphinx-build -b html -nW --keep-going -d docs/_build/doctrees docs/source docs/_build/html
+            sphinx-build -b html -n --keep-going -d docs/_build/doctrees docs/source docs/_build/html
           # environment:
             # READTHEDOCS: 'True'
             # RUN_APIDOC: 'False'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      # see: https://circleci.com/docs/2.0/circleci-images/#python
+      - image: circleci/python:3.7-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-pip
+
+      - run: |
+          pip install numpy==1.17.4
+          pip install --user .[docs,testing]
+
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+
+      # Build the docs
+      - run:
+          name: Build docs to store
+          # nit-picky mode, turn warnings into errors,
+          # but don't stop the build on errors (so we can still inspect the doc artifacts)
+          command: |
+            sphinx-build -b html -nW --keep-going -d docs/_build/doctrees docs/source docs/_build/html
+          # environment:
+            # READTHEDOCS: 'True'
+            # RUN_APIDOC: 'False'
+      - store_artifacts:
+          path: docs/_build/html/
+          destination: html
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,39 +4,6 @@ on: [push, pull_request]
 
 jobs:
 
-  # The docs action is currently replaced by a build with CircleCI (see .circleci/config.yml)
-  # When/if GitHub actions allows for storage of (unzipped) artifacts, we can move back to this action
-  # docs:
-
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-
-  #   - name: Set up Python 3.7
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: 3.7
-
-  #   - name: Install system dependencies
-  #     # remove occasionally problematic repositories we don't use anyway
-  #     run: |
-  #       sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-  #       sudo apt update
-  #       sudo apt install texlive-base texlive-generic-recommended texlive-fonts-recommended texlive-latex-base texlive-latex-recommended texlive-latex-extra dvipng dvidvi
-
-  #   - name: Install python dependencies
-  #     run: |
-  #       pip install numpy==1.17.4
-  #       pip install -e .[docs,testing]
-
-  #   - name: Build documentation
-  #     env:
-  #       READTHEDOCS: 'True'
-  #     run:
-  #       SPHINXOPTS='-n' make -C docs html
-
   pre-commit:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,36 +4,38 @@ on: [push, pull_request]
 
 jobs:
 
-  docs:
+  # The docs action is currently replaced by a build with CircleCI (see .circleci/config.yml)
+  # When/if GitHub actions allows for storage of (unzipped) artifacts, we can move back to this action
+  # docs:
 
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
 
-    steps:
-    - uses: actions/checkout@v2
+  #   steps:
+  #   - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
+  #   - name: Set up Python 3.7
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: 3.7
 
-    - name: Install system dependencies
-      # remove occasionally problematic repositories we don't use anyway
-      run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-        sudo apt update
-        sudo apt install texlive-base texlive-generic-recommended texlive-fonts-recommended texlive-latex-base texlive-latex-recommended texlive-latex-extra dvipng dvidvi
+  #   - name: Install system dependencies
+  #     # remove occasionally problematic repositories we don't use anyway
+  #     run: |
+  #       sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+  #       sudo apt update
+  #       sudo apt install texlive-base texlive-generic-recommended texlive-fonts-recommended texlive-latex-base texlive-latex-recommended texlive-latex-extra dvipng dvidvi
 
-    - name: Install python dependencies
-      run: |
-        pip install numpy==1.17.4
-        pip install -e .[docs,testing]
+  #   - name: Install python dependencies
+  #     run: |
+  #       pip install numpy==1.17.4
+  #       pip install -e .[docs,testing]
 
-    - name: Build documentation
-      env:
-        READTHEDOCS: 'True'
-      run:
-        SPHINXOPTS='-n' make -C docs html
+  #   - name: Build documentation
+  #     env:
+  #       READTHEDOCS: 'True'
+  #     run:
+  #       SPHINXOPTS='-n' make -C docs html
 
   pre-commit:
 


### PR DESCRIPTION
closes #4028 

As discussed there, the main reason for this is to allow for the built documentation to be viewed during PR reviews.

This is already working on #4060, under my CircleCI account: https://app.circleci.com/pipelines/github/chrisjsewell/aiida_core?branch=docs-revamp-intro-install2, but I think I need someone else to set up an account for aiidateam.

Note you can also use this action to create a shortcut in the PR checks list, to open the `index.html`, but it's not super necessary:

```yaml
on: [status]

jobs:
  circleci_artifacts_redirector_job:
    runs-on: ubuntu-latest
    name: Run CircleCI artifacts redirector
    steps:
      - name: GitHub Action step
        uses: larsoner/circleci-artifacts-redirector-action@master
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          artifact-path: 0/html/index.html
```