### PR TITLE
`QueryBuilder`: fix type string filter generation for `Group` subclasses

### DIFF
--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -282,7 +282,7 @@ def get_group_type_filter(classifiers, subclassing):
     """
     from aiida.common.escaping import escape_for_sql_like
 
-    value = classifiers['ormclass_type_string'].lstrip(GROUP_ENTITY_TYPE_PREFIX)
+    value = classifiers['ormclass_type_string'][len(GROUP_ENTITY_TYPE_PREFIX):]
 
     if not subclassing:
         filters = {'==': value}

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -114,6 +114,22 @@ class TestQueryBuilder(AiidaTestCase):
         self.assertEqual(classifiers['ormclass_type_string'], 'process.calculation.calcjob.CalcJobNode.')
         self.assertEqual(classifiers['process_type_string'], 'aiida.calculations:arithmetic.add')
 
+    def test_get_group_type_filter(self):
+        """Test the `aiida.orm.querybuilder.get_group_type_filter` function."""
+        from aiida.orm.querybuilder import get_group_type_filter
+
+        classifiers = {'ormclass_type_string': 'group.core'}
+        self.assertEqual(get_group_type_filter(classifiers, False), {'==': 'core'})
+        self.assertEqual(get_group_type_filter(classifiers, True), {'like': '%'})
+
+        classifiers = {'ormclass_type_string': 'group.core.auto'}
+        self.assertEqual(get_group_type_filter(classifiers, False), {'==': 'core.auto'})
+        self.assertEqual(get_group_type_filter(classifiers, True), {'like': 'core.auto%'})
+
+        classifiers = {'ormclass_type_string': 'group.pseudo.family'}
+        self.assertEqual(get_group_type_filter(classifiers, False), {'==': 'pseudo.family'})
+        self.assertEqual(get_group_type_filter(classifiers, True), {'like': 'pseudo.family%'})
+
     def test_process_query(self):
         """
         Test querying for a process class.


### PR DESCRIPTION
Fixes #4143 

The `aiida.orm.querybuilder.get_group_type_filter` function that is
responsible for generating the correct filters for the `type_string`
when a `Group` or subclass of it is appended, contained a bug. To
generate the correct type string, it should strip the `group.` prefix
from the provided ORM classifier. This was incorrectly done with the
string method `lstrip`, which does not strip an entire prefix as is, but
will strip any characters that are matched starting from the left. This
would cause extra characters to be erroneously stripped if the rest of
the type string started with any letters in the sequence `group.`. For
example `group.pseudo.family` would be stripped to `seudo.family`. The
solution is to use the first N characters where N is the length of the
prefix.