### PR TITLE
Docs: Add release version pinning to install instructions

### DIFF
--- a/docs/source/intro/get_started.rst
+++ b/docs/source/intro/get_started.rst
@@ -85,22 +85,22 @@ Install Software
 
     :fa:`download,mr-1` **Install from Conda**
 
-    .. code-block:: console
+    .. parsed-literal::
 
-        $ conda create -n aiida -c conda-forge aiida-core aiida-core.services
-        $ conda activate aiida
-        $ reentry scan
+        conda create -n aiida -c conda-forge aiida-core=\ |release|\  aiida-core.services=\ |release|
+        conda activate aiida
+        reentry scan
 
-    `Conda <https://docs.conda.io>`__ provides a cross-platform package management system, from which we can install all the basic components of the AiiDA infrastructure in an isolated environment:
+    `Conda <https://docs.conda.io>`__ provides a cross-platform package management system, from which we can install all the basic components of the AiiDA infrastructure in an isolated environment.
 
     ----------------------------------------------
 
     :fa:`download,mr-1` **Install with pip**
 
-    .. code-block:: console
+    .. parsed-literal::
 
-        $ pip install aiida-core
-        $ reentry scan
+        pip install aiida-core==\ |release|
+        reentry scan
 
     ``aiida-core`` can be installed from `PyPi <https://pypi.org/project/aiida-core>`__.
     It is strongly recommended that you install into a :ref:`virtual environment <intro:install:virtual_environments>`.

--- a/docs/source/intro/get_started.rst
+++ b/docs/source/intro/get_started.rst
@@ -99,7 +99,7 @@ Install Software
 
     .. parsed-literal::
 
-        pip install aiida-core==\ |release|
+        pip install aiida-core
         reentry scan
 
     ``aiida-core`` can be installed from `PyPi <https://pypi.org/project/aiida-core>`__.


### PR DESCRIPTION
Conda is having a hard time solving the environment without versions specified (I think due to some tricky dependency requirement balances between aiida-core and erlang). It basically hangs on:

```console
$ conda create -n aiida -c conda-forge aiida-core aiida-core.services
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: - 
```

Providing the actual version appears to solve this, and so in this PR I have added the release version to the install instructions.
Following https://stackoverflow.com/a/27418207/5033292, the release version is a variable, and so will auto-update for new releases of aiida-core.