### PR TITLE
Increase the default for `runner.poll.interval` config option to 60

### DIFF
--- a/aiida/manage/configuration/options.py
+++ b/aiida/manage/configuration/options.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Definition of known configuration options and methods to parse and get option values."""
-
 import collections
 
 __all__ = ('get_option', 'get_option_names', 'parse_option')
@@ -28,7 +27,7 @@ CONFIG_OPTIONS = {
         'key': 'runner_poll_interval',
         'valid_type': 'int',
         'valid_values': None,
-        'default': 1,
+        'default': 60,
         'description': 'The polling interval in seconds to be used by process runners',
         'global_only': False,
     },


### PR DESCRIPTION
Fixes #4149 

This option is used to define the `poll_interval` argument of all
`Runner` instances that are created to run all processes. It determines
the interval with which the state of a subprocess, that a `WorkChain` is
waiting on, is checked whether it is terminated. If that is the case, a
callback is called which will signal to the `WorkChain` that it can
continue.

This polling is a backup mechanism in case the broadcast by the process
when it terminates is missed by the caller, which would cause it to wait
indefinitely. The original default of 1 was causing unnecessary load on
the CPUs as well as the database that each time had to query for the
process state. When running many calculations this would spin the CPUs
noticeably. Since this is supposed to be a fail-safe mechanism and it
should only be required rarely, it is fine to increase the time
significantly to reduce the load.