### PR TITLE
Reinstate broadcast subscription of workchain for child processes

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -358,7 +358,7 @@ def main():
 
     # Run the `MultiplyAddWorkChain`
     print('Running the `MultiplyAddWorkChain`')
-    run_base_restart_workchain()
+    run_multiply_add_workchain()
 
     # Submitting the Calculations the new way directly through the launchers
     print('Submitting {} calculations to the daemon'.format(NUMBER_CALCULATIONS))

--- a/aiida/engine/daemon/runner.py
+++ b/aiida/engine/daemon/runner.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Function that starts a daemon runner."""
-
 import logging
 import signal
 
@@ -28,7 +27,7 @@ def start_daemon():
         manager = get_manager()
         runner = manager.create_daemon_runner()
         manager.set_runner(runner)
-    except Exception as exception:
+    except Exception:
         LOGGER.exception('daemon runner failed to start')
         raise
 

--- a/aiida/engine/processes/workchains/awaitable.py
+++ b/aiida/engine/processes/workchains/awaitable.py
@@ -9,7 +9,6 @@
 ###########################################################################
 # pylint: disable=too-few-public-methods
 """Enums and function for the awaitables of Processes."""
-
 from enum import Enum
 
 from plumpy.utils import AttributesDict

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -9,19 +9,22 @@
 ###########################################################################
 # pylint: disable=global-statement
 """Runners that can run and submit processes."""
-
 import collections
+import functools
 import logging
 import signal
-import tornado.ioloop
+import threading
+import uuid
 
+import kiwipy
 import plumpy
+import tornado.ioloop
 
 from aiida.common import exceptions
 from aiida.orm import load_node
 from aiida.plugins.utils import PluginVersionProvider
 
-from .processes import futures
+from .processes import futures, ProcessState
 from .processes.calcjobs import manager
 from . import transports
 from . import utils
@@ -262,27 +265,61 @@ class Runner:  # pylint: disable=too-many-public-methods
         result, node = self._run(process, *args, **inputs)
         return ResultAndPk(result, node.pk)
 
-    def call_on_calculation_finish(self, pk, callback):
-        """
-        Callback to be called when the calculation of the given pk is terminated
+    def call_on_process_finish(self, pk, callback):
+        """Schedule a callback when the process of the given pk is terminated.
 
-        :param pk: the pk of the calculation
-        :param callback: the function to be called upon calculation termination
-        """
-        calculation = load_node(pk=pk)
-        self._poll_calculation(calculation, callback)
+        This method will add a broadcast subscriber that will listen for state changes of the target process to be
+        terminated. As a fail-safe, a polling-mechanism is used to check the state of the process, should the broadcast
+        message be missed by the subscriber, in order to prevent the caller to wait indefinitely.
 
-    def get_calculation_future(self, pk):
+        :param pk: pk of the process
+        :param callback: function to be called upon process termination
         """
-        Get a future for an orm Calculation. The future will have the calculation node
-        as the result when finished.
+        node = load_node(pk=pk)
+        subscriber_identifier = str(uuid.uuid4())
+        event = threading.Event()
 
-        :return: A future representing the completion of the calculation node
+        def inline_callback(event, *args, **kwargs):  # pylint: disable=unused-argument
+            """Callback to wrap the actual callback, that will always remove the subscriber that will be registered.
+
+            As soon as the callback is called successfully once, the `event` instance is toggled, such that if this
+            inline callback is called a second time, the actual callback is not called again.
+            """
+            if event.is_set():
+                return
+
+            try:
+                callback()
+            finally:
+                event.set()
+                self._communicator.remove_broadcast_subscriber(subscriber_identifier)
+
+        broadcast_filter = kiwipy.BroadcastFilter(functools.partial(inline_callback, event), sender=pk)
+        for state in [ProcessState.FINISHED, ProcessState.KILLED, ProcessState.EXCEPTED]:
+            broadcast_filter.add_subject_filter('state_changed.*.{}'.format(state.value))
+
+        LOGGER.info('adding subscriber for broadcasts of %d', pk)
+        self._communicator.add_broadcast_subscriber(broadcast_filter, subscriber_identifier)
+        self._poll_process(node, functools.partial(inline_callback, event))
+
+    def get_process_future(self, pk):
+        """Return a future for a process.
+
+        The future will have the process node as the result when finished.
+
+        :return: A future representing the completion of the process node
         """
-        return futures.CalculationFuture(pk, self._loop, self._poll_interval, self._communicator)
+        return futures.ProcessFuture(pk, self._loop, self._poll_interval, self._communicator)
 
-    def _poll_calculation(self, calc_node, callback):
-        if calc_node.is_terminated:
-            self._loop.add_callback(callback, calc_node.pk)
+    def _poll_process(self, node, callback):
+        """Check whether the process state of the node is terminated and call the callback or reschedule it.
+
+        :param node: the process node
+        :param callback: callback to be called when process is terminated
+        """
+        if node.is_terminated:
+            args = [node.__class__.__name__, node.pk]
+            LOGGER.info('%s<%d> confirmed to be terminated by backup polling mechanism', *args)
+            self._loop.add_callback(callback)
         else:
-            self._loop.call_later(self._poll_interval, self._poll_calculation, calc_node, callback)
+            self._loop.call_later(self._poll_interval, self._poll_process, node, callback)

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -43,10 +43,9 @@ class Runner:  # pylint: disable=too-many-public-methods
     _closed = False
 
     def __init__(self, poll_interval=0, loop=None, communicator=None, rmq_submit=False, persister=None):
-        """
-        Construct a new runner
+        """Construct a new runner.
 
-        :param poll_interval: interval in seconds between polling for status of active calculations
+        :param poll_interval: interval in seconds between polling for status of active sub processes
         :param loop: an event loop to use, if none is suppled a new one will be created
         :type loop: :class:`tornado.ioloop.IOLoop`
         :param communicator: the communicator to use
@@ -67,7 +66,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         self._plugin_version_provider = PluginVersionProvider()
 
         if communicator is not None:
-            self._communicator = communicator
+            self._communicator = plumpy.wrap_communicator(communicator, self._loop)
             self._controller = plumpy.RemoteProcessThreadController(communicator)
         elif self._rmq_submit:
             LOGGER.warning('Disabling RabbitMQ submission, no communicator provided')

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -165,7 +165,7 @@ class Manager:
         return self._communicator
 
     def create_communicator(self, task_prefetch_count=None, with_orm=True):
-        """Create a Communicator
+        """Create a Communicator.
 
         :param task_prefetch_count: optional specify how many tasks this communicator take simultaneously
         :param with_orm: if True, use ORM (de)serializers. If false, use json.

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -302,6 +302,7 @@ class Manager:
         import plumpy
         from aiida.engine import persistence
         from aiida.manage.external import rmq
+
         runner = self.create_runner(rmq_submit=True, loop=loop)
         runner_loop = runner.loop
 
@@ -313,10 +314,7 @@ class Manager:
             loader=persistence.get_object_loader()
         )
 
-        def callback(*args, **kwargs):
-            return plumpy.create_task(functools.partial(task_receiver, *args, **kwargs), loop=runner_loop)
-
-        runner.communicator.add_task_subscriber(callback)
+        runner.communicator.add_task_subscriber(task_receiver)
 
         return runner
 

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -799,7 +799,7 @@ class Node(Entity, metaclass=AbstractNodeMeta):
         """Validate adding a link of the given type from a given node to ourself.
 
         This function will first validate the types of the inputs, followed by the node and link types and validate
-        whether in principle a link of that type between the nodes of these types is allowed.the
+        whether in principle a link of that type between the nodes of these types is allowed.
 
         Subsequently, the validity of the "degree" of the proposed link is validated, which means validating the
         number of links of the given type from the given node type is allowed.

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -25,7 +25,7 @@ pg8000~=1.13
 pgsu~=0.1.0
 pgtest>=1.3.1,~=1.3
 pika~=1.1
-plumpy~=0.14.5
+plumpy~=0.15.0
 psutil~=5.6
 psycopg2-binary>=2.8.3,~=2.8
 pyblake2~=1.1; python_version < "3.6"

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpy<1.18,~=1.17
 - paramiko~=2.6
 - pika~=1.1
-- plumpy~=0.14.5
+- plumpy~=0.15.0
 - pgsu~=0.1.0
 - psutil~=5.6
 - psycopg2>=2.8.3,~=2.8

--- a/requirements/requirements-py-3.5.txt
+++ b/requirements/requirements-py-3.5.txt
@@ -78,7 +78,7 @@ pgsu==0.1.0
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.14.5
+plumpy==0.15.0
 prometheus-client==0.7.1
 prompt-toolkit==2.0.10
 psutil==5.7.0

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -78,7 +78,7 @@ pgtest==1.3.2
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.14.5
+plumpy==0.15.0
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -77,7 +77,7 @@ pgtest==1.3.2
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.14.5
+plumpy==0.15.0
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -76,7 +76,7 @@ pgtest==1.3.2
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.14.5
+plumpy==0.15.0
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/setup.json
+++ b/setup.json
@@ -37,7 +37,7 @@
     "numpy~=1.17,<1.18",
     "paramiko~=2.6",
     "pika~=1.1",
-    "plumpy~=0.14.5",
+    "plumpy~=0.15.0",
     "pgsu~=0.1.0",
     "psutil~=5.6",
     "psycopg2-binary~=2.8,>=2.8.3",

--- a/tests/engine/test_futures.py
+++ b/tests/engine/test_futures.py
@@ -30,7 +30,7 @@ class TestWf(AiidaTestCase):
         process = test_processes.DummyProcess()
 
         # No polling
-        future = processes.futures.CalculationFuture(
+        future = processes.futures.ProcessFuture(
             pk=process.pid, poll_interval=None, communicator=manager.get_communicator()
         )
 
@@ -46,7 +46,7 @@ class TestWf(AiidaTestCase):
         process = test_processes.DummyProcess()
 
         # No communicator
-        future = processes.futures.CalculationFuture(pk=process.pid, loop=runner.loop, poll_interval=0)
+        future = processes.futures.ProcessFuture(pk=process.pid, loop=runner.loop, poll_interval=0)
 
         runner.run(process)
         calc_node = runner.run_until_complete(gen.with_timeout(self.TIMEOUT, future))

--- a/tests/engine/test_rmq.py
+++ b/tests/engine/test_rmq.py
@@ -45,7 +45,7 @@ class TestProcessControl(AiidaTestCase):
         @gen.coroutine
         def do_submit():
             calc_node = submit(test_processes.DummyProcess)
-            yield self.wait_for_calc(calc_node)
+            yield self.wait_for_process(calc_node)
 
             self.assertTrue(calc_node.is_finished_ok)
             self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.FINISHED.value)
@@ -61,7 +61,7 @@ class TestProcessControl(AiidaTestCase):
             term_b = Int(10)
 
             calc_node = submit(test_processes.AddProcess, a=term_a, b=term_b)
-            yield self.wait_for_calc(calc_node)
+            yield self.wait_for_process(calc_node)
             self.assertTrue(calc_node.is_finished_ok)
             self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.FINISHED.value)
 
@@ -77,7 +77,7 @@ class TestProcessControl(AiidaTestCase):
         @gen.coroutine
         def do_exception():
             calc_node = submit(test_processes.ExceptionProcess)
-            yield self.wait_for_calc(calc_node)
+            yield self.wait_for_process(calc_node)
 
             self.assertFalse(calc_node.is_finished_ok)
             self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.EXCEPTED.value)
@@ -147,15 +147,15 @@ class TestProcessControl(AiidaTestCase):
             result = yield self.wait_future(future)
             self.assertTrue(result)
 
-            self.wait_for_calc(calc_node)
+            self.wait_for_process(calc_node)
             self.assertTrue(calc_node.is_killed)
             self.assertEqual(calc_node.process_status, kill_message)
 
         self.runner.loop.run_sync(do_kill)
 
     @gen.coroutine
-    def wait_for_calc(self, calc_node, timeout=2.):
-        future = self.runner.get_calculation_future(calc_node.pk)
+    def wait_for_process(self, calc_node, timeout=2.):
+        future = self.runner.get_process_future(calc_node.pk)
         raise gen.Return((yield with_timeout(future, timeout)))
 
     @staticmethod

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -11,7 +11,6 @@ import inspect
 import unittest
 
 import plumpy
-import plumpy.test_utils
 import pytest
 from tornado import gen
 
@@ -758,12 +757,6 @@ class TestWorkchain(AiidaTestCase):
                 test_case.assertEqual(self.ctx.result_b.outputs.result, val)
 
         run_and_check_success(Workchain)
-
-    def test_persisting(self):
-        persister = plumpy.test_utils.TestPersister()
-        runner = get_manager().get_runner()
-        workchain = Wf(runner=runner)
-        launch.run(workchain)
 
     def test_namespace_nondb_mapping(self):
         """


### PR DESCRIPTION
Fixes #4151

When a `WorkChain` step submits sub processes, awaitables will be
created for them. Only when these awaitables have been resolved, meaning
the subprocesses, have terminated, can the workchain continue to the
next step.

The original concept was, for each awaitable, to schedule a callback
once the process had reached a terminal state. The callback was supposed
to be triggered by having the runner add a broadcast subscriber that would
listen for state changes of the sub process. As a fail-safe, a polling
mechanism would also check periodically just in case the broadcast
message would be missed and prevent the caller from waiting indefinitely.

However, the broadcast subscriber was never added and so the system
relied solely on the polling mechanism. This completely undermines the
benefits of having an event-based mechanism, so in this commit the
`Runner.call_on_process_finish` now also registers the broadcast
subscriber.

Note that the affected code had some references to `calculation` which
has been generalized to `process`, since this also applies to workflows
that might waited upon. The `CalculationFuture` has been renamed to
`ProcessFuture` in similar vein. It is currently not used, but it could
have been used for the problem that this commit solves, so it has been
decided to leave it in for now and not remove it entirely.