### PR TITLE
Fix bug in `BaseRestartWorkChain.inspect_process`

### DIFF
--- a/aiida/engine/processes/workchains/restart.py
+++ b/aiida/engine/processes/workchains/restart.py
@@ -255,7 +255,7 @@ class BaseRestartWorkChain(WorkChain):
 
             self.report(template.format(*report_args))
 
-            return report.exit_code
+            return last_report.exit_code
 
         # Otherwise the process was successful and no handler returned anything so we consider the work done
         self.ctx.is_finished = True


### PR DESCRIPTION
Fixes #4165 

If at the end of the method, `last_report` is defined, meaning at least
one handler returned a report, it should return the corresponding exit
code, except it was erroneously accessing that of the `report` variable,
which could very well be `None` if the last called handler returned
nothing.