### PR TITLE
Raise when calling `Node.objects.delete` for node with incoming links

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -56,7 +56,7 @@ class Node(Entity, metaclass=AbstractNodeMeta):
     # pylint: disable=too-many-public-methods
 
     class Collection(EntityCollection):
-        """The collection of AuthInfo entries."""
+        """The collection of nodes."""
 
         def delete(self, node_id):
             """Delete a `Node` from the collection with the given id
@@ -68,8 +68,15 @@ class Node(Entity, metaclass=AbstractNodeMeta):
             if not node.is_stored:
                 return
 
+            if node.get_incoming().all():
+                raise exceptions.InvalidOperation(
+                    'cannot delete Node<{}> because it has incoming links'.format(node.pk)
+                )
+
             if node.get_outgoing().all():
-                raise exceptions.InvalidOperation('cannot delete Node<{}> because it has output links'.format(node.pk))
+                raise exceptions.InvalidOperation(
+                    'cannot delete Node<{}> because it has outgoing links'.format(node.pk)
+                )
 
             repository = node._repository  # pylint: disable=protected-access
             self._backend.nodes.delete(node_id)


### PR DESCRIPTION
Fixes #4167 

This guard was already in place for a node that has outgoing links but
if a node had only incoming links, the method would happily delete it.
This means that one could delete output nodes for example as long as
they had not been used as inputs. Note also that this would leave the
link in place as the deletion is not cascaded automatically.

Deletion through the objects collection currently cannot deal with
automated cascading rules on links and nodes. These rules are
implemented in the ORM itself through the graph traversal rules for
deletion. Nodes that are not isolated should therefore only be deleted
through the utility function that makes sure to leave the resulting
provenance graph in a coherent state.