### PR TITLE
Fix bug in `TrajectoryData.get_step_data`

### DIFF
--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -351,9 +351,9 @@ class TrajectoryData(ArrayData):
         time = self.get_times()
         if time is not None:
             time = time[index]
-        cells = self.get_cells()
-        if cells is not None:
-            cell = cells[index, :, :]
+        cell = self.get_cells()
+        if cell is not None:
+            cell = cell[index, :, :]
         return (self.get_stepids()[index], time, cell, self.symbols, self.get_positions()[index, :, :], vel)
 
     def get_step_structure(self, index, custom_kinds=None):

--- a/aiida/tools/data/array/trajectory.py
+++ b/aiida/tools/data/array/trajectory.py
@@ -15,9 +15,11 @@ from aiida.engine import calcfunction
 @calcfunction
 def _get_aiida_structure_inline(trajectory, parameters):
     """
-    Creates :py:class:`aiida.orm.nodes.data.structure.StructureData` using ASE.
+    CalcFunction to extract a :py:class:`aiida.orm.nodes.data.structure.StructureData`
+    from a `TrajectoryData`.
 
-    .. note:: requires ASE module.
+    :param parameters: A dictionary whose key-value pairs are passed as
+        additional kwargs to the :py:meth:``TrajectoryData.get_step_structure`` method.
     """
     kwargs = {}
     if parameters is not None:

--- a/tests/orm/data/test_trajectory.py
+++ b/tests/orm/data/test_trajectory.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the `TrajectoryData` class."""
+
+import numpy as np
+import pytest
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm import TrajectoryData, StructureData
+
+
+class TestTrajectoryData(AiidaTestCase):
+    """Test for the `TrajectoryData` class."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super().setUpClass(*args, **kwargs)
+        cls.symbols = ['H'] * 5 + ['Cl'] * 5
+        cls.stepids = np.arange(1000, 3000, 10)
+        cls.times = cls.stepids * 0.01
+        cls.positions = np.arange(6000, dtype=float).reshape((200, 10, 3))
+        cls.velocities = -np.arange(6000, dtype=float).reshape((200, 10, 3))
+        cls.cells = np.array([[[3., 0.1, 0.3], [-0.05, 3., -0.2], [0.02, -0.08, 3.]]] * 200
+                            ) + np.arange(0, 0.2, 0.001)[:, np.newaxis, np.newaxis]
+
+    def test_trajectory_get_index_from_stepid(self):
+        """Test the `get_index_from_stepid` method."""
+        traj = TrajectoryData()
+        traj.set_trajectory(
+            symbols=self.symbols,
+            positions=self.positions,
+            stepids=self.stepids,
+            cells=self.cells,
+            times=self.times,
+            velocities=self.velocities
+        )
+
+        index = traj.get_index_from_stepid(1050)
+        self.assertEqual(index, 5)
+
+        with pytest.raises(ValueError):
+            index = traj.get_index_from_stepid(2333)
+
+    def test_trajectory_get_step_data(self):
+        """Test the `get_step_data` method."""
+        traj = TrajectoryData()
+        traj.set_trajectory(
+            symbols=self.symbols,
+            positions=self.positions,
+            stepids=self.stepids,
+            cells=self.cells,
+            times=self.times,
+            velocities=self.velocities
+        )
+
+        stepid, time, cell, symbols, positions, velocities = traj.get_step_data(-2)
+        self.assertEqual(stepid, self.stepids[-2])
+        self.assertEqual(time, self.times[-2])
+        self.assertListEqual(cell.tolist(), self.cells[-2, :, :].tolist())
+        self.assertListEqual(symbols, self.symbols)
+        self.assertListEqual(positions.tolist(), self.positions[-2, :, :].tolist())
+        self.assertListEqual(velocities.tolist(), self.velocities[-2, :, :].tolist())
+
+    def test_trajectory_get_step_data_empty(self):
+        """Test the `get_step_data` method when some arrays are not defined."""
+        traj = TrajectoryData()
+        traj.set_trajectory(symbols=self.symbols, positions=self.positions)
+
+        stepid, time, cell, symbols, positions, velocities = traj.get_step_data(3)
+        self.assertEqual(stepid, 3)
+        self.assertEqual(time, None)
+        self.assertEqual(cell, None)
+        self.assertListEqual(symbols, self.symbols)
+        self.assertListEqual(positions.tolist(), self.positions[3, :, :].tolist())
+        self.assertEqual(velocities, None)
+
+    def test_trajectory_get_step_structure(self):
+        """Test the `get_step_structure` method."""
+        traj = TrajectoryData()
+        traj.set_trajectory(
+            symbols=self.symbols,
+            positions=self.positions,
+            stepids=self.stepids,
+            cells=self.cells,
+            times=self.times,
+            velocities=self.velocities
+        )
+
+        structure = traj.get_step_structure(50)
+        # is there a better way to compare StructureData nodes?
+        self.assertIsInstance(structure, StructureData)
+        self.assertListEqual(structure.cell, self.cells[50, :, :].tolist())
+        for site, kind, pos in zip(structure.sites, self.symbols, self.positions[50, :, :]):
+            # note: this may depend on the ordering of the sites
+            self.assertEqual(site.kind_name, kind)
+            self.assertListEqual(list(site.position), pos.tolist())
+
+        with pytest.raises(IndexError):
+            structure = traj.get_step_structure(500)


### PR DESCRIPTION
Fixes #4170 

If a `TrajectoryData` does not contain an array `cells` the
`get_step_data` method should define and return `cell = None`.
There was a typo that caused an error in this case.