### PR TITLE
remove readthedocs-sphinx-search

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -41,7 +41,6 @@ python-dateutil~=2.8
 python-memcached~=1.59
 pytz~=2019.3
 pyyaml~=5.1.2
-readthedocs-sphinx-search==0.1.0rc1
 reentry~=1.3
 seekpath>=1.9.3,~=1.9
 simplejson~=3.16

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,8 +50,6 @@ extensions = [
     'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.todo', 'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive', 'aiida.sphinxext', 'sphinx_panels', 'sphinx_copybutton'
 ]
-if ON_RTD:
-    extensions.append('sphinx_search.extension')
 ipython_mplbackend = ''
 copybutton_selector = 'div:not(.no-copy)>div.highlight pre'
 copybutton_prompt_text = '$ '

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -128,9 +128,6 @@ def _generate_rtd_requirement_set():
     for key in ('testing', 'docs', 'rest', 'atomic_tools'):
         install_requirements.update({Requirement.parse(r) for r in setup_cfg['extras_require'][key]})
 
-    # add requirement for "search as you type"
-    install_requirements.update({Requirement.parse('readthedocs-sphinx-search==0.1.0rc1')})
-
     return install_requirements
 
 


### PR DESCRIPTION
There seem to be unresolved UX issues, at least with the pydata sphinx theme
we are now using.
We may consider reintroducing the extension once these have been
resolved.