### PR TITLE
`NodeTranslator`: do not assume `get_export_formats` exists

### DIFF
--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -416,17 +416,14 @@ class NodeTranslator(BaseTranslator):
             for name in get_entry_point_names(entry_point_group):
                 try:
                     node_cls = load_entry_point(entry_point_group, name)
-                except LoadingEntryPointError:
-                    pass
-                else:
-                    node_cls.get_export_formats()
-                try:
                     available_formats = node_cls.get_export_formats()
-                    if available_formats:
-                        full_type = construct_full_type(node_cls.class_node_type, '')
-                        all_formats[full_type] = available_formats
-                except AttributeError:
-                    pass
+                except (AttributeError, LoadingEntryPointError):
+                    continue
+
+                if available_formats:
+                    full_type = construct_full_type(node_cls.class_node_type, '')
+                    all_formats[full_type] = available_formats
+
         return all_formats
 
     @staticmethod

--- a/tests/restapi/test_translator.py
+++ b/tests/restapi/test_translator.py
@@ -1,0 +1,15 @@
+"""Tests for the `aiida.restapi.translator` module."""
+# pylint: disable=invalid-name
+from aiida.restapi.translator.nodes.node import NodeTranslator
+from aiida.orm import Data
+
+
+def test_get_all_download_formats():
+    """Test the `get_all_download_formats` method."""
+    NodeTranslator.get_all_download_formats()
+
+
+def test_get_all_download_formats_missing_get_export_formats(monkeypatch):
+    """Test `get_all_download_formats` does not except if a `Data` class does not implement `get_export_formats`."""
+    monkeypatch.delattr(Data, 'get_export_formats')
+    NodeTranslator.get_all_download_formats()


### PR DESCRIPTION
Fixes #4185 

The `get_all_download_formats` will try to call `get_export_formats` on
all the known plugin types. However, it is not guaranteed that all
plugins implement this method. This was properly considered in the case
that `full_type` is not None, however, in the other case the
`AttributeError` was not being caught causing the REST API to except.