### PR TITLE
Process on finish call without using LoopCommunicator

### DIFF
--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -270,7 +270,7 @@ class WorkChain(Process):
         """
         for awaitable in self._awaitables:
             if awaitable.target == AwaitableTarget.PROCESS:
-                callback = functools.partial(self._run_task, self.on_process_finished, awaitable)
+                callback = functools.partial(self.call_soon, self.on_process_finished, awaitable)
                 self.runner.call_on_process_finish(awaitable.pk, callback)
             else:
                 assert "invalid awaitable target '{}'".format(awaitable.target)

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -314,7 +314,10 @@ class Manager:
             loader=persistence.get_object_loader()
         )
 
-        runner.communicator.add_task_subscriber(task_receiver)
+        def callback(*args, **kwargs):
+            return plumpy.create_task(functools.partial(task_receiver, *args, **kwargs), loop=runner_loop)
+
+        runner.communicator.add_task_subscriber(callback)
 
         return runner
 

--- a/tests/engine/test_futures.py
+++ b/tests/engine/test_futures.py
@@ -31,7 +31,7 @@ class TestWf(AiidaTestCase):
 
         # No polling
         future = processes.futures.ProcessFuture(
-            pk=process.pid, poll_interval=None, communicator=manager.get_communicator()
+            pk=process.pid, loop=runner.loop, poll_interval=None, communicator=manager.get_communicator()
         )
 
         run(process)


### PR DESCRIPTION
In PR #4154, the LoopCommunicator was used as the runner's communicator.
This makes it easy to schecule callbacks into the correct event loops,
however, the `Process` has its own mechanism to do this. In object
method `_schedule_rpc` process schedule the callback into its event
loop. Using `LoopCommunitor` lead to a problem that when controller send
the controlling message by rpc for example when calling
`controller.pause_process` the `pause` subscriber is run by
`plumpy.futures.create_task`, which is not necessary. 
I didn't find using `LoopCommunicator` cause any exceptions, however, it is not expected in design correctly? Therefore, I propose to conservatively not use `LoopCommunicator` as communicator one for all in `runner`. 

`call_on_process_finish` receive a callback which not expected to be a
coroutine (otherwise it is supposed to be wait there and `inline_callback` also should be a coroutine. Through, this not cause problem for `tornado`.), however, in `action_awaitables` we schedule `_run_task` which
is a corotinefunction to it. The `call_soon` method of Process object is
more proper here.