### PR TITLE
`CalcJob`: move job resource validation to the `Scheduler` class

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -59,7 +59,8 @@ disable=bad-continuation,
     no-else-raise,
     import-outside-toplevel,
     cyclic-import,
-    duplicate-code
+    duplicate-code,
+    too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -81,15 +81,8 @@ def validate_calc_job(inputs, ctx):  # pylint: disable=inconsistent-return-state
     except KeyError:
         return 'input `metadata.options.resources` is required but is not specified'
 
-    default_mpiprocs_per_machine = computer.get_default_mpiprocs_per_machine()
-    num_mpiprocs_per_machine = resources.get('num_mpiprocs_per_machine', None)
-    tot_num_mpiprocs = resources.get('tot_num_mpiprocs', None)
-    if num_mpiprocs_per_machine is None and tot_num_mpiprocs is None and default_mpiprocs_per_machine is not None:
-        # Only set the default value if tot_num_mpiprocs is not provided. Otherwise, it means that the user provided
-        # both `num_machines` and `tot_num_mpiprocs`, and we have to ignore the `num_mpiprocs_per_machine` default.
-        resources['num_mpiprocs_per_machine'] = default_mpiprocs_per_machine
-
     try:
+        scheduler.preprocess_resources(resources, computer.get_default_mpiprocs_per_machine())
         scheduler.validate_resources(**resources)
     except (ValueError, TypeError) as exception:
         return 'input `metadata.options.resources` is not valid for the {} scheduler: {}'.format(scheduler, exception)
@@ -405,13 +398,7 @@ class CalcJob(Process):
 
         # Set resources, also with get_default_mpiprocs_per_machine
         resources = self.node.get_option('resources')
-        default_mpiprocs_per_machine = computer.get_default_mpiprocs_per_machine()
-        num_mpiprocs_per_machine = resources.get('num_mpiprocs_per_machine', None)
-        tot_num_mpiprocs = resources.get('tot_num_mpiprocs', None)
-        if num_mpiprocs_per_machine is None and tot_num_mpiprocs is None and default_mpiprocs_per_machine is not None:
-            # Only set the default value if tot_num_mpiprocs is not provided. Otherwise, it means that the user provided
-            # both `num_machines` and `tot_num_mpiprocs`, and we have to ignore the `num_mpiprocs_per_machine` default.
-            resources['num_mpiprocs_per_machine'] = default_mpiprocs_per_machine
+        scheduler.preprocess_resources(resources, computer.get_default_mpiprocs_per_machine())
         job_tmpl.job_resource = scheduler.create_job_resource(**resources)
 
         subst_dict = {'tot_num_mpiprocs': job_tmpl.job_resource.get_tot_num_mpiprocs()}

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -7,16 +7,15 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-This module defines the main data structures used by the Scheduler.
+"""Data structures used by `Scheduler` instances.
 
 In particular, there is the definition of possible job states (job_states),
 the data structure to be filled for job submission (JobTemplate), and
 the data structure that is returned when querying for jobs in the scheduler
 (JobInfo).
 """
-from abc import abstractclassmethod
-from enum import Enum
+import abc
+import enum
 
 from aiida.common import AIIDA_LOGGER
 from aiida.common.extendeddicts import AttributeDict, DefaultFieldsAttributeDict
@@ -28,7 +27,7 @@ __all__ = (
 )
 
 
-class JobState(Enum):
+class JobState(enum.Enum):
     """Enumeration of possible scheduler states of a CalcJob.
 
     There is no FAILED state as every completed job is put in DONE, regardless of success.
@@ -42,14 +41,11 @@ class JobState(Enum):
     DONE = 'done'
 
 
-class JobResource(DefaultFieldsAttributeDict):
-    """
-    A class to store the job resources. It must be inherited and redefined by the specific
-    plugin, that should contain a ``_job_resource_class`` attribute pointing to the correct
-    JobResource subclass.
+class JobResource(DefaultFieldsAttributeDict, metaclass=abc.ABCMeta):
+    """Data structure to store job resources.
 
-    It should at least define the get_tot_num_mpiprocs() method, plus an __init__ to accept
-    its set of variables.
+    Each `Scheduler` implementation must define the `_job_resource_class` attribute to be a subclass of this class.
+    It should at least define the `get_tot_num_mpiprocs` method, plus a constructor to accept its set of variables.
 
     Typical attributes are:
 
@@ -61,12 +57,12 @@ class JobResource(DefaultFieldsAttributeDict):
     * ``tot_num_mpiprocs``
     * ``parallel_env``
 
-    The __init__ should take care of checking the values.
+    The constructor should take care of checking the values.
     The init should raise only ValueError or TypeError on invalid parameters.
     """
     _default_fields = tuple()
 
-    @abstractclassmethod
+    @abc.abstractclassmethod
     def validate_resources(cls, **kwargs):
         """Validate the resources against the job resource class of this scheduler.
 
@@ -76,34 +72,22 @@ class JobResource(DefaultFieldsAttributeDict):
         """
 
     @classmethod
-    def accepts_default_mpiprocs_per_machine(cls):
-        """
-        Return True if this JobResource accepts a 'default_mpiprocs_per_machine'
-        key, False otherwise.
-
-        Should be implemented in each subclass.
-        """
-        raise NotImplementedError
-
-    @classmethod
     def get_valid_keys(cls):
-        """
-        Return a list of valid keys to be passed to the __init__
-        """
+        """Return a list of valid keys to be passed to the constructor."""
         return list(cls._default_fields)
 
+    @abc.abstractclassmethod
+    def accepts_default_mpiprocs_per_machine(cls):
+        """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
+
+    @abc.abstractmethod
     def get_tot_num_mpiprocs(self):
-        """
-        Return the total number of cpus of this job resource.
-        """
-        raise NotImplementedError
+        """Return the total number of cpus of this job resource."""
 
 
 class NodeNumberJobResource(JobResource):
-    """
-    An implementation of JobResource for schedulers that support
-    the specification of a number of nodes and a number of cpus per node
-    """
+    """`JobResource` for schedulers that support the specification of a number of nodes and cpus per node."""
+
     _default_fields = (
         'num_machines',
         'num_mpiprocs_per_machine',
@@ -112,162 +96,86 @@ class NodeNumberJobResource(JobResource):
     )
 
     @classmethod
-    def validate_resources(cls, **kwargs):  # pylint: disable=too-many-branches,too-many-statements
+    def validate_resources(cls, **kwargs):
         """Validate the resources against the job resource class of this scheduler.
 
         :param kwargs: dictionary of values to define the job resources
+        :return: attribute dictionary with the parsed parameters populated
         :raises ValueError: if the resources are invalid or incomplete
-        :return: tuple (num_machines, num_mpiprocs_per_machine, num_cores_per_machine, num_cores_per_mpiproc)
         """
-        params = AttributeDict()
+        resources = AttributeDict()
 
-        try:
-            num_machines = int(kwargs.pop('num_machines'))
-        except KeyError:
-            num_machines = None
-        except ValueError:
-            raise ValueError('num_machines must an integer')
+        def is_greater_equal_one(parameter):
+            value = getattr(resources, parameter, None)
+            if value is not None and value < 1:
+                raise ValueError('`{}` must be greater than or equal to one.'.format(parameter))
 
-        try:
-            default_mpiprocs_per_machine = kwargs.pop('default_mpiprocs_per_machine')
-            if default_mpiprocs_per_machine is not None:
-                default_mpiprocs_per_machine = int(default_mpiprocs_per_machine)
-        except KeyError:
-            default_mpiprocs_per_machine = None
-        except ValueError:
-            raise ValueError('default_mpiprocs_per_machine must an integer')
-
-        try:
-            num_mpiprocs_per_machine = int(kwargs.pop('num_mpiprocs_per_machine'))
-        except KeyError:
-            num_mpiprocs_per_machine = None
-        except ValueError:
-            raise ValueError('num_mpiprocs_per_machine must an integer')
-
-        try:
-            tot_num_mpiprocs = int(kwargs.pop('tot_num_mpiprocs'))
-        except KeyError:
-            tot_num_mpiprocs = None
-        except ValueError:
-            raise ValueError('tot_num_mpiprocs must an integer')
-
-        try:
-            params.num_cores_per_machine = int(kwargs.pop('num_cores_per_machine'))
-        except KeyError:
-            params.num_cores_per_machine = None
-        except ValueError:
-            raise ValueError('num_cores_per_machine must an integer')
-
-        try:
-            params.num_cores_per_mpiproc = int(kwargs.pop('num_cores_per_mpiproc'))
-        except KeyError:
-            params.num_cores_per_mpiproc = None
-        except ValueError:
-            raise ValueError('num_cores_per_mpiproc must an integer')
+        # Validate that all fields are valid integers if they are specified, otherwise initialize them to `None`
+        for parameter in list(cls._default_fields) + ['tot_num_mpiprocs']:
+            try:
+                setattr(resources, parameter, int(kwargs.pop(parameter)))
+            except KeyError:
+                setattr(resources, parameter, None)
+            except ValueError:
+                raise ValueError('`{}` must be an integer when specified'.format(parameter))
 
         if kwargs:
-            raise TypeError(
-                'The following parameters were not recognized for '
-                'the JobResource: {}'.format(kwargs.keys())
+            raise ValueError('these parameters are not recognized: {}'.format(kwargs.keys()))
+
+        # At least two of the following parameters need to be defined as non-zero
+        if [resources.num_machines, resources.num_mpiprocs_per_machine, resources.tot_num_mpiprocs].count(None) > 1:
+            raise ValueError(
+                'At least two among `num_machines`, `num_mpiprocs_per_machine` or `tot_num_mpiprocs` must be specified.'
             )
 
-        if num_machines is None:
-            # Use default value, if not provided
-            if num_mpiprocs_per_machine is None:
-                num_mpiprocs_per_machine = default_mpiprocs_per_machine
+        for parameter in ['num_machines', 'num_mpiprocs_per_machine']:
+            is_greater_equal_one(parameter)
 
-            if num_mpiprocs_per_machine is None or tot_num_mpiprocs is None:
-                raise TypeError(
-                    'At least two among num_machines, '
-                    'num_mpiprocs_per_machine or tot_num_mpiprocs must be specified'
-                )
-            else:
-                # To avoid divisions by zero
-                if num_mpiprocs_per_machine <= 0:
-                    raise ValueError('num_mpiprocs_per_machine must be >= 1')
-                num_machines = tot_num_mpiprocs // num_mpiprocs_per_machine
-        else:
-            if tot_num_mpiprocs is None:
-                # Only set the default value if tot_num_mpiprocs is not provided.
-                # Otherwise, it means that the user provided both
-                # num_machines and tot_num_mpiprocs, and we have to ignore
-                # the default value of tot_num_mpiprocs
-                if num_mpiprocs_per_machine is None:
-                    num_mpiprocs_per_machine = default_mpiprocs_per_machine
+        # Here we now that at least two of the three required variables are defined and greater equal than one.
+        if resources.num_machines is None:
+            resources.num_machines = resources.tot_num_mpiprocs // resources.num_mpiprocs_per_machine
+        elif resources.num_mpiprocs_per_machine is None:
+            resources.num_mpiprocs_per_machine = resources.tot_num_mpiprocs // resources.num_machines
+        elif resources.tot_num_mpiprocs is None:
+            resources.tot_num_mpiprocs = resources.num_mpiprocs_per_machine * resources.num_machines
 
-            if num_mpiprocs_per_machine is None:
-                if tot_num_mpiprocs is None:
-                    raise TypeError(
-                        'At least two among num_machines, '
-                        'num_mpiprocs_per_machine or tot_num_mpiprocs must be specified'
-                    )
-                else:
-                    # To avoid divisions by zero
-                    if num_machines <= 0:
-                        raise ValueError('num_machines must be >= 1')
-                    num_mpiprocs_per_machine = tot_num_mpiprocs // num_machines
+        if resources.tot_num_mpiprocs != resources.num_mpiprocs_per_machine * resources.num_machines:
+            raise ValueError('`tot_num_mpiprocs` is not equal to `num_mpiprocs_per_machine * num_machines`.')
 
-        params.num_machines = num_machines
-        params.num_mpiprocs_per_machine = num_mpiprocs_per_machine
+        is_greater_equal_one('num_mpiprocs_per_machine')
+        is_greater_equal_one('num_machines')
 
-        if tot_num_mpiprocs is not None:
-            if tot_num_mpiprocs != params.num_mpiprocs_per_machine * params.num_machines:
-                raise ValueError(
-                    'tot_num_mpiprocs must be equal to '
-                    'num_mpiprocs_per_machine * num_machines, and in particular it '
-                    'should be a multiple of num_mpiprocs_per_machine and/or '
-                    'num_machines'
-                )
-
-        if params.num_mpiprocs_per_machine <= 0:
-            raise ValueError('num_mpiprocs_per_machine must be >= 1')
-        if params.num_machines <= 0:
-            raise ValueError('num_machine must be >= 1')
-
-        return params.num_machines, params.num_mpiprocs_per_machine, \
-            params.num_cores_per_machine, params.num_cores_per_mpiproc
+        return resources
 
     def __init__(self, **kwargs):
         """Initialize the job resources from the passed arguments.
 
         :raises ValueError: if the resources are invalid or incomplete
         """
-        super().__init__()
         resources = self.validate_resources(**kwargs)
-        self.num_machines, self.num_mpiprocs_per_machine, \
-        self.num_cores_per_machine, self.num_cores_per_mpiproc = resources
+        super().__init__(resources)
 
     @classmethod
     def get_valid_keys(cls):
-        """
-        Return a list of valid keys to be passed to the __init__
-        """
-        return super().get_valid_keys() + ['tot_num_mpiprocs', 'default_mpiprocs_per_machine']
+        """Return a list of valid keys to be passed to the constructor."""
+        return super().get_valid_keys() + ['tot_num_mpiprocs']
 
     @classmethod
     def accepts_default_mpiprocs_per_machine(cls):
-        """
-        Return True if this JobResource accepts a 'default_mpiprocs_per_machine'
-        key, False otherwise.
-        """
+        """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
         return True
 
     def get_tot_num_mpiprocs(self):
-        """
-        Return the total number of cpus of this job resource.
-        """
+        """Return the total number of cpus of this job resource."""
         return self.num_machines * self.num_mpiprocs_per_machine
 
 
 class ParEnvJobResource(JobResource):
-    """
-    An implementation of JobResource for schedulers that support
-    the specification of a parallel environment (a string) + the total number of nodes
-    """
+    """`JobResource` for schedulers that support the specification of a parallel environment and number of MPI procs."""
+
     _default_fields = (
         'parallel_env',
         'tot_num_mpiprocs',
-        'default_mpiprocs_per_machine',
     )
 
     @classmethod
@@ -275,23 +183,31 @@ class ParEnvJobResource(JobResource):
         """Validate the resources against the job resource class of this scheduler.
 
         :param kwargs: dictionary of values to define the job resources
+        :return: attribute dictionary with the parsed parameters populated
         :raises ValueError: if the resources are invalid or incomplete
         """
-        try:
-            str(kwargs.pop('parallel_env'))
-        except (KeyError, TypeError, ValueError):
-            raise ValueError('`parallel_env` must be specified and must be a string')
+        resources = AttributeDict()
 
         try:
-            tot_num_mpiprocs = int(kwargs.pop('tot_num_mpiprocs'))
+            resources.parallel_env = kwargs.pop('parallel_env')
+        except KeyError:
+            raise ValueError('`parallel_env` must be specified and must be a string')
+        else:
+            if not isinstance(resources.parallel_env, str):
+                raise ValueError('`parallel_env` must be specified and must be a string')
+
+        try:
+            resources.tot_num_mpiprocs = int(kwargs.pop('tot_num_mpiprocs'))
         except (KeyError, ValueError):
             raise ValueError('`tot_num_mpiprocs` must be specified and must be an integer')
 
-        if tot_num_mpiprocs <= 0:
-            raise ValueError('`tot_num_mpiprocs` must be greater or equal than one.')
+        if resources.tot_num_mpiprocs < 1:
+            raise ValueError('`tot_num_mpiprocs` must be greater than or equal to one.')
 
-        if kwargs.pop('default_mpiprocs_per_machine', None) is not None:
-            raise ValueError('`default_mpiprocs_per_machine` cannot be set for schedulers that use `ParEnvJobResource`')
+        if kwargs:
+            raise ValueError('these parameters were not recognized: {}'.format(kwargs.keys()))
+
+        return resources
 
     def __init__(self, **kwargs):
         """
@@ -300,33 +216,25 @@ class ParEnvJobResource(JobResource):
 
         :raises ValueError: if the resources are invalid or incomplete
         """
-        super().__init__()
-        self.validate_resources(**kwargs)
-        self.parallel_env = kwargs['parallel_env']
-        self.tot_num_mpiprocs = kwargs['tot_num_mpiprocs']
-
-    def get_tot_num_mpiprocs(self):
-        """
-        Return the total number of cpus of this job resource.
-        """
-        return self.tot_num_mpiprocs
+        resources = self.validate_resources(**kwargs)
+        super().__init__(resources)
 
     @classmethod
     def accepts_default_mpiprocs_per_machine(cls):
-        """
-        Return True if this JobResource accepts a 'default_mpiprocs_per_machine'
-        key, False otherwise.
-        """
+        """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
         return False
+
+    def get_tot_num_mpiprocs(self):
+        """Return the total number of cpus of this job resource."""
+        return self.tot_num_mpiprocs
 
 
 class JobTemplate(DefaultFieldsAttributeDict):  # pylint: disable=too-many-instance-attributes
-    """
-    A template for submitting jobs. This contains all required information
-    to create the job header.
+    """A template for submitting jobs to a scheduler.
 
-    The required fields are: working_directory, job_name, num_machines,
-      num_mpiprocs_per_machine, argv.
+    This contains all required information to create the job header.
+
+    The required fields are: working_directory, job_name, num_machines, num_mpiprocs_per_machine, argv.
 
     Fields:
 

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -120,7 +120,7 @@ class NodeNumberJobResource(JobResource):
                 raise ValueError('`{}` must be an integer when specified'.format(parameter))
 
         if kwargs:
-            raise ValueError('these parameters are not recognized: {}'.format(kwargs.keys()))
+            raise ValueError('these parameters were not recognized: {}'.format(', '.join(list(kwargs.keys()))))
 
         # At least two of the following parameters need to be defined as non-zero
         if [resources.num_machines, resources.num_mpiprocs_per_machine, resources.tot_num_mpiprocs].count(None) > 1:
@@ -205,7 +205,7 @@ class ParEnvJobResource(JobResource):
             raise ValueError('`tot_num_mpiprocs` must be greater than or equal to one.')
 
         if kwargs:
-            raise ValueError('these parameters were not recognized: {}'.format(kwargs.keys()))
+            raise ValueError('these parameters were not recognized: {}'.format(', '.join(list(kwargs.keys()))))
 
         return resources
 

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -64,47 +64,37 @@ _MAP_STATUS_PBS_COMMON = {
 
 
 class PbsJobResource(NodeNumberJobResource):
-    """
-    Base class for PBS job resources
-    """
+    """Class for PBS job resources."""
 
-    def __init__(self, **kwargs):
+    @classmethod
+    def validate_resources(cls, **kwargs):
+        """Validate the resources against the job resource class of this scheduler.
+
+        This extends the base class validator and calculates the `num_cores_per_machine` fields to pass to PBSlike
+        schedulers. Checks that `num_cores_per_machine` is a multiple of `num_cores_per_mpiproc` and/or
+        `num_mpiprocs_per_machine`.
+
+        :param kwargs: dictionary of values to define the job resources
+        :return: attribute dictionary with the parsed parameters populated
+        :raises ValueError: if the resources are invalid or incomplete
         """
-        It extends the base class init method and calculates the
-        num_cores_per_machine fields to pass to PBSlike schedulers.
+        resources = super().validate_resources(**kwargs)
 
-        Checks that num_cores_per_machine is a multiple of
-        num_cores_per_mpiproc and/or num_mpiprocs_per_machine
+        if resources.num_cores_per_machine is not None and resources.num_cores_per_mpiproc is not None:
+            if resources.num_cores_per_machine != resources.num_cores_per_mpiproc * resources.num_mpiprocs_per_machine:
+                raise ValueError(
+                    '`num_cores_per_machine` must be equal to `num_cores_per_mpiproc * num_mpiprocs_per_machine` and in'
+                    ' particular it should be a multiple of `num_cores_per_mpiproc` and/or `num_mpiprocs_per_machine`'
+                )
 
-        Check sequence
+        elif resources.num_cores_per_mpiproc is not None:
+            if resources.num_cores_per_mpiproc < 1:
+                raise ValueError('num_cores_per_mpiproc must be greater than or equal to one.')
 
-        1. If num_cores_per_mpiproc and num_cores_per_machine both are
-           specified check whether it satisfies the check
-        2. If only num_cores_per_mpiproc is passed, calculate
-           num_cores_per_machine
-        3. If only num_cores_per_machine is passed, use it
-        """
-        super().__init__(**kwargs)
+            # In this plugin we never used num_cores_per_mpiproc so if it is not defined it is OK.
+            resources.num_cores_per_machine = (resources.num_cores_per_mpiproc * resources.num_mpiprocs_per_machine)
 
-        value_error = (
-            'num_cores_per_machine must be equal to '
-            'num_cores_per_mpiproc * num_mpiprocs_per_machine, '
-            'and in perticular it should be a multiple of '
-            'num_cores_per_mpiproc and/or num_mpiprocs_per_machine'
-        )
-
-        if self.num_cores_per_machine is not None and self.num_cores_per_mpiproc is not None:
-            if self.num_cores_per_machine != (self.num_cores_per_mpiproc * self.num_mpiprocs_per_machine):
-                # If user specify both values, check if specified
-                # values are correct
-                raise ValueError(value_error)
-        elif self.num_cores_per_mpiproc is not None:
-            if self.num_cores_per_mpiproc <= 0:
-                raise ValueError('num_cores_per_mpiproc must be >=1')
-            # calculate num_cores_per_machine
-            # In this plugin we never used num_cores_per_mpiproc so if it
-            # is not defined it is OK.
-            self.num_cores_per_machine = (self.num_cores_per_mpiproc * self.num_mpiprocs_per_machine)
+        return resources
 
 
 class PbsBaseClass(Scheduler):

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -8,18 +8,17 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Implementation of `Scheduler` base class."""
-from abc import abstractmethod
+import abc
 
-import aiida.common
-from aiida.common.lang import classproperty
+from aiida.common import exceptions, log
 from aiida.common.escaping import escape_for_bash
-from aiida.common.exceptions import AiidaException, FeatureNotAvailable
-from aiida.schedulers.datastructures import JobTemplate
+from aiida.common.lang import classproperty
+from aiida.schedulers.datastructures import JobResource, JobTemplate
 
 __all__ = ('Scheduler', 'SchedulerError', 'SchedulerParsingError')
 
 
-class SchedulerError(AiidaException):
+class SchedulerError(exceptions.AiidaException):
     pass
 
 
@@ -27,12 +26,10 @@ class SchedulerParsingError(SchedulerError):
     pass
 
 
-class Scheduler:
-    """
-    Base class for all schedulers.
-    """
+class Scheduler(metaclass=abc.ABCMeta):
+    """Base class for a job scheduler."""
 
-    _logger = aiida.common.AIIDA_LOGGER.getChild('scheduler')
+    _logger = log.AIIDA_LOGGER.getChild('scheduler')
 
     # A list of features
     # Features that should be defined in the plugins:
@@ -56,24 +53,27 @@ class Scheduler:
     def __init__(self):
         self._transport = None
 
-    def set_transport(self, transport):
-        """
-        Set the transport to be used to query the machine or to submit scripts.
-        This class assumes that the transport is open and active.
-        """
-        self._transport = transport
+        if not issubclass(self._job_resource_class, JobResource):
+            raise RuntimeError('the class attribute `_job_resource_class` is not a subclass of `JobResource`.')
 
     @classmethod
     def get_valid_schedulers(cls):
-        from aiida.plugins.entry_point import get_entry_point_names
+        """Return all available scheduler plugins.
 
+        .. deprecated:: 1.3.0
+
+            Will be removed in `2.0.0`, use `aiida.plugins.entry_point.get_entry_point_names` instead
+        """
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning
+        from aiida.plugins.entry_point import get_entry_point_names
+        message = 'method is deprecated, use `aiida.plugins.entry_point.get_entry_point_names` instead'
+        warnings.warn(message, AiidaDeprecationWarning)  # pylint: disable=no-member
         return get_entry_point_names('aiida.schedulers')
 
     @classmethod
     def get_short_doc(cls):
-        """
-        Return the first non-empty line of the class docstring, if available
-        """
+        """Return the first non-empty line of the class docstring, if available."""
         # Remove empty lines
         docstring = cls.__doc__
         if not docstring:
@@ -93,36 +93,26 @@ class Scheduler:
 
     @property
     def logger(self):
-        """
-        Return the internal logger.
-        """
+        """Return the internal logger."""
         try:
             return self._logger
         except AttributeError:
-            from aiida.common.exceptions import InternalError
-
-            raise InternalError('No self._logger configured for {}!')
+            raise exceptions.InternalError('No self._logger configured for {}!')
 
     @classproperty
-    def job_resource_class(self):
-        return self._job_resource_class
+    def job_resource_class(cls):  # pylint: disable=no-self-argument
+        return cls._job_resource_class
 
     @classmethod
     def create_job_resource(cls, **kwargs):
-        """
-        Create a suitable job resource from the kwargs specified
-        """
+        """Create a suitable job resource from the kwargs specified."""
         # pylint: disable=not-callable
-
-        if cls._job_resource_class is None:
-            raise NotImplementedError
-
         return cls._job_resource_class(**kwargs)
 
     def get_submit_script(self, job_tmpl):
-        """
-        Return the submit script as a string.
-        :parameter job_tmpl: a aiida.schedulers.datastrutures.JobTemplate object.
+        """Return the submit script as a string.
+
+        :parameter job_tmpl: a `aiida.schedulers.datastrutures.JobTemplate` instance.
 
         The plugin returns something like
 
@@ -134,11 +124,8 @@ class Scheduler:
         postpend_code
         postpend_computer
         """
-
-        from aiida.common.exceptions import InternalError
-
         if not isinstance(job_tmpl, JobTemplate):
-            raise InternalError('job_tmpl should be of type JobTemplate')
+            raise exceptions.InternalError('job_tmpl should be of type JobTemplate')
 
         empty_line = ''
 
@@ -176,55 +163,30 @@ class Scheduler:
 
         return '\n'.join(script_lines)
 
-    @abstractmethod
+    @abc.abstractmethod
     def _get_submit_script_header(self, job_tmpl):
-        """
-        Return the submit script header, using the parameters from the
-        job_tmpl.
+        """Return the submit script header, using the parameters from the job template.
 
-        :param job_tmpl: a JobTemplate instance with relevant parameters set.
+        :param job_tmpl: a `JobTemplate` instance with relevant parameters set.
         """
-        raise NotImplementedError
 
     def _get_submit_script_footer(self, job_tmpl):
-        """
-        Return the submit script final part, using the parameters from the
-        job_tmpl.
+        """Return the submit script final part, using the parameters from the job template.
 
-        :param job_tmpl: a JobTemplate instance with relevant parameters set.
+        :param job_tmpl: a `JobTemplate` instance with relevant parameters set.
         """
-        # pylint: disable=no-self-use, unused-argument
+        # pylint: disable=no-self-use,unused-argument
         return None
 
     def _get_run_line(self, codes_info, codes_run_mode):
-        """
-        Return a string with the line to execute a specific code with
-        specific arguments.
+        """Return a string with the line to execute a specific code with specific arguments.
 
-        :parameter codes_info: a list of aiida.common.datastructures.CodeInfo
-          objects. Each contains the information needed to run the code. I.e.
-          cmdline_params, stdin_name, stdout_name, stderr_name, join_files.
-          See the documentation of JobTemplate and CodeInfo
-        :parameter codes_run_mode: contains the information on how to launch the
-          multiple codes. As described in aiida.common.datastructures.CodeRunMode
-
-
-            argv: an array with the executable and the command line arguments.
-              The first argument is the executable. This should contain
-              everything, including the mpirun command etc.
-            stdin_name: the filename to be used as stdin, relative to the
-              working dir, or None if no stdin redirection is required.
-            stdout_name: the filename to be used to store the standard output,
-              relative to the working dir,
-              or None if no stdout redirection is required.
-            stderr_name: the filename to be used to store the standard error,
-              relative to the working dir,
-              or None if no stderr redirection is required.
-            join_files: if True, stderr is redirected to stdout; the value of
-              stderr_name is ignored.
-
-        Return a string with the following format:
-        [executable] [args] {[ < stdin ]} {[ < stdout ]} {[2>&1 | 2> stderr]}
+        :parameter codes_info: a list of `aiida.common.datastructures.CodeInfo` objects. Each contains the information
+            needed to run the code. I.e. `cmdline_params`, `stdin_name`, `stdout_name`, `stderr_name`, `join_files`. See
+            the documentation of `JobTemplate` and `CodeInfo`.
+        :parameter codes_run_mode: instance of `aiida.common.datastructures.CodeRunMode` contains the information on how
+            to launch the multiple codes.
+        :return: string with format: [executable] [args] {[ < stdin ]} {[ < stdout ]} {[2>&1 | 2> stderr]}
         """
         from aiida.common.datastructures import CodeRunMode
 
@@ -260,40 +222,30 @@ class Scheduler:
 
         raise NotImplementedError('Unrecognized code run mode')
 
-    @abstractmethod
+    @abc.abstractmethod
     def _get_joblist_command(self, jobs=None, user=None):
+        """Return the command to get the most complete description possible of currently active jobs.
+
+        .. note::
+
+            Typically one can pass only either jobs or user, depending on the specific plugin. The choice can be done
+            according to the value returned by `self.get_feature('can_query_by_user')`
+
+        :param jobs: either None to get a list of all jobs in the machine, or a list of jobs.
+        :param user: either None, or a string with the username (to show only jobs of the specific user).
         """
-        Return the qstat (or equivalent) command to run with the required
-        command-line parameters to get the most complete description possible;
-        also specifies the output format of qsub to be the one to be used
-        by the parse_queue_output method.
-
-        Must be implemented in the plugin.
-
-        :param jobs: either None to get a list of all jobs in the machine,
-               or a list of jobs.
-        :param user: either None, or a string with the username (to show only
-                     jobs of the specific user).
-
-        Note: typically one can pass only either jobs or user, depending on the
-            specific plugin. The choice can be done according to the value
-            returned by self.get_feature('can_query_by_user')
-        """
-        raise NotImplementedError
 
     def _get_detailed_job_info_command(self, job_id):
-        """
-        Return the command to run to get the detailed information on a job.
-        This is typically called after the job has finished, to retrieve
-        the most detailed information possible about the job. This is done
-        because most schedulers just make finished jobs disappear from the
-        'qstat' command, and instead sometimes it is useful to know some
-        more detailed information about the job exit status, etc.
+        """Return the command to run to get detailed information for a given job.
+
+        This is typically called after the job has finished, to retrieve the most detailed information possible about
+        the job. This is done because most schedulers just make finished jobs disappear from the `qstat` command, and
+        instead sometimes it is useful to know some more detailed information about the job exit status, etc.
 
         :raises: :class:`aiida.common.exceptions.FeatureNotAvailable`
         """
         # pylint: disable=no-self-use,not-callable,unused-argument
-        raise FeatureNotAvailable('Cannot get detailed job info')
+        raise exceptions.FeatureNotAvailable('Cannot get detailed job info')
 
     def get_detailed_job_info(self, job_id):
         """Return the detailed job info.
@@ -336,7 +288,7 @@ class Scheduler:
         with self.transport:
             retval, stdout, stderr = self.transport.exec_command_wait(command)
 
-        return u"""Detailed jobinfo obtained with command '{}'
+        return """Detailed jobinfo obtained with command '{}'
 Return Code: {}
 -------------------------------------------------------------
 stdout:
@@ -345,33 +297,23 @@ stderr:
 {}
 """.format(command, retval, stdout, stderr)
 
-    @abstractmethod
+    @abc.abstractmethod
     def _parse_joblist_output(self, retval, stdout, stderr):
-        """
-        Parse the joblist output ('qstat'), as returned by executing the
-        command returned by _get_joblist_command method.
+        """Parse the joblist output as returned by executing the command returned by `_get_joblist_command` method.
 
-        To be implemented by the plugin.
-
-        Return a list of JobInfo objects, one of each job,
-        each with at least its default params implemented.
+        :return: list of `JobInfo` objects, one of each job each with at least its default params implemented.
         """
-        raise NotImplementedError
 
     def get_jobs(self, jobs=None, user=None, as_dict=False):
-        """
-        Get the list of jobs and return it.
+        """Return the list of currently active jobs.
 
-        Typically, this function does not need to be modified by the plugins.
+        .. note:: typically, only either jobs or user can be specified. See also comments in `_get_joblist_command`.
 
         :param list jobs: a list of jobs to check; only these are checked
         :param str user: a string with a user: only jobs of this user are checked
-        :param list as_dict: if False (default), a list of JobInfo objects is
-             returned. If True, a dictionary is returned, having as key the
-             job_id and as value the JobInfo object.
-
-        Note: typically, only either jobs or user can be specified. See also
-        comments in _get_joblist_command.
+        :param list as_dict: if False (default), a list of JobInfo objects is returned. If True, a dictionary is
+            returned, having as key the job_id and as value the JobInfo object.
+        :return: list of active jobs
         """
         with self.transport:
             retval, stdout, stderr = self.transport.exec_command_wait(self._get_joblist_command(jobs=jobs, user=user))
@@ -387,85 +329,66 @@ stderr:
 
     @property
     def transport(self):
-        """
-        Return the transport set for this scheduler.
-        """
+        """Return the transport set for this scheduler."""
         if self._transport is None:
             raise SchedulerError('Use the set_transport function to set the transport for the scheduler first.')
 
         return self._transport
 
-    @abstractmethod
-    def _get_submit_command(self, submit_script):
+    def set_transport(self, transport):
+        """Set the transport to be used to query the machine or to submit scripts.
+
+        This class assumes that the transport is open and active.
         """
-        Return the string to execute to submit a given script.
+        self._transport = transport
 
-        To be implemented by the plugin.
+    @abc.abstractmethod
+    def _get_submit_command(self, submit_script):
+        """Return the string to execute to submit a given script.
 
-        :param str submit_script: the path of the submit script relative to the
-            working directory.
-            IMPORTANT: submit_script should be already escaped.
+        .. warning:: the `submit_script` should already have been bash-escaped
+
+        :param submit_script: the path of the submit script relative to the working directory.
         :return: the string to execute to submit a given script.
         """
-        raise NotImplementedError
 
-    @abstractmethod
+    @abc.abstractmethod
     def _parse_submit_output(self, retval, stdout, stderr):
-        """
-        Parse the output of the submit command, as returned by executing the
-        command returned by _get_submit_command command.
+        """Parse the output of the submit command returned by calling the `_get_submit_command` command.
 
-        To be implemented by the plugin.
-
-        :return: a string with the JobID.
+        :return: a string with the job ID.
         """
-        raise NotImplementedError
 
     def submit_from_script(self, working_directory, submit_script):
+        """Submit the submission script to the scheduler.
+
+        :return: return a string with the job ID in a valid format to be used for querying.
         """
-        Goes in the working directory and submits the submit_script.
-
-        Return a string with the JobID in a valid format to be used for
-        querying.
-
-        Typically, this function does not need to be modified by the plugins.
-        """
-
         self.transport.chdir(working_directory)
-        retval, stdout, stderr = self.transport.exec_command_wait(
-            self._get_submit_command(escape_for_bash(submit_script))
-        )
-        return self._parse_submit_output(retval, stdout, stderr)
+        result = self.transport.exec_command_wait(self._get_submit_command(escape_for_bash(submit_script)))
+        return self._parse_submit_output(*result)
 
     def kill(self, jobid):
-        """
-        Kill a remote job, and try to parse the output message of the scheduler
-        to check if the scheduler accepted the command.
+        """Kill a remote job and parse the return value of the scheduler to check if the command succeeded.
 
-        ..note:: On some schedulers, even if the command is accepted, it may
-        take some seconds for the job to actually disappear from the queue.
+        ..note::
 
-        :param str jobid: the job id to be killed
+            On some schedulers, even if the command is accepted, it may take some seconds for the job to actually
+            disappear from the queue.
 
+        :param jobid: the job ID to be killed
         :return: True if everything seems ok, False otherwise.
         """
         retval, stdout, stderr = self.transport.exec_command_wait(self._get_kill_command(jobid))
         return self._parse_kill_output(retval, stdout, stderr)
 
+    @abc.abstractmethod
     def _get_kill_command(self, jobid):
-        """
-        Return the command to kill the job with specified jobid.
+        """Return the command to kill the job with specified jobid."""
 
-        To be implemented by the plugin.
-        """
-        raise NotImplementedError
-
+    @abc.abstractmethod
     def _parse_kill_output(self, retval, stdout, stderr):
-        """
-        Parse the output of the kill command.
-
-        To be implemented by the plugin.
+        """Parse the output of the kill command.
 
         :return: True if everything seems ok, False otherwise.
         """
-        raise NotImplementedError

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -44,6 +44,15 @@ class Scheduler:
     # The class to be used for the job resource.
     _job_resource_class = None
 
+    @classmethod
+    def validate_resources(cls, **resources):
+        """Validate the resources against the job resource class of this scheduler.
+
+        :param resources: keyword arguments to define the job resources
+        :raises ValueError: if the resources are invalid or incomplete
+        """
+        cls._job_resource_class.validate_resources(**resources)
+
     def __init__(self):
         self._transport = None
 

--- a/tests/engine/test_calc_job.py
+++ b/tests/engine/test_calc_job.py
@@ -163,7 +163,7 @@ class TestCalcJob(AiidaTestCase):
         inputs['code'] = self.remote_code
         inputs['metadata']['computer'] = orm.Computer('different', 'localhost', 'desc', 'local', 'direct')
 
-        with self.assertRaises(exceptions.InputValidationError):
+        with self.assertRaises(ValueError):
             ArithmeticAddCalculation(inputs=inputs)
 
     def test_remote_code_set_computer_explicit(self):
@@ -176,7 +176,7 @@ class TestCalcJob(AiidaTestCase):
         inputs['code'] = self.remote_code
 
         # Setting explicitly a computer that is not the same as that of the `code` should raise
-        with self.assertRaises(exceptions.InputValidationError):
+        with self.assertRaises(ValueError):
             inputs['metadata']['computer'] = orm.Computer('different', 'localhost', 'desc', 'local', 'direct').store()
             process = ArithmeticAddCalculation(inputs=inputs)
 
@@ -201,7 +201,7 @@ class TestCalcJob(AiidaTestCase):
         inputs = deepcopy(self.inputs)
         inputs['code'] = self.local_code
 
-        with self.assertRaises(exceptions.InputValidationError):
+        with self.assertRaises(ValueError):
             ArithmeticAddCalculation(inputs=inputs)
 
     def test_invalid_parser_name(self):
@@ -210,7 +210,7 @@ class TestCalcJob(AiidaTestCase):
         inputs['code'] = self.remote_code
         inputs['metadata']['options']['parser_name'] = 'invalid_parser'
 
-        with self.assertRaises(exceptions.InputValidationError):
+        with self.assertRaises(ValueError):
             ArithmeticAddCalculation(inputs=inputs)
 
     def test_invalid_resources(self):
@@ -219,7 +219,7 @@ class TestCalcJob(AiidaTestCase):
         inputs['code'] = self.remote_code
         inputs['metadata']['options']['resources'] = {'num_machines': 'invalid_type'}
 
-        with self.assertRaises(exceptions.InputValidationError):
+        with self.assertRaises(ValueError):
             ArithmeticAddCalculation(inputs=inputs)
 
     @pytest.mark.timeout(5)


### PR DESCRIPTION
Fixes #3887 

This is necessary because the resource validation is scheduler
dependent. Up till now, the `CalcJob` defined a validator on the entire
input namespace that validates the `metadata.options.resources` input.
Specifically, it demanded that the `num_machines` keyword was defined,
which is indeed a requirement for the `NodeNumberJobResource`, used for
schedulers like SLURM, however, this field doesn't even make sense for
schedulers like LSF and SGE that use the `ParEnvJobResource` type of job
resources.

The solution is to delegate the validation of the resources to the
scheduler which in turn delegates it to the `JobResource` class that it
uses. The validation used to happend on construction of the job resource
instance, but is factored out to the `validate_resources` classmethod.
This allows it to be called without having to construct an instance
which is more efficient.

Finally, the signature of the `CalcJob` input validators is changed and
no longer raise an `InputValidationError` but instead return an error
message as the interface of `Port.validator` requires. The port itself
will detect if an error message is returned and raise a `ValueError`
with all the relevant error messages.