### PR TITLE
Only color directories in `verdi node repo ls --color`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -145,7 +145,7 @@ function-name-hint=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=x,y,z,i,j,k,ex,Run,_,pk,TemplatereplacerCalculation,ArithmeticAddCalculation,MultiplyAddWorkChain
+good-names=x,y,z,i,j,k,ex,Run,_,pk,fg,TemplatereplacerCalculation,ArithmeticAddCalculation,MultiplyAddWorkChain
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/aiida/cmdline/utils/repository.py
+++ b/aiida/cmdline/utils/repository.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utility functions for command line commands operating on the repository."""
-
 import click
 
 
@@ -23,8 +22,5 @@ def list_repository_contents(node, path, color):
 
     for entry in node.list_objects(path):
         bold = bool(entry.type == FileType.DIRECTORY)
-
-        if color:
-            click.secho(entry.name, bold=bold, fg='blue')
-        else:
-            click.secho(entry.name, bold=bold)
+        fg = 'blue' if color and entry.type == FileType.DIRECTORY else None
+        click.secho(entry.name, bold=bold, fg=fg)

--- a/tests/cmdline/utils/test_repository.py
+++ b/tests/cmdline/utils/test_repository.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=redefined-outer-name,invalid-name
+"""Tests for the :mod:`aiida.cmdline.utils.repository` module."""
+import io
+
+import pytest
+
+from aiida.cmdline.utils.repository import list_repository_contents
+from aiida.orm import FolderData
+
+
+@pytest.fixture
+def runner():
+    """Return a `click` test runner."""
+    from click.testing import CliRunner
+    return CliRunner()
+
+
+@pytest.fixture
+def folder_data():
+    """Create a `FolderData` instance with basic file and directory structure."""
+    node = FolderData()
+    node.put_object_from_filelike(io.StringIO(''), key='nested/file.txt')
+    node.put_object_from_filelike(io.StringIO(''), key='file.txt')
+
+    return node
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_list_repository_contents(capsys, folder_data):
+    """Test the `list_repository_contents` method."""
+    list_repository_contents(folder_data, path='', color=True)
+    assert capsys.readouterr().out == 'file.txt\nnested\n'
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_list_repository_contents_color(runner, folder_data):
+    """Test the `list_repository_contents` method.
+
+    The `click` library will automatically strip the ANSI sequences that are used to present color in the terminal when
+    echo'ing to anything other then a terminal. Trying to call `list_repository_contents` normally and capturing the
+    output will then not contain the sequences so we cannot test the `--color` flag. Instead we run within `click`'s
+    `isolation` context manager of the test runner, setting `color=True` which will prevent the ANSI sequences from
+    being stripped, allowing us to check for them in the output
+    """
+    with runner.isolation(color=True) as outstreams:
+        list_repository_contents(folder_data, path='', color=True)
+
+    values = outstreams[0].getvalue()
+    # \x1b[22m  normal text
+    # \x1b[0m   unset sequence
+    # \x1b[34m  blue text
+    # \x1b[1m   bold text
+    assert values == b'\x1b[22mfile.txt\x1b[0m\n\x1b[34m\x1b[1mnested\x1b[0m\n'


### PR DESCRIPTION
Fixes #4183 

The help string says that the `--color` flag can be used to color
directories different from files to easily distinguish them, except the
implementation colored all files, regardless of type.