### PR TITLE
do not install tests/ and util/ packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     EXTRAS_REQUIRE['all'] = list({item for sublist in EXTRAS_REQUIRE.values() for item in sublist if item != 'bpython'})
 
     setup(
-        packages=find_packages(),
+        packages=find_packages(include=['aiida', 'aiida.*']),
         long_description=open(os.path.join(THIS_FOLDER, 'README.md')).read(),
         long_description_content_type='text/markdown',
         **SETUP_JSON


### PR DESCRIPTION
The previous generic "find_packages()" call in setup.py  would also
catch the tests/ and utils/ subfolders, installing them into the user's
python environment.  This not only affected installs from github, but
also source releases on PyPI.