### PR TITLE
`BaseRestartWorkChain`: do not assume `metadata` exists in inputs

### DIFF
--- a/aiida/engine/processes/workchains/restart.py
+++ b/aiida/engine/processes/workchains/restart.py
@@ -154,7 +154,7 @@ class BaseRestartWorkChain(WorkChain):
             raise AttributeError('no process input dictionary was defined in `self.ctx.inputs`')
 
         # Set the `CALL` link label
-        unwrapped_inputs['metadata']['call_link_label'] = 'iteration_{:02d}'.format(self.ctx.iteration)
+        unwrapped_inputs.setdefault('metadata', {})['call_link_label'] = 'iteration_{:02d}'.format(self.ctx.iteration)
 
         inputs = self._wrap_bare_dict_inputs(self._process_class.spec().inputs, unwrapped_inputs)
         node = self.submit(self._process_class, **inputs)

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -11,20 +11,25 @@
 # pylint: disable=invalid-name,inconsistent-return-statements,no-self-use,no-member
 import pytest
 
-from aiida.engine import CalcJob, BaseRestartWorkChain, process_handler, ProcessState, ProcessHandlerReport, ExitCode
+from aiida import engine
+from aiida.engine.processes.workchains.awaitable import Awaitable
 
 
-class SomeWorkChain(BaseRestartWorkChain):
+class SomeWorkChain(engine.BaseRestartWorkChain):
     """Dummy class."""
 
-    _process_class = CalcJob
+    _process_class = engine.CalcJob
 
-    @process_handler(priority=200)
+    def setup(self):
+        super().setup()
+        self.ctx.inputs = {}
+
+    @engine.process_handler(priority=200)
     def handler_a(self, node):
         if node.exit_status == 400:
-            return ProcessHandlerReport(do_break=False, exit_code=ExitCode(418, 'IMATEAPOT'))
+            return engine.ProcessHandlerReport(do_break=False, exit_code=engine.ExitCode(418, 'IMATEAPOT'))
 
-    @process_handler(priority=100)
+    @engine.process_handler(priority=100)
     def handler_b(self, _):
         return
 
@@ -49,8 +54,8 @@ def test_excepted_process(generate_work_chain, generate_calculation_node):
     """Test that the workchain aborts if the sub process was excepted."""
     process = generate_work_chain(SomeWorkChain, {})
     process.setup()
-    process.ctx.children = [generate_calculation_node(ProcessState.EXCEPTED)]
-    assert process.inspect_process() == BaseRestartWorkChain.exit_codes.ERROR_SUB_PROCESS_EXCEPTED
+    process.ctx.children = [generate_calculation_node(engine.ProcessState.EXCEPTED)]
+    assert process.inspect_process() == engine.BaseRestartWorkChain.exit_codes.ERROR_SUB_PROCESS_EXCEPTED
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
@@ -58,8 +63,8 @@ def test_killed_process(generate_work_chain, generate_calculation_node):
     """Test that the workchain aborts if the sub process was killed."""
     process = generate_work_chain(SomeWorkChain, {})
     process.setup()
-    process.ctx.children = [generate_calculation_node(ProcessState.KILLED)]
-    assert process.inspect_process() == BaseRestartWorkChain.exit_codes.ERROR_SUB_PROCESS_KILLED
+    process.ctx.children = [generate_calculation_node(engine.ProcessState.KILLED)]
+    assert process.inspect_process() == engine.BaseRestartWorkChain.exit_codes.ERROR_SUB_PROCESS_KILLED
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
@@ -76,7 +81,8 @@ def test_unhandled_failure(generate_work_chain, generate_calculation_node):
     assert process.ctx.unhandled_failure is True
 
     process.ctx.children.append(generate_calculation_node(exit_status=100))
-    assert process.inspect_process() == BaseRestartWorkChain.exit_codes.ERROR_SECOND_CONSECUTIVE_UNHANDLED_FAILURE  # pylint: disable=no-member
+    assert process.inspect_process(
+    ) == engine.BaseRestartWorkChain.exit_codes.ERROR_SECOND_CONSECUTIVE_UNHANDLED_FAILURE  # pylint: disable=no-member
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
@@ -108,7 +114,29 @@ def test_unhandled_reset_after_handled(generate_work_chain, generate_calculation
 
     # Even though `handler_a` was followed by `handler_b`, we should retrieve the exit_code from `handler_a` because
     # `handler_b` returned `None` which should not overwrite the last report.
-    assert isinstance(result, ExitCode)
+    assert isinstance(result, engine.ExitCode)
     assert result.status == 418
     assert result.message == 'IMATEAPOT'
     assert process.ctx.unhandled_failure is False
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_run_process(generate_work_chain, generate_calculation_node, monkeypatch):
+    """Test the `run_process` method."""
+
+    def mock_submit(_, process_class, **kwargs):
+        """Mock the submission to just return an empty `CalcJobNode`."""
+        assert process_class is SomeWorkChain._process_class  # pylint: disable=protected-access
+        assert 'metadata' in kwargs
+        assert kwargs['metadata']['call_link_label'] == 'iteration_01'
+        return generate_calculation_node()
+
+    monkeypatch.setattr(SomeWorkChain, 'submit', mock_submit)
+
+    process = generate_work_chain(SomeWorkChain, {})
+    process.setup()
+    result = process.run_process()
+
+    assert isinstance(result, engine.ToContext)
+    assert isinstance(result['children'], Awaitable)
+    assert process.node.get_extra(SomeWorkChain._considered_handlers_extra) == [[]]  # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #4209 

The contract of the base restart work chain is that the `setup` will
define the `self.ctx.inputs` attribute, however, it is not defined what
its contents should be. The `run_process` method was unjustly assuming
that the `metadata` key would be set to a dictionary, which is not
always the case. In this fix, we simply check for its existence and
create the dictionary if it doesn't yet exist.