### PR TITLE
Add the `--paused` flag to `verdi process list`

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -9,7 +9,6 @@
 ###########################################################################
 # pylint: disable=too-many-arguments
 """`verdi process` command."""
-
 import click
 
 from kiwipy import communications
@@ -37,6 +36,7 @@ def verdi_process():
 @options.ALL(help='Show all entries, regardless of their process state.')
 @options.PROCESS_STATE()
 @options.PROCESS_LABEL()
+@options.PAUSED()
 @options.EXIT_STATUS()
 @options.FAILED()
 @options.PAST_DAYS()
@@ -44,8 +44,8 @@ def verdi_process():
 @options.RAW()
 @decorators.with_dbenv()
 def process_list(
-    all_entries, group, process_state, process_label, exit_status, failed, past_days, limit, project, raw, order_by,
-    order_dir
+    all_entries, group, process_state, process_label, paused, exit_status, failed, past_days, limit, project, raw,
+    order_by, order_dir
 ):
     """Show a list of running or terminated processes.
 
@@ -61,7 +61,7 @@ def process_list(
         relationships['with_node'] = group
 
     builder = CalculationQueryBuilder()
-    filters = builder.get_filters(all_entries, process_state, process_label, exit_status, failed)
+    filters = builder.get_filters(all_entries, process_state, process_label, paused, exit_status, failed)
     query_set = builder.get_query_set(
         relationships=relationships, filters=filters, order_by={order_by: order_dir}, past_days=past_days, limit=limit
     )

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -324,6 +324,8 @@ PROCESS_STATE = OverridableOption(
     help='Only include entries with this process state.'
 )
 
+PAUSED = OverridableOption('--paused', 'paused', is_flag=True, help='Only include entries that are paused.')
+
 PROCESS_LABEL = OverridableOption(
     '-L',
     '--process-label',

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -47,6 +47,7 @@ class CalculationQueryBuilder:
         all_entries=False,
         process_state=None,
         process_label=None,
+        paused=False,
         exit_status=None,
         failed=False,
         node_types=None
@@ -58,6 +59,7 @@ class CalculationQueryBuilder:
         :param all_entries: boolean to negate filtering for process state
         :param process_state: filter for this process state attribute
         :param process_label: filter for this process label attribute
+        :param paused: boolean, if True, filter for processes that are paused
         :param exit_status: filter for this exit status
         :param failed: boolean to filter only failed processes
         :return: dictionary of filters suitable for a QueryBuilder.append() call
@@ -68,6 +70,7 @@ class CalculationQueryBuilder:
         exit_status_attribute = self.mapper.get_attribute('exit_status')
         process_label_attribute = self.mapper.get_attribute('process_label')
         process_state_attribute = self.mapper.get_attribute('process_state')
+        paused_attribute = self.mapper.get_attribute('paused')
 
         filters = {}
 
@@ -84,6 +87,9 @@ class CalculationQueryBuilder:
                 filters[process_label_attribute] = {'like': process_label}
             else:
                 filters[process_label_attribute] = process_label
+
+        if paused:
+            filters[paused_attribute] = True
 
         if failed:
             filters[process_state_attribute] = {'==': ProcessState.FINISHED.value}

--- a/aiida/cmdline/utils/query/mapping.py
+++ b/aiida/cmdline/utils/query/mapping.py
@@ -12,8 +12,7 @@ from aiida.cmdline.utils.query import formatting
 
 
 class ProjectionMapper:
-    """
-    Class to map projection names from the CLI to entity labels, attributes and formatters.
+    """Class to map projection names from the CLI to entity labels, attributes and formatters.
 
     The command line interface will often have to display database entities and their attributes. The names of
     the attributes exposed on the CLI do not always match one-to-one with the attributes in the ORM and often
@@ -28,7 +27,6 @@ class ProjectionMapper:
     _valid_projections = []
 
     def __init__(self, projection_labels=None, projection_attributes=None, projection_formatters=None):
-        # pylint: disable=unused-variable,undefined-variable
         if not self._valid_projections:
             raise NotImplementedError('no valid projections were specified by the sub class')
 
@@ -108,7 +106,6 @@ class CalculationProjectionMapper(ProjectionMapper):
             'exit_status': exit_status_key,
         }
 
-        # pylint: disable=line-too-long
         default_formatters = {
             'ctime':
             lambda value: formatting.format_relative_time(value['ctime']),

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -162,6 +162,10 @@ class TestVerdiProcess(AiidaTestCase):
             if state == ProcessState.FINISHED:
                 calc.set_exit_status(1)
 
+            # Set the waiting work chain as paused as well
+            if state == ProcessState.WAITING:
+                calc.pause()
+
             calc.store()
             cls.calcs.append(calc)
 
@@ -194,13 +198,13 @@ class TestVerdiProcess(AiidaTestCase):
             flag_value = 'asc'
             result = self.cli_runner.invoke(cmd_process.process_list, ['-r', '-O', 'id', flag, flag_value])
             self.assertIsNone(result.exception, result.output)
-            result_num_asc = [l.split()[0] for l in get_result_lines(result)]
+            result_num_asc = [line.split()[0] for line in get_result_lines(result)]
             self.assertEqual(len(result_num_asc), 6)
 
             flag_value = 'desc'
             result = self.cli_runner.invoke(cmd_process.process_list, ['-r', '-O', 'id', flag, flag_value])
             self.assertIsNone(result.exception, result.output)
-            result_num_desc = [l.split()[0] for l in get_result_lines(result)]
+            result_num_desc = [line.split()[0] for line in get_result_lines(result)]
             self.assertEqual(len(result_num_desc), 6)
 
             self.assertEqual(result_num_asc, list(reversed(result_num_desc)))
@@ -261,6 +265,12 @@ class TestVerdiProcess(AiidaTestCase):
                 self.assertEqual(len(get_result_lines(result)), 3)  # Should only match the active `WorkFunctionNodes`
                 for line in get_result_lines(result):
                     self.assertIn(self.process_label, line.strip())
+
+        # There should be exactly one paused
+        for flag in ['--paused']:
+            result = self.cli_runner.invoke(cmd_process.process_list, ['-r', flag])
+            self.assertClickResultNoException(result)
+            self.assertEqual(len(get_result_lines(result)), 1)
 
     def test_process_show(self):
         """Test verdi process show"""


### PR DESCRIPTION
Fixes #4212 

This flag will filter for processes that are currently paused which is
useful to find calculation jobs that may have hit the exponential
backoff mechanism, among other things.