### PR TITLE
docs: use new page rank feature

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,3 +20,7 @@ python:
 sphinx:
     builder: html
     fail_on_warning: true
+
+search:
+  ranking:
+    reference/apidoc/*: -5

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,4 @@ sphinx:
 
 search:
   ranking:
-    reference/apidoc/*: -5
+    reference/apidoc/*: -7


### PR DESCRIPTION
ReadTheDocs just introduced a way to control the search rank of
documentation pages, allowing us to push hits in the autogenerated API
docs further down in the list of search results.

See https://github.com/readthedocs/readthedocs.org/issues/7082#issuecomment-653120310