### PR TITLE
update paramiko to 2.7

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ev
 
-ssh-keygen -q -t rsa -b 4096 -m PEM -N "" -f "${HOME}/.ssh/id_rsa"
+ssh-keygen -q -t rsa -b 4096 -N "" -f "${HOME}/.ssh/id_rsa"
 ssh-keygen -y -f "${HOME}/.ssh/id_rsa" >> "${HOME}/.ssh/authorized_keys"
 ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -21,7 +21,7 @@ Very briefly, first create a new private/public keypair (``aiida``/``aiida.pub``
 
 .. code-block:: console
 
-   $ ssh-keygen -t rsa -b 4096 -m PEM -f ~/.ssh/aiida
+   $ ssh-keygen -t rsa -b 4096 -f ~/.ssh/aiida
 
 Copy the public key to the remote machine, normally this will add the public key to the rmote machine's ``~/.ssh/authorized_keys``:
 

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 - jinja2~=2.10
 - kiwipy[rmq]~=0.5.5
 - numpy<1.18,~=1.17
-- paramiko~=2.6
+- paramiko~=2.7
 - pika~=1.1
 - plumpy~=0.15.0
 - pgsu~=0.1.0

--- a/setup.json
+++ b/setup.json
@@ -35,7 +35,7 @@
         "jinja2~=2.10",
         "kiwipy[rmq]~=0.5.5",
         "numpy~=1.17,<1.18",
-        "paramiko~=2.6",
+        "paramiko~=2.7",
         "pika~=1.1",
         "plumpy~=0.15.0",
         "pgsu~=0.1.0",


### PR DESCRIPTION
Version 2.7 of paramiko finally brings support for the OpenSSH private
key format, which has been the default on MacOS for some time.

See https://github.com/paramiko/paramiko/pull/1343