### PR TITLE
ci: don't fail job if coverage upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         name: aiida-pytests-py3.5-${{ matrix.backend }}
         flags: ${{ matrix.backend }}
         file: ./coverage.xml
-        fail_ci_if_error: true
+        fail_ci_if_error: false  # don't fail job, if coverage upload fails
 
   verdi:
 


### PR DESCRIPTION
The upload of test coverage reports to codecov sometimes fails,
currently causing the job to fail.

Since maintaining test coverage is currently not a strict requirement,
we can live with not getting it right some of the time.