### PR TITLE
Add the `verdi profile caching` command

### DIFF
--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -531,5 +531,20 @@ If you suspect a node is being reused in error (e.g. during development), you ca
    The node in question should no longer be reused.
 
 
+How to validate the configuration
+---------------------------------
+
+To check that the configuration file can be found by AiiDA and it has the correct syntax, use the following command:
+
+.. code-block:: console
+
+    $ verdi profile caching
+
+The command emits a critical error if the caching configuration file cannot be found or contains wrong syntax.
+Otherwise, it will show the parsed configuration for the current default profile.
+Pass another profile as an argument to see the corresponding caching configuration.
+If no configuration is defined for the requested profile, a warning is displayed.
+
+
 .. |Computer| replace:: :py:class:`~aiida.orm.Computer`
 .. |CalcJob| replace:: :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob`

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -440,6 +440,7 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
+      caching     Show the caching configuration for a profile.
       delete      Delete one or more profiles.
       list        Display a list of all available profiles.
       setdefault  Set a profile as the default one.

--- a/tests/utils/configuration.py
+++ b/tests/utils/configuration.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module that defines methods to mock an AiiDA instance complete with mock configuration and profile."""
-
 import contextlib
 import os
 import shutil


### PR DESCRIPTION
Fixes #4240 

This command will try to load the caching configuration from the caching
configuration file, for any given profile. This is useful for users to
make sure that the file is correctly named and contains correct syntax,
before actually starting to run new calculations.

To test this, a new pytest fixture is created that creates a completely
new and independent configuration folder, along with fixtures to create
profiles to add to the config and caching configuration files. Similar
code already exists for normal unittests, but this can be removed once
those have been refactored to pytests.