### PR TITLE
Remove None values before invoking setup command

### DIFF
--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -168,4 +168,6 @@ def quicksetup(
         'db_password': db_password,
         'repository': repository,
     }
+    # we remove None values, because invoke appears to parse it as a string, i.e None -> "None"
+    setup_parameters = {k: v for k, v in setup_parameters.items() if v is not None}
     ctx.invoke(setup, **setup_parameters)


### PR DESCRIPTION
We think/hope this fixes #4032.
I'm not sure if there is a good unit test to confirm this? (just looking at tests/cmdline/commands/test_setup.py)