### PR TITLE
Deprecate getter and setter methods of `Computer` properties

### DIFF
--- a/.ci/test_plugin_testcase.py
+++ b/.ci/test_plugin_testcase.py
@@ -55,7 +55,7 @@ class PluginTestCase1(PluginTestCase):
         from aiida import orm
 
         computer = orm.Computer(
-            name='localhost',
+            label='localhost',
             hostname='localhost',
             description='my computer',
             transport_type='local',
@@ -80,7 +80,7 @@ class PluginTestCase1(PluginTestCase):
         work after resetting the DB.
         """
         from aiida import orm
-        self.assertEqual(orm.Computer.objects.get(name='localhost').uuid, self.computer.uuid)
+        self.assertEqual(orm.Computer.objects.get(label='localhost').uuid, self.computer.uuid)
 
     def test_tear_down(self):
         """

--- a/aiida/backends/testimplbase.py
+++ b/aiida/backends/testimplbase.py
@@ -69,7 +69,7 @@ class AiidaTestImplementation(ABC):
     def create_computer(self):
         """This method creates and stores a computer."""
         self.computer = orm.Computer(
-            name='localhost',
+            label='localhost',
             hostname='localhost',
             transport_type='local',
             scheduler_type='pbspro',

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -94,15 +94,15 @@ def aiida_localhost(temp_dir):
     from aiida.orm import Computer
     from aiida.common.exceptions import NotExistent
 
-    name = 'localhost-test'
+    label = 'localhost-test'
 
     try:
-        computer = Computer.objects.get(name=name)
+        computer = Computer.objects.get(label=label)
     except NotExistent:
         computer = Computer(
-            name=name,
+            label=label,
             description='localhost computer set up by test manager',
-            hostname=name,
+            hostname=label,
             workdir=temp_dir,
             transport_type='local',
             scheduler_type='direct'

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -36,9 +36,9 @@ class ComputerBuilder:  # pylint: disable=too-many-instance-attributes
         spec = {}
         spec['label'] = computer.label
         spec['description'] = computer.description
-        spec['hostname'] = computer.get_hostname()
-        spec['scheduler'] = computer.get_scheduler_type()
-        spec['transport'] = computer.get_transport_type()
+        spec['hostname'] = computer.hostname
+        spec['scheduler'] = computer.scheduler_type
+        spec['transport'] = computer.transport_type
         spec['prepend_text'] = computer.get_prepend_text()
         spec['append_text'] = computer.get_append_text()
         spec['work_dir'] = computer.get_workdir()
@@ -70,7 +70,7 @@ class ComputerBuilder:  # pylint: disable=too-many-instance-attributes
         passed_keys = set(self._computer_spec.keys())
         used = set()
 
-        computer = Computer(name=self._get_and_count('label', used), hostname=self._get_and_count('hostname', used))
+        computer = Computer(label=self._get_and_count('label', used), hostname=self._get_and_count('hostname', used))
 
         computer.set_description(self._get_and_count('description', used))
         computer.set_scheduler_type(self._get_and_count('scheduler', used))

--- a/docs/source/working_with_aiida/cookbook.rst
+++ b/docs/source/working_with_aiida/cookbook.rst
@@ -28,7 +28,7 @@ you can use a modification of the following script::
         """
         from aiida import orm
 
-        computer = Computer.get(name='deneb')
+        computer = Computer.get(label='deneb')
         transport = computer.get_transport()
         scheduler = computer.get_scheduler()
         scheduler.set_transport(transport)
@@ -114,7 +114,7 @@ Here is, as an example, an useful utility function::
         manager = get_manager()
         profile = manager.get_profile()
         return AuthInfo.objects.get(
-            dbcomputer_id=Computer.get(name=computername).id,
+            dbcomputer_id=Computer.get(label=computername).id,
             aiidauser_id=User.get(email=profile.default_user).id
         )
 

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -37,7 +37,7 @@ class TestVerdiCalculation(AiidaTestCase):
         from aiida.engine import ProcessState
 
         cls.computer = orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
         cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -120,7 +120,7 @@ class TestVerdiCodeCommands(AiidaTestCase):
     def setUpClass(cls, *args, **kwargs):
         super().setUpClass(*args, **kwargs)
         cls.computer = orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
     def setUp(self):

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -146,13 +146,13 @@ class TestVerdiComputerSetup(AiidaTestCase):
         result = self.cli_runner.invoke(computer_setup, options, input=user_input)
         self.assertIsNone(result.exception, msg='There was an unexpected exception. Output: {}'.format(result.output))
 
-        new_computer = orm.Computer.objects.get(name=label)
+        new_computer = orm.Computer.objects.get(label=label)
         self.assertIsInstance(new_computer, orm.Computer)
 
         self.assertEqual(new_computer.description, options_dict_full['description'])
         self.assertEqual(new_computer.hostname, options_dict_full['hostname'])
-        self.assertEqual(new_computer.get_transport_type(), options_dict_full['transport'])
-        self.assertEqual(new_computer.get_scheduler_type(), options_dict_full['scheduler'])
+        self.assertEqual(new_computer.transport_type, options_dict_full['transport'])
+        self.assertEqual(new_computer.scheduler_type, options_dict_full['scheduler'])
         self.assertEqual(new_computer.get_mpirun_command(), options_dict_full['mpirun-command'].split())
         self.assertEqual(new_computer.get_shebang(), options_dict_full['shebang'])
         self.assertEqual(new_computer.get_workdir(), options_dict_full['work-dir'])
@@ -173,13 +173,13 @@ class TestVerdiComputerSetup(AiidaTestCase):
         result = self.cli_runner.invoke(computer_setup, options)
 
         self.assertIsNone(result.exception, result.output[-1000:])
-        new_computer = orm.Computer.objects.get(name=options_dict['label'])
+        new_computer = orm.Computer.objects.get(label=options_dict['label'])
         self.assertIsInstance(new_computer, orm.Computer)
 
         self.assertEqual(new_computer.description, options_dict['description'])
         self.assertEqual(new_computer.hostname, options_dict['hostname'])
-        self.assertEqual(new_computer.get_transport_type(), options_dict['transport'])
-        self.assertEqual(new_computer.get_scheduler_type(), options_dict['scheduler'])
+        self.assertEqual(new_computer.transport_type, options_dict['transport'])
+        self.assertEqual(new_computer.scheduler_type, options_dict['scheduler'])
         self.assertEqual(new_computer.get_mpirun_command(), options_dict['mpirun-command'].split())
         self.assertEqual(new_computer.get_shebang(), options_dict['shebang'])
         self.assertEqual(new_computer.get_workdir(), options_dict['work-dir'])
@@ -203,7 +203,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
 
         self.assertIsNone(result.exception, result.output[-1000:])
 
-        new_computer = orm.Computer.objects.get(name=options_dict['label'])
+        new_computer = orm.Computer.objects.get(label=options_dict['label'])
         self.assertIsInstance(new_computer, orm.Computer)
         self.assertIsNone(new_computer.get_default_mpiprocs_per_machine())
 
@@ -218,7 +218,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
 
         self.assertIsNone(result.exception, result.output[-1000:])
 
-        new_computer = orm.Computer.objects.get(name=options_dict['label'])
+        new_computer = orm.Computer.objects.get(label=options_dict['label'])
         self.assertIsInstance(new_computer, orm.Computer)
         self.assertIsNone(new_computer.get_default_mpiprocs_per_machine())
 
@@ -298,7 +298,7 @@ scheduler: direct
             result = self.cli_runner.invoke(computer_setup, options)
 
         self.assertClickResultNoException(result)
-        self.assertIsInstance(orm.Computer.objects.get(name=label), orm.Computer)
+        self.assertIsInstance(orm.Computer.objects.get(label=label), orm.Computer)
 
 
 class TestVerdiComputerConfigure(AiidaTestCase):
@@ -529,7 +529,7 @@ class TestVerdiComputerCommands(AiidaTestCase):
         super().setUpClass(*args, **kwargs)
         cls.computer_name = 'comp_cli_test_computer'
         cls.comp = orm.Computer(
-            name=cls.computer_name,
+            label=cls.computer_name,
             hostname='localhost',
             transport_type='local',
             scheduler_type='direct',
@@ -638,9 +638,9 @@ class TestVerdiComputerCommands(AiidaTestCase):
         # Check that the name really was changed
         # The old name should not be available
         with self.assertRaises(NotExistent):
-            orm.Computer.objects.get(name='comp_cli_test_computer')
+            orm.Computer.objects.get(label='comp_cli_test_computer')
         # The new name should be avilable
-        orm.Computer.objects.get(name='renamed_test_computer')
+        orm.Computer.objects.get(label='renamed_test_computer')
 
         # Now change the name back
         options = ['renamed_test_computer', 'comp_cli_test_computer']
@@ -651,9 +651,9 @@ class TestVerdiComputerCommands(AiidaTestCase):
         # Check that the name really was changed
         # The old name should not be available
         with self.assertRaises(NotExistent):
-            orm.Computer.objects.get(name='renamed_test_computer')
+            orm.Computer.objects.get(label='renamed_test_computer')
         # The new name should be avilable
-        orm.Computer.objects.get(name='comp_cli_test_computer')
+        orm.Computer.objects.get(label='comp_cli_test_computer')
 
     def test_computer_delete(self):
         """
@@ -663,7 +663,7 @@ class TestVerdiComputerCommands(AiidaTestCase):
 
         # Setup a computer to delete during the test
         orm.Computer(
-            name='computer_for_test_delete',
+            label='computer_for_test_delete',
             hostname='localhost',
             transport_type='local',
             scheduler_type='direct',
@@ -683,7 +683,7 @@ class TestVerdiComputerCommands(AiidaTestCase):
         self.assertClickResultNoException(result)
         # Check that the computer really was deleted
         with self.assertRaises(NotExistent):
-            orm.Computer.objects.get(name='computer_for_test_delete')
+            orm.Computer.objects.get(label='computer_for_test_delete')
 
     def test_computer_duplicate_interactive(self):
         """Test 'verdi computer duplicate' in interactive mode."""
@@ -696,11 +696,11 @@ class TestVerdiComputerCommands(AiidaTestCase):
         )
         self.assertIsNone(result.exception, result.output)
 
-        new_computer = orm.Computer.objects.get(name=label)
+        new_computer = orm.Computer.objects.get(label=label)
         self.assertEqual(self.comp.description, new_computer.description)
-        self.assertEqual(self.comp.get_hostname(), new_computer.get_hostname())
-        self.assertEqual(self.comp.get_transport_type(), new_computer.get_transport_type())
-        self.assertEqual(self.comp.get_scheduler_type(), new_computer.get_scheduler_type())
+        self.assertEqual(self.comp.hostname, new_computer.hostname)
+        self.assertEqual(self.comp.transport_type, new_computer.transport_type)
+        self.assertEqual(self.comp.scheduler_type, new_computer.scheduler_type)
         self.assertEqual(self.comp.get_shebang(), new_computer.get_shebang())
         self.assertEqual(self.comp.get_workdir(), new_computer.get_workdir())
         self.assertEqual(self.comp.get_mpirun_command(), new_computer.get_mpirun_command())
@@ -717,11 +717,11 @@ class TestVerdiComputerCommands(AiidaTestCase):
         )
         self.assertIsNone(result.exception, result.output)
 
-        new_computer = orm.Computer.objects.get(name=label)
+        new_computer = orm.Computer.objects.get(label=label)
         self.assertEqual(self.comp.description, new_computer.description)
-        self.assertEqual(self.comp.get_hostname(), new_computer.get_hostname())
-        self.assertEqual(self.comp.get_transport_type(), new_computer.get_transport_type())
-        self.assertEqual(self.comp.get_scheduler_type(), new_computer.get_scheduler_type())
+        self.assertEqual(self.comp.hostname, new_computer.hostname)
+        self.assertEqual(self.comp.transport_type, new_computer.transport_type)
+        self.assertEqual(self.comp.scheduler_type, new_computer.scheduler_type)
         self.assertEqual(self.comp.get_shebang(), new_computer.get_shebang())
         self.assertEqual(self.comp.get_workdir(), new_computer.get_workdir())
         self.assertEqual(self.comp.get_mpirun_command(), new_computer.get_mpirun_command())
@@ -744,13 +744,13 @@ def test_interactive(clear_database_before_test, aiida_localhost, non_interactiv
     result = CliRunner().invoke(computer_setup, input=user_input)
     assert result.exception is None, 'There was an unexpected exception. Output: {}'.format(result.output)
 
-    new_computer = orm.Computer.objects.get(name=label)
+    new_computer = orm.Computer.objects.get(label=label)
     assert isinstance(new_computer, orm.Computer)
 
     assert new_computer.description == options_dict['description']
     assert new_computer.hostname == options_dict['hostname']
-    assert new_computer.get_transport_type() == options_dict['transport']
-    assert new_computer.get_scheduler_type() == options_dict['scheduler']
+    assert new_computer.transport_type == options_dict['transport']
+    assert new_computer.scheduler_type == options_dict['scheduler']
     assert new_computer.get_mpirun_command() == options_dict['mpirun-command'].split()
     assert new_computer.get_shebang() == options_dict['shebang']
     assert new_computer.get_workdir() == options_dict['work-dir']

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -532,7 +532,7 @@ class TestVerdiDataTrajectory(AiidaTestCase, DummyVerdiDataListable, DummyVerdiD
     def setUpClass(cls):  # pylint: disable=arguments-differ
         super().setUpClass()
         orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
         cls.ids = cls.create_trajectory_data()
 
@@ -613,7 +613,7 @@ class TestVerdiDataStructure(AiidaTestCase, DummyVerdiDataListable, DummyVerdiDa
     def setUpClass(cls):  # pylint: disable=arguments-differ
         super().setUpClass()
         orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
         cls.ids = cls.create_structure_data()
 
@@ -795,7 +795,7 @@ class TestVerdiDataCif(AiidaTestCase, DummyVerdiDataListable, DummyVerdiDataExpo
         """Setup class to test CifData."""
         super().setUpClass()
         orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
         cls.ids = cls.create_cif_data()

--- a/tests/cmdline/commands/test_export.py
+++ b/tests/cmdline/commands/test_export.py
@@ -49,7 +49,7 @@ class TestVerdiExport(AiidaTestCase):
         from aiida import orm
 
         cls.computer = orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
         cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1423,11 +1423,11 @@ class TestDoubleStar(AiidaTestCase):
         # pylint: disable=no-member
         expected_dict = {
             'description': self.computer.description,
-            'scheduler_type': self.computer.get_scheduler_type(),
+            'scheduler_type': self.computer.scheduler_type,
             'hostname': self.computer.hostname,
             'uuid': self.computer.uuid,
             'name': self.computer.name,
-            'transport_type': self.computer.get_transport_type(),
+            'transport_type': self.computer.transport_type,
             'id': self.computer.id,
             'metadata': self.computer.get_metadata(),
         }


### PR DESCRIPTION
Prepares for #2926 

From `aiida-core==1.0.0`, we have started using properties for getters
and setters of the basic attributes of ORM entities. Rule of thumb here
is that if the attribute corresponds to a column on the underlying
database model, a property is used.

In addition, `label` is the preferred name for the third entity
identifier, alongside the ID and UUID. This is already the case for most
entities, except for `Computer` which is still using `name`. Here,
`name` is deprecated and replaced for `label`. The changes are not yet
propagated to the backend, which will be done once the deprecated
resources are fully removed. This is fine because the backend is not
part of the public API so doesn't have to go through a deprecation path.
The `name` keyword in `Computer.objects.get` is also deprecated and
replaced by `label`.