### PR TITLE
`verdi status`: do not except when no profile is configured

### DIFF
--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -14,6 +14,7 @@ import enum
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.utils import echo
 from aiida.common.log import override_log_level
 from ..utils.echo import ExitCode
 
@@ -63,6 +64,11 @@ def verdi_status(no_rmq):
 
     manager = get_manager()
     profile = manager.get_profile()
+
+    if profile is None:
+        print_status(ServiceStatus.WARNING, 'profile', 'no profile configured yet')
+        echo.echo_info('Configure a profile by running `verdi quicksetup` or `verdi setup`.')
+        return
 
     try:
         profile = manager.get_profile()

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -8,12 +8,14 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for `verdi status`."""
+import pytest
+
 from aiida.cmdline.commands import cmd_status
 from aiida.cmdline.utils.echo import ExitCode
 
 
 def test_status(run_cli_command):
-    """Test running verdi status."""
+    """Test `verdi status`."""
     options = []
     result = run_cli_command(cmd_status.verdi_status, options)
 
@@ -25,8 +27,16 @@ def test_status(run_cli_command):
         assert string in result.output
 
 
+@pytest.mark.usefixtures('create_empty_config_instance')
+def test_status_no_profile(run_cli_command):
+    """Test `verdi status` when there is no profile."""
+    options = []
+    result = run_cli_command(cmd_status.verdi_status, options)
+    assert 'no profile configured yet' in result.output
+
+
 def test_status_no_rmq(run_cli_command):
-    """Test running verdi status, with no rmq check"""
+    """Test `verdi status` without a check for RabbitMQ."""
     options = ['--no-rmq']
     result = run_cli_command(cmd_status.verdi_status, options)
 


### PR DESCRIPTION
Fixes #4250 

Instead, print that no profile could be found and suggest that one is
setup with `verdi quicksetup` or `verdi setup`.

To test this, a new pytest fixture is created that creates a completely
new and independent configuration folder, along with fixtures to create
profiles to add to the config and caching configuration files. Similar
code already exists for normal unittests, but this can be removed once
those have been refactored to pytests.