### PR TITLE
Adding support for `peer` authentication

### DIFF
--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -24,12 +24,16 @@ def create_sqlalchemy_engine(profile, **kwargs):
     from sqlalchemy import create_engine
     from aiida.common import json
 
+    # The hostname may be `None`, which is a valid value in the case of peer authentication for example. In this case
+    # it should be converted to an empty string, because otherwise the `None` will be converted to string literal "None"
+    hostname = profile.database_hostname or ''
     separator = ':' if profile.database_port else ''
+
     engine_url = 'postgresql://{user}:{password}@{hostname}{separator}{port}/{name}'.format(
         separator=separator,
         user=profile.database_username,
         password=profile.database_password,
-        hostname=profile.database_hostname,
+        hostname=hostname,
         port=profile.database_port,
         name=profile.database_name
     )


### PR DESCRIPTION
In Postgres it is possible to use `peer` authentication.

This is signaled by a `hostname` set to `None` by `pgsu`.
In this case, the part `user:password@hostname:port` of
the connection string of the SQLAlchemy engine should be left empty.

This fixes #4032 