### PR TITLE
Fix pre-commit configuration to reinstate `pylint` running

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,11 @@ repos:
     hooks:
     -   id: pylint
         name: pylint
+        entry: pylint
+        types: [python]
         language: system
         exclude: *exclude_files
 
-    hooks:
     -   id: dm-generate-all
         name: Update all requirements files
         entry: python ./utils/dependency_management.py generate-all


### PR DESCRIPTION
The `pylint` hook was ignored because the `hook` key in the `local`
category was defined twice. In this case `pre-commit` won't complain
that the file is invalid but the second just overwrites the first
declaration. In addition, the hook was missing the keys `entry`, which
is required, and the `types` key which restricts it to running only on
Python file.