### PR TITLE
Add section on SSH passphrase storage with osx keychain

### DIFF
--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -157,6 +157,22 @@ Try logging in to the remote computer; it should no longer require a passphrase.
 The key and its corresponding passphrase are now stored by the agent until it is stopped.
 After a reboot, remember to run ``ssh-add ~/.ssh/aiida`` again before starting the AiiDA daemon.
 
+Integrating the ssh-agent with keychain on OSX
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On OSX Sierra and later, the native ``ssh-add`` client allows passphrases to be stored persistently in the `OSX keychain <https://support.apple.com/en-gb/guide/keychain-access/kyca1083/mac>`__. You can store the passphrase to keychain using the OSX only ``-k`` argument:
+
+.. code:: bash
+
+    ssh-add -k ~/.ssh/aiida
+
+Then to tell SSH to look in your OSX keychain for key passphrases, you must specify in your ``~/.ssh/config``:
+
+.. code:: bash
+
+   Host *
+      UseKeychain yes
+
 AiiDA configuration
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -167,7 +167,7 @@ Store the passphrase in the keychain using the OSX-specific ``-k`` argument:
 
     ssh-add -k ~/.ssh/aiida
 
-Then to tell SSH to look in your OSX keychain for key passphrases, you must specify in your ``~/.ssh/config``:
+To instruct ssh to look in the OSX keychain for key passphrases, add the following lines to ``~/.ssh/config``:
 
 .. code:: bash
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -160,7 +160,8 @@ After a reboot, remember to run ``ssh-add ~/.ssh/aiida`` again before starting t
 Integrating the ssh-agent with keychain on OSX
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On OSX Sierra and later, the native ``ssh-add`` client allows passphrases to be stored persistently in the `OSX keychain <https://support.apple.com/en-gb/guide/keychain-access/kyca1083/mac>`__. You can store the passphrase to keychain using the OSX only ``-k`` argument:
+On OSX Sierra and later, the native ``ssh-add`` client allows passphrases to be stored persistently in the `OSX keychain <https://support.apple.com/en-gb/guide/keychain-access/kyca1083/mac>`__.
+Store the passphrase in the keychain using the OSX-specific ``-k`` argument:
 
 .. code:: bash
 


### PR DESCRIPTION
Some extra guidance for my fellow Mac users 😄 