### PR TITLE
DOC: pip install package groups for zsh

### DIFF
--- a/docs/source/intro/installation.rst
+++ b/docs/source/intro/installation.rst
@@ -462,7 +462,7 @@ In order to install any of these package groups, simply append them as a comma s
 
 .. code-block:: console
 
-    $ pip install -e aiida-core[atomic_tools,docs]
+    $ pip install -e "aiida-core[atomic_tools,docs]"
 
 .. admonition:: Kerberos on Ubuntu
    :class: note title-icon-troubleshoot


### PR DESCRIPTION
quatation mark the name of package groups so the command also works for `zsh` .