### PR TITLE
Pin Python version for test-install:pip workflow to 3.7.7.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -99,7 +99,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -155,7 +155,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -185,7 +185,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -43,9 +43,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        # The Python version is pinned due to issue #4256.
+        # The pinning should be removed as soon as issue #3709 is resolved.
+        python-version: 3.7.7
 
     - name: Pip install
       run: |
@@ -95,7 +97,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        # Python version 3.7.7 is pinned due to issue #4256.
+        # The pinning should be removed as soon as issue #3709 is resolved.
+        python-version: [3.5, 3.6, 3.7.7, 3.8]
         backend: ['django', 'sqlalchemy']
 
     services:
@@ -121,7 +125,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -42,12 +42,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        # The Python version is pinned due to issue #4256.
-        # The pinning should be removed as soon as issue #3709 is resolved.
-        python-version: 3.7.7
+        python-version: 3.8
 
     - name: Pip install
       run: |
@@ -72,7 +70,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         update-conda: true
-        python-version: 3.7
+        python-version: 3.8
     - run: conda --version
     - run: python --version
     - run: which python


### PR DESCRIPTION
As a stop-gap solution for issue #4256.