### PR TITLE
Docs: various fixes for the command line reference

### DIFF
--- a/aiida/cmdline/commands/cmd_completioncommand.py
+++ b/aiida/cmdline/commands/cmd_completioncommand.py
@@ -17,13 +17,11 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 
 @verdi.command('completioncommand')
 def verdi_completioncommand():
-    """
-    Return the code to activate bash completion.
+    """Return the code to activate bash completion.
 
-    :note: this command is mainly for back-compatibility.
-        You should rather use:;
-
-            eval "$(_VERDI_COMPLETE=source verdi)"
+    \b
+    This command is mainly for back-compatibility.
+    You should rather use: eval "$(_VERDI_COMPLETE=source verdi)"
     """
     from click_completion import get_auto_shell, get_code
     click.echo(get_code(shell=get_auto_shell()))

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -19,7 +19,7 @@ from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 
 @verdi.command('shell')
 @decorators.with_dbenv()
-@click.option('--plain', is_flag=True, help='Use a plain Python shell.)')
+@click.option('--plain', is_flag=True, help='Use a plain Python shell.')
 @click.option(
     '--no-startup',
     is_flag=True,

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -15,7 +15,7 @@ Below is a list with all available subcommands.
 ``verdi calcjob``
 -----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -39,7 +39,7 @@ Below is a list with all available subcommands.
 ``verdi code``
 --------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -64,7 +64,7 @@ Below is a list with all available subcommands.
 ``verdi comment``
 -----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -85,16 +85,14 @@ Below is a list with all available subcommands.
 ``verdi completioncommand``
 ---------------------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS]
 
       Return the code to activate bash completion.
 
-      :note: this command is mainly for back-compatibility.     You should
-      rather use:;
-
-              eval "$(_VERDI_COMPLETE=source verdi)"
+      This command is mainly for back-compatibility.
+      You should rather use: eval "$(_VERDI_COMPLETE=source verdi)"
 
     Options:
       --help  Show this message and exit.
@@ -105,7 +103,7 @@ Below is a list with all available subcommands.
 ``verdi computer``
 ------------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -132,7 +130,7 @@ Below is a list with all available subcommands.
 ``verdi config``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] OPTION_NAME OPTION_VALUE
 
@@ -149,7 +147,7 @@ Below is a list with all available subcommands.
 ``verdi daemon``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -173,7 +171,7 @@ Below is a list with all available subcommands.
 ``verdi data``
 --------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -188,7 +186,7 @@ Below is a list with all available subcommands.
 ``verdi database``
 ------------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -207,7 +205,7 @@ Below is a list with all available subcommands.
 ``verdi devel``
 ---------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -229,7 +227,7 @@ Below is a list with all available subcommands.
 ``verdi export``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -249,7 +247,7 @@ Below is a list with all available subcommands.
 ``verdi graph``
 ---------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -267,7 +265,7 @@ Below is a list with all available subcommands.
 ``verdi group``
 ---------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -294,7 +292,7 @@ Below is a list with all available subcommands.
 ``verdi help``
 --------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] [COMMAND]
 
@@ -309,57 +307,49 @@ Below is a list with all available subcommands.
 ``verdi import``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] [--] [ARCHIVES]...
 
       Import data from an AiiDA archive file.
 
-      The archive can be specified by its relative or absolute file path, or its
-      HTTP URL.
+      The archive can be specified by its relative or absolute file path, or its HTTP URL.
 
     Options:
-      -w, --webpages TEXT...          Discover all URL targets pointing to files
-                                      with the .aiida extension for these HTTP
-                                      addresses. Automatically discovered archive
-                                      URLs will be downloadeded and added to
-                                      ARCHIVES for importing
+      -w, --webpages TEXT...          Discover all URL targets pointing to files with the
+                                      .aiida extension for these HTTP addresses. Automatically
+                                      discovered archive URLs will be downloadeded and added
+                                      to ARCHIVES for importing
 
-      -G, --group GROUP               Specify group to which all the import nodes
-                                      will be added. If such a group does not
-                                      exist, it will be created automatically.
+      -G, --group GROUP               Specify group to which all the import nodes will be
+                                      added. If such a group does not exist, it will be
+                                      created automatically.
 
       -e, --extras-mode-existing [keep_existing|update_existing|mirror|none|ask]
-                                      Specify which extras from the export archive
-                                      should be imported for nodes that are
-                                      already contained in the database: ask:
-                                      import all extras and prompt what to do for
-                                      existing extras. keep_existing: import all
-                                      extras and keep original value of existing
-                                      extras. update_existing: import all extras
-                                      and overwrite value of existing extras.
-                                      mirror: import all extras and remove any
-                                      existing extras that are not present in the
-                                      archive. none: do not import any extras.
+                                      Specify which extras from the export archive should be
+                                      imported for nodes that are already contained in the
+                                      database: ask: import all extras and prompt what to do
+                                      for existing extras. keep_existing: import all extras
+                                      and keep original value of existing extras.
+                                      update_existing: import all extras and overwrite value
+                                      of existing extras. mirror: import all extras and remove
+                                      any existing extras that are not present in the archive.
+                                      none: do not import any extras.
 
       -n, --extras-mode-new [import|none]
-                                      Specify whether to import extras of new
-                                      nodes: import: import extras. none: do not
-                                      import extras.
+                                      Specify whether to import extras of new nodes: import:
+                                      import extras. none: do not import extras.
 
       --comment-mode [newest|overwrite]
-                                      Specify the way to import Comments with
-                                      identical UUIDs: newest: Only the newest
-                                      Comments (based on mtime)
-                                      (default).overwrite: Replace existing
-                                      Comments with those from the import file.
+                                      Specify the way to import Comments with identical UUIDs:
+                                      newest: Only the newest Comments (based on mtime)
+                                      (default).overwrite: Replace existing Comments with
+                                      those from the import file.
 
-      --migration / --no-migration    Force migration of export file archives, if
-                                      needed.  [default: True]
+      --migration / --no-migration    Force migration of export file archives, if needed.
+                                      [default: True]
 
-      -n, --non-interactive           Non-interactive mode: never prompt for
-                                      input.
-
+      -n, --non-interactive           Non-interactive mode: never prompt for input.
       --help                          Show this message and exit.
 
 
@@ -368,7 +358,7 @@ Below is a list with all available subcommands.
 ``verdi node``
 --------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -396,7 +386,7 @@ Below is a list with all available subcommands.
 ``verdi plugin``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -414,7 +404,7 @@ Below is a list with all available subcommands.
 ``verdi process``
 -----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -440,7 +430,7 @@ Below is a list with all available subcommands.
 ``verdi profile``
 -----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
@@ -461,21 +451,18 @@ Below is a list with all available subcommands.
 ``verdi quicksetup``
 --------------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS]
 
       Setup a new profile in a fully automated fashion.
 
     Options:
-      -n, --non-interactive           Non-interactive mode: never prompt for
-                                      input.
-
+      -n, --non-interactive           Non-interactive mode: never prompt for input.
       --profile PROFILE               The name of the new profile.  [required]
-      --email EMAIL                   Email address associated with the data you
-                                      generate. The email address is exported
-                                      along with the data, when sharing it.
-                                      [required]
+      --email EMAIL                   Email address associated with the data you generate. The
+                                      email address is exported along with the data, when
+                                      sharing it.  [required]
 
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
@@ -491,16 +478,14 @@ Below is a list with all available subcommands.
       --db-name NONEMPTYSTRING        Name of the database to create.
       --db-username NONEMPTYSTRING    Name of the database user to create.
       --db-password TEXT              Password of the database user.
-      --su-db-name TEXT               Name of the template database to connect to
-                                      as the database superuser.
+      --su-db-name TEXT               Name of the template database to connect to as the
+                                      database superuser.
 
       --su-db-username TEXT           User name of the database super user.
-      --su-db-password TEXT           Password to connect as the database
-                                      superuser.
-
+      --su-db-password TEXT           Password to connect as the database superuser.
       --repository DIRECTORY          Absolute path to the file repository.
-      --config FILEORURL              Load option values from configuration file
-                                      in yaml format (local path or URL).
+      --config FILEORURL              Load option values from configuration file in yaml
+                                      format (local path or URL).
 
       --help                          Show this message and exit.
 
@@ -510,18 +495,18 @@ Below is a list with all available subcommands.
 ``verdi rehash``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] [NODES]...
 
       Recompute the hash for nodes in the database.
 
-      The set of nodes that will be rehashed can be filtered by their identifier
-      and/or based on their class.
+      The set of nodes that will be rehashed can be filtered by their identifier and/or
+      based on their class.
 
     Options:
-      -e, --entry-point PLUGIN  Only include nodes that are class or sub class of
-                                the class identified by this entry point.
+      -e, --entry-point PLUGIN  Only include nodes that are class or sub class of the class
+                                identified by this entry point.
 
       -f, --force               Do not ask for confirmation.
       --help                    Show this message and exit.
@@ -532,7 +517,7 @@ Below is a list with all available subcommands.
 ``verdi restapi``
 -----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS]
 
@@ -546,8 +531,8 @@ Below is a list with all available subcommands.
       -H, --hostname HOSTNAME  Hostname.
       -P, --port INTEGER       Port number.
       -c, --config-dir PATH    Path to the configuration directory
-      --wsgi-profile           Whether to enable WSGI profiler middleware for
-                               finding bottlenecks
+      --wsgi-profile           Whether to enable WSGI profiler middleware for finding
+                               bottlenecks
 
       --hookup / --no-hookup   Hookup app to flask server
       --help                   Show this message and exit.
@@ -558,7 +543,7 @@ Below is a list with all available subcommands.
 ``verdi run``
 -------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] [--] SCRIPTNAME [VARARGS]...
 
@@ -567,19 +552,19 @@ Below is a list with all available subcommands.
     Options:
       --auto-group                    Enables the autogrouping
       -l, --auto-group-label-prefix TEXT
-                                      Specify the prefix of the label of the auto
-                                      group (numbers might be automatically
-                                      appended to generate unique names per run).
+                                      Specify the prefix of the label of the auto group
+                                      (numbers might be automatically appended to generate
+                                      unique names per run).
 
-      -n, --group-name TEXT           Specify the name of the auto group
-                                      [DEPRECATED, USE --auto-group-label-prefix
-                                      instead]. This also enables auto-grouping.
+      -n, --group-name TEXT           Specify the name of the auto group [DEPRECATED, USE
+                                      --auto-group-label-prefix instead]. This also enables
+                                      auto-grouping.
 
-      -e, --exclude TEXT              Exclude these classes from auto grouping
-                                      (use full entrypoint strings).
+      -e, --exclude TEXT              Exclude these classes from auto grouping (use full
+                                      entrypoint strings).
 
-      -i, --include TEXT              Include these classes from auto grouping
-                                      (use full entrypoint strings or "all").
+      -i, --include TEXT              Include these classes from auto grouping  (use full
+                                      entrypoint strings or "all").
 
       --help                          Show this message and exit.
 
@@ -589,21 +574,18 @@ Below is a list with all available subcommands.
 ``verdi setup``
 ---------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS]
 
       Setup a new profile.
 
     Options:
-      -n, --non-interactive           Non-interactive mode: never prompt for
-                                      input.
-
+      -n, --non-interactive           Non-interactive mode: never prompt for input.
       --profile PROFILE               The name of the new profile.  [required]
-      --email EMAIL                   Email address associated with the data you
-                                      generate. The email address is exported
-                                      along with the data, when sharing it.
-                                      [required]
+      --email EMAIL                   Email address associated with the data you generate. The
+                                      email address is exported along with the data, when
+                                      sharing it.  [required]
 
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
@@ -617,13 +599,11 @@ Below is a list with all available subcommands.
 
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.  [required]
-      --db-username NONEMPTYSTRING    Name of the database user to create.
-                                      [required]
-
+      --db-username NONEMPTYSTRING    Name of the database user to create.  [required]
       --db-password TEXT              Password of the database user.  [required]
       --repository DIRECTORY          Absolute path to the file repository.
-      --config FILEORURL              Load option values from configuration file
-                                      in yaml format (local path or URL).
+      --config FILEORURL              Load option values from configuration file in yaml
+                                      format (local path or URL).
 
       --help                          Show this message and exit.
 
@@ -633,22 +613,19 @@ Below is a list with all available subcommands.
 ``verdi shell``
 ---------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS]
 
       Start a python shell with preloaded AiiDA environment.
 
     Options:
-      --plain                         Use a plain Python shell.)
-      --no-startup                    When using plain Python, ignore the
-                                      PYTHONSTARTUP environment variable and
-                                      ~/.pythonrc.py script.
+      --plain                         Use a plain Python shell.
+      --no-startup                    When using plain Python, ignore the PYTHONSTARTUP
+                                      environment variable and ~/.pythonrc.py script.
 
       -i, --interface [ipython|bpython]
-                                      Specify an interactive interpreter
-                                      interface.
-
+                                      Specify an interactive interpreter interface.
       --help                          Show this message and exit.
 
 
@@ -657,7 +634,7 @@ Below is a list with all available subcommands.
 ``verdi status``
 ----------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS]
 
@@ -673,7 +650,7 @@ Below is a list with all available subcommands.
 ``verdi user``
 --------------
 
-::
+.. code:: console
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -17,11 +17,11 @@ Validates consistency of setup.json and
  * reentry dependency in pyproject.toml
 
 """
-
+import collections
+import json
 import os
 import sys
-import json
-from collections import OrderedDict
+
 import click
 
 FILENAME_TOML = 'pyproject.toml'
@@ -35,7 +35,7 @@ FILEPATH_TOML = os.path.join(ROOT_DIR, FILENAME_TOML)
 def get_setup_json():
     """Return the `setup.json` as a python dictionary """
     with open(FILEPATH_SETUP_JSON, 'r') as fil:
-        return json.load(fil, object_pairs_hook=OrderedDict)
+        return json.load(fil, object_pairs_hook=collections.OrderedDict)
 
 
 def write_setup_json(data):
@@ -143,8 +143,10 @@ def validate_verdi_documentation():
     from click import Context
     from aiida.cmdline.commands.cmd_verdi import verdi
 
+    width = 90  # The maximum width of the formatted help strings in characters
+
     # Set the `verdi data` command to isolated mode such that external plugin commands are not discovered
-    ctx = Context(verdi)
+    ctx = Context(verdi, terminal_width=width)
     command = verdi.get_command(ctx, 'data')
     command.set_exclude_external_plugins(True)
 
@@ -159,7 +161,7 @@ def validate_verdi_documentation():
     block = ['{}\n{}\n{}\n\n'.format(header, '=' * len(header), message)]
 
     for name, command in sorted(verdi.commands.items()):
-        ctx = click.Context(command)
+        ctx = click.Context(command, terminal_width=width)
 
         header_label = '.. _reference:command-line:verdi-{name:}:'.format(name=name)
         header_string = '``verdi {name:}``'.format(name=name)
@@ -168,7 +170,7 @@ def validate_verdi_documentation():
         block.append(header_label + '\n\n')
         block.append(header_string + '\n')
         block.append(header_underline + '\n\n')
-        block.append('::\n\n')  # Mark the beginning of a literal block
+        block.append('.. code:: console\n\n')  # Mark the beginning of a literal block
         for line in ctx.get_help().split('\n'):
             if line:
                 block.append('    {}\n'.format(line))


### PR DESCRIPTION
The reference of the command line interface is generated automatically
by the `verdi-autodocs` pre-commit hook, that uses `click` itself to
format the help strings of the top-level commands. A few changes are
made to improve the appearance of the generated docs:

 * Specify explicit maximum width, by setting `terminal_width` when the
   `Context` object is constructed. It is set to 90 because with the
   current styling of the docs, this nicely fills the code boxes that are
   rendered for the documentation
 * Switch from `::` markers to `.. code:: console` in front of each
   command help string. This ensure the code is properly formatted and
   certain keywords are not colored because they are interpreted as
   Python keywords.
 * The docstrings of some `verdi` commands were adapted such that they
   are formatted properly. The `\b` magic marker is used to instruct
   `click` to respect literal whitespace, such as newline characters.