### PR TITLE
Add benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,5 @@
-## Run benchmarks on the three OSs
-## We run only on one python version (a recent one)
-## I think that different python versions might share hardware resources so results might have a much larger fluctuation
+# Note: this workflow is currently being tested,
+# and so currently is only activated for the benchmark-test-cjs branch 
 
 name: Performance benchmarks
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[tests]
+        pip install -r requirements/requirements-py-3.8.txt
     - name: Run benchmarks
       run: pytest --benchmark-only --benchmark-json output.json
     - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,5 @@
 # Note: this workflow is currently being tested,
-# and so is only activated for the benchmark-test-cjs branch 
+# and so is only activated for the benchmark-test-cjs branch
 
 name: Performance benchmarks
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,5 @@
 # Note: this workflow is currently being tested,
-# and so currently is only activated for the benchmark-test-cjs branch 
+# and so is only activated for the benchmark-test-cjs branch 
 
 name: Performance benchmarks
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,49 @@
+## Run benchmarks on the three OSs
+## We run only on one python version (a recent one)
+## I think that different python versions might share hardware resources so results might have a much larger fluctuation
+
+name: Performance benchmarks
+
+on:
+  push:
+    branches:
+      - benchmark-test-cjs
+
+jobs:
+
+  benchmarks:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[tests]
+    - name: Run benchmarks
+      run: pytest --benchmark-only --benchmark-json output.json
+    - name: Store benchmark result
+      ## Run only on push on develop! Otherwise people (or other branches) might access to the github-actions branch
+      ## This is currently disabled because we are in a workflow that has the correct 'on' settings (only push,
+      ## and only 'develop'). Otherwise, enable this
+      #if: "github.event_name == 'push' && github.ref == 'refs/heads/develop'"
+      uses: rhysd/github-action-benchmark@v1
+      with:
+        name: "Benchmark on ${{ matrix.os }}"
+        tool: "pytest"
+        output-file-path: output.json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'
+        comment-on-alert: false
+        fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install python dependencies
@@ -43,6 +43,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '200%'
+        alert-threshold: '110%'
         comment-on-alert: false
         fail-on-alert: false


### PR DESCRIPTION
As discussed earlier I want to trial this workflow in the `benchmark-test-cjs` branch.
However, after some head-scratching, it appears that the file has to be added to the default branch before it is recognised by Github Action: https://github.community/t/workflow-files-only-picked-up-from-master/16129/12
As you can see this workflow only triggers for the `benchmark-test-cjs` branch for now, so will not actually affect anything just yet