### PR TITLE
`verdi computer` option to switch off login shell

### DIFF
--- a/.github/config/localhost-config.yaml
+++ b/.github/config/localhost-config.yaml
@@ -1,2 +1,3 @@
 ---
+use_login_shell: true
 safe_interval: 0

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -42,7 +42,6 @@ class LocalTransport(Transport):
     ``unset PYTHONPATH`` if you plan on running calculations that use Python.
     """
 
-    # There are no valid parameters for the local transport
     _valid_auth_options = []
 
     # There is no real limit on how fast you can safely connect to a localhost, unlike often the case with SSH transport
@@ -744,7 +743,12 @@ class LocalTransport(Transport):
 
         # Note: The outer shell will eat one level of escaping, while
         # 'bash -l -c ...' will eat another. Thus, we need to escape again.
-        command = 'bash -l -c ' + escape_for_bash(command)
+        if self._use_login_shell:
+            bash_commmand = 'bash -l -c '
+        else:
+            bash_commmand = 'bash -c '
+
+        command = bash_commmand + escape_for_bash(command)
 
         proc = subprocess.Popen(
             command,

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -743,10 +743,7 @@ class LocalTransport(Transport):
 
         # Note: The outer shell will eat one level of escaping, while
         # 'bash -l -c ...' will eat another. Thus, we need to escape again.
-        if self._use_login_shell:
-            bash_commmand = 'bash -l -c '
-        else:
-            bash_commmand = 'bash -c '
+        bash_commmand = self._bash_command_str + '-c '
 
         command = bash_commmand + escape_for_bash(command)
 
@@ -807,11 +804,8 @@ class LocalTransport(Transport):
 
         :param str remotedir: the full path of the remote directory
         """
-        script = ' ; '.join([
-            'if [ -d {escaped_remotedir} ]', 'then cd {escaped_remotedir}', 'bash', "else echo ' ** The directory'",
-            "echo ' ** {remotedir}'", "echo ' ** seems to have been deleted, I logout...'", 'fi'
-        ]).format(escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir)
-        cmd = 'bash -c "{}"'.format(script)
+        connect_string = self._gotocomputer_string(remotedir)
+        cmd = 'bash -c {}'.format(connect_string)
         return cmd
 
     def rename(self, oldpath, newpath):

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -311,6 +311,13 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         return 'True'
 
     @classmethod
+    def _get_use_login_shell_suggestion_string(cls, computer):  # pylint: disable=unused-argument
+        """
+        Return a suggestion for the specific field.
+        """
+        return 'True'
+
+    @classmethod
     def _get_load_system_host_keys_suggestion_string(cls, computer):  # pylint: disable=unused-argument
         """
         Return a suggestion for the specific field.
@@ -361,6 +368,8 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         Initialize the SshTransport class.
 
         :param machine: the machine to connect to
+        :param use_login_shell: (optional, default True)
+           if False, do not use a login shell when executing command
         :param load_system_host_keys: (optional, default False)
            if False, do not load the system host keys
         :param key_policy: (optional, default = paramiko.RejectPolicy())
@@ -1232,7 +1241,12 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
 
         # Note: The default shell will eat one level of escaping, while
         # 'bash -l -c ...' will eat another. Thus, we need to escape again.
-        channel.exec_command('bash -l -c ' + escape_for_bash(command_to_execute))
+        if self._use_login_shell:
+            bash_commmand = 'bash -l -c '
+        else:
+            bash_commmand = 'bash -c '
+
+        channel.exec_command(bash_commmand + escape_for_bash(command_to_execute))
 
         stdin = channel.makefile('wb', bufsize)
         stdout = channel.makefile('rb', bufsize)

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -77,10 +77,20 @@ class Transport(abc.ABC):
     def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         """
         __init__ method of the Transport base class.
+
+        :param safe_interval: (optional, default self._DEFAULT_SAFE_OPEN_INTERVAL)
+           Minimum time interval in seconds between opening new connections.
+        :param use_login_shell: (optional, default True)
+           if False, do not use a login shell when executing command
         """
         from aiida.common import AIIDA_LOGGER
         self._safe_open_interval = kwargs.pop('safe_interval', self._DEFAULT_SAFE_OPEN_INTERVAL)
         self._use_login_shell = kwargs.pop('use_login_shell', True)
+        if self._use_login_shell:
+            self._bash_command_str = 'bash -l '
+        else:
+            self._bash_command_str = 'bash '
+
         self._logger = AIIDA_LOGGER.getChild('transport').getChild(self.__class__.__name__)
         self._logger_extra = None
         self._is_open = False
@@ -211,6 +221,13 @@ class Transport(abc.ABC):
         This is used to provide a default in ``verdi computer configure``.
         """
         return cls._DEFAULT_SAFE_OPEN_INTERVAL
+
+    @classmethod
+    def _get_use_login_shell_suggestion_string(cls, computer):  # pylint: disable=unused-argument
+        """
+        Return a suggestion for the specific field.
+        """
+        return 'True'
 
     @property
     def logger(self):
@@ -774,6 +791,18 @@ class Transport(abc.ABC):
 
     def has_magic(self, string):
         return self._MAGIC_CHECK.search(string) is not None
+
+    def _gotocomputer_string(self, remotedir):
+        """command executed when goto computer."""
+        connect_string = (
+            """ "if [ -d {escaped_remotedir} ] ;"""
+            """ then cd {escaped_remotedir} ; {bash_command} ; else echo '  ** The directory' ; """
+            """echo '  ** {remotedir}' ; echo '  ** seems to have been deleted, I logout...' ; fi" """.format(
+                bash_command=self._bash_command_str, escaped_remotedir="'{}'".format(remotedir), remotedir=remotedir
+            )
+        )
+
+        return connect_string
 
 
 class TransportInternalError(InternalError):

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -47,14 +47,32 @@ class Transport(abc.ABC):
     _valid_auth_params = None
     _MAGIC_CHECK = re.compile('[*?[]')
     _valid_auth_options = []
-    _common_auth_options = [(
-        'safe_interval', {
-            'type': float,
-            'prompt': 'Connection cooldown time (s)',
-            'help': 'Minimum time interval in seconds between opening new connections.',
-            'callback': validate_positive_number
-        }
-    )]
+    _common_auth_options = [
+        (
+            'use_login_shell', {
+                'default':
+                True,
+                'switch':
+                True,
+                'prompt':
+                'Use login shell when executing command',
+                'help':
+                ' Not using a login shell can help suppress potential'
+                ' spurious text output that can prevent AiiDA from parsing the output of commands,'
+                ' but may result in some startup files (.profile) not being sourced.',
+                'non_interactive_default':
+                True
+            }
+        ),
+        (
+            'safe_interval', {
+                'type': float,
+                'prompt': 'Connection cooldown time (s)',
+                'help': 'Minimum time interval in seconds between opening new connections.',
+                'callback': validate_positive_number
+            }
+        ),
+    ]
 
     def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         """
@@ -62,6 +80,7 @@ class Transport(abc.ABC):
         """
         from aiida.common import AIIDA_LOGGER
         self._safe_open_interval = kwargs.pop('safe_interval', self._DEFAULT_SAFE_OPEN_INTERVAL)
+        self._use_login_shell = kwargs.pop('use_login_shell', True)
         self._logger = AIIDA_LOGGER.getChild('transport').getChild(self.__class__.__name__)
         self._logger_extra = None
         self._is_open = False

--- a/docs/source/intro/troubleshooting.rst
+++ b/docs/source/intro/troubleshooting.rst
@@ -269,6 +269,13 @@ To test if a the computer does not produce spurious output, run (after configuri
 
 which checks and, in case of problems, suggests how to solve the problem.
 
+.. note::
+
+    If the methods explained above do not work, you can configure AiiDA to not use a login shell when connecting to your computer, which may prevent the spurious output from being printed:
+    During ``verdi computer configure``, set ``-no-use-login-shell`` or when asked to use a login shell, set it to ``False``.
+    Note, however, that this may result in a slightly different environment, since `certain startup files are only sourced for login shells <https://unix.stackexchange.com/a/46856/155909>`_.
+
+
 .. _StackExchange thread: https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc
 
 

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -370,8 +370,15 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         comp = self.comp_builder.new()
         comp.store()
 
-        result = self.cli_runner.invoke(computer_configure, ['local', comp.label], input='\n', catch_exceptions=False)
+        command_input = ('{use_login_shell}\n{safe_interval}\n').format(use_login_shell='False', safe_interval='1.0')
+        result = self.cli_runner.invoke(
+            computer_configure, ['local', comp.label], input=command_input, catch_exceptions=False
+        )
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
+
+        new_auth_params = comp.get_authinfo(self.user).get_auth_params()
+        self.assertEqual(new_auth_params['use_login_shell'], False)
+        self.assertEqual(new_auth_params['safe_interval'], 1.0)
 
     def test_ssh_interactive(self):
         """
@@ -411,6 +418,7 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         self.assertEqual(new_auth_params['port'], port)
         self.assertEqual(new_auth_params['look_for_keys'], look_for_keys)
         self.assertEqual(new_auth_params['key_filename'], key_filename)
+        self.assertEqual(new_auth_params['use_login_shell'], True)
 
     def test_local_from_config(self):
         """Test configuring a computer from a config file"""

--- a/tests/transports/test_local.py
+++ b/tests/transports/test_local.py
@@ -48,3 +48,16 @@ class TestBasicConnection(unittest.TestCase):
         """Test constructor."""
         with LocalTransport():
             pass
+
+
+def test_gotocomputer():
+    """Test gotocomputer"""
+    with LocalTransport() as transport:
+        cmd_str = transport.gotocomputer_command('/remote_dir/')
+
+        expected_str = (
+            """bash -c  "if [ -d '/remote_dir/' ] ;"""
+            """ then cd '/remote_dir/' ; bash -l  ; else echo '  ** The directory' ; """
+            """echo '  ** /remote_dir/' ; echo '  ** seems to have been deleted, I logout...' ; fi" """
+        )
+        assert cmd_str == expected_str

--- a/tests/transports/test_ssh.py
+++ b/tests/transports/test_ssh.py
@@ -55,3 +55,16 @@ class TestBasicConnection(unittest.TestCase):
 
         # Reset logging level
         logging.disable(logging.NOTSET)
+
+
+def test_gotocomputer():
+    """Test gotocomputer"""
+    with SshTransport(machine='localhost', timeout=30, use_login_shell=False, key_policy='AutoAddPolicy') as transport:
+        cmd_str = transport.gotocomputer_command('/remote_dir/')
+
+        expected_str = (
+            """ssh -t localhost   "if [ -d '/remote_dir/' ] ;"""
+            """ then cd '/remote_dir/' ; bash  ; else echo '  ** The directory' ; """
+            """echo '  ** /remote_dir/' ; echo '  ** seems to have been deleted, I logout...' ; fi" """
+        )
+        assert cmd_str == expected_str


### PR DESCRIPTION
Issue closing https://github.com/aiidateam/aiida-core/issues/2978 happened to me when connecting to [TianHe-2](https://en.wikipedia.org/wiki/Tianhe-2) . The messages output to the login shell was set in file `/etc/profile`. I make a rough fix and let it set in `verdi computer configuration ssh` . 

EDIT:
local transport plugin should also configurable with on/off login shell. As well as `gotocomputer_command` of all transport plugins. To avoid repeating define `bash_command` and repeating gotocomputer command string, encapsulating them in `Tranport` class.
