### PR TITLE
Create restapi endpoint for counting full_types

### DIFF
--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -131,6 +131,7 @@ class AiidaApi(Api):
             '/nodes/projectable_properties/',
             '/nodes/statistics/',
             '/nodes/full_types/',
+            '/nodes/full_types_count/',
             '/nodes/download_formats/',
             '/nodes/page/',
             '/nodes/page/<int:page>/',

--- a/aiida/restapi/common/config.py
+++ b/aiida/restapi/common/config.py
@@ -16,7 +16,7 @@ API_CONFIG = {
     'LIMIT_DEFAULT': 400,  # default records total
     'PERPAGE_DEFAULT': 20,  # default records per page
     'PREFIX': '/api/v4',  # prefix for all URLs
-    'VERSION': '4.0.1',
+    'VERSION': '4.1.0',
 }
 
 APP_CONFIG = {

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -208,8 +208,8 @@ class Utils:
             return (resource_type, page, node_id, query_type)
 
         if path[0] in [
-            'projectable_properties', 'statistics', 'full_types', 'download', 'download_formats', 'report', 'status',
-            'input_files', 'output_files'
+            'projectable_properties', 'statistics', 'full_types', 'full_types_count', 'download', 'download_formats',
+            'report', 'status', 'input_files', 'output_files'
         ]:
             query_type = path.pop(0)
             if path:

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -264,14 +264,22 @@ class Node(BaseResource):
         elif query_type == 'statistics':
             headers = self.utils.build_headers(url=request.url, total_count=0)
             if filters:
-                usr = filters['user']['==']
+                user_pk = filters['user']['==']
             else:
-                usr = None
-            results = self.trans.get_statistics(usr)
+                user_pk = None
+            results = self.trans.get_statistics(user_pk)
 
         elif query_type == 'full_types':
             headers = self.utils.build_headers(url=request.url, total_count=0)
             results = self.trans.get_namespace()
+
+        elif query_type == 'full_types_count':
+            headers = self.utils.build_headers(url=request.url, total_count=0)
+            if filters:
+                user_pk = filters['user']['==']
+            else:
+                user_pk = None
+            results = self.trans.get_namespace(user_pk=user_pk, count_nodes=True)
 
         # TODO improve the performance of tree endpoint by getting the data from database faster
         # TODO add pagination for this endpoint (add default max limit)

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -577,12 +577,12 @@ class NodeTranslator(BaseTranslator):
         return qmanager.get_creation_statistics(user_pk=user_pk)
 
     @staticmethod
-    def get_namespace():
+    def get_namespace(user_pk=None, count_nodes=False):
         """
         return full_types of the nodes
         """
 
-        return get_node_namespace().get_description()
+        return get_node_namespace(user_pk=user_pk, count_nodes=count_nodes).get_description()
 
     def get_io_tree(self, uuid_pattern, tree_in_limit, tree_out_limit):
         # pylint: disable=too-many-statements,too-many-locals

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -55,3 +55,31 @@ def restrict_sqlalchemy_queuepool(aiida_profile):
     backend_manager = get_manager().get_backend_manager()
     backend_manager.reset_backend_environment()
     backend_manager.load_backend_environment(aiida_profile, pool_timeout=1, max_overflow=0)
+
+
+@pytest.fixture
+def populate_restapi_database(clear_database_before_test):
+    """Populates the database with a considerable set of nodes to test the restAPI"""
+    # pylint: disable=unused-argument
+    from aiida import orm
+
+    struct_forcif = orm.StructureData().store()
+    orm.StructureData().store()
+    orm.StructureData().store()
+
+    orm.Dict().store()
+    orm.Dict().store()
+
+    orm.CifData(ase=struct_forcif.get_ase()).store()
+
+    orm.KpointsData().store()
+
+    orm.FolderData().store()
+
+    orm.CalcFunctionNode().store()
+    orm.CalcJobNode().store()
+    orm.CalcJobNode().store()
+
+    orm.WorkFunctionNode().store()
+    orm.WorkFunctionNode().store()
+    orm.WorkChainNode().store()

--- a/tests/restapi/test_identifiers.py
+++ b/tests/restapi/test_identifiers.py
@@ -8,62 +8,219 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the `aiida.restapi.common.identifiers` module."""
-from aiida.backends.testbase import AiidaTestCase
+from threading import Thread
+
+import pytest
+import requests
+
+from aiida import orm
 from aiida.restapi.common.identifiers import get_full_type_filters, FULL_TYPE_CONCATENATOR, LIKE_OPERATOR_CHARACTER
 
 
-class TestIdentifiers(AiidaTestCase):
-    """Tests for the :py:mod:`~aiida.restapi.common.identifiers` module."""
+def test_get_full_type_filters():
+    """Coverage test for the `get_full_type_filters` function."""
 
-    def test_get_full_type_filters(self):
-        """Test the `get_full_type_filters` function."""
+    # Equals on both
+    filters = get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}process_type')
+    assert filters['node_type'] == {'==': 'node_type'}
+    assert filters['process_type'] == {'==': 'process_type'}
 
-        with self.assertRaises(TypeError):
-            get_full_type_filters(10)
+    # Like on `node_type`
+    filters = get_full_type_filters(f'node_type{LIKE_OPERATOR_CHARACTER}{FULL_TYPE_CONCATENATOR}process_type')
+    assert filters['node_type'] == {'like': 'node\\_type%'}
+    assert filters['process_type'] == {'==': 'process_type'}
 
-        with self.assertRaises(ValueError):
-            get_full_type_filters('string_without_full_type_concatenator')
+    # Like on `process_type`
+    filters = get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}process_type{LIKE_OPERATOR_CHARACTER}')
+    assert filters['node_type'] == {'==': 'node_type'}
+    assert filters['process_type'] == {'like': 'process\\_type%'}
 
-        with self.assertRaises(ValueError):
-            get_full_type_filters(
-                'too_many_{like}{like}{concat}process_type'.format(
-                    like=LIKE_OPERATOR_CHARACTER, concat=FULL_TYPE_CONCATENATOR
-                )
-            )
+    # Like on both
+    filters = get_full_type_filters(
+        'node_type{like}{concat}process_type{like}'.format(like=LIKE_OPERATOR_CHARACTER, concat=FULL_TYPE_CONCATENATOR)
+    )
+    assert filters['node_type'] == {'like': 'node\\_type%'}
+    assert filters['process_type'] == {'like': 'process\\_type%'}
 
-        with self.assertRaises(ValueError):
-            get_full_type_filters(
-                'node_type{concat}too_many_{like}{like}'.format(
-                    like=LIKE_OPERATOR_CHARACTER, concat=FULL_TYPE_CONCATENATOR
-                )
-            )
+    # Test patologic case of process_type = '' / None
+    filters = get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}')
+    assert filters['node_type'] == {'==': 'node_type'}
+    assert filters['process_type'] == {'or': [{'==': ''}, {'==': None}]}
 
-        with self.assertRaises(ValueError):
-            get_full_type_filters(f'not_at_{LIKE_OPERATOR_CHARACTER}_the_end{FULL_TYPE_CONCATENATOR}process_type')
+    filters = get_full_type_filters(f'node_type{LIKE_OPERATOR_CHARACTER}{FULL_TYPE_CONCATENATOR}')
+    assert filters['node_type'] == {'like': 'node\\_type%'}
+    assert filters['process_type'] == {'or': [{'==': ''}, {'==': None}]}
 
-        with self.assertRaises(ValueError):
-            get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}not_at_{LIKE_OPERATOR_CHARACTER}_the_end')
 
-        # Equals on both
-        filters = get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}process_type')
-        self.assertEqual(filters['node_type'], 'node\\_type')
-        self.assertEqual(filters['process_type'], 'process\\_type')
+def test_get_filters_errors():
+    """Test the `get_full_type_filters` function."""
 
-        # Like on `node_type`
-        filters = get_full_type_filters(f'node_type{LIKE_OPERATOR_CHARACTER}{FULL_TYPE_CONCATENATOR}process_type')
-        self.assertEqual(filters['node_type'], {'like': 'node\\_type%'})
-        self.assertEqual(filters['process_type'], 'process\\_type')
+    with pytest.raises(TypeError):
+        get_full_type_filters(10)
 
-        # Like on `process_type`
-        filters = get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}process_type{LIKE_OPERATOR_CHARACTER}')
-        self.assertEqual(filters['node_type'], 'node\\_type')
-        self.assertEqual(filters['process_type'], {'like': 'process\\_type%'})
+    with pytest.raises(ValueError):
+        get_full_type_filters('string_without_full_type_concatenator')
 
-        # Like on both
-        filters = get_full_type_filters(
-            'node_type{like}{concat}process_type{like}'.format(
+    with pytest.raises(ValueError):
+        get_full_type_filters(
+            'too_many_{like}{like}{concat}process_type'.format(
                 like=LIKE_OPERATOR_CHARACTER, concat=FULL_TYPE_CONCATENATOR
             )
         )
-        self.assertEqual(filters['node_type'], {'like': 'node\\_type%'})
-        self.assertEqual(filters['process_type'], {'like': 'process\\_type%'})
+
+    with pytest.raises(ValueError):
+        get_full_type_filters(
+            'node_type{concat}too_many_{like}{like}'.format(
+                like=LIKE_OPERATOR_CHARACTER, concat=FULL_TYPE_CONCATENATOR
+            )
+        )
+
+    with pytest.raises(ValueError):
+        get_full_type_filters(f'not_at_{LIKE_OPERATOR_CHARACTER}_the_end{FULL_TYPE_CONCATENATOR}process_type')
+
+    with pytest.raises(ValueError):
+        get_full_type_filters(f'node_type{FULL_TYPE_CONCATENATOR}not_at_{LIKE_OPERATOR_CHARACTER}_the_end')
+
+
+@pytest.mark.parametrize(
+    'process_class', [orm.CalcFunctionNode, orm.CalcJobNode, orm.WorkFunctionNode, orm.WorkChainNode]
+)
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_full_type_unregistered(process_class, restapi_server, server_url):
+    """Functionality test for the compatibility with old process_type entries.
+
+    This will only check the integrity of the shape of the tree, there is no checking on how the
+    data should be represented internally in term of full types, labels, etc. The only thing that
+    must work correctly is the internal consistency of `full_type` as it is interpreted by the
+    get_full_type_filters and the querybuilder.
+    """
+    # pylint: disable=too-many-statements
+    calc_unreg11 = process_class()
+    calc_unreg11.set_process_type('unregistered_type1.process1')
+    calc_unreg11.store()
+
+    calc_unreg21 = process_class()
+    calc_unreg21.set_process_type('unregistered_type2.process1')
+    calc_unreg21.store()
+
+    calc_unreg22 = process_class()
+    calc_unreg22.set_process_type('unregistered_type2.process2')
+    calc_unreg22.store()
+
+    server = restapi_server()
+    server_thread = Thread(target=server.serve_forever)
+
+    try:
+        server_thread.start()
+        type_count_response = requests.get(f'{server_url}/nodes/full_types', timeout=10)
+    finally:
+        server.shutdown()
+
+    # All nodes = only processes
+    # The main branch for all nodes does not currently return a queryable full_type
+    current_namespace = type_count_response.json()['data']
+    assert len(current_namespace['subspaces']) == 1
+
+    # All processes = only one kind of process (Calculation/Workflow)
+    current_namespace = current_namespace['subspaces'][0]
+    query_all = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(current_namespace['full_type']))
+    assert len(current_namespace['subspaces']) == 1
+    assert query_all.count() == 3
+
+    # All subprocesses = only one kind of subprocess (calcfunc/workfunc or calcjob/workchain)
+    current_namespace = current_namespace['subspaces'][0]
+    query_all = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(current_namespace['full_type']))
+    assert len(current_namespace['subspaces']) == 1
+    assert query_all.count() == 3
+
+    # One branch for each registered plugin and one for all unregistered
+    # (there are only unregistered here)
+    current_namespace = current_namespace['subspaces'][0]
+    query_all = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(current_namespace['full_type']))
+    assert len(current_namespace['subspaces']) == 1
+    assert query_all.count() == 3
+
+    # There are only two  process types: unregistered_type1 (1) and unregistered_type2 (2)
+    # The unregistered branch does not currently return a queryable full_type
+    current_namespace = current_namespace['subspaces'][0]
+    assert len(current_namespace['subspaces']) == 2
+
+    type_namespace = current_namespace['subspaces'][0]
+    query_type = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(type_namespace['full_type']))
+    assert len(type_namespace['subspaces']) == 1
+    assert query_type.count() == 1
+
+    type_namespace = current_namespace['subspaces'][1]
+    query_type = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(type_namespace['full_type']))
+    assert len(type_namespace['subspaces']) == 2
+    assert query_type.count() == 2
+
+    # Finally we check each specific subtype (1 for unregistered_type1 and 2 for unregistered_type2)
+    # These are lead nodes without any further subspace
+    type_namespace = current_namespace['subspaces'][0]['subspaces'][0]
+    query_type = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(type_namespace['full_type']))
+    assert len(type_namespace['subspaces']) == 0
+    assert query_type.count() == 1
+
+    type_namespace = current_namespace['subspaces'][1]['subspaces'][0]
+    query_type = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(type_namespace['full_type']))
+    assert len(type_namespace['subspaces']) == 0
+    assert query_type.count() == 1
+
+    type_namespace = current_namespace['subspaces'][1]['subspaces'][1]
+    query_type = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(type_namespace['full_type']))
+    assert len(type_namespace['subspaces']) == 0
+    assert query_type.count() == 1
+
+
+@pytest.mark.parametrize('node_class', [orm.CalcFunctionNode, orm.Dict])
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_full_type_backwards_compatibility(node_class, restapi_server, server_url):
+    """Functionality test for the compatibility with old process_type entries.
+
+    This will only check the integrity of the shape of the tree, there is no checking on how the
+    data should be represented internally in term of full types, labels, etc. The only thing that
+    must work correctly is the internal consistency of `full_type` as it is interpreted by the
+    get_full_type_filters and the querybuilder.
+    """
+    node_empty = node_class()
+    node_empty.process_type = ''
+    node_empty.store()
+
+    node_nones = node_class()
+    node_nones.process_type = None
+    node_nones.store()
+
+    server = restapi_server()
+    server_thread = Thread(target=server.serve_forever)
+
+    try:
+        server_thread.start()
+        type_count_response = requests.get(f'{server_url}/nodes/full_types', timeout=10)
+    finally:
+        server.shutdown()
+
+    # All nodes (contains either a process branch or data branch)
+    # The main branch for all nodes does not currently return a queryable full_type
+    current_namespace = type_count_response.json()['data']
+    assert len(current_namespace['subspaces']) == 1
+
+    # All subnodes (contains a workflow, calculation or data_type branch)
+    current_namespace = current_namespace['subspaces'][0]
+    query_all = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(current_namespace['full_type']))
+    assert len(current_namespace['subspaces']) == 1
+    assert query_all.count() == 2
+
+    # If this is a process node, there is an extra branch before the leaf
+    # (calcfunction, workfunction, calcjob or workchain)
+    if issubclass(node_class, orm.ProcessNode):
+        current_namespace = current_namespace['subspaces'][0]
+        query_all = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(current_namespace['full_type']))
+        assert len(current_namespace['subspaces']) == 1
+        assert query_all.count() == 2
+
+    # This will be the last leaf: the specific data type or the empty process_type
+    current_namespace = current_namespace['subspaces'][0]
+    query_all = orm.QueryBuilder().append(orm.Node, filters=get_full_type_filters(current_namespace['full_type']))
+    assert len(current_namespace['subspaces']) == 0
+    assert query_all.count() == 2

--- a/tests/restapi/test_identifiers.py
+++ b/tests/restapi/test_identifiers.py
@@ -10,8 +10,8 @@
 """Tests for the `aiida.restapi.common.identifiers` module."""
 from threading import Thread
 
-import pytest
 import requests
+import pytest
 
 from aiida import orm
 from aiida.restapi.common.identifiers import get_full_type_filters, FULL_TYPE_CONCATENATOR, LIKE_OPERATOR_CHARACTER

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -1067,15 +1067,20 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         Test the rest api call to get list of available node namespace
         """
-        url = f'{self.get_url_prefix()}/nodes/full_types'
-        with self.app.test_client() as client:
-            rv_obj = client.get(url)
-            response = json.loads(rv_obj.data)
-            expected_data_keys = ['path', 'namespace', 'subspaces', 'label', 'full_type']
-            response_keys = response['data'].keys()
-            for dkay in expected_data_keys:
-                self.assertIn(dkay, response_keys)
-            RESTApiTestCase.compare_extra_response_data(self, 'nodes', url, response)
+        endpoint_datakeys = {
+            '/nodes/full_types': ['path', 'namespace', 'subspaces', 'label', 'full_type'],
+            '/nodes/full_types_count': ['path', 'namespace', 'subspaces', 'label', 'full_type', 'counter'],
+        }
+
+        for endpoint_suffix, expected_data_keys in endpoint_datakeys.items():
+            url = f'{self.get_url_prefix()}{endpoint_suffix}'
+            with self.app.test_client() as client:
+                rv_obj = client.get(url)
+                response = json.loads(rv_obj.data)
+                response_keys = response['data'].keys()
+                for dkay in expected_data_keys:
+                    self.assertIn(dkay, response_keys)
+                RESTApiTestCase.compare_extra_response_data(self, 'nodes', url, response)
 
     def test_comments(self):
         """

--- a/tests/restapi/test_statistics.py
+++ b/tests/restapi/test_statistics.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Unit tests for REST API statistics."""
+from threading import Thread
+
+import requests
+import pytest
+
+
+def linearize_namespace(tree_namespace, linear_namespace=None):
+    """Linearize a branched namespace with full_type, count, and subspaces"""
+    if linear_namespace is None:
+        linear_namespace = {}
+
+    full_type = tree_namespace['full_type']
+    while full_type[-1] != '.':
+        full_type = full_type[0:-1]
+
+    counter = tree_namespace['counter']
+    subspaces = tree_namespace['subspaces']
+
+    linear_namespace[full_type] = counter
+    for subspace in subspaces:
+        linearize_namespace(subspace, linear_namespace)
+
+    return linear_namespace
+
+
+@pytest.mark.usefixtures('populate_restapi_database')
+def test_count_consistency(restapi_server, server_url):
+    """
+    Test the consistency in values between full_type_count and statistics
+    """
+    server = restapi_server()
+    server_thread = Thread(target=server.serve_forever)
+
+    try:
+        server_thread.start()
+        type_count_response = requests.get(f'{server_url}/nodes/full_types_count', timeout=10)
+        statistics_response = requests.get(f'{server_url}/nodes/statistics', timeout=10)
+    finally:
+        server.shutdown()
+
+    type_count_dict = linearize_namespace(type_count_response.json()['data'])
+    statistics_dict = statistics_response.json()['data']['types']
+
+    for full_type, count in statistics_dict.items():
+        if full_type in type_count_dict:
+            assert count == type_count_dict[full_type]


### PR DESCRIPTION
Fixes #4247 
Fixes #4541

Work in progress: currently only the end leaves are counted, and not the container branches.

- Changes in `aiida/restapi/api.py` and `aiida/restapi/common/utils.py` only add the new endpoint to relevant lists, and `aiida/restapi/resources.py` redirects the request to the new endpoint to an internal function.
- The internal function (`get_namespace`) resides in `aiida/restapi/translator/nodes/node.py`, and is the same as the one requested for the `full_types` endpoint, except it has been adapted with an optional keyword to count the nodes. This in turn is passed to `get_node_namespace` inside of `aiida/restapi/common/identifiers.py`.
- Most modifications where done in `aiida/restapi/common/identifiers.py`, where the namespace class is defined. The initialization was adapted to include a counter, which receives an `None` value unless the option to count nodes was selected when calling `get_node_namespace`. This value gets returned when the `get_description` method is called (when requesting the endpoint).