### PR TITLE
ci: unpin python version

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -98,9 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Python version 3.7.7 is pinned due to issue #4256.
-        # The pinning should be removed as soon as issue #3709 is resolved.
-        python-version: [3.5, 3.6, 3.7.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         backend: ['django', 'sqlalchemy']
 
     services:


### PR DESCRIPTION
The virtual environment of runners on Github Actions had an issue, where
installing a different pyyaml version than the one present resulted in
an error.
The issue has been resolved in the latest image, and so the workaround
of specifically requesting the (outdated) python version 3.7.7 can be
dropped.

See https://github.com/actions/virtual-environments/issues/1202#issuecomment-670157812