### PR TITLE
rerun flaky tests

### DIFF
--- a/requirements/requirements-py-3.5.txt
+++ b/requirements/requirements-py-3.5.txt
@@ -98,6 +98,7 @@ pyparsing==2.4.6
 pyrsistent==0.15.7
 pytest==5.4.2
 pytest-cov==2.8.1
+pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
 python-dateutil==2.8.1
 python-editor==1.0.4

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -97,6 +97,7 @@ pyparsing==2.4.6
 pyrsistent==0.15.7
 pytest==5.4.2
 pytest-cov==2.8.1
+pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
 python-dateutil==2.8.1
 python-editor==1.0.4

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -96,6 +96,7 @@ pyparsing==2.4.6
 pyrsistent==0.15.7
 pytest==5.4.2
 pytest-cov==2.8.1
+pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
 python-dateutil==2.8.1
 python-editor==1.0.4

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -95,6 +95,7 @@ pyparsing==2.4.6
 pyrsistent==0.15.7
 pytest==5.4.2
 pytest-cov==2.8.1
+pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
 python-dateutil==2.8.1
 python-editor==1.0.4

--- a/setup.json
+++ b/setup.json
@@ -104,6 +104,7 @@
             "pytest~=5.4",
             "pytest-timeout~=1.3",
             "pytest-cov~=2.7",
+            "pytest-rerunfailures~=9.0",
             "coverage<5.0",
             "sqlalchemy-diff~=0.1.3"
         ],

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -86,7 +86,8 @@ class TestVerdiDaemon(AiidaTestCase):
         finally:
             self.daemon_client.stop_daemon(wait=True)
 
-    @pytest.mark.skip(reason='Test fails non-deterministically; see issue #3051.')
+    # Tracked in issue #3051
+    @pytest.mark.flaky(reruns=2)
     def test_daemon_start_number(self):
         """Test `verdi daemon start` with a specific number of workers."""
 
@@ -111,7 +112,8 @@ class TestVerdiDaemon(AiidaTestCase):
         finally:
             self.daemon_client.stop_daemon(wait=True)
 
-    @pytest.mark.skip(reason='Test fails non-deterministically; see issue #3051.')
+    # Tracked in issue #3051
+    @pytest.mark.flaky(reruns=2)
     def test_daemon_start_number_config(self):
         """Test `verdi daemon start` with `daemon.default_workers` config option being set."""
         number = 3

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -1287,7 +1287,7 @@ class TestWorkChainExpose(AiidaTestCase):
             }
         )
 
-    @unittest.skip('Functionality of `WorkChain.exposed_outputs` is broken.')
+    @unittest.skip('Functionality of `Process.exposed_outputs` is broken for nested namespaces, see issue #3533.')
     def test_nested_expose(self):
         res = launch.run(
             GrandParentExposeWorkChain,

--- a/tests/manage/backup/test_backup_script.py
+++ b/tests/manage/backup/test_backup_script.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 
 from dateutil.parser import parse
+import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import utils, json
@@ -281,6 +282,8 @@ class TestBackupScriptIntegration(AiidaTestCase):
         super().setUpClass(*args, **kwargs)
         cls._bs_instance = backup_setup.BackupSetup()
 
+    # Tracked in issue #2134
+    @pytest.mark.flaky(reruns=2)
     def test_integration(self):
         """Test integration"""
         from aiida.common.utils import Capturing

--- a/tests/orm/data/test_data.py
+++ b/tests/orm/data/test_data.py
@@ -11,6 +11,7 @@
 
 import os
 import numpy
+import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
@@ -67,6 +68,8 @@ class TestData(AiidaTestCase):
             'for this data class, add a generator of a dummy instance here'.format(data_class)
         )
 
+    # Tracked in issue #4281
+    @pytest.mark.flaky(reruns=2)
     def test_data_exporters(self):
         """Verify that the return value of the export methods of all `Data` sub classes have the correct type.
 

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name,missing-docstring,too-many-lines
 """Tests for the QueryBuilder."""
 import warnings
+import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
@@ -130,6 +131,8 @@ class TestQueryBuilder(AiidaTestCase):
         self.assertEqual(get_group_type_filter(classifiers, False), {'==': 'pseudo.family'})
         self.assertEqual(get_group_type_filter(classifiers, True), {'like': 'pseudo.family%'})
 
+    # Tracked in issue #4281
+    @pytest.mark.flaky(reruns=2)
     def test_process_query(self):
         """
         Test querying for a process class.

--- a/tests/restapi/test_threaded_restapi.py
+++ b/tests/restapi/test_threaded_restapi.py
@@ -62,6 +62,8 @@ def test_run_threaded_server(restapi_server, server_url, aiida_localhost):
             pytest.fail('Thread did not close/join within 1 min after REST API server was called to shutdown')
 
 
+# Tracked in issue #4281
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures('clear_database_before_test', 'restrict_sqlalchemy_queuepool')
 def test_run_without_close_session(restapi_server, server_url, aiida_localhost, capfd):
     """Run AiiDA REST API threaded in a separate thread and perform many sequential requests"""

--- a/tests/tools/importexport/test_specific_import.py
+++ b/tests/tools/importexport/test_specific_import.py
@@ -13,8 +13,6 @@ import os
 import shutil
 import tempfile
 
-import unittest
-
 import numpy as np
 
 from aiida import orm
@@ -268,7 +266,6 @@ class TestSpecificImport(AiidaTestCase):
             'Unable to find the repository folder for Node with UUID={}'.format(node_uuid), str(exc.exception)
         )
 
-    @unittest.skip('Reenable when issue #3199 is solve (PR #3242): Fix `extract_tree`')
     @with_temp_dir
     def test_empty_repo_folder_export(self, temp_dir):
         """Check a Node's empty repository folder is exported properly"""


### PR DESCRIPTION
Over time, we've accumulated a handful of tests that pass just fine most
of the time, but fail every now and then when the bits align with the
wrong star.
While the right thing to do would be a deep dive into astrology, there's
always so many other things to do!

As a mitigation strategy, this PR marks those tests as 'flaky' and uses
the pytest-rerunfailures plugin to automatically try re-running those
tests a few times before considering them failed.

Note that this also makes it easier to identify flaky tests, a simple
`git grep mark.flaky` will do the trick.

P.S. Mentioning issues of tests that are marked as flaky: #2134 #3051 #4281 