### PR TITLE
Pin ase dependency to <3.20 for Python 3.5.

### DIFF
--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -3,7 +3,7 @@ alabaster==0.7.12
 aldjemy==0.9.1
 alembic==1.4.1
 aniso8601==8.0.0
-ase==3.19.0
+ase==3.20.0
 attrs==19.3.0
 Babel==2.8.0
 backcall==0.1.0

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -3,7 +3,7 @@ alabaster==0.7.12
 aldjemy==0.9.1
 alembic==1.4.1
 aniso8601==8.0.0
-ase==3.19.0
+ase==3.20.0
 attrs==19.3.0
 Babel==2.8.0
 backcall==0.1.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -3,7 +3,7 @@ alabaster==0.7.12
 aldjemy==0.9.1
 alembic==1.4.1
 aniso8601==8.0.0
-ase==3.19.0
+ase==3.20.0
 attrs==19.3.0
 Babel==2.8.0
 backcall==0.1.0

--- a/setup.json
+++ b/setup.json
@@ -80,7 +80,8 @@
         ],
         "atomic_tools": [
             "PyCifRW~=4.4",
-            "ase~=3.18",
+            "ase~=3.18; python_version>'3.5'",
+            "ase~=3.18,<3.20; python_version<='3.5'",
             "pymatgen>=2019.7.2",
             "pymysql~=0.9.3",
             "seekpath~=1.9,>=1.9.3",


### PR DESCRIPTION
Resolves issue #4295.

I recommend to create a hotfix release for this.