### PR TITLE
Deprecate methods that refer to a computer's label as name

### DIFF
--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -271,4 +271,4 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force):
                 clean_remote(transport, path)
                 counter += 1
 
-        echo.echo_success('{} remote folders cleaned on {}'.format(counter, computer.name))
+        echo.echo_success('{} remote folders cleaned on {}'.format(counter, computer.label))

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -9,16 +9,16 @@
 ###########################################################################
 # pylint: disable=invalid-name,too-many-statements,too-many-branches
 """`verdi computer` command."""
-
 from functools import partial
 
 import click
+import tabulate
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options, arguments
 from aiida.cmdline.params.options.commands import computer as options_computer
 from aiida.cmdline.utils import echo
-from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.decorators import with_dbenv, deprecated_command
 from aiida.cmdline.utils.multi_line_input import ensure_scripts
 from aiida.common.exceptions import ValidationError, InputValidationError
 from aiida.plugins.entry_point import get_entry_points
@@ -260,10 +260,10 @@ def computer_setup(ctx, non_interactive, **kwargs):
     except ValidationError as err:
         echo.echo_critical('unable to store the computer: {}. Exiting...'.format(err))
     else:
-        echo.echo_success('Computer<{}> {} created'.format(computer.pk, computer.name))
+        echo.echo_success('Computer<{}> {} created'.format(computer.pk, computer.label))
 
     echo.echo_info('Note: before the computer can be used, it has to be configured with the command:')
-    echo.echo_info('  verdi computer configure {} {}'.format(computer.get_transport_type(), computer.name))
+    echo.echo_info('  verdi computer configure {} {}'.format(computer.transport_type, computer.label))
 
 
 @verdi_computer.command('duplicate')
@@ -316,20 +316,20 @@ def computer_duplicate(ctx, computer, non_interactive, **kwargs):
     except (ComputerBuilder.ComputerValidationError, ValidationError) as e:
         echo.echo_critical('{}: {}'.format(type(e).__name__, e))
     else:
-        echo.echo_success('stored computer {}<{}>'.format(computer.name, computer.pk))
+        echo.echo_success('stored computer {}<{}>'.format(computer.label, computer.pk))
 
     try:
         computer.store()
     except ValidationError as err:
         echo.echo_critical('unable to store the computer: {}. Exiting...'.format(err))
     else:
-        echo.echo_success('Computer<{}> {} created'.format(computer.pk, computer.name))
+        echo.echo_success('Computer<{}> {} created'.format(computer.pk, computer.label))
 
     is_configured = computer.is_user_configured(orm.User.objects.get_default())
 
     if not is_configured:
         echo.echo_info('Note: before the computer can be used, it has to be configured with the command:')
-        echo.echo_info('  verdi computer configure {} {}'.format(computer.get_transport_type(), computer.name))
+        echo.echo_info('  verdi computer configure {} {}'.format(computer.transport_type, computer.label))
 
 
 @verdi_computer.command('enable')
@@ -344,15 +344,15 @@ def computer_enable(computer, user):
         authinfo = computer.get_authinfo(user)
     except NotExistent:
         echo.echo_critical(
-            "User with email '{}' is not configured for computer '{}' yet.".format(user.email, computer.name)
+            "User with email '{}' is not configured for computer '{}' yet.".format(user.email, computer.label)
         )
 
     if not authinfo.enabled:
         authinfo.enabled = True
-        echo.echo_info("Computer '{}' enabled for user {}.".format(computer.name, user.get_full_name()))
+        echo.echo_info("Computer '{}' enabled for user {}.".format(computer.label, user.get_full_name()))
     else:
         echo.echo_info(
-            "Computer '{}' was already enabled for user {} {}.".format(computer.name, user.first_name, user.last_name)
+            "Computer '{}' was already enabled for user {} {}.".format(computer.label, user.first_name, user.last_name)
         )
 
 
@@ -370,15 +370,17 @@ def computer_disable(computer, user):
         authinfo = computer.get_authinfo(user)
     except NotExistent:
         echo.echo_critical(
-            "User with email '{}' is not configured for computer '{}' yet.".format(user.email, computer.name)
+            "User with email '{}' is not configured for computer '{}' yet.".format(user.email, computer.label)
         )
 
     if authinfo.enabled:
         authinfo.enabled = False
-        echo.echo_info("Computer '{}' disabled for user {}.".format(computer.name, user.get_full_name()))
+        echo.echo_info("Computer '{}' disabled for user {}.".format(computer.label, user.get_full_name()))
     else:
         echo.echo_info(
-            "Computer '{}' was already disabled for user {} {}.".format(computer.name, user.first_name, user.last_name)
+            "Computer '{}' was already disabled for user {} {}.".format(
+                computer.label, user.first_name, user.last_name
+            )
         )
 
 
@@ -400,7 +402,7 @@ def computer_list(all_entries, raw):
     if not computers:
         echo.echo_info("No computers configured yet. Use 'verdi computer setup'")
 
-    sort = lambda computer: computer.name
+    sort = lambda computer: computer.label
     highlight = lambda comp: comp.is_user_configured(user) and comp.is_user_enabled(user)
     hide = lambda comp: not (comp.is_user_configured(user) and comp.is_user_enabled(user)) and not all_entries
     echo.echo_formatted_list(computers, ['name'], sort=sort, highlight=highlight, hide=hide)
@@ -411,36 +413,57 @@ def computer_list(all_entries, raw):
 @with_dbenv()
 def computer_show(computer):
     """Show detailed information for a computer."""
-    echo.echo(computer.full_text_info)
+    table = []
+    table.append(['Label', computer.label])
+    table.append(['PK', computer.pk])
+    table.append(['UUID', computer.uuid])
+    table.append(['Description', computer.description])
+    table.append(['Hostname', computer.hostname])
+    table.append(['Transport type', computer.transport_type])
+    table.append(['Scheduler type', computer.scheduler_type])
+    table.append(['Work directory', computer.get_workdir()])
+    table.append(['Shebang', computer.get_shebang()])
+    table.append(['Mpirun command', ' '.join(computer.get_mpirun_command())])
+    table.append(['Prepend text', computer.get_prepend_text()])
+    table.append(['Append text', computer.get_append_text()])
+    echo.echo(tabulate.tabulate(table))
 
 
 @verdi_computer.command('rename')
 @arguments.COMPUTER()
 @arguments.LABEL('NEW_NAME')
+@deprecated_command("This command has been deprecated. Please use 'verdi computer relabel' instead.")
+@click.pass_context
 @with_dbenv()
-def computer_rename(computer, new_name):
+def computer_rename(ctx, computer, new_name):
     """Rename a computer."""
+    ctx.invoke(computer_relabel, computer=computer, label=new_name)
+
+
+@verdi_computer.command('relabel')
+@arguments.COMPUTER()
+@arguments.LABEL('LABEL')
+@with_dbenv()
+def computer_relabel(computer, label):
+    """Relabel a computer."""
     from aiida.common.exceptions import UniquenessError
 
-    old_name = computer.get_name()
+    old_label = computer.label
 
-    if old_name == new_name:
-        echo.echo_critical('The old and new names are the same.')
+    if old_label == label:
+        echo.echo_critical('The old and new labels are the same.')
 
     try:
-        computer.set_name(new_name)
+        computer.label = label
         computer.store()
     except ValidationError as error:
         echo.echo_critical('Invalid input! {}'.format(error))
     except UniquenessError as error:
         echo.echo_critical(
-            'Uniqueness error encountered! Probably a '
-            "computer with name '{}' already exists"
-            ''.format(new_name)
+            "Uniqueness error encountered! Probably a computer with label '{}' already exists: {}".format(label, error)
         )
-        echo.echo_critical('(Message was: {})'.format(error))
 
-    echo.echo_success("Computer '{}' renamed to '{}'".format(old_name, new_name))
+    echo.echo_success("Computer '{}' relabeled to '{}'".format(old_label, label))
 
 
 @verdi_computer.command('test')
@@ -472,15 +495,15 @@ def computer_test(user, print_traceback, computer):
     if user is None:
         user = orm.User.objects.get_default()
 
-    echo.echo_info('Testing computer<{}> for user<{}>...'.format(computer.name, user.email))
+    echo.echo_info('Testing computer<{}> for user<{}>...'.format(computer.label, user.email))
 
     try:
         authinfo = computer.get_authinfo(user)
     except NotExistent:
-        echo.echo_critical('Computer<{}> is not yet configured for user<{}>'.format(computer.name, user.email))
+        echo.echo_critical('Computer<{}> is not yet configured for user<{}>'.format(computer.label, user.email))
 
     if not authinfo.enabled:
-        echo.echo_warning('Computer<{}> is disabled for user<{}>'.format(computer.name, user.email))
+        echo.echo_warning('Computer<{}> is disabled for user<{}>'.format(computer.label, user.email))
         click.confirm('Do you really want to test it?', abort=True)
 
     scheduler = authinfo.computer.get_scheduler()
@@ -568,14 +591,14 @@ def computer_delete(computer):
     from aiida.common.exceptions import InvalidOperation
     from aiida import orm
 
-    compname = computer.name
+    label = computer.label
 
     try:
         orm.Computer.objects.delete(computer.id)
     except InvalidOperation as error:
         echo.echo_critical(str(error))
 
-    echo.echo_success("Computer '{}' deleted.".format(compname))
+    echo.echo_success("Computer '{}' deleted.".format(label))
 
 
 @verdi_computer.group('configure')
@@ -594,12 +617,11 @@ def computer_configure():
 @arguments.COMPUTER()
 def computer_config_show(computer, user, defaults, as_option_string):
     """Show the current configuration for a computer."""
-    import tabulate
     from aiida.common.escaping import escape_for_bash
 
     transport_cls = computer.get_transport_class()
     option_list = [
-        param for param in transport_cli.create_configure_cmd(computer.get_transport_type()).params
+        param for param in transport_cli.create_configure_cmd(computer.transport_type).params
         if isinstance(param, click.core.Option)
     ]
     option_list = [option for option in option_list if option.name in transport_cls.get_valid_auth_params()]

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -85,6 +85,6 @@ def remote_cat(datum, path):
 def remote_show(datum):
     """Show information for a RemoteData object."""
     click.echo('- Remote computer name:')
-    click.echo('  {}'.format(datum.get_computer_name()))
+    click.echo('  {}'.format(datum.computer.label))
     click.echo('- Remote folder full path:')
     click.echo('  {}'.format(datum.get_remote_path()))

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -123,7 +123,7 @@ def get_node_summary(node):
         pass
     else:
         if computer is not None:
-            table.append(['computer', '[{}] {}'.format(node.computer.pk, node.computer.name)])
+            table.append(['computer', '[{}] {}'.format(node.computer.pk, node.computer.label)])
 
     return tabulate(table, headers=table_headers)
 

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -74,7 +74,7 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
         if not remote_working_directory.strip():
             raise exceptions.ConfigurationError(
                 "[submission of calculation {}] No remote_working_directory configured for computer '{}'".format(
-                    node.pk, computer.name
+                    node.pk, computer.label
                 )
             )
 
@@ -94,7 +94,7 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
                 raise exceptions.ConfigurationError(
                     '[submission of calculation {}] '
                     'Unable to create the remote directory {} on '
-                    "computer '{}': {}".format(node.pk, remote_working_directory, computer.name, exc)
+                    "computer '{}': {}".format(node.pk, remote_working_directory, computer.label, exc)
                 )
         # Store remotely with sharding (here is where we choose
         # the folder structure of remote jobs; then I store this
@@ -211,7 +211,7 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
                 for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_copy_list:
                     handle.write(
                         'would have copied {} to {} in working directory on remote {}'.format(
-                            remote_abs_path, dest_rel_path, computer.name
+                            remote_abs_path, dest_rel_path, computer.label
                         )
                     )
 
@@ -220,7 +220,7 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
                 for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_symlink_list:
                     handle.write(
                         'would have created symlinks from {} to {} in working directory on remote {}'.format(
-                            remote_abs_path, dest_rel_path, computer.name
+                            remote_abs_path, dest_rel_path, computer.label
                         )
                     )
 
@@ -230,7 +230,7 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
             if remote_computer_uuid == computer.uuid:
                 logger.debug(
                     '[submission of calculation {}] copying {} remotely, directly on the machine {}'.format(
-                        node.pk, dest_rel_path, computer.name
+                        node.pk, dest_rel_path, computer.label
                     )
                 )
                 try:
@@ -251,7 +251,7 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
             if remote_computer_uuid == computer.uuid:
                 logger.debug(
                     '[submission of calculation {}] copying {} remotely, directly on the machine {}'.format(
-                        node.pk, dest_rel_path, computer.name
+                        node.pk, dest_rel_path, computer.label
                     )
                 )
                 try:

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -329,7 +329,7 @@ class CalcJob(Process):
         for code in codes:
             if not code.can_run_on(computer):
                 raise InputValidationError('The selected code {} for calculation {} cannot run on computer {}'.format(
-                    code.pk, self.node.pk, computer.name))
+                    code.pk, self.node.pk, computer.label))
 
             if code.is_local() and code.get_local_executable() in folder.get_content_list():
                 raise PluginInternalError('The plugin created a file {} that is also the executable name!'.format(

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -50,9 +50,9 @@ class AuthInfo(entities.Entity):
 
     def __str__(self):
         if self.enabled:
-            return 'AuthInfo for {} on {}'.format(self.user.email, self.computer.name)
+            return 'AuthInfo for {} on {}'.format(self.user.email, self.computer.label)
 
-        return 'AuthInfo for {} on {} [DISABLED]'.format(self.user.email, self.computer.name)
+        return 'AuthInfo for {} on {} [DISABLED]'.format(self.user.email, self.computer.label)
 
     @property
     def enabled(self):
@@ -138,7 +138,7 @@ class AuthInfo(entities.Entity):
         :rtype: :class:`aiida.transports.Transport`
         """
         computer = self.computer
-        transport_type = computer.get_transport_type()
+        transport_type = computer.transport_type
 
         try:
             transport_class = TransportFactory(transport_type)

--- a/aiida/orm/nodes/data/remote.py
+++ b/aiida/orm/nodes/data/remote.py
@@ -29,7 +29,12 @@ class RemoteData(Data):
             self.set_remote_path(remote_path)
 
     def get_computer_name(self):
-        return self.computer.name
+        """Get label of this node's computer.
+
+        .. deprecated:: 1.4.0
+            Will be removed in `v2.0.0`, use the `self.computer.label` property instead.
+        """
+        return self.computer.label
 
     def get_remote_path(self):
         return self.get_attribute('remote_path')
@@ -71,7 +76,7 @@ class RemoteData(Data):
                 if exception.errno == 2:  # file does not exist
                     raise IOError(
                         'The required remote file {} on {} does not exist or has been deleted.'.format(
-                            full_path, self.computer.name
+                            full_path, self.computer.label
                         )
                     )
                 raise
@@ -93,7 +98,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.name)
+                        format(full_path, self.computer.label)
                     )
                     exc.errno = exception.errno
                     raise exc
@@ -106,7 +111,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.name)
+                        format(full_path, self.computer.label)
                     )
                     exc.errno = exception.errno
                     raise exc
@@ -130,7 +135,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.name)
+                        format(full_path, self.computer.label)
                     )
                     exc.errno = exception.errno
                     raise exc
@@ -143,7 +148,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.name)
+                        format(full_path, self.computer.label)
                     )
                     exc.errno = exception.errno
                     raise exc

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -72,9 +72,9 @@ class ComputerBuilder:  # pylint: disable=too-many-instance-attributes
 
         computer = Computer(label=self._get_and_count('label', used), hostname=self._get_and_count('hostname', used))
 
-        computer.set_description(self._get_and_count('description', used))
-        computer.set_scheduler_type(self._get_and_count('scheduler', used))
-        computer.set_transport_type(self._get_and_count('transport', used))
+        computer.description = self._get_and_count('description', used)
+        computer.scheduler_type = self._get_and_count('scheduler', used)
+        computer.transport_type = self._get_and_count('transport', used)
         computer.set_prepend_text(self._get_and_count('prepend_text', used))
         computer.set_append_text(self._get_and_count('append_text', used))
         computer.set_workdir(self._get_and_count('work_dir', used))

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -221,11 +221,11 @@ def default_node_sublabels(node):
     elif class_node_type == 'data.bool.Bool.':
         sublabel = '{}'.format(node.get_attribute('value', ''))
     elif class_node_type == 'data.code.Code.':
-        sublabel = '{}@{}'.format(os.path.basename(node.get_execname()), node.get_computer_name())
+        sublabel = '{}@{}'.format(os.path.basename(node.get_execname()), node.computer.label)
     elif class_node_type == 'data.singlefile.SinglefileData.':
         sublabel = node.filename
     elif class_node_type == 'data.remote.RemoteData.':
-        sublabel = '@{}'.format(node.get_computer_name())
+        sublabel = '@{}'.format(node.computer.label)
     elif class_node_type == 'data.structure.StructureData.':
         sublabel = node.get_formula()
     elif class_node_type == 'data.cif.CifData.':

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -26,10 +26,10 @@ TRANSPORT_PARAMS = []
 # pylint: disable=unused-argument
 def match_comp_transport(ctx, param, computer, transport_type):
     """Check the computer argument against the transport type."""
-    if computer.get_transport_type() != transport_type:
+    if computer.transport_type != transport_type:
         echo.echo_critical(
             'Computer {} has transport of type "{}", not {}!'.format(
-                computer.name, computer.get_transport_type(), transport_type
+                computer.label, computer.transport_type, transport_type
             )
         )
     return computer
@@ -42,12 +42,12 @@ def configure_computer_main(computer, user, **kwargs):
 
     user = user or orm.User.objects.get_default()
 
-    echo.echo_info('Configuring computer {} for user {}.'.format(computer.name, user.email))
+    echo.echo_info('Configuring computer {} for user {}.'.format(computer.label, user.email))
     if user.email != get_manager().get_profile().default_user:
         echo.echo_info('Configuring different user, defaults may not be appropriate.')
 
     computer.configure(user=user, **kwargs)
-    echo.echo_success('{} successfully configured for {}'.format(computer.name, user.email))
+    echo.echo_success('{} successfully configured for {}'.format(computer.label, user.email))
 
 
 def common_params(command_func):

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -188,11 +188,17 @@ class Transport(abc.ABC):
 
     @classmethod
     def get_valid_transports(cls):
-        """
-        :return: a list of existing plugin names
-        """
-        from aiida.plugins.entry_point import get_entry_point_names
+        """Return the list of registered transport entry points.
 
+        .. deprecated:: 1.4.0
+
+            Will be removed in `2.0.0`, use `aiida.plugins.entry_point.get_entry_point_names` instead
+        """
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning
+        from aiida.plugins.entry_point import get_entry_point_names
+        message = 'method is deprecated, use `aiida.plugins.entry_point.get_entry_point_names` instead'
+        warnings.warn(message, AiidaDeprecationWarning)  # pylint: disable=no-member
         return get_entry_point_names('aiida.transports')
 
     @classmethod

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -119,6 +119,7 @@ Below is a list with all available subcommands.
       duplicate  Duplicate a computer allowing to change some parameters.
       enable     Enable the computer for the given user.
       list       List all available computers.
+      relabel    Relabel a computer.
       rename     Rename a computer.
       setup      Create a new computer.
       show       Show detailed information for a computer.

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -30,7 +30,7 @@ class TestVerdiCodeSetup(AiidaTestCase):
     def setUpClass(cls, *args, **kwargs):
         super().setUpClass(*args, **kwargs)
         cls.computer = orm.Computer(
-            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
     def setUp(self):
@@ -50,12 +50,12 @@ class TestVerdiCodeSetup(AiidaTestCase):
         label = 'noninteractive_remote'
         options = [
             '--non-interactive', '--label={}'.format(label), '--description=description',
-            '--input-plugin=arithmetic.add', '--on-computer', '--computer={}'.format(self.computer.name),
+            '--input-plugin=arithmetic.add', '--on-computer', '--computer={}'.format(self.computer.label),
             '--remote-abs-path=/remote/abs/path'
         ]
         result = self.cli_runner.invoke(setup_code, options)
         self.assertClickResultNoException(result)
-        self.assertIsInstance(orm.Code.get_from_string('{}@{}'.format(label, self.computer.name)), orm.Code)
+        self.assertIsInstance(orm.Code.get_from_string('{}@{}'.format(label, self.computer.label)), orm.Code)
 
     def test_noninteractive_upload(self):
         """Test non-interactive code setup."""
@@ -89,7 +89,7 @@ class TestVerdiCodeSetup(AiidaTestCase):
         # local file
         label = 'noninteractive_config'
         with tempfile.NamedTemporaryFile('w') as handle:
-            handle.write(config_file_template.format(label=label, computer=self.computer.name))
+            handle.write(config_file_template.format(label=label, computer=self.computer.label))
             handle.flush()
             result = self.cli_runner.invoke(
                 setup_code,
@@ -103,7 +103,7 @@ class TestVerdiCodeSetup(AiidaTestCase):
         fake_url = 'https://my.url.com'
         with mock.patch(
             'urllib.request.urlopen',
-            return_value=config_file_template.format(label=label, computer=self.computer.name)
+            return_value=config_file_template.format(label=label, computer=self.computer.label)
         ):
             result = self.cli_runner.invoke(setup_code, ['--non-interactive', '--config', fake_url])
 
@@ -189,7 +189,7 @@ class TestVerdiCodeCommands(AiidaTestCase):
             code.label = 'code2'
             code.store()
 
-        options = ['-A', '-a', '-o', '--input-plugin=arithmetic.add', '--computer={}'.format(self.computer.name)]
+        options = ['-A', '-a', '-o', '--input-plugin=arithmetic.add', '--computer={}'.format(self.computer.label)]
         result = self.cli_runner.invoke(code_list, options)
         self.assertIsNone(result.exception, result.output)
         self.assertTrue(str(self.code.pk) in result.output, 'PK of first code should be included')
@@ -243,10 +243,10 @@ class TestVerdiCodeNoCodes(AiidaTestCase):
 def test_interactive_remote(clear_database_before_test, aiida_localhost, non_interactive_editor):
     """Test interactive remote code setup."""
     label = 'interactive_remote'
-    user_input = '\n'.join([label, 'description', 'arithmetic.add', 'yes', aiida_localhost.name, '/remote/abs/path'])
+    user_input = '\n'.join([label, 'description', 'arithmetic.add', 'yes', aiida_localhost.label, '/remote/abs/path'])
     result = CliRunner().invoke(setup_code, input=user_input)
     assert result.exception is None
-    assert isinstance(orm.Code.get_from_string('{}@{}'.format(label, aiida_localhost.name)), orm.Code)
+    assert isinstance(orm.Code.get_from_string('{}@{}'.format(label, aiida_localhost.label)), orm.Code)
 
 
 @pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
@@ -267,10 +267,10 @@ def test_mixed(clear_database_before_test, aiida_localhost, non_interactive_edit
     from aiida.orm import Code
     label = 'mixed_remote'
     options = ['--description=description', '--on-computer', '--remote-abs-path=/remote/abs/path']
-    user_input = '\n'.join([label, 'arithmetic.add', aiida_localhost.name])
+    user_input = '\n'.join([label, 'arithmetic.add', aiida_localhost.label])
     result = CliRunner().invoke(setup_code, options, input=user_input)
     assert result.exception is None
-    assert isinstance(Code.get_from_string('{}@{}'.format(label, aiida_localhost.name)), Code)
+    assert isinstance(Code.get_from_string('{}@{}'.format(label, aiida_localhost.label)), Code)
 
 
 @pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -19,7 +19,7 @@ import pytest
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_computer import computer_setup
-from aiida.cmdline.commands.cmd_computer import computer_show, computer_list, computer_rename, computer_delete
+from aiida.cmdline.commands.cmd_computer import computer_show, computer_list, computer_relabel, computer_delete
 from aiida.cmdline.commands.cmd_computer import computer_test, computer_configure, computer_duplicate
 
 
@@ -605,54 +605,49 @@ class TestVerdiComputerCommands(AiidaTestCase):
         # Exceptions should arise
         self.assertIsNotNone(result.exception)
 
-    def test_computer_rename(self):
+    def test_computer_relabel(self):
         """
-        Test if 'verdi computer rename' command works
+        Test if 'verdi computer relabel' command works
         """
         from aiida.common.exceptions import NotExistent
 
         # See if the command complains about not getting an invalid computer
-        options = ['not_existent_computer_name']
-        result = self.cli_runner.invoke(computer_rename, options)
-        # Exception should be raised
+        options = ['not_existent_computer_label']
+        result = self.cli_runner.invoke(computer_relabel, options)
         self.assertIsNotNone(result.exception)
 
-        # See if the command complains about not getting both names
+        # See if the command complains about not getting both labels
         options = ['comp_cli_test_computer']
-        result = self.cli_runner.invoke(computer_rename, options)
-        # Exception should be raised
+        result = self.cli_runner.invoke(computer_relabel, options)
         self.assertIsNotNone(result.exception)
 
-        # The new name must be different to the old one
+        # The new label must be different to the old one
         options = ['comp_cli_test_computer', 'comp_cli_test_computer']
-        result = self.cli_runner.invoke(computer_rename, options)
-        # Exception should be raised
+        result = self.cli_runner.invoke(computer_relabel, options)
         self.assertIsNotNone(result.exception)
 
-        # Change a computer name successully.
-        options = ['comp_cli_test_computer', 'renamed_test_computer']
-        result = self.cli_runner.invoke(computer_rename, options)
-        # Exception should be not be raised
+        # Change a computer label successully.
+        options = ['comp_cli_test_computer', 'relabeled_test_computer']
+        result = self.cli_runner.invoke(computer_relabel, options)
         self.assertIsNone(result.exception, result.output)
 
-        # Check that the name really was changed
-        # The old name should not be available
+        # Check that the label really was changed
+        # The old label should not be available
         with self.assertRaises(NotExistent):
             orm.Computer.objects.get(label='comp_cli_test_computer')
-        # The new name should be avilable
-        orm.Computer.objects.get(label='renamed_test_computer')
+        # The new label should be available
+        orm.Computer.objects.get(label='relabeled_test_computer')
 
-        # Now change the name back
-        options = ['renamed_test_computer', 'comp_cli_test_computer']
-        result = self.cli_runner.invoke(computer_rename, options)
-        # Exception should be not be raised
+        # Now change the label back
+        options = ['relabeled_test_computer', 'comp_cli_test_computer']
+        result = self.cli_runner.invoke(computer_relabel, options)
         self.assertIsNone(result.exception, result.output)
 
-        # Check that the name really was changed
-        # The old name should not be available
+        # Check that the label really was changed
+        # The old label should not be available
         with self.assertRaises(NotExistent):
-            orm.Computer.objects.get(label='renamed_test_computer')
-        # The new name should be avilable
+            orm.Computer.objects.get(label='relabeled_test_computer')
+        # The new label should be available
         orm.Computer.objects.get(label='comp_cli_test_computer')
 
     def test_computer_delete(self):

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -194,7 +194,7 @@ class TestAutoGroups(AiidaTestCase):
             ArithmeticAdd = CalculationFactory('arithmetic.add')
 
             computer = Computer(
-                name='localhost-example-{}'.format(sys.argv[1]),
+                label='localhost-example-{}'.format(sys.argv[1]),
                 hostname='localhost',
                 description='my computer',
                 transport_type='local',

--- a/tests/cmdline/params/types/test_code.py
+++ b/tests/cmdline/params/types/test_code.py
@@ -69,7 +69,7 @@ def test_get_by_label(setup_codes, parameter_type):
 def test_get_by_fullname(setup_codes, parameter_type):
     """Verify that using the LABEL@machinename will retrieve the correct entity."""
     entity_01, entity_02, entity_03 = setup_codes
-    identifier = '{}@{}'.format(entity_01.label, entity_01.computer.name)
+    identifier = '{}@{}'.format(entity_01.label, entity_01.computer.label)
     result = parameter_type.convert(identifier, None, None)
     assert result.uuid == entity_01.uuid
 

--- a/tests/cmdline/params/types/test_computer.py
+++ b/tests/cmdline/params/types/test_computer.py
@@ -36,9 +36,9 @@ class TestComputerParamType(AiidaTestCase):
         }
 
         cls.param = ComputerParamType()
-        cls.entity_01 = orm.Computer(name='computer_01', **kwargs).store()
-        cls.entity_02 = orm.Computer(name=str(cls.entity_01.pk), **kwargs).store()
-        cls.entity_03 = orm.Computer(name=str(cls.entity_01.uuid), **kwargs).store()
+        cls.entity_01 = orm.Computer(label='computer_01', **kwargs).store()
+        cls.entity_02 = orm.Computer(label=str(cls.entity_01.pk), **kwargs).store()
+        cls.entity_03 = orm.Computer(label=str(cls.entity_01.uuid), **kwargs).store()
 
     def test_get_by_id(self):
         """
@@ -60,7 +60,7 @@ class TestComputerParamType(AiidaTestCase):
         """
         Verify that using the LABEL will retrieve the correct entity
         """
-        identifier = '{}'.format(self.entity_01.name)
+        identifier = '{}'.format(self.entity_01.label)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
@@ -71,11 +71,11 @@ class TestComputerParamType(AiidaTestCase):
         Verify that using an ambiguous identifier gives precedence to the ID interpretation
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
-        identifier = '{}'.format(self.entity_02.name)
+        identifier = '{}'.format(self.entity_02.label)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.name, OrmEntityLoader.label_ambiguity_breaker)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -86,10 +86,10 @@ class TestComputerParamType(AiidaTestCase):
         Verify that using an ambiguous identifier gives precedence to the UUID interpretation
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
-        identifier = '{}'.format(self.entity_03.name)
+        identifier = '{}'.format(self.entity_03.label)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.name, OrmEntityLoader.label_ambiguity_breaker)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)

--- a/tests/cmdline/utils/test_common.py
+++ b/tests/cmdline/utils/test_common.py
@@ -21,7 +21,7 @@ class TestCommonUtilities(AiidaTestCase):
         """Test the `get_node_summary` utility."""
         from aiida.cmdline.utils.common import get_node_summary
 
-        computer_label = self.computer.name  # pylint: disable=no-member
+        computer_label = self.computer.label  # pylint: disable=no-member
 
         code = orm.Code(
             input_plugin_name='arithmetic.add',

--- a/tests/common/test_serialize.py
+++ b/tests/common/test_serialize.py
@@ -75,7 +75,7 @@ class TestSerialize(AiidaTestCase):
 
         # pylint: disable=no-member
         self.assertEqual(computer.uuid, deserialized.uuid)
-        self.assertEqual(computer.name, deserialized.name)
+        self.assertEqual(computer.label, deserialized.label)
 
     def test_serialize_unstored_node(self):
         """Test that you can't serialize an unstored node"""

--- a/tests/orm/data/test_code.py
+++ b/tests/orm/data/test_code.py
@@ -47,7 +47,7 @@ def test_get_full_text_info(create_codes):
             assert ['List of files/folders:', ''] in full_text_info
         else:
             assert ['Type', 'remote'] in full_text_info
-            assert ['Remote machine', code.computer.name] in full_text_info
+            assert ['Remote machine', code.computer.label] in full_text_info
             assert ['Remote absolute path', code.get_remote_exec_path()] in full_text_info
 
     for code in create_codes:

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -24,7 +24,7 @@ class TestComputer(AiidaTestCase):
         import tempfile
 
         new_comp = orm.Computer(
-            name='bbb', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
+            label='bbb', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida'
         ).store()
 
         # Configure the computer - no parameters for local transport
@@ -43,7 +43,7 @@ class TestComputer(AiidaTestCase):
     def test_delete(self):
         """Test the deletion of a `Computer` instance."""
         new_comp = orm.Computer(
-            name='aaa', hostname='aaa', transport_type='local', scheduler_type='pbspro', workdir='/tmp/aiida'
+            label='aaa', hostname='aaa', transport_type='local', scheduler_type='pbspro', workdir='/tmp/aiida'
         ).store()
 
         comp_pk = new_comp.pk

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1435,10 +1435,10 @@ class TestDoubleStar(AiidaTestCase):
             'scheduler_type': self.computer.scheduler_type,
             'hostname': self.computer.hostname,
             'uuid': self.computer.uuid,
-            'name': self.computer.name,
+            'name': self.computer.label,
             'transport_type': self.computer.transport_type,
             'id': self.computer.id,
-            'metadata': self.computer.get_metadata(),
+            'metadata': self.computer.metadata,
         }
 
         qb = orm.QueryBuilder()

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -129,22 +129,22 @@ class RESTApiTestCase(AiidaTestCase):
         calc1.store()
 
         dummy_computers = [{
-            'name': 'test1',
+            'label': 'test1',
             'hostname': 'test1.epfl.ch',
             'transport_type': 'ssh',
             'scheduler_type': 'pbspro',
         }, {
-            'name': 'test2',
+            'label': 'test2',
             'hostname': 'test2.epfl.ch',
             'transport_type': 'ssh',
             'scheduler_type': 'torque',
         }, {
-            'name': 'test3',
+            'label': 'test3',
             'hostname': 'test3.epfl.ch',
             'transport_type': 'local',
             'scheduler_type': 'slurm',
         }, {
-            'name': 'test4',
+            'label': 'test4',
             'hostname': 'test4.epfl.ch',
             'transport_type': 'ssh',
             'scheduler_type': 'slurm',

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -81,7 +81,7 @@ class TestCode(AiidaTestCase):
 
         self.assertTrue(code.can_run_on(self.computer))
         othercomputer = orm.Computer(
-            name='another_localhost',
+            label='another_localhost',
             hostname='localhost',
             transport_type='local',
             scheduler_type='pbspro',

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1393,7 +1393,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
             d2 = SinglefileData(file=handle).store()
 
         unsavedcomputer = orm.Computer(
-            name='localhost2', hostname='localhost', scheduler_type='direct', transport_type='local'
+            label='localhost2', hostname='localhost', scheduler_type='direct', transport_type='local'
         )
 
         with self.assertRaises(ValueError):

--- a/tests/tools/importexport/orm/test_computers.py
+++ b/tests/tools/importexport/orm/test_computers.py
@@ -60,7 +60,7 @@ class TestComputer(AiidaTestCase):
         calc2.seal()
 
         # Store locally the computer name
-        comp_name = str(comp.name)
+        comp_name = str(comp.label)
         comp_uuid = str(comp.uuid)
 
         # Export the first job calculation
@@ -149,14 +149,14 @@ class TestComputer(AiidaTestCase):
         calc1.seal()
 
         # Store locally the computer name
-        comp1_name = str(comp1.name)
+        comp1_name = str(comp1.label)
 
         # Export the first job calculation
         filename1 = os.path.join(temp_dir, 'export1.aiida')
         export([calc1], filename=filename1, silent=True)
 
         # Rename the computer
-        comp1.set_name(comp1_name + '_updated')
+        comp1.label = comp1_name + '_updated'
 
         # Store a second calculation
         calc2_label = 'calc2'
@@ -223,7 +223,7 @@ class TestComputer(AiidaTestCase):
 
         # Set the computer name
         comp1_name = 'localhost_1'
-        self.computer.set_name(comp1_name)
+        self.computer.label = comp1_name
 
         # Store a calculation
         calc1_label = 'calc1'
@@ -243,7 +243,7 @@ class TestComputer(AiidaTestCase):
         self.insert_data()
 
         # Set the computer name to the same name as before
-        self.computer.set_name(comp1_name)
+        self.computer.label = comp1_name
 
         # Store a second calculation
         calc2_label = 'calc2'
@@ -263,7 +263,7 @@ class TestComputer(AiidaTestCase):
         self.insert_data()
 
         # Set the computer name to the same name as before
-        self.computer.set_name(comp1_name)
+        self.computer.label = comp1_name
 
         # Store a third calculation
         calc3_label = 'calc3'
@@ -319,8 +319,8 @@ class TestComputer(AiidaTestCase):
         # Set the computer name
         comp1_name = 'localhost_1'
         comp1_metadata = {'workdir': '/tmp/aiida'}
-        self.computer.set_name(comp1_name)
-        self.computer.set_metadata(comp1_metadata)
+        self.computer.label = comp1_name
+        self.computer.metadata = comp1_metadata
 
         # Store a calculation
         calc1_label = 'calc1'
@@ -368,7 +368,7 @@ class TestComputer(AiidaTestCase):
             builder = orm.QueryBuilder()
             builder.append(
                 orm.Computer, project=['metadata'], tag='comp', filters={'name': {
-                    '!==': self.computer.name
+                    '!==': self.computer.label
                 }}
             )
             self.assertEqual(builder.count(), 1, 'Expected only one computer')


### PR DESCRIPTION
Fixes #4304 and fixes #4313 

All entities use `label` as the human readable string identifier, but
`Computer` was using `name`. This was already changed in the front-end
ORM in a previous commit where a `label` property was introduced and
the old `name` properties were deprecated, however, a few derivative
methods in other classes were missed and still use contain "name".
These methods are now also deprecated:

  * `verdi computer rename`: use `verdi computer relabel` instead
  * `Code.get_computer_name`: use `self.computer.label` instead
  * `Code.get_full_text_info`: will be removed
  * `RemoteData.get_computer_name`: use `self.computer.label` instead
  * `Transport.get_valid_transports`: `get_entry_point_names` instead

Finally, deprecations of `Computer` getters and setters as introduced
in commit 592dd365658b0b were still being used internally leading to
a lot of deprecation warnings. These have now been properly replaced.