### PR TITLE
Cleanup of BackendNode/ModelEntities internals

### DIFF
--- a/aiida/orm/implementation/django/entities.py
+++ b/aiida/orm/implementation/django/entities.py
@@ -77,15 +77,6 @@ class DjangoModelEntity(typing.Generic[ModelType]):
         return self._dbmodel.pk
 
     @property
-    def pk(self):
-        """
-        Get the principal key for this entry
-
-        :return: the principal key
-        """
-        return self._dbmodel.id
-
-    @property
     def is_stored(self):
         """
         Is this entity stored?

--- a/aiida/orm/implementation/nodes.py
+++ b/aiida/orm/implementation/nodes.py
@@ -16,7 +16,7 @@ from . import backends
 __all__ = ('BackendNode', 'BackendNodeCollection')
 
 
-class BackendNode(backends.BackendEntity):
+class BackendNode(backends.BackendEntity, metaclass=abc.ABCMeta):
     """Wrapper around a `DbNode` instance to set and retrieve data independent of the database implementation."""
 
     # pylint: disable=too-many-public-methods

--- a/aiida/orm/implementation/sqlalchemy/entities.py
+++ b/aiida/orm/implementation/sqlalchemy/entities.py
@@ -85,15 +85,6 @@ class SqlaModelEntity(typing.Generic[ModelType]):
         return self._dbmodel.id
 
     @property
-    def pk(self):
-        """
-        Get the principal key for this entry
-
-        :return: the principal key
-        """
-        return self._dbmodel.id
-
-    @property
     def is_stored(self):
         """
         Is this entity stored?


### PR DESCRIPTION
Set up BackendNode as a metaclass after checking that all methods were
implemented in the child classes.

Removed the duplicated pk methods from the specific classes of model
entities (SqlaModelEntity and DjangoModelEntity), since it is already
implemented in the class BackendEntity (from which nodes also inherit
through the intermediate class BackendNode).

Fix #2495 (or at least as far as we could interpret what the issue referred to)