### PR TITLE
`CalcJob`: improve scheduler resource validation error message

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -81,11 +81,12 @@ def validate_calc_job(inputs, ctx):  # pylint: disable=too-many-return-statement
     except KeyError:
         return 'input `metadata.options.resources` is required but is not specified'
 
+    scheduler.preprocess_resources(resources, computer.get_default_mpiprocs_per_machine())
+
     try:
-        scheduler.preprocess_resources(resources, computer.get_default_mpiprocs_per_machine())
         scheduler.validate_resources(**resources)
-    except (ValueError, TypeError) as exception:
-        return 'input `metadata.options.resources` is not valid for the {} scheduler: {}'.format(scheduler, exception)
+    except ValueError as exception:
+        return 'input `metadata.options.resources` is not valid for the `{}` scheduler: {}'.format(scheduler, exception)
 
 
 def validate_parser(parser_name, _):

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -112,12 +112,14 @@ class NodeNumberJobResource(JobResource):
 
         # Validate that all fields are valid integers if they are specified, otherwise initialize them to `None`
         for parameter in list(cls._default_fields) + ['tot_num_mpiprocs']:
-            try:
-                setattr(resources, parameter, int(kwargs.pop(parameter)))
-            except KeyError:
+            value = kwargs.pop(parameter, None)
+            if value is None:
                 setattr(resources, parameter, None)
-            except ValueError:
-                raise ValueError('`{}` must be an integer when specified'.format(parameter))
+            else:
+                try:
+                    setattr(resources, parameter, int(value))
+                except ValueError:
+                    raise ValueError('`{}` must be an integer when specified'.format(parameter))
 
         if kwargs:
             raise ValueError('these parameters were not recognized: {}'.format(', '.join(list(kwargs.keys()))))
@@ -198,7 +200,7 @@ class ParEnvJobResource(JobResource):
 
         try:
             resources.tot_num_mpiprocs = int(kwargs.pop('tot_num_mpiprocs'))
-        except (KeyError, ValueError):
+        except (KeyError, TypeError, ValueError):
             raise ValueError('`tot_num_mpiprocs` must be specified and must be an integer')
 
         if resources.tot_num_mpiprocs < 1:

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -41,6 +41,9 @@ class Scheduler(metaclass=abc.ABCMeta):
     # The class to be used for the job resource.
     _job_resource_class = None
 
+    def __str__(self):
+        return self.__class__.__name__
+
     @classmethod
     def preprocess_resources(cls, resources, default_mpiprocs_per_machine=None):
         """Pre process the resources.


### PR DESCRIPTION
Fixes #4227 

The `NodeNumberJobResource.validate_resources` contained a bug, such
that when one of the default fields was set to `None` it would not be
caught. Instead it would bubble up and be caught in the validator of the
`CalcJob` input namespace `validate_calc_job`, which did catch the
`TypeError` thrown by `Scheduler.validate_resources`.

The `TypeError` was thrown by `None` being cast to `int` in the
`NodeNumberJobResource.validate_resources`, however, at this stage, a
`None` value should be accepted. Only if an actual value is specified
should it be checked to be a valid integer. The check that sufficient
fields have none `None` values is done later on. This will provide a
more intuitive error message, instead of the vague message:

  'field must be greater than or equal to one'

that was raised due to the bug even when the field was not explicitly
set by the user, causing even more confusion.

Note that since the bug in the validate resources is now fixed, and
therefore properly raises `ValueError` in case of a problem, the input
validator no longer needs nor should catch the `TypeError`.

Finally, the `__str__` method is implemented for the `Scheduler` class
such that it formats in a nicer way in error messages.