### PR TITLE
Fix/issue 4286 pip 2020 resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install numpy==1.17.4
-        pip install .[all]
+        pip install -e .[all]
         pip freeze
 
     - name: Run pre-commit
@@ -121,7 +121,7 @@ jobs:
     - name: Install aiida-core
       run: |
         pip install --use-feature=2020-resolver -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip install --use-feature=2020-resolver --no-deps .
+        pip install --use-feature=2020-resolver --no-deps -e .
         reentry scan
         pip freeze
 
@@ -162,7 +162,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install numpy==1.17.4
-        pip install .
+        pip install -e .
 
     - name: Run verdi
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,8 @@ jobs:
 
     - name: Install aiida-core
       run: |
-        pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip install --no-deps -e .
+        pip install --use-feature=2020-resolver -r requirements/requirements-py-${{ matrix.python-version }}.txt
+        pip install --use-feature=2020-resolver --no-deps -e .
         reentry scan
         pip freeze
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install numpy==1.17.4
-        pip install -e .[all]
+        pip install .[all]
         pip freeze
 
     - name: Run pre-commit
@@ -121,7 +121,7 @@ jobs:
     - name: Install aiida-core
       run: |
         pip install --use-feature=2020-resolver -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip install --use-feature=2020-resolver --no-deps -e .
+        pip install --use-feature=2020-resolver --no-deps .
         reentry scan
         pip freeze
 
@@ -162,7 +162,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install numpy==1.17.4
-        pip install -e .
+        pip install .
 
     - name: Run verdi
       run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -41,6 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    strategy:
+      matrix:
+        pip-feature-flag: [ '', '--use-feature=2020-resolver' ]
+
     steps:
     - uses: actions/checkout@v2
 
@@ -51,7 +55,8 @@ jobs:
 
     - name: Pip install
       run: |
-        python -m pip install -e .
+        python -m pip --version
+        python -m pip install -e . ${{ matrix.pip-feature-flag }}
         python -m pip freeze
 
     - name: Test importing aiida

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Pip install
       run: |
         python -m pip --version
-        python -m pip install -e .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
+        python -m pip install .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
         python -m pip freeze
 
     - name: Test importing aiida
@@ -88,7 +88,7 @@ jobs:
       run: |
         conda env create -f environment.yml -n test-environment
         source activate test-environment
-        python -m pip install --no-deps -e .
+        python -m pip install --no-deps .
 
     - name: Test importing aiida
       run: |
@@ -148,7 +148,7 @@ jobs:
 
     - name: Install aiida-core
       run: |
-        pip install -e .[atomic_tools,docs,notebook,rest,tests]
+        pip install .[atomic_tools,docs,notebook,rest,tests]
         reentry scan
 
     - run: pip freeze

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -44,6 +44,7 @@ jobs:
     strategy:
       matrix:
         pip-feature-flag: [ '', '--use-feature=2020-resolver' ]
+        extras: [ '', '[atomic_tools,docs,notebook,rest,tests]' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -56,7 +57,7 @@ jobs:
     - name: Pip install
       run: |
         python -m pip --version
-        python -m pip install -e . ${{ matrix.pip-feature-flag }}
+        python -m pip install -e .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
         python -m pip freeze
 
     - name: Test importing aiida

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Pip install
       run: |
         python -m pip --version
-        python -m pip install .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
+        python -m pip install -e .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
         python -m pip freeze
 
     - name: Test importing aiida
@@ -88,7 +88,7 @@ jobs:
       run: |
         conda env create -f environment.yml -n test-environment
         source activate test-environment
-        python -m pip install --no-deps .
+        python -m pip install --no-deps -e .
 
     - name: Test importing aiida
       run: |
@@ -148,7 +148,7 @@ jobs:
 
     - name: Install aiida-core
       run: |
-        pip install .[atomic_tools,docs,notebook,rest,tests]
+        pip install -e .[atomic_tools,docs,notebook,rest,tests]
         reentry scan
 
     - run: pip freeze


### PR DESCRIPTION
 * Test whether our installation paths are compatible with the pip version 20.2 `2020-resolver` feature flag.
 * Ensure that tests also cover _extras_.

Resolves #4286 .