### PR TITLE
move seekpath import inside function

### DIFF
--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -34,3 +34,6 @@ while true; do
     fi
 
 done
+
+$VERDI devel check-load-time
+$VERDI devel check-undesired-imports

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -48,6 +48,24 @@ def devel_check_load_time():
     echo.echo_success('no issues detected')
 
 
+@verdi_devel.command('check-undesired-imports')
+def devel_check_undesired_imports():
+    """Check that verdi does not import python modules it shouldn't.
+
+    Note: The blacklist was taken from the list of packages in the 'atomic_tools' extra but can be extended.
+    """
+    loaded_modules = 0
+
+    for modulename in ['seekpath', 'CifFile', 'ase', 'pymatgen', 'spglib', 'pymysql']:
+        if modulename in sys.modules:
+            echo.echo_warning('Detected loaded module "{}"'.format(modulename))
+            loaded_modules += 1
+
+    if loaded_modules > 0:
+        echo.echo_critical('Detected {} unwanted modules'.format(loaded_modules))
+    echo.echo_success('no issues detected')
+
+
 @verdi_devel.command('run_daemon')
 @decorators.with_dbenv()
 def devel_run_daemon():

--- a/aiida/tools/data/array/kpoints/__init__.py
+++ b/aiida/tools/data/array/kpoints/__init__.py
@@ -12,8 +12,6 @@ Various utilities to deal with KpointsData instances or create new ones
 (e.g. band paths, kpoints from a parsed input text file, ...)
 """
 from aiida.orm import KpointsData, Dict
-from aiida.tools.data.array.kpoints import legacy
-from aiida.tools.data.array.kpoints import seekpath
 
 __all__ = ('get_kpoints_path', 'get_explicit_kpoints_path')
 
@@ -112,6 +110,8 @@ def _seekpath_get_kpoints_path(structure, **kwargs):
     :param symprec: the symmetry precision used internally by SPGLIB
     :param angle_tolerance: the angle_tolerance used internally by SPGLIB
     """
+    from aiida.tools.data.array.kpoints import seekpath
+
     assert structure.pbc == (True, True, True), 'Seekpath only implemented for three-dimensional structures'
 
     recognized_args = ['with_time_reversal', 'recipe', 'threshold', 'symprec', 'angle_tolerance']
@@ -150,6 +150,8 @@ def _seekpath_get_explicit_kpoints_path(structure, **kwargs):
     :param symprec: the symmetry precision used internally by SPGLIB
     :param angle_tolerance: the angle_tolerance used internally by SPGLIB
     """
+    from aiida.tools.data.array.kpoints import seekpath
+
     assert structure.pbc == (True, True, True), 'Seekpath only implemented for three-dimensional structures'
 
     recognized_args = ['with_time_reversal', 'reference_distance', 'recipe', 'threshold', 'symprec', 'angle_tolerance']
@@ -170,6 +172,8 @@ def _legacy_get_kpoints_path(structure, **kwargs):
     :param epsilon_length: threshold on lengths comparison, used to get the bravais lattice info
     :param epsilon_angle: threshold on angles comparison, used to get the bravais lattice info
     """
+    from aiida.tools.data.array.kpoints import legacy
+
     args_recognized = ['cartesian', 'epsilon_length', 'epsilon_angle']
     args_unknown = set(kwargs).difference(args_recognized)
 
@@ -200,6 +204,8 @@ def _legacy_get_explicit_kpoints_path(structure, **kwargs):
     :param float epsilon_length: threshold on lengths comparison, used to get the bravais lattice info
     :param float epsilon_angle: threshold on angles comparison, used to get the bravais lattice info
     """
+    from aiida.tools.data.array.kpoints import legacy
+
     args_recognized = ['value', 'kpoint_distance', 'cartesian', 'epsilon_length', 'epsilon_angle']
     args_unknown = set(kwargs).difference(args_recognized)
 

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -216,11 +216,12 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      check-load-time   Check for common indicators that slowdown `verdi`.
-      configure-backup  Configure backup of the repository folder.
-      run_daemon        Run a daemon instance in the current interpreter.
-      tests             Run the unittest suite or parts of it.
-      validate-plugins  Validate all plugins by checking they can be loaded.
+      check-load-time          Check for common indicators that slowdown `verdi`.
+      check-undesired-imports  Check that verdi does not import python modules it shouldn't.
+      configure-backup         Configure backup of the repository folder.
+      run_daemon               Run a daemon instance in the current interpreter.
+      tests                    Run the unittest suite or parts of it.
+      validate-plugins         Validate all plugins by checking they can be loaded.
 
 
 .. _reference:command-line:verdi-export:


### PR DESCRIPTION
Fixes #4323 

Prior to this commit, importing aiida.tools caused an import of the
seekpath package, which is not a required dependency of aiida-core (only
of the 'atomic_tools' extra).