### PR TITLE
Add 'extras' column to Group database class

### DIFF
--- a/aiida/backends/djsite/db/migrations/0045_dbgroup_extras.py
+++ b/aiida/backends/djsite/db/migrations/0045_dbgroup_extras.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Migration to add the `extras` JSONB column to the `DbGroup` model."""
+# pylint: disable=invalid-name
+import django.contrib.postgres.fields.jsonb
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.45'
+DOWN_REVISION = '1.0.44'
+
+
+class Migration(migrations.Migration):
+    """Migrate to add the extras column to the dbgroup table."""
+    dependencies = [
+        ('db', '0044_dbgroup_type_string'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dbgroup',
+            name='extras',
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict, null=False),
+        ),
+        upgrade_schema_version(REVISION, DOWN_REVISION),
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -21,7 +21,7 @@ class DeserializationException(AiidaException):
     pass
 
 
-LATEST_MIGRATION = '0044_dbgroup_type_string'
+LATEST_MIGRATION = '0045_dbgroup_extras'
 
 
 def _update_schema_version(version, apps, _):
@@ -273,7 +273,7 @@ def _deserialize_attribute(mainitem, subitems, sep, original_class=None, origina
         try:
             return json.loads(mainitem['tval'])
         except ValueError:
-            raise DeserializationException('Error in the content of the json field')
+            raise DeserializationException('Error in the content of the json field') from ValueError
     else:
         raise DeserializationException("The type field '{}' is not recognized".format(mainitem['datatype']))
 
@@ -426,7 +426,8 @@ class ModelModifierV0025:
         try:
             attr = cls.objects.get(dbnode=dbnode_node, key=key)
         except ObjectDoesNotExist:
-            raise AttributeError('{} with key {} for node {} not found in db'.format(cls.__name__, key, dbnode.pk))
+            raise AttributeError('{} with key {} for node {} not found in db'.format(cls.__name__, key, dbnode.pk)) \
+                from ObjectDoesNotExist
 
         return self.getvalue(attr)
 
@@ -674,7 +675,7 @@ class ModelModifierV0025:
                     'another entry already exists and the creation would '
                     'violate an uniqueness constraint.\nFurther details: '
                     '{}'.format(cls.__name__, exc)
-                )
+                ) from exc
             raise
 
     @staticmethod
@@ -806,7 +807,7 @@ class ModelModifierV0025:
                 raise ValueError(
                     'Unable to store the value: it must be either a basic datatype, or json-serializable: {}'.
                     format(value)
-                )
+                ) from TypeError
 
             new_entry.datatype = 'json'
             new_entry.tval = jsondata

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -254,6 +254,8 @@ class DbGroup(m.Model):
     # On user deletion, remove his/her groups too (not the calcuations, only
     # the groups
     user = m.ForeignKey(DbUser, on_delete=m.CASCADE, related_name='dbgroups')
+    # JSON Extras
+    extras = JSONField(default=dict, null=False)
 
     class Meta:  # pylint: disable=too-few-public-methods
         unique_together = (('label', 'type_string'),)

--- a/aiida/backends/sqlalchemy/migrations/versions/0edcdd5a30f0_add_extras_to_group.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/0edcdd5a30f0_add_extras_to_group.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=no-member,invalid-name
+"""Migration to add the `extras` JSONB column to the `DbGroup` model.
+
+Revision ID: 0edcdd5a30f0
+Revises: bf591f31dd12
+Create Date: 2019-04-03 14:38:50.585639
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '0edcdd5a30f0'
+down_revision = 'bf591f31dd12'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade: Add the extras column to the 'db_dbgroup' table"""
+    op.add_column('db_dbgroup', sa.Column('extras', postgresql.JSONB(astext_type=sa.Text())))
+    op.execute(text("""
+    UPDATE db_dbgroup
+    SET extras='{}'
+    """))
+    op.alter_column('db_dbgroup', 'extras', nullable=False)
+
+
+def downgrade():
+    """Downgrade: Drop the extras column from the 'db_dbgroup' table"""
+    op.drop_column('db_dbgroup', 'extras')

--- a/aiida/backends/sqlalchemy/migrations/versions/0edcdd5a30f0_dbgroup_extras.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/0edcdd5a30f0_dbgroup_extras.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=no-member,invalid-name
+"""Migration to add the `extras` JSONB column to the `DbGroup` model.
+
+Revision ID: 0edcdd5a30f0
+Revises: bf591f31dd12
+Create Date: 2019-04-03 14:38:50.585639
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '0edcdd5a30f0'
+down_revision = 'bf591f31dd12'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade: Add the extras column to the 'db_dbgroup' table"""
+    op.add_column('db_dbgroup', sa.Column('extras', postgresql.JSONB(astext_type=sa.Text())))
+    op.execute(text("""
+    UPDATE db_dbgroup
+    SET extras='{}'
+    """))
+    op.alter_column('db_dbgroup', 'extras', nullable=False)
+
+
+def downgrade():
+    """Downgrade: Drop the extras column from the 'db_dbgroup' table"""
+    op.drop_column('db_dbgroup', 'extras')

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import relationship, backref
 from sqlalchemy.schema import Column, Table, UniqueConstraint, Index
 from sqlalchemy.types import Integer, String, DateTime, Text
 
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
@@ -46,6 +46,8 @@ class DbGroup(Base):
 
     time = Column(DateTime(timezone=True), default=timezone.now)
     description = Column(Text, nullable=True)
+
+    extras = Column(JSONB, default=dict, nullable=False)
 
     user_id = Column(Integer, ForeignKey('db_dbuser.id', ondelete='CASCADE', deferrable=True, initially='DEFERRED'))
     user = relationship('DbUser', backref=backref('dbgroups', cascade='merge'))

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-""" AiiDA Group entites"""
+"""AiiDA Group entites"""
 from abc import ABCMeta
 from enum import Enum
 import warnings
@@ -77,7 +77,7 @@ class GroupTypeString(Enum):
     USER = 'user'
 
 
-class Group(entities.Entity, metaclass=GroupMeta):
+class Group(entities.Entity, entities.EntityExtrasMixin, metaclass=GroupMeta):
     """An AiiDA ORM implementation of group of nodes."""
 
     class Collection(entities.Collection):

--- a/aiida/orm/implementation/django/utils.py
+++ b/aiida/orm/implementation/django/utils.py
@@ -114,9 +114,9 @@ class ModelWrapper:
     def _flush(self, fields=None):
         """Flush the fields of the model to the database.
 
-        .. note:: If the wrapped model is not actually save in the database yet, this method is a no-op.
+        .. note:: If the wrapped model is not actually saved in the database yet, this method is a no-op.
 
-        :param fields: the model fields whose currently value to flush to the database
+        :param fields: the model fields whose current value to flush to the database
         """
         if self.is_saved():
             try:

--- a/aiida/orm/implementation/sqlalchemy/utils.py
+++ b/aiida/orm/implementation/sqlalchemy/utils.py
@@ -120,9 +120,9 @@ class ModelWrapper:
     def _flush(self, fields=()):
         """Flush the fields of the model to the database.
 
-        .. note:: If the wrapped model is not actually save in the database yet, this method is a no-op.
+        .. note:: If the wrapped model is not actually saved in the database yet, this method is a no-op.
 
-        :param fields: the model fields whose currently value to flush to the database
+        :param fields: the model fields whose current value to flush to the database
         """
         if self.is_saved():
             for field in fields:

--- a/aiida/orm/nodes/data/remote.py
+++ b/aiida/orm/nodes/data/remote.py
@@ -34,7 +34,7 @@ class RemoteData(Data):
         .. deprecated:: 1.4.0
             Will be removed in `v2.0.0`, use the `self.computer.label` property instead.
         """
-        return self.computer.label
+        return self.computer.label  # pylint: disable=no-member
 
     def get_remote_path(self):
         return self.get_attribute('remote_path')
@@ -76,7 +76,8 @@ class RemoteData(Data):
                 if exception.errno == 2:  # file does not exist
                     raise IOError(
                         'The required remote file {} on {} does not exist or has been deleted.'.format(
-                            full_path, self.computer.label
+                            full_path,
+                            self.computer.label  # pylint: disable=no-member
                         )
                     )
                 raise
@@ -98,7 +99,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.label)
+                        format(full_path, self.computer.label)  # pylint: disable=no-member
                     )
                     exc.errno = exception.errno
                     raise exc
@@ -111,7 +112,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.label)
+                        format(full_path, self.computer.label)  # pylint: disable=no-member
                     )
                     exc.errno = exception.errno
                     raise exc
@@ -135,7 +136,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.label)
+                        format(full_path, self.computer.label)  # pylint: disable=no-member
                     )
                     exc.errno = exception.errno
                     raise exc
@@ -148,7 +149,7 @@ class RemoteData(Data):
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
                     exc = IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.label)
+                        format(full_path, self.computer.label)  # pylint: disable=no-member
                     )
                     exc.errno = exception.errno
                     raise exc

--- a/tests/backends/aiida_django/migrations/test_migrations_0045_dbgroup_extras.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_0045_dbgroup_extras.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=import-error,no-name-in-module,invalid-name
+"""Test migration to add the `extras` JSONB column to the `DbGroup` model."""
+
+from .test_migrations_common import TestMigrations
+
+
+class TestGroupExtrasMigration(TestMigrations):
+    """Test migration to add the `extras` JSONB column to the `DbGroup` model."""
+
+    migrate_from = '0044_dbgroup_type_string'
+    migrate_to = '0045_dbgroup_extras'
+
+    def setUpBeforeMigration(self):
+        DbGroup = self.apps.get_model('db', 'DbGroup')
+
+        group = DbGroup(label='01', user_id=self.default_user.id, type_string='user')
+        group.save()
+        self.group_pk = group.pk
+
+    def test_extras(self):
+        """Test that the model now has an extras column with empty dictionary as default."""
+        DbGroup = self.apps.get_model('db', 'DbGroup')
+
+        group = DbGroup.objects.get(pk=self.group_pk)
+        self.assertEqual(group.extras, {})


### PR DESCRIPTION
Fixes #4303 

The changes in this PR can be summarized by two points:
* Move all methods of the `Node` backend entity classes related to `attributes` and `extras` to two mixin classes: `AttributesBackendEntity` and `ExtrasBackendEntity`. Add these as parent classes to the `BackendNode` class.
* Add an `extras` column to the `db_dbgroup` table, which contains mutable  information that can be stored for `Group` instances. Provide the methods for the frontend class (`Group`) and mix in the methods for the backend class (`BackendGroup`).

Notes: 
* After taking a closer look at the idea of setting the `extras` column to `null` by default in the database, I think it's not really necessary. For nodes, the extras are almost never empty, because [when the node is stored the AiiDA hash is written to the extras](https://github.com/aiidateam/aiida-core/blob/develop/aiida/orm/nodes/node.py#L1075). Groups can of course have empty extras, but usually a user won't have that many groups for it to make a difference, so I don't think it's worth adding extra logic to the backend entities do deal with this. I did find that the `attributes` of `FolderData` are actually empty, so I suppose we could set these to `null` in the database. But then we's still have to adjust the `AttributesBackendEntity` methods to deal with this.

Questions:
* ~~Why is the `_aiida_hash` stored as an `extra` and not as an `attribute`? I.e.: why do we need the functionality to re-hash a `Node`?~~ See #2231
* ~~Might it be better to split this into two PR's? The first one would be: "Add mix-in classes for the attributes and extras methods" and include the first two commits.~~ Yes! Done, see #4376 

List of TODO's:
- [x] ~~Add unit tests~~
- [x] ~~Consider changing the default value for extras stored in the database to `null` instead of an empty dictionary `'{}'`. This is currently also the default for the `Node` extras, so if we make this change for both it might meaningfully reduce the size of the database. This will require some changes in the extras methods to deal with the `null` value stored in the database, however.~~
- [x] ~~Consider writing two "mix-in" classes for the extras methods of the `Node`/`Group` class and the corresponding Django and SqlAlchemy backend classes, as they are pretty much the same at each layer.~~
- [x] ~~Consider adding an `extras` mixing class for the frontend classes.~~
- [x] ~~(**Nitpicking alert**) Homogenize the directory structures of the `backend` subpackage. Why use `djsite` instead of `django`? Why are the models of django in `backends.djsite.db.models.py`, whereas for SqlAlchemy they are spread over different modules in `backends.sqlalchemy.models`?~~