### PR TITLE
slurm plugin: always raise for non-zero exit code

### DIFF
--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -228,7 +228,7 @@ class SlurmScheduler(Scheduler):
             # Verified on slurm versions 17.11.2, 19.05.3-2 and 20.02.2.
             # See also https://github.com/aiidateam/aiida-core/issues/4326
             if len(joblist) == 1:
-                joblist += joblist[0]
+                joblist += [joblist[0]]
 
             command.append('--jobs={}'.format(','.join(joblist)))
 


### PR DESCRIPTION
potentially fixes #4326 

Prior to this change, cases where squeue would return a non-zero exit
code but an empty stderr would not lead to a SchedulerError.
This is fixed by adapting the slurm joblist command such that it is
always expected to produce exit code zero, and raising whenever a
non-zero exit code is encountered.