### PR TITLE
REST API: POST endpoint for QueryBuilder queryhelp JSON payloads

### DIFF
--- a/.ci/polish/cli.py
+++ b/.ci/polish/cli.py
@@ -102,26 +102,27 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
     import uuid
     from aiida.orm import Code, Int, Str
     from aiida.engine import run_get_node, submit
-    from lib.expression import generate, validate, evaluate  # pylint: disable=import-error
-    from lib.workchain import generate_outlines, format_outlines, write_workchain  # pylint: disable=import-error
+
+    lib_expression = importlib.import_module('lib.expression')
+    lib_workchain = importlib.import_module('lib.workchain')
 
     if use_calculations and not isinstance(code, Code):
         raise click.BadParameter('if you specify the -C flag, you have to specify a code as well')
 
     if expression is None:
-        expression = generate()
+        expression = lib_expression.generate()
 
-    valid, error = validate(expression)
+    valid, error = lib_expression.validate(expression)
 
     if not valid:
         click.echo(f"the expression '{expression}' is invalid: {error}")
         sys.exit(1)
 
     filename = f'polish_{str(uuid.uuid4().hex)}.py'
-    evaluated = evaluate(expression, modulo)
-    outlines, stack = generate_outlines(expression)
-    outlines_string = format_outlines(outlines, use_calculations, use_calcfunctions)
-    write_workchain(outlines_string, filename=filename)
+    evaluated = lib_expression.evaluate(expression, modulo)
+    outlines, stack = lib_workchain.generate_outlines(expression)
+    outlines_string = lib_workchain.format_outlines(outlines, use_calculations, use_calcfunctions)
+    lib_workchain.write_workchain(outlines_string, filename=filename)
 
     click.echo(f'Expression: {expression}')
 

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -38,7 +38,15 @@ from aiida.restapi.common import config
     help='Whether to enable WSGI profiler middleware for finding bottlenecks'
 )
 @click.option('--hookup/--no-hookup', 'hookup', is_flag=True, default=None, help='Hookup app to flask server')
-def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup):
+@click.option(
+    '--posting/--no-posting',
+    'posting',
+    is_flag=True,
+    default=config.CLI_DEFAULTS['POSTING'],
+    help='Enable POST endpoints (currently only /querybuilder).',
+    hidden=True,
+)
+def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup, posting):
     """
     Run the AiiDA REST API server.
 
@@ -55,4 +63,5 @@ def restapi(hostname, port, config_dir, debug, wsgi_profile, hookup):
         debug=debug,
         wsgi_profile=wsgi_profile,
         hookup=hookup,
+        posting=posting,
     )

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -25,13 +25,8 @@ class App(Flask):
 
     def __init__(self, *args, **kwargs):
 
-        # Decide whether or not to catch the internal server exceptions (
-        # default is True)
-        catch_internal_server = True
-        try:
-            catch_internal_server = kwargs.pop('catch_internal_server')
-        except KeyError:
-            pass
+        # Decide whether or not to catch the internal server exceptions (default is True)
+        catch_internal_server = kwargs.pop('catch_internal_server', True)
 
         # Basic initialization
         super().__init__(*args, **kwargs)

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -90,11 +90,16 @@ class AiidaApi(Api):
           configuration and PREFIX
         """
 
-        from aiida.restapi.resources import ProcessNode, CalcJobNode, Computer, User, Group, Node, ServerInfo
+        from aiida.restapi.common.config import CLI_DEFAULTS
+        from aiida.restapi.resources import (
+            ProcessNode, CalcJobNode, Computer, User, Group, Node, ServerInfo, QueryBuilder
+        )
 
         self.app = app
 
         super().__init__(app=app, prefix=kwargs['PREFIX'], catch_all_404s=True)
+
+        posting = kwargs.pop('posting', CLI_DEFAULTS['POSTING'])
 
         self.add_resource(
             ServerInfo,
@@ -105,6 +110,15 @@ class AiidaApi(Api):
             strict_slashes=False,
             resource_class_kwargs=kwargs
         )
+
+        if posting:
+            self.add_resource(
+                QueryBuilder,
+                '/querybuilder/',
+                endpoint='querybuilder',
+                strict_slashes=False,
+                resource_class_kwargs=kwargs,
+            )
 
         ## Add resources and endpoints to the api
         self.add_resource(

--- a/aiida/restapi/common/config.py
+++ b/aiida/restapi/common/config.py
@@ -47,4 +47,5 @@ CLI_DEFAULTS = {
     'WSGI_PROFILE': False,
     'HOOKUP_APP': True,
     'CATCH_INTERNAL_SERVER': False,
+    'POSTING': True,  # Include POST endpoints (currently only /querybuilder)
 }

--- a/aiida/restapi/common/identifiers.py
+++ b/aiida/restapi/common/identifiers.py
@@ -69,7 +69,7 @@ def construct_full_type(node_type, process_type):
     :return: the full type, which is a unique identifier
     """
     if node_type is None:
-        process_type = ''
+        node_type = ''
 
     if process_type is None:
         process_type = ''

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -39,6 +39,7 @@ def run_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **kwargs)
     :param wsgi_profile: use WSGI profiler middleware for finding bottlenecks in web application
     :param hookup: If true, hook up application to built-in server, else just return it. This parameter
         is deprecated as of AiiDA 1.2.1. If you don't intend to run the API (hookup=False) use `configure_api` instead.
+    :param posting: Whether or not to include POST-enabled endpoints (currently only `/querybuilder`).
 
     :returns: tuple (app, api) if hookup==False or runs app if hookup==True
     """
@@ -80,6 +81,7 @@ def configure_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **k
     :param catch_internal_server:  If true, catch and print internal server errors with full python traceback.
         Useful during app development.
     :param wsgi_profile: use WSGI profiler middleware for finding bottlenecks in the web application
+    :param posting: Whether or not to include POST-enabled endpoints (currently only `/querybuilder`).
 
     :returns: Flask RESTful API
     :rtype: :py:class:`flask_restful.Api`
@@ -89,6 +91,7 @@ def configure_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **k
     config = kwargs.pop('config', CLI_DEFAULTS['CONFIG_DIR'])
     catch_internal_server = kwargs.pop('catch_internal_server', CLI_DEFAULTS['CATCH_INTERNAL_SERVER'])
     wsgi_profile = kwargs.pop('wsgi_profile', CLI_DEFAULTS['WSGI_PROFILE'])
+    posting = kwargs.pop('posting', CLI_DEFAULTS['POSTING'])
 
     if kwargs:
         raise ValueError(f'Unknown keyword arguments: {kwargs}')
@@ -121,4 +124,4 @@ def configure_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **k
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
     # Instantiate and return a Flask RESTful API by associating its app
-    return flask_api(app, **config_module.API_CONFIG)
+    return flask_api(app, posting=posting, **config_module.API_CONFIG)

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -121,4 +121,4 @@ def configure_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **k
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
     # Instantiate and return a Flask RESTful API by associating its app
-    return flask_api(app, **API_CONFIG)
+    return flask_api(app, **config_module.API_CONFIG)

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -563,10 +563,10 @@ class NodeTranslator(BaseTranslator):
 
         for node_entry in results[result_name]:
             # construct full_type and add it to every node
-            try:
-                node_entry['full_type'] = construct_full_type(node_entry['node_type'], node_entry['process_type'])
-            except KeyError:
-                node_entry['full_type'] = None
+            node_entry['full_type'] = (
+                construct_full_type(node_entry.get('node_type'), node_entry.get('process_type'))
+                if node_entry.get('node_type') or node_entry.get('process_type') else None
+            )
 
         return results
 

--- a/tests/restapi/test_config.py
+++ b/tests/restapi/test_config.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the configuration options from `aiida.restapi.common.config` when running the REST API."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+
+@pytest.fixture
+def create_app():
+    """Set up Flask App"""
+    from aiida.restapi.run_api import configure_api
+
+    def _create_app(**kwargs):
+        catch_internal_server = kwargs.pop('catch_internal_server', True)
+        api = configure_api(catch_internal_server=catch_internal_server, **kwargs)
+        api.app.config['TESTING'] = True
+        return api.app
+
+    return _create_app
+
+
+def test_posting(create_app):
+    """Test CLI_DEFAULTS['POSTING'] configuration"""
+    from aiida.restapi.common.config import API_CONFIG
+
+    app = create_app(posting=False)
+
+    url = f'{API_CONFIG["PREFIX"]}/querybuilder'
+    for method in ('get', 'post'):
+        with app.test_client() as client:
+            response = getattr(client, method)(url)
+
+        assert response.status_code == 404
+        assert response.status == '404 NOT FOUND'
+
+    del app
+    app = create_app(posting=True)
+
+    url = f'{API_CONFIG["PREFIX"]}/querybuilder'
+    for method in ('get', 'post'):
+        with app.test_client() as client:
+            response = getattr(client, method)(url)
+
+        assert response.status_code != 404
+        assert response.status != '404 NOT FOUND'


### PR DESCRIPTION
Closes #3646 

This is the first pass at implementing a `/query`-endpoint with an HTTP POST functionality to pass a `QueryBuilder` queryhelp JSON object and receive the results back in the "standard" AiiDA REST API data format.

A few things differ for the returned "standard" data format:
- ~All entities will have the `full_type` key.~ (See [comment below](https://github.com/aiidateam/aiida-core/pull/4337#issuecomment-742597142)).
  This is a small price to pay (in my opinion) in order to get the value for this for custom plugin `Node`s when relevant (the `NodeTranslator` is used for this endpoint to be as general as possible).
- Links will not have the `link_type` and `link_label` keys, but these will still be present as the regular `type` and `label` keys, respectively, which is returned normally from `QueryBuilder`.
  We may consider to also remove these extra keys from the regular output in other endpoints with links, but that's for another time.

So far, I have tested this with a variety of `Node`s, trying to get incoming and outgoing, projecting various and differing things. The latter has led to the code's current state that ensure that what is returned is equivalent to what the `QueryBuilder` would normally return.
I have also tested retrieving different entities, e.g., the `User` related to a `Node`. This also works fine.

For now, I have implemented it such that the payload (the posted queryhelp JSON) will be taken at face value and passed on. This is done for simplicity and because I expect most will use this by setting up a `QueryBuilder` instance and passing the instance's `queryhelp` property as a payload. However, manually written queryhelp dictionaries dumped as JSON should work as well, as long as it works for the `QueryBuilder`...
One _could_ create a parser, re-defining the queryhelp keys, however, I don't see the point of this right now.

Currently missing in this PR:
- [x] From @giovannipizzi (see [comment below](https://github.com/aiidateam/aiida-core/pull/4337#issuecomment-683403494)): Allow a config file to enable/disable this endpoint (e.g., we would disable it on MC by default).
- [x] Tests.
- [X] Account for manually written queryhelp dictionaries that work with `QueryBuilder`, but may fail in the POST functionality. (This may include custom projection values.)
  Somewhat fixed, specifically in terms of the `project` keyword (using wilcard (`*`) or not including the keyword).
- [X] Determine whether a custom `Translator` class should be created for this endpoint, or if it's overkill. This will, e.g., make it able to accommodate the differences in the returned "standard" data format mentioned above, but also adds a lot of extra code, which may obscure the functionality (or make it more transparent, depending on the code-reader).
  *Edit*: This does not seem to be necessary. It can still be done in the future, but using `NodeTranslator` or similar is fine.
- [ ] Possibly add entry in documentation about this feature.