### PR TITLE
CI: limit upper version of `setuptools<50` for Jenkins build

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -76,6 +76,7 @@ pipeline {
         }
         stage('Build') {
             steps {
+                sh 'pip install --upgrade --user pip'
                 sh 'pip install --user .[all]'
                 // To be able to do ssh localhost
                 sh 'ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = [ "setuptools>=40.8.0", "wheel", "reentry~=1.3", "fastentrypoints~=0.12",]
+requires = [ "setuptools>=40.8.0,<50", "wheel", "reentry~=1.3", "fastentrypoints~=0.12",]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -177,7 +177,7 @@ def generate_pyproject_toml():
 
     pyproject = {
         'build-system': {
-            'requires': ['setuptools>=40.8.0', 'wheel',
+            'requires': ['setuptools>=40.8.0,<50', 'wheel',
                          str(reentry_requirement), 'fastentrypoints~=0.12'],
             'build-backend': 'setuptools.build_meta:__legacy__',
         }


### PR DESCRIPTION
Fixes #4342 

Builds on Jenkins started failing after `setuptools==0.50.0` was
released on August 30, 2020. This new version gets automatically
installed when using a `pyproject.toml` for the build system, but it
causes the installation of the `aiida-core` package through `pip` to
fail with the exception:

    ModuleNotFoundError: No module named 'setuptools._distutils'

Temporarily limiting the version of `setuptools` in the `pyproject.toml`
works around the problem for the time being.

The build is updated to also update the version of `pip` before
installing the package.