### PR TITLE
New item/attr setter for Dict nodes

### DIFF
--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -19,7 +19,25 @@ __all__ = ('Dict',)
 
 
 class Dict(Data):
-    """`Data` sub class to represent a dictionary."""
+    """`Data` sub class to represent a dictionary.
+
+    The dictionary key-value pairs are stored in the database in a column named `attributes`.
+    We will then say that these are "database-attributes", or "attributes in a database sense".
+    However, these are not "python-attributes" ("attributes in the python sense"), and can only
+    be accessed with the set/get item special methods or through the `dict` special property.
+
+        # These will set a database storeable key-value pair
+        dict_node[key] = value
+        dict_node.dict.key = value
+
+    If you try to set this directly as a "python-attribute", it will only be kept in memory for
+    as long as that node object persists, but it won't appear in the `dict` property nor will
+    it be stored in the database.
+
+        #  This will just set a transient `key` attribute on the node
+        dict_node.key = value
+
+    """
 
     def __init__(self, **kwargs):
         """Store a dictionary as a `Node` instance.
@@ -37,7 +55,10 @@ class Dict(Data):
             self.set_dict(dictionary)
 
     def __getitem__(self, key):
-        return self.get_dict()[key]
+        return self.get_attribute(key)
+
+    def __setitem__(self, key, value):
+        self.set_attribute(key, value)
 
     def set_dict(self, dictionary):
         """ Replace the current dictionary with another one.

--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -21,22 +21,29 @@ __all__ = ('Dict',)
 class Dict(Data):
     """`Data` sub class to represent a dictionary.
 
-    The dictionary key-value pairs are stored in the database in a column named `attributes`.
-    We will then say that these are "database-attributes", or "attributes in a database sense".
-    However, these are not "python-attributes" ("attributes in the python sense"), and can only
-    be accessed with the set/get item special methods or through the `dict` special property.
+    The dictionary contents of a `Dict` node are stored in the database as attributes. The dictionary
+    can be initialized through the `dict` argument in the constructor. After construction, values can
+    be retrieved and updated through the item getters and setters, respectively:
 
-        # These will set a database storeable key-value pair
-        dict_node[key] = value
-        dict_node.dict.key = value
+        node['key'] = 'value'
 
-    If you try to set this directly as a "python-attribute", it will only be kept in memory for
-    as long as that node object persists, but it won't appear in the `dict` property nor will
-    it be stored in the database.
+    Alternatively, the `dict` property returns an instance of the `AttributeManager` that can be used
+    to get and set values through attribute notation:
 
-        #  This will just set a transient `key` attribute on the node
-        dict_node.key = value
+        node.dict.key = 'value'
 
+    Note that trying to set dictionary values directly on the node, e.g. `node.key = value`, will not
+    work as intended. It will merely set the `key` attribute on the node instance, but will not be
+    stored in the database. As soon as the node goes out of scope, the value will be lost.
+
+    It is also relevant to note here the difference in something being an "attribute of a node" (in
+    the sense that it is stored in the "attribute" column of the database when the node is stored)
+    and something being an "attribute of a python object" (in the sense of being able to modify and
+    access it as if it was a property of the variable, e.g. `node.key = value`). This is true of all
+    types of nodes, but it becomes more relevant for `Dict` nodes where one is constantly manipulating
+    these attributes.
+
+    Finally, all dictionary mutations will be forbidden once the node is stored.
     """
 
     def __init__(self, **kwargs):

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -129,7 +129,6 @@ class AttributeManager:  # pylint: disable=too-few-public-methods
         """
         # Possibly add checks here
         self.__dict__['_node'] = node
-        #self._node = node
 
     def __dir__(self):
         """

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -128,6 +128,9 @@ class AttributeManager:  # pylint: disable=too-few-public-methods
         :param node: the node object.
         """
         # Possibly add checks here
+        # We cannot set `self._node` because it would go through the __setattr__ method
+        # which uses said _node by calling `self._node.set_attribute(name, value)`.
+        # Instead, we need to manually set it through the `self.__dict__` property.
         self.__dict__['_node'] = node
 
     def __dir__(self):

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -128,7 +128,8 @@ class AttributeManager:  # pylint: disable=too-few-public-methods
         :param node: the node object.
         """
         # Possibly add checks here
-        self._node = node
+        self.__dict__['_node'] = node
+        #self._node = node
 
     def __dir__(self):
         """
@@ -159,6 +160,9 @@ class AttributeManager:  # pylint: disable=too-few-public-methods
         :param name: name of the key whose value is required.
         """
         return self._node.get_attribute(name)
+
+    def __setattr__(self, name, value):
+        self._node.set_attribute(name, value)
 
     def __getitem__(self, name):
         """

--- a/tests/orm/data/test_dict.py
+++ b/tests/orm/data/test_dict.py
@@ -42,7 +42,7 @@ class TestDict(AiidaTestCase):
 
     def test_set_item(self):
         """Test the methods for setting the item.
-        
+
         * `__setitem__` directly on the node
         * `__setattr__` through the `AttributeManager` returned by the `dict` property
         """

--- a/tests/orm/data/test_dict.py
+++ b/tests/orm/data/test_dict.py
@@ -41,9 +41,10 @@ class TestDict(AiidaTestCase):
         self.assertEqual(self.node['nested'], self.dictionary['nested'])
 
     def test_set_item(self):
-        """Test the methods for setting the item:
-        * `__setitem__` directly in `Dict`
-        * `__setattr__` throught the `AttributeManager`
+        """Test the methods for setting the item.
+        
+        * `__setitem__` directly on the node
+        * `__setattr__` through the `AttributeManager` returned by the `dict` property
         """
         self.node['value'] = 2
         self.assertEqual(self.node['value'], 2)

--- a/tests/orm/data/test_dict.py
+++ b/tests/orm/data/test_dict.py
@@ -39,3 +39,13 @@ class TestDict(AiidaTestCase):
         """Test the `__getitem__` method."""
         self.assertEqual(self.node['value'], self.dictionary['value'])
         self.assertEqual(self.node['nested'], self.dictionary['nested'])
+
+    def test_set_item(self):
+        """Test the methods for setting the item:
+        * `__setitem__` directly in `Dict`
+        * `__setattr__` throught the `AttributeManager`
+        """
+        self.node['value'] = 2
+        self.assertEqual(self.node['value'], 2)
+        self.node.dict.value = 3
+        self.assertEqual(self.node['value'], 3)


### PR DESCRIPTION
Fixes #2883 

The following two ways for setting (key:val) pairs in the dicts stored inside a Dict node were failing (the first one silently, the second one with an error message) but are now valid:

```
dict_node = Dict()
dict_node.dict.x = 'Set a value for x'
dict_node['x'] = 'Overwrite the value for x'
```