### PR TITLE
Introduce equality concept for nodes + tests

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -128,6 +128,18 @@ class Node(Entity, metaclass=AbstractNodeMeta):
         )
         super().__init__(backend_entity)
 
+    def __eq__(self, other):
+        """The uuid should uniquely identify a node.
+
+        Note that although there may be ways in which users may end up manually modifying the
+        uuid of a node, and thus ending up with different nodes with the same uuid, the problem
+        is with them doing these modifications and not with the equality being based on uuid.
+
+        In other words, if any procedure modifies uuids in a way that you end up having different
+        nodes with the same uuid, it is the procedure that must be considered to be buggy.
+        """
+        return self.uuid == other.uuid
+
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, str(self))
 

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -54,6 +54,14 @@ class TestNodeAttributesExtras(AiidaTestCase):
         super().setUp()
         self.node = Data()
 
+    def test_equality(self):
+        """Test the `__eq__` method."""
+        node1 = Node()
+        node2 = node1
+        node3 = Node()
+        self.assertTrue(node1 == node2)
+        self.assertTrue(node1 != node3)
+
     def test_attributes(self):
         """Test the `Node.attributes` property."""
         original_attribute = {'nested': {'a': 1}}


### PR DESCRIPTION
Two nodes will evaluate to be equal if their uuid coincides.

Fixes #1917 