### PR TITLE
Bump base docker image version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.2.0
+FROM aiidateam/aiida-prerequisites:0.2.1
 
 USER root
 


### PR DESCRIPTION
fixes #4339 

The new image is based on the latest stable Bionic Beaver (18.04)
Ubuntu distribution, which contains fixes for critical vulnerabilities.

Additionally, this image contains a fix for `ruamel.yaml` package
installation.