### PR TITLE
Add dir creation to transport and execmanager

### DIFF
--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -330,6 +330,7 @@ class LocalTransport(Transport):
         if os.path.exists(the_destination) and not overwrite:
             raise OSError('Destination already exists: not overwriting it')
 
+        self.makedirs(os.path.dirname(the_destination), ignore_existing=True)
         shutil.copyfile(localpath, the_destination)
 
     def puttree(self, localpath, remotepath, *args, **kwargs):

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -789,6 +789,7 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         if self.isfile(remotepath) and not overwrite:
             raise OSError('Destination already exists: not overwriting it')
 
+        self.makedirs(os.path.dirname(remotepath), ignore_existing=True)
         return self.sftp.put(localpath, remotepath, callback=callback)
 
     def puttree(self, localpath, remotepath, callback=None, dereference=True, overwrite=True):  # pylint: disable=too-many-branches,arguments-differ,unused-argument


### PR DESCRIPTION
Fix #4350 

I wasn't entirely sure if the responsibility to create the intermediate folders should fall within the engine (making sure it first creates directories and then copies files) or the transport (making sure, whenever a file needs to be copied, to make the directory if it doesn't exist). I put it in both places (see L205 of `execmanager.py`, and changes in `ssh`/`local` transports) with the original intention of later removing one of these after deciding where the responsibility falls, but now I think there could actually be an argument for keeping both (thus having a safeguard against transports plugin that think that files and mkdirs should be separate, while also making sure there won't be problem for distracted users/designers in case they need to do direct calls the transport).

Two extra comments:

1. I also changed the capitalization of the global `execlogger` because pylint was complaining (and introduced the underscore because the risk of reading "EXE CLOGGER" is just too high).
2. I was thinking of adding tests for this; the execmanager only tests the `retrieve_files_from_list` method and I thought it might be worth it to add a test for `upload_calculation`, but it is apparently a bit more complicated than I originally thought so first I wanted to make sure that (a) the modification there is ok and (b) this is not being test elsewhere.