### PR TITLE
Fix profile creation in the test fixture manager

### DIFF
--- a/aiida/manage/tests/__init__.py
+++ b/aiida/manage/tests/__init__.py
@@ -272,6 +272,12 @@ class TemporaryProfileManager(ProfileManager):
             'database_name': self.profile_info.get('database_name'),
             'database_username': self.profile_info.get('database_username'),
             'database_password': self.profile_info.get('database_password'),
+            'broker_protocol': self.profile_info.get('broker_protocol'),
+            'broker_username': self.profile_info.get('broker_username'),
+            'broker_password': self.profile_info.get('broker_password'),
+            'broker_host': self.profile_info.get('broker_host'),
+            'broker_port': self.profile_info.get('broker_port'),
+            'broker_virtual_host': self.profile_info.get('broker_virtual_host'),
             'repository_uri': 'file://' + self.repo,
         }
         return dictionary


### PR DESCRIPTION
Fixes #4359 

The test profile provided by the test fixture manager was broken after
the recent added feature where the broker configuration becomes
configurable. Since the test fixture uses custom code to create the
profile that is not tested in the test suite of `aiida-core`, it went
unnoticed that it was not updated to also include the broker
information. Adding the broker defaults fixes the problem, but really
the fixture code should be rewritten to not have its own profile
generation code.