### PR TITLE
Ci/continue on errors with 2020 resolver

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -43,6 +43,7 @@ jobs:
 
     continue-on-error: ${{ contains(matrix.pip-feature-flag, '2020-resolver') }}
     strategy:
+      fail-fast: false
       matrix:
         pip-feature-flag: [ '', '--use-feature=2020-resolver' ]
         extras: [ '', '[atomic_tools,docs,notebook,rest,tests]' ]

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    continue-on-error: ${{ contains(matrix.pip-feature-flag, '2020-resolver') }}
     strategy:
       matrix:
         pip-feature-flag: [ '', '--use-feature=2020-resolver' ]

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -57,14 +57,22 @@ jobs:
         python-version: 3.8
 
     - name: Pip install
+      id: pip_install
+      continue-on-error: ${{ contains(matrix.pip-feature-flag, '2020-resolver') }}
       run: |
         python -m pip --version
         python -m pip install -e .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
         python -m pip freeze
 
     - name: Test importing aiida
+      if: steps.pip_install.outcome == 'success'
       run:
         python -c "import aiida"
+
+    - name: Warn about pip 2020 resolver issues.
+      if: steps.pip_install.outcome == 'failure' && contains(matrix.pip-feature-flag, '2020-resolver')
+      run: |
+        echo "::warning ::Encountered issues with the pip 2020-resolver."
 
   install-with-conda:
 


### PR DESCRIPTION
Updates the `test-install` workflow to not fail when any of the pip-2020 resolver related steps or jobs fails. This is to reduce disruption to our own processes related to that feature.

See this run for what this looks like in practice: https://github.com/aiidateam/aiida-core/actions/runs/253813527

The compromise here is that in order to not block merges, the associated steps and jobs still get a little green check-mark, but there is a warning displayed if issues with the 2020-resolver are encountered. Unfortunately I did not find a better way to indicate issues, because GitHub actions is not really good about this particular use case. If you know of a better way, I'm open to suggestions, but keep in mind that I already spend some time on researching and experimenting with this.