### PR TITLE
Update citations in `README.md` and documentation landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,10 @@ If you are experiencing problems with your AiiDA installation, please refer to t
 
 ## How to cite
 
-If you use AiiDA in your research, please consider citing the AiiDA paper:
+If you use AiiDA in your research, please consider citing the following publications:
 
-> Giovanni Pizzi, Andrea Cepellotti, Riccardo Sabatini, Nicola Marzari,
-> and Boris Kozinsky, *AiiDA: automated interactive infrastructure and
-> database for computational science*, Comp. Mat. Sci 111, 218-230
-> (2016); <https://doi.org/10.1016/j.commatsci.2015.09.013>;
-> <http://www.aiida.net>.
+ * **AiiDA >= 1.0**: S. P. Huber *et al.*, *AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and data provenance*, Scientific Data **7**, 300 (2020); DOI: [10.1038/s41597-020-00638-4](https://doi.org/10.1038/s41597-020-00638-4)
+ * **AiiDA < 1.0**: Giovanni Pizzi, Andrea Cepellotti, Riccardo Sabatini, Nicola Marzari,and Boris Kozinsky, *AiiDA: automated interactive infrastructure and database for computational science*, Comp. Mat. Sci **111**, 218-230 (2016); DOI: [10.1016/j.commatsci.2015.09.013](https://doi.org/10.1016/j.commatsci.2015.09.013)
 
 ## License
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -110,13 +110,11 @@ How to cite
 
 If you use AiiDA for your research, please cite the following work:
 
-.. highlights:: **AiiDA 1.0:** Sebastiaan. P. Huber, Spyros Zoupanos, Martin Uhrin, Leopold Talirz, Leonid Kahle, Rico Häuselmann, Dominik Gresch, Tiziano Müller, Aliaksandr V. Yakutovich, Casper W. Andersen, Francisco F. Ramirez, Carl S. Adorf, Fernando Gargiulo, Snehal Kumbhar, Elsa Passaro, Conrad Johnston, Andrius Merkys, Andrea Cepellotti, Nicolas Mounet, Nicola Marzari, Boris Kozinsky, Giovanni Pizzi, *AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and data provenance*, `arXiv:2003.12476 (2020) <https://arxiv.org/abs/2003.12476>`_;
-    `http://www.aiida.net <http://www.aiida.net>`_.
+.. highlights:: **AiiDA >= 1.0:** Sebastiaan. P. Huber, Spyros Zoupanos, Martin Uhrin, Leopold Talirz, Leonid Kahle, Rico Häuselmann, Dominik Gresch, Tiziano Müller, Aliaksandr V. Yakutovich, Casper W. Andersen, Francisco F. Ramirez, Carl S. Adorf, Fernando Gargiulo, Snehal Kumbhar, Elsa Passaro, Conrad Johnston, Andrius Merkys, Andrea Cepellotti, Nicolas Mounet, Nicola Marzari, Boris Kozinsky, Giovanni Pizzi, *AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and data provenance*, Scientific Data **7**, 300 (2020); DOI: [10.1038/s41597-020-00638-4](https://doi.org/10.1038/s41597-020-00638-4)
 
-.. highlights:: **AiiDA 0.x:** Giovanni Pizzi, Andrea Cepellotti, Riccardo Sabatini, Nicola Marzari,
+.. highlights:: **AiiDA < 1.0:** Giovanni Pizzi, Andrea Cepellotti, Riccardo Sabatini, Nicola Marzari,
     and Boris Kozinsky, *AiiDA: automated interactive infrastructure and database
-    for computational science*, Comp. Mat. Sci 111, 218-230 (2016);
-    https://doi.org/10.1016/j.commatsci.2015.09.013; http://www.aiida.net.
+    for computational science*, Comp. Mat. Sci 111, 218-230 (2016); DOI: [10.1016/j.commatsci.2015.09.013](https://doi.org/10.1016/j.commatsci.2015.09.013)
 
 
 ****************


### PR DESCRIPTION
The second AiiDA paper was published in Scientific Data on September 8,
2020. The suggested citations are updated, where the original AiiDA
paper is kept to be cited when people use AiiDA with version before v1.0