### PR TITLE
🧪 Skip code CI if docs only PR

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -5,37 +5,9 @@ on:
     branches-ignore: [gh-pages]
   pull_request:
     branches-ignore: [gh-pages]
+    paths-ignore: ['docs/**']
 
 jobs:
-
-  pre-commit:
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install system dependencies
-      run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-        sudo apt update
-        sudo apt install libkrb5-dev ruby ruby-dev
-
-    - name: Install python dependencies
-      run: |
-        pip install numpy==1.17.4
-        pip install -e .[all]
-        pip freeze
-
-    - name: Run pre-commit
-      run:
-        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
   check-requirements:
 

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -1,0 +1,38 @@
+name: continuous-integration
+
+on:
+  push:
+    branches-ignore: [gh-pages]
+  pull_request:
+    branches-ignore: [gh-pages]
+
+jobs:
+
+  pre-commit:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install system dependencies
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt update
+        sudo apt install libkrb5-dev ruby ruby-dev
+
+    - name: Install python dependencies
+      run: |
+        pip install numpy==1.17.4
+        pip install -e .[all]
+        pip freeze
+
+    - name: Run pre-commit
+      run:
+        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )


### PR DESCRIPTION
Split the `ci.yml` into `ci-code.yml` and `ci-style.yml`, so that ci-code jobs can be skipped if the only change in the PR are to files in the docs folder.

closes #3055