### PR TITLE
Unpin numpy version from 1.17.X to allow the newest version (1.19)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - cache-pip
 
       - run: |
-          pip install numpy==1.17.4
+          # pip install numpy==1.17.4
           pip install --user .[docs,tests]
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,7 @@ jobs:
           keys:
             - cache-pip
 
-      - run: |
-          # pip install numpy==1.17.4
-          pip install --user .[docs,tests]
+      - run: pip install --user .[docs,tests]
 
       - save_cache:
           key: cache-pip

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -137,7 +137,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install numpy==1.17.4
+        # pip install numpy==1.17.4
         pip install -e .
 
     - name: Run verdi

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -136,9 +136,7 @@ jobs:
         python-version: 3.8
 
     - name: Install python dependencies
-      run: |
-        # pip install numpy==1.17.4
-        pip install -e .
+      run: pip install -e .
 
     - name: Run verdi
       run: |

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -29,7 +29,6 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        # pip install numpy==1.17.4
         pip install -e .[all]
         pip freeze
 

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install numpy==1.17.4
+        # pip install numpy==1.17.4
         pip install -e .[all]
         pip freeze
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install numpy==1.17.4
+        # pip install numpy==1.17.4
         pip install transifex-client sphinx-intl
         pip install -e .[docs,tests]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        # pip install numpy==1.17.4
         pip install transifex-client sphinx-intl
         pip install -e .[docs,tests]
 

--- a/aiida/tools/data/array/kpoints/legacy.py
+++ b/aiida/tools/data/array/kpoints/legacy.py
@@ -342,7 +342,7 @@ def get_explicit_kpoints_path(
     explicit_kpoints = [tuple(point_coordinates[path[0][0]])]
     labels = [(0, path[0][0])]
 
-    if not all([_.is_integer() for _ in num_points]):
+    if not all([_.is_integer() for _ in num_points if isinstance(_, (float, numpy.float64))]):
         raise ValueError('Could not determine number of points as a whole number. num_points={}'.format(num_points))
     num_points = [int(_) for _ in num_points]
 

--- a/aiida/tools/data/array/kpoints/legacy.py
+++ b/aiida/tools/data/array/kpoints/legacy.py
@@ -342,6 +342,10 @@ def get_explicit_kpoints_path(
     explicit_kpoints = [tuple(point_coordinates[path[0][0]])]
     labels = [(0, path[0][0])]
 
+    if not all([_.is_integer() for _ in num_points]):
+        raise ValueError('Could not determine number of points as a whole number. num_points={}'.format(num_points))
+    num_points = [int(_) for _ in num_points]
+
     for count_piece, i in enumerate(path):
         ini_label = i[0]
         end_label = i[1]

--- a/aiida/tools/data/array/kpoints/legacy.py
+++ b/aiida/tools/data/array/kpoints/legacy.py
@@ -342,8 +342,8 @@ def get_explicit_kpoints_path(
     explicit_kpoints = [tuple(point_coordinates[path[0][0]])]
     labels = [(0, path[0][0])]
 
-    if not all([_.is_integer() for _ in num_points if isinstance(_, (float, numpy.float64))]):
-        raise ValueError('Could not determine number of points as a whole number. num_points={}'.format(num_points))
+    assert all([_.is_integer() for _ in num_points if isinstance(_, (float, numpy.float64))]
+               ), 'Could not determine number of points as a whole number. num_points={}'.format(num_points)
     num_points = [int(_) for _ in num_points]
 
     for count_piece, i in enumerate(path):

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - ipython~=7.0
 - jinja2~=2.10
 - kiwipy[rmq]~=0.5.5
-- numpy~=1.19
+- numpy~=1.17
 - paramiko~=2.7
 - pika~=1.1
 - plumpy~=0.15.0

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - ipython~=7.0
 - jinja2~=2.10
 - kiwipy[rmq]~=0.5.5
-- numpy<1.18,~=1.17
+- numpy~=1.19
 - paramiko~=2.7
 - pika~=1.1
 - plumpy~=0.15.0

--- a/setup.json
+++ b/setup.json
@@ -34,7 +34,7 @@
         "ipython~=7.0",
         "jinja2~=2.10",
         "kiwipy[rmq]~=0.5.5",
-        "numpy~=1.17,<1.18",
+        "numpy~=1.19",
         "paramiko~=2.7",
         "pika~=1.1",
         "plumpy~=0.15.0",

--- a/setup.json
+++ b/setup.json
@@ -34,7 +34,7 @@
         "ipython~=7.0",
         "jinja2~=2.10",
         "kiwipy[rmq]~=0.5.5",
-        "numpy~=1.19",
+        "numpy~=1.17",
         "paramiko~=2.7",
         "pika~=1.1",
         "plumpy~=0.15.0",


### PR DESCRIPTION
This is an attempt to try and unpin the hard constraint on `numpy`.

This was introduced in f5d6cba, the reason for it can be seen in the commit message.

I have tried following the [wiki page](https://github.com/aiidateam/aiida-core/wiki/AiiDA-Dependency-Management) on how to update dependencies, and am currently trying the semi-automatic update of the requirements files by creating this PR.