### PR TITLE
Dependencies: increase minimum version requirement `plumpy~=0.15.1`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpy~=1.17
 - paramiko~=2.7
 - pika~=1.1
-- plumpy~=0.15.0
+- plumpy~=0.15.1
 - pgsu~=0.1.0
 - psutil~=5.6
 - psycopg2>=2.8.3,~=2.8

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -78,7 +78,7 @@ pgtest==1.3.2
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.15.0
+plumpy==0.15.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -77,7 +77,7 @@ pgtest==1.3.2
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.15.0
+plumpy==0.15.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -76,7 +76,7 @@ pgtest==1.3.2
 pickleshare==0.7.5
 pika==1.1.0
 pluggy==0.13.1
-plumpy==0.15.0
+plumpy==0.15.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/setup.json
+++ b/setup.json
@@ -36,7 +36,7 @@
         "numpy~=1.17",
         "paramiko~=2.7",
         "pika~=1.1",
-        "plumpy~=0.15.0",
+        "plumpy~=0.15.1",
         "pgsu~=0.1.0",
         "psutil~=5.6",
         "psycopg2-binary~=2.8,>=2.8.3",


### PR DESCRIPTION
Fixes #4346 

The patch release of `plumpy` comes with a simple fix that will prevent
the printing of many warnings when running processes. So although not
critical, it does improve user experience.