### PR TITLE
Implement `next` and `iter` for the `Node.open` deprecation wrapper

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -67,6 +67,12 @@ class WarnWhenNotEntered:
     def __del__(self):
         self._warn_if_not_entered('del')
 
+    def __iter__(self):
+        return self._fileobj.__iter__()
+
+    def __next__(self):
+        return self._fileobj.__next__()
+
     def read(self, *args, **kwargs):
         self._warn_if_not_entered('read')
         return self._fileobj.read(*args, **kwargs)

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -9,6 +9,7 @@
 ###########################################################################
 # pylint: disable=too-many-public-methods
 """Tests for the Node ORM class."""
+import io
 import os
 import tempfile
 
@@ -842,3 +843,20 @@ def test_store_from_cache():
     assert clone.is_stored
     assert clone.get_cache_source() == data.uuid
     assert data.get_hash() == clone.get_hash()
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_open_wrapper():
+    """Test the wrapper around the return value of ``Node.open``.
+
+    This should be remove in v2.0.0 because the wrapper should be removed.
+    """
+    filename = 'test'
+    node = Node()
+    node.put_object_from_filelike(io.StringIO('test'), filename)
+
+    # Both `iter` and `next` should not raise
+    next(node.open(filename))
+    iter(node.open(filename))
+    node.open(filename).__next__()
+    node.open(filename).__iter__()


### PR DESCRIPTION
Fixes #4396 

The return value of `Node.open` was wrapped in `WarnWhenNotEntered` in
`aiida-core==1.4.0` in order to warn users that use the method without a
context manager, which will start to raise in v2.0. Unfortunately, the
raising came a little early as the wrapper does not implement the
`__iter__` and `__next__` methods, which can be called by clients.

An example is `numpy.genfromtxt` which will notice the return value of
`Node.open` is filelike and so will wrap it in `iter`. Without the
current fix, this raises a `TypeError`. The proper fix would be to
forward all magic methods to the wrapped filelike object, but it is not
clear how to do this.