### PR TITLE
Add path creation when copying remote files

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -159,8 +159,11 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
     remote_symlink_list = calc_info.remote_symlink_list or []
     provenance_exclude_list = calc_info.provenance_exclude_list or []
 
-    # Creates the directory structure locally and first to prevent unnecessary transport
-    # calls when copying the individual files
+    # First creates the directory structure locally before copying the sandbox folder, so that all the intermediate
+    # folders for the files in the copy_lists are there before calling the copy methods of the transport (or else
+    # these will fail).
+    # Alternatively, one would have to call the path creation methods of the transports just before calling the
+    # copy methods to make sure each path is there, unnecessarily duplicating the number of connections requested.
     for _, _, target_relpath in local_copy_list + remote_copy_list + remote_symlink_list:
         dirname = os.path.dirname(target_relpath)
         if dirname:

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -212,7 +212,10 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
                     )
                 )
                 try:
-                    transport.makedirs(os.path.dirname(dest_rel_path), ignore_existing=True)
+                    # We have to create the directory first: if it doesn't exist the copy call will fail
+                    dirname = os.path.dirname(dest_rel_path)
+                    if dirname:
+                        transport.makedirs(dirname, ignore_existing=True)
                     transport.copy(remote_abs_path, dest_rel_path)
                 except (IOError, OSError):
                     logger.warning(
@@ -234,7 +237,10 @@ def upload_calculation(node, transport, calc_info, folder, inputs=None, dry_run=
                     )
                 )
                 try:
-                    transport.makedirs(os.path.dirname(dest_rel_path), ignore_existing=True)
+                    # We have to create the directory first: if it doesn't exist the copy call will fail
+                    dirname = os.path.dirname(dest_rel_path)
+                    if dirname:
+                        transport.makedirs(dirname, ignore_existing=True)
                     transport.symlink(remote_abs_path, dest_rel_path)
                 except (IOError, OSError):
                     logger.warning(

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -15,7 +15,6 @@ import pytest
 
 from aiida import orm
 from aiida.engine.daemon import execmanager
-from aiida.common.folders import Folder
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.transports.plugins.local import LocalTransport
 
@@ -95,49 +94,53 @@ def test_upload_local_copy_list(fixture_sandbox, aiida_localhost, aiida_local_co
     assert node.list_object_names() == []
 
 
-def test_upload_calculation(tmp_path_factory, aiida_localhost):
+def test_upload_calculation(aiida_localhost, aiida_local_code_factory, fixture_sandbox, tmp_path):
     """Test the `upload_calculation` function, and specifically the copy lists."""
 
-    # First we need to create the nodes with the data (a local FolderData and a RemoteData).
+    # FolderData: needs to be stored when is checked by upload_calculation
     folder_node = orm.FolderData()
     folder_node.put_object_from_filelike(io.StringIO('dummy_content_1'), 'file_1.txt')
     folder_node.store()
 
-    tempdir = tmp_path_factory.mktemp('tempdir')
-    remote_node = orm.RemoteData(computer=aiida_localhost, remote_path=str(tempdir))
+    # RemoteData: upload_calculation will not check if it is stored (should it?)
+    remote_node = orm.RemoteData(computer=aiida_localhost, remote_path=str(tmp_path))
 
-    source_path2 = str(tempdir / 'file_2.txt')
+    source_path2 = str(tmp_path / 'file_2.txt')
     with open(source_path2, 'w') as handle:
         handle.write('dummy_content_2')
         handle.flush()
 
-    source_path3 = str(tempdir / 'file_3.txt')
+    source_path3 = str(tmp_path / 'file_3.txt')
     with open(source_path3, 'w') as handle:
         handle.write('dummy_content_3')
         handle.flush()
 
-    # Then we need to set up the code, the CalcJob and the scratch folder
-    code = orm.Code(input_plugin_name='arithmetic.add', remote_computer_exec=[aiida_localhost, '/bin/true']).store()
-
-    calc_node = orm.CalcJobNode(computer=aiida_localhost).store()
-
-    folder = Folder(abspath=str(tmp_path_factory.mktemp('folder')))
-
-    # Set up the code info and copy the files creating folders for each
+    # CodeInfo: needs to be set up as normal for any CalcJob
+    code_node = aiida_local_code_factory('arithmetic.add', '/bin/bash')
     code_info = CodeInfo()
-    code_info.code_uuid = code.uuid
+    code_info.code_uuid = code_node.uuid
+
+    # CalcInfo: besides normal setups, we also need to manually set calc_info.uuid
+    # as we are skipping the step of the engine were this happens.
+    calc_node = orm.CalcJobNode(computer=aiida_localhost).store()
     calc_info = CalcInfo()
+    calc_info.uuid = calc_node.uuid
     calc_info.codes_info = [code_info]
     calc_info.local_copy_list = [(folder_node.uuid, 'file_1.txt', 'local_file/file_1.txt')]
     calc_info.remote_copy_list = [(remote_node.computer.uuid, source_path2, 'remote_file/file_2.txt')]
     calc_info.remote_symlink_list = [(remote_node.computer.uuid, source_path3, 'symlink_file/file_3.sym')]
-    calc_info.uuid = calc_node.uuid
 
+    # We need to manually open a transport and pass it to upload_calculation, together
+    # with a pre-set up sandbox folder (in this case it can be empty since we are mostly
+    # checking through the copy lists)
     with LocalTransport() as transport:
-        execmanager.upload_calculation(calc_node, transport, calc_info, folder, inputs={})
+        execmanager.upload_calculation(calc_node, transport, calc_info, fixture_sandbox)
 
     calc_folder_path = pathlib.Path(calc_node.get_remote_workdir())
 
+    # Although in principle not necessary, the checks are performed increasingly from the
+    # existence of folders to content of contained files so it will be easier to identify
+    # which part of the copying is broken.
     list_of_folders = [
         calc_folder_path / 'local_file',
         calc_folder_path / 'remote_file',
@@ -160,5 +163,3 @@ def test_upload_calculation(tmp_path_factory, aiida_localhost):
     full_file_path = str(calc_folder_path / 'symlink_file/file_3.sym')
     with open(full_file_path, 'r') as handle:
         assert handle.read() == 'dummy_content_3'
-
-    folder.erase()

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -10,9 +10,13 @@
 """Tests for the :mod:`aiida.engine.daemon.execmanager` module."""
 import io
 import os
+import pathlib
 import pytest
 
+from aiida import orm
 from aiida.engine.daemon import execmanager
+from aiida.common.folders import Folder
+from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.transports.plugins.local import LocalTransport
 
 
@@ -63,7 +67,6 @@ def test_upload_local_copy_list(fixture_sandbox, aiida_localhost, aiida_local_co
 
     Specifically, verify that files in the ``local_copy_list`` do not end up in the repository of the node.
     """
-    from aiida.common.datastructures import CalcInfo, CodeInfo
     from aiida.orm import CalcJobNode, SinglefileData
 
     inputs = {
@@ -90,3 +93,72 @@ def test_upload_local_copy_list(fixture_sandbox, aiida_localhost, aiida_local_co
         execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
 
     assert node.list_object_names() == []
+
+
+def test_upload_calculation(tmp_path_factory, aiida_localhost):
+    """Test the `upload_calculation` function, and specifically the copy lists."""
+
+    # First we need to create the nodes with the data (a local FolderData and a RemoteData).
+    folder_node = orm.FolderData()
+    folder_node.put_object_from_filelike(io.StringIO('dummy_content_1'), 'file_1.txt')
+    folder_node.store()
+
+    tempdir = tmp_path_factory.mktemp('tempdir')
+    remote_node = orm.RemoteData(computer=aiida_localhost, remote_path=str(tempdir))
+
+    source_path2 = str(tempdir / 'file_2.txt')
+    with open(source_path2, 'w') as handle:
+        handle.write('dummy_content_2')
+        handle.flush()
+
+    source_path3 = str(tempdir / 'file_3.txt')
+    with open(source_path3, 'w') as handle:
+        handle.write('dummy_content_3')
+        handle.flush()
+
+    # Then we need to set up the code, the CalcJob and the scratch folder
+    code = orm.Code(input_plugin_name='arithmetic.add', remote_computer_exec=[aiida_localhost, '/bin/true']).store()
+
+    calc_node = orm.CalcJobNode(computer=aiida_localhost).store()
+
+    folder = Folder(abspath=str(tmp_path_factory.mktemp('folder')))
+
+    # Set up the code info and copy the files creating folders for each
+    code_info = CodeInfo()
+    code_info.code_uuid = code.uuid
+    calc_info = CalcInfo()
+    calc_info.codes_info = [code_info]
+    calc_info.local_copy_list = [(folder_node.uuid, 'file_1.txt', 'local_file/file_1.txt')]
+    calc_info.remote_copy_list = [(remote_node.computer.uuid, source_path2, 'remote_file/file_2.txt')]
+    calc_info.remote_symlink_list = [(remote_node.computer.uuid, source_path3, 'symlink_file/file_3.sym')]
+    calc_info.uuid = calc_node.uuid
+
+    with LocalTransport() as transport:
+        execmanager.upload_calculation(calc_node, transport, calc_info, folder, inputs={})
+
+    calc_folder_path = pathlib.Path(calc_node.get_remote_workdir())
+
+    list_of_folders = [
+        calc_folder_path / 'local_file',
+        calc_folder_path / 'remote_file',
+        calc_folder_path / 'symlink_file',
+    ]
+    assert sorted(list(calc_folder_path.iterdir())) == sorted(list_of_folders)
+
+    assert list((calc_folder_path / 'local_file').iterdir()) == [calc_folder_path / 'local_file/file_1.txt']
+    assert list((calc_folder_path / 'remote_file').iterdir()) == [calc_folder_path / 'remote_file/file_2.txt']
+    assert list((calc_folder_path / 'symlink_file').iterdir()) == [calc_folder_path / 'symlink_file/file_3.sym']
+
+    full_file_path = str(calc_folder_path / 'local_file/file_1.txt')
+    with open(full_file_path, 'r') as handle:
+        assert handle.read() == 'dummy_content_1'
+
+    full_file_path = str(calc_folder_path / 'remote_file/file_2.txt')
+    with open(full_file_path, 'r') as handle:
+        assert handle.read() == 'dummy_content_2'
+
+    full_file_path = str(calc_folder_path / 'symlink_file/file_3.sym')
+    with open(full_file_path, 'r') as handle:
+        assert handle.read() == 'dummy_content_3'
+
+    folder.erase()


### PR DESCRIPTION
If the `remote_copy_list` or the `symlink_copy_list` were provided with
a target path that required the creation of intermediate folders, the
CalcJob would have fail. This should fix that problem.

* Also added tests for the `upload_calculation` method of the
execmanager (in general and for this specific case)

* Replaced `execlogger` by `EXEC_LOGGER` to comply with pylint naming
conventions for global variables.