### PR TITLE
Add option to delete builder attributes

### DIFF
--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -7,7 +7,6 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=cell-var-from-loop, line-too-long
 """Convenience classes to help building the input dictionaries for Processes."""
 import collections
 
@@ -49,14 +48,14 @@ class ProcessBuilderNamespace(collections.abc.MutableMapping):
                     return self._data.get(name)
             elif port.has_default():
 
-                def fgetter(self, name=name, default=port.default):
+                def fgetter(self, name=name, default=port.default):  # pylint: disable=cell-var-from-loop
                     return self._data.get(name, default)
             else:
 
                 def fgetter(self, name=name):
                     return self._data.get(name, None)
 
-            def fsetter(self, value):
+            def fsetter(self, value, name=name):
                 self._data[name] = value
 
             fgetter.__doc__ = str(port)

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -7,10 +7,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=cell-var-from-loop
+# pylint: disable=cell-var-from-loop, line-too-long
 """Convenience classes to help building the input dictionaries for Processes."""
 import collections
 
+from aiida.orm import Node
 from aiida.engine.processes.ports import PortNamespace
 
 __all__ = ('ProcessBuilder', 'ProcessBuilderNamespace')
@@ -112,6 +113,9 @@ class ProcessBuilderNamespace(collections.abc.MutableMapping):
     def __delitem__(self, item):
         self._data.__delitem__(item)
 
+    def __delattr__(self, item):
+        self._data.__delitem__(item)
+
     def _update(self, *args, **kwds):
         """Update the values of the builder namespace passing a mapping as argument or individual keyword value pairs.
 
@@ -160,8 +164,6 @@ class ProcessBuilderNamespace(collections.abc.MutableMapping):
         :param value: a nested mapping of port values
         :return: the same mapping but without any nested namespace that is completely empty.
         """
-        from aiida.orm import Node
-
         if isinstance(value, collections.abc.Mapping) and not isinstance(value, Node):
             result = {}
             for key, sub_value in value.items():
@@ -174,7 +176,7 @@ class ProcessBuilderNamespace(collections.abc.MutableMapping):
         return value
 
 
-class ProcessBuilder(ProcessBuilderNamespace):
+class ProcessBuilder(ProcessBuilderNamespace):  # pylint: disable=too-many-ancestors
     """A process builder that helps setting up the inputs for creating a new process."""
 
     def __init__(self, process_class):
@@ -188,4 +190,5 @@ class ProcessBuilder(ProcessBuilderNamespace):
 
     @property
     def process_class(self):
+        """Straighforward wrapper for the process_class"""
         return self._process_class

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -37,6 +37,10 @@ class ProcessBuilderNamespace(collections.abc.MutableMapping):
         self._valid_fields = []
         self._data = {}
 
+        # The name and port objects have to be passed to the defined functions as defaults for
+        # their arguments, because this way the content at the time of defining the method is
+        # saved. If they are used directly in the body, it will try to capture the value from
+        # its enclosing scope at the time of being called.
         for name, port in port_namespace.items():
 
             self._valid_fields.append(name)

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -193,5 +193,5 @@ class ProcessBuilder(ProcessBuilderNamespace):  # pylint: disable=too-many-ances
 
     @property
     def process_class(self):
-        """Straighforward wrapper for the process_class"""
+        """Return the process class for which this builder is constructed."""
         return self._process_class

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -15,15 +15,18 @@ from aiida.engine.processes.builder import ProcessBuilder
 from aiida import orm
 
 
-#@pytest.mark.usefixtures('clear_database_before_test')
 def test_access_methods():
-    """Test for the access methods (setter, getter, delete)."""
-    builder = ProcessBuilder(ArithmeticAddCalculation)
+    """Test for the access methods (setter, getter, delete).
 
+    The setters are used again after calling the delete in order to check that they still work
+    after the deletion (including the validation process).
+    """
     node_numb = orm.Int(4)
     node_dict = orm.Dict(dict={'value': 4})
 
     # AS ITEMS
+    builder = ProcessBuilder(ArithmeticAddCalculation)
+
     builder['x'] = node_numb
     assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}
 
@@ -37,6 +40,9 @@ def test_access_methods():
     assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}
 
     # AS ATTRIBUTES
+    del builder
+    builder = ProcessBuilder(ArithmeticAddCalculation)
+
     builder.x = node_numb
     assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}
 

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for `aiida.engine.processes.builder.ProcessBuilder`."""
+
+from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+from aiida.engine.processes.builder import ProcessBuilder
+
+
+def test_access_methods():
+    """Test for the access methods (setter, getter, delete)."""
+    builder = ProcessBuilder(ArithmeticAddCalculation)
+
+    # AS ITEMS
+    builder['metadata'] = {'label': 'test'}
+    assert dict(builder) == {'metadata': {'label': 'test'}}
+    del builder['metadata']
+    assert dict(builder) == {}
+
+    # AS ATTRIBUTES
+    builder.metadata = {'label': 'test'}
+    assert dict(builder) == {'metadata': {'label': 'test'}}
+    del builder.metadata
+    assert dict(builder) == {}

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -8,23 +8,43 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for `aiida.engine.processes.builder.ProcessBuilder`."""
+import pytest
 
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from aiida.engine.processes.builder import ProcessBuilder
+from aiida import orm
 
 
+#@pytest.mark.usefixtures('clear_database_before_test')
 def test_access_methods():
     """Test for the access methods (setter, getter, delete)."""
     builder = ProcessBuilder(ArithmeticAddCalculation)
 
+    node_numb = orm.Int(4)
+    node_dict = orm.Dict(dict={'value': 4})
+
     # AS ITEMS
-    builder['metadata'] = {'label': 'test'}
-    assert dict(builder) == {'metadata': {'label': 'test'}}
-    del builder['metadata']
-    assert dict(builder) == {}
+    builder['x'] = node_numb
+    assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}
+
+    del builder['x']
+    assert dict(builder) == {'metadata': {'options': {}}}
+
+    with pytest.raises(ValueError):
+        builder['x'] = node_dict
+
+    builder['x'] = node_numb
+    assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}
 
     # AS ATTRIBUTES
-    builder.metadata = {'label': 'test'}
-    assert dict(builder) == {'metadata': {'label': 'test'}}
-    del builder.metadata
-    assert dict(builder) == {}
+    builder.x = node_numb
+    assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}
+
+    del builder.x
+    assert dict(builder) == {'metadata': {'options': {}}}
+
+    with pytest.raises(ValueError):
+        builder.x = node_dict
+
+    builder.x = node_numb
+    assert dict(builder) == {'metadata': {'options': {}}, 'x': node_numb}


### PR DESCRIPTION
Fixes #4381 

The builder object was able to delete already set inputs as
items (`del builder['input_name']`), but not as attributes
(`del builder.input_name`). This is not consistent with how
these inputs can be set or accessed (both `builder.input_name`
and `builder['input_name']` are possible).

Also added tests for these two ways of accessing inputs.