### PR TITLE
Add `--delete-nodes` flag to verdi group delete

### DIFF
--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -470,6 +470,10 @@ GROUP_CLEAR = OverridableOption(
     '-c', '--clear', is_flag=True, default=False, help='Remove all the nodes from the group.'
 )
 
+GROUP_DELETE_NODES = OverridableOption(
+    '--delete-nodes', is_flag=True, default=False, help='Delete all nodes in the group along with the group itself.'
+)
+
 RAW = OverridableOption(
     '-r',
     '--raw',


### PR DESCRIPTION
Fixes #4358
Fixes #4356.

The current implementation of `verdi group delete` uses two flags:

* `--clear` removes all the nodes from the group before deleting it. Deleting a group that contains nodes fails unless the group is empty or the `--clear` flag is passed to the command.
* `--force` means that the user will not be prompted for confirmation.

This PR removes the `--clear` flag, instead warning the user in case the group is not empty. Moreover, it adds the `--delete-nodes` flag, which allows the user to delete all nodes in a group along with the group itself. The current implementation works as follows (Slightly adjusted from #4358):

* By default (no flags), the command prompts when trying to delete a group. If the group is not empty, the prompt clearly shows how many nodes the group contains with a warning.
* When using the `-f/--force` flag, no warning or prompt is shown and *only* the group is deleted, even if it is not empty.
* When using the `--delete-nodes` flag, two warnings are shown that describe how many nodes the group contains as well as how many nodes would be deleted using the default [traversal rules](https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/provenance/consistency.html#traversal-rules) (usually more). The prompt includes a warning that this operation cannot be undone, similar to what appears in `verdi node delete`.
 * When using both `--force` and --delete-nodes, no prompt is shown, and both the group as well as its nodes are deleted, according to the default [traversal rules](https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/provenance/consistency.html#traversal-rules).

### Questions/TODO

- [ ] Fix/Add tests.
- [ ] Fix/add documentation.
- [ ] Currently the implementation only uses the default traversal rules for deleting the nodes in the group. Should the user also be able to add traversal rules options using `graph_traversal_rules`? Of course, these don't make sense unless the `--delete-nodes` flag is passed, so the command should probably fail in case the user passes any traversal rules options without also passing the `--delete-nodes` flag. What do you think?
