### PR TITLE
✨ NEW: `structure.data.import` plugin entrypoint

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -17,6 +17,7 @@ from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_optio
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.pluginable import Pluginable
 
 LIST_PROJECT_HEADERS = ['Id', 'Label', 'Formula']
 EXPORT_FORMATS = ['cif', 'xsf', 'xyz']
@@ -151,7 +152,7 @@ def structure_export(**kwargs):
     data_export(node, output, fmt, other_args=kwargs, overwrite=force)
 
 
-@structure.group('import')
+@structure.group('import', entry_point_group='aiida.cmdline.data.structure.import', cls=Pluginable)
 def structure_import():
     """Import a crystal structure from file into a StructureData object."""
 

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -53,6 +53,7 @@ class EntryPointFormat(enum.Enum):
 ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP = {
     'aiida.calculations': 'aiida.orm.nodes.process.calculation.calcjob',
     'aiida.cmdline.data': 'aiida.cmdline.data',
+    'aiida.cmdline.data.structure.import': 'aiida.cmdline.data.structure.import',
     'aiida.cmdline.computer.configure': 'aiida.cmdline.computer.configure',
     'aiida.data': 'aiida.orm.nodes.data',
     'aiida.groups': 'aiida.orm.groups',

--- a/docs/source/topics/plugins.rst
+++ b/docs/source/topics/plugins.rst
@@ -212,10 +212,15 @@ Usage::
 -----------------
 
 ``verdi`` uses the `click_` framework, which makes it possible to add new subcommands to existing verdi commands, such as ``verdi data mydata``.
-AiiDA expects each entry point to be either a ``click.Command`` or ``click.CommandGroup``.
+AiiDA expects each entry point to be either a ``click.Command`` or ``click.CommandGroup``. At present extra commands can be injected at the following levels:
+
+  * As a :ref:`direct subcommand of verdi data<spec-verdi-data>`
+  * As a :ref:`subcommand of verdi data structure import<spec-verdi-data-structure-import>`
 
 
-Spec::
+.. _spec-verdi-data:
+
+Spec for ``verdi data``::
 
    entry_points={
       "aiida.cmdline.data": [
@@ -242,6 +247,32 @@ Usage:
 .. code-block:: bash
 
    verdi data mydata animate --format=Format PK
+
+.. _spec-verdi-data-structure-import:
+
+Spec for ``verdi data structure import``::
+
+   entry_points={
+      "aiida.cmdline.data.structure.import": [
+         "myformat = aiida_mycode.commands.myformat:myformat"
+      ]
+   }
+
+``aiida_mycode/commands/myformat.py``::
+
+   import click
+   @click.group()
+   @click.argument('filename', type=click.File('r'))
+   myformat(filename):
+      """commandline help for myformat import command"""
+      ...
+
+Usage:
+
+.. code-block:: bash
+
+   verdi data structure import myformat a_file.myfmt
+
 
 ``aiida.tools.dbexporters``
 ---------------------------

--- a/setup.json
+++ b/setup.json
@@ -145,6 +145,8 @@
             "trajectory = aiida.cmdline.commands.cmd_data.cmd_trajectory:trajectory",
             "upf = aiida.cmdline.commands.cmd_data.cmd_upf:upf"
         ],
+        "aiida.cmdline.data.structure.import": [
+        ],
         "aiida.data": [
             "array = aiida.orm.nodes.data.array.array:ArrayData",
             "array.bands = aiida.orm.nodes.data.array.bands:BandsData",


### PR DESCRIPTION
The use case is that I would like to add an option to import structures from a CP2K input file.
While this could be done in an `aiida-cp2k` cli or an extension of `verdi data`, it would make more sense to add it directly here.
On the other hand it might not be a good idea to open up too many entry points since we would have to maintain those.