### PR TITLE
Non-zero return code upon error in `verdi import`

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -351,6 +351,9 @@ Below is a list with all available subcommands.
       --migration / --no-migration    Force migration of export file archives, if needed.
                                       [default: True]
 
+      --fail-fast                     Exit immediately if an error occurs during import or
+                                      migration.  [default: False]
+
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
 


### PR DESCRIPTION
Fixes #4430

`verdi import` will now exit with return code `1` if an error occurs at
any point during the import/migration.

A `--fail-fast` flag is added to `verdi import`, which will ensure an
immediate exit if an error occurs during the import/migration of a list
of archives (either local files or URLs).

---

Missing:
- [ ] Tests