### PR TITLE
node.open: more useful warnings

### DIFF
--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -417,7 +417,10 @@ class CifData(SinglefileData):
         """
         if not kwargs and self._ase:
             return self.ase
-        return CifData.read_cif(self.open(), **kwargs)
+        with self.open() as handle:
+            cif = CifData.read_cif(handle, **kwargs)
+
+        return cif
 
     def set_ase(self, aseatoms):
         """


### PR DESCRIPTION
aiida-core started warning when methods like `Node.read` and `Node.del`
are used outside a context manager.
The warning, however, did not include any indication of where the
problematic function call was made (nor did it include instructions on
how to fix it).

Furthermore, this PR fixes an overlooked use of `Node.read` in
aiida-core that did not rely on the context manager.