### PR TITLE
Docs: link to packaging plugins howto

### DIFF
--- a/docs/source/howto/faq.rst
+++ b/docs/source/howto/faq.rst
@@ -66,7 +66,7 @@ That is to say, if the safe interval is set to 60 seconds, any single worker is 
 Why would a process that runs fine locally raise an exception when submitted to the daemon?
 ===========================================================================================
 This is almost always caused by an import issue.
-To determine exactly what might be going wrong, first `set the loglevel <intro:increase-logging-verbosity>` to ``DEBUG`` by executing the command:
+To determine exactly what might be going wrong, first :ref:`set the loglevel <intro:increase-logging-verbosity>` to ``DEBUG`` by executing the command:
 
 .. code-block:: console
 

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -9,6 +9,11 @@ How to write a plugin for an external code
     Before starting to write a new plugin, check the `aiida plugin registry <https://aiidateam.github.io/aiida-registry/>`_.
     If a plugin for your code is already available, you can skip straight to :ref:`how-to:run-codes`.
 
+.. tip::
+
+    This how to walks you through all logical steps of how AiiDA interacts with an external code.
+    If you already know the basics and would like to get started with a new plugin package quickly, check out :ref:`how-to:plugins`.
+
 To run an external code with AiiDA, you need a corresponding *calculation* plugin, which tells AiiDA how to:
 
 1. Prepare the required input files.


### PR DESCRIPTION
The how to on supporting external codes in AiiDA did not link to the
packaging guide. While the how to is great for learning how AiiDA works,
developers who want to get started as quickly as possible are better off
using the AiiDA plugin cutter.

Mentioning @sponce24 who stumbled over this