### PR TITLE
cmdline/utils/multi_line_input: fix "referenced before assignment"

### DIFF
--- a/aiida/cmdline/utils/multi_line_input.py
+++ b/aiida/cmdline/utils/multi_line_input.py
@@ -17,7 +17,8 @@ def edit_multiline_template(template_name, comment_marker='#=', extension=None, 
     """Open a template file for editing in a text editor.
 
     :param template: name of the template to use from the ``aiida.cmdline.templates`` directory.
-    :param comment_marker: the set of symbols that mark a comment line that should be stripped from the final value
+    :param comment_marker: the set of symbols that mark a comment line that should be stripped
+                           from the final value
     :param extension: the file extension to give to the rendered template file.
     :param kwargs: keywords that will be passed to the template rendering engine.
     :return: the final string value entered in the editor with all comment lines stripped.
@@ -30,6 +31,8 @@ def edit_multiline_template(template_name, comment_marker='#=', extension=None, 
     if content:
         # Remove all comments, which are all lines that start with the comment marker
         value = re.sub(f'(^{re.escape(comment_marker)}.*$\n)+', '', content, flags=re.M).strip()
+    else:
+        value = ''
 
     return value
 


### PR DESCRIPTION
can be triggered by leaving a pre/post script for a code empty:

    Traceback (most recent call last):
      File "/scratch/tiziano/virtualenvs/aiida/bin/verdi", line 12, in <module>
        sys.exit(verdi())
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 829, in __call__
        return self.main(*args, **kwargs)
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 782, in main
        rv = self.invoke(ctx)
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 1257, in invoke
        sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 700, in make_context
        self.parse_args(ctx, args)
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 1048, in parse_args
        value, args = param.handle_parse_result(ctx, opts, args)
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 1630, in handle_parse_result
        value = invoke_param_callback(self.callback, ctx, self, value)
      File "/scratch/tiziano/virtualenvs/aiida/lib/python3.6/site-packages/click/core.py", line 123, in invoke_param_callback
        return callback(ctx, param, value)
      File "/scratch/tiziano/work/aiida/aiida_core/aiida/cmdline/params/options/interactive.py", line 274, in prompt_callback
        value = self.prompt_loop(ctx, param, value)
      File "/scratch/tiziano/work/aiida/aiida_core/aiida/cmdline/params/options/interactive.py", line 208, in simple_prompt_loop
        value = self.prompt_func(ctx)
      File "/scratch/tiziano/work/aiida/aiida_core/aiida/cmdline/params/options/interactive.py", line 309, in prompt_func
        return edit_multiline_template(self.template, extension=self.extension, **kwargs)
      File "/scratch/tiziano/work/aiida/aiida_core/aiida/cmdline/utils/multi_line_input.py", line 34, in edit_multiline_template
        return value
    UnboundLocalError: local variable 'value' referenced before assignment