### PR TITLE
Docs: Add redirects from old documenation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ needs_sphinx = '1.5.0'
 extensions = [
     'sphinx.ext.intersphinx', 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.viewcode', 'sphinx.ext.coverage',
     'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.todo', 'IPython.sphinxext.ipython_console_highlighting',
-    'IPython.sphinxext.ipython_directive', 'aiida.sphinxext', 'sphinx_panels', 'sphinx_copybutton'
+    'IPython.sphinxext.ipython_directive', 'aiida.sphinxext', 'sphinx_panels', 'sphinx_copybutton', 'sphinxext.rediraffe'
 ]
 ipython_mplbackend = ''
 copybutton_selector = 'div:not(.no-copy)>div.highlight pre'
@@ -192,6 +192,7 @@ html_logo = 'images/logo_aiida_docs.png'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 html_css_files = ['aiida-custom.css']
+rediraffe_redirects = 'redirects.txt'
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -1,0 +1,14 @@
+# Installation
+install/quick_installation.rst intro/get_started.rst
+install/prerequisites.rst intro/get_started.rst
+install/installation.rst intro/get_started.rst
+install/configuration.rst howto/installation.rst
+install/updating_installation.rst howto/installation.rst
+install/troubleshooting.rst intro/troubleshooting.rst
+
+# working_with_aiida
+working_with_aiida/index.rst howto/index.rst
+get_started/index.rst intro/get_started.rst
+get_started/computers.rst howto/run_codes.rst
+get_started/codes.rst howto/run_codes.rst
+verdi/verdi_user_guide.rst topics/cli.rst

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -133,6 +133,7 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+sphinxext-rediraffe==0.2.4
 SQLAlchemy==1.3.13
 sqlalchemy-diff==0.1.3
 SQLAlchemy-Utils==0.34.2

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -132,6 +132,7 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+sphinxext-rediraffe==0.2.4
 SQLAlchemy==1.3.13
 sqlalchemy-diff==0.1.3
 SQLAlchemy-Utils==0.34.2

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -131,6 +131,7 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+sphinxext-rediraffe==0.2.4
 SQLAlchemy==1.3.13
 sqlalchemy-diff==0.1.3
 SQLAlchemy-Utils==0.34.2

--- a/setup.json
+++ b/setup.json
@@ -74,7 +74,8 @@
             "sphinx~=2.2",
             "sphinxcontrib-details-directive~=0.1.0",
             "sphinx-panels~=0.4.0",
-            "sphinx-copybutton~=0.2.12"
+            "sphinx-copybutton~=0.2.12",
+            "sphinxext-rediraffe~=0.2.4"
         ],
         "atomic_tools": [
             "PyCifRW~=4.4",


### PR DESCRIPTION
This adds redirects from old documentation,
e.g. if you try to open https://aiida.readthedocs.io/projects/aiida-core/en/latest/install/quick_installation.html, it will redirect you to https://aiida.readthedocs.io/projects/aiida-core/en/v1.0.0/intro/get_started.html