### PR TITLE
Docs: Add docs live build to tox configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,10 +82,14 @@ setenv =
 commands = pytest {posargs}
 
 [testenv:py{36,37,38}-docs-{clean,update}]
+description = 
+    clean: Build the documentation (remove any existing build)
+    update: Build the documentation (modify any existing build)
 deps =
     py36: -rrequirements/requirements-py-3.6.txt
     py37: -rrequirements/requirements-py-3.7.txt
     py38: -rrequirements/requirements-py-3.8.txt
+passenv = RUN_APIDOC
 setenv =
     update: RUN_APIDOC = False
 changedir = docs
@@ -94,7 +98,24 @@ commands =
     clean: make clean
     make debug
 
+[testenv:py{36,37,38}-docs-live]
+# tip remove apidocs before using this feature
+description = Build the documentation and launch browser (with live updates)
+deps =
+    py36: -rrequirements/requirements-py-3.6.txt
+    py37: -rrequirements/requirements-py-3.7.txt
+    py38: -rrequirements/requirements-py-3.8.txt
+    sphinx-autobuild
+setenv =
+    RUN_APIDOC = False
+commands =
+    sphinx-autobuild \
+        --re-ignore build/.* \
+        --port 0 --open-browser \
+        -n -b {posargs:html} docs/source/ docs/build/{posargs:html}
+
 [testenv:py{36,37,38}-pre-commit]
+description = Run the pre-commit checks
 extras = all
 commands = pre-commit run {posargs}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ commands =
     make debug
 
 [testenv:py{36,37,38}-docs-live]
-# tip remove apidocs before using this feature
+# tip: remove apidocs before using this feature (`cd docs; make clean`)
 description = Build the documentation and launch browser (with live updates)
 deps =
     py36: -rrequirements/requirements-py-3.6.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ setenv =
 commands = pytest {posargs}
 
 [testenv:py{36,37,38}-docs-{clean,update}]
-description = 
+description =
     clean: Build the documentation (remove any existing build)
     update: Build the documentation (modify any existing build)
 deps =


### PR DESCRIPTION
Basically, if you `tox -e py38-docs-live` it will build the docs then launch a browser page showing them, then if you alter the docs it will trigger a sphinx rebuild and automagically refresh the web page when finished.

Tip, ensure you don't have an existing build present with apidocs in (i.e. run without `RUN_APIDOC = False`), to speed up rebuilds.