### PR TITLE
Pre-commit: reintroduce pylint rules

### DIFF
--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -409,10 +409,9 @@ class ProcessNode(Node):
         :return: http response
         """
 
-        ## Decode url parts
+        headers = self.utils.build_headers(url=request.url, total_count=1)
+
         path = unquote(request.path)
-        url = unquote(request.url)
-        url_root = unquote(request.url_root)
 
         ## Parse request
         (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
@@ -428,14 +427,11 @@ class ProcessNode(Node):
             projectable_properties, ordering = self.trans.get_projectable_properties()
             results = dict(fields=projectable_properties, ordering=ordering)
 
-        ## Build response and return it
-        headers = self.utils.build_headers(url=request.url, total_count=1)
-
         ## Build response
         data = dict(
             method=request.method,
-            url=url,
-            url_root=url_root,
+            url=unquote(request.url),
+            url_root=unquote(request.url_root),
             path=path,
             id=node_id,
             query_string=request.query_string.decode('utf-8'),

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -8,10 +8,22 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Translator for node"""
+import pkgutil
+import imp
+import inspect
+import os
+
 from aiida import orm
-from aiida.common.exceptions import InputValidationError, ValidationError, InvalidOperation
+from aiida.orm import Node, Data
+from aiida.common.exceptions import (
+    InputValidationError, ValidationError, InvalidOperation, LoadingEntryPointError, EntryPointError
+)
 from aiida.manage.manager import get_manager
+from aiida.plugins.entry_point import load_entry_point, get_entry_point_names
 from aiida.restapi.translator.base import BaseTranslator
+from aiida.restapi.common.identifiers import get_full_type_filters
+from aiida.restapi.common.exceptions import RestFeatureNotAvailable, RestInputValidationError, RestValidationError
+from aiida.restapi.common.identifiers import get_node_namespace, load_entry_point_from_full_type, construct_full_type
 
 
 class NodeTranslator(BaseTranslator):
@@ -197,7 +209,6 @@ class NodeTranslator(BaseTranslator):
         if full_type:
             # If full_type is not none, convert it into node_type
             # and process_type filters to pass it to query help
-            from aiida.restapi.common.identifiers import get_full_type_filters
             full_type_filter = get_full_type_filters(full_type)
             filters.update(full_type_filter)
 
@@ -301,11 +312,6 @@ class NodeTranslator(BaseTranslator):
         :param recursive: True/False (go recursively into submodules)
         """
 
-        import pkgutil
-        import imp
-        import inspect
-        import os
-
         # If no parent class is specified set it to self.__class
         parent = self.__class__ if parent is None else parent
 
@@ -331,7 +337,7 @@ class NodeTranslator(BaseTranslator):
             if parent_class is None:
                 raise TypeError('argument parent_class cannot be None')
 
-                # Recursively check the subpackages
+        # Recursively check the subpackages
         results = {}
 
         for _, name, is_pkg in pkgutil.walk_packages([package_path]):
@@ -355,6 +361,7 @@ class NodeTranslator(BaseTranslator):
             # Look in submodules
             elif is_pkg and recursive:
                 results.update(self._get_subclasses(parent=app_module, parent_class=parent_class))
+
         return results
 
     def get_derived_properties(self, node):
@@ -389,11 +396,6 @@ class NodeTranslator(BaseTranslator):
         """
         returns dict of possible node formats for all available node types
         """
-        from aiida.plugins.entry_point import load_entry_point, get_entry_point_names
-        from aiida.restapi.common.identifiers import load_entry_point_from_full_type, construct_full_type
-        from aiida.common import EntryPointError
-        from aiida.common.exceptions import LoadingEntryPointError
-        from aiida.restapi.common.exceptions import RestFeatureNotAvailable, RestInputValidationError
 
         all_formats = {}
 
@@ -442,14 +444,12 @@ class NodeTranslator(BaseTranslator):
         invoke the get_downloadable_data method in the Data transaltor.
         Otherwise it raises RestFeatureNotAvailable exception
         """
-        from aiida.orm import Data
-        from aiida.restapi.translator.nodes.data import DataTranslator  # pylint: disable=cyclic-import
-        from aiida.restapi.common.exceptions import RestFeatureNotAvailable
 
         # This needs to be here because currently, for all nodes the `NodeTranslator` will be instantiated. Once that
         # logic is cleaned where the correct translator sub class is instantiated based on the node type that is
         # referenced, this hack can be removed.
         if isinstance(node, Data):
+            from .data import DataTranslator  # pylint: disable=cyclic-import
             downloadable_data = DataTranslator.get_downloadable_data(node, download_format=download_format)
             return downloadable_data
 
@@ -464,8 +464,6 @@ class NodeTranslator(BaseTranslator):
         :param filename: folder name (optional)
         :return: folder list
         """
-        from aiida.restapi.common.exceptions import RestInputValidationError
-
         try:
             flist = node.list_objects(filename)
         except IOError:
@@ -484,7 +482,6 @@ class NodeTranslator(BaseTranslator):
         :param filename: folder or file name (optional)
         :return: file content in bytes to download
         """
-        from aiida.restapi.common.exceptions import RestInputValidationError, RestValidationError
 
         if filename:
             try:
@@ -523,7 +520,6 @@ class NodeTranslator(BaseTranslator):
         :param file_name: name of the file to return its contents
         :return:
         """
-        import os
         file_parts = file_name.split(os.sep)
 
         if len(file_parts) > 1:
@@ -565,8 +561,6 @@ class NodeTranslator(BaseTranslator):
         else:
             result_name = self.__label__
 
-        from aiida.restapi.common.identifiers import construct_full_type
-
         for node_entry in results[result_name]:
             # construct full_type and add it to every node
             try:
@@ -588,8 +582,6 @@ class NodeTranslator(BaseTranslator):
         return full_types of the nodes
         """
 
-        from aiida.restapi.common.identifiers import get_node_namespace
-
         return get_node_namespace().get_description()
 
     def get_io_tree(self, uuid_pattern, tree_in_limit, tree_out_limit):
@@ -599,8 +591,6 @@ class NodeTranslator(BaseTranslator):
         :param uuid_pattern: main node uuid
         :return: json data to display node tree
         """
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node
 
         def get_node_description(node):
             """
@@ -619,7 +609,7 @@ class NodeTranslator(BaseTranslator):
         # Check whether uuid_pattern identifies a unique node
         self._check_id_validity(uuid_pattern)
 
-        qb_obj = QueryBuilder()
+        qb_obj = orm.QueryBuilder()
         qb_obj.append(Node, tag='main', project=['*'], filters=self._id_filter)
 
         nodes = []
@@ -647,7 +637,7 @@ class NodeTranslator(BaseTranslator):
             })
 
         # get all incoming
-        qb_obj = QueryBuilder()
+        qb_obj = orm.QueryBuilder()
         qb_obj.append(Node, tag='main', project=['*'], filters=self._id_filter)
         qb_obj.append(Node, tag='in', project=['*'], edge_project=['label', 'type'],
                       with_outgoing='main').order_by({'in': [{
@@ -686,7 +676,7 @@ class NodeTranslator(BaseTranslator):
                 })
 
         # get all outgoing
-        qb_obj = QueryBuilder()
+        qb_obj = orm.QueryBuilder()
         qb_obj.append(Node, tag='main', project=['*'], filters=self._id_filter)
         qb_obj.append(Node, tag='out', project=['*'], edge_project=['label', 'type'],
                       with_incoming='main').order_by({'out': [{
@@ -725,12 +715,12 @@ class NodeTranslator(BaseTranslator):
                 })
 
         # count total no of nodes
-        builder = QueryBuilder()
+        builder = orm.QueryBuilder()
         builder.append(Node, tag='main', project=['id'], filters=self._id_filter)
         builder.append(Node, tag='in', project=['id'], with_outgoing='main')
         total_no_of_incomings = builder.count()
 
-        builder = QueryBuilder()
+        builder = orm.QueryBuilder()
         builder.append(Node, tag='main', project=['id'], filters=self._id_filter)
         builder.append(Node, tag='out', project=['id'], with_incoming='main')
         total_no_of_outgoings = builder.count()

--- a/aiida/tools/data/array/kpoints/seekpath.py
+++ b/aiida/tools/data/array/kpoints/seekpath.py
@@ -138,22 +138,19 @@ def get_kpoints_path(structure, parameters):
     result = {}
     rawdict = seekpath.get_path(structure=structure_tuple, **parameters)
 
+    result['parameters'] = Dict(dict=rawdict)
+
     # Replace conv structure with AiiDA StructureData
     conv_lattice = rawdict.pop('conv_lattice')
     conv_positions = rawdict.pop('conv_positions')
     conv_types = rawdict.pop('conv_types')
-    conv_tuple = (conv_lattice, conv_positions, conv_types)
-    conv_structure = spglib_tuple_to_structure(conv_tuple, kind_info, kinds)
+    result['conv_structure'] = spglib_tuple_to_structure((conv_lattice, conv_positions, conv_types), kind_info, kinds)
 
     # Replace primitive structure with AiiDA StructureData
     primitive_lattice = rawdict.pop('primitive_lattice')
     primitive_positions = rawdict.pop('primitive_positions')
     primitive_types = rawdict.pop('primitive_types')
-    primitive_tuple = (primitive_lattice, primitive_positions, primitive_types)
-    primitive_structure = spglib_tuple_to_structure(primitive_tuple, kind_info, kinds)
-
-    result['parameters'] = Dict(dict=rawdict)
-    result['primitive_structure'] = primitive_structure
-    result['conv_structure'] = conv_structure
+    result['primitive_structure'] = spglib_tuple_to_structure((primitive_lattice, primitive_positions, primitive_types),
+                                                              kind_info, kinds)
 
     return result

--- a/aiida/tools/dbimporters/plugins/mpds.py
+++ b/aiida/tools/dbimporters/plugins/mpds.py
@@ -187,9 +187,8 @@ class MpdsDbImporter(DbImporter):
         content = self.get_response_content(response, fmt=ApiFormat.JSON)
 
         count = content['count']
-        npages = content['npages']
 
-        for page in range(npages):
+        for page in range(content['npages']):
 
             response = self.get(q=json.dumps(query), fmt=fmt, pagesize=pagesize, page=page)
             content = self.get_response_content(response, fmt=fmt)
@@ -209,9 +208,8 @@ class MpdsDbImporter(DbImporter):
 
             elif fmt == ApiFormat.CIF:
 
-                lines = content.splitlines()
                 cif = []
-                for line in lines:
+                for line in content.splitlines():
                     if cif:
                         if line.startswith('data_'):
                             text = '\n'.join(cif)
@@ -219,9 +217,8 @@ class MpdsDbImporter(DbImporter):
                             yield text
                         else:
                             cif.append(line)
-                    else:
-                        if line.startswith('data_'):
-                            cif.append(line)
+                    elif line.startswith('data_'):
+                        cif.append(line)
                 if cif:
                     yield '\n'.join(cif)
 

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -610,6 +610,7 @@ def _collect_archive_data(
     :raises `~aiida.common.exceptions.LicensingException`:
         if any node is licensed under forbidden license.
     """
+    # pylint: disable=too-many-locals
     EXPORT_LOGGER.debug('STARTING EXPORT...')
 
     # Backwards-compatibility
@@ -866,6 +867,7 @@ def _collect_entity_queries(
     include_logs: bool = True,
 ) -> Dict[str, orm.QueryBuilder]:
     """Gather partial queries for all entities to export."""
+    # pylint: disable=too-many-locals
     # Progress bar initialization - Entities
     progress_bar = get_progress_bar(total=1, disable=silent)
     progress_bar.set_description_str('Initializing export of all entities', refresh=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,11 @@ disable = [
     "inconsistent-return-statements",
     "locally-disabled",
     "logging-fstring-interpolation",
-    "missing-class-docstring",
-    "missing-function-docstring",
     "no-else-raise",
     "too-few-public-methods",
     "too-many-ancestors",
     "too-many-arguments",
     "too-many-instance-attributes",
-    "too-many-locals",
     "useless-suppression",
 ]
 
@@ -44,6 +41,11 @@ good-names = [
     "ArithmeticAddCalculation",
     "MultiplyAddWorkChain"
 ]
+no-docstring-rgx = "^_,setUp,tearDown"
+docstring-min-length = 5
+
+[tool.pylint.design]
+max-locals = 20
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tests/backends/aiida_sqlalchemy/test_query.py
+++ b/tests/backends/aiida_sqlalchemy/test_query.py
@@ -10,6 +10,7 @@
 """Tests for generic queries."""
 
 from aiida.backends.testbase import AiidaTestCase
+from aiida.orm import Group, User, Computer, Node, Data, ProcessNode, QueryBuilder
 
 
 class TestQueryBuilderSQLA(AiidaTestCase):
@@ -17,14 +18,10 @@ class TestQueryBuilderSQLA(AiidaTestCase):
 
     def test_clsf_sqla(self):
         """Test SQLA classifiers"""
-        from aiida.orm import Group, User, Computer, Node, Data
-        from aiida.orm import ProcessNode
         from aiida.backends.sqlalchemy.models.node import DbNode
         from aiida.backends.sqlalchemy.models.group import DbGroup
         from aiida.backends.sqlalchemy.models.user import DbUser
         from aiida.backends.sqlalchemy.models.computer import DbComputer
-
-        from aiida.orm.querybuilder import QueryBuilder
 
         q_b = QueryBuilder()
         for aiida_cls, orm_cls in zip((Group, User, Computer, Node, Data, ProcessNode),
@@ -39,8 +36,6 @@ class QueryBuilderLimitOffsetsTestSQLA(AiidaTestCase):
 
     def test_ordering_limits_offsets_sqla(self):
         """Test ordering limits offsets of SQLA query results."""
-        from aiida.orm import Node, Data
-        from aiida.orm.querybuilder import QueryBuilder
         # Creating 10 nodes with an attribute that can be ordered
         for i in range(10):
             node = Data()

--- a/tests/sphinxext/conftest.py
+++ b/tests/sphinxext/conftest.py
@@ -33,12 +33,16 @@ def reference_result():
 
 
 class SphinxBuild:
+    """Class for testing sphinx builds"""
 
     def __init__(self, app: SphinxTestApp, src: Path):
         self.app = app
         self.src = src
 
     def build(self, assert_pass=True):
+        """Build sphinx app.
+
+        :param assert_pass: if True, assert that no warnings are raised during build"""
         try:
             sys.path.append(os.path.abspath(WORKCHAIN_DIR))
             self.app.build()
@@ -63,6 +67,15 @@ class SphinxBuild:
 
 @pytest.fixture
 def sphinx_build_factory(make_app, tmp_path):
+    """SphinxBuild factory fixture
+
+    Usage::
+
+        def test_wc(sphinx_build_factory):
+            ...
+            sphinx_build = sphinx_build_factory('workchain', buildername='xml')
+            sphinx_build.build(assert_pass=True)
+    """
 
     def _func(src_folder, **kwargs):
         shutil.copytree(SRC_DIR / src_folder, tmp_path / src_folder)


### PR DESCRIPTION
In 65ad067b18cffeb639994efe9a372ec1475e1615 the following pylint rules
were accidentally disabled:

 * missing-class-docstring
 * missing-function-docstring
 * too-many-ancestors
 * too-many-locals

This commit reintroduces all but the "too-many-ancestors" rule, which
was deemed not to be helpful, since it has never prompted refactoring in
the past.