### PR TITLE
Refactor archive progress bar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
                 aiida/engine/processes/calcjobs/calcjob.py|
                 aiida/tools/groups/paths.py|
                 aiida/tools/importexport/dbexport/__init__.py|
-                aiida/tools/importexport/common/progress_reporter.py|
+                aiida/common/progress_reporter.py|
             )$
 
 -   repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,8 @@ repos:
             (?x)^(
                 aiida/engine/processes/calcjobs/calcjob.py|
                 aiida/tools/groups/paths.py|
-                aiida/tools/importexport/dbexport/__init__.py
+                aiida/tools/importexport/dbexport/__init__.py|
+                aiida/tools/importexport/common/progress_reporter.py|
             )$
 
 -   repo: local

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -100,12 +100,10 @@ def create(
     their provenance, according to the rules outlined in the documentation.
     You can modify some of those rules using options of this command.
     """
-    from tqdm import tqdm
     from aiida.common.log import override_log_formatter_context
-    from aiida.common.progress_reporter import set_progress_reporter
+    from aiida.common.progress_reporter import set_progress_bar_tqdm
     from aiida.tools.importexport import export, ExportFileFormat, EXPORT_LOGGER
     from aiida.tools.importexport.common.exceptions import ArchiveExportError
-    from aiida.tools.importexport.common.config import BAR_FORMAT
 
     entities = []
 
@@ -143,7 +141,7 @@ def create(
         export_format = ExportFileFormat.TAR_GZIPPED
 
     if verbosity in ['DEBUG', 'INFO']:
-        set_progress_reporter(tqdm, bar_format=BAR_FORMAT, leave=(verbosity == 'DEBUG'))
+        set_progress_bar_tqdm(leave=(verbosity == 'DEBUG'))
     EXPORT_LOGGER.setLevel(verbosity)
 
     try:

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -9,7 +9,6 @@
 ###########################################################################
 # pylint: disable=too-many-arguments,import-error,too-many-locals
 """`verdi export` command."""
-from functools import partial
 import os
 import tempfile
 
@@ -144,7 +143,7 @@ def create(
         export_format = ExportFileFormat.TAR_GZIPPED
 
     if verbosity in ['DEBUG', 'INFO']:
-        set_progress_reporter(partial(tqdm, bar_format=BAR_FORMAT, leave=(verbosity == 'DEBUG')))
+        set_progress_reporter(tqdm, bar_format=BAR_FORMAT, leave=(verbosity == 'DEBUG'))
     EXPORT_LOGGER.setLevel(verbosity)
 
     try:

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -67,7 +67,7 @@ def inspect(archive, version, data, meta_data):
 @options.NODES()
 @options.ARCHIVE_FORMAT()
 @options.FORCE(help='overwrite output file if it already exists')
-@options.VERBOSE()
+@options.VERBOSE(help='Do not remove progress bars after a process completes')
 @options.graph_traversal_rules(GraphTraversalRules.EXPORT.value)
 @click.option(
     '--include-logs/--exclude-logs',

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=too-many-arguments,import-error,too-many-locals
 """`verdi export` command."""
-
+from functools import partial
 import os
 import tempfile
 
@@ -95,8 +95,11 @@ def create(
     their provenance, according to the rules outlined in the documentation.
     You can modify some of those rules using options of this command.
     """
+    from tqdm import tqdm
+    from aiida.common.progress_reporter import set_progress_reporter
     from aiida.tools.importexport import export, ExportFileFormat
     from aiida.tools.importexport.common.exceptions import ArchiveExportError
+    from aiida.tools.importexport.common.config import BAR_FORMAT
 
     entities = []
 
@@ -133,8 +136,10 @@ def create(
     elif archive_format == 'tar.gz':
         export_format = ExportFileFormat.TAR_GZIPPED
 
+    set_progress_reporter(partial(tqdm, bar_format=BAR_FORMAT, leave=verbose))
+
     try:
-        export(entities, filename=output_file, file_format=export_format, verbose=verbose, **kwargs)
+        export(entities, filename=output_file, file_format=export_format, **kwargs)
     except ArchiveExportError as exception:
         echo.echo_critical(f'failed to write the archive file. Exception: {exception}')
     else:

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -102,6 +102,7 @@ def create(
     You can modify some of those rules using options of this command.
     """
     from tqdm import tqdm
+    from aiida.common.log import override_log_formatter_context
     from aiida.common.progress_reporter import set_progress_reporter
     from aiida.tools.importexport import export, ExportFileFormat, EXPORT_LOGGER
     from aiida.tools.importexport.common.exceptions import ArchiveExportError
@@ -147,7 +148,8 @@ def create(
     EXPORT_LOGGER.setLevel(verbosity)
 
     try:
-        export(entities, filename=output_file, file_format=export_format, **kwargs)
+        with override_log_formatter_context('%(message)s'):
+            export(entities, filename=output_file, file_format=export_format, **kwargs)
     except ArchiveExportError as exception:
         echo.echo_critical(f'failed to write the archive file. Exception: {exception}')
     else:

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -67,6 +67,7 @@ def inspect(archive, version, data, meta_data):
 @options.NODES()
 @options.ARCHIVE_FORMAT()
 @options.FORCE(help='overwrite output file if it already exists')
+@options.VERBOSE()
 @options.graph_traversal_rules(GraphTraversalRules.EXPORT.value)
 @click.option(
     '--include-logs/--exclude-logs',
@@ -83,7 +84,7 @@ def inspect(archive, version, data, meta_data):
 @decorators.with_dbenv()
 def create(
     output_file, codes, computers, groups, nodes, archive_format, force, input_calc_forward, input_work_forward,
-    create_backward, return_backward, call_calc_backward, call_work_backward, include_comments, include_logs
+    create_backward, return_backward, call_calc_backward, call_work_backward, include_comments, include_logs, verbose
 ):
     """
     Export subsets of the provenance graph to file for sharing.
@@ -133,7 +134,7 @@ def create(
         export_format = ExportFileFormat.TAR_GZIPPED
 
     try:
-        export(entities, filename=output_file, file_format=export_format, **kwargs)
+        export(entities, filename=output_file, file_format=export_format, verbose=verbose, **kwargs)
     except ArchiveExportError as exception:
         echo.echo_critical(f'failed to write the archive file. Exception: {exception}')
     else:

--- a/aiida/common/__init__.py
+++ b/aiida/common/__init__.py
@@ -20,5 +20,9 @@ from .exceptions import *
 from .extendeddicts import *
 from .links import *
 from .log import *
+from .progress_reporter import *
 
-__all__ = (datastructures.__all__ + exceptions.__all__ + extendeddicts.__all__ + links.__all__ + log.__all__)
+__all__ = (
+    datastructures.__all__ + exceptions.__all__ + extendeddicts.__all__ + links.__all__ + log.__all__ +
+    progress_reporter.__all__
+)

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -220,9 +220,7 @@ def override_log_formatter_context(fmt: str):
     Be aware! This may fail if the number of handlers is changed within the decorated function/method.
     """
     temp_formatter = logging.Formatter(fmt=fmt)
-    cached_formatters = []
-    for handler in AIIDA_LOGGER.handlers:
-        cached_formatters.append(handler.formatter)
+    cached_formatters = [handler.formatter for handler in AIIDA_LOGGER.handlers]
 
     for handler in AIIDA_LOGGER.handlers:
         handler.setFormatter(temp_formatter)

--- a/aiida/common/progress_reporter.py
+++ b/aiida/common/progress_reporter.py
@@ -17,15 +17,52 @@ and indeed a valid implementation is::
     set_progress_reporter(tqdm, bar_format='{l_bar}{bar}{r_bar}')
 
 """
-from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, ContextManager, Iterator, Optional
+from types import TracebackType
+from typing import Any, Optional, Type
 
-__all__ = ('get_progress_reporter', 'set_progress_reporter', 'progress_reporter_base', 'ProgressIncrementerBase')
+__all__ = (
+    'get_progress_reporter', 'set_progress_reporter', 'set_progress_bar_tqdm', 'ProgressReporterAbstract',
+    'TQDM_BAR_FORMAT'
+)
+
+TQDM_BAR_FORMAT = '{desc:40.40}{percentage:6.1f}%|{bar}| {n_fmt}/{total_fmt}'
 
 
-class ProgressIncrementerBase:
-    """A base class for incrementing a progress reporter."""
+class ProgressReporterAbstract:
+    """An abstract class for incrementing a progress reporter.
+
+    This class provides the base interface for any `ProgressReporter` class.
+
+    Example Usage::
+
+        with ProgressReporter(total=10, desc="A process:") as progress:
+            for i in range(10):
+                progress.set_description_str(f"A process: {i}")
+                progress.update()
+
+    """
+
+    def __init__(self, *, total: int, desc: Optional[str] = None, **kwargs: Any):
+        """Initialise the progress reporting contextmanager.
+
+        :param total: The number of expected iterations.
+        :param desc: A description of the process
+
+        """
+        self.total = total
+        self.desc = desc
+        self.increment = 0
+
+    def __enter__(self) -> 'ProgressReporterAbstract':
+        """Enter the contextmanager."""
+        return self
+
+    def __exit__(
+        self, exctype: Optional[Type[BaseException]], excinst: Optional[BaseException], exctb: Optional[TracebackType]
+    ):
+        """Exit the contextmanager."""
+        return False
 
     def set_description_str(self, text: Optional[str] = None, refresh: bool = True):
         """Set the text shown by the progress reporter.
@@ -34,6 +71,7 @@ class ProgressIncrementerBase:
         :param refresh: Force refresh of the progress reporter
 
         """
+        self.desc = text
 
     def update(self, n: int = 1):  # pylint: disable=invalid-name
         """Update the progress counter.
@@ -41,34 +79,20 @@ class ProgressIncrementerBase:
         :param n: Increment to add to the internal counter of iterations
 
         """
+        self.increment += n
 
 
-@contextmanager
-def progress_reporter_base(*,
-                           total: int,
-                           desc: Optional[str] = None,
-                           **kwargs: Any) -> Iterator[ProgressIncrementerBase]:
-    """A context manager for providing a progress reporter for a process.
+class ProgressReporterNull(ProgressReporterAbstract):
+    """A null implementation of the progress reporter.
 
-    Example Usage::
-
-        with progress_reporter(total=10, desc="A process:") as progress:
-            for i in range(10):
-                progress.set_description_str(f"A process: {i}")
-                progress.update()
-
-    :param total: The number of expected iterations.
-    :param desc: A description of the process
-    :yield: A class for incrementing the progress reporter
-
+    This implementation does not output anything.
     """
-    yield ProgressIncrementerBase()
 
 
-PROGRESS_REPORTER = progress_reporter_base
+PROGRESS_REPORTER: Type[ProgressReporterAbstract] = ProgressReporterNull  # pylint: disable=invalid-name
 
 
-def get_progress_reporter() -> Callable[..., ContextManager[Any]]:
+def get_progress_reporter() -> Type[ProgressReporterAbstract]:
     """Return the progress reporter
 
     Example Usage::
@@ -83,19 +107,19 @@ def get_progress_reporter() -> Callable[..., ContextManager[Any]]:
     return PROGRESS_REPORTER  # type: ignore
 
 
-def set_progress_reporter(reporter: Optional[Callable[..., ContextManager[Any]]] = None, **kwargs: Any):
+def set_progress_reporter(reporter: Optional[Type[ProgressReporterAbstract]] = None, **kwargs: Any):
     """Set the progress reporter implementation
 
-    :param reporter: A context manager for providing a progress reporter for a process.
-        If None, reset to default null reporter
+    :param reporter: A progress reporter for a process.  If None, reset to ``ProgressReporterNull``.
 
     :param kwargs: If present, set a partial function with these kwargs
 
     The reporter should be a context manager that implements the
-    :func:`~aiida.common.progress_reporter.progress_reporter_base` interface.
+    :func:`~aiida.common.progress_reporter.ProgressReporterAbstract` interface.
 
     Example Usage::
 
+        set_progress_reporter(ProgressReporterNull)
         with get_progress_reporter()(total=10, desc="A process:") as progress:
             for i in range(10):
                 progress.set_description_str(f"A process: {i}")
@@ -104,8 +128,23 @@ def set_progress_reporter(reporter: Optional[Callable[..., ContextManager[Any]]]
     """
     global PROGRESS_REPORTER
     if reporter is None:
-        PROGRESS_REPORTER = progress_reporter_base  # type: ignore
+        PROGRESS_REPORTER = ProgressReporterNull  # type: ignore
     elif kwargs:
         PROGRESS_REPORTER = partial(reporter, **kwargs)  # type: ignore
     else:
         PROGRESS_REPORTER = reporter  # type: ignore
+
+
+def set_progress_bar_tqdm(bar_format: Optional[str] = TQDM_BAR_FORMAT, leave: Optional[bool] = False, **kwargs: Any):
+    """Set a `tqdm <https://github.com/tqdm/tqdm>` implementation of the progress reporter interface.
+
+    See :func:`~aiida.common.progress_reporter.set_progress_reporter` for details.
+
+    :param bar_format: Specify a custom bar string format.
+    :param leave: If True, keeps all traces of the progressbar upon termination of iteration.
+            If `None`, will leave only if `position` is `0`.
+    :param kwargs: pass to the tqdm init
+
+    """
+    from tqdm import tqdm
+    set_progress_reporter(tqdm, bar_format=bar_format, leave=leave, **kwargs)

--- a/aiida/common/progress_reporter.py
+++ b/aiida/common/progress_reporter.py
@@ -136,7 +136,7 @@ def set_progress_reporter(reporter: Optional[Type[ProgressReporterAbstract]] = N
 
 
 def set_progress_bar_tqdm(bar_format: Optional[str] = TQDM_BAR_FORMAT, leave: Optional[bool] = False, **kwargs: Any):
-    """Set a `tqdm <https://github.com/tqdm/tqdm>` implementation of the progress reporter interface.
+    """Set a `tqdm <https://github.com/tqdm/tqdm>`__ implementation of the progress reporter interface.
 
     See :func:`~aiida.common.progress_reporter.set_progress_reporter` for details.
 

--- a/aiida/common/progress_reporter.py
+++ b/aiida/common/progress_reporter.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=global-statement,unused-argument
+"""Provide a singleton progress reporter implementation.
+
+The interface is inspired by `tqdm <https://github.com/tqdm/tqdm>`,
+and indeed a valid implementation is::
+
+    from tqdm import tqdm
+    set_progress_reporter(tqdm)
+
+"""
+from contextlib import contextmanager
+from typing import Any, Callable, ContextManager, Iterator, Optional
+
+__all__ = ('get_progress_reporter', 'set_progress_reporter', 'progress_reporter_base', 'ProgressIncrementerBase')
+
+
+class ProgressIncrementerBase:
+    """A base class for incrementing a progress reporter."""
+
+    def set_description_str(self, text: Optional[str] = None, refresh: bool = True):
+        """Set the text shown by the progress reporter.
+
+        :param text: The text to show
+        :param refresh: Force refresh of the progress reporter
+
+        """
+
+    def update(self, n: int = 1):  # pylint: disable=invalid-name
+        """Update the progress counter.
+
+        :param n: Increment to add to the internal counter of iterations
+
+        """
+
+
+@contextmanager
+def progress_reporter_base(*,
+                           total: int,
+                           desc: Optional[str] = None,
+                           **kwargs: Any) -> Iterator[ProgressIncrementerBase]:
+    """A context manager for providing a progress reporter for a process.
+
+    Example Usage::
+
+        with progress_reporter(total=10, desc="A process:") as progress:
+            for i in range(10):
+                progress.set_description_str(f"A process: {i}")
+                progress.update()
+
+    :param total: The number of expected iterations.
+    :param desc: A description of the process
+    :yield: A class for incrementing the progress reporter
+
+    """
+    yield ProgressIncrementerBase()
+
+
+PROGRESS_REPORTER = progress_reporter_base
+
+
+def get_progress_reporter() -> Callable[..., ContextManager[Any]]:
+    """Return the progress reporter
+
+    Example Usage::
+
+        with get_progress_reporter()(total=10, desc="A process:") as progress:
+            for i in range(10):
+                progress.set_description_str(f"A process: {i}")
+                progress.update()
+
+    """
+    global PROGRESS_REPORTER
+    return PROGRESS_REPORTER  # type: ignore
+
+
+def set_progress_reporter(reporter: Optional[Callable[..., ContextManager[Any]]] = None):
+    """Set the progress reporter implementation
+
+    :param reporter: A context manager for providing a progress reporter for a process.
+        If None, reset to default null reporter
+
+    The reporter should be a context manager that implements the
+    :func:`~aiida.common.progress_reporter.progress_reporter_base` interface.
+
+    Example Usage::
+
+        with get_progress_reporter()(total=10, desc="A process:") as progress:
+            for i in range(10):
+                progress.set_description_str(f"A process: {i}")
+                progress.update()
+
+    """
+    global PROGRESS_REPORTER
+    PROGRESS_REPORTER = reporter or progress_reporter_base  # type: ignore

--- a/aiida/tools/importexport/common/config.py
+++ b/aiida/tools/importexport/common/config.py
@@ -21,9 +21,6 @@ DUPL_SUFFIX = ' (Imported #{})'
 # The name of the subfolder in which the node files are stored
 NODES_EXPORT_SUBFOLDER = 'nodes'
 
-# Progress bar
-BAR_FORMAT = '{desc:40.40}{percentage:6.1f}%|{bar}| {n_fmt}/{total_fmt}'
-
 # Giving names to the various entities. Attributes and links are not AiiDA
 # entities but we will refer to them as entities in the file (to simplify
 # references to them).

--- a/aiida/tools/importexport/common/progress_bar.py
+++ b/aiida/tools/importexport/common/progress_bar.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from aiida.common.lang import type_check
 
-from aiida.tools.importexport.common.config import BAR_FORMAT
+from aiida.common.progress_reporter import TQDM_BAR_FORMAT as BAR_FORMAT
 from aiida.tools.importexport.common.exceptions import ProgressBarError
 
 __all__ = ('get_progress_bar', 'close_progress_bar')

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -546,7 +546,7 @@ def export(
     extract_time = report_data['time_collect_stop'] - report_data['time_collect_start']
     EXPORT_LOGGER.debug(f'Data extracted in {extract_time:6.2g} s.')
 
-    if export_data is None:
+    if export_data is not None:
         try:
             report_data['time_write_start'] = time.time()
             report_data['writer_data'] = writer.write(export_data=export_data)  # type: ignore

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -261,9 +261,7 @@ def _write_to_json_archive(
 
 class WriterJsonZip(ArchiveWriterAbstract):
     """An archive writer,
-    which writes database data as a single JSON and repository data in a folder system.
-
-    The entire containing folder is then compressed as a zip file.
+    which writes database data as a single JSON and repository data in a zipped folder system.
     """
 
     def __init__(self, filename: str, progress_context: Optional[ProgressContext] = None, **kwargs: Any):
@@ -311,6 +309,18 @@ class WriterJsonTar(ArchiveWriterAbstract):
     The entire containing folder is then compressed as a tar file.
     """
 
+    def __init__(self, filename: str, progress_context: Optional[ProgressContext] = None, **kwargs: Any):
+        """A writer for zipped archives.
+
+        :param filename: the filename (possibly including the absolute path)
+            of the file on which to export.
+        :param progress_context: A context manager for creating and updating a progress bar
+        :param sandbox_in_repo: Create the temporary uncompressed folder within the aiida repository
+
+        """
+        super().__init__(filename, progress_context, **kwargs)
+        self.sandbox_in_repo = kwargs.get('sandbox_in_repo', True)
+
     @property
     def file_format_verbose(self) -> str:
         return 'Gzipped tarball (compressed)'
@@ -326,7 +336,7 @@ class WriterJsonTar(ArchiveWriterAbstract):
         :returns: A dictionary of data about the write process
 
         """
-        with SandboxFolder() as folder:
+        with SandboxFolder(sandbox_in_repo=self.sandbox_in_repo) as folder:
             _write_to_json_archive(
                 folder=folder,
                 export_data=export_data,

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -39,7 +39,7 @@ from aiida.common.exceptions import LicensingException
 from aiida.common.folders import Folder, RepositoryFolder, SandboxFolder
 from aiida.common.links import GraphTraversalRules
 from aiida.common.lang import type_check
-from aiida.common.log import LOG_LEVEL_REPORT, override_log_formatter
+from aiida.common.log import LOG_LEVEL_REPORT
 from aiida.common.progress_reporter import get_progress_reporter
 from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.orm.utils._repository import Repository
@@ -568,7 +568,6 @@ def export(
     return ExportReport(**report_data)
 
 
-@override_log_formatter('%(message)s')
 def _collect_archive_data(
     entities: Optional[Iterable[Any]] = None,
     allowed_licenses: Optional[Union[list, Callable]] = None,

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -291,7 +291,7 @@ class WriterJsonTar(ArchiveWriterAbstract):
     The entire containing folder is then compressed as a tar file.
     """
 
-    def __init__(self, filename: str, **kwargs: Any):
+    def __init__(self, filename: str, sandbox_in_repo: bool = True, **kwargs: Any):
         """A writer for zipped archives.
 
         :param filename: the filename (possibly including the absolute path)
@@ -300,7 +300,7 @@ class WriterJsonTar(ArchiveWriterAbstract):
 
         """
         super().__init__(filename, **kwargs)
-        self.sandbox_in_repo = kwargs.get('sandbox_in_repo', True)
+        self.sandbox_in_repo = sandbox_in_repo
 
     @property
     def file_format_verbose(self) -> str:

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -410,13 +410,10 @@ def export(
 
     Note, the logging level and progress reporter should be set externally, for example::
 
-        from functools import partial
-        from tqdm import tqdm
-        from aiida.common.progress_reporter import set_progress_reporter
-        from aiida.tools.importexport.common.config import BAR_FORMAT
+        from aiida.common.progress_reporter import set_progress_bar_tqdm
 
         EXPORT_LOGGER.setLevel('DEBUG')
-        set_progress_reporter(partial(tqdm, bar_format=BAR_FORMAT, leave=True))
+        set_progress_bar_tqdm(leave=True)
         export(...)
 
     .. deprecated:: 1.5.0
@@ -549,7 +546,7 @@ def export(
     extract_time = report_data['time_collect_stop'] - report_data['time_collect_start']
     EXPORT_LOGGER.debug(f'Data extracted in {extract_time:6.2g} s.')
 
-    if export_data is not None:
+    if export_data is None:
         try:
             report_data['time_write_start'] = time.time()
             report_data['writer_data'] = writer.write(export_data=export_data)  # type: ignore

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -101,9 +101,9 @@ class ArchiveData:
     # list of {'input': <UUID>, 'output': <UUID>, 'label': <LABEL>, 'type': <TYPE>}
     link_uuids: List[dict]
     # all entity data from the database, except Node extras and attributes
-    # {'ENTITY_NAME': {<UUID>: {'db_key': 'value', ...}, ...}, ...}
+    # {'ENTITY_NAME': {<Pk>: {'db_key': 'value', ...}, ...}, ...}
     entity_data: Dict[str, Dict[int, dict]]
-    # Iterable of Node (uuid, attributes, extras)
+    # Iterable of Node (pk, attributes, extras)
     node_data: Iterable[Tuple[str, dict, dict]]
 
     def __repr__(self) -> str:

--- a/aiida/tools/importexport/dbimport/backends/django/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/django/__init__.py
@@ -21,6 +21,7 @@ from aiida.common import timezone, json
 from aiida.common.folders import SandboxFolder, RepositoryFolder
 from aiida.common.links import LinkType, validate_link_label
 from aiida.common.log import override_log_formatter
+from aiida.common.progress_reporter import TQDM_BAR_FORMAT as BAR_FORMAT
 from aiida.common.utils import grouper, get_object_from_string
 from aiida.manage.configuration import get_config_option
 from aiida.orm.utils._repository import Repository
@@ -28,7 +29,7 @@ from aiida.orm import QueryBuilder, Node, Group, ImportGroup
 
 from aiida.tools.importexport.common import exceptions, get_progress_bar, close_progress_bar
 from aiida.tools.importexport.common.archive import extract_tree, extract_tar, extract_zip
-from aiida.tools.importexport.common.config import DUPL_SUFFIX, EXPORT_VERSION, NODES_EXPORT_SUBFOLDER, BAR_FORMAT
+from aiida.tools.importexport.common.config import DUPL_SUFFIX, EXPORT_VERSION, NODES_EXPORT_SUBFOLDER
 from aiida.tools.importexport.common.config import (
     NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME, USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME
 )

--- a/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla/__init__.py
@@ -21,6 +21,7 @@ from aiida.common import timezone, json
 from aiida.common.folders import SandboxFolder, RepositoryFolder
 from aiida.common.links import LinkType
 from aiida.common.log import override_log_formatter
+from aiida.common.progress_reporter import TQDM_BAR_FORMAT as BAR_FORMAT
 from aiida.common.utils import get_object_from_string
 from aiida.orm import QueryBuilder, Node, Group, ImportGroup
 from aiida.orm.utils.links import link_triple_exists, validate_link
@@ -28,7 +29,7 @@ from aiida.orm.utils._repository import Repository
 
 from aiida.tools.importexport.common import exceptions, get_progress_bar, close_progress_bar
 from aiida.tools.importexport.common.archive import extract_tree, extract_tar, extract_zip
-from aiida.tools.importexport.common.config import DUPL_SUFFIX, EXPORT_VERSION, NODES_EXPORT_SUBFOLDER, BAR_FORMAT
+from aiida.tools.importexport.common.config import DUPL_SUFFIX, EXPORT_VERSION, NODES_EXPORT_SUBFOLDER
 from aiida.tools.importexport.common.config import (
     NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME, USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME
 )

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -18,6 +18,8 @@ py:class builtins.object
 py:class builtins.str
 py:class builtins.dict
 
+py:class AbstractContextManager
+
 ### AiiDA
 
 # issues with order of object processing and type hinting
@@ -60,6 +62,8 @@ py:class topika.Connection
 
 py:class tornado.ioloop.IOLoop
 py:class tornado.concurrent.Future
+
+py:class tqdm.std.tqdm
 
 py:class IPython.core.magic.Magics
 

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -18,7 +18,7 @@ py:class builtins.object
 py:class builtins.str
 py:class builtins.dict
 
-py:class AbstractContextManager
+py:class traceback
 
 ### AiiDA
 


### PR DESCRIPTION
As proposed in https://github.com/aiidateam/aiida-core/issues/4053#issuecomment-714873506, this PR refactors the progress bar implementation in for the archive export to remove the singleton approach and make all calls to the progress bar a context manager.
I also improved some progress bars to give better feedback (in particular the entity field collection).

I've tested this implementation (see below) and find no issues.

As an added bonus, I have also added a verbose option to the CLI (-v), such that this will set the progress bars to be left on screen (i.e. `leave=True`)