### PR TITLE
Docs: Add  `verdi process status` command to tutorial

### DIFF
--- a/docs/source/intro/tutorial.rst
+++ b/docs/source/intro/tutorial.rst
@@ -570,7 +570,7 @@ Depending on which step the workflow is running, you should get something like t
 We can see that the ``MultiplyAddWorkChain`` is currently waiting for its *child process*, the ``ArithmeticAddCalculation``, to finish.
 Check the process list again for *all* processes (You should know how by now!).
 After about half a minute, all the processes should be in the ``Finished`` state.
-You can also see a nice overview of the processes called by the work chain with the ``verdi process status`` command:
+The ``verdi process status`` command prints a *hierarchical* overview of the processes called by the work chain:
 
 .. code-block:: console
 

--- a/docs/source/intro/tutorial.rst
+++ b/docs/source/intro/tutorial.rst
@@ -570,6 +570,17 @@ Depending on which step the workflow is running, you should get something like t
 We can see that the ``MultiplyAddWorkChain`` is currently waiting for its *child process*, the ``ArithmeticAddCalculation``, to finish.
 Check the process list again for *all* processes (You should know how by now!).
 After about half a minute, all the processes should be in the ``Finished`` state.
+You can also see a nice overview of the processes called by the work chain with the ``verdi process status`` command:
+
+.. code-block:: console
+
+    $ verdi process status 19
+    MultiplyAddWorkChain<19> Finished [0] [3:result]
+        ├── multiply<20> Finished [0]
+        └── ArithmeticAddCalculation<22> Finished [0]
+
+The bracket ``[3:result]`` indicates the current step in the outline of the :py:class:`~aiida.workflows.arithmetic.multiply_add.MultiplyAddWorkChain` (step 3, with name ``result``).
+The ``process status`` is particularly useful for debugging complex work chains, since it helps pinpoint where a problem occurred.
 
 We can now generate the full provenance graph for the ``WorkChain`` with:
 


### PR DESCRIPTION
Fixes #4505 

Currently the `verdi process status` command is only mentioned once in the documentation (in [topics/processes/usage](https://aiida-core.readthedocs.io/en/latest/topics/processes/usage.html#verdi-process-status) ). Since this command is both useful for getting a nice succinct overview of a work chain and debugging, it deserves a mention in the basic tutorial.

This PR adds the command just before generating the final provenance graph.