### PR TITLE
Add group extras to archive

### DIFF
--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -9,10 +9,6 @@
 ###########################################################################
 # pylint: disable=too-many-arguments,import-error,too-many-locals
 """`verdi export` command."""
-import os
-import tempfile
-import shutil
-
 import click
 import tabulate
 
@@ -193,7 +189,11 @@ def create(
 def migrate(input_file, output_file, force, silent, in_place, archive_format, version):
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """Migrate an export archive to a more recent format version."""
+    from distutils.version import StrictVersion
+    import os
+    import shutil
     import tarfile
+    import tempfile
     import zipfile
 
     from aiida.common import json
@@ -234,7 +234,7 @@ def migrate(input_file, output_file, force, silent, in_place, archive_format, ve
             echo.echo_critical(f'export archive does not contain the required file {fhandle.filename}')
 
         old_version = migration.verify_metadata_version(metadata)
-        if version <= old_version:
+        if StrictVersion(version) <= StrictVersion(old_version):
             echo.echo_success(f'nothing to be done - archive already at version {old_version} >= {version}')
             return
 

--- a/aiida/tools/importexport/common/config.py
+++ b/aiida/tools/importexport/common/config.py
@@ -191,7 +191,10 @@ def get_all_fields_info():
         },
         'type_string': {},
         'uuid': {},
-        'label': {}
+        'label': {},
+        'extras': {
+            'convert_type': 'jsonb'
+        }
     }
     all_fields_info[LOG_ENTITY_NAME] = {
         'uuid': {},

--- a/aiida/tools/importexport/dbimport/backends/django.py
+++ b/aiida/tools/importexport/dbimport/backends/django.py
@@ -377,6 +377,12 @@ def _store_entity_data(
     fields_info = reader.metadata.all_fields_info.get(entity_name, {})
     unique_identifier = reader.metadata.unique_identifiers.get(entity_name, None)
 
+    if entity_name == NODE_ENTITY_NAME:
+        # in the current export process these fields are not present,
+        # because they are retrieved by a separate query
+        fields_info.setdefault('attributes', {'convert_type': 'jsonb'})
+        fields_info.setdefault('extras', {'convert_type': 'jsonb'})
+
     pbar_base_str = f'{entity_name}s - '
 
     # EXISTING ENTRIES

--- a/aiida/tools/importexport/dbimport/backends/sqla.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla.py
@@ -417,6 +417,12 @@ def _store_entity_data(
     fields_info = reader.metadata.all_fields_info.get(entity_name, {})
     unique_identifier = reader.metadata.unique_identifiers.get(entity_name, None)
 
+    if entity_name == NODE_ENTITY_NAME:
+        # in the current export process these fields are not present,
+        # because they are retrieved by a separate query
+        fields_info.setdefault('attributes', {'convert_type': 'jsonb'})
+        fields_info.setdefault('extras', {'convert_type': 'jsonb'})
+
     pbar_base_str = f'{entity_name}s - '
 
     # EXISTING ENTRIES

--- a/aiida/tools/importexport/dbimport/utils.py
+++ b/aiida/tools/importexport/dbimport/utils.py
@@ -189,6 +189,10 @@ def deserialize_attributes(attributes_data, conversion_data):
     import datetime
     import pytz
 
+    if conversion_data == 'jsonb':
+        # we do not make any changes
+        return attributes_data
+
     if isinstance(attributes_data, dict):
         ret_data = {}
         for key, value in attributes_data.items():
@@ -218,8 +222,6 @@ def deserialize_attributes(attributes_data, conversion_data):
 
 def deserialize_field(key, value, fields_info, import_unique_ids_mappings, foreign_ids_reverse_mappings):
     """Deserialize field using deserialize attributes"""
-    if key in ('attributes', 'extras'):
-        return (key, value)
     try:
         field_info = fields_info[key]
     except KeyError:

--- a/aiida/tools/importexport/migration/__init__.py
+++ b/aiida/tools/importexport/migration/__init__.py
@@ -8,6 +8,8 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Migration archive files from old export versions to the newest, used by `verdi export migrate` command."""
+from distutils.version import StrictVersion
+
 from aiida.common.lang import type_check
 from aiida.tools.importexport import EXPORT_VERSION
 from aiida.tools.importexport.common.exceptions import DanglingLinkError, ArchiveMigrationError
@@ -53,7 +55,7 @@ def migrate_recursively(metadata, data, folder, version=EXPORT_VERSION):
     try:
         if old_version == version:
             return old_version
-        if old_version > version:
+        if StrictVersion(old_version) > StrictVersion(version):
             raise ArchiveMigrationError('Backward migrations are not supported')
         elif old_version in MIGRATE_FUNCTIONS:
             MIGRATE_FUNCTIONS[old_version](metadata, data, folder)


### PR DESCRIPTION
fixes #4497 

Group extras were introduced recently but not yet exported to AiiDA archives.
This commit adds group extras to the AiiDA archive.

Instead of special-casing deserialization of attributes and extras based on the field name, a `convert_type: "jsonb"` is introduced, which is used to indicate JSON-binary fields.