### PR TITLE
Fix hill notation for `get_formula()`

### DIFF
--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -503,11 +503,13 @@ def get_formula(symbol_list, mode='hill', separator=''):
     if mode in ['hill', 'hill_compact']:
         symbol_set = set(symbol_list)
         first_symbols = []
-        for special_symbol in ['C', 'H']:
-            # remove C and H if present from list and put them at the beginning
-            if special_symbol in symbol_set:
-                symbol_set.remove(special_symbol)
-                first_symbols.append(special_symbol)
+        # remove C (and possibly H) if present from list and put them at the beginning
+        if 'C' in symbol_set:
+            symbol_set.remove('C')
+            first_symbols.append('C')
+            if 'H' in symbol_set:
+                symbol_set.remove('H')
+                first_symbols.append('H')
         ordered_symbol_set = first_symbols + list(sorted(symbol_set))
         the_symbol_list = [[symbol_list.count(elem), elem] for elem in ordered_symbol_set]
 

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -503,14 +503,11 @@ def get_formula(symbol_list, mode='hill', separator=''):
     if mode in ['hill', 'hill_compact']:
         symbol_set = set(symbol_list)
         first_symbols = []
-        if 'C' in symbol_set:
-            # remove C (and H if present) from list and put them at the
-            # beginning
-            symbol_set.remove('C')
-            first_symbols.append('C')
-            if 'H' in symbol_set:
-                symbol_set.remove('H')
-                first_symbols.append('H')
+        for special_symbol in ['C', 'H']:
+            # remove C and H if present from list and put them at the beginning
+            if special_symbol in symbol_set:
+                symbol_set.remove(special_symbol)
+                first_symbols.append(special_symbol)
         ordered_symbol_set = first_symbols + list(sorted(symbol_set))
         the_symbol_list = [[symbol_list.count(elem), elem] for elem in ordered_symbol_set]
 

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -501,16 +501,10 @@ def get_formula(symbol_list, mode='hill', separator=''):
     # for hill and count cases, simply count the occurences of each
     # chemical symbol (with some re-ordering in hill)
     if mode in ['hill', 'hill_compact']:
-        symbol_set = set(symbol_list)
-        first_symbols = []
-        # remove C (and possibly H) if present from list and put them at the beginning
-        if 'C' in symbol_set:
-            symbol_set.remove('C')
-            first_symbols.append('C')
-            if 'H' in symbol_set:
-                symbol_set.remove('H')
-                first_symbols.append('H')
-        ordered_symbol_set = first_symbols + list(sorted(symbol_set))
+        if 'C' in symbol_list:
+            ordered_symbol_set = sorted(set(symbol_list), key=lambda elem: {'C': '0', 'H': '1'}.get(elem, elem))
+        else:
+            ordered_symbol_set = sorted(set(symbol_list))
         the_symbol_list = [[symbol_list.count(elem), elem] for elem in ordered_symbol_set]
 
     elif mode in ['count', 'count_compact']:

--- a/tests/orm/data/test_structure.py
+++ b/tests/orm/data/test_structure.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for StructureData-related functions."""
+
+from aiida.orm.nodes.data.structure import get_formula
+
+
+def test_get_formula_hill():
+    """Make sure 'hill' and 'hill_compact' modes actually sort according to hill notation"""
+    symbol_lists = [(['F', 'H', 'O', 'N', 'Zn', 'C', 'H', 'C'], 'C2 H2 F N O Zn'), (['F', 'O', 'N', 'Zn'], 'F N O Zn'),
+                    (['F', 'O', 'N', 'C', 'Zn', 'C'], 'C2 F N O Zn'), (['F', 'H', 'O', 'N', 'Zn', 'H'], 'H2 F N O Zn')]
+    for symbol_list, expected_result in symbol_lists:
+        assert get_formula(symbol_list, mode='hill', separator=' ') == expected_result
+        assert get_formula(symbol_list, mode='hill_compact', separator=' ') == expected_result

--- a/tests/orm/data/test_structure.py
+++ b/tests/orm/data/test_structure.py
@@ -13,9 +13,13 @@ from aiida.orm.nodes.data.structure import get_formula
 
 
 def test_get_formula_hill():
-    """Make sure 'hill' and 'hill_compact' modes actually sort according to hill notation"""
+    """Make sure 'hill' and 'hill_compact' modes actually sort according to hill notation
+
+    Wikipedia reference for the Hill system:
+    https://en.wikipedia.org/wiki/Chemical_formula#Hill_system
+    """
     symbol_lists = [(['F', 'H', 'O', 'N', 'Zn', 'C', 'H', 'C'], 'C2 H2 F N O Zn'), (['F', 'O', 'N', 'Zn'], 'F N O Zn'),
-                    (['F', 'O', 'N', 'C', 'Zn', 'C'], 'C2 F N O Zn'), (['F', 'H', 'O', 'N', 'Zn', 'H'], 'H2 F N O Zn')]
+                    (['F', 'O', 'N', 'C', 'Zn', 'C'], 'C2 F N O Zn'), (['F', 'H', 'O', 'N', 'Zn', 'H'], 'F H2 N O Zn')]
     for symbol_list, expected_result in symbol_lists:
         assert get_formula(symbol_list, mode='hill', separator=' ') == expected_result
         assert get_formula(symbol_list, mode='hill_compact', separator=' ') == expected_result


### PR DESCRIPTION
C and H should be put first in the formula, and every other element should be sorted alphabetically.

It used to be so that it would only sort H if C was also present.

This PR fixes this as well as introduce a test to check both `'hill'` and `'hill_compact'` modes follow these rules correctly.