### PR TITLE
RabbitMQ: remove validation of `broker_parameters` from profile

### DIFF
--- a/docs/source/intro/installation.rst
+++ b/docs/source/intro/installation.rst
@@ -689,6 +689,13 @@ The following parameters can be configured:
 +--------------+---------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------+
 | Virtual host | ``--broker-virtual-host`` | ``''``        | Optional virtual host. Should not contain the leading forward slash, this will be added automatically by AiiDA.         |
 +--------------+---------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------+
+| Parameters   | not available             |  n.a.         | These are additional broker parameters that are typically encoded as URL parameters, for example, to specify SSL        |
+|              |                           |               | parameters such as the filepath to the certificate that is to be used. The parameters are currently not definable       |
+|              |                           |               | through the CLI but have to be added manually in the ``config.json``. A key ``broker_parameters`` should be added that  |
+|              |                           |               | is a dictionary, which can contain fields: ``cafile``, ``capath``, ``cadata``, ``certfile``, ``keyfile`` and            |
+|              |                           |               | ``no_verify_ssl``.                                                                                                      |
++--------------+---------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------+
+
 
 
 verdi setup

--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
 - sqlalchemy>=1.3.10,~=1.3
 - tabulate~=0.8.5
 - tornado<5.0
+- topika~=0.2.2
 - tqdm~=4.45
 - tzlocal~=2.0
 - upf_to_json~=0.9.2

--- a/requirements/requirements-py-3.5.txt
+++ b/requirements/requirements-py-3.5.txt
@@ -142,7 +142,7 @@ sympy==1.5.1
 tabulate==0.8.6
 terminado==0.8.3
 testpath==0.4.4
-topika==0.2.1
+topika==0.2.2
 tornado==4.5.3
 tqdm==4.45.0
 traitlets==4.3.3

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -141,7 +141,7 @@ sympy==1.5.1
 tabulate==0.8.6
 terminado==0.8.3
 testpath==0.4.4
-topika==0.2.1
+topika==0.2.2
 tornado==4.5.3
 tqdm==4.45.0
 traitlets==4.3.3

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -140,7 +140,7 @@ sympy==1.5.1
 tabulate==0.8.6
 terminado==0.8.3
 testpath==0.4.4
-topika==0.2.1
+topika==0.2.2
 tornado==4.5.3
 tqdm==4.45.0
 traitlets==4.3.3

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -139,7 +139,7 @@ sympy==1.5.1
 tabulate==0.8.6
 terminado==0.8.3
 testpath==0.4.4
-topika==0.2.1
+topika==0.2.2
 tornado==4.5.3
 tqdm==4.45.0
 traitlets==4.3.3

--- a/setup.json
+++ b/setup.json
@@ -51,6 +51,7 @@
         "sqlalchemy~=1.3,>=1.3.10",
         "tabulate~=0.8.5",
         "tornado<5.0",
+        "topika~=0.2.2",
         "tqdm~=4.45",
         "tzlocal~=2.0",
         "upf_to_json~=0.9.2",

--- a/tests/manage/external/test_rmq.py
+++ b/tests/manage/external/test_rmq.py
@@ -16,7 +16,6 @@ from aiida.manage.external import rmq
 @pytest.mark.parametrize(('args', 'kwargs', 'expected'), (
     ((), {}, 'amqp://guest:guest@127.0.0.1:5672?'),
     ((), {'heartbeat': 1}, 'amqp://guest:guest@127.0.0.1:5672?'),
-    ((), {'invalid_parameters': 1}, ValueError),
     ((), {'cafile': 'file', 'cadata': 'ab'}, 'amqp://guest:guest@127.0.0.1:5672?'),
     (('amqps', 'jojo', 'rabbit', '192.168.0.1', 6783), {}, 'amqps://jojo:rabbit@192.168.0.1:6783?'),
 ))  # yapf: disable


### PR DESCRIPTION
Fixes #4540 

This validation was added as an attempt to help users with detecting
invalid parameters in the `broker_parameters` dictionary of a profile,
but `aiida-core` internally has no real limitations here. It is the
libraries underneath that decide what is acceptable and this can differ
from library to library plus it is not always clear. For example,
currently we use `topika` and `pika` which behave different from
`aiormq` which will be replacing them soon once `tornado` is replaced
with `asyncio`. It is best to not limit the options on `aiida-core`'s
side and just let it fail downstream as to not artificially limit the
parameters that might be perfectly acceptable by the libraries
downstream.