### PR TITLE
docs: include ipython magics from source code

### DIFF
--- a/.ci/test_ipython_magics.py
+++ b/.ci/test_ipython_magics.py
@@ -21,6 +21,8 @@ def test_ipython_magics():
 %aiida
 qb=QueryBuilder()
 qb.append(Node)
+qb.all()
+Dict().store()
 """
     result = ipy.run_cell(cell)
 

--- a/.ci/test_ipython_magics.py
+++ b/.ci/test_ipython_magics.py
@@ -7,23 +7,21 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Test the AiiDA iPython magics."""
+from IPython.testing.globalipapp import get_ipython
+from aiida.tools.ipython.ipython_magics import register_ipython_extension
+
+
+def test_ipython_magics():
+    """Test that the %aiida magic can be loaded and adds the QueryBuilder and Node variables."""
+    ipy = get_ipython()
+    register_ipython_extension(ipy)
+
+    cell = """
+%aiida
+qb=QueryBuilder()
+qb.append(Node)
 """
-File to be executed by IPython in order to register the line magic %aiida
+    result = ipy.run_cell(cell)
 
-This file can be put into the startup folder in order to have the line
-magic available at startup.
-The start up folder is usually at ``.ipython/profile_default/startup/``
-"""
-
-# DOCUMENTATION MARKER
-if __name__ == '__main__':
-
-    try:
-        import aiida
-        del aiida
-    except ImportError:
-        # AiiDA is not installed in this Python environment
-        pass
-    else:
-        from aiida.tools.ipython.ipython_magics import register_ipython_extension
-        register_ipython_extension()
+    assert result.success

--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -24,6 +24,7 @@ verdi daemon stop
 
 # tests for the testing infrastructure
 pytest --noconftest .ci/test_test_manager.py
+pytest --noconftest .ci/test_ipython_magics.py
 pytest --noconftest .ci/test_profile_manager.py
 python .ci/test_plugin_testcase.py  # uses custom unittest test runner
 

--- a/aiida/tools/ipython/aiida_magic_register.py
+++ b/aiida/tools/ipython/aiida_magic_register.py
@@ -15,6 +15,7 @@ magic available at startup.
 The start up folder is usually at ``.ipython/profile_default/startup/``
 """
 
+# DOCUMENTATION MARKER
 if __name__ == '__main__':
 
     try:

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -34,10 +34,8 @@ Usage
    In [2]: %aiida
 """
 
-from IPython import version_info  # pylint: disable=no-name-in-module
-from IPython.core import magic  # pylint: disable=no-name-in-module,import-error
-
-from aiida.common import json
+from IPython import version_info, get_ipython
+from IPython.core import magic
 
 
 def add_to_ns(local_ns, name, obj):
@@ -99,6 +97,8 @@ class AiiDALoaderMagics(magic.Magics):
         """
         Output in JSON format.
         """
+        from aiida.common import json
+
         obj = {'current_state': self.current_state}
         if version_info[0] >= 3:
             return obj
@@ -130,11 +130,10 @@ class AiiDALoaderMagics(magic.Magics):
 
         return latex
 
-    def _repr_pretty_(self, pretty_print, cycle):
+    def _repr_pretty_(self, pretty_print, cycle):  # pylint: disable=unused-argument
         """
         Output in text format.
         """
-        # pylint: disable=unused-argument
         if self.is_warning:
             warning_str = '** '
         else:
@@ -146,6 +145,24 @@ class AiiDALoaderMagics(magic.Magics):
 
 def load_ipython_extension(ipython):
     """
-    Triggers the load of all the AiiDA magic commands.
+    Registers the %aiida IPython extension.
+
+    .. deprecated:: v3.0.0
+        Use :py:func:`~aiida.tools.ipython.ipython_magics.register_ipython_extension` instead.
     """
+    register_ipython_extension(ipython)
+
+
+def register_ipython_extension(ipython=None):
+    """
+    Registers the %aiida IPython extension.
+
+    The %aiida IPython extension provides the same environment as the `verdi shell`.
+
+    :param ipython: InteractiveShell instance. If omitted, the global InteractiveShell is used.
+
+    """
+    if ipython is None:
+        ipython = get_ipython()
+
     ipython.register_magics(AiiDALoaderMagics)

--- a/docs/source/intro/installation.rst
+++ b/docs/source/intro/installation.rst
@@ -246,57 +246,41 @@ The AiiDA daemon is controlled using three simple commands:
 Using AiiDA in Jupyter
 ----------------------
 
-`Jupyter <http://jupyter.org>`_ is an open-source web application that allows you to create in-browser notebooks containing live code, visualizations and formatted text.
+  1. Install the AiiDA ``notebook`` extra **inside** the AiiDA python environment, e.g. by running ``pip install aiida-core[notebook]``.
 
-Originally born out of the iPython project, it now supports code written in many languages and customized iPython kernels.
+  2. (optional) Register the ``%aiida`` IPython magic for loading the same environment as in the ``verdi shell``:
 
-If you didn't already install AiiDA with the ``[notebook]`` option (during ``pip install``), run ``pip install jupyter`` **inside** the virtualenv, and then run **from within the virtualenv**:
+     Copy the following code snippet into ``<home_folder>/.ipython/profile_default/startup/aiida_magic_register.py``
+
+     .. literalinclude:: ../../../aiida/tools/ipython/aiida_magic_register.py
+         :start-after: # DOCUMENTATION MARKER
+
+     .. note:: Use ``ipython locate profile`` if you're unsure about the location of your ipython profile folder.
+
+
+With this setup, you're ready to use AiiDA in Jupyter notebeooks.
+
+Start a Jupyter notebook server:
 
 .. code-block:: console
 
     $ jupyter notebook
 
-This will open a tab in your browser. Click on ``New -> Python`` and type:
+This will open a tab in your browser. Click on ``New -> Python``.
 
-.. code-block:: python
-
-   import aiida
-
-followed by ``Shift-Enter``. If no exception is thrown, you can use AiiDA in Jupyter.
-
-If you want to set the same environment as in a ``verdi shell``,
-add the following code to a ``.py`` file (create one if there isn't any) in ``<home_folder>/.ipython/profile_default/startup/``:
-
-.. code-block:: python
-
-    try:
-        import aiida
-    except ImportError:
-        pass
-    else:
-        import IPython
-        from aiida.tools.ipython.ipython_magics import load_ipython_extension
-
-        # Get the current Ipython session
-        ipython = IPython.get_ipython()
-
-        # Register the line magic
-        load_ipython_extension(ipython)
-
-This file will be executed when the ipython kernel starts up and enable the line magic ``%aiida``.
-Alternatively, if you have a ``aiida-core`` repository checked out locally,
-you can just copy the file ``<aiida-core>/aiida/tools/ipython/aiida_magic_register.py`` to the same folder.
-The current ipython profile folder can be located using:
-
-.. code-block:: console
-
-   $ ipython locate profile
-
-After this, if you open a Jupyter notebook as explained above and type in a cell:
+If you registered the ``%aiida`` IPython magic, simply run:
 
 .. code-block:: ipython
 
    %aiida
 
-followed by ``Shift-Enter``. You should receive the message "Loaded AiiDA DB environment."
-This line magic should also be enabled in standard ipython shells.
+After executing the cell by ``Shift-Enter``, you should receive the message "Loaded AiiDA DB environment."
+Otherwise, you can load the profile manually as you would in a Python script:
+
+.. code-block:: python
+
+   from aiida import load_profile, orm
+   load_profile()
+   qb = orm.QueryBuilder()
+   # ...
+

--- a/docs/source/intro/installation.rst
+++ b/docs/source/intro/installation.rst
@@ -283,4 +283,3 @@ Otherwise, you can load the profile manually as you would in a Python script:
    load_profile()
    qb = orm.QueryBuilder()
    # ...
-


### PR DESCRIPTION
fixes #4547 

 * docs: Remove duplication of snippet to register the AiiDA ipython magics from the
aiida-core codebase
 * docs: Also revisit the corresponding section of the documentation, starting with the setup, and removing some generic information about jupyter.
 * test AiiDA ipython magic
 * move some additional lines from the registration snippet to
aiida-core (where we can adapt it if the IPython API ever changes)
 * rename misnomer `load_ipython_extension` to
   `register_ipython_extension` with deprecation far in the future