### PR TITLE
pre-commit: fix E0611 pylint warning

### DIFF
--- a/.ci/polish/cli.py
+++ b/.ci/polish/cli.py
@@ -102,8 +102,8 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
     import uuid
     from aiida.orm import Code, Int, Str
     from aiida.engine import run_get_node, submit
-    from lib.expression import generate, validate, evaluate  # pylint: disable=import-error
-    from lib.workchain import generate_outlines, format_outlines, write_workchain  # pylint: disable=import-error
+    from .lib.expression import generate, validate, evaluate
+    from .lib.workchain import generate_outlines, format_outlines, write_workchain
 
     if use_calculations and not isinstance(code, Code):
         raise click.BadParameter('if you specify the -C flag, you have to specify a code as well')


### PR DESCRIPTION
Replace the global import from lib with a local one to silence
"no-name-in-module" warnigns.

.ci/polish/cli.py:105:4: E0611: No name 'expression' in module 'lib' (no-name-in-module)
.ci/polish/cli.py:106:4: E0611: No name 'workchain' in module 'lib' (no-name-in-module)