### PR TITLE
Enforce verdi quicksetup --non-interactive

### DIFF
--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -166,7 +166,7 @@ class Postgres(PGSU):
         :returns: tuple (dbname, created)
         """
         if not self.interactive:
-            return dbname, not self.db_exists(dbuser)
+            return dbname, not self.db_exists(dbname)
         create = True
         while create and self.db_exists(dbname):
             echo.echo_info(f'database {dbname} already exists!')

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -116,6 +116,8 @@ class Postgres(PGSU):
         :param str dbuser: Name of the user to be created or reused.
         :returns: tuple (dbuser, created)
         """
+        if not self.interactive:
+            return dbuser, not self.dbuser_exists(dbuser)
         create = True
         while create and self.dbuser_exists(dbuser):
             echo.echo_info(f'Database user "{dbuser}" already exists!')
@@ -163,6 +165,8 @@ class Postgres(PGSU):
         :param str dbname: Name of the database to be created or reused.
         :returns: tuple (dbname, created)
         """
+        if not self.interactive:
+            return dbname, not self.db_exists(dbuser)
         create = True
         while create and self.db_exists(dbname):
             echo.echo_info(f'database {dbname} already exists!')


### PR DESCRIPTION
When in non-interactive mode, do not ask whether to use existing user/database