### PR TITLE
reversing: daemon start and profile setup sections

### DIFF
--- a/docs/source/intro/install_system.rst
+++ b/docs/source/intro/install_system.rst
@@ -215,7 +215,7 @@ This is the *recommended* installation method to setup AiiDA on a personal lapto
           (aiida) $ reentry scan
 
    ---
-   
+
    **Setup profile**
 
    Next, set up an AiiDA configuration profile and related data storage, with the ``verdi quicksetup`` command.

--- a/docs/source/intro/install_system.rst
+++ b/docs/source/intro/install_system.rst
@@ -215,6 +215,23 @@ This is the *recommended* installation method to setup AiiDA on a personal lapto
           (aiida) $ reentry scan
 
    ---
+   
+   **Setup profile**
+
+   Next, set up an AiiDA configuration profile and related data storage, with the ``verdi quicksetup`` command.
+
+   .. code-block:: console
+
+       (aiida) $ verdi quicksetup
+       Info: enter "?" for help
+       Info: enter "!" to ignore the default and set no value
+       Profile name: me
+       Email Address (for sharing data): me@user.com
+       First name: my
+       Last name: name
+       Institution: where-i-work
+
+   ---
 
    **Start verdi daemons**
 
@@ -231,23 +248,6 @@ This is the *recommended* installation method to setup AiiDA on a personal lapto
    .. tip::
 
        Do not start more daemons then there are physical processors on your system.
-
-   ---
-
-   **Setup profile**
-
-   Next, set up an AiiDA configuration profile and related data storage, with the ``verdi quicksetup`` command.
-
-   .. code-block:: console
-
-       (aiida) $ verdi quicksetup
-       Info: enter "?" for help
-       Info: enter "!" to ignore the default and set no value
-       Profile name: me
-       Email Address (for sharing data): me@user.com
-       First name: my
-       Last name: name
-       Institution: where-i-work
 
    ---
 


### PR DESCRIPTION
Informing the profile setup before starting the daemons because if a person has no AiiDA profile, there will be an error.