### PR TITLE
Improve `verdi node delete` performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,8 @@ repos:
             (?x)^(
                 aiida/common/progress_reporter.py|
                 aiida/engine/processes/calcjobs/calcjob.py|
+                aiida/manage/database/delete/nodes.py|
+                aiida/tools/graph/graph_traversers.py|
                 aiida/tools/groups/paths.py|
                 aiida/tools/importexport/archive/.*py|
                 aiida/tools/importexport/dbexport/__init__.py|

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -296,13 +296,13 @@ def tree(nodes, depth):
 
 
 @verdi_node.command('delete')
-@arguments.NODES('nodes', required=True)
+@click.argument('pks', type=int, nargs=-1, metavar='PKs')
 @options.VERBOSE()
 @options.DRY_RUN()
 @options.FORCE()
 @options.graph_traversal_rules(GraphTraversalRules.DELETE.value)
 @with_dbenv()
-def node_delete(nodes, dry_run, verbose, force, **kwargs):
+def node_delete(pks, dry_run, verbose, force, **kwargs):
     """Delete nodes from the provenance graph.
 
     This will not only delete the nodes explicitly provided via the command line, but will also include
@@ -317,9 +317,7 @@ def node_delete(nodes, dry_run, verbose, force, **kwargs):
     elif verbose:
         verbosity = 2
 
-    node_pks_to_delete = [node.pk for node in nodes]
-
-    delete_nodes(node_pks_to_delete, dry_run=dry_run, verbosity=verbosity, force=force, **kwargs)
+    delete_nodes(pks, dry_run=dry_run, verbosity=verbosity, force=force, **kwargs)
 
 
 @verdi_node.command('rehash')

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -296,19 +296,20 @@ def tree(nodes, depth):
 
 
 @verdi_node.command('delete')
-@click.argument('pks', type=int, nargs=-1, metavar='PKs')
+@click.argument('identifier', nargs=-1, metavar='NODES')
 @options.VERBOSE()
 @options.DRY_RUN()
 @options.FORCE()
 @options.graph_traversal_rules(GraphTraversalRules.DELETE.value)
 @with_dbenv()
-def node_delete(pks, dry_run, verbose, force, **kwargs):
+def node_delete(identifier, dry_run, verbose, force, **kwargs):
     """Delete nodes from the provenance graph.
 
     This will not only delete the nodes explicitly provided via the command line, but will also include
     the nodes necessary to keep a consistent graph, according to the rules outlined in the documentation.
     You can modify some of those rules using options of this command.
     """
+    from aiida.orm.utils.loaders import NodeEntityLoader
     from aiida.manage.database.delete.nodes import delete_nodes
 
     verbosity = 1
@@ -316,6 +317,15 @@ def node_delete(pks, dry_run, verbose, force, **kwargs):
         verbosity = 0
     elif verbose:
         verbosity = 2
+
+    pks = []
+
+    for obj in identifier:
+        # we only load the node if we need to convert from a uuid/label
+        if isinstance(obj, int):
+            pks.append(obj)
+        else:
+            pks.append(NodeEntityLoader.load_entity(obj).pk)
 
     delete_nodes(pks, dry_run=dry_run, verbosity=verbosity, force=force, **kwargs)
 

--- a/aiida/manage/database/delete/nodes.py
+++ b/aiida/manage/database/delete/nodes.py
@@ -8,12 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Function to delete nodes from the database."""
+from typing import Iterable
 
 import click
 from aiida.cmdline.utils import echo
 
 
-def delete_nodes(pks, verbosity=0, dry_run=False, force=False, **kwargs):
+def delete_nodes(
+    pks: Iterable[int], verbosity: int = 0, dry_run: bool = False, force: bool = False, **traversal_rules: bool
+):
     """Delete nodes by a list of pks.
 
     This command will delete not only the specified nodes, but also the ones that are
@@ -36,41 +39,37 @@ def delete_nodes(pks, verbosity=0, dry_run=False, force=False, **kwargs):
     inputs, and so on.
 
     :param pks: a list of the PKs of the nodes to delete
-    :param bool force: do not ask for confirmation to delete nodes.
-    :param int verbosity: 0 prints nothing,
+    :param force: do not ask for confirmation to delete nodes.
+    :param verbosity: 0 prints nothing,
                           1 prints just sums and total,
                           2 prints individual nodes.
 
-    :param kwargs: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
+    :param dry_run:
+        Just perform a dry run and do not delete anything.
+        Print statistics according to the verbosity level set.
+    :param force: Do not ask for confirmation to delete nodes
+
+    :param traversal_rules: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
         are toggleable and what the defaults are.
-    :param bool dry_run:
-        Just perform a dry run and do not delete anything. Print statistics according
-        to the verbosity level set.
-    :param bool force:
-        Do not ask for confirmation to delete nodes.
     """
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals,too-many-statements
     from aiida.backends.utils import delete_nodes_and_connections
-    from aiida.common import exceptions
     from aiida.orm import Node, QueryBuilder, load_node
     from aiida.tools.graph.graph_traversers import get_nodes_delete
 
-    starting_pks = []
-    for pk in pks:
-        try:
-            load_node(pk)
-        except exceptions.NotExistent:
-            echo.echo_warning(f'warning: node with pk<{pk}> does not exist, skipping')
-        else:
-            starting_pks.append(pk)
+    def _missing_callback(_pks: Iterable[int]):
+        for _pk in _pks:
+            echo.echo_warning(f'warning: node with pk<{_pk}> does not exist, skipping')
+
+    # echo.echo('Finding nodes to delete...')
+    pks_set_to_delete = get_nodes_delete(pks, get_links=False, missing_callback=_missing_callback,
+                                         **traversal_rules)['nodes']
 
     # An empty set might be problematic for the queries done below.
-    if not starting_pks:
+    if not pks_set_to_delete:
         if verbosity:
             echo.echo('Nothing to delete')
         return
-
-    pks_set_to_delete = get_nodes_delete(starting_pks, **kwargs)['nodes']
 
     if verbosity > 0:
         echo.echo(
@@ -78,19 +77,19 @@ def delete_nodes(pks, verbosity=0, dry_run=False, force=False, **kwargs):
                 'would' if dry_run else 'will', len(pks_set_to_delete), 's' if len(pks_set_to_delete) > 1 else ''
             )
         )
-        if verbosity > 1:
-            builder = QueryBuilder().append(
-                Node, filters={'id': {
-                    'in': pks_set_to_delete
-                }}, project=('uuid', 'id', 'node_type', 'label')
-            )
-            echo.echo(f"The nodes I {'would' if dry_run else 'will'} delete:")
-            for uuid, pk, type_string, label in builder.iterall():
-                try:
-                    short_type_string = type_string.split('.')[-2]
-                except IndexError:
-                    short_type_string = type_string
-                echo.echo(f'   {uuid} {pk} {short_type_string} {label}')
+    if verbosity > 1:
+        builder = QueryBuilder().append(
+            Node, filters={'id': {
+                'in': pks_set_to_delete
+            }}, project=('uuid', 'id', 'node_type', 'label')
+        )
+        echo.echo(f"The nodes I {'would' if dry_run else 'will'} delete:")
+        for uuid, pk, type_string, label in builder.iterall():
+            try:
+                short_type_string = type_string.split('.')[-2]
+            except IndexError:
+                short_type_string = type_string
+            echo.echo(f'   {uuid} {pk} {short_type_string} {label}')
 
     if dry_run:
         if verbosity > 0:

--- a/aiida/manage/database/delete/nodes.py
+++ b/aiida/manage/database/delete/nodes.py
@@ -61,7 +61,6 @@ def delete_nodes(
         for _pk in _pks:
             echo.echo_warning(f'warning: node with pk<{_pk}> does not exist, skipping')
 
-    # echo.echo('Finding nodes to delete...')
     pks_set_to_delete = get_nodes_delete(pks, get_links=False, missing_callback=_missing_callback,
                                          **traversal_rules)['nodes']
 

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -8,34 +8,59 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module for functions to traverse AiiDA graphs."""
+import sys
+from typing import Any, Callable, cast, Dict, Iterable, List, Mapping, Optional, Set
 
 from numpy import inf
+
+from aiida import orm
+from aiida.common import exceptions
 from aiida.common.links import GraphTraversalRules, LinkType
+from aiida.orm.utils.links import LinkQuadruple
+from aiida.tools.graph.age_entities import Basket
+from aiida.tools.graph.age_rules import UpdateRule, RuleSequence, RuleSaveWalkers, RuleSetWalkers
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+
+    class TraverseGraphOutput(TypedDict, total=False):
+        nodes: Set[int]
+        links: Optional[Set[LinkQuadruple]]
+        rules: Dict[str, bool]
+else:
+    TraverseGraphOutput = Mapping[str, Any]
 
 
-def get_nodes_delete(starting_pks, get_links=False, **kwargs):
+def get_nodes_delete(
+    starting_pks: Iterable[int],
+    get_links: bool = False,
+    missing_callback: Optional[Callable[[Iterable[int]], None]] = None,
+    **traversal_rules: bool
+) -> TraverseGraphOutput:
     """
     This function will return the set of all nodes that can be connected
     to a list of initial nodes through any sequence of specified authorized
     links and directions for deletion.
 
-    :type starting_pks: list or tuple or set
     :param starting_pks: Contains the (valid) pks of the starting nodes.
 
-    :param bool get_links:
+    :param get_links:
         Pass True to also return the links between all nodes (found + initial).
 
-    :param bool create_forward: will traverse CREATE links in the forward direction.
-    :param bool call_calc_forward: will traverse CALL_CALC links in the forward direction.
-    :param bool call_work_forward: will traverse CALL_WORK links in the forward direction.
+    :param missing_callback: A callback to handle missing starting_pks or if None raise NotExistent
+
+    :param traversal_rules: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
+        are toggleable and what the defaults are.
+
     """
-    traverse_links = validate_traversal_rules(GraphTraversalRules.DELETE, **kwargs)
+    traverse_links = validate_traversal_rules(GraphTraversalRules.DELETE, **traversal_rules)
 
     traverse_output = traverse_graph(
         starting_pks,
         get_links=get_links,
         links_forward=traverse_links['forward'],
-        links_backward=traverse_links['backward']
+        links_backward=traverse_links['backward'],
+        missing_callback=missing_callback
     )
 
     function_output = {
@@ -44,30 +69,31 @@ def get_nodes_delete(starting_pks, get_links=False, **kwargs):
         'rules': traverse_links['rules_applied']
     }
 
-    return function_output
+    return cast(TraverseGraphOutput, function_output)
 
 
-def get_nodes_export(starting_pks, get_links=False, **kwargs):
+def get_nodes_export(
+    starting_pks: Iterable[int], get_links: bool = False, **traversal_rules: bool
+) -> TraverseGraphOutput:
     """
     This function will return the set of all nodes that can be connected
     to a list of initial nodes through any sequence of specified authorized
     links and directions for export. This will also return the links and
     the traversal rules parsed.
 
-    :type starting_pks: list or tuple or set
     :param starting_pks: Contains the (valid) pks of the starting nodes.
 
-    :param bool get_links:
+    :param get_links:
         Pass True to also return the links between all nodes (found + initial).
 
-    :param bool input_calc_forward: will traverse INPUT_CALC links in the forward direction.
-    :param bool create_backward: will traverse CREATE links in the backward direction.
-    :param bool return_backward: will traverse RETURN links in the backward direction.
-    :param bool input_work_forward: will traverse INPUT_WORK links in the forward direction.
-    :param bool call_calc_backward: will traverse CALL_CALC links in the backward direction.
-    :param bool call_work_backward: will traverse CALL_WORK links in the backward direction.
+    :param input_calc_forward: will traverse INPUT_CALC links in the forward direction.
+    :param create_backward: will traverse CREATE links in the backward direction.
+    :param return_backward: will traverse RETURN links in the backward direction.
+    :param input_work_forward: will traverse INPUT_WORK links in the forward direction.
+    :param call_calc_backward: will traverse CALL_CALC links in the backward direction.
+    :param call_work_backward: will traverse CALL_WORK links in the backward direction.
     """
-    traverse_links = validate_traversal_rules(GraphTraversalRules.EXPORT, **kwargs)
+    traverse_links = validate_traversal_rules(GraphTraversalRules.EXPORT, **traversal_rules)
 
     traverse_output = traverse_graph(
         starting_pks,
@@ -82,50 +108,49 @@ def get_nodes_export(starting_pks, get_links=False, **kwargs):
         'rules': traverse_links['rules_applied']
     }
 
-    return function_output
+    return cast(TraverseGraphOutput, function_output)
 
 
-def validate_traversal_rules(ruleset=GraphTraversalRules.DEFAULT, **kwargs):
+def validate_traversal_rules(
+    ruleset: GraphTraversalRules = GraphTraversalRules.DEFAULT, **traversal_rules: bool
+) -> dict:
     """
     Validates the keywords with a ruleset template and returns a parsed dictionary
     ready to be used.
 
-    :type ruleset: :py:class:`aiida.common.links.GraphTraversalRules`
     :param ruleset: Ruleset template used to validate the set of rules.
-    :param bool input_calc_forward: will traverse INPUT_CALC links in the forward direction.
-    :param bool input_calc_backward: will traverse INPUT_CALC links in the backward direction.
-    :param bool create_forward: will traverse CREATE links in the forward direction.
-    :param bool create_backward: will traverse CREATE links in the backward direction.
-    :param bool return_forward: will traverse RETURN links in the forward direction.
-    :param bool return_backward: will traverse RETURN links in the backward direction.
-    :param bool input_work_forward: will traverse INPUT_WORK links in the forward direction.
-    :param bool input_work_backward: will traverse INPUT_WORK links in the backward direction.
-    :param bool call_calc_forward: will traverse CALL_CALC links in the forward direction.
-    :param bool call_calc_backward: will traverse CALL_CALC links in the backward direction.
-    :param bool call_work_forward: will traverse CALL_WORK links in the forward direction.
-    :param bool call_work_backward: will traverse CALL_WORK links in the backward direction.
+    :param input_calc_forward: will traverse INPUT_CALC links in the forward direction.
+    :param input_calc_backward: will traverse INPUT_CALC links in the backward direction.
+    :param create_forward: will traverse CREATE links in the forward direction.
+    :param create_backward: will traverse CREATE links in the backward direction.
+    :param return_forward: will traverse RETURN links in the forward direction.
+    :param return_backward: will traverse RETURN links in the backward direction.
+    :param input_work_forward: will traverse INPUT_WORK links in the forward direction.
+    :param input_work_backward: will traverse INPUT_WORK links in the backward direction.
+    :param call_calc_forward: will traverse CALL_CALC links in the forward direction.
+    :param call_calc_backward: will traverse CALL_CALC links in the backward direction.
+    :param call_work_forward: will traverse CALL_WORK links in the forward direction.
+    :param call_work_backward: will traverse CALL_WORK links in the backward direction.
     """
-    from aiida.common import exceptions
-
     if not isinstance(ruleset, GraphTraversalRules):
         raise TypeError(
             f'ruleset input must be of type aiida.common.links.GraphTraversalRules\ninstead, it is: {type(ruleset)}'
         )
 
-    rules_applied = {}
-    links_forward = []
-    links_backward = []
+    rules_applied: Dict[str, bool] = {}
+    links_forward: List[LinkType] = []
+    links_backward: List[LinkType] = []
 
     for name, rule in ruleset.value.items():
 
         follow = rule.default
 
-        if name in kwargs:
+        if name in traversal_rules:
 
             if not rule.toggleable:
                 raise ValueError(f'input rule {name} is not toggleable for ruleset {ruleset}')
 
-            follow = kwargs.pop(name)
+            follow = traversal_rules.pop(name)
 
             if not isinstance(follow, bool):
                 raise ValueError(f'the value of rule {name} must be boolean, but it is: {follow}')
@@ -141,8 +166,8 @@ def validate_traversal_rules(ruleset=GraphTraversalRules.DEFAULT, **kwargs):
 
         rules_applied[name] = follow
 
-    if kwargs:
-        error_message = f"unrecognized keywords: {', '.join(kwargs.keys())}"
+    if traversal_rules:
+        error_message = f"unrecognized keywords: {', '.join(traversal_rules.keys())}"
         raise exceptions.ValidationError(error_message)
 
     valid_output = {
@@ -154,36 +179,33 @@ def validate_traversal_rules(ruleset=GraphTraversalRules.DEFAULT, **kwargs):
     return valid_output
 
 
-def traverse_graph(starting_pks, max_iterations=None, get_links=False, links_forward=(), links_backward=()):
+def traverse_graph(
+    starting_pks: Iterable[int],
+    max_iterations: Optional[int] = None,
+    get_links: bool = False,
+    links_forward: Iterable[LinkType] = (),
+    links_backward: Iterable[LinkType] = (),
+    missing_callback: Optional[Callable[[Iterable[int]], None]] = None
+) -> TraverseGraphOutput:
     """
     This function will return the set of all nodes that can be connected
     to a list of initial nodes through any sequence of specified links.
     Optionally, it may also return the links that connect these nodes.
 
-    :type starting_pks: list or tuple or set
     :param starting_pks: Contains the (valid) pks of the starting nodes.
 
-    :type max_iterations: int or None
     :param max_iterations:
         The number of iterations to apply the set of rules (a value of 'None' will
         iterate until no new nodes are added).
 
-    :param bool get_links:
-        Pass True to also return the links between all nodes (found + initial).
+    :param get_links: Pass True to also return the links between all nodes (found + initial).
 
-    :type links_forward: aiida.common.links.LinkType
-    :param links_forward:
-        List with all the links that should be traversed in the forward direction.
+    :param links_forward: List with all the links that should be traversed in the forward direction.
+    :param links_backward: List with all the links that should be traversed in the backward direction.
 
-    :type links_backward: aiida.common.links.LinkType
-    :param links_backward:
-        List with all the links that should be traversed in the backward direction.
+    :param missing_callback: A callback to handle missing starting_pks or if None raise NotExistent
     """
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
-    from aiida import orm
-    from aiida.tools.graph.age_entities import Basket
-    from aiida.tools.graph.age_rules import UpdateRule, RuleSequence, RuleSaveWalkers, RuleSetWalkers
-    from aiida.common import exceptions
 
     if max_iterations is None:
         max_iterations = inf
@@ -204,31 +226,31 @@ def traverse_graph(starting_pks, max_iterations=None, get_links=False, links_for
         linktype_list.append(linktype.value)
     filters_backwards = {'type': {'in': linktype_list}}
 
-    if not isinstance(starting_pks, (list, set, tuple)):
-        raise TypeError(f'starting_pks must be of type list, set or tuple\ninstead, it is {type(starting_pks)}')
-
-    if not starting_pks:
-        if get_links:
-            output = {'nodes': set(), 'links': set()}
-        else:
-            output = {'nodes': set(), 'links': None}
-        return output
+    if not isinstance(starting_pks, Iterable):  # pylint: disable=isinstance-second-argument-not-valid-type
+        raise TypeError(f'starting_pks must be an iterable\ninstead, it is {type(starting_pks)}')
 
     if any([not isinstance(pk, int) for pk in starting_pks]):
         raise TypeError(f'one of the starting_pks is not of type int:\n {starting_pks}')
     operational_set = set(starting_pks)
 
+    if not operational_set:
+        if get_links:
+            return {'nodes': set(), 'links': set()}
+        return {'nodes': set(), 'links': None}
+
     query_nodes = orm.QueryBuilder()
     query_nodes.append(orm.Node, project=['id'], filters={'id': {'in': operational_set}})
     existing_pks = set(query_nodes.all(flat=True))
     missing_pks = operational_set.difference(existing_pks)
-    if missing_pks:
+    if missing_pks and missing_callback is None:
         raise exceptions.NotExistent(
-            f'The following pks are not in the database and must be pruned before this   call: {missing_pks}'
+            f'The following pks are not in the database and must be pruned before this call: {missing_pks}'
         )
+    elif missing_pks and missing_callback is not None:
+        missing_callback(missing_pks)
 
     rules = []
-    basket = Basket(nodes=operational_set)
+    basket = Basket(nodes=existing_pks)
 
     # When max_iterations is finite, the order of traversal may affect the result
     # (its not the same to first go backwards and then forwards than vice-versa)
@@ -269,4 +291,4 @@ def traverse_graph(starting_pks, max_iterations=None, get_links=False, links_for
     if get_links:
         output['links'] = results['nodes_nodes'].keyset
 
-    return output
+    return cast(TraverseGraphOutput, output)

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -48,6 +48,7 @@ def get_nodes_delete(
         Pass True to also return the links between all nodes (found + initial).
 
     :param missing_callback: A callback to handle missing starting_pks or if None raise NotExistent
+    	For example to ignore them: ``missing_callback=lambda missing_pks: None``
 
     :param traversal_rules: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
         are toggleable and what the defaults are.

--- a/aiida/tools/importexport/dbexport/__init__.py
+++ b/aiida/tools/importexport/dbexport/__init__.py
@@ -280,7 +280,7 @@ def export(
         _check_node_licenses(node_ids_to_be_exported, allowed_licenses, forbidden_licenses)
 
         # write the link data
-        if traverse_output['links']:
+        if traverse_output['links'] is not None:
             with get_progress_reporter()(total=len(traverse_output['links']), desc='Writing links') as progress:
                 for link in traverse_output['links']:
                     progress.update()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 # Global options
 
 [mypy]
-python_version = 3.6
 
 check_untyped_defs = True
 scripts_are_modules = True


### PR DESCRIPTION
`verdi node delete` is amazingly inefficient;

1) it loads every node as part of click (from a list of pk/uuids) (in `node_delete`)
2) then converts that back to a list of pks (in `node_delete`)
3) then loads all the nodes again to check if they exist (in `delete_nodes`)
4) then performs a query to check (again!) for non-existent pks (in `traverse_graph`)
5) and finally uses the pks to actually compute the full pk/link set to delete, and deletes them.

This PR essentially removes steps 1-3.

It also adds type checking to the files concerned.