### PR TITLE
Fix wrong raise from dict nodes

### DIFF
--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -62,7 +62,10 @@ class Dict(Data):
             self.set_dict(dictionary)
 
     def __getitem__(self, key):
-        return self.get_attribute(key)
+        try:
+            return self.get_attribute(key)
+        except AttributeError as exc:
+            raise KeyError from exc
 
     def __setitem__(self, key, value):
         self.set_attribute(key, value)

--- a/tests/orm/data/test_dict.py
+++ b/tests/orm/data/test_dict.py
@@ -50,3 +50,15 @@ class TestDict(AiidaTestCase):
         self.assertEqual(self.node['value'], 2)
         self.node.dict.value = 3
         self.assertEqual(self.node['value'], 3)
+
+    def test_correct_raises(self):
+        """Test that the methods for accessing the item raise the correct error.
+
+        * `dictnode['inexistent']` should raise KeyError
+        * `dictnode.dict.inexistent` should raise AttributeError
+        """
+        with self.assertRaises(KeyError):
+            _ = self.node['inexistent_key']
+
+        with self.assertRaises(AttributeError):
+            _ = self.node.dict.inexistent_key


### PR DESCRIPTION
When accessing an attribute as a dict (`dictnode['key']`), the error raised was an AttributeError instead of a KeyError, which is rather unusual. This has been fixed and a test that checks the correct error raise has been added.

Fixes #4454