### PR TITLE
CI: Add workflow to run tests against various RabbitMQ versions

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -81,7 +81,6 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install postgresql-10 graphviz
 

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -23,7 +23,6 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install libkrb5-dev ruby ruby-dev
 

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -1,0 +1,67 @@
+name: rabbitmq
+
+on:
+    push:
+        branches-ignore: [gh-pages]
+    pull_request:
+        branches-ignore: [gh-pages]
+        paths-ignore: ['docs/**']
+
+jobs:
+
+    tests:
+
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+
+        strategy:
+            fail-fast: false
+            matrix:
+                rabbitmq: [3.5, 3.6, 3.7, 3.8]
+
+        services:
+            postgres:
+                image: postgres:10
+                env:
+                    POSTGRES_DB: test_django
+                    POSTGRES_PASSWORD: ''
+                    POSTGRES_HOST_AUTH_METHOD: trust
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                ports:
+                -   5432:5432
+            rabbitmq:
+                image: rabbitmq:${{ matrix.rabbitmq }}
+                ports:
+                -   5672:5672
+
+        steps:
+        -   uses: actions/checkout@v2
+
+        -   name: Set up Python 3.8
+            uses: actions/setup-python@v2
+            with:
+                python-version: 3.8
+
+        -   name: Install system dependencies
+            run: |
+                sudo apt update
+                sudo apt install postgresql-10
+
+        -   name: Upgrade pip
+            run: |
+                pip install --upgrade pip
+                pip --version
+
+        -   name: Install aiida-core
+            run: |
+                pip install -r requirements/requirements-py-3.8.txt
+                pip install --no-deps -e .
+                reentry scan
+                pip freeze
+
+        -   name: Run tests
+            run: pytest -sv tests/manage/external/test_rmq.py

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -150,7 +150,6 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install postgresql-10 graphviz
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,6 +228,13 @@ def backend():
 
 
 @pytest.fixture
+def communicator():
+    """Get the ``Communicator`` instance of the currently loaded profile to communicate with RabbitMQ."""
+    from aiida.manage.manager import get_manager
+    return get_manager().get_communicator()
+
+
+@pytest.fixture
 def skip_if_not_django(backend):
     """Fixture that will skip any test that uses it when a profile is loaded with any other backend then Django."""
     from aiida.orm.implementation.django.backend import DjangoBackend

--- a/tests/manage/external/test_rmq.py
+++ b/tests/manage/external/test_rmq.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the `aiida.manage.external.rmq` module."""
+from kiwipy.rmq import RmqThreadCommunicator
 import pytest
 
 from aiida.manage.external import rmq
@@ -34,3 +35,22 @@ def test_get_rmq_url(args, kwargs, expected):
     else:
         with pytest.raises(expected):
             rmq.get_rmq_url(*args, **kwargs)
+
+
+@pytest.mark.parametrize('url', ('amqp://guest:guest@127.0.0.1:5672',))
+def test_communicator(url):
+    """Test the instantiation of a ``kiwipy.rmq.RmqThreadCommunicator``.
+
+    This class is used by all runners to communicate with the RabbitMQ server.
+    """
+    RmqThreadCommunicator.connect(connection_params={'url': url})
+
+
+def test_add_rpc_subscriber(communicator):
+    """Test ``add_rpc_subscriber``."""
+    communicator.add_rpc_subscriber(None)
+
+
+def test_add_broadcast_subscriber(communicator):
+    """Test ``add_broadcast_subscriber``."""
+    communicator.add_broadcast_subscriber(None)


### PR DESCRIPTION
The main test workflow runs against a single version of RabbitMQ but
experience has shown that the code can break for different versions of
the RabbitMQ server. Here we add a new CI workflow that runs various
unit tests through pytest that simulate the typical interaction with the
RabbitMQ server in normal AiiDA operation. The difference is that these
are tested against the currently available versions of RabbitMQ.

The current setup, still only tests part of the functionality that AiiDA
uses, for example, the default credentials and virtual host are used.
Connections over TLS are also not tested. These options would require
the RabbitMQ service that is running in a docker container to be
configured differently. It is not clear how these various options can be
parametrized in concert with the actual unit tests.