### PR TITLE
Add options for transport tasks

### DIFF
--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -32,6 +32,9 @@ UPDATE_COMMAND = 'update'
 RETRIEVE_COMMAND = 'retrieve'
 KILL_COMMAND = 'kill'
 
+RETRY_INTERVAL_OPTION = 'transport.task_retry_initial_interval'
+MAX_ATTEMPTS_OPTION = 'transport.task_maximum_attempts'
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,8 +64,8 @@ def task_upload_job(process, transport_queue, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as SUBMITTING, skipping task_update_job')
         raise Return
 
-    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
-    max_attempts = get_config().get_option('transport.task_maximum_attempts')
+    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -122,8 +125,8 @@ def task_submit_job(node, transport_queue, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as WITHSCHEDULER, skipping task_submit_job')
         raise Return(node.get_job_id())
 
-    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
-    max_attempts = get_config().get_option('transport.task_maximum_attempts')
+    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -170,8 +173,8 @@ def task_update_job(node, job_manager, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as RETRIEVING, skipping task_update_job')
         raise Return(True)
 
-    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
-    max_attempts = get_config().get_option('transport.task_maximum_attempts')
+    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
     job_id = node.get_job_id()
@@ -231,8 +234,8 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
         logger.warning(f'CalcJob<{node.pk}> already marked as PARSING, skipping task_retrieve_job')
         raise Return
 
-    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
-    max_attempts = get_config().get_option('transport.task_maximum_attempts')
+    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -289,8 +292,8 @@ def task_kill_job(node, transport_queue, cancellable):
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
-    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
-    max_attempts = get_config().get_option('transport.task_maximum_attempts')
+    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
 
     if node.get_state() in [CalcJobState.UPLOADING, CalcJobState.SUBMITTING]:
         logger.warning(f'CalcJob<{node.pk}> killed, it was in the {node.get_state()} state')

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -32,9 +32,6 @@ UPDATE_COMMAND = 'update'
 RETRIEVE_COMMAND = 'retrieve'
 KILL_COMMAND = 'kill'
 
-TRANSPORT_TASK_RETRY_INITIAL_INTERVAL = get_config().get_option('transport.task_retry_initial_interval')
-TRANSPORT_TASK_MAXIMUM_ATTEMPTS = get_config().get_option('transport.task_maximum_attempts')
-
 logger = logging.getLogger(__name__)
 
 
@@ -64,8 +61,8 @@ def task_upload_job(process, transport_queue, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as SUBMITTING, skipping task_update_job')
         raise Return
 
-    initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
+    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
+    max_attempts = get_config().get_option('transport.task_maximum_attempts')
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -125,8 +122,8 @@ def task_submit_job(node, transport_queue, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as WITHSCHEDULER, skipping task_submit_job')
         raise Return(node.get_job_id())
 
-    initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
+    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
+    max_attempts = get_config().get_option('transport.task_maximum_attempts')
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -173,8 +170,8 @@ def task_update_job(node, job_manager, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as RETRIEVING, skipping task_update_job')
         raise Return(True)
 
-    initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
+    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
+    max_attempts = get_config().get_option('transport.task_maximum_attempts')
 
     authinfo = node.computer.get_authinfo(node.user)
     job_id = node.get_job_id()
@@ -234,8 +231,8 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
         logger.warning(f'CalcJob<{node.pk}> already marked as PARSING, skipping task_retrieve_job')
         raise Return
 
-    initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
+    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
+    max_attempts = get_config().get_option('transport.task_maximum_attempts')
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -292,8 +289,8 @@ def task_kill_job(node, transport_queue, cancellable):
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
-    initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
+    initial_interval = get_config().get_option('transport.task_retry_initial_interval')
+    max_attempts = get_config().get_option('transport.task_maximum_attempts')
 
     if node.get_state() in [CalcJobState.UPLOADING, CalcJobState.SUBMITTING]:
         logger.warning(f'CalcJob<{node.pk}> killed, it was in the {node.get_state()} state')

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -22,6 +22,7 @@ from aiida.common.folders import SandboxFolder
 from aiida.engine.daemon import execmanager
 from aiida.engine.utils import exponential_backoff_retry, interruptable_task
 from aiida.schedulers.datastructures import JobState
+from aiida.manage.configuration import get_config
 
 from ..process import ProcessState
 
@@ -31,8 +32,8 @@ UPDATE_COMMAND = 'update'
 RETRIEVE_COMMAND = 'retrieve'
 KILL_COMMAND = 'kill'
 
-TRANSPORT_TASK_RETRY_INITIAL_INTERVAL = 20
-TRANSPORT_TASK_MAXIMUM_ATTEMTPS = 5
+TRANSPORT_TASK_RETRY_INITIAL_INTERVAL = get_config().get_option('transport.task_retry_initial_interval')
+TRANSPORT_TASK_MAXIMUM_ATTEMPTS = get_config().get_option('transport.task_maximum_attempts')
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ def task_upload_job(process, transport_queue, cancellable):
         raise Return
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
+    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -125,7 +126,7 @@ def task_submit_job(node, transport_queue, cancellable):
         raise Return(node.get_job_id())
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
+    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -173,7 +174,7 @@ def task_update_job(node, job_manager, cancellable):
         raise Return(True)
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
+    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
 
     authinfo = node.computer.get_authinfo(node.user)
     job_id = node.get_job_id()
@@ -234,7 +235,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
         raise Return
 
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
+    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -292,7 +293,7 @@ def task_kill_job(node, transport_queue, cancellable):
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
-    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
+    max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMPTS
 
     if node.get_state() in [CalcJobState.UPLOADING, CalcJobState.SUBMITTING]:
         logger.warning(f'CalcJob<{node.pk}> killed, it was in the {node.get_state()} state')

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -154,7 +154,8 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
     This coroutine will loop ``max_attempts`` times, calling the ``fct`` function, breaking immediately when the call
     finished without raising an exception, at which point the returned result will be raised, wrapped in a
     ``tornado.gen.Result`` instance. If an exception is caught, the function will yield a ``tornado.gen.sleep`` with a
-    time interval equal to the ``initial_interval`` multiplied by ``2*N`` where ``N`` is the number of excepted calls.
+    time interval equal to the ``initial_interval`` multiplied by ``2 ** (N - 1)`` where ``N`` is the number of
+    excepted calls.
 
     :param fct: the function to call, which will be turned into a coroutine first if it is not already
     :param initial_interval: the time to wait after the first caught exception before calling the coroutine again

--- a/aiida/manage/configuration/options.py
+++ b/aiida/manage/configuration/options.py
@@ -185,6 +185,22 @@ CONFIG_OPTIONS = {
         'description': 'Boolean whether to print AiiDA deprecation warnings',
         'global_only': False,
     },
+    'transport.task_retry_initial_interval': {
+        'key': 'task_retry_initial_interval',
+        'valid_type': 'int',
+        'valid_values': None,
+        'default': 20,
+        'description': 'Initial time interval for the exponential backoff mechanism.',
+        'global_only': False,
+    },
+    'transport.task_maximum_attempts': {
+        'key': 'task_maximum_attempts',
+        'valid_type': 'int',
+        'valid_values': None,
+        'default': 5,
+        'description': 'Maximum number of transport task attempts before a Process is Paused.',
+        'global_only': False,
+    },
 }
 
 


### PR DESCRIPTION
When encountering failures during the execution of transport tasks, a runner
will wait for a time interval between transport task attempts. This time
interval between attemps is increased using an exponential backoff
mechanism, i.e. the time interval is equal to:

`(TRANSPORT_TASK_RETRY_INITIAL_INTERVAL) * 2 ** (N_ATTEMPT - 1)`

where `N_ATTEMPT` is the number of failed attempts. This mechanism is
interrupted once the `TRANSPORT_TASK_MAXIMUM_ATTEMPTS` is reached.

The initial interval and maximum attempts are currently fixed to 20
seconds and 5, respectively. This commit adds two configuration options
that use these defaults, but allow the user to adjust them using `verdi
config`.