### PR TITLE
Fix command for getting config options

### DIFF
--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -22,7 +22,7 @@ from aiida.common.folders import SandboxFolder
 from aiida.engine.daemon import execmanager
 from aiida.engine.utils import exponential_backoff_retry, interruptable_task
 from aiida.schedulers.datastructures import JobState
-from aiida.manage.configuration import get_config
+from aiida.manage.configuration import get_config_option
 
 from ..process import ProcessState
 
@@ -64,8 +64,8 @@ def task_upload_job(process, transport_queue, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as SUBMITTING, skipping task_update_job')
         raise Return
 
-    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
-    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
+    initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -125,8 +125,8 @@ def task_submit_job(node, transport_queue, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as WITHSCHEDULER, skipping task_submit_job')
         raise Return(node.get_job_id())
 
-    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
-    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
+    initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -173,8 +173,8 @@ def task_update_job(node, job_manager, cancellable):
         logger.warning(f'CalcJob<{node.pk}> already marked as RETRIEVING, skipping task_update_job')
         raise Return(True)
 
-    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
-    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
+    initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
     job_id = node.get_job_id()
@@ -234,8 +234,8 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
         logger.warning(f'CalcJob<{node.pk}> already marked as PARSING, skipping task_retrieve_job')
         raise Return
 
-    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
-    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
+    initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
     authinfo = node.computer.get_authinfo(node.user)
 
@@ -292,8 +292,8 @@ def task_kill_job(node, transport_queue, cancellable):
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
-    initial_interval = get_config().get_option(RETRY_INTERVAL_OPTION)
-    max_attempts = get_config().get_option(MAX_ATTEMPTS_OPTION)
+    initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
+    max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
     if node.get_state() in [CalcJobState.UPLOADING, CalcJobState.SUBMITTING]:
         logger.warning(f'CalcJob<{node.pk}> killed, it was in the {node.get_state()} state')


### PR DESCRIPTION
Currently the transport options for the EBM (#4583) are obtained by using 
the get_config function, e.g.:

initial_interval = get_config_option(RETRY_INTERVAL_OPTION)

However, it seems that get_config does not get you the current
configuration, see #4586. 

Replacing get_config().get_option() with get_config_option() fixes this
issue for the EBM options.