### PR TITLE
Dependencies: update minimum version for `notebook>=6.1.5`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - jinja2~=2.10
 - kiwipy[rmq]~=0.6.1
 - numpy~=1.17
-- pamqp~=2.0
+- pamqp~=2.3
 - paramiko~=2.7
 - plumpy~=0.17.1
 - pgsu~=0.1.0

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -2,7 +2,7 @@ aiida-export-migration-tests==0.9.0
 alabaster==0.7.12
 aldjemy==0.9.1
 alembic==1.4.1
-aio-pika~=6.6.1
+aio-pika==6.6.1
 aniso8601==8.0.0
 appdirs==1.4.4
 appnope==0.1.0
@@ -69,12 +69,12 @@ mpmath==1.1.0
 nbconvert==5.6.1
 nbformat==5.0.4
 networkx==2.4
-notebook~=6.0.0
+notebook==6.1.5
 numpy==1.17.5
 orderedmultidict==1.0.1
 packaging==20.3
 palettable==3.3.0
-pamqp~=2.0
+pamqp==2.3
 pandas==0.25.3
 pandocfilters==1.4.2
 paramiko==2.7.1
@@ -110,7 +110,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.8.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.3.4
-pytest-asyncio~=0.12.0
+pytest-asyncio==0.12.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -2,7 +2,7 @@ aiida-export-migration-tests==0.9.0
 alabaster==0.7.12
 aldjemy==0.9.1
 alembic==1.4.1
-aio-pika~=6.6.1
+aio-pika==6.6.1
 aniso8601==8.0.0
 appdirs==1.4.4
 appnope==0.1.0
@@ -68,12 +68,12 @@ mpmath==1.1.0
 nbconvert==5.6.1
 nbformat==5.0.4
 networkx==2.4
-notebook~=6.0.0
+notebook==6.1.5
 numpy==1.17.5
 orderedmultidict==1.0.1
 packaging==20.3
 palettable==3.3.0
-pamqp~=2.0
+pamqp==2.3
 pandas==0.25.3
 pandocfilters==1.4.2
 paramiko==2.7.1
@@ -110,7 +110,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.8.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.3.4
-pytest-asyncio~=0.12.0
+pytest-asyncio==0.12.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -1,7 +1,7 @@
 aiida-export-migration-tests==0.9.0
 alabaster==0.7.12
 aldjemy==0.9.1
-aio-pika~=6.6.1
+aio-pika==6.6.1
 alembic==1.4.1
 aniso8601==8.0.0
 appnope==0.1.0
@@ -64,12 +64,12 @@ mpmath==1.1.0
 nbconvert==5.6.1
 nbformat==5.0.4
 networkx==2.4
-notebook~=6.0.0
+notebook==6.1.5
 numpy==1.17.5
 orderedmultidict==1.0.1
 packaging==20.3
 palettable==3.3.0
-pamqp~=2.0
+pamqp==2.3
 pandas==0.25.3
 pandocfilters==1.4.2
 paramiko==2.7.1
@@ -103,7 +103,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.8.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.3.4
-pytest-asyncio~=0.12.0
+pytest-asyncio==0.12.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -1,7 +1,7 @@
 aiida-export-migration-tests==0.9.0
 alabaster==0.7.12
 aldjemy==0.9.1
-aio-pika~=6.6.1
+aio-pika==6.6.1
 alembic==1.4.3
 aniso8601==8.0.0
 archive-path==0.2.1
@@ -62,12 +62,12 @@ mpmath==1.1.0
 nbconvert==5.6.1
 nbformat==5.0.8
 networkx==2.5
-notebook~=6.0.0
+notebook==6.1.5
 numpy==1.19.4
 orderedmultidict==1.0.1
 packaging==20.4
 palettable==3.3.0
-pamqp~=2.0
+pamqp==2.3
 pandas==1.1.4
 pandocfilters==1.4.3
 paramiko==2.7.2

--- a/setup.json
+++ b/setup.json
@@ -38,7 +38,7 @@
         "jinja2~=2.10",
         "kiwipy[rmq]~=0.6.1",
         "numpy~=1.17",
-        "pamqp~=2.0",
+        "pamqp~=2.3",
         "paramiko~=2.7",
         "plumpy~=0.17.1",
         "pgsu~=0.1.0",
@@ -91,7 +91,7 @@
         ],
         "notebook": [
             "jupyter~=1.0",
-            "notebook~=6.0"
+            "notebook~=6.0,>=6.1.5"
         ],
         "pre-commit": [
             "mypy==0.790",

--- a/setup.json
+++ b/setup.json
@@ -91,7 +91,7 @@
         ],
         "notebook": [
             "jupyter~=1.0",
-            "notebook~=6.0,>=6.1.5"
+            "notebook~=6.1,>=6.1.5"
         ],
         "pre-commit": [
             "mypy==0.790",


### PR DESCRIPTION
Lower versions suffer from vulnerability `GHSA-c7vm-f5p4-8fqh`.

Also update the requirement files to only use explicit pinned versions.
The compatibility operator was erroneously used for the `aio-pika`,
`pamqp` and `pytest-asyncio` dependencies.

For `pamqp` the minimum required version is upped to `2.3` since that
was the version that introduced the `support_deprecated_rabbitmq`
function that is required from that library.