### PR TITLE
WIP: parse more info from upf header

### DIFF
--- a/tests/orm/data/test_upf.py
+++ b/tests/orm/data/test_upf.py
@@ -175,11 +175,12 @@ class TestUpfParser(AiidaTestCase):
         upf_contents = '\n'.join([
             '<PP_INFO>'
             'Human readable section is completely irrelevant for parsing!',
-            '<PP_HEADER',
+            '<PP_HEADER>',
             'contents before element tag',
             'O                     Element',
+            '4.00000000000         Z valence',
             'contents following element tag',
-            '>',
+            '</PP_HEADER>',
         ])
         path_to_upf = os.path.join(self.temp_dir, upf_filename)
         with open(path_to_upf, 'w') as upf_file:
@@ -189,6 +190,7 @@ class TestUpfParser(AiidaTestCase):
         # check that parsed data matches the expected one
         self.assertEqual(parsed_data['version'], '1')
         self.assertEqual(parsed_data['element'], 'O')
+        self.assertEqual(parsed_data['z_valence'], 4.00)
 
     def test_upf_version_two(self):
         """Check if parsing for regular UPF file (version 2) succeeds."""
@@ -201,6 +203,7 @@ class TestUpfParser(AiidaTestCase):
             '<PP_HEADER',
             'contents before element tag',
             "element=\"Al\"",
+            "z_valence=\"    4.00\"",
             'contents following element tag',
             '>',
         ])
@@ -212,6 +215,7 @@ class TestUpfParser(AiidaTestCase):
         # check that parsed data matches the expected one
         self.assertEqual(parsed_data['version'], '2.0.1')
         self.assertEqual(parsed_data['element'], 'Al')
+        self.assertEqual(parsed_data['z_valence'], 4.00)
 
     def test_additional_header_line(self):
         """Regression #2228: check if parsing succeeds if additional header line is present."""
@@ -309,11 +313,11 @@ class TestUpfParser(AiidaTestCase):
         upf_contents = '\n'.join([
             '<PP_INFO>'
             'Human readable section is completely irrelevant for parsing!',
-            '<PP_HEADER',
+            '<PP_HEADER>',
             'contents before element tag',
             'element should be here but is missing',
             'contents following element tag',
-            '>',
+            '</PP_HEADER>',
         ])
         path_to_upf = os.path.join(self.temp_dir, upf_filename)
         with open(path_to_upf, 'w') as upf_file:
@@ -354,11 +358,11 @@ class TestUpfParser(AiidaTestCase):
         upf_contents = '\n'.join([
             '<PP_INFO>'
             'Human readable section is completely irrelevant for parsing!',
-            '<PP_HEADER',
+            '<PP_HEADER>',
             'contents before element tag',
             'Ab                     Element',
             'contents following element tag',
-            '>',
+            '</PP_HEADER>',
         ])
         path_to_upf = os.path.join(self.temp_dir, upf_filename)
         with open(path_to_upf, 'w') as upf_file:

--- a/tests/tools/importexport/test_prov_redesign.py
+++ b/tests/tools/importexport/test_prov_redesign.py
@@ -206,6 +206,7 @@ class TestProvenanceRedesign(AiidaTestCase):
             '<PP_HEADER',
             'contents before element tag',
             "element=\"Al\"",
+            "z_valence=\"    11.00\"",
             'contents following element tag',
             '>',
         ])


### PR DESCRIPTION
The `parse_upf` method is very old and only support parsing the element from upf file. I find it is sometimes helpful to also parse the `z_valence`(I want to get this value to set `nbands` before I run the scf calculation, I am curious why we cannot set things like `nbands_factor` in quantum-espresso) and more information from the upf file's `PP_HEADER` such as the type of PP. Just like what @simonpintarelli did in https://github.com/aiidateam/aiida-core/pull/3308 to support converting upf to json. I propose to have a tool to elaborately parsing the upf(or maybe if necessary for other types of pseudopotentials). From the time being, I just add a parser for 'z_valence'. It might useful to parse the following infos from file, [element, z_valence, pp_type, pp_energy, functional, wfc_cutoff, rho_cutoff, relativistic]. 

Here are the things worth to be discussed:

- I am not sure whether to set each of the info as an attribute of `UpfData` or collect them as a dict and set it as one attribute. 
- What's kinds of infos from pp file going to be store?
- Do we need and maintain another package to parse the upf(such as [upf_to_json](https://github.com/simonpintarelli/upf_to_json) by @simonpintarelli , and I think that package can be simplified or replaced by a more versatile one) . Meanwhile, how versatile it would be for other simulation code. Or maybe this tool can be a part of `aiida-pseudo`?

Pining @giovannipizzi @simonpintarelli for inputs before I moving forward.