### PR TITLE
Fix bug in SqlAlchemy migrations

### DIFF
--- a/aiida/backends/sqlalchemy/manager.py
+++ b/aiida/backends/sqlalchemy/manager.py
@@ -7,16 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=import-error,no-name-in-module
 """Utilities and configuration of the SqlAlchemy database schema."""
-
 import os
 import contextlib
-
-from alembic import command
-from alembic.config import Config
-from alembic.runtime.environment import EnvironmentContext
-from alembic.script import ScriptDirectory
 
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -24,7 +17,6 @@ from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.common import NotExistent
 from ..manager import BackendManager, SettingsManager, Setting
 
-ALEMBIC_FILENAME = 'alembic.ini'
 ALEMBIC_REL_PATH = 'migrations'
 
 # The database schema version required to perform schema reset for a given code schema generation
@@ -37,18 +29,44 @@ class SqlaBackendManager(BackendManager):
     @staticmethod
     @contextlib.contextmanager
     def alembic_config():
-        """Context manager to return an instance of an Alembic configuration with the current connection inserted.
+        """Context manager to return an instance of an Alembic configuration.
 
-        :return: instance of :py:class:`alembic.config.Config`
+        The current database connection is added in the `attributes` property, through which it can then also be
+        retrieved, also in the `env.py` file, which is run when the database is migrated.
         """
         from . import ENGINE
+        from alembic.config import Config
 
         with ENGINE.begin() as connection:
             dir_path = os.path.dirname(os.path.realpath(__file__))
-            config = Config(os.path.join(dir_path, ALEMBIC_FILENAME))
+            config = Config()
             config.set_main_option('script_location', os.path.join(dir_path, ALEMBIC_REL_PATH))
             config.attributes['connection'] = connection  # pylint: disable=unsupported-assignment-operation
             yield config
+
+    @contextlib.contextmanager
+    def alembic_script(self):
+        """Context manager to return an instance of an Alembic `ScriptDirectory`."""
+        from alembic.script import ScriptDirectory
+
+        with self.alembic_config() as config:
+            yield ScriptDirectory.from_config(config)
+
+    @contextlib.contextmanager
+    def migration_context(self):
+        """Context manager to return an instance of an Alembic migration context.
+
+        This migration context will have been configured with the current database connection, which allows this context
+        to be used to inspect the contents of the database, such as the current revision.
+        """
+        from alembic.runtime.environment import EnvironmentContext
+        from alembic.script import ScriptDirectory
+
+        with self.alembic_config() as config:
+            script = ScriptDirectory.from_config(config)
+            with EnvironmentContext(config, script) as context:
+                context.configure(context.config.attributes['connection'])
+                yield context.get_context()
 
     def get_settings_manager(self):
         """Return an instance of the `SettingsManager`.
@@ -80,29 +98,13 @@ class SqlaBackendManager(BackendManager):
 
         :return: boolean, True if the database schema version is ahead of the code schema version.
         """
-        from alembic.util import CommandError
-
-        # In the case of SqlAlchemy, if the database revision is ahead of the code, that means the revision stored in
-        # the database is not even present in the code base. Therefore we cannot locate it in the revision graph and
-        # determine whether it is ahead of the current code head. We simply try to get the revision and if it does not
-        # exist it means it is ahead.
-        with self.alembic_config() as config:
-            try:
-                script = ScriptDirectory.from_config(config)
-                script.get_revision(self.get_schema_version_database())
-            except CommandError:
-                # Raised when the revision of the database is not present in the revision graph.
-                return True
-            else:
-                return False
+        with self.alembic_script() as script:
+            return self.get_schema_version_database() not in [entry.revision for entry in script.walk_revisions()]
 
     def get_schema_version_code(self):
         """Return the code schema version."""
-        with self.alembic_config() as config:
-            script = ScriptDirectory.from_config(config)
-            schema_version_code = script.get_current_head()
-
-        return schema_version_code
+        with self.alembic_script() as script:
+            return script.get_current_head()
 
     def get_schema_version_reset(self, schema_generation_code):
         """Return schema version the database should have to be able to automatically reset to code schema generation.
@@ -117,38 +119,24 @@ class SqlaBackendManager(BackendManager):
 
         :return: `distutils.version.StrictVersion` with schema version of the database
         """
-
-        def get_database_version(revision, _):
-            """Get the current revision."""
-            if isinstance(revision, tuple) and revision:
-                config.attributes['rev'] = revision[0]  # pylint: disable=unsupported-assignment-operation
-            else:
-                config.attributes['rev'] = None  # pylint: disable=unsupported-assignment-operation
-            return []
-
-        with self.alembic_config() as config:
-
-            script = ScriptDirectory.from_config(config)
-
-            with EnvironmentContext(config, script, fn=get_database_version):
-                script.run_env()
-                return config.attributes['rev']  # pylint: disable=unsubscriptable-object
+        with self.migration_context() as context:
+            return context.get_current_revision()
 
     def set_schema_version_database(self, version):
         """Set the database schema version.
 
         :param version: string with schema version to set
         """
-        # pylint: disable=cyclic-import
-        from aiida.manage.manager import get_manager
-        backend = get_manager()._load_backend(schema_check=False)  # pylint: disable=protected-access
-        backend.execute_raw(r"""UPDATE alembic_version SET version_num='{}';""".format(version))
+        with self.migration_context() as context:
+            return context.stamp(context.script, 'head')
 
     def _migrate_database_version(self):
         """Migrate the database to the current schema version."""
         super()._migrate_database_version()
+        from alembic.command import upgrade
+
         with self.alembic_config() as config:
-            command.upgrade(config, 'head')
+            upgrade(config, 'head')
 
 
 class SqlaSettingsManager(SettingsManager):

--- a/aiida/backends/sqlalchemy/migrations/env.py
+++ b/aiida/backends/sqlalchemy/migrations/env.py
@@ -7,49 +7,28 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=unused-import
-"""Upper lewel SQLAlchemy migration funcitons."""
+"""Upper level SQLAlchemy migration funcitons."""
 from alembic import context
-
-# The available SQLAlchemy tables
-from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
-from aiida.backends.sqlalchemy.models.comment import DbComment
-from aiida.backends.sqlalchemy.models.computer import DbComputer
-from aiida.backends.sqlalchemy.models.group import DbGroup
-from aiida.backends.sqlalchemy.models.log import DbLog
-from aiida.backends.sqlalchemy.models.node import DbLink, DbNode
-from aiida.backends.sqlalchemy.models.settings import DbSetting
-from aiida.backends.sqlalchemy.models.user import DbUser
-from aiida.common.exceptions import DbContentError
-from aiida.backends.sqlalchemy.models.base import Base
-target_metadata = Base.metadata  # pylint: disable=invalid-name
-
-
-def run_migrations_offline():
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output."""
-    raise NotImplementedError('This feature is not currently supported.')
 
 
 def run_migrations_online():
     """Run migrations in 'online' mode.
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context."""
+    The connection should have been passed to the config, which we use to configue the migration context.
+    """
 
-    # This is the Alembic Config object, which provides
-    # access to the values within the .ini file in use.
-    # It is initialized by alembic and we enrich it here
-    # to point to the right database configuration.
-    #  pylint: disable=no-member
-    config = context.config
+    # pylint: disable=unused-import
+    from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
+    from aiida.backends.sqlalchemy.models.comment import DbComment
+    from aiida.backends.sqlalchemy.models.computer import DbComputer
+    from aiida.backends.sqlalchemy.models.group import DbGroup
+    from aiida.backends.sqlalchemy.models.log import DbLog
+    from aiida.backends.sqlalchemy.models.node import DbLink, DbNode
+    from aiida.backends.sqlalchemy.models.settings import DbSetting
+    from aiida.backends.sqlalchemy.models.user import DbUser
+    from aiida.common.exceptions import DbContentError
+    from aiida.backends.sqlalchemy.models.base import Base
+    config = context.config  # pylint: disable=no-member
 
     connectable = config.attributes.get('connection', None)
 
@@ -58,21 +37,20 @@ def run_migrations_online():
         raise ConfigurationError('An initialized connection is expected for the AiiDA online migrations.')
 
     with connectable.connect() as connection:
-        context.configure(
+        context.configure(  # pylint: disable=no-member
             connection=connection,
-            target_metadata=target_metadata,
+            target_metadata=Base.metadata,
             transaction_per_migration=True,
         )
 
-        with context.begin_transaction():
-            context.run_migrations()
+        context.run_migrations()  # pylint: disable=no-member
 
 
 try:
     if context.is_offline_mode():  # pylint: disable=no-member
-        run_migrations_offline()
-    else:
-        run_migrations_online()
+        NotImplementedError('This feature is not currently supported.')
+
+    run_migrations_online()
 except NameError:
     # This will occur in an environment that is just compiling the documentation
     pass

--- a/aiida/backends/sqlalchemy/migrations/versions/0edcdd5a30f0_dbgroup_extras.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/0edcdd5a30f0_dbgroup_extras.py
@@ -18,7 +18,6 @@ Create Date: 2019-04-03 14:38:50.585639
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
 revision = '0edcdd5a30f0'
@@ -29,12 +28,10 @@ depends_on = None
 
 def upgrade():
     """Upgrade: Add the extras column to the 'db_dbgroup' table"""
-    op.add_column('db_dbgroup', sa.Column('extras', postgresql.JSONB(astext_type=sa.Text())))
-    op.execute(text("""
-    UPDATE db_dbgroup
-    SET extras='{}'
-    """))
-    op.alter_column('db_dbgroup', 'extras', nullable=False)
+    op.add_column(
+        'db_dbgroup', sa.Column('extras', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='{}')
+    )
+    op.alter_column('db_dbgroup', 'extras', server_default=None)
 
 
 def downgrade():


### PR DESCRIPTION
Fixes #4590 

### SqlAlchemy: improve the alembic migration code

The code in `aiida.backends.sqlalchemy.manager` is used, among other
things, to control the database migrations. It can be used to get info
like the current revision of the database, current revision of the code
and to actually migrate the database. The migrations are performed
through `alembic`. This library has the somewhat weird approach of
loading the `env.py` file, which then actually calls the migrations.
This file somehow needs to get the configuration of the environment, for
example the connection to the database, and it does so by loading it
from the config that is imported. This config is actually built
dynamically in the `SqlBackendManager`.

The old implementation was correctly building up the configuration
object but was then calling the CLI commands of `alembic` to perform the
various operations, which was unnecessarily complex and inefficient. For
most operations, essentially everything but performing the actual
migrations, one can construct a `MigrationContext` directly, which
allows to inspect the state of the database, for example to get the
current database revision. For anything related to the revisions in the
code, e.g., to get the current head of the code, we can instantiate an
instance of the `ScriptDirectory` which allows one to inspect the
available revisions.

Through these changes, the `env.py` file is no longer loaded everytime,
even when it is not necessary, such as when simply retrieving the
current revision of the database.


### SqlAlchemy: fix bug in `Group` extras migration with revision `0edcddc585917

This migration added the JSONB column `extras` to the `DbGroup` model.
Since this needs to be a non-nullable column, but existing group rows
would have a null value, the migration was implemented by first adding
the column as nullable, after which all rows had their value set to the
default, before making the column non-nullable.

This approach was working when the revision was run by itself in an
isolated way, which is how the unit test is run, and so that passed.
However, as soon as it was run with multiple revisions in a sequence the
migration would fail with the message that the `db_dbgroup` table has
pending event triggers as soon as the final instruction to change the
nullability of the column was executed. The cause for this was never
found.

As an alternative, the migration is adapted to instead create the column
directly as non-nullable, but also provide a server default. This will
also avoid the exception of existing rows with a null value, just as the
original approach, but now when we remove the server default in a second
operation, we no longer hit the problem of the pending trigger events.

