### PR TITLE
Config: do not overwrite when loaded and not migrated

### DIFF
--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -51,14 +51,19 @@ class Config:  # pylint: disable=too-many-public-methods
             config = Config(filepath, check_and_migrate_config({}))
             config.store()
         else:
+            migrated = False
+
             # If the configuration file needs to be migrated first create a specific backup so it can easily be reverted
             if config_needs_migrating(config):
+                migrated = True
                 echo.echo_warning(f'current configuration file `{filepath}` is outdated and will be migrated')
                 filepath_backup = cls._backup(filepath)
                 echo.echo_warning(f'original backed up to `{filepath_backup}`')
 
             config = Config(filepath, check_and_migrate_config(config))
-            config.store()
+
+            if migrated:
+                config.store()
 
         return config
 


### PR DESCRIPTION
Fixes #4606 

The `Config.from_file` classmethod used to load the `config.json` file
into memory was always writing the contents from memory to disk if it
was read, even if the content was not migrated. This is unnecessary and
so the write is now only performed if the config was migrated.