### PR TITLE
Daemon: replace deprecated classmethods of `asyncio.Task` in shutdown

### DIFF
--- a/aiida/engine/daemon/runner.py
+++ b/aiida/engine/daemon/runner.py
@@ -19,6 +19,28 @@ from aiida.manage.manager import get_manager
 LOGGER = logging.getLogger(__name__)
 
 
+async def shutdown_runner(runner):
+    """Cleanup tasks tied to the service's shutdown."""
+    LOGGER.info('Received signal to shut down the daemon runner')
+
+    try:
+        from asyncio import all_tasks
+        from asyncio import current_task
+    except ImportError:
+        # Necessary for Python 3.6 as `asyncio.all_tasks` and `asyncio.current_task` were introduced in Python 3.7. The
+        # Standalone functions should be used as the classmethods are removed as of Python 3.9.
+        all_tasks = asyncio.Task.all_tasks
+        current_task = asyncio.Task.current_task
+
+    tasks = [task for task in all_tasks() if task is not current_task()]
+
+    for task in tasks:
+        task.cancel()
+
+    await asyncio.gather(*tasks, return_exceptions=True)
+    runner.close()
+
+
 def start_daemon():
     """Start a daemon runner for the currently configured profile."""
     daemon_client = get_daemon_client()
@@ -32,21 +54,9 @@ def start_daemon():
         LOGGER.exception('daemon runner failed to start')
         raise
 
-    async def shutdown(runner):
-        """Cleanup tasks tied to the service's shutdown."""
-        LOGGER.info('Received signal to shut down the daemon runner')
-
-        tasks = [t for t in asyncio.Task.all_tasks() if t is not asyncio.Task.current_task()]
-
-        for task in tasks:
-            task.cancel()
-
-        await asyncio.gather(*tasks, return_exceptions=True)
-        runner.close()
-
     signals = (signal.SIGTERM, signal.SIGINT)
     for s in signals:  # pylint: disable=invalid-name
-        runner.loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown(runner)))
+        runner.loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown_runner(runner)))
 
     try:
         LOGGER.info('Starting a daemon runner')

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -103,6 +103,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.10.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
+pytest-asyncio==0.12.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/setup.json
+++ b/setup.json
@@ -106,6 +106,7 @@
             "pg8000~=1.13",
             "pgtest~=1.3,>=1.3.1",
             "pytest~=6.0",
+            "pytest-asyncio~=0.12",
             "pytest-timeout~=1.3",
             "pytest-cov~=2.7",
             "pytest-rerunfailures~=9.1,>=9.1.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,17 +221,31 @@ def create_profile() -> Profile:
 
 
 @pytest.fixture
-def backend():
-    """Get the ``Backend`` instance of the currently loaded profile."""
+def manager(aiida_profile):  # pylint: disable=unused-argument
+    """Get the ``Manager`` instance of the currently loaded profile."""
     from aiida.manage.manager import get_manager
-    return get_manager().get_backend()
+    return get_manager()
 
 
 @pytest.fixture
-def communicator():
+def event_loop(manager):
+    """Get the event loop instance of the currently loaded profile.
+
+    This is automatically called as a fixture for any test marked with ``@pytest.mark.asyncio``.
+    """
+    yield manager.get_runner().loop
+
+
+@pytest.fixture
+def backend(manager):
+    """Get the ``Backend`` instance of the currently loaded profile."""
+    return manager.get_backend()
+
+
+@pytest.fixture
+def communicator(manager):
     """Get the ``Communicator`` instance of the currently loaded profile to communicate with RabbitMQ."""
-    from aiida.manage.manager import get_manager
-    return get_manager().get_communicator()
+    return manager.get_communicator()
 
 
 @pytest.fixture

--- a/tests/engine/daemon/test_runner.py
+++ b/tests/engine/daemon/test_runner.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Unit tests for the :mod:`aiida.engine.daemon.runner` module."""
+import pytest
+
+from aiida.engine.daemon.runner import shutdown_runner
+
+
+@pytest.mark.asyncio
+async def test_shutdown_runner(manager):
+    """Test the ``shutdown_runner`` method."""
+    runner = manager.get_runner()
+    await shutdown_runner(runner)
+
+    try:
+        assert runner.is_closed()
+    finally:
+        # Reset the runner of the manager, because once closed it cannot be reused by other tests.
+        manager._runner = None  # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #4594 

The `shutdown` function, that was attached to the loop of the daemon
runner in `aiida.engine.daemon.runner.start_daemon`, was calling the
classmethods `current_task` and `all_tasks` of `asyncio.Task` which have
been deprecated in Python 3.7 and are removed in Python 3.9. This would
prevent the daemon runners from being shutdown in Python 3.9. The
methods have been replaced with top level functions that can be imported
directl from `asyncio`.

This was not noticed in the tests because in the tests the daemon is
stopped but it is not checked whether this happens successfully. Anyway,
the error would only show up in the daemon log. To test the shutdown
method, it has been made into a standalone coroutine and renamed to
`shutdown_runner`.

Since the `shutdown_runner` is a coroutine, the unit test that calls it
also has to be one and therefore we need `pytest-asyncio` as a
dependency. The `event_loop` fixture, that is provided by this library,
is overrided such that it provides the event loop of the `Manager`,
since in AiiDA only ever this single reentrant loop should be used.

Note that the current CI tests run against Python 3.6 and Python 3.9 and
so will still not catch this problem, however, the `test-install`
workflow _does_ run against Python 3.9. I have opted not to change the
continuous integrations to run against Python 3.9 instead of 3.8, since
they take more than twice the time. Supposedly this is because certain
dependencies have to be built and compiled from scratch when the
testing environment is started.