### PR TITLE
`CalcJob`: improve testing and documentation of `retrieve_list`

### DIFF
--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -32,25 +32,32 @@ class CalcInfo(DefaultFieldsAttributeDict):
 
     In the following descriptions all paths have to be considered relative
 
-    * retrieve_list: a list of strings or tuples that indicate files that are to be retrieved from the remote
-        after the calculation has finished and stored in the repository in a FolderData.
-        If the entry in the list is just a string, it is assumed to be the filepath on the remote and it will
-        be copied to '.' of the repository with name os.path.split(item)[1]
-        If the entry is a tuple it is expected to have the following format
+    * retrieve_list: a list of strings or tuples that indicate files that are to be retrieved from the remote after the
+        calculation has finished and stored in the ``retrieved_folder`` output node of type ``FolderData``. If the entry
+        in the list is just a string, it is assumed to be the filepath on the remote and it will be copied to the base
+        directory of the retrieved folder, where the name corresponds to the basename of the remote relative path. This
+        means that any remote folder hierarchy is ignored entirely.
 
-            ('remotepath', 'localpath', depth)
+        Remote folder hierarchy can be (partially) maintained by using a tuple instead, with the following format
 
-        If the 'remotepath' is a file or folder, it will be copied in the repository to 'localpath'.
-        However, if the 'remotepath' contains file patterns with wildcards, the 'localpath' should be set to '.'
-        and the depth parameter should be an integer that decides the localname. The 'remotepath' will be split on
-        file separators and the local filename will be determined by joining the N last elements, where N is
-        given by the depth variable.
+            (source, target, depth)
 
-        Example: ('some/remote/path/files/pattern*[0-9].xml', '.', 2)
+        The ``source`` and ``target`` elements are relative filepaths in the remote and retrieved folder. The contents
+        of ``source`` (whether it is a file or folder) are copied in its entirety to the ``target`` subdirectory in the
+        retrieved folder. If no subdirectory should be created, ``'.'`` should be specified for ``target``.
 
-        Will result in all files that match the pattern to be copied to the local repository with path
+        The ``source`` filepaths support glob patterns ``*`` in case the exact name of the files that are to be
+        retrieved are not know a priori.
 
-            'files/pattern*[0-9].xml'
+        The ``depth`` element can be used to control what level of nesting of the source folder hierarchy should be
+        maintained. If ``depth`` equals ``0`` or ``1`` (they are equivalent), only the basename of the ``source``
+        filepath is kept. For each additional level, another subdirectory of the remote hierarchy is kept. For example:
+
+            ('path/sub/file.txt', '.', 2)
+
+        will retrieve the ``file.txt`` and store it under the path:
+
+            sub/file.txt
 
     * retrieve_temporary_list: a list of strings or tuples that indicate files that will be retrieved
         and stored temporarily in a FolderData, that will be available only during the parsing call.

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -313,17 +313,18 @@ Note that the source path can point to a directory, in which case its contents w
 Retrieve list
 ~~~~~~~~~~~~~
 The retrieve list is a list of instructions of what files and folders should be retrieved by the engine once a calculation job has terminated.
-An instruction can have one of two forms:
+Each instruction should have one of two formats:
 
     * a string representing a relative filepath in the remote working directory
     * a tuple of length three that allows to control the name of the retrieved file or folder in the retrieved folder
 
-The first method is obviously the most simple, however, this requires one knows the exact name of the file or folder to be retrieved and in addition any subdirectories will be ignored when it is retrieved.
+The retrieve list can contain any number of instructions and can use both formats at the same time.
+The first format is obviously the simplest, however, this requires one knows the exact name of the file or folder to be retrieved and in addition any subdirectories will be ignored when it is retrieved.
 If the exact filename is not known and `glob patterns <https://en.wikipedia.org/wiki/Glob_%28programming%29>`_ should be used, or if the original folder structure should be (partially) kept, one should use the tuple format, which has the following format:
 
-    * `source relative path`: the relative path, with respect to the working directory on the remote, of the file or directory to retrieve
-    * `target relative path`: the relative path where to copy the files locally in the retrieved folder. The string ``'.'`` indicates the top level in the retrieved folder.
-    * `depth`: the number of levels of nesting in the folder hierarchy to maintain when copying, starting from the deepest file
+    * `source relative path`: the relative path, with respect to the working directory on the remote, of the file or directory to retrieve.
+    * `target relative path`: the relative path of the directory in the retrieved folder in to which the content of the source will be copied. The string ``'.'`` indicates the top level in the retrieved folder.
+    * `depth`: the number of levels of nesting in the source path to maintain when copying, starting from the deepest file.
 
 To illustrate the various possibilities, consider the following example file hierarchy in the remote working directory:
 
@@ -467,6 +468,7 @@ The same applies for folders that are to be retrieved:
             ├─ file_c.txt
             └─ file_d.txt
 
+Note that `target` here is not used to rename the retrieved file or folder, but indicates the path of the directory into which the source is copied.
 The target relative path is also compatible with glob patterns in the source relative paths:
 
 .. code:: bash

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -312,38 +312,169 @@ Note that the source path can point to a directory, in which case its contents w
 
 Retrieve list
 ~~~~~~~~~~~~~
-The retrieve list supports various formats to define what files should be retrieved.
-The simplest is retrieving a single file, whose filename you know before hand and you simply want to copy with the same name in the retrieved folder.
-Imagine you want to retrieve the files ``output1.out`` and ``output_folder/output2.out`` you would simply add them as strings to the retrieve list:
+The retrieve list is a list of instructions of what files and folders should be retrieved by the engine once a calculation job has terminated.
+An instruction can have one of two forms:
 
-.. code:: python
+    * a string representing a relative filepath in the remote working directory
+    * a tuple of length three that allows to control the name of the retrieved file or folder in the retrieved folder
 
-    calc_info.retrieve_list = ['output1.out', 'output_folder/output2.out']
-
-The retrieved files will be copied over keeping the exact names and hierarchy.
-If you require more control over the hierarchy and nesting, you can use tuples of length three instead, with the following items:
+The first method is obviously the most simple, however, this requires one knows the exact name of the file or folder to be retrieved and in addition any subdirectories will be ignored when it is retrieved.
+If the exact filename is not known and `glob patterns <https://en.wikipedia.org/wiki/Glob_%28programming%29>`_ should be used, or if the original folder structure should be (partially) kept, one should use the tuple format, which has the following format:
 
     * `source relative path`: the relative path, with respect to the working directory on the remote, of the file or directory to retrieve
-    * `target relative path`: the relative path where to copy the files locally in the retrieved folder. The string `'.'` indicates the top level in the retrieved folder.
+    * `target relative path`: the relative path where to copy the files locally in the retrieved folder. The string ``'.'`` indicates the top level in the retrieved folder.
     * `depth`: the number of levels of nesting in the folder hierarchy to maintain when copying, starting from the deepest file
 
-For example, imagine the calculation will have written a file in the remote working directory with the folder hierarchy ``some/remote/path/files/output.dat``.
-If you want to copy the file, with the final resulting path ``path/files/output.dat``, you would specify:
+To illustrate the various possibilities, consider the following example file hierarchy in the remote working directory:
 
-.. code:: python
+.. code:: bash
 
-    calc_info.retrieve_list = [('some/remote/path/files/output.dat', '.', 2)]
+    ├─ path
+    |  ├── sub
+    │  │   ├─ file_c.txt
+    │  │   └─ file_d.txt
+    |  └─ file_b.txt
+    └─ file_a.txt
 
-The depth of two, ensures that only two levels of nesting are copied.
-If the output files have dynamic names that one cannot know beforehand, the ``'*'`` glob pattern can be used.
-For example, if the code will generate a number of XML files in the folder ``relative/path/output`` with filenames that follow the pattern ``file_*[0-9].xml``, you can instruct to retrieve all of them as follows:
+Below, you will find examples for various use cases of files and folders to be retrieved.
+Each example starts with the format of the ``retrieve_list``, followed by a schematic depiction of the final file hierarchy that would be created in the retrieved folder.
 
-.. code:: python
+Explicit file or folder
+.......................
 
-    calc_info.retrieve_list = [('relative/path/output/file_*[0-9].xml', '.', 1)]
+Retrieving a single toplevel file or folder (with all its contents) where the final folder structure is not important.
 
-The second item when using globbing *has* to be ``'.'`` and the depth works just as before.
-In this example, all files matching the globbing pattern will be copied in the directory ``output`` in the retrieved folder data node.
+.. code:: bash
+
+    retrieve_list = ['file_a.txt']
+
+    └─ file_a.txt
+
+.. code:: bash
+
+    retrieve_list = ['path']
+
+    ├── sub
+    │   ├─ file_c.txt
+    │   └─ file_d.txt
+    └─ file_b.txt
+
+
+Explicit nested file or folder
+..............................
+
+Retrieving a single file or folder (with all its contents) that is located in a subdirectory in the remote working directory, where the final folder structure is not important.
+
+.. code:: bash
+
+    retrieve_list = ['path/file_b.txt']
+
+    └─ file_b.txt
+
+.. code:: bash
+
+    retrieve_list = ['path/sub']
+
+    ├─ file_c.txt
+    └─ file_d.txt
+
+
+Explicit nested file or folder keeping (partial) hierarchy
+..........................................................
+
+The following examples show how the file hierarchy of the retrieved files can be controlled.
+By changing the ``depth`` parameter of the tuple, one can control what part of the remote folder hierarchy is kept.
+In the given example, the maximum depth of the remote folder hierarchy is ``3``.
+The following example shows that by specifying ``3``, the exact folder structure is kept:
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/file_c.txt', '.', 3)]
+
+    └─ path
+        └─ sub
+           └─ file_c.txt
+
+For ``depth=2``, only two levels of nesting are kept (including the file itself) and so the ``path`` folder is discarded.
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/file_c.txt', '.', 2)]
+
+    └─ sub
+       └─ file_c.txt
+
+The same applies for directories.
+By specifying a directory for the first element, all its contents will be retrieved.
+With ``depth=1``, only the first level ``sub`` is kept of the folder hierarchy.
+
+.. code:: bash
+
+    retrieve_list = [('path/sub', '.', 1)]
+
+    └── sub
+        ├─ file_c.txt
+        └─ file_d.txt
+
+
+Pattern matching
+................
+
+If the exact file or folder name is not known beforehand, glob patterns can be used.
+In the following examples, all files that match ``*c.txt`` in the directory ``path/sub`` will be retrieved.
+Since ``depth=0`` the files will be copied without the ``path/sub`` subdirectory.
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/*c.txt', '.', 0)]
+
+    └─ file_c.txt
+
+To keep the subdirectory structure, one can set the depth parameter, just as in the previous examples.
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/*c.txt', '.', 2)]
+
+    └── sub
+        └─ file_c.txt
+
+
+Specific target directory
+.........................
+
+The final folder hierarchy of the retrieved files in the retrieved folder is not only determined by the hierarchy of the remote working directory, but can also be controlled through the second and third elements of the instructions tuples.
+The final ``depth`` element controls what level of hierarchy of the source is maintained, where the second element specifies the base path in the retrieved folder into which the remote files should be retrieved.
+For example, to retrieve a nested file, maintaining the remote hierarchy and storing it locally in the ``target`` directory, one can do the following:
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/file_c.txt', 'target', 3)]
+
+    └─ target
+        └─ path
+            └─ sub
+               └─ file_c.txt
+
+The same applies for folders that are to be retrieved:
+
+.. code:: bash
+
+    retrieve_list = [('path/sub', 'target', 1)]
+
+    └─ target
+        └── sub
+            ├─ file_c.txt
+            └─ file_d.txt
+
+The target relative path is also compatible with glob patterns in the source relative paths:
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/*c.txt', 'target', 0)]
+
+    └─ target
+        └─ file_c.txt
 
 
 Retrieve temporary list

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -7,54 +7,125 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida.engine.daemon.execmanager` module."""
 import io
 import os
+import pathlib
+import typing
+
 import pytest
 
 from aiida.engine.daemon import execmanager
 from aiida.transports.plugins.local import LocalTransport
 
 
+def serialize_file_hierarchy(dirpath: pathlib.Path) -> typing.Dict:
+    """Serialize the file hierarchy at ``dirpath``.
+
+    .. note:: empty directories are ignored.
+
+    :param dirpath: the base path.
+    :return: a mapping representing the file hierarchy, where keys are filenames. The leafs correspond to files and the
+        values are the text contents.
+    """
+    serialized = {}
+
+    for root, _, files in os.walk(dirpath):
+        for filepath in files:
+
+            relpath = pathlib.Path(root).relative_to(dirpath)
+            subdir = serialized
+            if relpath.parts:
+                for part in relpath.parts:
+                    subdir = subdir.setdefault(part, {})
+            subdir[filepath] = (pathlib.Path(root) / filepath).read_text()
+
+    return serialized
+
+
+def create_file_hierarchy(hierarchy: typing.Dict, basepath: pathlib.Path) -> None:
+    """Create the file hierarchy represented by the hierarchy created by ``serialize_file_hierarchy``.
+
+    .. note:: empty directories are ignored and are not created explicitly on disk.
+
+    :param hierarchy: mapping with structure returned by ``serialize_file_hierarchy``.
+    :param basepath: the basepath where to write the hierarchy to disk.
+    """
+    for filename, value in hierarchy.items():
+        if isinstance(value, dict):
+            create_file_hierarchy(value, basepath / filename)
+        else:
+            basepath.mkdir(parents=True, exist_ok=True)
+            (basepath / filename).write_text(value)
+
+
+@pytest.fixture
+def file_hierarchy():
+    """Return a sample nested file hierarchy."""
+    return {
+        'file_a.txt': 'file_a',
+        'path': {
+            'file_b.txt': 'file_b',
+            'sub': {
+                'file_c.txt': 'file_c',
+                'file_d.txt': 'file_d'
+            }
+        }
+    }
+
+
+def test_hierarchy_utility(file_hierarchy, tmp_path):
+    """Test that the ``create_file_hierarchy`` and ``serialize_file_hierarchy`` function as intended.
+
+    This is tested by performing a round-trip.
+    """
+    create_file_hierarchy(file_hierarchy, tmp_path)
+    assert serialize_file_hierarchy(tmp_path) == file_hierarchy
+
+
+# yapf: disable
 @pytest.mark.usefixtures('clear_database_before_test')
-def test_retrieve_files_from_list(tmp_path_factory, generate_calculation_node):
+@pytest.mark.parametrize('retrieve_list, expected_hierarchy', (
+    # Single file or folder, either toplevel or nested
+    (['file_a.txt'], {'file_a.txt': 'file_a'}),
+    (['path/sub/file_c.txt'], {'file_c.txt': 'file_c'}),
+    (['path'], {'path': {'file_b.txt': 'file_b', 'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),
+    (['path/sub'], {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}),
+    # Single nested file that is retrieved keeping a varying level of depth of original hierarchy
+    ([('path/sub/file_c.txt', '.', 3)], {'path': {'sub': {'file_c.txt': 'file_c'}}}),
+    ([('path/sub/file_c.txt', '.', 2)], {'sub': {'file_c.txt': 'file_c'}}),
+    ([('path/sub/file_c.txt', '.', 1)], {'file_c.txt': 'file_c'}),
+    ([('path/sub/file_c.txt', '.', 0)], {'file_c.txt': 'file_c'}),
+    # Single nested folder that is retrieved keeping a varying level of depth of original hierarchy
+    ([('path/sub', '.', 2)], {'path': {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),
+    ([('path/sub', '.', 1)], {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}),
+    # Using globbing patterns
+    ([('path/*', '.', 0)], {'file_b.txt': 'file_b', 'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}),
+    ([('path/sub/*', '.', 0)], {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}),  # This is identical to ['path/sub']
+    ([('path/sub/*c.txt', '.', 2)], {'sub': {'file_c.txt': 'file_c'}}),
+    ([('path/sub/*c.txt', '.', 0)], {'file_c.txt': 'file_c'}),
+    # Different target directory
+    ([('path/sub/file_c.txt', 'target', 3)], {'target': {'path': {'sub': {'file_c.txt': 'file_c'}}}}),
+    ([('path/sub', 'target', 1)], {'target': {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),
+    ([('path/sub/*c.txt', 'target', 2)], {'target': {'sub': {'file_c.txt': 'file_c'}}}),
+))
+# yapf: enable
+def test_retrieve_files_from_list(
+    tmp_path_factory, generate_calculation_node, file_hierarchy, retrieve_list, expected_hierarchy
+):
     """Test the `retrieve_files_from_list` function."""
-    node = generate_calculation_node()
-
-    retrieve_list = [
-        'file_a.txt',
-        ('sub/folder', 'sub/folder', 0),
-    ]
-
     source = tmp_path_factory.mktemp('source')
     target = tmp_path_factory.mktemp('target')
 
-    content_a = b'content_a'
-    content_b = b'content_b'
-
-    with open(str(source / 'file_a.txt'), 'wb') as handle:
-        handle.write(content_a)
-        handle.flush()
-
-    os.makedirs(str(source / 'sub' / 'folder'))
-
-    with open(str(source / 'sub' / 'folder' / 'file_b.txt'), 'wb') as handle:
-        handle.write(content_b)
-        handle.flush()
+    create_file_hierarchy(file_hierarchy, source)
 
     with LocalTransport() as transport:
-        transport.chdir(str(source))
-        execmanager.retrieve_files_from_list(node, transport, str(target), retrieve_list)
+        node = generate_calculation_node()
+        transport.chdir(source)
+        execmanager.retrieve_files_from_list(node, transport, target, retrieve_list)
 
-    assert sorted(os.listdir(str(target))) == sorted(['file_a.txt', 'sub'])
-    assert os.listdir(str(target / 'sub')) == ['folder']
-    assert os.listdir(str(target / 'sub' / 'folder')) == ['file_b.txt']
-
-    with open(str(target / 'sub' / 'folder' / 'file_b.txt'), 'rb') as handle:
-        assert handle.read() == content_b
-
-    with open(str(target / 'file_a.txt'), 'rb') as handle:
-        assert handle.read() == content_a
+    assert serialize_file_hierarchy(target) == expected_hierarchy
 
 
 @pytest.mark.usefixtures('clear_database_before_test')

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -109,6 +109,8 @@ def test_hierarchy_utility(file_hierarchy, tmp_path):
     ([('path/sub/file_c.txt', 'target', 3)], {'target': {'path': {'sub': {'file_c.txt': 'file_c'}}}}),
     ([('path/sub', 'target', 1)], {'target': {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),
     ([('path/sub/*c.txt', 'target', 2)], {'target': {'sub': {'file_c.txt': 'file_c'}}}),
+    # Missing files should be ignored and not cause the retrieval to except
+    (['file_a.txt', 'file_u.txt', 'path/file_u.txt', ('path/sub/file_u.txt', '.', 3)], {'file_a.txt': 'file_a'}),
 ))
 # yapf: enable
 def test_retrieve_files_from_list(


### PR DESCRIPTION
Fixes #4609 

The documentation on the `retrieve_list` syntax and its functioning was
incorrect. The inaccuracies are corrected and extensive examples are
provided that give an example file hierarchy for the remote working
directory and then for a variety of definitions of the `retrieve_list`
the resulting file structure in the retrieved folder is depicted.