### PR TITLE
CI: manually install `numpy==1.19.4` to prevent release candidate

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -92,6 +92,7 @@ jobs:
 
     - name: Install aiida-core
       run: |
+        pip install numpy==1.19.4
         pip install --use-feature=2020-resolver -r requirements/requirements-py-${{ matrix.python-version }}.txt
         pip install --use-feature=2020-resolver --no-deps -e .
         reentry scan

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -155,6 +155,12 @@ jobs:
         sudo apt install postgresql-10 graphviz
 
     - run: pip install --upgrade pip
+    # Work-around issue caused by pymatgen's setup process, which will install the latest
+    # numpy version (including release candidates) regardless of our actual specification:
+    - name: Install numpy [py36]
+      if: matrix.python-version == 3.6
+      run: |
+        pip install `grep 'numpy==' requirements/requirements-py-${{ matrix.python-version }}.txt`
 
     - name: Install aiida-core
       run: |


### PR DESCRIPTION
Fixes #4614 

This is the usual problem that occurs when `numpy` releases a candidate
release. Even though we specify limits to not install this, `pymatgen`
installs it as a dependency in their build process where limits are
ignored and so the latest release gets installed. In this case
`numpy==1.20.0rc1` is getting installed and that dropped support for
Python 3.6 and so our builds on that version brick.

The workaround is to manually install the compatible version, in this
case `numpy==1.19.4` before installing `aiida-core`. This way `pymatgen`
will simply use that in their build process.