### PR TITLE
Engine: remote `with_persistence=False` from process function runner

### DIFF
--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -113,7 +113,7 @@ def process_function(node_class):
             :rtype: (dict, int)
             """
             manager = get_manager()
-            runner = manager.get_runner(with_persistence=False)
+            runner = manager.get_runner()
             inputs = process_class.create_inputs(*args, **kwargs)
 
             # Remove all the known inputs from the kwargs


### PR DESCRIPTION
Fixes #4632 

In principle the runner for a process function does not need a persister
since it runs in one go and does not have intermediate steps at which
the progress needs to be persisted. However, since the process function
implementation calls `Manager.get_runner`, if a runner has not yet been
created in the interpreter, one will be created and set to be the global
one. This is where the problem occurs because the process function
specifies `with_persistence=False` for the runner. This will cause any
subsequent process submissions to fail since the `submit` function will
call `runner.persister.save_checkpoint` which will fail since the
`persister` of the runner is `None`.