### PR TITLE
`RemoteData`: deprecate automatic opening of a transport

### DIFF
--- a/aiida/orm/nodes/data/remote.py
+++ b/aiida/orm/nodes/data/remote.py
@@ -9,7 +9,9 @@
 ###########################################################################
 """Data plugin that models a folder on a remote computer."""
 import os
+import warnings
 
+from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.orm import AuthInfo
 from .data import Data
 
@@ -42,13 +44,17 @@ class RemoteData(Data):
     def set_remote_path(self, val):
         self.set_attribute('remote_path', val)
 
-    @property
-    def is_empty(self):
+    def is_empty(self, transport=None):
         """
         Check if remote folder is empty
+
+        :param transport: optional transport to use, if not specified one will be opened. From `v3.0.0` this argument
+            will be required.
         """
-        authinfo = self.get_authinfo()
-        transport = authinfo.get_transport()
+        if transport is None:
+            warnings.warn('`transport` is `None`, this will start to raise in `v3.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
+            authinfo = self.get_authinfo()
+            transport = authinfo.get_transport()
 
         with transport:
             try:
@@ -59,16 +65,21 @@ class RemoteData(Data):
 
             return not transport.listdir()
 
-    def getfile(self, relpath, destpath):
+    def getfile(self, relpath, destpath, transport=None):
         """
         Connects to the remote folder and retrieves the content of a file.
 
         :param relpath:  The relative path of the file on the remote to retrieve.
         :param destpath: The absolute path of where to store the file on the local machine.
+        :param transport: optional transport to use, if not specified one will be opened. From `v3.0.0` this argument
+            will be required.
         """
-        authinfo = self.get_authinfo()
+        if transport is None:
+            warnings.warn('`transport` is `None`, this will start to raise in `v3.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
+            authinfo = self.get_authinfo()
+            transport = authinfo.get_transport()
 
-        with authinfo.get_transport() as transport:
+        with transport:
             try:
                 full_path = os.path.join(self.get_remote_path(), relpath)
                 transport.getfile(full_path, destpath)
@@ -79,30 +90,33 @@ class RemoteData(Data):
                             full_path,
                             self.computer.label  # pylint: disable=no-member
                         )
-                    )
+                    ) from exception
                 raise
 
-    def listdir(self, relpath='.'):
+    def listdir(self, relpath='.', transport=None):
         """
         Connects to the remote folder and lists the directory content.
 
         :param relpath: If 'relpath' is specified, lists the content of the given subfolder.
+        :param transport: optional transport to use, if not specified one will be opened. From `v3.0.0` this argument
+            will be required.
         :return: a flat list of file/directory names (as strings).
         """
-        authinfo = self.get_authinfo()
+        if transport is None:
+            warnings.warn('`transport` is `None`, this will start to raise in `v3.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
+            authinfo = self.get_authinfo()
+            transport = authinfo.get_transport()
 
-        with authinfo.get_transport() as transport:
+        with transport:
             try:
                 full_path = os.path.join(self.get_remote_path(), relpath)
                 transport.chdir(full_path)
             except IOError as exception:
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
-                    exc = IOError(
-                        'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
-                        format(full_path, self.computer.label)  # pylint: disable=no-member
-                    )
-                    exc.errno = exception.errno
-                    raise exc
+                    raise IOError(
+                        f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
+                        'directory or has been deleted.'
+                    ) from exception
                 else:
                     raise
 
@@ -110,36 +124,37 @@ class RemoteData(Data):
                 return transport.listdir()
             except IOError as exception:
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
-                    exc = IOError(
+                    raise IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
                         format(full_path, self.computer.label)  # pylint: disable=no-member
-                    )
-                    exc.errno = exception.errno
-                    raise exc
+                    ) from exception
                 else:
                     raise
 
-    def listdir_withattributes(self, path='.'):
+    def listdir_withattributes(self, path='.', transport=None):
         """
         Connects to the remote folder and lists the directory content.
 
         :param relpath: If 'relpath' is specified, lists the content of the given subfolder.
+        :param transport: optional transport to use, if not specified one will be opened. From `v3.0.0` this argument
+            will be required.
         :return: a list of dictionaries, where the documentation is in :py:class:Transport.listdir_withattributes.
         """
-        authinfo = self.get_authinfo()
+        if transport is None:
+            warnings.warn('`transport` is `None`, this will start to raise in `v3.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
+            authinfo = self.get_authinfo()
+            transport = authinfo.get_transport()
 
-        with authinfo.get_transport() as transport:
+        with transport:
             try:
                 full_path = os.path.join(self.get_remote_path(), path)
                 transport.chdir(full_path)
             except IOError as exception:
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
-                    exc = IOError(
+                    raise IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
                         format(full_path, self.computer.label)  # pylint: disable=no-member
-                    )
-                    exc.errno = exception.errno
-                    raise exc
+                    ) from exception
                 else:
                     raise
 
@@ -147,23 +162,27 @@ class RemoteData(Data):
                 return transport.listdir_withattributes()
             except IOError as exception:
                 if exception.errno == 2 or exception.errno == 20:  # directory not existing or not a directory
-                    exc = IOError(
+                    raise IOError(
                         'The required remote folder {} on {} does not exist, is not a directory or has been deleted.'.
                         format(full_path, self.computer.label)  # pylint: disable=no-member
-                    )
-                    exc.errno = exception.errno
-                    raise exc
+                    ) from exception
                 else:
                     raise
 
-    def _clean(self):
+    def _clean(self, transport=None):
         """
         Remove all content of the remote folder on the remote computer
+
+        :param transport: optional transport to use, if not specified one will be opened. From `v3.0.0` this argument
+            will be required.
         """
         from aiida.orm.utils.remote import clean_remote
 
-        authinfo = self.get_authinfo()
-        transport = authinfo.get_transport()
+        if transport is None:
+            warnings.warn('`transport` is `None`, this will start to raise in `v3.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
+            authinfo = self.get_authinfo()
+            transport = authinfo.get_transport()
+
         remote_dir = self.get_remote_path()
 
         with transport:
@@ -176,12 +195,18 @@ class RemoteData(Data):
 
         try:
             self.get_remote_path()
-        except AttributeError:
-            raise ValidationError("attribute 'remote_path' not set.")
+        except AttributeError as exception:
+            raise ValidationError("attribute 'remote_path' not set.") from exception
 
         computer = self.computer
         if computer is None:
             raise ValidationError('Remote computer not set.')
 
     def get_authinfo(self):
+        """Return the ``AuthInfo`` for the computer and user of this node.
+
+        .. deprecated:: 1.6.0
+            Will be removed in v3.0.0
+        """
+        warnings.warn('this method is deprecated and will be removed in `v3.0.0`', AiidaDeprecationWarning)  # pylint: disable=no-member
         return AuthInfo.objects.get(dbcomputer=self.computer, aiidauser=self.user)


### PR DESCRIPTION
Fixes #4636 

The methods of the `RemoteData` class that require a transport now, for
convenience, automatically open that transport for the caller. However,
in a high-throughput context this is not scalable as each call opening
its own transport will incur too many opened connections to the target
machine.

Instead, a single transport should be opened that is then passed to the
method calls. All affected methods now have an argument `transport` that
allows to pass a transport in. If it is not passed a deprecation warning
is emitted as this usage will raise in the future as the argument will
be made required.

Note that there is one backwards-incompatible change. The `is_empty`
property had to be changed into a method in order for it to take the
transport as argument. It is not clear whether there is a scheme in
which a property can be transformed into a method in a backwards
compatible way through a deprecation pathway.