### PR TITLE
CLI: ensure `verdi database version` works even if schema outdated

### DIFF
--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -31,7 +31,9 @@ def database_version():
     """
     from aiida.manage.manager import get_manager
 
-    backend_manager = get_manager().get_backend_manager()
+    manager = get_manager()
+    manager._load_backend(schema_check=False)  # pylint: disable=protected-access
+    backend_manager = manager.get_backend_manager()
 
     echo.echo('Generation: ', bold=True, nl=False)
     echo.echo(backend_manager.get_schema_generation_database())


### PR DESCRIPTION
Fixes #4640 

The command was failing if the database schema was out of sync because
the backend was loaded, through `get_manager`, with the default schema
check on. Since the database does not actually have to be used, other
than to retrieve the current schema version and generation, we can load
the backend without the check.