### PR TITLE
Dependencies: update requirement `plumpy~=0.18.1`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
 - numpy~=1.17
 - pamqp~=2.3
 - paramiko~=2.7
-- plumpy~=0.18.0
+- plumpy~=0.18.1
 - pgsu~=0.1.0
 - psutil~=5.6
 - psycopg2>=2.8.3,~=2.8

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -86,7 +86,7 @@ pgsu==0.1.0
 pgtest==1.3.2
 pickleshare==0.7.5
 pluggy==0.13.1
-plumpy==0.18.0
+plumpy==0.18.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -85,7 +85,7 @@ pgsu==0.1.0
 pgtest==1.3.2
 pickleshare==0.7.5
 pluggy==0.13.1
-plumpy==0.18.0
+plumpy==0.18.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -80,7 +80,7 @@ pgsu==0.1.0
 pgtest==1.3.2
 pickleshare==0.7.5
 pluggy==0.13.1
-plumpy==0.18.0
+plumpy==0.18.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.4
 psutil==5.7.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -81,7 +81,7 @@ pika==1.1.0
 Pillow==8.0.1
 plotly==4.12.0
 pluggy==0.13.1
-plumpy==0.18.0
+plumpy==0.18.1
 prometheus-client==0.8.0
 prompt-toolkit==3.0.8
 psutil==5.7.3

--- a/setup.json
+++ b/setup.json
@@ -40,7 +40,7 @@
         "numpy~=1.17",
         "pamqp~=2.3",
         "paramiko~=2.7",
-        "plumpy~=0.18.0",
+        "plumpy~=0.18.1",
         "pgsu~=0.1.0",
         "psutil~=5.6",
         "psycopg2-binary~=2.8,>=2.8.3",


### PR DESCRIPTION
Fixes #4635 

This patch release of `plumpy` fixes a critical bug that makes the new
`asyncio` based implementation of the engine compatible with Jupyter
notebooks.