### PR TITLE
cli: notify users of runner usage

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -54,6 +54,7 @@ def process_list(
     # pylint: disable=too-many-locals
     from tabulate import tabulate
     from aiida.cmdline.utils.common import print_last_process_state_change, check_worker_load
+    from aiida.engine.daemon.client import get_daemon_client
 
     relationships = {}
 
@@ -77,15 +78,19 @@ def process_list(
         echo.echo(tabulated)
         echo.echo(f'\nTotal results: {len(projected)}\n')
         print_last_process_state_change()
-        # Second query to get active process count
-        # Currently this is slow but will be fixed wiith issue #2770
-        # We place it at the end so that the user can Ctrl+C after getting the process table.
-        builder = CalculationQueryBuilder()
-        filters = builder.get_filters(process_state=('created', 'waiting', 'running'))
-        query_set = builder.get_query_set(filters=filters)
-        projected = builder.get_projected(query_set, projections=['pk'])
-        worker_slot_use = len(projected) - 1
-        check_worker_load(worker_slot_use)
+
+        if not get_daemon_client().is_daemon_running:
+            echo.echo_warning('the daemon is not running', bold=True)
+        else:
+            # Second query to get active process count
+            # Currently this is slow but will be fixed with issue #2770
+            # We place it at the end so that the user can Ctrl+C after getting the process table.
+            builder = CalculationQueryBuilder()
+            filters = builder.get_filters(process_state=('created', 'waiting', 'running'))
+            query_set = builder.get_query_set(filters=filters)
+            projected = builder.get_projected(query_set, projections=['pk'])
+            worker_slot_use = len(projected) - 1
+            check_worker_load(worker_slot_use)
 
 
 @verdi_process.command('show')

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -49,18 +49,14 @@ def format_local_time(timestamp, format_str='%Y-%m-%d %H:%M:%S'):
 def print_last_process_state_change(process_type=None):
     """
     Print the last time that a process of the specified type has changed its state.
-    This function will also print a warning if the daemon is not running.
 
     :param process_type: optional process type for which to get the latest state change timestamp.
         Valid process types are either 'calculation' or 'work'.
     """
-    from aiida.cmdline.utils.echo import echo_info, echo_warning
+    from aiida.cmdline.utils.echo import echo_info
     from aiida.common import timezone
     from aiida.common.utils import str_timedelta
-    from aiida.engine.daemon.client import get_daemon_client
     from aiida.engine.utils import get_process_state_change_timestamp
-
-    client = get_daemon_client()
 
     timestamp = get_process_state_change_timestamp(process_type)
 
@@ -71,9 +67,6 @@ def print_last_process_state_change(process_type=None):
         formatted = format_local_time(timestamp, format_str='at %H:%M:%S on %Y-%m-%d')
         relative = str_timedelta(timedelta, negative_to_zero=True, max_num_fields=1)
         echo_info(f'last time an entry changed state: {relative} ({formatted})')
-
-    if not client.is_daemon_running:
-        echo_warning('the daemon is not running', bold=True)
 
 
 def get_node_summary(node):
@@ -476,8 +469,8 @@ def get_num_workers():
                 raise CircusCallError
         try:
             return response['numprocesses']
-        except KeyError:
-            raise CircusCallError('Circus did not return the number of daemon processes')
+        except KeyError as exc:
+            raise CircusCallError('Circus did not return the number of daemon processes') from exc
 
 
 def check_worker_load(active_slots):
@@ -511,3 +504,7 @@ def check_worker_load(active_slots):
             echo.echo('')  # New line
             echo.echo_warning(f'{percent_load * 100:.0f}% of the available daemon worker slots have been used!')
             echo.echo_warning("Increase the number of workers with 'verdi daemon incr'.\n")
+        else:
+            echo.echo_info(f'Using {percent_load * 100:.0f}% of the available daemon worker slots')
+    else:
+        echo.echo_info('No active daemon workers')

--- a/aiida/engine/__init__.py
+++ b/aiida/engine/__init__.py
@@ -14,6 +14,7 @@
 # yapf: disable
 # pylint: disable=wildcard-import
 
+from .daemon import *
 from .exceptions import *
 from .launch import *
 from .persistence import *
@@ -30,6 +31,7 @@ __all__ = (
     'CalcJob',
     'CalcJobOutputPort',
     'CalcJobProcessSpec',
+    'DaemonClient',
     'ExitCode',
     'ExitCodesNamespace',
     'FunctionProcess',

--- a/aiida/engine/daemon/__init__.py
+++ b/aiida/engine/daemon/__init__.py
@@ -7,3 +7,17 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Module with resources for the daemon."""
+
+# AUTO-GENERATED
+
+# yapf: disable
+# pylint: disable=wildcard-import
+
+from .client import *
+
+__all__ = (
+    'DaemonClient',
+)
+
+# yapf: enable

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -7,10 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Controls the daemon
-"""
-
+"""Client to interact with the daemon."""
 import enum
 import os
 import shutil
@@ -30,6 +27,8 @@ VIRTUALENV = os.environ.get('VIRTUAL_ENV', None)
 
 # see https://github.com/python/typing/issues/182
 JsonDictType = Dict[str, Any]
+
+__all__ = ('DaemonClient',)
 
 
 class ControllerProtocol(enum.Enum):


### PR DESCRIPTION
The extra query performed in `verdi process list` to get the load on the
daemon runners is slow - and usually results in no output for the user.
This PR at least lets the user know what is being queried (which also may be useful
to monitor runner load).