### PR TITLE
Feat: Improve error message for unconfigured computers

### DIFF
--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -600,7 +600,15 @@ class Computer(entities.Entity):
         """
         from . import authinfos
 
-        return authinfos.AuthInfo.objects(self.backend).get(dbcomputer_id=self.id, aiidauser_id=user.id)
+        try:
+            authinfo = authinfos.AuthInfo.objects(self.backend).get(dbcomputer_id=self.id, aiidauser_id=user.id)
+        except exceptions.NotExistent:
+            raise exceptions.NotExistent(
+                f'Computer `{self.label}` (ID={self.id}) not configured for user `{user.get_short_name()}` '
+                f'(ID={user.id}) - use `verdi computer configure ` first'
+            )
+
+        return authinfo
 
     def is_user_configured(self, user):
         """

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -602,11 +602,11 @@ class Computer(entities.Entity):
 
         try:
             authinfo = authinfos.AuthInfo.objects(self.backend).get(dbcomputer_id=self.id, aiidauser_id=user.id)
-        except exceptions.NotExistent:
+        except exceptions.NotExistent as exc:
             raise exceptions.NotExistent(
                 f'Computer `{self.label}` (ID={self.id}) not configured for user `{user.get_short_name()}` '
-                f'(ID={user.id}) - use `verdi computer configure ` first'
-            )
+                f'(ID={user.id}) - use `verdi computer configure` first'
+            ) from exc
 
         return authinfo
 

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -103,3 +103,19 @@ class TestComputerConfigure(AiidaTestCase):
 
         with self.assertRaises(ValueError):
             comp.configure(username='radames', invalid_auth_param='TEST')
+
+    def test_non_configure_error(self):
+        """Configure a computer for local transport and check it is configured."""
+        self.comp_builder.label = 'test_non_configure_error'
+        self.comp_builder.transport = 'local'
+        comp = self.comp_builder.new()
+        comp.store()
+
+        with self.assertRaises(exceptions.NotExistent) as exc:
+            comp.get_authinfo(self.user)
+
+        self.assertIn(str(comp.id), str(exc.exception))
+        self.assertIn(comp.label, str(exc.exception))
+        self.assertIn(self.user.get_short_name(), str(exc.exception))
+        self.assertIn(str(self.user.id), str(exc.exception))
+        self.assertIn('verdi computer configure', str(exc.exception))


### PR DESCRIPTION
Fixes #4645

I added a check to the `get_authinfo` method of the computer class that improves on the error raised by the call to `authinfos.AuthInfo.objects(...).get(...)` when a (computer, user) couple is not found for the requested case. Also added a test that checks for the correct error raised, and also that the critical pieces of information are present in the error message.