### PR TITLE
`Docs`: Add redirect for database backup page

### DIFF
--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -21,6 +21,7 @@ datatypes/index.rst topics/data_types.rst
 datatypes/functionality.rst topics/data_types.rst
 datatypes/kpoints.rst topics/data_types.rst
 datatypes/bands.rst topics/data_types.rst
+backup/index.rst howto/installation.rst
 
 # fix https://www.materialscloud.org/dmp
 apidoc/aiida.orm.rst reference/apidoc/aiida.orm.rst


### PR DESCRIPTION
Fixes #4674 

Adds a redirect from the old database backup page to the "How to manage your installation" page in the revamped docs.