### PR TITLE
Fix: pre-store hash for -0. and 0. is now the same

### DIFF
--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -288,5 +288,7 @@ def float_to_text(value, sig):
     :param value: the float value to convert
     :param sig: choose how many digits after the comma should be output
     """
+    if value == 0:
+        value = 0.  # Identify value of -0. and overwrite with 0.
     fmt = f'{{:.{sig}g}}'
     return fmt.format(value)

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -36,6 +36,7 @@ class FloatToTextTest(unittest.TestCase):
     """
 
     def test_subnormal(self):
+        self.assertEqual(float_to_text(-0.00, sig=2), '0')  # 0 is always printed as '0'
         self.assertEqual(float_to_text(3.555, sig=2), '3.6')
         self.assertEqual(float_to_text(3.555, sig=3), '3.56')
         self.assertEqual(float_to_text(3.141592653589793238462643383279502884197, sig=14), '3.1415926535898')


### PR DESCRIPTION
Fixes #4610

The `-0.` is converted to `0.` in the process of storing the node in the DB, but this was not being considered by the `aiida/common/hashing.py : make_hash` method. This led to `aiida/orm/nodes/node.py : _get_hash` would return a different hash for unstored and stored `Float` nodes with content `-0.`