### PR TITLE
remove leftover use of Computer.name

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -338,7 +338,7 @@ def computer_disable(computer, user):
 
 @verdi_computer.command('list')
 @options.ALL(help='Show also disabled or unconfigured computers.')
-@options.RAW(help='Show only the computer names, one per line.')
+@options.RAW(help='Show only the computer labels, one per line.')
 @with_dbenv()
 def computer_list(all_entries, raw):
     """List all available computers."""
@@ -346,7 +346,7 @@ def computer_list(all_entries, raw):
 
     if not raw:
         echo.echo_info('List of configured computers')
-        echo.echo_info("Use 'verdi computer show COMPUTERNAME' to display more detailed information")
+        echo.echo_info("Use 'verdi computer show COMPUTERLABEL' to display more detailed information")
 
     computers = Computer.objects.all()
     user = User.objects.get_default()
@@ -357,7 +357,7 @@ def computer_list(all_entries, raw):
     sort = lambda computer: computer.label
     highlight = lambda comp: comp.is_user_configured(user) and comp.is_user_enabled(user)
     hide = lambda comp: not (comp.is_user_configured(user) and comp.is_user_enabled(user)) and not all_entries
-    echo.echo_formatted_list(computers, ['name'], sort=sort, highlight=highlight, hide=hide)
+    echo.echo_formatted_list(computers, ['label'], sort=sort, highlight=highlight, hide=hide)
 
 
 @verdi_computer.command('show')

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -323,9 +323,11 @@ Below is a list with all available subcommands.
                                       .aiida extension for these HTTP addresses. Automatically
                                       discovered archive URLs will be downloaded and added to
                                       ARCHIVES for importing
+
       -G, --group GROUP               Specify group to which all the import nodes will be
                                       added. If such a group does not exist, it will be
                                       created automatically.
+
       -e, --extras-mode-existing [keep_existing|update_existing|mirror|none|ask]
                                       Specify which extras from the export archive should be
                                       imported for nodes that are already contained in the
@@ -336,20 +338,25 @@ Below is a list with all available subcommands.
                                       of existing extras. mirror: import all extras and remove
                                       any existing extras that are not present in the archive.
                                       none: do not import any extras.
+
       -n, --extras-mode-new [import|none]
                                       Specify whether to import extras of new nodes: import:
                                       import extras. none: do not import extras.
+
       --comment-mode [newest|overwrite]
                                       Specify the way to import Comments with identical UUIDs:
                                       newest: Only the newest Comments (based on mtime)
                                       (default).overwrite: Replace existing Comments with
                                       those from the import file.
+
       --migration / --no-migration    Force migration of archive file archives, if needed.
                                       [default: True]
+
       -v, --verbosity [DEBUG|INFO|WARNING|CRITICAL]
                                       Control the verbosity of console logging
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
+
       --help                          Show this message and exit.
 
 
@@ -460,10 +467,12 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
+
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you generate. The
                                       email address is exported along with the data, when
                                       sharing it.  [required]
+
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
@@ -473,28 +482,34 @@ Below is a list with all available subcommands.
                                       Database backend to use.
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
                                       authentication.
+
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.
       --db-username NONEMPTYSTRING    Name of the database user to create.
       --db-password TEXT              Password of the database user.
       --su-db-name TEXT               Name of the template database to connect to as the
                                       database superuser.
+
       --su-db-username TEXT           User name of the database super user.
       --su-db-password TEXT           Password to connect as the database superuser.
       --broker-protocol [amqp|amqps]  Protocol to use for the message broker.  [default: amqp]
       --broker-username NONEMPTYSTRING
                                       Username to use for authentication with the message
                                       broker.  [default: guest]
+
       --broker-password NONEMPTYSTRING
                                       Password to use for authentication with the message
                                       broker.  [default: guest]
+
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.  [default: ]
+
       --repository DIRECTORY          Absolute path to the file repository.
       --config FILEORURL              Load option values from configuration file in yaml
                                       format (local path or URL).
+
       --help                          Show this message and exit.
 
 
@@ -515,6 +530,7 @@ Below is a list with all available subcommands.
     Options:
       -e, --entry-point PLUGIN  Only include nodes that are class or sub class of the class
                                 identified by this entry point.
+
       -f, --force               Do not ask for confirmation.
       --help                    Show this message and exit.
 
@@ -540,6 +556,7 @@ Below is a list with all available subcommands.
       -c, --config-dir PATH    Path to the configuration directory
       --wsgi-profile           Whether to enable WSGI profiler middleware for finding
                                bottlenecks
+
       --hookup / --no-hookup   Hookup app to flask server
       --help                   Show this message and exit.
 
@@ -561,13 +578,17 @@ Below is a list with all available subcommands.
                                       Specify the prefix of the label of the auto group
                                       (numbers might be automatically appended to generate
                                       unique names per run).
+
       -n, --group-name TEXT           Specify the name of the auto group [DEPRECATED, USE
                                       --auto-group-label-prefix instead]. This also enables
                                       auto-grouping.
+
       -e, --exclude TEXT              Exclude these classes from auto grouping (use full
                                       entrypoint strings).
+
       -i, --include TEXT              Include these classes from auto grouping  (use full
                                       entrypoint strings or "all").
+
       --help                          Show this message and exit.
 
 
@@ -585,10 +606,12 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
+
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you generate. The
                                       email address is exported along with the data, when
                                       sharing it.  [required]
+
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
@@ -598,26 +621,33 @@ Below is a list with all available subcommands.
                                       Database backend to use.
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
                                       authentication.
+
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.  [required]
       --db-username NONEMPTYSTRING    Name of the database user to create.  [required]
       --db-password TEXT              Password of the database user.  [required]
       --broker-protocol [amqp|amqps]  Protocol to use for the message broker.  [default: amqp;
                                       required]
+
       --broker-username NONEMPTYSTRING
                                       Username to use for authentication with the message
                                       broker.  [default: guest; required]
+
       --broker-password NONEMPTYSTRING
                                       Password to use for authentication with the message
                                       broker.  [default: guest; required]
+
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1;
                                       required]
+
       --broker-port INTEGER           Port for the message broker.  [default: 5672; required]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.  [default: ; required]
+
       --repository DIRECTORY          Absolute path to the file repository.
       --config FILEORURL              Load option values from configuration file in yaml
                                       format (local path or URL).
+
       --help                          Show this message and exit.
 
 
@@ -636,6 +666,7 @@ Below is a list with all available subcommands.
       --plain                         Use a plain Python shell.
       --no-startup                    When using plain Python, ignore the PYTHONSTARTUP
                                       environment variable and ~/.pythonrc.py script.
+
       -i, --interface [ipython|bpython]
                                       Specify an interactive interpreter interface.
       --help                          Show this message and exit.

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -323,11 +323,9 @@ Below is a list with all available subcommands.
                                       .aiida extension for these HTTP addresses. Automatically
                                       discovered archive URLs will be downloaded and added to
                                       ARCHIVES for importing
-
       -G, --group GROUP               Specify group to which all the import nodes will be
                                       added. If such a group does not exist, it will be
                                       created automatically.
-
       -e, --extras-mode-existing [keep_existing|update_existing|mirror|none|ask]
                                       Specify which extras from the export archive should be
                                       imported for nodes that are already contained in the
@@ -338,25 +336,20 @@ Below is a list with all available subcommands.
                                       of existing extras. mirror: import all extras and remove
                                       any existing extras that are not present in the archive.
                                       none: do not import any extras.
-
       -n, --extras-mode-new [import|none]
                                       Specify whether to import extras of new nodes: import:
                                       import extras. none: do not import extras.
-
       --comment-mode [newest|overwrite]
                                       Specify the way to import Comments with identical UUIDs:
                                       newest: Only the newest Comments (based on mtime)
                                       (default).overwrite: Replace existing Comments with
                                       those from the import file.
-
       --migration / --no-migration    Force migration of archive file archives, if needed.
                                       [default: True]
-
       -v, --verbosity [DEBUG|INFO|WARNING|CRITICAL]
                                       Control the verbosity of console logging
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
-
       --help                          Show this message and exit.
 
 
@@ -467,12 +460,10 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
-
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you generate. The
                                       email address is exported along with the data, when
                                       sharing it.  [required]
-
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
@@ -482,34 +473,28 @@ Below is a list with all available subcommands.
                                       Database backend to use.
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
                                       authentication.
-
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.
       --db-username NONEMPTYSTRING    Name of the database user to create.
       --db-password TEXT              Password of the database user.
       --su-db-name TEXT               Name of the template database to connect to as the
                                       database superuser.
-
       --su-db-username TEXT           User name of the database super user.
       --su-db-password TEXT           Password to connect as the database superuser.
       --broker-protocol [amqp|amqps]  Protocol to use for the message broker.  [default: amqp]
       --broker-username NONEMPTYSTRING
                                       Username to use for authentication with the message
                                       broker.  [default: guest]
-
       --broker-password NONEMPTYSTRING
                                       Password to use for authentication with the message
                                       broker.  [default: guest]
-
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.  [default: ]
-
       --repository DIRECTORY          Absolute path to the file repository.
       --config FILEORURL              Load option values from configuration file in yaml
                                       format (local path or URL).
-
       --help                          Show this message and exit.
 
 
@@ -530,7 +515,6 @@ Below is a list with all available subcommands.
     Options:
       -e, --entry-point PLUGIN  Only include nodes that are class or sub class of the class
                                 identified by this entry point.
-
       -f, --force               Do not ask for confirmation.
       --help                    Show this message and exit.
 
@@ -556,7 +540,6 @@ Below is a list with all available subcommands.
       -c, --config-dir PATH    Path to the configuration directory
       --wsgi-profile           Whether to enable WSGI profiler middleware for finding
                                bottlenecks
-
       --hookup / --no-hookup   Hookup app to flask server
       --help                   Show this message and exit.
 
@@ -578,17 +561,13 @@ Below is a list with all available subcommands.
                                       Specify the prefix of the label of the auto group
                                       (numbers might be automatically appended to generate
                                       unique names per run).
-
       -n, --group-name TEXT           Specify the name of the auto group [DEPRECATED, USE
                                       --auto-group-label-prefix instead]. This also enables
                                       auto-grouping.
-
       -e, --exclude TEXT              Exclude these classes from auto grouping (use full
                                       entrypoint strings).
-
       -i, --include TEXT              Include these classes from auto grouping  (use full
                                       entrypoint strings or "all").
-
       --help                          Show this message and exit.
 
 
@@ -606,12 +585,10 @@ Below is a list with all available subcommands.
     Options:
       -n, --non-interactive           In non-interactive mode, the CLI never prompts but
                                       simply uses default values for options that define one.
-
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you generate. The
                                       email address is exported along with the data, when
                                       sharing it.  [required]
-
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
@@ -621,33 +598,26 @@ Below is a list with all available subcommands.
                                       Database backend to use.
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
                                       authentication.
-
       --db-port INTEGER               Database server port.
       --db-name NONEMPTYSTRING        Name of the database to create.  [required]
       --db-username NONEMPTYSTRING    Name of the database user to create.  [required]
       --db-password TEXT              Password of the database user.  [required]
       --broker-protocol [amqp|amqps]  Protocol to use for the message broker.  [default: amqp;
                                       required]
-
       --broker-username NONEMPTYSTRING
                                       Username to use for authentication with the message
                                       broker.  [default: guest; required]
-
       --broker-password NONEMPTYSTRING
                                       Password to use for authentication with the message
                                       broker.  [default: guest; required]
-
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1;
                                       required]
-
       --broker-port INTEGER           Port for the message broker.  [default: 5672; required]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.  [default: ; required]
-
       --repository DIRECTORY          Absolute path to the file repository.
       --config FILEORURL              Load option values from configuration file in yaml
                                       format (local path or URL).
-
       --help                          Show this message and exit.
 
 
@@ -666,7 +636,6 @@ Below is a list with all available subcommands.
       --plain                         Use a plain Python shell.
       --no-startup                    When using plain Python, ignore the PYTHONSTARTUP
                                       environment variable and ~/.pythonrc.py script.
-
       -i, --interface [ipython|bpython]
                                       Specify an interactive interpreter interface.
       --help                          Show this message and exit.

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - click-completion~=0.5.1
 - click-config-file~=0.6.0
 - click-spinner~=0.1.8
-- click~=7.0
+- click~=7.1
 - dataclasses~=0.7
 - django~=2.2
 - ete3~=3.1

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -17,7 +17,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 circus==0.17.1
-Click==7.0
+Click==7.1.2
 click-completion==0.5.2
 click-config-file==0.6.0
 click-spinner==0.1.8

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -17,7 +17,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 circus==0.17.1
-Click==7.0
+Click==7.1.2
 click-completion==0.5.2
 click-config-file==0.6.0
 click-spinner==0.1.8

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -16,7 +16,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 circus==0.17.1
-Click==7.0
+Click==7.1.2
 click-completion==0.5.2
 click-config-file==0.6.0
 click-spinner==0.1.8

--- a/setup.json
+++ b/setup.json
@@ -29,7 +29,7 @@
         "click-completion~=0.5.1",
         "click-config-file~=0.6.0",
         "click-spinner~=0.1.8",
-        "click~=7.0",
+        "click~=7.1",
         "dataclasses~=0.7; python_version < '3.7.0'",
         "django~=2.2",
         "ete3~=3.1",


### PR DESCRIPTION
Remove leftover use of deprecated Computer.name attribute in `verdi
computer list`.

```
23:40 $ verdi computer list
Info: List of configured computers
Info: Use 'verdi computer show COMPUTERNAME' to display more detailed information
/Users/leopold/Personal/Postdoc-MARVEL/repos/aiida/aiida_rmq/aiida/orm/computers.py:738: AiidaDeprecationWarning: this property is deprecated, use the `label` property instead
  warnings.warn('this property is deprecated, use the `label` property instead', AiidaDeprecationWarning)  # pylint: disable=no-member
```