### PR TITLE
Fix: `PluginVersionProvider` should cache process class

### DIFF
--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -672,7 +672,7 @@ class Process(plumpy.processes.Process):
 
     def _setup_metadata(self) -> None:
         """Store the metadata on the ProcessNode."""
-        version_info = self.runner.plugin_version_provider.get_version_info(self)
+        version_info = self.runner.plugin_version_provider.get_version_info(self.__class__)
         self.node.set_attribute_many(version_info)
 
         for name, metadata in self.metadata.items():


### PR DESCRIPTION
Currently, the `PluginVersionProvider` is caching process instance, rather than class.
This PR fixes the bug, meaning the cache will now work correctly.
Removing the reference to the process instance also is a step towards allowing it to be garbage collected.

This is part of the fix for https://github.com/aiidateam/aiida-core/issues/4603#issuecomment-767646196