### PR TITLE
ci: update paramiko version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - kiwipy[rmq]~=0.7.1
 - numpy~=1.17
 - pamqp~=2.3
-- paramiko~=2.7
+- paramiko>=2.7.2,~=2.7
 - plumpy~=0.18.4
 - pgsu~=0.1.0
 - psutil~=5.6

--- a/requirements/requirements-py-3.6.txt
+++ b/requirements/requirements-py-3.6.txt
@@ -77,7 +77,7 @@ palettable==3.3.0
 pamqp==2.3
 pandas==0.25.3
 pandocfilters==1.4.2
-paramiko==2.7.1
+paramiko==2.7.2
 parso==0.6.2
 pathspec==0.8.0
 pexpect==4.8.0

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -76,7 +76,7 @@ palettable==3.3.0
 pamqp==2.3
 pandas==0.25.3
 pandocfilters==1.4.2
-paramiko==2.7.1
+paramiko==2.7.2
 parso==0.6.2
 pathspec==0.8.0
 pexpect==4.8.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -72,7 +72,7 @@ palettable==3.3.0
 pamqp==2.3
 pandas==0.25.3
 pandocfilters==1.4.2
-paramiko==2.7.1
+paramiko==2.7.2
 parso==0.6.2
 pexpect==4.8.0
 pg8000==1.13.2

--- a/setup.json
+++ b/setup.json
@@ -39,7 +39,7 @@
         "kiwipy[rmq]~=0.7.1",
         "numpy~=1.17",
         "pamqp~=2.3",
-        "paramiko~=2.7",
+        "paramiko~=2.7,>=2.7.2",
         "plumpy~=0.18.4",
         "pgsu~=0.1.0",
         "psutil~=5.6",


### PR DESCRIPTION
fix #4685

Now that the Github Action runners switched to Ubuntu 20.04, the default SSH
key format of OpenSSH changed and is no longer supported by paramiko
<=2.7.1.