### PR TITLE
CI: Remove `--use-feature=2020-resolver` pip feature flag tests.

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -42,11 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
-    continue-on-error: ${{ contains(matrix.pip-feature-flag, '2020-resolver') }}
     strategy:
       fail-fast: false
       matrix:
-        pip-feature-flag: [ '', '--use-feature=2020-resolver' ]
         extras: [ '', '[atomic_tools,docs,notebook,rest,tests]' ]
 
     steps:
@@ -61,21 +59,15 @@ jobs:
 
     - name: Pip install
       id: pip_install
-      continue-on-error: ${{ contains(matrix.pip-feature-flag, '2020-resolver') }}
       run: |
         python -m pip --version
-        python -m pip install -e .${{ matrix.extras }} ${{ matrix.pip-feature-flag }}
+        python -m pip install -e .${{ matrix.extras }}
         python -m pip freeze
 
     - name: Test importing aiida
       if: steps.pip_install.outcome == 'success'
       run:
         python -c "import aiida"
-
-    - name: Warn about pip 2020 resolver issues.
-      if: steps.pip_install.outcome == 'failure' && contains(matrix.pip-feature-flag, '2020-resolver')
-      run: |
-        echo "::warning ::Encountered issues with the pip 2020-resolver."
 
   install-with-conda:
 


### PR DESCRIPTION
The feature is now on by default in the latest stable release.