### PR TITLE
CI: Increase timeout for test-install test suite.

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -121,7 +121,7 @@ jobs:
 
     needs: [install-with-pip, install-with-conda]
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 55
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The current timeout of 35min is regularly exceeded resulting in test failures. This change increases it to 55min.