### PR TITLE
Allow setting `rerunnable` from `metadata['options']`

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -211,6 +211,8 @@ class CalcJob(Process):
                  'inserted before any non-scheduler command')
         spec.input('metadata.options.queue_name', valid_type=str, required=False,
             help='Set the name of the queue on the remote computer')
+        spec.input('metadata.options.rerunnable', valid_type=bool, required=False,
+            help='Determines if the calculation can be requeued / rerun.')
         spec.input('metadata.options.account', valid_type=str, required=False,
             help='Set the account to use in for the queue on the remote computer')
         spec.input('metadata.options.qos', valid_type=str, required=False,
@@ -526,7 +528,7 @@ class CalcJob(Process):
         job_tmpl = JobTemplate()
         job_tmpl.shebang = computer.get_shebang()
         job_tmpl.submit_as_hold = False
-        job_tmpl.rerunnable = False
+        job_tmpl.rerunnable = self.options.get('rerunnable', False)
         job_tmpl.job_environment = {}
         # 'email', 'email_on_started', 'email_on_terminated',
         job_tmpl.job_name = f'aiida-{self.node.pk}'

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -166,6 +166,11 @@ class DirectScheduler(aiida.schedulers.Scheduler):
             lines.append('# ENVIRONMENT VARIABLES  END  ###')
             lines.append(empty_line)
 
+        if job_tmpl.rerunnable:
+            self.logger.warning(
+                "The 'rerunnable' option is set to 'True', but has no effect when using the direct scheduler."
+            )
+
         lines.append(empty_line)
 
         ## The following code is not working as there's an empty line

--- a/aiida/schedulers/plugins/sge.py
+++ b/aiida/schedulers/plugins/sge.py
@@ -168,8 +168,9 @@ class SgeScheduler(aiida.schedulers.Scheduler):
             lines.append(f'#$ -h {job_tmpl.submit_as_hold}')
 
         if job_tmpl.rerunnable:
-            # if isinstance(job_tmpl.rerunnable, str):
-            lines.append(f'#$ -r {job_tmpl.rerunnable}')
+            lines.append('#$ -r yes')
+        else:
+            lines.append('#$ -r no')
 
         if job_tmpl.email:
             # If not specified, but email events are set, PBSPro

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -555,6 +555,13 @@ The full list of available options are documented below as part of the ``CalcJob
     :expand-namespaces:
 
 
+The ``rerunnable`` option enables the scheduler to re-launch the calculation if it has failed, for example due to node failure or a failure to launch the job. It corresponds to the ``--requeue`` option in SLURM, and the ``-r`` option in SGE, LSF, and PBS. The following two conditions must be met in order for this to work well with AiiDA:
+
+- the scheduler assigns the same job-id to the restarted job
+- the code produces the same results if it has already partially run before (not every scheduler may produce this situation)
+
+Because this depends on the scheduler, its configuration, and the code used, we cannot say conclusively when it will work -- do your own testing! It has been tested on a cluster using SLURM, but that does not guarantee other SLURM clusters behave in the same way.
+
 .. _topics:calculations:usage:calcjobs:launch:
 
 Launch

--- a/tests/schedulers/test_direct.py
+++ b/tests/schedulers/test_direct.py
@@ -9,12 +9,11 @@
 ###########################################################################
 # pylint: disable=invalid-name,protected-access
 """Tests for the `DirectScheduler` plugin."""
-import logging
 import unittest
 
 from aiida.schedulers.plugins.direct import DirectScheduler
 from aiida.schedulers import SchedulerError
-from aiida.common.log import NotInTestingFilter
+from aiida.common.log import AIIDA_LOGGER
 
 # This was executed with ps -o pid,stat,user,time | tail -n +2
 mac_ps_output_str = """21259 S+   broeder   0:00.04
@@ -97,14 +96,14 @@ def test_submit_script_rerunnable(caplog):
     direct = DirectScheduler()
     job_tmpl = JobTemplate()
 
-    # AiiDA by default filters logging when testing
-    direct.logger.removeFilter(NotInTestingFilter)
+    # caplog needs the logs to be propagated
+    original_propagate_value = AIIDA_LOGGER.propagate
+    AIIDA_LOGGER.propagate = True
 
     job_tmpl.rerunnable = True
-    with caplog.at_level(logging.WARNING, logger=direct.logger.name):
-        direct._get_submit_script_header(job_tmpl)
+    direct._get_submit_script_header(job_tmpl)
 
     assert 'rerunnable' in caplog.text
     assert 'has no effect' in caplog.text
 
-    direct.logger.addFilter(NotInTestingFilter)
+    AIIDA_LOGGER.propagate = original_propagate_value

--- a/tests/schedulers/test_direct.py
+++ b/tests/schedulers/test_direct.py
@@ -13,7 +13,6 @@ import unittest
 
 from aiida.schedulers.plugins.direct import DirectScheduler
 from aiida.schedulers import SchedulerError
-from aiida.common.log import AIIDA_LOGGER
 
 # This was executed with ps -o pid,stat,user,time | tail -n +2
 mac_ps_output_str = """21259 S+   broeder   0:00.04
@@ -89,21 +88,15 @@ class TestParserGetJobList(unittest.TestCase):
         self.assertIn('11383', job_ids)
 
 
-def test_submit_script_rerunnable(caplog):
+def test_submit_script_rerunnable(aiida_caplog):
     """Test that setting the `rerunnable` option gives a warning."""
     from aiida.schedulers.datastructures import JobTemplate
 
     direct = DirectScheduler()
     job_tmpl = JobTemplate()
 
-    # caplog needs the logs to be propagated
-    original_propagate_value = AIIDA_LOGGER.propagate
-    AIIDA_LOGGER.propagate = True
-
     job_tmpl.rerunnable = True
     direct._get_submit_script_header(job_tmpl)
 
-    assert 'rerunnable' in caplog.text
-    assert 'has no effect' in caplog.text
-
-    AIIDA_LOGGER.propagate = original_propagate_value
+    assert 'rerunnable' in aiida_caplog.text
+    assert 'has no effect' in aiida_caplog.text

--- a/tests/schedulers/test_lsf.py
+++ b/tests/schedulers/test_lsf.py
@@ -138,6 +138,30 @@ def test_submit_script():
     assert '#BSUB -G account_id' in submit_script_text
     assert "'mpirun' '-np' '2' 'pw.x' '-npool' '1' < 'aiida.in'" in submit_script_text
 
+def test_submit_script_rerunnable():
+    """Test the `rerunnable` option of the submit script."""
+    from aiida.schedulers.datastructures import JobTemplate
+    from aiida.common.datastructures import CodeInfo, CodeRunMode
+
+    scheduler = LsfScheduler()
+
+    job_tmpl = JobTemplate()
+    job_tmpl.job_resource = scheduler.create_job_resource(tot_num_mpiprocs=2, parallel_env='b681e480bd.cern.ch')
+    code_info = CodeInfo()
+    code_info.cmdline_params = []
+    job_tmpl.codes_info = [code_info]
+    job_tmpl.codes_run_mode = CodeRunMode.SERIAL
+
+    job_tmpl.rerunnable = True
+    submit_script_text = scheduler.get_submit_script(job_tmpl)
+    assert '#BSUB -r\n' in submit_script_text
+    assert '#BSUB -rn' not in submit_script_text
+
+    job_tmpl.rerunnable = False
+    submit_script_text = scheduler.get_submit_script(job_tmpl)
+    assert '#BSUB -r\n' not in submit_script_text
+    assert '#BSUB -rn' in submit_script_text
+
 
 def test_create_job_resource():
     """

--- a/tests/schedulers/test_lsf.py
+++ b/tests/schedulers/test_lsf.py
@@ -138,6 +138,7 @@ def test_submit_script():
     assert '#BSUB -G account_id' in submit_script_text
     assert "'mpirun' '-np' '2' 'pw.x' '-npool' '1' < 'aiida.in'" in submit_script_text
 
+
 def test_submit_script_rerunnable():
     """Test the `rerunnable` option of the submit script."""
     from aiida.schedulers.datastructures import JobTemplate

--- a/tests/schedulers/test_pbspro.py
+++ b/tests/schedulers/test_pbspro.py
@@ -1063,3 +1063,27 @@ class TestSubmitScript(unittest.TestCase):
             job_tmpl.job_resource = scheduler.create_job_resource(
                 num_machines=1, num_mpiprocs_per_machine=1, num_cores_per_machine=24, num_cores_per_mpiproc=23
             )
+
+    def test_submit_script_rerunnable(self):  # pylint: disable=no-self-use
+        """Test the `rerunnable` option of the submit script."""
+        from aiida.schedulers.datastructures import JobTemplate
+        from aiida.common.datastructures import CodeInfo, CodeRunMode
+
+        scheduler = PbsproScheduler()
+
+        job_tmpl = JobTemplate()
+        job_tmpl.job_resource = scheduler.create_job_resource(num_machines=1, num_mpiprocs_per_machine=1)
+        code_info = CodeInfo()
+        code_info.cmdline_params = []
+        job_tmpl.codes_info = [code_info]
+        job_tmpl.codes_run_mode = CodeRunMode.SERIAL
+
+        job_tmpl.rerunnable = True
+        submit_script_text = scheduler.get_submit_script(job_tmpl)
+        assert '#PBS -r y' in submit_script_text
+        assert '#PBS -r n' not in submit_script_text
+
+        job_tmpl.rerunnable = False
+        submit_script_text = scheduler.get_submit_script(job_tmpl)
+        assert '#PBS -r y' not in submit_script_text
+        assert '#PBS -r n' in submit_script_text

--- a/tests/schedulers/test_slurm.py
+++ b/tests/schedulers/test_slurm.py
@@ -364,6 +364,34 @@ class TestSubmitScript:
                 num_machines=1, num_mpiprocs_per_machine=1, num_cores_per_machine=24, num_cores_per_mpiproc=23
             )
 
+    def test_submit_script_rerunnable(self):
+        """
+        Test the creation of a submission script with the `rerunnable` option.
+        """
+        from aiida.schedulers.datastructures import JobTemplate
+        from aiida.common.datastructures import CodeInfo, CodeRunMode
+
+        scheduler = SlurmScheduler()
+
+        # minimal job template setup
+        job_tmpl = JobTemplate()
+        job_tmpl.job_resource = scheduler.create_job_resource(num_machines=1, num_mpiprocs_per_machine=1)
+        code_info = CodeInfo()
+        code_info.cmdline_params = []
+        job_tmpl.codes_info = [code_info]
+        job_tmpl.codes_run_mode = CodeRunMode.SERIAL
+
+        # Test the `rerunnable` setting
+        job_tmpl.rerunnable = True
+        submit_script_text = scheduler.get_submit_script(job_tmpl)
+        assert '#SBATCH --requeue' in submit_script_text
+        assert '#SBATCH --no-requeue' not in submit_script_text
+
+        job_tmpl.rerunnable = False
+        submit_script_text = scheduler.get_submit_script(job_tmpl)
+        assert '#SBATCH --requeue' not in submit_script_text
+        assert '#SBATCH --no-requeue' in submit_script_text
+
 
 class TestJoblistCommand:
     """

--- a/tests/schedulers/test_torque.py
+++ b/tests/schedulers/test_torque.py
@@ -1003,3 +1003,27 @@ class TestSubmitScript(unittest.TestCase):
             job_tmpl.job_resource = scheduler.create_job_resource(
                 num_machines=1, num_mpiprocs_per_machine=1, num_cores_per_machine=24, num_cores_per_mpiproc=23
             )
+
+    def test_submit_script_rerunnable(self):  # pylint: disable=no-self-use
+        """Test the `rerunnable` option of the submit script."""
+        from aiida.schedulers.datastructures import JobTemplate
+        from aiida.common.datastructures import CodeInfo, CodeRunMode
+
+        scheduler = TorqueScheduler()
+
+        job_tmpl = JobTemplate()
+        job_tmpl.job_resource = scheduler.create_job_resource(num_machines=1, num_mpiprocs_per_machine=1)
+        code_info = CodeInfo()
+        code_info.cmdline_params = []
+        job_tmpl.codes_info = [code_info]
+        job_tmpl.codes_run_mode = CodeRunMode.SERIAL
+
+        job_tmpl.rerunnable = True
+        submit_script_text = scheduler.get_submit_script(job_tmpl)
+        assert '#PBS -r y' in submit_script_text
+        assert '#PBS -r n' not in submit_script_text
+
+        job_tmpl.rerunnable = False
+        submit_script_text = scheduler.get_submit_script(job_tmpl)
+        assert '#PBS -r y' not in submit_script_text
+        assert '#PBS -r n' in submit_script_text


### PR DESCRIPTION
The `rerunnable` option is currently implemented in the scheduler plugins ([LSF](https://github.com/aiidateam/aiida-core/blob/48fa47584c993cdac019c6199bc045a4c19da152/aiida/schedulers/plugins/lsf.py#L306), [PBS](https://github.com/aiidateam/aiida-core/blob/develop/aiida/schedulers/plugins/pbsbaseclasses.py#L197), [SGE](https://github.com/aiidateam/aiida-core/blob/develop/aiida/schedulers/plugins/sge.py#L170), [SLURM](https://github.com/aiidateam/aiida-core/blob/48fa47584c993cdac019c6199bc045a4c19da152/aiida/schedulers/plugins/slurm.py#L272)), but there was no way to activate it for a particular `CalcJob`. This PR adds a `metadata.options.rerunnable` flag that is forwarded to the `JobTemplate`.

This is a follow-up on a [discussion on Slack](https://app.slack.com/client/T470FLBSQ/C466S5PG8/thread/C466S5PG8-1603730677.038100) with @giovannipizzi and @espenfl.

Important points raised there:
- it might depend on scheduler settings of the cluster whether re-queueing gives the same job id
- (depending again on the scheduler config) it's possible that a code would execute more than once, so it should only be applied for idempotent codes

I've now been running this in production for a while, and did not notice any adverse affects. In our case, submitting jobs to SLURM can trigger the allocation of new nodes; if that fails for some reason, SLURM needs to re-queue the jobs such that it can assign different nodes to the job.

Some open questions:
- is there a good place to test this? I looked at [test_calc_job.py](https://github.com/aiidateam/aiida-core/blob/develop/tests/engine/test_calc_job.py), but since the option doesn't affect the direct scheduler there's no way to check it was used. Do we have a calcjob test with different schedulers?
- related to the first point, should the direct scheduler warn when the (unused) `rerunnable` flag is set?
- looking at the [SGE implementation](https://github.com/aiidateam/aiida-core/blob/develop/aiida/schedulers/plugins/sge.py#L170), I'm not sure if that expects a `bool` (as do all the other schedulers), or a `str`.

