### PR TITLE
`verdi group remove-nodes`: Add warning when nodes are not in `Group`

### DIFF
--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -52,6 +52,11 @@ def group_remove_nodes(group, nodes, clear, force):
     label = group.label
     klass = group.__class__.__name__
 
+    if nodes and clear:
+        echo.echo_critical(
+            'Specify either the `--clear` flag to remove all nodes or the identifiers of the nodes you want to remove.'
+        )
+
     if not force:
 
         if nodes:

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -47,12 +47,30 @@ def group_add_nodes(group, force, nodes):
 @with_dbenv()
 def group_remove_nodes(group, nodes, clear, force):
     """Remove nodes from a group."""
-    if clear:
-        message = f'Do you really want to remove ALL the nodes from Group<{group.label}>?'
-    else:
-        message = f'Do you really want to remove {len(nodes)} nodes from Group<{group.label}>?'
+    from aiida.orm import QueryBuilder, Group, Node
 
     if not force:
+        node_pks = [node.pk for node in nodes]
+
+        query = QueryBuilder()
+        query.append(Group, filters={'id': group.pk}, tag='group')
+        query.append(Node, with_group='group', filters={'id': {'in': node_pks}}, project='id')
+
+        group_node_pks = query.all(flat=True)
+
+        if not group_node_pks:
+            echo.echo_critical(f'None of the specified nodes are in Group<{group.label}>.')
+            return
+
+        if len(node_pks) > len(group_node_pks):
+            node_pks = [node_pk for node_pk in node_pks if node_pk not in group_node_pks]
+            echo.echo_warning(f'{len(node_pks)} nodes with PK {node_pks} are not in Group<{group.label}>.')
+
+        if clear:
+            message = f'Are you sure you want to remove ALL the nodes from Group<{group.label}>?'
+        else:
+            message = f'Are you sure you want to remove {len(group_node_pks)} nodes from Group<{group.label}>?'
+
         click.confirm(message, abort=True)
 
     if clear:

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -70,7 +70,6 @@ def group_remove_nodes(group, nodes, clear, force):
 
             if not group_node_pks:
                 echo.echo_critical(f'None of the specified nodes are in {klass}<{label}>.')
-                return
 
             if len(node_pks) > len(group_node_pks):
                 node_pks = set(node_pks).difference(set(group_node_pks))


### PR DESCRIPTION
Fixes #4438

Currently the `verdi group remove-nodes` command does not raise any
warning when the nodes that the user wants to remove are not in the
group. It also says it removed the number of requested nodes from the
group, even when none of them are in the group specified.

Here we:

* Raise a warning when any of the nodes requested are not in the
specified group, and list the PK's of the nodes that are missing.
* Have the command fail with a `Critical` message when **neither** the
`--clear` flag nor any nodes are provided.
* Have the command fail with a `Critical` message when **both** the
`--clear` flag nor any nodes are provided.
* Have the command fail with a `Critical` message when none of the
requested nodes are in the group.

Note that the Group.remove_nodes() command still does not raise any
warning when the requested nodes are not in the group.