### PR TITLE
CI: Add retry for polish workchains

### DIFF
--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -203,6 +203,7 @@ def run_via_daemon(workchains, inputs, sleep, timeout):
     except AttributeError:
         click.secho('Failed: ', fg='red', bold=True, nl=False)
         click.secho(f'the workchain<{workchain.pk}> did not return a result output node', bold=True)
+        click.echo(str(workchain.attributes))
         return None
 
     return result, total_time

--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -9,6 +9,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Command line interface to dynamically create and run a WorkChain that can evaluate a reversed polish expression."""
+import importlib
+import sys
+import time
 
 import click
 
@@ -71,8 +74,16 @@ from aiida.cmdline.utils import decorators
     default=False,
     help='Only evaluate the expression and generate the workchain but do not launch it'
 )
+@click.option(
+    '-r',
+    '--retries',
+    type=click.INT,
+    default=1,
+    show_default=True,
+    help='Number of retries for running via the daemon'
+)
 @decorators.with_dbenv()
-def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout, modulo, dry_run, daemon):
+def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout, modulo, dry_run, daemon, retries):
     """
     Evaluate the expression in Reverse Polish Notation in both a normal way and by procedurally generating
     a workchain that encodes the sequence of operators and gets the stack of operands as an input. Multiplications
@@ -96,11 +107,8 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
     If no expression is specified, a random one will be generated that adheres to these rules
     """
     # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-branches
-    import importlib
-    import sys
-    import time
     from aiida.orm import Code, Int, Str
-    from aiida.engine import run_get_node, submit
+    from aiida.engine import run_get_node
 
     lib_expression = importlib.import_module('lib.expression')
     lib_workchain = importlib.import_module('lib.workchain')
@@ -138,32 +146,15 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
             inputs['code'] = code
 
         if daemon:
-            workchain = submit(workchains.Polish00WorkChain, **inputs)
-            start_time = time.time()
-            timed_out = True
-
-            while time.time() - start_time < timeout:
-                time.sleep(sleep)
-
-                if workchain.is_terminated:
-                    timed_out = False
-                    total_time = time.time() - start_time
+            # the daemon tests have been known to fail on Jenkins, when the result node cannot be found
+            # to mitigate this, we can retry multiple times
+            for _ in range(retries):
+                output = run_via_daemon(workchains, inputs, sleep, timeout)
+                if output is not None:
                     break
-
-            if timed_out:
-                click.secho('Failed: ', fg='red', bold=True, nl=False)
-                click.secho(
-                    f'the workchain<{workchain.pk}> did not finish in time and the operation timed out', bold=True
-                )
+            if output is None:
                 sys.exit(1)
-
-            try:
-                result = workchain.outputs.result
-            except AttributeError:
-                click.secho('Failed: ', fg='red', bold=True, nl=False)
-                click.secho(f'the workchain<{workchain.pk}> did not return a result output node', bold=True)
-                click.echo(str(workchain.attributes))
-                sys.exit(1)
+            result, total_time = output
 
         else:
             start_time = time.time()
@@ -184,6 +175,37 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
             click.secho('Success: ', fg='green', bold=True, nl=False)
             click.secho(f'the workchain accurately reproduced the evaluated value in {total_time:.2f}s', bold=True)
             sys.exit(0)
+
+
+def run_via_daemon(workchains, inputs, sleep, timeout):
+    """Run via the daemon, polling until it is terminated or timeout."""
+    from aiida.engine import submit
+
+    workchain = submit(workchains.Polish00WorkChain, **inputs)
+    start_time = time.time()
+    timed_out = True
+
+    while time.time() - start_time < timeout:
+        time.sleep(sleep)
+
+        if workchain.is_terminated:
+            timed_out = False
+            total_time = time.time() - start_time
+            break
+
+    if timed_out:
+        click.secho('Failed: ', fg='red', bold=True, nl=False)
+        click.secho(f'the workchain<{workchain.pk}> did not finish in time and the operation timed out', bold=True)
+        return None
+
+    try:
+        result = workchain.outputs.result
+    except AttributeError:
+        click.secho('Failed: ', fg='red', bold=True, nl=False)
+        click.secho(f'the workchain<{workchain.pk}> did not return a result output node', bold=True)
+        return None
+
+    return result, total_time
 
 
 if __name__ == '__main__':

--- a/.molecule/default/test_polish_workchains.yml
+++ b/.molecule/default/test_polish_workchains.yml
@@ -56,7 +56,7 @@
       set -e
       declare -a EXPRESSIONS=({{ polish_expressions | map('quote') | join(' ') }})
       for expression in "${EXPRESSIONS[@]}"; do
-        {{ venv_bin }}/verdi -p {{ aiida_backend }} run --auto-group -l polish -- "{{ polish_script }}" -X add! -C -F -d -t {{ polish_timeout }} "$expression"
+        {{ venv_bin }}/verdi -p {{ aiida_backend }} run --auto-group -l polish -- "{{ polish_script }}" -X add! -C -F -d -t {{ polish_timeout }} -r 2 "$expression"
       done
     args:
       executable: /bin/bash


### PR DESCRIPTION
Polish workchain executions (submitting via a daemon) have been sporadically failing, with two errors identified:

https://theossrv6.epfl.ch/jenkins/blue/organizations/jenkins/aiida_core_aiidateam/detail/PR-4729/1/pipeline

```
{'version': {'core': '1.5.2'}, 'exception': 'Traceback (most recent call last):\n  File "/opt/conda/lib/python3.7/site-packages/aiida/orm/utils/managers.py", line 83, in __getattr__\n    return self._get_node_by_link_label(label=name)\n  File "/opt/conda/lib/python3.7/site-packages/aiida/orm/utils/managers.py", line 64, in _get_node_by_link_label\n    return self._node.get_outgoing(link_type=self._link_type).get_node_by_label(label)\n  File "/opt/conda/lib/python3.7/site-packages/aiida/orm/utils/links.py", line 300, in get_node_by_label\n    raise exceptions.NotExistent(f\'no neighbor with the label {label} found\')\naiida.common.exceptions.NotExistent: no neighbor with the label result found\n\nDuring handling of the above exception, another exception occurred:\n\naiida.common.exceptions.NotExistentAttributeError: Node<143> does not have an output with link label \'result\'\n', 'checkpoints': '!plumpy:bundle\n\'!!meta\':\n  class_name: polish_workchains.polish_f7863ed90d43505883874975e9377e76:Polish00WorkChain\n  types:\n    _future: S\n  user:\n    object_loader: aiida.engine.persistence:ObjectLoader\nCONTEXT: !aiida_attributedict\n  calculations:\n  - !aiida_node \'b563bcc2-bbdf-4ab0-b423-925296b105ca\'\n  iterators: []\n  iterators_sign: []\n  iterators_stack: []\n  operands:\n  - 3\n  - 3\n  - -1\n  result: !aiida_node \'3b945e28-368d-4564-ab19-c70ce2f5fc57\'\n  workchains:\n  - !aiida_node \'155a41b0-7501-45f5-bcea-2f76d21297a9\'\nINPUTS_PARSED: "!plumpy:attributes_frozendict\\ncode: !aiida_node \'7cc094b0-55ef-4b66-b0e4-c233ba2026e1\'\\n\\\n  metadata: !plumpy:attributes_frozendict\\n  call_link_label: CALL\\n  store_provenance:\\\n  \\ true\\nmodulo: !aiida_node \'960b50ab-3288-4897-b67a-6df9bf683fc8\'\\noperands: !aiida_node\\\n  \\ \'4da6ca30-4030-492d-aaf5-c5d724b8f2a6\'\\n"\nINPUTS_RAW: \'!plumpy:attributes_frozendict\n\n  code: !aiida_node \'\'7cc094b0-55ef-4b66-b0e4-c233ba2026e1\'\'\n\n  modulo: !aiida_node \'\'960b50ab-3288-4897-b67a-6df9bf683fc8\'\'\n\n  operands: !aiida_node \'\'4da6ca30-4030-492d-aaf5-c5d724b8f2a6\'\'\n\n  \'\n_awaitables: []\n_creation_time: 1612875513.0140836\n_enable_persistence: true\n_future:\n  \'!!meta\':\n    class_name: plumpy.persistence:SavableFuture\n  _result: null\n  _state: PENDING\n_parent_pid: null\n_paused: null\n_pid: 134\n_pre_paused_status: null\n_state:\n  \'!!meta\':\n    class_name: plumpy.process_states:Running\n  args: !!python/tuple []\n  in_state: true\n  kwargs: {}\n  run_fn: _do_step\n_status: null\ncalc_id: 134\nstepper_state:\n  \'!!meta\':\n    class_name: plumpy.workchains:_BlockStepper\n  _pos: 3\n  stepper_state:\n    \'!!meta\':\n      class_name: plumpy.workchains:_FunctionStepper\n    _fn: post_raise_power\n', 'process_label': 'Polish00WorkChain', 'process_state': 'excepted', 'stepper_state_info': '3:post_raise_power'}

```

https://theossrv6.epfl.ch/jenkins/blue/organizations/jenkins/aiida_core_aiidateam/detail/develop/996/pipeline

```
{'sealed': True, 'version': {'core': '1.5.2'}, 'exception': 'concurrent.futures._base.TimeoutError\n', 'process_label': 'Polish00WorkChain', 'process_state': 'excepted', 'process_status': 'Waiting for child processes: 325, 326', 'stepper_state_info': '1:raise_power'}
```

To mitigate this whilst I further investigate, this PR adds a retry when executing each workchain.