### PR TITLE
Bump aiida-prerequisites base image to 0.3.0

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.2.1
+FROM aiidateam/aiida-prerequisites:0.3.0
 
 # to run the tests
 RUN pip install ansible~=2.10.0 molecule~=3.1.0

--- a/.molecule/default/Dockerfile
+++ b/.molecule/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.2.1
+FROM aiidateam/aiida-prerequisites:0.3.0
 
 # allow for collection of query statistics
 # (must also be intialised on each database)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.2.1
+FROM aiidateam/aiida-prerequisites:0.3.0
 
 USER root
 


### PR DESCRIPTION
Changes in the new image
- Updated conda (4.9.2)
- Start ssh-agent at user's startup