### PR TITLE
close django connection in REST API

### DIFF
--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -858,3 +858,7 @@ def close_session(wrapped, _, args, kwargs):
         return wrapped(*args, **kwargs)
     finally:
         get_manager().get_backend().get_session().close()
+
+        from django.db import connection
+        # Close django connection if open (not needed by REST API)
+        connection.close()

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -857,8 +857,11 @@ def close_session(wrapped, _, args, kwargs):
     try:
         return wrapped(*args, **kwargs)
     finally:
-        get_manager().get_backend().get_session().close()
+        backend = get_manager().get_backend()
+        backend.get_session().close()
 
-        from django.db import connection
         # Close django connection if open (not needed by REST API)
-        connection.close()
+        from aiida.orm.implementation.django.backend import DjangoBackend
+        if isinstance(backend, DjangoBackend):
+            from django.db import connection
+            connection.close()

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -861,7 +861,6 @@ def close_session(wrapped, _, args, kwargs):
         backend.get_session().close()
 
         # Close django connection if open (not needed by REST API)
-        from aiida.orm.implementation.django.backend import DjangoBackend
-        if isinstance(backend, DjangoBackend):
+        if 'Django' in type(backend).__name__:  # don't want to import the backend class, gives error
             from django.db import connection
             connection.close()

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -51,10 +51,11 @@ def server_url():
 def restrict_sqlalchemy_queuepool(aiida_profile):
     """Create special SQLAlchemy engine for use with QueryBuilder - backend-agnostic"""
     from aiida.manage.manager import get_manager
+    from sqlalchemy.pool import QueuePool
 
     backend_manager = get_manager().get_backend_manager()
     backend_manager.reset_backend_environment()
-    backend_manager.load_backend_environment(aiida_profile, pool_timeout=1, max_overflow=0)
+    backend_manager.load_backend_environment(aiida_profile, poolclass=QueuePool, pool_timeout=1, max_overflow=0)
 
 
 @pytest.fixture


### PR DESCRIPTION
Note: This is a draft meant for testing e.g. on Materials Cloud.

In regular operation, AiiDA keeps several connections to the postgresql database persistently open.
One set of connections ([up to 5 by default](https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool)) comes from the SQLA connection pool, which is present on both sqla and django profiles (since both use the QueryBuilder).
For django profiles, there is an additional persistent connection opened by django.
See [here](https://github.com/aiidateam/aiida-core/issues/4374#issuecomment-694303925) for a short summary.

[The default connection limit of postgresql is 100](https://www.postgresql.org/docs/14/runtime-config-connection.html); see [here](https://brandur.org/postgres-connections) for why it is a good idea to keep the number of connections from exploding.
As long as AiiDA users don't use more than 100/6=16 daemon runners (that number would need to include AiiDA shells + REST APIs), they will not hit that limit in regular use.

For Materials Cloud, the situation is different, however.
Currently, Materials Cloud runs one independent AiiDA REST API process per profile, all of which connect to the same postgresql database, and some profiles include further AiiDA-based services that also make use of the REST API.
We've therefore hit the limit of 100 connections (and even more) some time ago.

The Materials Cloud use case is very different from "operational" AiiDA use: on Materials Cloud, database access is needed during user-initiated queries but there are long periods of inactivity between those (there are no running jobs that would access the database with high frequency).
The benefit from keeping postgresql connections open is therefore less relevant (as [shown here](https://github.com/aiidateam/aiida-core/issues/4374#issuecomment-701404620), opening a postgresql connection on materials cloud takes ~6-10ms).

This PR

 * Replaces the default `QueuePool` of sqla by a `NullPool` that will release a connection as soon as it is no longer needed
 * For django profiles: Closes the persistent Django connection at the end of every REST API request

I've tested that even storing ORM entities still works inside the REST
API, i.e. if needed the django connection is simply reestablished on the
fly.