### PR TITLE
Skip test 'TestVerdiProcessDaemon::test_pause_play_kill'.

### DIFF
--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -64,6 +64,7 @@ class TestVerdiProcessDaemon(AiidaTestCase):
         os.kill(self.daemon.pid, signal.SIGTERM)
         super().tearDown()
 
+    @pytest.mark.skip(reason='fails to complete randomly (see issue #4731)')
     @pytest.mark.requires_rmq
     def test_pause_play_kill(self):
         """


### PR DESCRIPTION
The test randomly fails to complete within a reasonable amount of time
leading to a significant disruption of our CI pipeline.

Investigated in issue #4731.