### PR TITLE
🧪 TESTS: Fix plumpy incompatibility

### DIFF
--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -680,7 +680,8 @@ class TestWorkchain(AiidaTestCase):
         run_and_check_success(MainWorkChain)
 
     def test_if_block_persistence(self):
-        """
+        """Test a reloaded `If` conditional can be resumed.
+
         This test was created to capture issue #902
         """
         runner = get_manager().get_runner()


### PR DESCRIPTION
As of https://github.com/aiidateam/plumpy/commit/7004bd96bbaa678b5486a62677e139216877deef, a paused workchain will hang if it is closed then played.

This should not be an issue, because processes that are closed should no longer be ran.
In fact, it should probably raise an exception if you try to call `.play()` on a closed process (see https://github.com/aiidateam/plumpy/issues/208)

This test also looked faulty, in that it should test that the reloaded workchain can be played, not the original workchain?