### PR TITLE
`verdi calcjob gotocomputer`: Add proxy command

### DIFF
--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -1340,6 +1340,9 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         if 'key_filename' in self._connect_args and self._connect_args['key_filename']:
             further_params.append(f"-i {escape_for_bash(self._connect_args['key_filename'])}")
 
+        if 'proxy_command' in self._connect_args and self._connect_args['proxy_command']:
+            further_params.append(f"-o ProxyCommand={escape_for_bash(self._connect_args['proxy_command'])}")
+
         further_params_str = ' '.join(further_params)
 
         connect_string = self._gotocomputer_string(remotedir)

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -426,7 +426,7 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         if self._is_open:
             raise InvalidOperation('Cannot open the transport twice')
         # Open a SSHClient
-        connection_arguments = self._connect_args
+        connection_arguments = self._connect_args.copy()
         if 'key_filename' in connection_arguments and not connection_arguments['key_filename']:
             connection_arguments.pop('key_filename')
         proxystring = connection_arguments.pop('proxy_command', None)

--- a/tests/transports/test_ssh.py
+++ b/tests/transports/test_ssh.py
@@ -59,11 +59,17 @@ class TestBasicConnection(unittest.TestCase):
 
 def test_gotocomputer():
     """Test gotocomputer"""
-    with SshTransport(machine='localhost', timeout=30, use_login_shell=False, key_policy='AutoAddPolicy') as transport:
+    with SshTransport(
+        machine='localhost',
+        timeout=30,
+        use_login_shell=False,
+        key_policy='AutoAddPolicy',
+        proxy_command='ssh -W localhost:22 localhost'
+    ) as transport:
         cmd_str = transport.gotocomputer_command('/remote_dir/')
 
         expected_str = (
-            """ssh -t localhost   "if [ -d '/remote_dir/' ] ;"""
+            """ssh -t localhost -o ProxyCommand="ssh -W localhost:22 localhost" "if [ -d '/remote_dir/' ] ;"""
             """ then cd '/remote_dir/' ; bash  ; else echo '  ** The directory' ; """
             """echo '  ** /remote_dir/' ; echo '  ** seems to have been deleted, I logout...' ; fi" """
         )

--- a/tests/transports/test_ssh.py
+++ b/tests/transports/test_ssh.py
@@ -64,12 +64,12 @@ def test_gotocomputer():
         timeout=30,
         use_login_shell=False,
         key_policy='AutoAddPolicy',
-        proxy_command='ssh -W localhost:22 localhost'
+        proxy_command='ssh -W localhost:22 localhost',
     ) as transport:
         cmd_str = transport.gotocomputer_command('/remote_dir/')
 
         expected_str = (
-            """ssh -t localhost -o ProxyCommand="ssh -W localhost:22 localhost" "if [ -d '/remote_dir/' ] ;"""
+            """ssh -t localhost -o ProxyCommand='ssh -W localhost:22 localhost'  "if [ -d '/remote_dir/' ] ;"""
             """ then cd '/remote_dir/' ; bash  ; else echo '  ** The directory' ; """
             """echo '  ** /remote_dir/' ; echo '  ** seems to have been deleted, I logout...' ; fi" """
         )


### PR DESCRIPTION
Currently the `verdi calcjob gocomputer` command does not work in case
the connection to the remote computer is via a proxy. Here we add the
`ProxyCommand` option to the parameters for the `ssh` command.