### PR TITLE
👌 IMPROVE: Garbage collect on process termination

### DIFF
--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -226,6 +226,6 @@ class ProcessLauncher(plumpy.ProcessLauncher):
         await asyncio.sleep(0)  # allow other async tasks to complete first
         del node
         del result
-        gc.collect() 
+        gc.collect()
 
         return serialized

--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -223,7 +223,7 @@ class ProcessLauncher(plumpy.ProcessLauncher):
             raise
 
         # before returning we ensure the garbage collection runs, to clear any memory used by the task
-        await asyncio.sleep(0)  # allow other async tasks to complete first
+        await asyncio.sleep(1)  # allow other async tasks to complete first
         del node
         del result
         gc.collect()


### PR DESCRIPTION
Partially addresses #4603 

After completion of `aiida-sleep calc -n 1 -t 1 -p 500000 -o 500000 --submit` (on https://github.com/chrisjsewell/aiida-integration-tests):

without:

```
CONTAINER ID   NAME                 CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
2969011fe639   aiida-int-core       4.60%     915.9MiB / 1.942GiB   46.05%    2.58GB / 699MB    813MB / 11.8MB    84
```

with:

```
CONTAINER ID   NAME                 CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
2969011fe639   aiida-int-core       3.50%     816.2MiB / 1.942GiB   41.04%    2.73GB / 738MB    822MB / 11.8MB    84
```

so it definitely makes a difference, but see below for more debugging

EDIT:

ooo actually, if you change `asyncio.sleep(0)` to `asyncio.sleep(1)`:

```
CONTAINER ID   NAME                 CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O         PIDS
2969011fe639   aiida-int-core       3.31%     512.6MiB / 1.942GiB   25.77%    3.05GB / 832MB   1.71GB / 12.3MB   95
```

and the process is gone 🎉 
