### PR TITLE
👌 IMPROVE: verdi daemon status

### DIFF
--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -14,7 +14,7 @@ import functools
 import logging
 import signal
 import threading
-from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, NamedTuple, Optional, Set, Tuple, Type, Union
 import uuid
 
 import kiwipy
@@ -88,6 +88,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         self._job_manager = manager.JobManager(self._transport)
         self._persister = persister
         self._plugin_version_provider = PluginVersionProvider()
+        self.continued_processes: Set[int] = set()
 
         if communicator is not None:
             self._communicator = wrap_communicator(communicator, self._loop)


### PR DESCRIPTION
This is a proof of concept for closing #4667, and feedback would be appreciated.

Currently, when `verdi daemon start x` is run, this starts the circus daemon with settings to start *x* workers via the command `verdi devel run_daemon`. With the default `respawn=True` set, circus will maintain *x* workers running by simply spawning new workers if any die (see https://github.com/circus-tent/circus/blob/4b08197dedbe6416248d23f9983bd42cd97c96ab/circus/watcher.py#L554-L556).

This means that if there are any exceptions raised when starting the daemon it will simply die and be respawned by circus in an endless loop.
`verdi daemon status` does not currently "acknowledge" this issue; you will just see a new PID every time you run it.

Ideally then we want to "ping" the `Runner` inside a daemon worker, to check it is healthy (and return a non-zero exit code if not).
One way to do this is via RabbitMQ, by setting up an additional RPC subscriber, as I have added here.
If I then e,g, add a `raise Exception` to `aiida-core/aiida/cmdline/commands/cmd_devel.py::devel_run_daemon` we now get:

```console
root@ae5122fc408b:~# verdi daemon status
Profile: default
Daemon is running as PID 668593 since 2021-02-22 07:13:26
Active workers [1]:
   PID    MEM %    CPU %  started              status
------  -------  -------  -------------------  --------------
668647        0        0  2021-02-22 07:13:31  Not responding
Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers
```

This "ping" could also send back additional data and so while I was at it I have added code to record the processes that are currently running on that daemon (started via the `ProcessLauncher`):

```console
root@ae5122fc408b:~# verdi daemon status
Profile: default
Daemon is running as PID 653054 since 2021-02-22 06:45:57
Active workers [4]:
   PID    MEM %    CPU %  started              status
------  -------  -------  -------------------  ----------------
653059   15.893     65.3  2021-02-22 06:45:57  50/200 processes
653060   15.416     64.7  2021-02-22 06:45:57  50/200 processes
653061   14.343     65    2021-02-22 06:45:57  49/200 processes
654850   10.186     55.3  2021-02-22 06:48:34  34/200 processes
Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers
```

One issue with this is that, particularly when lots of new processes have just been submitted, it may take a while for the worker to reply to the RPC, leading to a laggy `verdi daemon status` and also time outs. So we may not want to ping the workers by default.

```
root@ae5122fc408b:~# verdi daemon status
Profile: default
Daemon is running as PID 653054 since 2021-02-22 06:45:57
Active workers [4]:
   PID    MEM %    CPU %  started              status
------  -------  -------  -------------------  ----------------
653059   13.082      6.7  2021-02-22 06:45:57  Response timeout
653060   12.427      5.2  2021-02-22 06:45:57  Response timeout
653061   11.798      4.6  2021-02-22 06:45:57  Response timeout
654850    9.472      2.6  2021-02-22 06:48:34  Response timeout
Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers
```