### PR TITLE
👌 IMPROVE: add type checking for aiida/orm/nodes/process

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,11 @@ repos:
         files: >-
             (?x)^(
                 aiida/common/progress_reporter.py|
-                aiida/manage/manager.py|
                 aiida/engine/.*py|
+                aiida/manage/manager.py|
                 aiida/manage/database/delete/nodes.py|
+                aiida/orm/nodes/node.py|
+                aiida/orm/nodes/process/.*py|
                 aiida/tools/graph/graph_traversers.py|
                 aiida/tools/groups/paths.py|
                 aiida/tools/importexport/archive/.*py|

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -130,7 +130,7 @@ async def task_submit_job(node: CalcJobNode, transport_queue: TransportQueue, ca
     initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
     max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
-    authinfo = node.computer.get_authinfo(node.user)
+    authinfo = node.get_authinfo()
 
     async def do_submit():
         with transport_queue.request_transport(authinfo) as request:
@@ -177,7 +177,7 @@ async def task_update_job(node: CalcJobNode, job_manager, cancellable: Interrupt
     initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
     max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
-    authinfo = node.computer.get_authinfo(node.user)
+    authinfo = node.get_authinfo()
     job_id = node.get_job_id()
 
     async def do_update():
@@ -240,7 +240,7 @@ async def task_retrieve_job(
     initial_interval = get_config_option(RETRY_INTERVAL_OPTION)
     max_attempts = get_config_option(MAX_ATTEMPTS_OPTION)
 
-    authinfo = node.computer.get_authinfo(node.user)
+    authinfo = node.get_authinfo()
 
     async def do_retrieve():
         with transport_queue.request_transport(authinfo) as request:
@@ -249,7 +249,7 @@ async def task_retrieve_job(
             # Perform the job accounting and set it on the node if successful. If the scheduler does not implement this
             # still set the attribute but set it to `None`. This way we can distinguish calculation jobs for which the
             # accounting was called but could not be set.
-            scheduler = node.computer.get_scheduler()
+            scheduler = node.computer.get_scheduler()  # type: ignore[union-attr]
             scheduler.set_transport(transport)
 
             try:
@@ -300,7 +300,7 @@ async def task_kill_job(node: CalcJobNode, transport_queue: TransportQueue, canc
         logger.warning(f'CalcJob<{node.pk}> killed, it was in the {node.get_state()} state')
         return True
 
-    authinfo = node.computer.get_authinfo(node.user)
+    authinfo = node.get_authinfo()
 
     async def do_kill():
         with transport_queue.request_transport(authinfo) as request:

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -9,10 +9,13 @@
 ###########################################################################
 # pylint: disable=too-many-lines,too-many-arguments
 """Package for node ORM classes."""
+import datetime
 import importlib
+from logging import Logger
 import warnings
 import traceback
-from typing import List, Optional
+from typing import Any, Dict, IO, Iterator, List, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
 from aiida.common import exceptions
 from aiida.common.escaping import sql_string_match
@@ -33,20 +36,25 @@ from ..entities import Collection as EntityCollection
 from ..querybuilder import QueryBuilder
 from ..users import User
 
+if TYPE_CHECKING:
+    from aiida.repository import File
+    from ..implementation import Backend
+    from ..implementation.nodes import BackendNode
+
 __all__ = ('Node',)
 
-_NO_DEFAULT = tuple()
+_NO_DEFAULT = tuple()  # type: ignore[var-annotated]
 
 
 class WarnWhenNotEntered:
     """Temporary wrapper to warn when `Node.open` is called outside of a context manager."""
 
-    def __init__(self, fileobj, name):
-        self._fileobj = fileobj
+    def __init__(self, fileobj: Union[IO[str], IO[bytes]], name: str) -> None:
+        self._fileobj: Union[IO[str], IO[bytes]] = fileobj
         self._name = name
         self._was_entered = False
 
-    def _warn_if_not_entered(self, method):
+    def _warn_if_not_entered(self, method) -> None:
         """Fire a warning if the object wrapper has not yet been entered."""
         if not self._was_entered:
             msg = f'\nThe method `{method}` was called on the return value of `{self._name}.open()`' + \
@@ -63,34 +71,34 @@ class WarnWhenNotEntered:
 
             warnings.warn(msg, AiidaDeprecationWarning)  # pylint: disable=no-member
 
-    def __enter__(self):
+    def __enter__(self) -> Union[IO[str], IO[bytes]]:
         self._was_entered = True
         return self._fileobj.__enter__()
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         self._fileobj.__exit__(*args)
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str):
         if key == '_fileobj':
             return self._fileobj
         return getattr(self._fileobj, key)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._warn_if_not_entered('del')
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Union[str, bytes]]:
         return self._fileobj.__iter__()
 
-    def __next__(self):
+    def __next__(self) -> Union[str, bytes]:
         return self._fileobj.__next__()
 
-    def read(self, *args, **kwargs):
+    def read(self, *args: Any, **kwargs: Any) -> Union[str, bytes]:
         self._warn_if_not_entered('read')
         return self._fileobj.read(*args, **kwargs)
 
-    def close(self, *args, **kwargs):
+    def close(self, *args: Any, **kwargs: Any) -> None:
         self._warn_if_not_entered('close')
-        return self._fileobj.close(*args, **kwargs)
+        return self._fileobj.close(*args, **kwargs)  # type: ignore[call-arg]
 
 
 class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractNodeMeta):
@@ -114,7 +122,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
     class Collection(EntityCollection):
         """The collection of nodes."""
 
-        def delete(self, node_id):
+        def delete(self, node_id: int) -> None:
             """Delete a `Node` from the collection with the given id
 
             :param node_id: the node id
@@ -135,14 +143,14 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             repository.erase(force=True)
 
     # This will be set by the metaclass call
-    _logger = None
+    _logger: Optional[Logger] = None
 
     # A tuple of attribute names that can be updated even after node is stored
     # Requires Sealable mixin, but needs empty tuple for base class
-    _updatable_attributes = tuple()
+    _updatable_attributes: Tuple[str, ...] = tuple()
 
     # A tuple of attribute names that will be ignored when creating the hash.
-    _hash_ignored_attributes = tuple()
+    _hash_ignored_attributes: Tuple[str, ...] = tuple()
 
     # Flag that determines whether the class can be cached.
     _cachable = False
@@ -155,15 +163,21 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
     _unstorable_message = 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
     # These are to be initialized in the `initialization` method
-    _incoming_cache = None
-    _repository = None
+    _incoming_cache: Optional[List[LinkTriple]] = None
+    _repository: Optional[Repository] = None
 
     @classmethod
-    def from_backend_entity(cls, backend_entity):
+    def from_backend_entity(cls, backend_entity: 'BackendNode') -> 'Node':
         entity = super().from_backend_entity(backend_entity)
         return entity
 
-    def __init__(self, backend=None, user=None, computer=None, **kwargs):
+    def __init__(
+        self,
+        backend: Optional['Backend'] = None,
+        user: Optional[User] = None,
+        computer: Optional[Computer] = None,
+        **kwargs: Any
+    ) -> None:
         backend = backend or get_manager().get_backend()
 
         if computer and not computer.is_stored:
@@ -180,10 +194,14 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         )
         super().__init__(backend_entity)
 
-    def __repr__(self):
+    @property
+    def backend_entity(self) -> 'BackendNode':
+        return super().backend_entity
+
+    def __repr__(self) -> str:
         return f'<{self.__class__.__name__}: {str(self)}>'
 
-    def __str__(self):
+    def __str__(self) -> str:
         if not self.is_stored:
             return f'uuid: {self.uuid} (unstored)'
 
@@ -197,7 +215,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         """Deep copying a Node is not supported in general, but only for the Data sub class."""
         raise exceptions.InvalidOperation('deep copying a base Node is not supported')
 
-    def initialize(self):
+    def initialize(self) -> None:
         """
         Initialize internal variables for the backend node
 
@@ -211,7 +229,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         # Calls the initialisation from the RepositoryMixin
         self._repository = Repository(uuid=self.uuid, is_stored=self.is_stored, base_path=self._repository_base_path)
 
-    def _validate(self):
+    def _validate(self) -> bool:
         """Check if the attributes and files retrieved from the database are valid.
 
         Must be able to work even before storing: therefore, use the `get_attr` and similar methods that automatically
@@ -223,7 +241,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         # pylint: disable=no-self-use
         return True
 
-    def validate_storability(self):
+    def validate_storability(self) -> None:
         """Verify that the current node is allowed to be stored.
 
         :raises `aiida.common.exceptions.StoringNotAllowed`: if the node does not match all requirements for storing
@@ -238,13 +256,13 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             raise exceptions.StoringNotAllowed(msg)
 
     @classproperty
-    def class_node_type(cls):
+    def class_node_type(cls) -> str:
         """Returns the node type of this node (sub) class."""
         # pylint: disable=no-self-argument,no-member
         return cls._plugin_type_string
 
     @property
-    def logger(self):
+    def logger(self) -> Optional[Logger]:
         """Return the logger configured for this Node.
 
         :return: Logger object
@@ -252,16 +270,16 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self._logger
 
     @property
-    def uuid(self):
+    def uuid(self) -> str:
         """Return the node UUID.
 
         :return: the string representation of the UUID
-        :rtype: str
+
         """
         return self.backend_entity.uuid
 
     @property
-    def node_type(self):
+    def node_type(self) -> str:
         """Return the node type.
 
         :return: the node type
@@ -269,7 +287,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self.backend_entity.node_type
 
     @property
-    def process_type(self):
+    def process_type(self) -> Optional[str]:
         """Return the node process type.
 
         :return: the process type
@@ -277,7 +295,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self.backend_entity.process_type
 
     @process_type.setter
-    def process_type(self, value):
+    def process_type(self, value: str) -> None:
         """Set the node process type.
 
         :param value: the new value to set
@@ -285,7 +303,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self.backend_entity.process_type = value
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Return the node label.
 
         :return: the label
@@ -293,7 +311,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self.backend_entity.label
 
     @label.setter
-    def label(self, value):
+    def label(self, value: str) -> None:
         """Set the label.
 
         :param value: the new value to set
@@ -301,7 +319,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self.backend_entity.label = value
 
     @property
-    def description(self):
+    def description(self) -> str:
         """Return the node description.
 
         :return: the description
@@ -309,7 +327,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self.backend_entity.description
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str) -> None:
         """Set the description.
 
         :param value: the new value to set
@@ -317,7 +335,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self.backend_entity.description = value
 
     @property
-    def computer(self):
+    def computer(self) -> Optional[Computer]:
         """Return the computer of this node.
 
         :return: the computer or None
@@ -329,7 +347,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return None
 
     @computer.setter
-    def computer(self, computer):
+    def computer(self, computer: Optional[Computer]) -> None:
         """Set the computer of this node.
 
         :param computer: a `Computer`
@@ -345,7 +363,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self.backend_entity.computer = computer
 
     @property
-    def user(self):
+    def user(self) -> User:
         """Return the user of this node.
 
         :return: the user
@@ -354,7 +372,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return User.from_backend_entity(self.backend_entity.user)
 
     @user.setter
-    def user(self, user):
+    def user(self, user: User) -> None:
         """Set the user of this node.
 
         :param user: a `User`
@@ -366,7 +384,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self.backend_entity.user = user.backend_entity
 
     @property
-    def ctime(self):
+    def ctime(self) -> datetime.datetime:
         """Return the node ctime.
 
         :return: the ctime
@@ -374,14 +392,14 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self.backend_entity.ctime
 
     @property
-    def mtime(self):
+    def mtime(self) -> datetime.datetime:
         """Return the node mtime.
 
         :return: the mtime
         """
         return self.backend_entity.mtime
 
-    def list_objects(self, path=None, key=None):
+    def list_objects(self, path: Optional[str] = None, key: Optional[str] = None) -> List['File']:
         """Return a list of the objects contained in this repository, optionally in the given sub directory.
 
         .. deprecated:: 1.4.0
@@ -392,6 +410,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :return: a list of `File` named tuples representing the objects present in directory with the given path
         :raises FileNotFoundError: if the `path` does not exist in the repository of this node
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if key is not None:
             if path is not None:
                 raise ValueError('cannot specify both `path` and `key`.')
@@ -403,7 +423,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self._repository.list_objects(path)
 
-    def list_object_names(self, path=None, key=None):
+    def list_object_names(self, path: Optional[str] = None, key: Optional[str] = None) -> List[str]:
         """Return a list of the object names contained in this repository, optionally in the given sub directory.
 
         .. deprecated:: 1.4.0
@@ -411,8 +431,10 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         :param path: the relative path of the object within the repository.
         :param key: fully qualified identifier for the object within the repository
-        :return: a list of `File` named tuples representing the objects present in directory with the given path
+
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if key is not None:
             if path is not None:
                 raise ValueError('cannot specify both `path` and `key`.')
@@ -424,7 +446,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self._repository.list_object_names(path)
 
-    def open(self, path=None, mode='r', key=None):
+    def open(self, path: Optional[str] = None, mode: str = 'r', key: Optional[str] = None) -> WarnWhenNotEntered:
         """Open a file handle to the object with the given path.
 
         .. deprecated:: 1.4.0
@@ -437,6 +459,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param key: fully qualified identifier for the object within the repository
         :param mode: the mode under which to open the handle
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if key is not None:
             if path is not None:
                 raise ValueError('cannot specify both `path` and `key`.')
@@ -454,7 +478,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return WarnWhenNotEntered(self._repository.open(path, mode), repr(self))
 
-    def get_object(self, path=None, key=None):
+    def get_object(self, path: Optional[str] = None, key: Optional[str] = None) -> 'File':
         """Return the object with the given path.
 
         .. deprecated:: 1.4.0
@@ -464,6 +488,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param key: fully qualified identifier for the object within the repository
         :return: a `File` named tuple
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if key is not None:
             if path is not None:
                 raise ValueError('cannot specify both `path` and `key`.')
@@ -478,7 +504,10 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self._repository.get_object(path)
 
-    def get_object_content(self, path=None, mode='r', key=None):
+    def get_object_content(self,
+                           path: Optional[str] = None,
+                           mode: str = 'r',
+                           key: Optional[str] = None) -> Union[str, bytes]:
         """Return the content of a object with the given path.
 
         .. deprecated:: 1.4.0
@@ -487,6 +516,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param path: the relative path of the object within the repository.
         :param key: fully qualified identifier for the object within the repository
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if key is not None:
             if path is not None:
                 raise ValueError('cannot specify both `path` and `key`.')
@@ -504,7 +535,14 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self._repository.get_object_content(path, mode)
 
-    def put_object_from_tree(self, filepath, path=None, contents_only=True, force=False, key=None):
+    def put_object_from_tree(
+        self,
+        filepath: str,
+        path: Optional[str] = None,
+        contents_only: bool = True,
+        force: bool = False,
+        key: Optional[str] = None
+    ) -> None:
         """Store a new object under `path` with the contents of the directory located at `filepath` on this file system.
 
         .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
@@ -529,6 +567,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if force:
             warnings.warn('the `force` keyword is deprecated and will be removed in `v2.0.0`.', AiidaDeprecationWarning)  # pylint: disable=no-member
 
@@ -548,7 +588,15 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         self._repository.put_object_from_tree(filepath, path, contents_only, force)
 
-    def put_object_from_file(self, filepath, path=None, mode=None, encoding=None, force=False, key=None):
+    def put_object_from_file(
+        self,
+        filepath: str,
+        path: Optional[str] = None,
+        mode: Optional[str] = None,
+        encoding: Optional[str] = None,
+        force: bool = False,
+        key: Optional[str] = None
+    ) -> None:
         """Store a new object under `path` with contents of the file located at `filepath` on this file system.
 
         .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
@@ -573,6 +621,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
+        assert self._repository is not None, 'repository not initialised'
+
         # Note that the defaults of `mode` and `encoding` had to be change to `None` from `w` and `utf-8` resptively, in
         # order to detect when they were being passed such that the deprecation warning can be emitted. The defaults did
         # not make sense and so ignoring them is justified, since the side-effect of this function, a file being copied,
@@ -602,7 +652,15 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         self._repository.put_object_from_file(filepath, path, mode, encoding, force)
 
-    def put_object_from_filelike(self, handle, path=None, mode='w', encoding='utf8', force=False, key=None):
+    def put_object_from_filelike(
+        self,
+        handle: IO[Any],
+        path: Optional[str] = None,
+        mode: str = 'w',
+        encoding: str = 'utf8',
+        force: bool = False,
+        key: Optional[str] = None
+    ) -> None:
         """Store a new object under `path` with contents of filelike object `handle`.
 
         .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
@@ -622,6 +680,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if force:
             warnings.warn('the `force` keyword is deprecated and will be removed in `v2.0.0`.', AiidaDeprecationWarning)  # pylint: disable=no-member
 
@@ -639,7 +699,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         self._repository.put_object_from_filelike(handle, path, mode, encoding, force)
 
-    def delete_object(self, path=None, force=False, key=None):
+    def delete_object(self, path: Optional[str] = None, force: bool = False, key: Optional[str] = None) -> None:
         """Delete the object from the repository.
 
         .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
@@ -655,6 +715,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param force: boolean, if True, will skip the mutability check
         :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
+        assert self._repository is not None, 'repository not initialised'
+
         if force:
             warnings.warn('the `force` keyword is deprecated and will be removed in `v2.0.0`.', AiidaDeprecationWarning)  # pylint: disable=no-member
 
@@ -717,7 +779,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         """
         Comment.objects.delete(identifier)
 
-    def add_incoming(self, source, link_type, link_label):
+    def add_incoming(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
         """Add a link of the given type from a given node to ourself.
 
         :param source: the node from which the link is coming
@@ -734,7 +796,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         else:
             self._add_incoming_cache(source, link_type, link_label)
 
-    def validate_incoming(self, source, link_type, link_label):
+    def validate_incoming(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
         """Validate adding a link of the given type from a given node to ourself.
 
         This function will first validate the types of the inputs, followed by the node and link types and validate
@@ -761,7 +823,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             if builder.count() > 0:
                 raise ValueError('the link you are attempting to create would generate a cycle in the graph')
 
-    def validate_outgoing(self, target, link_type, link_label):  # pylint: disable=unused-argument,no-self-use
+    def validate_outgoing(self, target: 'Node', link_type: LinkType, link_label: str) -> None:  # pylint: disable=unused-argument,no-self-use
         """Validate adding a link of the given type from ourself to a given node.
 
         The validity of the triple (source, link, target) should be validated in the `validate_incoming` call.
@@ -777,7 +839,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         type_check(link_type, LinkType, f'link_type should be a LinkType enum but got: {type(link_type)}')
         type_check(target, Node, f'target should be a `Node` instance but got: {type(target)}')
 
-    def _add_incoming_cache(self, source, link_type, link_label):
+    def _add_incoming_cache(self, source: Node, link_type: LinkType, link_label: str) -> None:
         """Add an incoming link to the cache.
 
         .. note: the proposed link is not validated in this function, so this should not be called directly
@@ -788,6 +850,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param link_label: the link label
         :raise aiida.common.UniquenessError: if the given link triple already exists in the cache
         """
+        assert self._incoming_cache is not None, 'incoming_cache not initialised'
+
         link_triple = LinkTriple(source, link_type, link_label)
 
         if link_triple in self._incoming_cache:
@@ -796,8 +860,13 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self._incoming_cache.append(link_triple)
 
     def get_stored_link_triples(
-        self, node_class=None, link_type=(), link_label_filter=None, link_direction='incoming', only_uuid=False
-    ):
+        self,
+        node_class: Type['Node'] = None,
+        link_type: Union[LinkType, Sequence[LinkType]] = (),
+        link_label_filter: Optional[str] = None,
+        link_direction: str = 'incoming',
+        only_uuid: bool = False
+    ) -> List[LinkTriple]:
         """Return the list of stored link triples directly incoming to or outgoing of this node.
 
         Note this will only return link triples that are stored in the database. Anything in the cache is ignored.
@@ -805,7 +874,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         :param node_class: If specified, should be a class, and it filters only elements of that (subclass of) type
         :param link_type: Only get inputs of this link type, if empty tuple then returns all inputs of all link types.
         :param link_label_filter: filters the incoming nodes by its link label. This should be a regex statement as
-            one would pass directly to a QuerBuilder filter statement with the 'like' operation.
+            one would pass directly to a QueryBuilder filter statement with the 'like' operation.
         :param link_direction: `incoming` or `outgoing` to get the incoming or outgoing links, respectively.
         :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
         """
@@ -816,8 +885,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             raise TypeError(f'link_type should be a LinkType or tuple of LinkType: got {link_type}')
 
         node_class = node_class or Node
-        node_filters = {'id': {'==': self.id}}
-        edge_filters = {}
+        node_filters: Dict[str, Any] = {'id': {'==': self.id}}
+        edge_filters: Dict[str, Any] = {}
 
         if link_type:
             edge_filters['type'] = {'in': [t.value for t in link_type]}
@@ -848,7 +917,13 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return [LinkTriple(entry[0], LinkType(entry[1]), entry[2]) for entry in builder.all()]
 
-    def get_incoming(self, node_class=None, link_type=(), link_label_filter=None, only_uuid=False):
+    def get_incoming(
+        self,
+        node_class: Type['Node'] = None,
+        link_type: Union[LinkType, Sequence[LinkType]] = (),
+        link_label_filter: Optional[str] = None,
+        only_uuid: bool = False
+    ) -> LinkManager:
         """Return a list of link triples that are (directly) incoming into this node.
 
         :param node_class: If specified, should be a class or tuple of classes, and it filters only
@@ -859,6 +934,8 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             Here wildcards (% and _) can be passed in link label filter as we are using "like" in QB.
         :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
         """
+        assert self._incoming_cache is not None, 'incoming_cache not initialised'
+
         if not isinstance(link_type, tuple):
             link_type = (link_type,)
 
@@ -889,7 +966,13 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return LinkManager(link_triples)
 
-    def get_outgoing(self, node_class=None, link_type=(), link_label_filter=None, only_uuid=False):
+    def get_outgoing(
+        self,
+        node_class: Type['Node'] = None,
+        link_type: Union[LinkType, Sequence[LinkType]] = (),
+        link_label_filter: Optional[str] = None,
+        only_uuid: bool = False
+    ) -> LinkManager:
         """Return a list of link triples that are (directly) outgoing of this node.
 
         :param node_class: If specified, should be a class or tuple of classes, and it filters only
@@ -903,20 +986,23 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         link_triples = self.get_stored_link_triples(node_class, link_type, link_label_filter, 'outgoing', only_uuid)
         return LinkManager(link_triples)
 
-    def has_cached_links(self):
+    def has_cached_links(self) -> bool:
         """Feturn whether there are unstored incoming links in the cache.
 
         :return: boolean, True when there are links in the incoming cache, False otherwise
         """
+        assert self._incoming_cache is not None, 'incoming_cache not initialised'
         return bool(self._incoming_cache)
 
-    def store_all(self, with_transaction=True, use_cache=None):
+    def store_all(self, with_transaction: bool = True, use_cache=None) -> 'Node':
         """Store the node, together with all input links.
 
         Unstored nodes from cached incoming linkswill also be stored.
 
         :parameter with_transaction: if False, do not use a transaction because the caller will already have opened one.
         """
+        assert self._incoming_cache is not None, 'incoming_cache not initialised'
+
         if use_cache is not None:
             warnings.warn(  # pylint: disable=no-member
                 'the `use_cache` argument is deprecated and will be removed in `v2.0.0`', AiidaDeprecationWarning
@@ -935,7 +1021,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self.store(with_transaction)
 
-    def store(self, with_transaction=True, use_cache=None):  # pylint: disable=arguments-differ
+    def store(self, with_transaction: bool = True, use_cache=None) -> 'Node':  # pylint: disable=arguments-differ
         """Store the node in the database while saving its attributes and repository directory.
 
         After being called attributes cannot be changed anymore! Instead, extras can be changed only AFTER calling
@@ -984,12 +1070,14 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self
 
-    def _store(self, with_transaction=True, clean=True):
+    def _store(self, with_transaction: bool = True, clean: bool = True) -> 'Node':
         """Store the node in the database while saving its attributes and repository directory.
 
         :param with_transaction: if False, do not use a transaction because the caller will already have opened one.
         :param clean: boolean, if True, will clean the attributes and extras before attempting to store
         """
+        assert self._repository is not None, 'repository not initialised'
+
         # First store the repository folder such that if this fails, there won't be an incomplete node in the database.
         # On the flipside, in the case that storing the node does fail, the repository will now have an orphaned node
         # directory which will have to be cleaned manually sometime.
@@ -1008,19 +1096,24 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         return self
 
-    def verify_are_parents_stored(self):
+    def verify_are_parents_stored(self) -> None:
         """Verify that all `parent` nodes are already stored.
 
         :raise aiida.common.ModificationNotAllowed: if one of the source nodes of incoming links is not stored.
         """
+        assert self._incoming_cache is not None, 'incoming_cache not initialised'
+
         for link_triple in self._incoming_cache:
             if not link_triple.node.is_stored:
                 raise exceptions.ModificationNotAllowed(
                     f'Cannot store because source node of link triple {link_triple} is not stored'
                 )
 
-    def _store_from_cache(self, cache_node, with_transaction):
+    def _store_from_cache(self, cache_node: 'Node', with_transaction: bool) -> None:
         """Store this node from an existing cache node."""
+        assert self._repository is not None, 'repository not initialised'
+        assert cache_node._repository is not None, 'cache repository not initialised'  # pylint: disable=protected-access
+
         from aiida.orm.utils.mixins import Sealable
         assert self.node_type == cache_node.node_type
 
@@ -1046,21 +1139,21 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         self._add_outputs_from_cache(cache_node)
         self.set_extra('_aiida_cached_from', cache_node.uuid)
 
-    def _add_outputs_from_cache(self, cache_node):
+    def _add_outputs_from_cache(self, cache_node: 'Node') -> None:
         """Replicate the output links and nodes from the cached node onto this node."""
         for entry in cache_node.get_outgoing(link_type=LinkType.CREATE):
             new_node = entry.node.clone()
             new_node.add_incoming(self, link_type=LinkType.CREATE, link_label=entry.link_label)
             new_node.store()
 
-    def get_hash(self, ignore_errors=True, **kwargs):
+    def get_hash(self, ignore_errors: bool = True, **kwargs: Any) -> str:
         """Return the hash for this node based on its attributes."""
         if not self.is_stored:
             raise exceptions.InvalidOperation('You can get the hash only after having stored the node')
 
         return self._get_hash(ignore_errors=ignore_errors, **kwargs)
 
-    def _get_hash(self, ignore_errors=True, **kwargs):
+    def _get_hash(self, ignore_errors: bool = True, **kwargs: Any) -> str:
         """
         Return the hash for this node based on its attributes.
 
@@ -1072,10 +1165,12 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             if not ignore_errors:
                 raise
 
-    def _get_objects_to_hash(self):
+    def _get_objects_to_hash(self) -> List[Any]:
         """Return a list of objects which should be included in the hash."""
+        assert self._repository is not None, 'repository not initialised'
+
         objects = [
-            importlib.import_module(self.__module__.split('.', 1)[0]).__version__,
+            importlib.import_module(self.__module__.split('.', 1)[0]).__version__,  # type: ignore[attr-defined]
             {
                 key: val
                 for key, val in self.attributes_items()
@@ -1086,15 +1181,15 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         ]
         return objects
 
-    def rehash(self):
+    def rehash(self) -> None:
         """Regenerate the stored hash of the Node."""
         self.set_extra(_HASH_EXTRA_KEY, self.get_hash())
 
-    def clear_hash(self):
+    def clear_hash(self) -> None:
         """Sets the stored hash of the Node to None."""
         self.set_extra(_HASH_EXTRA_KEY, None)
 
-    def get_cache_source(self):
+    def get_cache_source(self) -> Optional[str]:
         """Return the UUID of the node that was used in creating this node from the cache, or None if it was not cached.
 
         :return: source node UUID or None
@@ -1102,14 +1197,14 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return self.get_extra('_aiida_cached_from', None)
 
     @property
-    def is_created_from_cache(self):
+    def is_created_from_cache(self) -> bool:
         """Return whether this node was created from a cached node.
 
         :return: boolean, True if the node was created by cloning a cached node, False otherwise
         """
         return self.get_cache_source() is not None
 
-    def _get_same_node(self):
+    def _get_same_node(self) -> Optional['Node']:
         """Returns a stored node from which the current Node can be cached or None if it does not exist
 
         If a node is returned it is a valid cache, meaning its `_aiida_hash` extra matches `self.get_hash()`.
@@ -1126,7 +1221,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         except StopIteration:
             return None
 
-    def get_all_same_nodes(self):
+    def get_all_same_nodes(self) -> List['Node']:
         """Return a list of stored nodes which match the type and hash of the current node.
 
         All returned nodes are valid caches, meaning their `_aiida_hash` extra matches `self.get_hash()`.
@@ -1136,7 +1231,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         """
         return list(self._iter_all_same_nodes())
 
-    def _iter_all_same_nodes(self, allow_before_store=False):
+    def _iter_all_same_nodes(self, allow_before_store=False) -> Iterator['Node']:
         """
         Returns an iterator of all same nodes.
 
@@ -1157,22 +1252,21 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         return (node for node in nodes_identical if node.is_valid_cache)
 
     @property
-    def is_valid_cache(self):
+    def is_valid_cache(self) -> bool:
         """Hook to exclude certain `Node` instances from being considered a valid cache."""
         # pylint: disable=no-self-use
         return True
 
-    def get_description(self):
+    def get_description(self) -> str:
         """Return a string with a description of the node.
 
         :return: a description string
-        :rtype: str
         """
         # pylint: disable=no-self-use
         return ''
 
     @staticmethod
-    def get_schema():
+    def get_schema() -> Dict[str, Any]:
         """
         Every node property contains:
             - display_name: display name of the property

--- a/aiida/orm/nodes/process/__init__.py
+++ b/aiida/orm/nodes/process/__init__.py
@@ -14,4 +14,4 @@ from .calculation import *
 from .process import *
 from .workflow import *
 
-__all__ = (calculation.__all__ + process.__all__ + workflow.__all__)
+__all__ = (calculation.__all__ + process.__all__ + workflow.__all__)  # type: ignore[name-defined]

--- a/aiida/orm/nodes/process/calculation/calcfunction.py
+++ b/aiida/orm/nodes/process/calculation/calcfunction.py
@@ -10,6 +10,7 @@
 """Module with `Node` sub class for calculation function processes."""
 
 from aiida.common.links import LinkType
+from aiida.orm import Node
 from aiida.orm.utils.mixins import FunctionCalculationMixin
 
 from .calculation import CalculationNode
@@ -20,7 +21,7 @@ __all__ = ('CalcFunctionNode',)
 class CalcFunctionNode(FunctionCalculationMixin, CalculationNode):
     """ORM class for all nodes representing the execution of a calcfunction."""
 
-    def validate_outgoing(self, target, link_type, link_label):
+    def validate_outgoing(self, target: Node, link_type: LinkType, link_label: str) -> None:
         """
         Validate adding a link of the given type from ourself to a given node.
 

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -8,16 +8,29 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module with `Node` sub class for calculation job processes."""
-
+import datetime
+from typing import Any, AnyStr, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING
 import warnings
 
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcJobState
 from aiida.common.lang import classproperty
 from aiida.common.links import LinkType
+from aiida.common.folders import Folder
 from aiida.common.warnings import AiidaDeprecationWarning
 
 from .calculation import CalculationNode
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.builder import ProcessBuilder
+    from aiida.orm import FolderData
+    from aiida.orm.authinfos import AuthInfo
+    from aiida.orm.utils.calcjob import CalcJobResultManager
+    from aiida.parsers import Parser
+    from aiida.schedulers.datastructures import JobInfo, JobState
+    from aiida.tools.calculations import CalculationTools
+    from aiida.transports import Transport
 
 __all__ = ('CalcJobNode',)
 
@@ -45,7 +58,7 @@ class CalcJobNode(CalculationNode):
     _tools = None
 
     @property
-    def tools(self):
+    def tools(self) -> 'CalculationTools':
         """Return the calculation tools that are registered for the process type associated with this calculation.
 
         If the entry point name stored in the `process_type` of the CalcJobNode has an accompanying entry point in the
@@ -76,7 +89,7 @@ class CalcJobNode(CalculationNode):
         return self._tools
 
     @classproperty
-    def _updatable_attributes(cls):  # pylint: disable=no-self-argument
+    def _updatable_attributes(cls) -> Tuple[str, ...]:  # pylint: disable=no-self-argument
         return super()._updatable_attributes + (
             cls.CALC_JOB_STATE_KEY,
             cls.REMOTE_WORKDIR_KEY,
@@ -91,7 +104,7 @@ class CalcJobNode(CalculationNode):
         )
 
     @classproperty
-    def _hash_ignored_attributes(cls):  # pylint: disable=no-self-argument
+    def _hash_ignored_attributes(cls) -> Tuple[str, ...]:  # pylint: disable=no-self-argument
         return super()._hash_ignored_attributes + (
             'queue_name',
             'account',
@@ -101,7 +114,7 @@ class CalcJobNode(CalculationNode):
             'max_memory_kb',
         )
 
-    def _get_objects_to_hash(self):
+    def _get_objects_to_hash(self) -> List[Any]:
         """Return a list of objects which should be included in the hash.
 
         This method is purposefully overridden from the base `Node` class, because we do not want to include the
@@ -112,7 +125,7 @@ class CalcJobNode(CalculationNode):
         """
         from importlib import import_module
         objects = [
-            import_module(self.__module__.split('.', 1)[0]).__version__,
+            import_module(self.__module__.split('.', 1)[0]).__version__,  # type: ignore[attr-defined]
             {
                 key: val
                 for key, val in self.attributes_items()
@@ -127,7 +140,7 @@ class CalcJobNode(CalculationNode):
         ]
         return objects
 
-    def get_builder_restart(self):
+    def get_builder_restart(self) -> 'ProcessBuilder':
         """Return a `ProcessBuilder` that is ready to relaunch the same `CalcJob` that created this node.
 
         The process class will be set based on the `process_type` of this node and the inputs of the builder will be
@@ -137,15 +150,14 @@ class CalcJobNode(CalculationNode):
         In addition to prepopulating the input nodes, which is implemented by the base `ProcessNode` class, here we
         also add the `options` that were passed in the `metadata` input of the `CalcJob` process.
 
-        :return: `~aiida.engine.processes.builder.ProcessBuilder` instance
         """
         builder = super().get_builder_restart()
-        builder.metadata.options = self.get_options()
+        builder.metadata.options = self.get_options()  # type: ignore[attr-defined]
 
         return builder
 
     @property
-    def _raw_input_folder(self):
+    def _raw_input_folder(self) -> Folder:
         """
         Get the input folder object.
 
@@ -154,13 +166,15 @@ class CalcJobNode(CalculationNode):
         """
         from aiida.common.exceptions import NotExistent
 
+        assert self._repository is not None, 'repository not initialised'
+
         return_folder = self._repository._get_base_folder()  # pylint: disable=protected-access
         if return_folder.exists():
             return return_folder
 
         raise NotExistent('the `_raw_input_folder` has not yet been created')
 
-    def get_option(self, name):
+    def get_option(self, name: str) -> Optional[Any]:
         """
         Retun the value of an option that was set for this CalcJobNode
 
@@ -170,7 +184,7 @@ class CalcJobNode(CalculationNode):
         """
         return self.get_attribute(name, None)
 
-    def set_option(self, name, value):
+    def set_option(self, name: str, value: Any) -> None:
         """
         Set an option to the given value
 
@@ -181,21 +195,21 @@ class CalcJobNode(CalculationNode):
         """
         self.set_attribute(name, value)
 
-    def get_options(self):
+    def get_options(self) -> Dict[str, Any]:
         """
         Return the dictionary of options set for this CalcJobNode
 
         :return: dictionary of the options and their values
         """
         options = {}
-        for name in self.process_class.spec_options.keys():
+        for name in self.process_class.spec_options.keys():  # type: ignore[attr-defined]
             value = self.get_option(name)
             if value is not None:
                 options[name] = value
 
         return options
 
-    def set_options(self, options):
+    def set_options(self, options: Dict[str, Any]) -> None:
         """
         Set the options for this CalcJobNode
 
@@ -204,7 +218,7 @@ class CalcJobNode(CalculationNode):
         for name, value in options.items():
             self.set_option(name, value)
 
-    def get_state(self):
+    def get_state(self) -> Optional[CalcJobState]:
         """Return the calculation job active sub state.
 
         The calculation job state serves to give more granular state information to `CalcJobs`, in addition to the
@@ -223,10 +237,9 @@ class CalcJobNode(CalculationNode):
 
         return state
 
-    def set_state(self, state):
+    def set_state(self, state: CalcJobState) -> None:
         """Set the calculation active job state.
 
-        :param state: a string with the state from ``aiida.common.datastructures.CalcJobState``.
         :raise: ValueError if state is invalid
         """
         if not isinstance(state, CalcJobState):
@@ -234,21 +247,21 @@ class CalcJobNode(CalculationNode):
 
         self.set_attribute(self.CALC_JOB_STATE_KEY, state.value)
 
-    def delete_state(self):
+    def delete_state(self) -> None:
         """Delete the calculation job state attribute if it exists."""
         try:
             self.delete_attribute(self.CALC_JOB_STATE_KEY)
         except AttributeError:
             pass
 
-    def set_remote_workdir(self, remote_workdir):
+    def set_remote_workdir(self, remote_workdir: str) -> None:
         """Set the absolute path to the working directory on the remote computer where the calculation is run.
 
         :param remote_workdir: absolute filepath to the remote working directory
         """
         self.set_attribute(self.REMOTE_WORKDIR_KEY, remote_workdir)
 
-    def get_remote_workdir(self):
+    def get_remote_workdir(self) -> Optional[str]:
         """Return the path to the remote (on cluster) scratch folder of the calculation.
 
         :return: a string with the remote path
@@ -256,10 +269,10 @@ class CalcJobNode(CalculationNode):
         return self.get_attribute(self.REMOTE_WORKDIR_KEY, None)
 
     @staticmethod
-    def _validate_retrieval_directive(directives):
+    def _validate_retrieval_directive(directives: Sequence[Union[str, Tuple[str, str, str]]]) -> None:
         """Validate a list or tuple of file retrieval directives.
 
-        :param directives: a list or tuple of file retrieveal directives
+        :param directives: a list or tuple of file retrieval directives
         :raise ValueError: if the format of the directives is invalid
         """
         if not isinstance(directives, (tuple, list)):
@@ -284,7 +297,7 @@ class CalcJobNode(CalculationNode):
             if not isinstance(directive[2], int):
                 raise ValueError('invalid directive, three element has to be an integer representing the depth')
 
-    def set_retrieve_list(self, retrieve_list):
+    def set_retrieve_list(self, retrieve_list: Sequence[Union[str, Tuple[str, str, str]]]) -> None:
         """Set the retrieve list.
 
         This list of directives will instruct the daemon what files to retrieve after the calculation has completed.
@@ -295,14 +308,14 @@ class CalcJobNode(CalculationNode):
         self._validate_retrieval_directive(retrieve_list)
         self.set_attribute(self.RETRIEVE_LIST_KEY, retrieve_list)
 
-    def get_retrieve_list(self):
+    def get_retrieve_list(self) -> Optional[Sequence[Union[str, Tuple[str, str, str]]]]:
         """Return the list of files/directories to be retrieved on the cluster after the calculation has completed.
 
         :return: a list of file directives
         """
         return self.get_attribute(self.RETRIEVE_LIST_KEY, None)
 
-    def set_retrieve_temporary_list(self, retrieve_temporary_list):
+    def set_retrieve_temporary_list(self, retrieve_temporary_list: Sequence[Union[str, Tuple[str, str, str]]]) -> None:
         """Set the retrieve temporary list.
 
         The retrieve temporary list stores files that are retrieved after completion and made available during parsing
@@ -313,7 +326,7 @@ class CalcJobNode(CalculationNode):
         self._validate_retrieval_directive(retrieve_temporary_list)
         self.set_attribute(self.RETRIEVE_TEMPORARY_LIST_KEY, retrieve_temporary_list)
 
-    def get_retrieve_temporary_list(self):
+    def get_retrieve_temporary_list(self) -> Optional[Sequence[Union[str, Tuple[str, str, str]]]]:
         """Return list of files to be retrieved from the cluster which will be available during parsing.
 
         :return: a list of file directives
@@ -360,7 +373,7 @@ class CalcJobNode(CalculationNode):
         """
         return self.get_attribute(self.RETRIEVE_SINGLE_FILE_LIST_KEY, None)
 
-    def set_job_id(self, job_id):
+    def set_job_id(self, job_id: Union[int, str]) -> None:
         """Set the job id that was assigned to the calculation by the scheduler.
 
         .. note:: the id will always be stored as a string
@@ -369,14 +382,14 @@ class CalcJobNode(CalculationNode):
         """
         return self.set_attribute(self.SCHEDULER_JOB_ID_KEY, str(job_id))
 
-    def get_job_id(self):
+    def get_job_id(self) -> Optional[str]:
         """Return job id that was assigned to the calculation by the scheduler.
 
         :return: the string representation of the scheduler job id
         """
         return self.get_attribute(self.SCHEDULER_JOB_ID_KEY, None)
 
-    def set_scheduler_state(self, state):
+    def set_scheduler_state(self, state: 'JobState') -> None:
         """Set the scheduler state.
 
         :param state: an instance of `JobState`
@@ -390,7 +403,7 @@ class CalcJobNode(CalculationNode):
         self.set_attribute(self.SCHEDULER_STATE_KEY, state.value)
         self.set_attribute(self.SCHEDULER_LAST_CHECK_TIME_KEY, timezone.datetime_to_isoformat(timezone.now()))
 
-    def get_scheduler_state(self):
+    def get_scheduler_state(self) -> Optional['JobState']:
         """Return the status of the calculation according to the cluster scheduler.
 
         :return: a JobState enum instance.
@@ -404,7 +417,7 @@ class CalcJobNode(CalculationNode):
 
         return JobState(state)
 
-    def get_scheduler_lastchecktime(self):
+    def get_scheduler_lastchecktime(self) -> Optional[datetime.datetime]:
         """Return the time of the last update of the scheduler state by the daemon or None if it was never set.
 
         :return: a datetime object or None
@@ -417,14 +430,14 @@ class CalcJobNode(CalculationNode):
 
         return value
 
-    def set_detailed_job_info(self, detailed_job_info):
+    def set_detailed_job_info(self, detailed_job_info: Optional[dict]) -> None:
         """Set the detailed job info dictionary.
 
         :param detailed_job_info: a dictionary with metadata with the accounting of a completed job
         """
         self.set_attribute(self.SCHEDULER_DETAILED_JOB_INFO_KEY, detailed_job_info)
 
-    def get_detailed_job_info(self):
+    def get_detailed_job_info(self) -> Optional[dict]:
         """Return the detailed job info dictionary.
 
         The scheduler is polled for the detailed job info after the job is completed and ready to be retrieved.
@@ -433,14 +446,14 @@ class CalcJobNode(CalculationNode):
         """
         return self.get_attribute(self.SCHEDULER_DETAILED_JOB_INFO_KEY, None)
 
-    def set_last_job_info(self, last_job_info):
+    def set_last_job_info(self, last_job_info: 'JobInfo') -> None:
         """Set the last job info.
 
         :param last_job_info: a `JobInfo` object
         """
         self.set_attribute(self.SCHEDULER_LAST_JOB_INFO_KEY, last_job_info.get_dict())
 
-    def get_last_job_info(self):
+    def get_last_job_info(self) -> Optional['JobInfo']:
         """Return the last information asked to the scheduler about the status of the job.
 
         The last job info is updated on every poll of the scheduler, except for the final poll when the job drops from
@@ -462,7 +475,7 @@ class CalcJobNode(CalculationNode):
 
         return job_info
 
-    def get_authinfo(self):
+    def get_authinfo(self) -> 'AuthInfo':
         """Return the `AuthInfo` that is configured for the `Computer` set for this node.
 
         :return: `AuthInfo`
@@ -476,14 +489,14 @@ class CalcJobNode(CalculationNode):
 
         return AuthInfo.from_backend_entity(self.backend.authinfos.get(computer=computer, user=self.user))
 
-    def get_transport(self):
+    def get_transport(self) -> 'Transport':
         """Return the transport for this calculation.
 
         :return: `Transport` configured with the `AuthInfo` associated to the computer of this node
         """
         return self.get_authinfo().get_transport()
 
-    def get_parser_class(self):
+    def get_parser_class(self) -> Optional[Type['Parser']]:
         """Return the output parser object for this calculation or None if no parser is set.
 
         :return: a `Parser` class.
@@ -499,11 +512,11 @@ class CalcJobNode(CalculationNode):
         return None
 
     @property
-    def link_label_retrieved(self):
+    def link_label_retrieved(self) -> str:
         """Return the link label used for the retrieved FolderData node."""
         return 'retrieved'
 
-    def get_retrieved_node(self):
+    def get_retrieved_node(self) -> Optional['FolderData']:
         """Return the retrieved data folder.
 
         :return: the retrieved FolderData node or None if not found
@@ -515,7 +528,7 @@ class CalcJobNode(CalculationNode):
             return None
 
     @property
-    def res(self):
+    def res(self) -> 'CalcJobResultManager':
         """
         To be used to get direct access to the parsed parameters.
 
@@ -528,7 +541,7 @@ class CalcJobNode(CalculationNode):
         from aiida.orm.utils.calcjob import CalcJobResultManager
         return CalcJobResultManager(self)
 
-    def get_scheduler_stdout(self):
+    def get_scheduler_stdout(self) -> Optional[AnyStr]:
         """Return the scheduler stderr output if the calculation has finished and been retrieved, None otherwise.
 
         :return: scheduler stderr output or None
@@ -546,7 +559,7 @@ class CalcJobNode(CalculationNode):
 
         return stdout
 
-    def get_scheduler_stderr(self):
+    def get_scheduler_stderr(self) -> Optional[AnyStr]:
         """Return the scheduler stdout output if the calculation has finished and been retrieved, None otherwise.
 
         :return: scheduler stdout output or None
@@ -564,6 +577,9 @@ class CalcJobNode(CalculationNode):
 
         return stderr
 
-    def get_description(self):
-        """Return a string with a description of the node based on its properties."""
-        return self.get_state()
+    def get_description(self) -> str:
+        """Return a description of the node based on its properties."""
+        state = self.get_state()
+        if not state:
+            return ''
+        return state.value

--- a/aiida/orm/nodes/process/calculation/calculation.py
+++ b/aiida/orm/nodes/process/calculation/calculation.py
@@ -25,25 +25,23 @@ class CalculationNode(ProcessNode):
     _unstorable_message = 'storing for this node has been disabled'
 
     @property
-    def inputs(self):
+    def inputs(self) -> NodeLinksManager:
         """Return an instance of `NodeLinksManager` to manage incoming INPUT_CALC links
 
         The returned Manager allows you to easily explore the nodes connected to this node
         via an incoming INPUT_CALC link.
         The incoming nodes are reachable by their link labels which are attributes of the manager.
 
-        :return: `NodeLinksManager`
         """
         return NodeLinksManager(node=self, link_type=LinkType.INPUT_CALC, incoming=True)
 
     @property
-    def outputs(self):
+    def outputs(self) -> NodeLinksManager:
         """Return an instance of `NodeLinksManager` to manage outgoing CREATE links
 
         The returned Manager allows you to easily explore the nodes connected to this node
         via an outgoing CREATE link.
         The outgoing nodes are reachable by their link labels which are attributes of the manager.
 
-        :return: `NodeLinksManager`
         """
         return NodeLinksManager(node=self, link_type=LinkType.CREATE, incoming=False)

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -10,14 +10,20 @@
 """Module with `Node` sub class for processes."""
 
 import enum
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
-from plumpy import ProcessState
+from plumpy.process_states import ProcessState
 
 from aiida.common.links import LinkType
 from aiida.common.lang import classproperty
 from aiida.orm.utils.mixins import Sealable
 
 from ..node import Node
+
+if TYPE_CHECKING:
+    from aiida.engine.processes import Process
+    from aiida.engine.processes.builder import ProcessBuilder
 
 __all__ = ('ProcessNode',)
 
@@ -48,7 +54,7 @@ class ProcessNode(Sealable, Node):
 
     _unstorable_message = 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
-    def __str__(self):
+    def __str__(self) -> str:
         base = super().__str__()
         if self.process_type:
             return f'{base} ({self.process_type})'
@@ -56,7 +62,7 @@ class ProcessNode(Sealable, Node):
         return f'{base}'
 
     @classproperty
-    def _updatable_attributes(cls):
+    def _updatable_attributes(cls) -> Tuple[str, ...]:
         # pylint: disable=no-self-argument
         return super()._updatable_attributes + (
             cls.PROCESS_PAUSED_KEY,
@@ -79,7 +85,7 @@ class ProcessNode(Sealable, Node):
         from aiida.orm.utils.log import create_logger_adapter
         return create_logger_adapter(self._logger, self)
 
-    def get_builder_restart(self):
+    def get_builder_restart(self) -> 'ProcessBuilder':
         """Return a `ProcessBuilder` that is ready to relaunch the process that created this node.
 
         The process class will be set based on the `process_type` of this node and the inputs of the builder will be
@@ -94,7 +100,7 @@ class ProcessNode(Sealable, Node):
         return builder
 
     @property
-    def process_class(self):
+    def process_class(self) -> Type['Process']:
         """Return the process class that was used to create this node.
 
         :return: `Process` class
@@ -128,7 +134,7 @@ class ProcessNode(Sealable, Node):
 
         return process_class
 
-    def set_process_type(self, process_type_string):
+    def set_process_type(self, process_type_string: str) -> None:
         """
         Set the process type string.
 
@@ -137,7 +143,7 @@ class ProcessNode(Sealable, Node):
         self.process_type = process_type_string
 
     @property
-    def process_label(self):
+    def process_label(self) -> Optional[str]:
         """
         Return the process label
 
@@ -145,7 +151,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.PROCESS_LABEL_KEY, None)
 
-    def set_process_label(self, label):
+    def set_process_label(self, label: str) -> None:
         """
         Set the process label
 
@@ -154,7 +160,7 @@ class ProcessNode(Sealable, Node):
         self.set_attribute(self.PROCESS_LABEL_KEY, label)
 
     @property
-    def process_state(self):
+    def process_state(self) -> Optional[ProcessState]:
         """
         Return the process state
 
@@ -167,7 +173,7 @@ class ProcessNode(Sealable, Node):
 
         return ProcessState(state)
 
-    def set_process_state(self, state):
+    def set_process_state(self, state: Union[str, ProcessState]):
         """
         Set the process state
 
@@ -178,7 +184,7 @@ class ProcessNode(Sealable, Node):
         return self.set_attribute(self.PROCESS_STATE_KEY, state)
 
     @property
-    def process_status(self):
+    def process_status(self) -> Optional[str]:
         """
         Return the process status
 
@@ -188,7 +194,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.PROCESS_STATUS_KEY, None)
 
-    def set_process_status(self, status):
+    def set_process_status(self, status: Optional[str]) -> None:
         """
         Set the process status
 
@@ -210,7 +216,7 @@ class ProcessNode(Sealable, Node):
         return self.set_attribute(self.PROCESS_STATUS_KEY, status)
 
     @property
-    def is_terminated(self):
+    def is_terminated(self) -> bool:
         """
         Return whether the process has terminated
 
@@ -222,7 +228,7 @@ class ProcessNode(Sealable, Node):
         return self.is_excepted or self.is_finished or self.is_killed
 
     @property
-    def is_excepted(self):
+    def is_excepted(self) -> bool:
         """
         Return whether the process has excepted
 
@@ -234,7 +240,7 @@ class ProcessNode(Sealable, Node):
         return self.process_state == ProcessState.EXCEPTED
 
     @property
-    def is_killed(self):
+    def is_killed(self) -> bool:
         """
         Return whether the process was killed
 
@@ -246,7 +252,7 @@ class ProcessNode(Sealable, Node):
         return self.process_state == ProcessState.KILLED
 
     @property
-    def is_finished(self):
+    def is_finished(self) -> bool:
         """
         Return whether the process has finished
 
@@ -259,7 +265,7 @@ class ProcessNode(Sealable, Node):
         return self.process_state == ProcessState.FINISHED
 
     @property
-    def is_finished_ok(self):
+    def is_finished_ok(self) -> bool:
         """
         Return whether the process has finished successfully
 
@@ -271,7 +277,7 @@ class ProcessNode(Sealable, Node):
         return self.is_finished and self.exit_status == 0
 
     @property
-    def is_failed(self):
+    def is_failed(self) -> bool:
         """
         Return whether the process has failed
 
@@ -283,7 +289,7 @@ class ProcessNode(Sealable, Node):
         return self.is_finished and self.exit_status != 0
 
     @property
-    def exit_status(self):
+    def exit_status(self) -> Optional[int]:
         """
         Return the exit status of the process
 
@@ -291,7 +297,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.EXIT_STATUS_KEY, None)
 
-    def set_exit_status(self, status):
+    def set_exit_status(self, status: Union[None, enum.Enum, int]) -> None:
         """
         Set the exit status of the process
 
@@ -309,7 +315,7 @@ class ProcessNode(Sealable, Node):
         return self.set_attribute(self.EXIT_STATUS_KEY, status)
 
     @property
-    def exit_message(self):
+    def exit_message(self) -> Optional[str]:
         """
         Return the exit message of the process
 
@@ -317,7 +323,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.EXIT_MESSAGE_KEY, None)
 
-    def set_exit_message(self, message):
+    def set_exit_message(self, message: Optional[str]) -> None:
         """
         Set the exit message of the process, if None nothing will be done
 
@@ -332,7 +338,7 @@ class ProcessNode(Sealable, Node):
         return self.set_attribute(self.EXIT_MESSAGE_KEY, message)
 
     @property
-    def exception(self):
+    def exception(self) -> Optional[str]:
         """
         Return the exception of the process or None if the process is not excepted.
 
@@ -345,7 +351,7 @@ class ProcessNode(Sealable, Node):
 
         return None
 
-    def set_exception(self, exception):
+    def set_exception(self, exception: str) -> None:
         """
         Set the exception of the process
 
@@ -357,7 +363,7 @@ class ProcessNode(Sealable, Node):
         return self.set_attribute(self.EXCEPTION_KEY, exception)
 
     @property
-    def checkpoint(self):
+    def checkpoint(self) -> Optional[Dict[str, Any]]:
         """
         Return the checkpoint bundle set for the process
 
@@ -365,7 +371,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.CHECKPOINT_KEY, None)
 
-    def set_checkpoint(self, checkpoint):
+    def set_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
         """
         Set the checkpoint bundle set for the process
 
@@ -373,7 +379,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.set_attribute(self.CHECKPOINT_KEY, checkpoint)
 
-    def delete_checkpoint(self):
+    def delete_checkpoint(self) -> None:
         """
         Delete the checkpoint bundle set for the process
         """
@@ -383,7 +389,7 @@ class ProcessNode(Sealable, Node):
             pass
 
     @property
-    def paused(self):
+    def paused(self) -> bool:
         """
         Return whether the process is paused
 
@@ -391,7 +397,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.PROCESS_PAUSED_KEY, False)
 
-    def pause(self):
+    def pause(self) -> None:
         """
         Mark the process as paused by setting the corresponding attribute.
 
@@ -400,7 +406,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.set_attribute(self.PROCESS_PAUSED_KEY, True)
 
-    def unpause(self):
+    def unpause(self) -> None:
         """
         Mark the process as unpaused by removing the corresponding attribute.
 
@@ -413,7 +419,7 @@ class ProcessNode(Sealable, Node):
             pass
 
     @property
-    def called(self):
+    def called(self) -> List['ProcessNode']:
         """
         Return a list of nodes that the process called
 
@@ -422,7 +428,7 @@ class ProcessNode(Sealable, Node):
         return self.get_outgoing(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK)).all_nodes()
 
     @property
-    def called_descendants(self):
+    def called_descendants(self) -> List['ProcessNode']:
         """
         Return a list of all nodes that have been called downstream of this process
 
@@ -437,7 +443,7 @@ class ProcessNode(Sealable, Node):
         return descendants
 
     @property
-    def caller(self):
+    def caller(self) -> Optional['ProcessNode']:
         """
         Return the process node that called this process node, or None if it does not have a caller
 
@@ -450,7 +456,7 @@ class ProcessNode(Sealable, Node):
         else:
             return caller
 
-    def validate_incoming(self, source, link_type, link_label):
+    def validate_incoming(self, source: Node, link_type: LinkType, link_label: str) -> None:
         """Validate adding a link of the given type from a given node to ourself.
 
         Adding an input link to a `ProcessNode` once it is stored is illegal because this should be taken care of
@@ -468,7 +474,7 @@ class ProcessNode(Sealable, Node):
             raise ValueError('attempted to add an input link after the process node was already stored.')
 
     @property
-    def is_valid_cache(self):
+    def is_valid_cache(self) -> bool:
         """
         Return whether the node is valid for caching
 
@@ -490,7 +496,7 @@ class ProcessNode(Sealable, Node):
 
         return is_valid_cache_func(self)
 
-    def _get_objects_to_hash(self):
+    def _get_objects_to_hash(self) -> List[Any]:
         """
         Return a list of objects which should be included in the hash.
         """

--- a/aiida/orm/nodes/process/workflow/workchain.py
+++ b/aiida/orm/nodes/process/workflow/workchain.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module with `Node` sub class for workchain processes."""
+from typing import Optional, Tuple
 
 from aiida.common.lang import classproperty
 
@@ -22,12 +23,12 @@ class WorkChainNode(WorkflowNode):
     STEPPER_STATE_INFO_KEY = 'stepper_state_info'
 
     @classproperty
-    def _updatable_attributes(cls):
+    def _updatable_attributes(cls) -> Tuple[str, ...]:
         # pylint: disable=no-self-argument
         return super()._updatable_attributes + (cls.STEPPER_STATE_INFO_KEY,)
 
     @property
-    def stepper_state_info(self):
+    def stepper_state_info(self) -> Optional[str]:
         """
         Return the stepper state info
 
@@ -35,7 +36,7 @@ class WorkChainNode(WorkflowNode):
         """
         return self.get_attribute(self.STEPPER_STATE_INFO_KEY, None)
 
-    def set_stepper_state_info(self, stepper_state_info):
+    def set_stepper_state_info(self, stepper_state_info: str) -> None:
         """
         Set the stepper state info
 

--- a/aiida/orm/nodes/process/workflow/workflow.py
+++ b/aiida/orm/nodes/process/workflow/workflow.py
@@ -10,6 +10,7 @@
 """Module with `Node` sub class for workflow processes."""
 
 from aiida.common.links import LinkType
+from aiida.orm import Node
 from aiida.orm.utils.managers import NodeLinksManager
 
 from ..process import ProcessNode
@@ -25,7 +26,7 @@ class WorkflowNode(ProcessNode):
     _unstorable_message = 'storing for this node has been disabled'
 
     @property
-    def inputs(self):
+    def inputs(self) -> NodeLinksManager:
         """Return an instance of `NodeLinksManager` to manage incoming INPUT_WORK links
 
         The returned Manager allows you to easily explore the nodes connected to this node
@@ -37,7 +38,7 @@ class WorkflowNode(ProcessNode):
         return NodeLinksManager(node=self, link_type=LinkType.INPUT_WORK, incoming=True)
 
     @property
-    def outputs(self):
+    def outputs(self) -> NodeLinksManager:
         """Return an instance of `NodeLinksManager` to manage outgoing RETURN links
 
         The returned Manager allows you to easily explore the nodes connected to this node
@@ -48,7 +49,7 @@ class WorkflowNode(ProcessNode):
         """
         return NodeLinksManager(node=self, link_type=LinkType.RETURN, incoming=False)
 
-    def validate_outgoing(self, target, link_type, link_label):
+    def validate_outgoing(self, target: Node, link_type: LinkType, link_label: str) -> None:
         """Validate adding a link of the given type from ourself to a given node.
 
         A workflow cannot 'create' Data, so if we receive an outgoing link to an unstored Data node, that means

--- a/aiida/orm/nodes/process/workflow/workfunction.py
+++ b/aiida/orm/nodes/process/workflow/workfunction.py
@@ -10,6 +10,7 @@
 """Module with `Node` sub class for workflow function processes."""
 
 from aiida.common.links import LinkType
+from aiida.orm import Node
 from aiida.orm.utils.mixins import FunctionCalculationMixin
 
 from .workflow import WorkflowNode
@@ -20,7 +21,7 @@ __all__ = ('WorkFunctionNode',)
 class WorkFunctionNode(FunctionCalculationMixin, WorkflowNode):
     """ORM class for all nodes representing the execution of a workfunction."""
 
-    def validate_outgoing(self, target, link_type, link_label):
+    def validate_outgoing(self, target: Node, link_type: LinkType, link_label: str) -> None:
         """
         Validate adding a link of the given type from ourself to a given node.
 


### PR DESCRIPTION
As the title suggests

Two changes to the code that should be reviewed:

1. Change `CalcJobNode.get_description` to return a string
2. In aiida/engine/processes/calcjobs/tasks.py, change `node.computer.get_authinfo(node.user)` to `node.get_authinfo()`, to use `CalcJobNode.get_authinfo` which checks if the computer is set.

One remaining question:

`Node.get_hash` defaults to `ignore_errors=True` which will return `None` on any exception.
This does not seem like a very good practice: is there a particular exception we should ignore and also should we log a warning to alert developers/users about any issues?