### PR TITLE
🐛 FIX: `ModificationNotAllowed` on workchain kill

### DIFF
--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -151,11 +151,6 @@ class WorkChain(Process):
         """
         self._awaitables.remove(awaitable)
 
-        if self.has_terminated:
-            # this can occur, for example, if the process was killed or excepted
-            # then we should not try to update it
-            return
-
         if awaitable.action == AwaitableAction.ASSIGN:
             self.ctx[awaitable.key] = value
         elif awaitable.action == AwaitableAction.APPEND:
@@ -171,6 +166,11 @@ class WorkChain(Process):
             assert f'Unknown awaitable action: {awaitable.action}'
 
         awaitable.resolved = True
+
+        if self.has_terminated:
+            # this can occur, for example, if the process was killed or excepted
+            # then we should not try to update it
+            return
 
         self._update_process_status()
 

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -151,6 +151,11 @@ class WorkChain(Process):
         """
         self._awaitables.remove(awaitable)
 
+        if self.has_terminated:
+            # this can occur, for example, if the process was killed or excepted
+            # then we should not try to update it
+            return
+
         if awaitable.action == AwaitableAction.ASSIGN:
             self.ctx[awaitable.key] = value
         elif awaitable.action == AwaitableAction.APPEND:

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -167,12 +167,10 @@ class WorkChain(Process):
 
         awaitable.resolved = True
 
-        if self.has_terminated:
-            # this can occur, for example, if the process was killed or excepted
+        if not self.has_terminated:
+            # the process may be terminated, for example, if the process was killed or excepted
             # then we should not try to update it
-            return
-
-        self._update_process_status()
+            self._update_process_status()
 
     def to_context(self, **kwargs: Union[Awaitable, ProcessNode]) -> None:
         """Add a dictionary of awaitables to the context.


### PR DESCRIPTION
copied from https://github.com/aiidateam/aiida-core/issues/3888#issuecomment-784345729

1. in `kill` the parent is killed first, then the children: https://github.com/aiidateam/aiida-core/blob/8c079175bbb32a6dc3b4ae663c586c7099cbb9a6/aiida/engine/processes/process.py#L294
2. when entering the `Wait` state awaitables (e.g. children) are each assigned to `on_process_finished`: https://github.com/aiidateam/aiida-core/blob/8c079175bbb32a6dc3b4ae663c586c7099cbb9a6/aiida/engine/processes/workchains/workchain.py#L263
3. when the child is killed, this calls `resolve_awaitable`, which tries to update the status: https://github.com/aiidateam/aiida-core/blob/8c079175bbb32a6dc3b4ae663c586c7099cbb9a6/aiida/engine/processes/workchains/workchain.py#L145
4. but doh the parent is already terminated and the node sealed -> `ModificationNotAllowed` 🤦 

so here in `resolve_awaitable` we want to check if the parent is already in a terminal state and, if so, skip the ctx and status update.
We still remove the awaitable from `self._awaitables`, to remove the references to the child process (so it can be garbage collected)