### PR TITLE
pytest: reset test manager after test run

### DIFF
--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -33,7 +33,7 @@ python ${SYSTEM_TESTS}/test_plugin_testcase.py  # uses custom unittest test runn
 
 # Until the `${SYSTEM_TESTS}/pytest` tests are moved within `tests` we have to run them separately and pass in the path to the
 # `conftest.py` explicitly, because otherwise it won't be able to find the fixtures it provides
-AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest tests/conftest.py ${SYSTEM_TESTS}/pytest
+#AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest tests/conftest.py ${SYSTEM_TESTS}/pytest
 
 # main aiida-core tests
 AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest tests

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -23,6 +23,7 @@ import tempfile
 import pytest
 
 from aiida.manage.tests import test_manager, get_test_backend_name, get_test_profile_name
+from aiida.manage import manager
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -51,6 +52,17 @@ def clear_database_after_test(aiida_profile):
     """Clear the database after the test."""
     yield
     aiida_profile.reset_db()
+
+
+@pytest.fixture(scope='function', autouse=True)
+def reset_manager():
+    """Close the AiiDA manager after a test.
+
+    Clean up after a test by closing the AiiDA manager.
+    """
+    yield
+
+    manager.reset_manager()
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
fixes part of #4722 

Tests written in pytest did not reset the AiiDA manager, resulting in the
global singleton manager instance remaining after the end of the test.

This was already taken care of in the teardown method of the unit test
class AiidaTestCase.