### PR TITLE
👌 IMPROVE: capture of node hashing errors

### DIFF
--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -17,7 +17,7 @@ __all__ = (
     'PluginInternalError', 'ValidationError', 'ConfigurationError', 'ProfileConfigurationError',
     'MissingConfigurationError', 'ConfigurationVersionError', 'IncompatibleDatabaseSchema', 'DbContentError',
     'InputValidationError', 'FeatureNotAvailable', 'FeatureDisabled', 'LicensingException', 'TestsNotAllowedError',
-    'UnsupportedSpeciesError', 'TransportTaskException', 'OutputParsingError'
+    'UnsupportedSpeciesError', 'TransportTaskException', 'OutputParsingError', 'HashingError'
 )
 
 
@@ -249,4 +249,10 @@ class OutputParsingError(ParsingError):
 class CircusCallError(AiidaException):
     """
     Raised when an attempt to contact Circus returns an error in the response
+    """
+
+
+class HashingError(AiidaException):
+    """
+    Raised when an attempt to hash an object fails via a known failure mode
     """

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -22,6 +22,8 @@ from operator import itemgetter
 import pytz
 
 from aiida.common.constants import AIIDA_FLOAT_PRECISION
+from aiida.common.exceptions import HashingError
+
 from .folders import Folder
 
 # The prefix of the hashed using pbkdf2_sha256 algorithm in Django
@@ -101,7 +103,6 @@ def make_hash(object_to_hash, **kwargs):
     hashing iteratively. Uses python's sorted function to sort unsorted
     sets and dictionaries by sorting the hashed keys.
     """
-
     hashes = _make_hash(object_to_hash, **kwargs)  # pylint: disable=assignment-from-no-return
 
     # use the Unlimited fanout hashing protocol outlined in
@@ -123,7 +124,7 @@ def _make_hash(object_to_hash, **_):
     Implementation of the ``make_hash`` function. The hash is created as a
     28 byte integer, and only later converted to a string.
     """
-    raise ValueError(f'Value of type {type(object_to_hash)} cannot be hashed')
+    raise HashingError(f'Value of type {type(object_to_hash)} cannot be hashed')
 
 
 def _single_digest(obj_type, obj_bytes=b''):

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -22,7 +22,17 @@ import shutil
 import tempfile
 import pytest
 
+from aiida.common.log import AIIDA_LOGGER
 from aiida.manage.tests import test_manager, get_test_backend_name, get_test_profile_name
+
+
+@pytest.fixture(scope='function')
+def aiida_caplog(caplog):
+    """A copy of pytest's caplog fixture, which allows ``AIIDA_LOGGER`` to propagate."""
+    propogate = AIIDA_LOGGER.propagate
+    AIIDA_LOGGER.propagate = True
+    yield caplog
+    AIIDA_LOGGER.propagate = propogate
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1056,7 +1056,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
     def get_hash(self, ignore_errors=True, **kwargs):
         """Return the hash for this node based on its attributes.
 
-        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError``s (logging the exception)
+        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError`` (logging the exception)
         """
         if not self.is_stored:
             raise exceptions.InvalidOperation('You can get the hash only after having stored the node')
@@ -1069,7 +1069,7 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
 
         This will always work, even before storing.
 
-        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError``s (logging the exception)
+        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError`` (logging the exception)
         """
         try:
             return make_hash(self._get_objects_to_hash(), **kwargs)

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1054,7 +1054,10 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
             new_node.store()
 
     def get_hash(self, ignore_errors=True, **kwargs):
-        """Return the hash for this node based on its attributes."""
+        """Return the hash for this node based on its attributes.
+
+        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError``s (logging the exception)
+        """
         if not self.is_stored:
             raise exceptions.InvalidOperation('You can get the hash only after having stored the node')
 
@@ -1065,17 +1068,25 @@ class Node(Entity, EntityAttributesMixin, EntityExtrasMixin, metaclass=AbstractN
         Return the hash for this node based on its attributes.
 
         This will always work, even before storing.
+
+        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError``s (logging the exception)
         """
         try:
             return make_hash(self._get_objects_to_hash(), **kwargs)
-        except Exception:  # pylint: disable=broad-except
+        except exceptions.HashingError:
             if not ignore_errors:
                 raise
+            self.logger.exception('Node hashing failed')
 
     def _get_objects_to_hash(self):
         """Return a list of objects which should be included in the hash."""
+        top_level_module = self.__module__.split('.', 1)[0]
+        try:
+            version = importlib.import_module(top_level_module).__version__
+        except (ImportError, AttributeError) as exc:
+            raise exceptions.HashingError("The node's package version could not be determined") from exc
         objects = [
-            importlib.import_module(self.__module__.split('.', 1)[0]).__version__,
+            version,
             {
                 key: val
                 for key, val in self.attributes_items()

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     import unittest
 
+from aiida.common.exceptions import HashingError
 from aiida.common.hashing import make_hash, float_to_text
 from aiida.common.folders import SandboxFolder
 from aiida.backends.testbase import AiidaTestCase
@@ -178,7 +179,7 @@ class MakeHashTest(unittest.TestCase):
         class MadeupClass:
             pass
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(HashingError):
             make_hash(MadeupClass())
 
     def test_folder(self):


### PR DESCRIPTION
Currently all exceptions are caught and ignored.
This commit adds a specific `HashingError` exception,
for known failure modes.
Only this exception is caught, if `ignore_errors=True`,
and the exception logged.

Also an `aiida_caplog` pytest fixture is added,
to enable logs from `AiiDA_LOGGER` to be captured.