### PR TITLE
🐛 FIX: Workchain run + CTRL-C

### DIFF
--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -275,10 +275,12 @@ class Runner:  # pylint: disable=too-many-public-methods
                 process_inited.kill(msg='Process was killed because the runner received an interrupt')
 
                 # gather all running processes and wait for all of them to finish, before finalising the run future
+                # we also want to capture interruptable tasks, so their exceptions are retrieved
                 process_tasks = [
-                    t for t in asyncio.all_tasks(loop=self.loop) if t.get_name().startswith('aiida-process')
+                    t for t in asyncio.all_tasks(loop=self.loop)
+                    if (t.get_name().startswith('aiida-process') and t.get_name().startswith('interruptable'))
                 ]
-                processes_future = asyncio.gather(*process_tasks, return_exceptions=True)  # capture kill exceptions
+                processes_future = asyncio.gather(*process_tasks, return_exceptions=True)  # capture kill interruption
                 processes_future.add_done_callback(_callback)
 
             original_handler_int = signal.getsignal(signal.SIGINT)

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -15,6 +15,7 @@ import contextlib
 from datetime import datetime
 import logging
 from typing import Any, Awaitable, Callable, Iterator, List, Optional, Tuple, Type, Union, TYPE_CHECKING
+import uuid
 
 if TYPE_CHECKING:
     from .processes import Process, ProcessBuilder
@@ -132,7 +133,8 @@ def interruptable_task(
             if not future.done():
                 future.set_result(result)
 
-    loop.create_task(execute_coroutine())
+    task = loop.create_task(execute_coroutine())
+    task.set_name(f'interruptable-{uuid.uuid4()}')
 
     return future
 


### PR DESCRIPTION
processes can be run, using the `Runner._run` function, in two distinct ways:

1. via the command-line, e.g. by `verdi run path/to/script.py`
2. within `verdi shell` (aka ipython)

For (1), if we wish a workchain to be killed "gracefully" (usually via CTRL-C), we need to wait for all the workchains children to finish (and their children ...) before ending the function.
This is currently not the case, because the parent workchain is killed first and the function only waits for this to finish. Hence you will end up with a process list like:

```
 132  18h ago    SleepWorkChain    ☠ Killed         Process was killed because the runner received an interrupt
 133  18h ago    SleepCalculation  ⏵ Waiting        Waiting for transport task: upload
 134  18h ago    SleepCalculation  ⏵ Waiting        Waiting for transport task: upload
```

For (2) you may be happy for the kill processes to continue in the background and immediately return control to the shell (see #4649).

This PR then does two things:

1. On the first kill signal the `Process.kill` task is started, but also the function is "reset" to wait for all processes to complete
2. On the second kill signal the function is immediately terminated, if in ipython leaving the kill task running in the background

In manual testing (add actual unit tests?), for the command-line we now correctly get:

```console
root@ce7b0c6b56bb:~# aiida-sleep workchain -nc 1 -t 10
setting up and running workchain 1
^C02/26/2021 04:57:40 PM <574281> aiida.engine.runners: [CRITICAL] runner received interrupt, killing process 324
02/26/2021 04:57:41 PM <574281> aiida.engine.transports: [ERROR] Exception whilst using transport:
Traceback (most recent call last):
  File "/root/aiida-core/aiida/engine/transports.py", line 110, in request_transport
    yield transport_request.future
  File "/root/aiida-core/aiida/engine/processes/calcjobs/tasks.py", line 78, in do_upload
    transport = await cancellable.with_interrupt(request)
  File "/root/aiida-core/aiida/engine/utils.py", line 96, in with_interrupt
    result = await next(wait_iter)
  File "/usr/lib/python3.8/asyncio/tasks.py", line 608, in _wait_for_one
    return f.result()  # May raise f.exception().
  File "/root/aiida-core/aiida/engine/processes/calcjobs/tasks.py", line 367, in execute
    skip_submit = await self._launch_task(task_upload_job, self.process, transport_queue)
  File "/root/aiida-core/aiida/engine/processes/calcjobs/tasks.py", line 425, in _launch_task
    result = await self._task
  File "/usr/lib/python3.8/asyncio/tasks.py", line 349, in __wakeup
    future.result()
plumpy.process_states.KillInterruption: Killed by parent<324>

uuid: ca4b8062-ec74-4ac4-a231-602742057a5d (pk: 324) (aiida.workflows:sleep)
root@ce7b0c6b56bb:~# verdi process list -a
  PK  Created    Process label     Process State    Process status
----  ---------  ----------------  ---------------  -----------------------------------------------------------
...
 324  17s ago    SleepWorkChain    ☠ Killed         Process was killed because the runner received an interrupt
 325  17s ago    SleepCalculation  ☠ Killed         Killed by parent<324>

Total results: 145

Info: last time an entry changed state: 12s ago (at 16:57:45 on 2021-02-26)

```

for `verdi shell` there is currently an issue whereby if you do `CTRL-C` x 2, and the loop continues running in the background, the `KillInterruption` exceptions are no longer caught, and so at a later time, you will get:

```python
In [3]: 

Unhandled exception in event loop:
  File "/root/aiida-core/aiida/engine/processes/calcjobs/tasks.py", line 367, in execute
    skip_submit = await self._launch_task(task_upload_job, self.process, transport_queue)
  File "/root/aiida-core/aiida/engine/processes/calcjobs/tasks.py", line 425, in _launch_task
    result = await self._task
  File "/usr/lib/python3.8/asyncio/tasks.py", line 349, in __wakeup
    future.result()

Exception Killed by parent<405>
Press ENTER to continue...
```

closes #4649 