### PR TITLE
👌 IMPROVE: Add 'exception' to projection mapping

### DIFF
--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -21,7 +21,8 @@ class CalculationQueryBuilder:
     _default_projections = ('pk', 'ctime', 'process_label', 'state', 'process_status')
     _valid_projections = (
         'pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'process_status', 'exit_status', 'sealed',
-        'process_label', 'label', 'description', 'node_type', 'paused', 'process_type', 'job_state', 'scheduler_state'
+        'process_label', 'label', 'description', 'node_type', 'paused', 'process_type', 'job_state', 'scheduler_state',
+        'exception'
     )
 
     def __init__(self, mapper=None):

--- a/aiida/cmdline/utils/query/mapping.py
+++ b/aiida/cmdline/utils/query/mapping.py
@@ -91,6 +91,7 @@ class CalculationProjectionMapper(ProjectionMapper):
         process_state_key = f'attributes.{ProcessNode.PROCESS_STATE_KEY}'
         process_status_key = f'attributes.{ProcessNode.PROCESS_STATUS_KEY}'
         exit_status_key = f'attributes.{ProcessNode.EXIT_STATUS_KEY}'
+        exception_key = f'attributes.{ProcessNode.EXCEPTION_KEY}'
 
         default_labels = {'pk': 'PK', 'uuid': 'UUID', 'ctime': 'Created', 'mtime': 'Modified', 'state': 'Process State'}
 
@@ -104,6 +105,7 @@ class CalculationProjectionMapper(ProjectionMapper):
             'process_state': process_state_key,
             'process_status': process_status_key,
             'exit_status': exit_status_key,
+            'exception': exception_key,
         }
 
         default_formatters = {

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -414,7 +414,7 @@ class Process(plumpy.processes.Process):
         :param exc_info: the sys.exc_info() object (type, value, traceback)
         """
         super().on_except(exc_info)
-        self.node.set_exception(''.join(traceback.format_exception(exc_info[0], exc_info[1], None)))
+        self.node.set_exception(''.join(traceback.format_exception(exc_info[0], exc_info[1], None)).rstrip())
         self.report(''.join(traceback.format_exception(*exc_info)))
 
     @override

--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -11,6 +11,7 @@
 """Components to communicate tasks to RabbitMQ."""
 from collections.abc import Mapping
 import logging
+import traceback
 
 from kiwipy import communications, Future
 import pamqp.encode
@@ -154,7 +155,7 @@ class ProcessLauncher(plumpy.ProcessLauncher):
 
         if not node.is_excepted and not node.is_sealed:
             node.logger.exception(message)
-            node.set_exception(str(exception))
+            node.set_exception(''.join(traceback.format_exception(type(exception), exception, None)).rstrip())
             node.set_process_state(ProcessState.EXCEPTED)
             node.seal()
 


### PR DESCRIPTION
When diagnosing issues with multiple processes excepting (e.g. #4595),
it would be helpful to view the exception type in `verdi process list`.

This PR adds `exception` to the list of allowed projections,
and also standardises the way the exception is set on the node (capturing both the type and message).

For example submitting a calculation after adding `raise AiidaException('oopsie!')` before: https://github.com/aiidateam/aiida-core/blob/c07e3ef0b9e9fff64888115aaf30479bbd76392e/aiida/manage/external/rmq.py#L206

```console
$ verdi process list -S excepted -P ctime pk process_state exception
Created       PK  Process state    Exception
---------  -----  ---------------  -----------------------------------------------
9m ago     10385  Excepted         aiida.common.exceptions.AiidaException: oopsie!
```