### PR TITLE
setup: move away from legacy build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=40.8.0", "wheel", "reentry~=1.3", "fastentrypoints~=0.12"]
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 
 [tool.pylint.master]
 load-plugins = "pylint_django"

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -191,7 +191,7 @@ def update_pyproject_toml():
         'requires': ['setuptools>=40.8.0', 'wheel',
                      str(reentry_requirement), 'fastentrypoints~=0.12'],
         'build-backend':
-        'setuptools.build_meta:__legacy__',
+        'setuptools.build_meta',
     })
 
     # write the new file


### PR DESCRIPTION
AiiDA was still using the `setuptools.build_meta:__legacy__` build
backend.
This can lead to issues when using a *system* version of setuptools
< 40.8.0, see [1].

I've tested that the `reentry_register` hook still works with the new
build backend.

[1] https://github.com/pypa/setuptools/issues/1694#issuecomment-466010982