### PR TITLE
fix pymatgen imports

### DIFF
--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -1852,7 +1852,7 @@ class StructureData(Data):
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors)
         """
-        from pymatgen import Structure
+        from pymatgen.core.structure import Structure
 
         if self.pbc != (True, True, True):
             raise ValueError('Periodic boundary conditions must apply in all three dimensions of real space')
@@ -1862,7 +1862,7 @@ class StructureData(Data):
 
         if (kwargs.pop('add_spin', False) and any([n.endswith('1') or n.endswith('2') for n in self.get_kind_names()])):
             # case when spins are defined -> no partial occupancy allowed
-            from pymatgen import Specie
+            from pymatgen.core.periodic_table import Specie
             oxidation_state = 0  # now I always set the oxidation_state to zero
             for site in self.sites:
                 kind = self.get_kind(site.kind_name)
@@ -1907,7 +1907,7 @@ class StructureData(Data):
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors)
         """
-        from pymatgen import Molecule
+        from pymatgen.core.structure import Molecule
 
         if kwargs:
             raise ValueError(f'Unrecognized parameters passed to pymatgen converter: {kwargs.keys()}')

--- a/aiida/tools/dbimporters/plugins/materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/materialsproject.py
@@ -12,7 +12,7 @@ import datetime
 import os
 import requests
 
-from pymatgen import MPRester
+from pymatgen.ext.matproj import MPRester
 
 from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2227,15 +2227,17 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests pymatgen -> StructureData, with partial occupancies and spins.
         This should raise a ValueError.
         """
-        import pymatgen
+        from pymatgen.core.periodic_table import Specie
+        from pymatgen.core.composition import Composition
+        from pymatgen.core.structure import Structure
 
-        Fe_spin_up = pymatgen.Specie('Fe', 0, properties={'spin': 1})
-        Mn_spin_up = pymatgen.Specie('Mn', 0, properties={'spin': 1})
-        Fe_spin_down = pymatgen.Specie('Fe', 0, properties={'spin': -1})
-        Mn_spin_down = pymatgen.Specie('Mn', 0, properties={'spin': -1})
-        FeMn1 = pymatgen.Composition({Fe_spin_up: 0.5, Mn_spin_up: 0.5})
-        FeMn2 = pymatgen.Composition({Fe_spin_down: 0.5, Mn_spin_down: 0.5})
-        a = pymatgen.Structure(
+        Fe_spin_up = Specie('Fe', 0, properties={'spin': 1})
+        Mn_spin_up = Specie('Mn', 0, properties={'spin': 1})
+        Fe_spin_down = Specie('Fe', 0, properties={'spin': -1})
+        Mn_spin_down = Specie('Mn', 0, properties={'spin': -1})
+        FeMn1 = Composition({Fe_spin_up: 0.5, Mn_spin_up: 0.5})
+        FeMn2 = Composition({Fe_spin_down: 0.5, Mn_spin_down: 0.5})
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[FeMn1, FeMn2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
         )
 
@@ -2243,9 +2245,9 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
             StructureData(pymatgen=a)
 
         # same, with vacancies
-        Fe1 = pymatgen.Composition({Fe_spin_up: 0.5})
-        Fe2 = pymatgen.Composition({Fe_spin_down: 0.5})
-        a = pymatgen.Structure(
+        Fe1 = Composition({Fe_spin_up: 0.5})
+        Fe2 = Composition({Fe_spin_down: 0.5})
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[Fe1, Fe2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
         )
 
@@ -2257,12 +2259,13 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
     def test_multiple_kinds_partial_occupancies():
         """Tests that a structure with multiple sites with the same element but different
         partial occupancies, get their own unique kind name."""
-        import pymatgen
+        from pymatgen.core.composition import Composition
+        from pymatgen.core.structure import Structure
 
-        Mg1 = pymatgen.Composition({'Mg': 0.50})
-        Mg2 = pymatgen.Composition({'Mg': 0.25})
+        Mg1 = Composition({'Mg': 0.50})
+        Mg2 = Composition({'Mg': 0.25})
 
-        a = pymatgen.Structure(
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[Mg1, Mg2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
         )
 
@@ -2275,12 +2278,13 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests that a structure with multiple sites with the same alloy symbols but different
         weights, get their own unique kind name
         """
-        import pymatgen
+        from pymatgen.core.composition import Composition
+        from pymatgen.core.structure import Structure
 
-        alloy_one = pymatgen.Composition({'Mg': 0.25, 'Al': 0.75})
-        alloy_two = pymatgen.Composition({'Mg': 0.45, 'Al': 0.55})
+        alloy_one = Composition({'Mg': 0.25, 'Al': 0.75})
+        alloy_two = Composition({'Mg': 0.45, 'Al': 0.55})
 
-        a = pymatgen.Structure(
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]],
             species=[alloy_one, alloy_two],
             coords=[[0, 0, 0], [0.5, 0.5, 0.5]]


### PR DESCRIPTION
fixes #4793 

pymatgen [made a breaking change in v2021.3.4](https://github.com/materialsproject/pymatgen/blob/master/CHANGES.rst#v202134) that removed many classes
from the top level of the package.
The alternative imports were already available in previous versions,
i.e. we don't need to upgrade the pymatgen dependency.