### PR TITLE
🐛 FIX: `max_memory_kb` usage for direct scheduler

### DIFF
--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -142,17 +142,8 @@ class DirectScheduler(aiida.schedulers.Scheduler):
                 lines.append('exec 2>&1')
 
         if job_tmpl.max_memory_kb:
-            try:
-                virtual_memory_kb = int(job_tmpl.max_memory_kb)
-                if virtual_memory_kb <= 0:
-                    raise ValueError
-            except ValueError:
-                raise ValueError(
-                    'max_memory_kb must be '
-                    "a positive integer (in kB)! It is instead '{}'"
-                    ''.format((job_tmpl.max_memory_kb))
-                )
-            lines.append(f'ulimit -v {virtual_memory_kb}')
+            self.logger.info('Physical memory limiting is not supported by the direct scheduler.')
+
         if not job_tmpl.import_sys_environment:
             lines.append('env --ignore-environment \\')
 

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -142,7 +142,7 @@ class DirectScheduler(aiida.schedulers.Scheduler):
                 lines.append('exec 2>&1')
 
         if job_tmpl.max_memory_kb:
-            self.logger.info('Physical memory limiting is not supported by the direct scheduler.')
+            self.logger.warning('Physical memory limiting is not supported by the direct scheduler.')
 
         if not job_tmpl.import_sys_environment:
             lines.append('env --ignore-environment \\')

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -401,8 +401,8 @@ class LsfScheduler(aiida.schedulers.Scheduler):
         # TODO: check if this is the memory per node  # pylint: disable=fixme
         if job_tmpl.max_memory_kb:
             try:
-                virtual_memory_kb = int(job_tmpl.max_memory_kb)
-                if virtual_memory_kb <= 0:
+                physical_memory_kb = int(job_tmpl.max_memory_kb)
+                if physical_memory_kb <= 0:
                     raise ValueError
             except ValueError:
                 raise ValueError(
@@ -412,7 +412,7 @@ class LsfScheduler(aiida.schedulers.Scheduler):
                 )
             # The -M option sets a per-process (soft) memory limit for all the
             # processes that belong to this job
-            lines.append(f'#BSUB -M {virtual_memory_kb}')
+            lines.append(f'#BSUB -M {physical_memory_kb}')
 
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -408,7 +408,7 @@ class LsfScheduler(aiida.schedulers.Scheduler):
                 raise ValueError(
                     'max_memory_kb must be '
                     "a positive integer (in kB)! It is instead '{}'"
-                    ''.format((job_tmpl.MaxMemoryKb))
+                    ''.format((job_tmpl.max_memory_kb))
                 )
             # The -M option sets a per-process (soft) memory limit for all the
             # processes that belong to this job

--- a/aiida/schedulers/plugins/pbspro.py
+++ b/aiida/schedulers/plugins/pbspro.py
@@ -86,8 +86,8 @@ class PbsproScheduler(PbsBaseClass):
 
         if max_memory_kb:
             try:
-                virtual_memory_kb = int(max_memory_kb)
-                if virtual_memory_kb <= 0:
+                physical_memory_kb = int(max_memory_kb)
+                if physical_memory_kb <= 0:
                     raise ValueError
             except ValueError:
                 raise ValueError(
@@ -95,7 +95,7 @@ class PbsproScheduler(PbsBaseClass):
                     "a positive integer (in kB)! It is instead '{}'"
                     ''.format((max_memory_kb))
                 )
-            select_string += f':mem={virtual_memory_kb}kb'
+            select_string += f':mem={physical_memory_kb}kb'
 
         return_lines.append(f'#PBS -l {select_string}')
         return return_lines

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -382,8 +382,8 @@ class SlurmScheduler(Scheduler):
         # It is the memory per node, not per cpu!
         if job_tmpl.max_memory_kb:
             try:
-                virtual_memory_kb = int(job_tmpl.max_memory_kb)
-                if virtual_memory_kb <= 0:
+                physical_memory_kb = int(job_tmpl.max_memory_kb)
+                if physical_memory_kb <= 0:
                     raise ValueError
             except ValueError:
                 raise ValueError(
@@ -393,7 +393,7 @@ class SlurmScheduler(Scheduler):
                 )
             # --mem: Specify the real memory required per node in MegaBytes.
             # --mem and  --mem-per-cpu  are  mutually exclusive.
-            lines.append(f'#SBATCH --mem={virtual_memory_kb // 1024}')
+            lines.append(f'#SBATCH --mem={physical_memory_kb // 1024}')
 
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -389,7 +389,7 @@ class SlurmScheduler(Scheduler):
                 raise ValueError(
                     'max_memory_kb must be '
                     "a positive integer (in kB)! It is instead '{}'"
-                    ''.format((job_tmpl.MaxMemoryKb))
+                    ''.format((job_tmpl.max_memory_kb))
                 )
             # --mem: Specify the real memory required per node in MegaBytes.
             # --mem and  --mem-per-cpu  are  mutually exclusive.

--- a/aiida/schedulers/plugins/torque.py
+++ b/aiida/schedulers/plugins/torque.py
@@ -81,8 +81,8 @@ class TorqueScheduler(PbsBaseClass):
 
         if max_memory_kb:
             try:
-                virtual_memory_kb = int(max_memory_kb)
-                if virtual_memory_kb <= 0:
+                physical_memory_kb = int(max_memory_kb)
+                if physical_memory_kb <= 0:
                     raise ValueError
             except ValueError:
                 raise ValueError(
@@ -92,7 +92,7 @@ class TorqueScheduler(PbsBaseClass):
                 )
             # There is always something before, at least the total #
             # of nodes
-            select_string += f',mem={virtual_memory_kb}kb'
+            select_string += f',mem={physical_memory_kb}kb'
 
         return_lines.append(f'#PBS -l {select_string}')
         return return_lines


### PR DESCRIPTION
Hi,

I am proposing my solution to the issue I raised a while ago #4526.

The changes are the following: 

* In all scheduler plugins I just renamed `virtual_memory_kb` to `physical_memory_kb` to avoid confusion.

* In the Direct scheduler, the `max_memory_kb` limit is ignored now and just a message is printed to logger. The justification behind this is that the previously used `ulimit -v` did impose a virtual memory limit (as opposed to a physical memory limit that all the other schedulers do) and therefore it's inequivalent (as a result, I always have to treat the direct scheduler differently in my workflows). There doesn't seem to be a straightforward standard way to limit the physical memory usage of a process in linux, so I decided just to ignore this variable.
