### PR TITLE
🐛 FIX: Add `broker_*` parameters to default test config.

### DIFF
--- a/aiida/manage/tests/__init__.py
+++ b/aiida/manage/tests/__init__.py
@@ -39,6 +39,12 @@ _DEFAULT_PROFILE_INFO = {
     'repo_dir': 'test_repo',
     'config_dir': '.aiida',
     'root_path': '',
+    'broker_protocol': 'amqp',
+    'broker_username': 'guest',
+    'broker_password': 'guest',
+    'broker_host': '127.0.0.1',
+    'broker_port': 5672,
+    'broker_virtual_host': ''
 }
 
 

--- a/tests/manage/tests/test_pytest_fixtures.py
+++ b/tests/manage/tests/test_pytest_fixtures.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Tests for the AiiDA pytest fixtures."""
+
+from aiida.manage.configuration import get_config
+from aiida.manage.configuration.config import Config
+
+
+def test_profile_config(aiida_profile):  # pylint: disable=unused-argument
+    """Check that the config file created with the test profile passes validation."""
+    Config.from_file(get_config().filepath)


### PR DESCRIPTION
Fixes #4830.

In the `TestProfileManager`, set the `broker_*` parameters only if they are explicitly present in the `profile_info`.

Previously, these were set to `None` by default, which caused the config validation to fail because only string values are allowed.

I think the "root cause" why this wasn't caught is because there is validation in the `Config` constructor, but not the `Profile` constructor. This is the code constructing the profile:

https://github.com/aiidateam/aiida-core/blob/75310e0bfbf8de02302de76f3e452b38e4164f33/aiida/manage/tests/__init__.py#L333-L336

Another option for fixing this issue would be explicitly setting the `broker_*` parameters in `_DEFAULT_PROFILE_INFO`: https://github.com/aiidateam/aiida-core/blob/75310e0bfbf8de02302de76f3e452b38e4164f33/aiida/manage/tests/__init__.py#L28-L42