### PR TITLE
Proof of Concept: Grafana REST-API

### DIFF
--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -92,7 +92,7 @@ class AiidaApi(Api):
 
         from aiida.restapi.common.config import CLI_DEFAULTS
         from aiida.restapi.resources import (
-            ProcessNode, CalcJobNode, Computer, User, Group, Node, ServerInfo, QueryBuilder
+            ProcessNode, CalcJobNode, Computer, User, Group, Node, ServerInfo, QueryBuilder, Grafana
         )
 
         self.app = app
@@ -116,6 +116,17 @@ class AiidaApi(Api):
                 QueryBuilder,
                 '/querybuilder/',
                 endpoint='querybuilder',
+                strict_slashes=False,
+                resource_class_kwargs=kwargs,
+            )
+
+            self.add_resource(
+                Grafana,
+                '/grafana/',
+                '/grafana/search/',
+                '/grafana/query/',
+                '/grafana/annotations/',
+                endpoint='grafana',
                 strict_slashes=False,
                 resource_class_kwargs=kwargs,
             )

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -420,8 +420,8 @@ class Utils:
 
         ## Type checks
         # mandatory parameters
-        if not isinstance(data, dict):
-            raise InputValidationError('data must be a dictionary')
+        if not isinstance(data, (dict, list)):
+            raise InputValidationError('data must be a dictionary or a list')
 
         # non-mandatory parameters
         if status is not None:

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -209,7 +209,7 @@ class Utils:
 
         if path[0] in [
             'projectable_properties', 'statistics', 'full_types', 'full_types_count', 'download', 'download_formats',
-            'report', 'status', 'input_files', 'output_files'
+            'report', 'status', 'input_files', 'output_files', 'search', 'query', 'annotations'
         ]:
             query_type = path.pop(0)
             if path:

--- a/aiida/restapi/grafana.py
+++ b/aiida/restapi/grafana.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+""" Resources for using grafana with the REST API """
+from datetime import datetime
+
+
+def deduce_mpiproc(data_dict):
+    """Description"""
+    data_resources = data_dict['resources']
+    manual_calculation = ('num_mpiprocs_per_machine' in data_resources) and ('num_machines' in data_resources)
+    ready_calculation = 'tot_num_mpiprocs' in data_resources
+
+    mpiproc = 0
+
+    if manual_calculation:
+        np_per_node = data_resources['num_mpiprocs_per_machine']
+        total_nodes = data_resources['num_machines']
+        mpiproc = total_nodes * np_per_node
+
+    if ready_calculation:
+        mpiproc = data_resources['tot_num_mpiprocs']
+
+    if 'last_job_info' in data_dict:
+        mpiproc = data_dict['last_job_info']['num_mpiprocs']
+
+    return mpiproc
+
+
+def process_grafana_request(entry_point, request_dict):
+    """Description"""
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    from aiida import orm
+
+    if entry_point == 'search':
+        #data = ['resource_usage', 'current_resource_usage']
+        data = ['current_resource_usage']
+
+    elif entry_point == 'query':
+        time_i = datetime.strptime(request_dict['range']['from'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        time_f = datetime.strptime(request_dict['range']['to'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        #time_d = request_dict['intervalMs']
+        target = request_dict['targets'][0]['target']
+
+        if target == 'resource_usage':
+
+            # Get intervals
+            delta_t = (time_f - time_i) / 100
+            interval_list = []
+            for interval_n in range(100):
+                time_ii = time_i + delta_t * interval_n
+                time_ff = time_i + delta_t * (interval_n + 1)
+                interval_list.append({'ti': time_ii, 'tf': time_ff})
+
+            datapoints = []
+            for interval in interval_list:
+                qb0 = orm.QueryBuilder()
+                qb0.append(
+                    orm.CalcJobNode,
+                    project=['attributes.resources', 'attributes.scheduler_lastchecktime'],
+                    filters={'ctime': {
+                        '<=': interval['tf']
+                    }},
+                )
+
+                total_processors = 0
+                for query_list in qb0.all():
+                    query_data = query_list[0]
+                    # 2016-03-03T03:46:03.811047+00:00
+                    query_time = datetime.strptime(query_list[1][:-6], '%Y-%m-%dT%H:%M:%S.%f')
+
+                    valid_time = query_time >= interval['ti']
+                    manual_calculation = ('num_mpiprocs_per_machine' in query_data) and ('num_machines' in query_data)
+                    ready_calculation = 'tot_num_mpiprocs' in query_data
+
+                    if manual_calculation and valid_time:
+                        np_per_node = query_data['num_mpiprocs_per_machine']
+                        total_nodes = query_data['num_machines']
+                        total_processors = total_processors + total_nodes * np_per_node
+
+                    if ready_calculation and valid_time:
+                        total_processors = total_processors + query_data['tot_num_mpiprocs']
+
+                timepoint = (interval['tf'].timestamp() + interval['ti'].timestamp()) * 500
+                datapoints.append([total_processors, timepoint])
+
+            data = [{'target': 'total_mpiproc', 'datapoints': datapoints}]
+
+        elif target == 'current_resource_usage':
+
+            workflows_running = 0
+
+            qb0 = orm.QueryBuilder()
+            qb0.append(
+                orm.ProcessNode,
+                tag='all_current',
+                filters={'attributes.process_state': {
+                    'in': ['created', 'waiting', 'running']
+                }},
+            )
+            set_all = {nodel[0].pk for nodel in qb0.all()}
+
+            qb0.append(
+                orm.ProcessNode,
+                with_incoming='all_current',
+                filters={'attributes.process_state': {
+                    'in': ['created', 'waiting', 'running']
+                }},
+            )
+            set_children = {nodel[0].pk for nodel in qb0.all()}
+
+            set_parents = set_all - set_children
+            workflows_running = len(set_parents)
+
+            mpiproc_waiting = 0
+            mpiproc_running = 0
+
+            qb0 = orm.QueryBuilder()
+            qb0.append(
+                orm.CalcJobNode,
+                filters={'attributes.process_state': {
+                    'in': ['created', 'waiting', 'running']
+                }},
+            )
+
+            for query_list in qb0.all():
+                query_node = query_list[0]
+                query_data = query_node.attributes
+
+                if 'RUNNING' in query_data['process_status']:
+                    mpiproc_running = mpiproc_running + deduce_mpiproc(query_data)
+
+                else:
+                    mpiproc_waiting = mpiproc_waiting + deduce_mpiproc(query_data)
+
+            timepoint0 = int(time_f.timestamp() * 1000)
+            data = [
+                {
+                    'target': 'workflows_running',
+                    'datapoints': [[workflows_running, timepoint0]]
+                },
+                {
+                    'target': 'mpiproc_running',
+                    'datapoints': [[mpiproc_running, timepoint0]]
+                },
+                {
+                    'target': 'mpiproc_waiting',
+                    'datapoints': [[mpiproc_waiting, timepoint0]]
+                },
+            ]
+
+    elif entry_point == 'annotations':
+        data = ['annotations']
+
+    return data

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -626,3 +626,33 @@ class CalcJobNode(ProcessNode):
         )
 
         return self.utils.build_response(status=200, headers=headers, data=data)
+
+
+class Grafana(BaseResource):
+    """Resource to expose information for Grafana."""
+
+    def get(self):  # pylint: disable=arguments-differ
+        """The GET / for Grafana just needs to return a 200 ok response."""
+        data = {}
+        headers = self.utils.build_headers(url=request.url, total_count=0)
+        return self.utils.build_response(status=200, headers=headers, data=data)
+
+    def post(self):  # pylint: disable=arguments-differ
+        """
+        Descript.
+        """
+        from aiida.restapi.grafana import process_grafana_request
+
+        ## Decode url parts to get the specific entry_point name
+        path_char = unquote(request.path)
+        path_list = self.utils.split_path(self.utils.strip_api_prefix(path_char))
+        entry_point = path_list.pop()
+
+        # Extra verifications?
+        # print(path_list) == ['grafana']
+        # entry_point in ['search', 'query', 'annotations']
+
+        request_dict = request.get_json(force=True)
+        data = process_grafana_request(entry_point, request_dict)
+        headers = self.utils.build_headers(url=request.url, total_count=0)
+        return self.utils.build_response(status=200, headers=headers, data=data)


### PR DESCRIPTION
This is in principle just a proof of concept of how we could communicate with [Grafana](https://grafana.com/) through the REST-API, as suggested in issue #4067. This first toy demo just shows the number of parent workflows currently running, and the number of mpi processors that are being requested and used by the currently running calcjobs. This is a display screenshot:

![test](https://user-images.githubusercontent.com/6209267/112857766-77e46500-90b1-11eb-8c42-1edb20c74478.png)

# Steps to reproduce

1. **Sign up:** go to Grafana and [open a free account](https://grafana.com/signup/cloud/connect-account?pg=login). You will have to create an organization when you do this*. Once in the Grafana Cloud Portal, click in the Grafana tile.
2. **Install the plugin:** go to [this page](https://grafana.com/grafana/plugins/simpod-json-datasource/) and you should see the option to install the plugin in blue on the left.
3. **Local setup:** Checkout this branch and then run `verdi restapi --posting`.
4. **Configure source:** Go back to the Grafana Home and look in the left side options for the "Configuration". Click on "Data Sources" and then click on "add data source". Look and "select" the JSON tile. The only thing you need to set is the `URL` to `http://127.0.0.1:5000/api/v4/grafana` and the `Access` to `Browser`. Then just choose a name and save it.
5. **Setup dashboard:** In the Grafana Home look in the left side options for the "Dashboards" and click on "Manage". Then click on "new dashboard", it should already had a panel deployed in which you can click on "Add an empty panel". In the "Query" tab on the bottom region, there is a selection box that currently shows `--Grafana--`: click there and choose the name of your recently selected source. There should be now another couple of boxes below, one of which says `metric`: select `current_resource_usage`. Finally, on the "Visualization" section on the right, select the "Gauge". Click on "Apply".

Now you can run a couple of your workchains and see if the gauges track correctly your resources. NOTE: Please let me know if you are having trouble with any of the steps or if some instructions are unclear, since I'm reconstructing this procedure after doing it myself through trial and error I'm not entirely sure these will be identical for a clean slate account...

*I am not really sure how the accounts and organizations work and depend on one another. If someone wants to check, I could try adding them to my organization to see how that works. Let me know via PM.

# Follow up

I'll leave this draft open for a little while; in the meantime I'll try thinking of a more interesting application of the displays and collect some feedback (ideas from all are welcome). I'll make a couple of specific pings:

- @giovannipizzi if you think this could be an interesting direction for REST-API development in AiiDA.
- @espenfl this was originally your idea, what do you think of this? what kind of information would you like to see displayed?
- @ltalirz and @CasperWA : so you are more than welcome to check this out too, but in principle I'm just pinging you so you are aware of this possible development since it also requires a POST method in the REST-API just as your recent querybuilder interface. This is currently a rather dirty implementation, so if we go forward I'll probably need some pointers on how to properly extend the REST-API from you.