### PR TITLE
CI: install default `postgresql` instead of specific version

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql-12 graphviz
+        sudo apt install postgresql graphviz
 
     - name: Upgrade pip and setuptools
       # It is crucial to update `setuptools` or the installation of `pymatgen` can break

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql-10 graphviz
+        sudo apt install postgresql-12 graphviz
 
     - name: Upgrade pip and setuptools
       # It is crucial to update `setuptools` or the installation of `pymatgen` can break

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -49,7 +49,7 @@ jobs:
         -   name: Install system dependencies
             run: |
                 sudo apt update
-                sudo apt install postgresql-10
+                sudo apt install postgresql-12
 
         -   name: Upgrade pip
             run: |

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -49,7 +49,7 @@ jobs:
         -   name: Install system dependencies
             run: |
                 sudo apt update
-                sudo apt install postgresql-12
+                sudo apt install postgresql
 
         -   name: Upgrade pip
             run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql-10 graphviz
+        sudo apt install postgresql-12 graphviz
     - name: Install aiida-core
       run: |
         pip install --upgrade pip setuptools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql-12 graphviz
+        sudo apt install postgresql graphviz
     - name: Install aiida-core
       run: |
         pip install --upgrade pip setuptools

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -163,7 +163,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql-12 graphviz
+        sudo apt install postgresql graphviz
 
     - name: Upgrade pip and setuptools
       # It is crucial to update `setuptools` or the installation of `pymatgen` can break

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -163,7 +163,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql-10 graphviz
+        sudo apt install postgresql-12 graphviz
 
     - name: Upgrade pip and setuptools
       # It is crucial to update `setuptools` or the installation of `pymatgen` can break


### PR DESCRIPTION
The CI configuration uses `ubuntu-latest` which recently became Ubuntu
Focal Fossa (20.04) which no longer has `postgresql-10` available, but
instead provides `postgres-12`. Here we switch to using the default
`postgresql`, which is line with our installation guide and works with both
versions of Ubuntu.