### PR TITLE
FIX: respect nested output namespaces in `Process.exposed_outputs`

### DIFF
--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -883,7 +883,7 @@ class Process(plumpy.processes.Process):
         # maps the exposed name to all outputs that belong to it
         top_namespace_map = collections.defaultdict(list)
         link_types = (LinkType.CREATE, LinkType.RETURN)
-        process_outputs_dict = {entry.link_label: entry.node for entry in node.get_outgoing(link_type=link_types)}
+        process_outputs_dict = node.get_outgoing(link_type=link_types).nested()
 
         for port_name in process_outputs_dict:
             top_namespace = port_name.split(namespace_separator)[0]

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -9,9 +9,8 @@
 ###########################################################################
 # pylint: disable=too-many-lines,missing-function-docstring,invalid-name,missing-class-docstring,no-self-use
 """Tests for the `WorkChain` class."""
-import inspect
-import unittest
 import asyncio
+import inspect
 
 import plumpy
 import pytest
@@ -1303,7 +1302,6 @@ class TestWorkChainExpose(AiidaTestCase):
             }
         )
 
-    @unittest.skip('Functionality of `Process.exposed_outputs` is broken for nested namespaces, see issue #3533.')
     def test_nested_expose(self):
         res = launch.run(
             GrandParentExposeWorkChain,


### PR DESCRIPTION
Fixes #3533 

The `exposed_outputs` method was detecting nested namespaces in the
dictionary of outputs of a node by using the namespace separator
character of the port namespace class. However, this character, which is
the `.`, gets converted to `__` when the link is stored in the database.
This transformation is necessary since the `.` is a reserved character
to enable attribute based dereferencing, e.g.

    node.outputs.some_output

Since link labels can contain underscores, we use a double underscore
which, together with the guarantee that link labels don't have leading
or terminating underscores, can uniquely determine the namespaces in any
given link label.

The solution is to not manually reconstruct the namespaces in the output
dictionary but simply use the `get_outgoing().nested()` method which
does it for us.