### PR TITLE
Fix `aiida.cmdline.utils.decorators.with_dbenv` always loading the db

### DIFF
--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -34,11 +34,13 @@ __all__ = ('with_dbenv', 'dbenv', 'only_if_daemon_running')
 
 def load_backend_if_not_loaded():
     """Load the current profile if necessary while running the spinner to show command hasn't crashed."""
-    from aiida.manage.configuration import load_profile
+    from aiida.manage.configuration import load_profile, PROFILE
     from aiida.manage.manager import get_manager
-    with spinner():
-        load_profile()
-        get_manager().get_backend()
+
+    if PROFILE is None:
+        with spinner():
+            load_profile()
+            get_manager().get_backend()
 
 
 def with_dbenv():


### PR DESCRIPTION
Fixes #4864 

The premise of the method `with_dbenv` is that it will load the profile
and corresponding database environment if not already loaded. However,
due to a bug in `load_backend_if_not_loaded` it was actually *always*
loading the environment for every call, even if the database env was
already loaded, leading to very expensive calls for nothing.