### PR TITLE
Fix `IndexError` in `override_log_formatter_context` utility

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -217,18 +217,19 @@ def override_log_formatter_context(fmt: str):
     """Temporarily use a different formatter for all handlers.
 
     NOTE: One can _only_ set `fmt` (not `datefmt` or `style`).
-    Be aware! This may fail if the number of handlers is changed within the decorated function/method.
     """
     temp_formatter = logging.Formatter(fmt=fmt)
-    cached_formatters = [handler.formatter for handler in AIIDA_LOGGER.handlers]
+    cached_formatters = {}
 
     for handler in AIIDA_LOGGER.handlers:
+        # Need a copy here so we keep the original one should the handler's formatter be changed during the yield
+        cached_formatters[handler] = copy.copy(handler.formatter)
         handler.setFormatter(temp_formatter)
 
     yield
 
-    for index, handler in enumerate(AIIDA_LOGGER.handlers):
-        handler.setFormatter(cached_formatters[index])
+    for handler, formatter in cached_formatters.items():
+        handler.setFormatter(formatter)
 
 
 def override_log_formatter(fmt: str):


### PR DESCRIPTION
Fixes #4872 

In the `aiida.common.log.override_log_formatter_context` utility
function, the formatting of all current AiiDA handlers is temporarily
changed for the duration of the yield, and then reset. The problem is
that the function assumed that the number of handlers would not change,
which is not necessarily the case. Additionally, it also relied on the
order of the handlers, which isn't guaranteed either.

The solution is to simply cache the handlers' formatters as a dictionary
and directly use those handler references to reset the cached formatter.
Note that we copy the `handler.formatter` return value because it may be
returned by reference and we want to keep the original formatter if it
is changed during the yield. Note also that it doesn't matter that the
AiiDA logger may have gained additional handlers during the yield, after
we recorded the cached formatters, but that is ok, because we didn't
temporarily change their formatter either.