### PR TITLE
`verdi status`: add version and repository UUID to the output

### DIFF
--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -55,6 +55,7 @@ STATUS_SYMBOLS = {
 def verdi_status(print_traceback, no_rmq):
     """Print status of AiiDA services."""
     # pylint: disable=broad-except,too-many-statements,too-many-branches
+    from aiida import __version__
     from aiida.cmdline.utils.daemon import get_daemon_status, delete_stale_pid_file
     from aiida.common.utils import Capturing
     from aiida.manage.manager import get_manager
@@ -62,7 +63,8 @@ def verdi_status(print_traceback, no_rmq):
 
     exit_code = ExitCode.SUCCESS
 
-    print_status(ServiceStatus.UP, 'config dir', AIIDA_CONFIG_FOLDER)
+    print_status(ServiceStatus.UP, 'version', f'AiiDA v{__version__}')
+    print_status(ServiceStatus.UP, 'config', AIIDA_CONFIG_FOLDER)
 
     manager = get_manager()
     profile = manager.get_profile()
@@ -74,7 +76,7 @@ def verdi_status(print_traceback, no_rmq):
 
     try:
         profile = manager.get_profile()
-        print_status(ServiceStatus.UP, 'profile', f'On profile {profile.name}')
+        print_status(ServiceStatus.UP, 'profile', profile.name)
     except Exception as exc:
         message = 'Unable to read AiiDA profile'
         print_status(ServiceStatus.ERROR, 'profile', message, exception=exc, print_traceback=print_traceback)
@@ -82,13 +84,14 @@ def verdi_status(print_traceback, no_rmq):
 
     # Getting the repository
     try:
-        repo_folder = profile.repository_path
+        container = profile.get_repository_container()
     except Exception as exc:
         message = 'Error with repository folder'
         print_status(ServiceStatus.ERROR, 'repository', message, exception=exc, print_traceback=print_traceback)
         exit_code = ExitCode.CRITICAL
     else:
-        print_status(ServiceStatus.UP, 'repository', repo_folder)
+        repository_status = f'Connected to {container.get_folder()} [UUID={container.container_id}]'
+        print_status(ServiceStatus.UP, 'repository', repository_status)
 
     # Getting the postgres status by trying to get a database cursor
     database_data = [profile.database_username, profile.database_hostname, profile.database_port]

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -10,8 +10,10 @@
 """Tests for `verdi status`."""
 import pytest
 
+from aiida import __version__
 from aiida.cmdline.commands import cmd_status
 from aiida.cmdline.utils.echo import ExitCode
+from aiida.manage.configuration import get_profile
 
 
 @pytest.mark.requires_rmq
@@ -26,6 +28,12 @@ def test_status(run_cli_command):
 
     for string in ['config', 'profile', 'postgres', 'rabbitmq', 'daemon']:
         assert string in result.output
+
+    profile = get_profile()
+    container = profile.get_repository_container()
+
+    assert __version__ in result.output
+    assert container.get_folder() in result.output
 
 
 @pytest.mark.usefixtures('empty_config')


### PR DESCRIPTION
Fixes #2522 

The new disk objectstore-based repository provides a UUID which is also
written in the database to which it is coupled. We add it here to the
output of `verdi status` as additional information.

In addition, we add the version of the package to the output. This way,
in troubleshooting, users do not have to run `verdi --version`
separately to get this information.