### PR TITLE
ORM: replace `InputValidationError` with `ValueError` and `TypeError`

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -19,7 +19,6 @@ from aiida.cmdline.params import options, arguments
 from aiida.cmdline.params.options.commands import code as options_code
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
-from aiida.common.exceptions import InputValidationError
 
 
 @verdi.group('code')
@@ -76,7 +75,6 @@ def set_code_builder(ctx, param, value):
 @with_dbenv()
 def setup_code(non_interactive, **kwargs):
     """Setup a new code."""
-    from aiida.common.exceptions import ValidationError
     from aiida.orm.utils.builders.code import CodeBuilder
 
     if kwargs.pop('on_computer'):
@@ -88,15 +86,15 @@ def setup_code(non_interactive, **kwargs):
 
     try:
         code = code_builder.new()
-    except InputValidationError as exception:
+    except ValueError as exception:
         echo.echo_critical(f'invalid inputs: {exception}')
 
     try:
         code.store()
-        code.reveal()
-    except ValidationError as exception:
+    except Exception as exception:  # pylint: disable=broad-except
         echo.echo_critical(f'Unable to store the Code: {exception}')
 
+    code.reveal()
     echo.echo_success(f'Code<{code.pk}> {code.full_label} created')
 
 
@@ -244,7 +242,7 @@ def relabel(code, label):
 
     try:
         code.relabel(label)
-    except InputValidationError as exception:
+    except (TypeError, ValueError) as exception:
         echo.echo_critical(f'invalid code label: {exception}')
     else:
         echo.echo_success(f'Code<{code.pk}> relabeled from {old_label} to {code.full_label}')

--- a/aiida/orm/implementation/django/querybuilder.py
+++ b/aiida/orm/implementation/django/querybuilder.py
@@ -18,7 +18,6 @@ from sqlalchemy.sql.expression import FunctionElement
 from sqlalchemy.types import Float, Boolean
 
 from aiida.backends.djsite.db import models
-from aiida.common.exceptions import InputValidationError
 from aiida.orm.implementation.querybuilder import BackendQueryBuilder
 
 
@@ -191,19 +190,19 @@ class DjangoQueryBuilder(BackendQueryBuilder):
             negation = False
         if operator in ('longer', 'shorter', 'of_length'):
             if not isinstance(value, int):
-                raise InputValidationError('You have to give an integer when comparing to a length')
+                raise TypeError('You have to give an integer when comparing to a length')
         elif operator in ('like', 'ilike'):
             if not isinstance(value, str):
-                raise InputValidationError(f'Value for operator {operator} has to be a string (you gave {value})')
+                raise TypeError(f'Value for operator {operator} has to be a string (you gave {value})')
         elif operator == 'in':
             try:
                 value_type_set = set(type(i) for i in value)
             except TypeError:
                 raise TypeError('Value for operator `in` could not be iterated')
             if not value_type_set:
-                raise InputValidationError('Value for operator `in` is an empty list')
+                raise ValueError('Value for operator `in` is an empty list')
             if len(value_type_set) > 1:
-                raise InputValidationError(f'Value for operator `in` contains more than one type: {value}')
+                raise ValueError(f'Value for operator `in` contains more than one type: {value}')
         elif operator in ('and', 'or'):
             expressions_for_this_path = []
             for filter_operation_dict in value:
@@ -298,7 +297,7 @@ class DjangoQueryBuilder(BackendQueryBuilder):
             #  Possible types are object, array, string, number, boolean, and null.
             valid_types = ('object', 'array', 'string', 'number', 'boolean', 'null')
             if value not in valid_types:
-                raise InputValidationError(f'value {value} for of_type is not among valid types\n{valid_types}')
+                raise ValueError(f'value {value} for of_type is not among valid types\n{valid_types}')
             expr = jsonb_typeof(database_entity) == value
         elif operator == 'like':
             type_filter, casted_entity = cast_according_to_type(database_entity, value)
@@ -330,7 +329,7 @@ class DjangoQueryBuilder(BackendQueryBuilder):
             ],
                         else_=False)
         else:
-            raise InputValidationError(f'Unknown operator {operator} for filters in JSON field')
+            raise ValueError(f'Unknown operator {operator} for filters in JSON field')
         return expr
 
     @staticmethod

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -18,14 +18,12 @@ likely be moved to a `SqlAlchemyBasedQueryBuilder` class and restore this abstra
 import abc
 import uuid
 
-# pylint: disable=no-name-in-module, import-error
+# pylint: disable=no-name-in-module,import-error
 from sqlalchemy_utils.types.choice import Choice
 from sqlalchemy.types import Integer, Float, Boolean, DateTime
 from sqlalchemy.dialects.postgresql import JSONB
 
-from aiida.common import exceptions
 from aiida.common.lang import type_check
-from aiida.common.exceptions import InputValidationError
 
 __all__ = ('BackendQueryBuilder',)
 
@@ -220,7 +218,7 @@ class BackendQueryBuilder:
         elif operator == 'in':
             expr = database_entity.in_(value)
         else:
-            raise InputValidationError(f'Unknown operator {operator} for filters on columns')
+            raise ValueError(f'Unknown operator {operator} for filters on columns')
         return expr
 
     def get_projectable_attribute(self, alias, column_name, attrpath, cast=None, **kwargs):
@@ -244,7 +242,7 @@ class BackendQueryBuilder:
         elif cast == 'd':
             entity = entity.astext.cast(DateTime)
         else:
-            raise InputValidationError(f'Unkown casting key {cast}')
+            raise ValueError(f'Unkown casting key {cast}')
         return entity
 
     def get_aiida_res(self, res):
@@ -399,13 +397,9 @@ class BackendQueryBuilder:
         """
         try:
             return getattr(alias, colname)
-        except AttributeError:
-            raise exceptions.InputValidationError(
+        except AttributeError as exc:
+            raise ValueError(
                 '{} is not a column of {}\n'
                 'Valid columns are:\n'
-                '{}'.format(
-                    colname,
-                    alias,
-                    '\n'.join(alias._sa_class_manager.mapper.c.keys())  # pylint: disable=protected-access
-                )
-            )
+                '{}'.format(colname, alias, '\n'.join(alias._sa_class_manager.mapper.c.keys()))  # pylint: disable=protected-access
+            ) from exc

--- a/aiida/orm/implementation/sqlalchemy/querybuilder.py
+++ b/aiida/orm/implementation/sqlalchemy/querybuilder.py
@@ -15,7 +15,6 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql.expression import case, FunctionElement
 from sqlalchemy.ext.compiler import compiles
 
-from aiida.common.exceptions import InputValidationError
 from aiida.common.exceptions import NotExistent
 from aiida.orm.implementation.querybuilder import BackendQueryBuilder
 
@@ -220,10 +219,10 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             negation = False
         if operator in ('longer', 'shorter', 'of_length'):
             if not isinstance(value, int):
-                raise InputValidationError('You have to give an integer when comparing to a length')
+                raise TypeError('You have to give an integer when comparing to a length')
         elif operator in ('like', 'ilike'):
             if not isinstance(value, str):
-                raise InputValidationError(f'Value for operator {operator} has to be a string (you gave {value})')
+                raise TypeError(f'Value for operator {operator} has to be a string (you gave {value})')
 
         elif operator == 'in':
             try:
@@ -231,9 +230,9 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             except TypeError:
                 raise TypeError('Value for operator `in` could not be iterated')
             if not value_type_set:
-                raise InputValidationError('Value for operator `in` is an empty list')
+                raise ValueError('Value for operator `in` is an empty list')
             if len(value_type_set) > 1:
-                raise InputValidationError(f'Value for operator `in` contains more than one type: {value}')
+                raise ValueError(f'Value for operator `in` contains more than one type: {value}')
         elif operator in ('and', 'or'):
             expressions_for_this_path = []
             for filter_operation_dict in value:
@@ -322,7 +321,7 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             #  Possible types are object, array, string, number, boolean, and null.
             valid_types = ('object', 'array', 'string', 'number', 'boolean', 'null')
             if value not in valid_types:
-                raise InputValidationError(f'value {value} for of_type is not among valid types\n{valid_types}')
+                raise ValueError(f'value {value} for of_type is not among valid types\n{valid_types}')
             expr = jsonb_typeof(database_entity) == value
         elif operator == 'like':
             type_filter, casted_entity = cast_according_to_type(database_entity, value)
@@ -354,7 +353,7 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             ],
                         else_=False)
         else:
-            raise InputValidationError(f'Unknown operator {operator} for filters in JSON field')
+            raise ValueError(f'Unknown operator {operator} for filters in JSON field')
         return expr
 
     @staticmethod

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -599,7 +599,6 @@ class TrajectoryData(ArrayData):
         :param bool dont_block: If True, interpreter is not blocked when figure is displayed.
         """
         from ase.data import atomic_numbers
-        from aiida.common.exceptions import InputValidationError
 
         # Reading the arrays I need:
         positions = self.get_positions()
@@ -632,9 +631,9 @@ class TrajectoryData(ArrayData):
         elif colors == 'cpk':
             from ase.data.colors import cpk_colors as colors
         else:
-            raise InputValidationError(f'Unknown color spec {colors}')
+            raise ValueError(f'Unknown color spec {colors}')
         if kwargs:
-            raise InputValidationError(f'Unrecognized keyword {kwargs.keys()}')
+            raise ValueError(f'Unrecognized keyword {kwargs.keys()}')
 
         if element_list is None:
             # If not all elements are allowed

--- a/aiida/orm/nodes/data/array/xy.py
+++ b/aiida/orm/nodes/data/array/xy.py
@@ -13,7 +13,7 @@ collections of y-arrays bound to a single x-array, and the methods to operate
 on them.
 """
 import numpy as np
-from aiida.common.exceptions import InputValidationError, NotExistent
+from aiida.common.exceptions import NotExistent
 from .array import ArrayData
 
 
@@ -43,19 +43,19 @@ class XyData(ArrayData):
     def _arrayandname_validator(array, name, units):
         """
         Validates that the array is an numpy.ndarray and that the name is
-        of type str. Raises InputValidationError if this not the case.
+        of type str. Raises TypeError or ValueError if this not the case.
         """
         if not isinstance(name, str):
-            raise InputValidationError('The name must always be a str.')
+            raise TypeError('The name must always be a str.')
 
         if not isinstance(array, np.ndarray):
-            raise InputValidationError('The input array must always be a numpy array')
+            raise TypeError('The input array must always be a numpy array')
         try:
             array.astype(float)
-        except ValueError:
-            raise InputValidationError('The input array must only contain floats')
+        except ValueError as exc:
+            raise TypeError('The input array must only contain floats') from exc
         if not isinstance(units, str):
-            raise InputValidationError('The units must always be a str.')
+            raise TypeError('The units must always be a str.')
 
     def set_x(self, x_array, x_name, x_units):
         """
@@ -86,20 +86,20 @@ class XyData(ArrayData):
 
         # checks that the input lengths match
         if len(y_arrays) != len(y_names):
-            raise InputValidationError('Length of arrays and names do not match!')
+            raise ValueError('Length of arrays and names do not match!')
         if len(y_units) != len(y_names):
-            raise InputValidationError('Length of units does not match!')
+            raise ValueError('Length of units does not match!')
 
         # Try to get the x_array
         try:
             x_array = self.get_x()[1]
-        except NotExistent:
-            raise InputValidationError('X array has not been set yet')
+        except NotExistent as exc:
+            raise ValueError('X array has not been set yet') from exc
         # validate each of the y_arrays
         for num, (y_array, y_name, y_unit) in enumerate(zip(y_arrays, y_names, y_units)):
             self._arrayandname_validator(y_array, y_name, y_unit)
             if np.shape(y_array) != np.shape(x_array):
-                raise InputValidationError(f'y_array {y_name} did not have the same shape has the x_array!')
+                raise ValueError(f'y_array {y_name} did not have the same shape has the x_array!')
             self.set_array(f'y_array_{num}', y_array)
 
         # if the y_arrays pass the initial validation, sets each

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -126,7 +126,7 @@ class Code(Data):
         """
         if '@' in str(value):
             msg = "Code labels must not contain the '@' symbol"
-            raise exceptions.InputValidationError(msg)
+            raise ValueError(msg)
 
         super(Code, self.__class__).label.fset(self, value)  # pylint: disable=no-member
 
@@ -191,7 +191,7 @@ class Code(Data):
 
         :raise aiida.common.NotExistent: if no code identified by the given string is found
         :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely a code
-        :raise aiida.common.InputValidationError: if neither a pk nor a label was passed in
+        :raise ValueError: if neither a pk nor a label was passed in
         """
         # pylint: disable=arguments-differ
         from aiida.orm.utils import load_code
@@ -211,7 +211,7 @@ class Code(Data):
             return cls.get_code_helper(label, machinename)
 
         else:
-            raise exceptions.InputValidationError('Pass either pk or code label (and machinename)')
+            raise ValueError('Pass either pk or code label (and machinename)')
 
     @classmethod
     def get_from_string(cls, code_string):
@@ -230,15 +230,15 @@ class Code(Data):
         :raise aiida.common.NotExistent: if no code identified by the given string is found
         :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
             a code
-        :raise aiida.common.InputValidationError: if code_string is not of string type
+        :raise TypeError: if code_string is not of string type
 
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError, InputValidationError
+        from aiida.common.exceptions import NotExistent, MultipleObjectsError
 
         try:
             label, _, machinename = code_string.partition('@')
         except AttributeError:
-            raise InputValidationError('the provided code_string is not of valid string type')
+            raise TypeError('the provided code_string is not of valid string type')
 
         try:
             return cls.get_code_helper(label, machinename)

--- a/aiida/orm/nodes/data/orbital.py
+++ b/aiida/orm/nodes/data/orbital.py
@@ -10,7 +10,7 @@
 """Data plugin to model an atomic orbital."""
 import copy
 
-from aiida.common.exceptions import ValidationError, InputValidationError
+from aiida.common.exceptions import ValidationError
 from aiida.plugins import OrbitalFactory
 from .data import Data
 
@@ -80,7 +80,7 @@ class OrbitalData(Data):
             try:
                 _orbital_type = orbital_dict['_orbital_type']
             except KeyError:
-                raise InputValidationError(f'No _orbital_type found in: {orbital_dict}')
+                raise ValueError(f'No _orbital_type found in: {orbital_dict}')
             orbital_dicts.append(orbital_dict)
         self.set_attribute('orbital_dicts', orbital_dicts)
 

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -30,7 +30,6 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import cast as type_cast
 from sqlalchemy.dialects.postgresql import array
 
-from aiida.common.exceptions import InputValidationError
 from aiida.common.links import LinkType
 from aiida.manage.manager import get_manager
 from aiida.common.exceptions import ConfigurationError
@@ -146,7 +145,7 @@ def get_querybuilder_classifiers_from_cls(cls, query):  # pylint: disable=invali
         ormclass = query.Node
 
     else:
-        raise InputValidationError(f'I do not know what to do with {cls}')
+        raise ValueError(f'I do not know what to do with {cls}')
 
     if ormclass == query.Node:
         is_valid_node_type_string(classifiers['ormclass_type_string'], raise_on_false=True)
@@ -419,7 +418,7 @@ class QueryBuilder:
         # One can apply the path as a keyword. Allows for jsons to be given to the QueryBuilder.
         path = kwargs.pop('path', [])
         if not isinstance(path, (tuple, list)):
-            raise InputValidationError('Path needs to be a tuple or a list')
+            raise TypeError('Path needs to be a tuple or a list')
         # If the user specified a path, I use the append method to analyze, see QueryBuilder.append
         for path_spec in path:
             if isinstance(path_spec, dict):
@@ -436,14 +435,14 @@ class QueryBuilder:
         # left to QueryBuilder.add_project.
         projection_dict = kwargs.pop('project', {})
         if not isinstance(projection_dict, dict):
-            raise InputValidationError('You need to provide the projections as dictionary')
+            raise TypeError('You need to provide the projections as dictionary')
         for key, val in projection_dict.items():
             self.add_projection(key, val)
 
         # For filters, I also expect a dictionary, and the checks are done lower.
         filter_dict = kwargs.pop('filters', {})
         if not isinstance(filter_dict, dict):
-            raise InputValidationError('You need to provide the filters as dictionary')
+            raise TypeError('You need to provide the filters as dictionary')
         for key, val in filter_dict.items():
             self.add_filter(key, val)
 
@@ -463,7 +462,7 @@ class QueryBuilder:
         # If kwargs is not empty, there is a problem:
         if kwargs:
             valid_keys = ('path', 'filters', 'project', 'limit', 'offset', 'order_by')
-            raise InputValidationError(
+            raise ValueError(
                 'Received additional keywords: {}'
                 '\nwhich I cannot process'
                 '\nValid keywords are: {}'
@@ -521,7 +520,7 @@ class QueryBuilder:
                     # This is not my first iteration!
                     # I check consistency with what was specified before
                     if new_ormclass != ormclass:
-                        raise InputValidationError('Non-matching types have been passed as list/tuple/set.')
+                        raise ValueError('Non-matching types have been passed as list/tuple/set.')
                 else:
                     # first iteration
                     ormclass = new_ormclass
@@ -659,28 +658,28 @@ class QueryBuilder:
         # the class or the type (not both)
 
         if cls is not None and entity_type is not None:
-            raise InputValidationError(f'You cannot specify both a class ({cls}) and a entity_type ({entity_type})')
+            raise ValueError(f'You cannot specify both a class ({cls}) and a entity_type ({entity_type})')
 
         if cls is None and entity_type is None:
-            raise InputValidationError('You need to specify at least a class or a entity_type')
+            raise ValueError('You need to specify at least a class or a entity_type')
 
         # Let's check if it is a valid class or type
         if cls:
             if isinstance(cls, (tuple, list, set)):
                 for sub_cls in cls:
                     if not inspect_isclass(sub_cls):
-                        raise InputValidationError(f"{sub_cls} was passed with kw 'cls', but is not a class")
+                        raise TypeError(f"{sub_cls} was passed with kw 'cls', but is not a class")
             else:
                 if not inspect_isclass(cls):
-                    raise InputValidationError(f"{cls} was passed with kw 'cls', but is not a class")
+                    raise TypeError(f"{cls} was passed with kw 'cls', but is not a class")
         elif entity_type is not None:
             if isinstance(entity_type, (tuple, list, set)):
                 for sub_type in entity_type:
                     if not isinstance(sub_type, str):
-                        raise InputValidationError(f'{sub_type} was passed as entity_type, but is not a string')
+                        raise TypeError(f'{sub_type} was passed as entity_type, but is not a string')
             else:
                 if not isinstance(entity_type, str):
-                    raise InputValidationError(f'{entity_type} was passed as entity_type, but is not a string')
+                    raise TypeError(f'{entity_type} was passed as entity_type, but is not a string')
 
         ormclass, classifiers = self._get_ormclass(cls, entity_type)
 
@@ -688,11 +687,11 @@ class QueryBuilder:
         # Let's get a tag
         if tag:
             if self._EDGE_TAG_DELIM in tag:
-                raise InputValidationError(
+                raise ValueError(
                     f'tag cannot contain {self._EDGE_TAG_DELIM}\nsince this is used as a delimiter for links'
                 )
             if tag in self.tag_to_alias_map.keys():
-                raise InputValidationError(f'This tag ({tag}) is already in use')
+                raise ValueError(f'This tag ({tag}) is already in use')
         else:
             tag = self._get_unique_tag(classifiers)
 
@@ -794,7 +793,7 @@ class QueryBuilder:
             joining_value = kwargs.pop('joining_value', None)
             for key, val in kwargs.items():
                 if key not in spec_to_function_map:
-                    raise InputValidationError(
+                    raise ValueError(
                         '{} is not a valid keyword '
                         'for joining specification\n'
                         'Valid keywords are: '
@@ -803,7 +802,7 @@ class QueryBuilder:
                         )
                     )
                 elif joining_keyword:
-                    raise InputValidationError(
+                    raise ValueError(
                         'You already specified joining specification {}\n'
                         'But you now also want to specify {}'
                         ''.format(joining_keyword, key)
@@ -812,17 +811,17 @@ class QueryBuilder:
                     joining_keyword = key
                     if joining_keyword == 'direction':
                         if not isinstance(val, int):
-                            raise InputValidationError('direction=n expects n to be an integer')
+                            raise TypeError('direction=n expects n to be an integer')
                         try:
                             if val < 0:
                                 joining_keyword = 'with_outgoing'
                             elif val > 0:
                                 joining_keyword = 'with_incoming'
                             else:
-                                raise InputValidationError('direction=0 is not valid')
+                                raise ValueError('direction=0 is not valid')
                             joining_value = self._path[-abs(val)]['tag']
                         except IndexError as exc:
-                            raise InputValidationError(
+                            raise ValueError(
                                 f'You have specified a non-existent entity with\ndirection={joining_value}\n{exc}\n'
                             )
                     else:
@@ -854,7 +853,7 @@ class QueryBuilder:
                     edge_tag = edge_destination_tag + self._EDGE_TAG_DELIM + tag
                 else:
                     if edge_tag in self.tag_to_alias_map.keys():
-                        raise InputValidationError(f'The tag {edge_tag} is already in use')
+                        raise ValueError(f'The tag {edge_tag} is already in use')
                 if self._debug:
                     print('I have chosen', edge_tag)
 
@@ -956,7 +955,7 @@ class QueryBuilder:
 
         for order_spec in order_by:
             if not isinstance(order_spec, dict):
-                raise InputValidationError(
+                raise TypeError(
                     'Invalid input for order_by statement: {}\n'
                     'I am expecting a dictionary ORMClass,'
                     '[columns to sort]'
@@ -974,7 +973,7 @@ class QueryBuilder:
                     elif isinstance(item_to_order_by, dict):
                         pass
                     else:
-                        raise InputValidationError(
+                        raise ValueError(
                             f'Cannot deal with input to order_by {item_to_order_by}\nof type{type(item_to_order_by)}\n'
                         )
                     for entityname, orderspec in item_to_order_by.items():
@@ -986,14 +985,14 @@ class QueryBuilder:
                         elif isinstance(orderspec, dict):
                             this_order_spec = orderspec
                         else:
-                            raise InputValidationError(
+                            raise TypeError(
                                 'I was expecting a string or a dictionary\n'
                                 'You provided {} {}\n'
                                 ''.format(type(orderspec), orderspec)
                             )
                         for key in this_order_spec:
                             if key not in allowed_keys:
-                                raise InputValidationError(
+                                raise ValueError(
                                     'The allowed keys for an order specification\n'
                                     'are {}\n'
                                     '{} is not valid\n'
@@ -1001,7 +1000,7 @@ class QueryBuilder:
                                 )
                         this_order_spec['order'] = this_order_spec.get('order', 'asc')
                         if this_order_spec['order'] not in possible_orders:
-                            raise InputValidationError(
+                            raise ValueError(
                                 'You gave {} as an order parameters,\n'
                                 'but it is not a valid order parameter\n'
                                 'Valid orders are: {}\n'
@@ -1040,7 +1039,7 @@ class QueryBuilder:
     def _process_filters(filters):
         """Process filters."""
         if not isinstance(filters, dict):
-            raise InputValidationError('Filters have to be passed as dictionaries')
+            raise TypeError('Filters have to be passed as dictionaries')
 
         processed_filters = {}
 
@@ -1175,18 +1174,18 @@ class QueryBuilder:
             elif isinstance(projection, str):
                 _thisprojection = {projection: {}}
             else:
-                raise InputValidationError(f'Cannot deal with projection specification {projection}\n')
+                raise ValueError(f'Cannot deal with projection specification {projection}\n')
             for spec in _thisprojection.values():
                 if not isinstance(spec, dict):
-                    raise InputValidationError(
+                    raise TypeError(
                         f'\nThe value of a key-value pair in a projection\nhas to be a dictionary\nYou gave: {spec}\n'
                     )
 
                 for key, val in spec.items():
                     if key not in self._VALID_PROJECTION_KEYS:
-                        raise InputValidationError(f'{key} is not a valid key {self._VALID_PROJECTION_KEYS}')
+                        raise ValueError(f'{key} is not a valid key {self._VALID_PROJECTION_KEYS}')
                     if not isinstance(val, str):
-                        raise InputValidationError(f'{val} has to be a string')
+                        raise TypeError(f'{val} has to be a string')
             _projections.append(_thisprojection)
         if self._debug:
             print('   projections have become:', _projections)
@@ -1215,7 +1214,7 @@ class QueryBuilder:
 
         if column_name == '*':
             if func is not None:
-                raise InputValidationError(
+                raise ValueError(
                     'Very sorry, but functions on the aliased class\n'
                     "(You specified '*')\n"
                     'will not work!\n'
@@ -1233,7 +1232,7 @@ class QueryBuilder:
             elif func == 'count':
                 entity_to_project = sa_func.count(entity_to_project)
             else:
-                raise InputValidationError(f'\nInvalid function specification {func}')
+                raise ValueError(f'\nInvalid function specification {func}')
             self._query = self._query.add_columns(entity_to_project)
 
     def _build_projections(self, tag, items_to_project=None):
@@ -1276,14 +1275,14 @@ class QueryBuilder:
             if specification in self.tag_to_alias_map.keys():
                 tag = specification
             else:
-                raise InputValidationError(
+                raise ValueError(
                     f'tag {specification} is not among my known tags\nMy tags are: {self.tag_to_alias_map.keys()}'
                 )
         else:
             if specification in self._cls_to_tag_map.keys():
                 tag = self._cls_to_tag_map[specification]
             else:
-                raise InputValidationError(
+                raise ValueError(
                     'You specified as a class for which I have to find a tag\n'
                     'The classes that I can do this for are:{}\n'
                     'The tags I have are: {}'.format(self._cls_to_tag_map.keys(), self.tag_to_alias_map.keys())
@@ -1298,7 +1297,7 @@ class QueryBuilder:
         :param bool debug: Turn debug on or off
         """
         if not isinstance(debug, bool):
-            return InputValidationError('I expect a boolean')
+            return TypeError('I expect a boolean')
         self._debug = debug
 
         return self
@@ -1311,7 +1310,7 @@ class QueryBuilder:
         """
 
         if (limit is not None) and (not isinstance(limit, int)):
-            raise InputValidationError('The limit has to be an integer, or None')
+            raise TypeError('The limit has to be an integer, or None')
         self._limit = limit
         return self
 
@@ -1326,7 +1325,7 @@ class QueryBuilder:
         :param int offset: integers of nr of rows to skip
         """
         if (offset is not None) and (not isinstance(offset, int)):
-            raise InputValidationError('offset has to be an integer, or None')
+            raise TypeError('offset has to be an integer, or None')
         self._offset = offset
         return self
 
@@ -1360,7 +1359,7 @@ class QueryBuilder:
                 is_attribute = (attr_key or column_name in ('attributes', 'extras'))
                 try:
                     column = self._impl.get_column(column_name, alias)
-                except InputValidationError:
+                except (ValueError, TypeError):
                     if is_attribute:
                         column = None
                     else:
@@ -1400,7 +1399,7 @@ class QueryBuilder:
         for entity, cls in (entities_cls_joined, entities_cls_to_join):
 
             if not issubclass(entity._sa_class_manager.class_, cls):
-                raise InputValidationError(
+                raise TypeError(
                     "You are attempting to join {} as '{}' of {}\n"
                     'This failed because you passed:\n'
                     ' - {} as entity joined (expected {})\n'
@@ -1795,7 +1794,7 @@ class QueryBuilder:
             try:
                 func = self._get_function_map()[calling_entity][joining_keyword]
             except KeyError:
-                raise InputValidationError(
+                raise ValueError(
                     f"'{joining_keyword}' is not a valid joining keyword for a '{calling_entity}' type entity"
                 )
 
@@ -1805,7 +1804,7 @@ class QueryBuilder:
                 try:
                     returnval = self.tag_to_alias_map[self._get_tag_from_specification(joining_value)], func
                 except KeyError:
-                    raise InputValidationError(
+                    raise ValueError(
                         'Key {} is unknown to the types I know about:\n'
                         '{}'.format(self._get_tag_from_specification(joining_value), self.tag_to_alias_map.keys())
                     )
@@ -1846,7 +1845,7 @@ class QueryBuilder:
         column_name = entitytag.split('.')[0]
         attrpath = entitytag.split('.')[1:]
         if attrpath and 'cast' not in entityspec.keys():
-            raise InputValidationError(
+            raise ValueError(
                 'In order to project ({}), I have to cast the the values,\n'
                 'but you have not specified the datatype to cast to\n'
                 "You can do this with keyword 'cast'".format(entitytag)
@@ -1903,7 +1902,7 @@ class QueryBuilder:
             try:
                 alias = self.tag_to_alias_map[tag]
             except KeyError:
-                raise InputValidationError(
+                raise ValueError(
                     'You looked for tag {} among the alias list\n'
                     'The tags I know are:\n{}'.format(tag, self.tag_to_alias_map.keys())
                 )
@@ -1986,7 +1985,7 @@ class QueryBuilder:
         }
 
         if self.nr_of_projections > len(self._attrkeys_as_in_sql_result):
-            raise InputValidationError('You are projecting the same key multiple times within the same node')
+            raise ValueError('You are projecting the same key multiple times within the same node')
         ######################### DONE #################################
 
         return self._query
@@ -2090,7 +2089,7 @@ class QueryBuilder:
         """
         from sqlalchemy.orm import Query
         if not isinstance(query, Query):
-            raise InputValidationError(f'{query} must be a subclass of {Query}')
+            raise TypeError(f'{query} must be a subclass of {Query}')
         self._query = query
         self._injected = True
 

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Manage code objects with lazy loading of the db env"""
-
 import enum
 import os
 
@@ -195,7 +194,7 @@ class CodeBuilder:
         if messages:
             raise self.CodeValidationError(f'{messages}')
 
-    class CodeValidationError(Exception):
+    class CodeValidationError(ValueError):
         """
         A CodeBuilder instance may raise this
 

--- a/aiida/tools/data/orbital/realhydrogen.py
+++ b/aiida/tools/data/orbital/realhydrogen.py
@@ -11,8 +11,7 @@
 A module defining hydrogen-like orbitals that are real valued (rather than
 complex-valued).
 """
-
-from aiida.common.exceptions import ValidationError, InputValidationError
+from aiida.common.exceptions import ValidationError
 
 from .orbital import Orbital, validate_len3_list_or_none, validate_float_or_none
 
@@ -354,9 +353,7 @@ class RealhydrogenOrbital(Orbital):
             if any([CONVERSION_DICT[x][y]['angular_momentum'] == angular_momentum for y in CONVERSION_DICT[x]])
         ]
         if not orbital_name:
-            raise InputValidationError(
-                f'No orbital name corresponding to the angular_momentum {angular_momentum} could be found'
-            )
+            raise ValueError(f'No orbital name corresponding to the angular_momentum {angular_momentum} could be found')
         if magnetic_number is not None:
             # finds angular momentum
             orbital_name = orbital_name[0]
@@ -366,7 +363,7 @@ class RealhydrogenOrbital(Orbital):
             ]
 
             if not orbital_name:
-                raise InputValidationError(
+                raise ValueError(
                     f'No orbital name corresponding to the magnetic_number {magnetic_number} could be found'
                 )
         return orbital_name[0]
@@ -382,7 +379,7 @@ class RealhydrogenOrbital(Orbital):
         name = name.upper()
         list_of_dicts = [CONVERSION_DICT[x][y] for x in CONVERSION_DICT for y in CONVERSION_DICT[x] if name in (y, x)]
         if not list_of_dicts:
-            raise InputValidationError('Invalid choice of projection name')
+            raise ValueError('Invalid choice of projection name')
         return list_of_dicts
 
 

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -14,7 +14,6 @@ from collections import defaultdict
 import numpy as np
 
 from aiida import orm
-from aiida.common.exceptions import InputValidationError
 from aiida.tools.graph.age_entities import Basket
 from aiida.common.lang import type_check
 
@@ -208,8 +207,8 @@ class QueryRule(Operation, metaclass=ABCMeta):
             for proj_tag, projectionlist in projections.items():
                 try:
                     self._querybuilder.add_projection(proj_tag, projectionlist)
-                except InputValidationError:
-                    raise KeyError('The projection for the edge-identifier is invalid.\n')
+                except (TypeError, ValueError) as exc:
+                    raise KeyError('The projection for the edge-identifier is invalid.\n') from exc
 
     def _load_results(self, target_set, operational_set):
         """Single application of the rules to the operational set

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -511,30 +511,29 @@ class TestQueryBuilder(AiidaTestCase):
         self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project=['id']).iterdict())), 4)
 
     def test_append_validation(self):
-        from aiida.common.exceptions import InputValidationError
 
         # So here I am giving two times the same tag
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(ValueError):
             orm.QueryBuilder().append(orm.StructureData, tag='n').append(orm.StructureData, tag='n')
         # here I am giving a wrong filter specifications
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(TypeError):
             orm.QueryBuilder().append(orm.StructureData, filters=['jajjsd'])
         # here I am giving a nonsensical projection:
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(ValueError):
             orm.QueryBuilder().append(orm.StructureData, project=True)
 
         # here I am giving a nonsensical projection for the edge:
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(ValueError):
             orm.QueryBuilder().append(orm.ProcessNode).append(orm.StructureData, edge_tag='t').add_projection('t', True)
         # Giving a nonsensical limit
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(TypeError):
             orm.QueryBuilder().append(orm.ProcessNode).limit(2.3)
         # Giving a nonsensical offset
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(TypeError):
             orm.QueryBuilder(offset=2.3)
 
         # So, I mess up one append, I want the QueryBuilder to clean it!
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(ValueError):
             qb = orm.QueryBuilder()
             # This also checks if we correctly raise for wrong keywords
             qb.append(orm.StructureData, tag='s', randomkeyword={})

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1009,7 +1009,7 @@ class TestNodeBasic(AiidaTestCase):
         """
         Checks that the method Code.get_from_string works correctly.
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError, InputValidationError
+        from aiida.common.exceptions import NotExistent, MultipleObjectsError
 
         # Create some code nodes
         code1 = orm.Code()
@@ -1035,7 +1035,7 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEqual(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Calling get_from_string for a non string type raises exception
-        with self.assertRaises(InputValidationError):
+        with self.assertRaises(TypeError):
             orm.Code.get_from_string(code1.id)
 
         # Test that the lookup of a nonexistent code works as expected


### PR DESCRIPTION
Fixes #3812 

The front-end ORM code threw an `InputValidationError` in a number a
places. However, this exception was intended for calculation plugins to
throw in the case of invalid input nodes. Where it was being used in the
ORM plain `ValueError` or `TypeError` exceptions should have been used.

Since the `InputValidationError` does not subclass either of the base
exception types, code that was catching this particular AiiDA-specific
exception will break after these changes. However, a scan of the most
used plugins revealed that this exception is actually not being caught
so this change should have little to no actual consequences.