### PR TITLE
`Manager`: check if repository container has been initialised

### DIFF
--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -134,13 +134,26 @@ class Profile:  # pylint: disable=too-many-public-methods
         """
         from disk_objectstore import Container
 
-        filepath = os.path.join(self.repository_path, 'container')
+        filepath = self._container_path
         container = Container(filepath)
 
-        if not container.is_initialised:
+        if not self.container_is_initialised:
             container.init_container(clear=True, **self.defaults['repository'])  # pylint: disable=unsubscriptable-object
 
         return container
+
+    @property
+    def container_is_initialised(self):
+        """Check if the container of the profile file repository has already been initialised."""
+        from disk_objectstore import Container
+        filepath = self._container_path
+        container = Container(filepath)
+        return container.is_initialised
+
+    @property
+    def _container_path(self):
+        """Return the path to the container of the profile file repository."""
+        return os.path.join(self.repository_path, 'container')
 
     @property
     def uuid(self):

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -136,7 +136,10 @@ class Manager:
         # yet known, we issue a warning in the case the repo and database are incompatible. In the future this might
         # then become an exception once we have verified that it is working reliably.
         if repository_check and not profile.is_test_profile:
-            repository_uuid_config = profile.get_repository_container().container_id
+            if profile.container_is_initialised:
+                repository_uuid_config = profile.get_repository_container().container_id
+            else:
+                repository_uuid_config = None
             repository_uuid_database = backend_manager.get_repository_uuid()
 
             from aiida.cmdline.utils import echo


### PR DESCRIPTION
Fixes #4885

When loading the backend of the profile with the `Manager._load_backend`
method, the `get_repository_container` method of the `Profile` is
called, initialising a container for the profile in case is has not yet
been initialised. This causes issues during the migration of the
database/repository, since here the presence of the container directory
results in a critical failure of the migration command.

Here we add a check in the `_load_backend` method to see if the
container of the profile has already been initialised. If it has, the
repository uuid obtained from the container, if not it is set to `None`.
This also removes the warning that was printed during the migration
or the creation of a new profile, since the repository uuid obtained
from the database backend is also `None` before the migration.