### PR TITLE
Reinstate `aiida.manage.tests.unittest_classes`

### DIFF
--- a/.github/system_tests/test_plugin_testcase.py
+++ b/.github/system_tests/test_plugin_testcase.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+Test the plugin test case
+
+This must be in a standalone script because it would clash with other tests,
+Since the dbenv gets loaded on the temporary profile.
+"""
+
+import sys
+import unittest
+import tempfile
+import shutil
+
+from aiida.manage.tests.unittest_classes import PluginTestCase, TestRunner
+
+
+class PluginTestCase1(PluginTestCase):
+    """
+    Test the PluginTestCase from utils.fixtures
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.data = self.get_data()
+        self.data_pk = self.data.pk
+        self.computer = self.get_computer(temp_dir=self.temp_dir)
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.temp_dir)
+
+    @staticmethod
+    def get_data():
+        """
+        Return some Dict
+        """
+        from aiida.plugins import DataFactory
+        data = DataFactory('dict')(dict={'data': 'test'})
+        data.store()
+        return data
+
+    @classmethod
+    def get_computer(cls, temp_dir):
+        """
+        Create and store a new computer, and return it
+        """
+        from aiida import orm
+
+        computer = orm.Computer(
+            label='localhost',
+            hostname='localhost',
+            description='my computer',
+            transport_type='local',
+            scheduler_type='direct',
+            workdir=temp_dir,
+            backend=cls.backend
+        ).store()
+        return computer
+
+    def test_data_loaded(self):
+        """
+        Check that the data node is indeed in the DB when calling load_node
+        """
+        from aiida import orm
+        self.assertEqual(orm.load_node(self.data_pk).uuid, self.data.uuid)
+
+    def test_computer_loaded(self):
+        """
+        Check that the computer is indeed in the DB when calling load_node
+
+        Note: Important to have at least two test functions in order to verify things
+        work after resetting the DB.
+        """
+        from aiida import orm
+        self.assertEqual(orm.Computer.objects.get(label='localhost').uuid, self.computer.uuid)
+
+    def test_tear_down(self):
+        """
+        Check that after tearing down, the previously stored nodes
+        are not there anymore.
+        """
+        from aiida.orm import load_node
+        super().tearDown()  # reset DB
+        with self.assertRaises(Exception):
+            load_node(self.data_pk)
+
+
+class PluginTestCase2(PluginTestCase):
+    """
+    Second PluginTestCase.
+    """
+
+    def test_dummy(self):
+        """
+        Dummy test for 2nd PluginTestCase class.
+
+        Just making sure that setup/teardown is safe for
+        multiple testcase classes (this was broken in #1425).
+        """
+        super().tearDown()
+
+
+if __name__ == '__main__':
+    MODULE = sys.modules[__name__]
+    SUITE = unittest.defaultTestLoader.loadTestsFromModule(MODULE)
+    RESULT = TestRunner().run(SUITE)
+
+    EXIT_CODE = int(not RESULT.wasSuccessful())
+    sys.exit(EXIT_CODE)

--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -29,6 +29,7 @@ verdi daemon stop
 pytest --noconftest ${SYSTEM_TESTS}/test_test_manager.py
 pytest --noconftest ${SYSTEM_TESTS}/test_ipython_magics.py
 pytest --noconftest ${SYSTEM_TESTS}/test_profile_manager.py
+python ${SYSTEM_TESTS}/test_plugin_testcase.py  # uses custom unittest test runner
 
 # Until the `${SYSTEM_TESTS}/pytest` tests are moved within `tests` we have to run them separately and pass in the path to the
 # `conftest.py` explicitly, because otherwise it won't be able to find the fixtures it provides

--- a/aiida/manage/tests/unittest_classes.py
+++ b/aiida/manage/tests/unittest_classes.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+Test classes and test runners for testing AiiDA plugins with unittest.
+"""
+import unittest
+import warnings
+
+from aiida.common.warnings import AiidaDeprecationWarning
+from aiida.manage.manager import get_manager
+from . import _GLOBAL_TEST_MANAGER, test_manager, get_test_backend_name, get_test_profile_name
+
+__all__ = ('PluginTestCase', 'TestRunner')
+
+warnings.warn(  # pylint: disable=no-member
+    'This module has been deprecated and will be removed soon. Please use the `pytest` fixtures instead.\n'
+    'See https://github.com/aiidateam/aiida-core/wiki/AiiDA-2.0-plugin-migration-guide#unit-tests',
+    AiidaDeprecationWarning
+)
+
+
+class PluginTestCase(unittest.TestCase):
+    """
+    Set up a complete temporary AiiDA environment for plugin tests.
+
+    Note: This test class needs to be run through the :py:class:`~aiida.manage.tests.unittest_classes.TestRunner`
+    and will **not** work simply with `python -m unittest discover`.
+
+    Usage example::
+
+        MyTestCase(aiida.manage.tests.unittest_classes.PluginTestCase):
+
+            def setUp(self):
+                # load my tests data
+
+            # optionally extend setUpClass / tearDownClass / tearDown if needed
+
+            def test_my_plugin(self):
+                # execute tests
+    """
+    # Filled in during setUpClass
+    backend = None  # type :class:`aiida.orm.implementation.Backend`
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_manager = _GLOBAL_TEST_MANAGER
+        if not cls.test_manager.has_profile_open():
+            raise ValueError(
+                'Fixture mananger has no open profile.' +
+                'Please use aiida.manage.tests.unittest_classes.TestRunner to run these tests.'
+            )
+
+        cls.backend = get_manager().get_backend()
+
+    def tearDown(self):
+        self.test_manager.reset_db()
+
+
+class TestRunner(unittest.runner.TextTestRunner):
+    """
+    Testrunner for unit tests using the fixture manager.
+
+    Usage example::
+
+        import unittest
+        from aiida.manage.tests.unittest_classes import TestRunner
+
+        tests = unittest.defaultTestLoader.discover('.')
+        TestRunner().run(tests)
+
+    """
+
+    # pylint: disable=arguments-differ
+    def run(self, suite, backend=None, profile_name=None):
+        """
+        Run tests using fixture manager for specified backend.
+
+        :param suite: A suite of tests, as returned e.g. by :py:meth:`unittest.TestLoader.discover`
+        :param backend: name of database backend to be used.
+        :param profile_name: name of test profile to be used or None (will use temporary profile)
+        """
+        warnings.warn(  # pylint: disable=no-member
+            'Please use "pytest" for testing AiiDA plugins. Support for "unittest" will be removed soon',
+            AiidaDeprecationWarning
+        )
+
+        with test_manager(
+            backend=backend or get_test_backend_name(), profile_name=profile_name or get_test_profile_name()
+        ):
+            return super().run(suite)


### PR DESCRIPTION
Fixes #4887 

Although this was officially deprecated and slated to be removed for
`v2.0` the deprecation warning only showed when using the `TestRunner`
class. However, many plugins only used the `PluginTestCase` run directly
through `pytest` and so didn't see the deprecation warning. Therefore,
we reinstate the module for now and will remove it in a couple of
months.