### PR TITLE
Config: warn when the configuration directory is created

### DIFF
--- a/.github/system_tests/test_profile_manager.py
+++ b/.github/system_tests/test_profile_manager.py
@@ -14,6 +14,7 @@ import warnings
 import sys
 
 from pgtest import pgtest
+import pytest
 
 from aiida.manage.tests import TemporaryProfileManager, TestManagerError, get_test_backend_name
 from aiida.common.utils import Capturing
@@ -42,6 +43,7 @@ class TemporaryProfileManagerTestCase(unittest.TestCase):
         self.profile_manager.create_aiida_db()
         self.assertTrue(self.profile_manager.postgres.db_exists(self.profile_manager.profile_info['database_name']))
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_create_use_destroy_profile2(self):
         """
         Test temporary test profile creation

--- a/.github/system_tests/test_test_manager.py
+++ b/.github/system_tests/test_test_manager.py
@@ -12,6 +12,8 @@ import unittest
 import warnings
 import sys
 
+import pytest
+
 from aiida.manage.tests import TestManager, get_test_backend_name
 
 
@@ -29,6 +31,7 @@ class TestManagerTestCase(unittest.TestCase):
     def tearDown(self):
         self.test_manager.destroy_all()
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_pgtest_argument(self):
         """
         Create a temporary profile, passing the pgtest argument.

--- a/docs/source/howto/installation.rst
+++ b/docs/source/howto/installation.rst
@@ -435,8 +435,8 @@ Backing up your installation
 
 A full backup of an AiiDA instance and AiiDA managed data requires a backup of:
 
-* the profile configuration in the ``config.json`` file located in the ``.aiida`` folder.
-  Typically located at ``~/.aiida`` (see also :ref:`intro:install:setup`).
+* the AiiDA configuration folder, which is typically named ``.aiida`` and located in the home folder (see also :ref:`intro:install:setup`).
+  This folder contains, among other things, the ``config.json`` configuration file and log files.
 
 * files associated with nodes in the repository folder (one per profile). Typically located in the ``.aiida`` folder.
 

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -9,8 +9,11 @@
 ###########################################################################
 """Tests for the Config class."""
 import os
+import pathlib
 import shutil
 import tempfile
+
+import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions, json
@@ -42,6 +45,7 @@ class TestConfigDirectory(AiidaTestCase):
             except KeyError:
                 pass
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_environment_variable_not_set(self):
         """Check that if the environment variable is not set, config folder will be created in `DEFAULT_AIIDA_PATH`.
 
@@ -63,10 +67,11 @@ class TestConfigDirectory(AiidaTestCase):
 
             config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
             self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, config_folder)
+            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
         finally:
             shutil.rmtree(directory)
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_environment_variable_set_single_path_without_config_folder(self):  # pylint: disable=invalid-name
         """If `AIIDA_PATH` is set but does not contain a configuration folder, it should be created."""
         try:
@@ -80,11 +85,12 @@ class TestConfigDirectory(AiidaTestCase):
             # This should have created the configuration directory in the path
             config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
             self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, config_folder)
+            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
 
         finally:
             shutil.rmtree(directory)
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_environment_variable_set_single_path_with_config_folder(self):  # pylint: disable=invalid-name
         """If `AIIDA_PATH` is set and already contains a configuration folder it should simply be used."""
         try:
@@ -99,10 +105,11 @@ class TestConfigDirectory(AiidaTestCase):
             # This should have created the configuration directory in the pathpath
             config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
             self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, config_folder)
+            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
         finally:
             shutil.rmtree(directory)
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_environment_variable_path_including_config_folder(self):  # pylint: disable=invalid-name
         """If `AIIDA_PATH` is set and the path contains the base name of the config folder, it should work, i.e:
 
@@ -122,11 +129,12 @@ class TestConfigDirectory(AiidaTestCase):
             # This should have created the configuration directory in the pathpath
             config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
             self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, config_folder)
+            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
 
         finally:
             shutil.rmtree(directory)
 
+    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
     def test_environment_variable_set_multiple_path(self):  # pylint: disable=invalid-name
         """If `AIIDA_PATH` is set with multiple paths without actual config folder, one is created in the last."""
         try:
@@ -142,7 +150,7 @@ class TestConfigDirectory(AiidaTestCase):
             # This should have created the configuration directory in the last path
             config_folder = os.path.join(directory_c, settings.DEFAULT_CONFIG_DIR_NAME)
             self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, config_folder)
+            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
 
         finally:
             shutil.rmtree(directory_a)


### PR DESCRIPTION
Fixes #4884 

The configuration directory is automatically created when it is loaded
and it doesn't exist yet. This is useful for new installations, however,
it can lead to problems when users accidentally make a mistake when
setting an explicit path with the `AIIDA_PATH` environment variable. If
a type is present in the path, instead of the intended existing config
being used, a new empty one is created.

We add a warning to when the base configuration directory is created, if
and only if the `AIIDA_PATH` variable is set. Otherwise the warning
would always show up, also for new profiles which is most likely not
desirable.

The `aiida.manage.configuration.settings` module is also migrated to use
the `pathlib` module for file system path manipulations.