### PR TITLE
Profile: only initialise the repository during the migration

### DIFF
--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -79,6 +79,7 @@ class AiidaTestCase(unittest.TestCase):
         cls._class_was_setup = True
 
         cls.refurbish_db()
+        cls.initialise_repository()
 
     @classmethod
     def tearDownClass(cls):
@@ -137,6 +138,14 @@ class AiidaTestCase(unittest.TestCase):
         reset_manager()
 
     @classmethod
+    def initialise_repository(cls):
+        """Initialise the repository"""
+        from aiida.manage.configuration import get_profile
+        profile = get_profile()
+        repository = profile.get_repository()
+        repository.initialise(clear=True, **profile.defaults['repository'])
+
+    @classmethod
     def refurbish_db(cls):
         """Clean up database and repopulate with initial data.
 
@@ -168,6 +177,7 @@ class AiidaTestCase(unittest.TestCase):
         # Clean the test repository
         shutil.rmtree(dirpath_repository, ignore_errors=True)
         os.makedirs(dirpath_repository)
+        cls.initialise_repository()
 
     @classproperty
     def computer(cls):  # pylint: disable=no-self-argument

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -79,7 +79,7 @@ def setup(
     # Migrate the database
     echo.echo_info('migrating the database.')
     manager = get_manager()
-    backend = manager._load_backend(schema_check=False)  # pylint: disable=protected-access
+    backend = manager._load_backend(schema_check=False, repository_check=False)  # pylint: disable=protected-access
 
     try:
         backend.migrate()
@@ -96,19 +96,11 @@ def setup(
     repository_uuid_database = backend_manager.get_repository_uuid()
     repository_uuid_profile = profile.get_repository().uuid
 
-    # If database contains no repository UUID, it should be a clean database so associate it with the repository
-    if repository_uuid_database is None:
-        backend_manager.set_repository_uuid(repository_uuid_profile)
-
-    # Otherwise, if the database UUID does not match that of the repository, it means they do not belong together. Note
-    # that if a new repository path was specified, which does not yet contain a container, the call to retrieve the
-    # repo by `get_repository_container` will initialize the container and generate a UUID. This guarantees that if a
-    # non-empty database is configured with an empty repository path, this check will hit.
-    elif repository_uuid_database != repository_uuid_profile:
+    if repository_uuid_database != repository_uuid_profile:
         echo.echo_critical(
             f'incompatible database and repository configured:\n'
             f'Database `{db_name}` is associated with the repository with UUID `{repository_uuid_database}`\n'
-            f'However, the configured repository `{repository}` has UUID `{repository_uuid_profile}`.'
+            f'However, the configured repository has UUID `{repository_uuid_profile}`.'
         )
 
     # Optionally setting configuration default user settings

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -129,22 +129,13 @@ class Profile:  # pylint: disable=too-many-public-methods
         self._test_profile = bool(self.name.startswith('test_'))
 
     def get_repository(self) -> 'Repository':
-        """Return the repository configured for this profile.
-
-        .. note:: The repository will automatically be initialised if it wasn't yet already.
-        """
+        """Return the repository configured for this profile."""
         from disk_objectstore import Container
         from aiida.repository import Repository
         from aiida.repository.backend import DiskObjectStoreRepositoryBackend
-
         container = Container(self.repository_path / 'container')
         backend = DiskObjectStoreRepositoryBackend(container=container)
-        repository = Repository(backend=backend)
-
-        if not repository.is_initialised:
-            repository.initialise(clear=True, **self.defaults['repository'])  # pylint: disable=unsubscriptable-object
-
-        return repository
+        return Repository(backend=backend)
 
     @property
     def uuid(self):

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -186,7 +186,10 @@ class Manager:
         from aiida.common import ConfigurationError
 
         if self._backend_manager is None:
-            self._load_backend()
+
+            if self._backend is None:
+                self._load_backend()
+
             profile = self.get_profile()
             if profile is None:
                 raise ConfigurationError(


### PR DESCRIPTION
Fixes #4897 

The new disk object store migration that will ship with `v2.0` requires
to be initialised once and only once, and it will generate the necessary
folders and configuration file. This process was being done in the
method `Profile.get_repository` guarded by a check in case it was
already initialised.

The problem with this was that the container could be initialised too
early during the early stages of a profile setup. As soon as the
repository was fetched, it would be initialised generating, among other
things, the UUID. This would then trigger the check that the database
contained the same UUID, which would of course fail, since the database
was empty. This could have been fixed by ignoring the check at this
point, but the real problem is that the repository should not be
initialised at this point. The only point at which the repo should be
initialised is during the corresponding database migration that
introduced the disk object store repository. Both for existing as well
as for new profiles, they will go through this migration and so it and
it alone should be responsible for initialising the repository.

This approach did create problems for the unittests though, as they
would sometimes clean the repository. It would this not by just removing
the contents, but it would delete the entire container. This meant it
had to be recreated, but since in normal operations this only happens
during the migration (which also during tests only happens once, unless
maybe during the migration tests themselves) and so an error would be
raised that the repository is not initialised. The solution is to
reinitialise a new repo as soon as the old one was destroyed. Currently
this is done by simply deleting the folder on disk and reinitialising an
entire new instance. In the future, it would be better if the existing
container could be kept and its contents could simply be dropped, but
this would require a feature in the `disk-objectstore` library.