### PR TITLE
CLI: set `localhost` as default for database hostname in `verdi setup`

### DIFF
--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -249,7 +249,7 @@ DB_HOST = OverridableOption(
     '--db-host',
     type=types.HostnameType(),
     help='Database server host. Leave empty for "peer" authentication.',
-    default=DEFAULT_DBINFO['host']
+    default='localhost'
 )
 
 DB_PORT = OverridableOption(

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -259,7 +259,7 @@ SETUP_DATABASE_BACKEND = QUICKSETUP_DATABASE_BACKEND.clone(
 
 SETUP_DATABASE_HOSTNAME = QUICKSETUP_DATABASE_HOSTNAME.clone(
     prompt='Database host',
-    contextual_default=functools.partial(get_profile_attribute_default, ('database_hostname', DEFAULT_DBINFO['host'])),
+    contextual_default=functools.partial(get_profile_attribute_default, ('database_hostname', 'localhost')),
     cls=options.interactive.InteractiveOption
 )
 


### PR DESCRIPTION
Fixes #4907 

The default was actually being defined on the option, however, it was
taken from the `pgsu.DEFAULT_DSN` dictionary, which defines the database
hostname to be `None`. Still, 9 out of 10 times the database is on the
localhost so not having this as a default is kind of annoying and
unnecessary.