### PR TITLE
Migrations: only show progress it not empty in file repository migration

### DIFF
--- a/aiida/backends/djsite/db/migrations/0047_migrate_repository.py
+++ b/aiida/backends/djsite/db/migrations/0047_migrate_repository.py
@@ -7,9 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=invalid-name,too-few-public-methods
+# pylint: disable=invalid-name,too-few-public-methods,no-name-in-module,import-error
 """Migrate the file repository to the new disk object store based implementation."""
-# pylint: disable=no-name-in-module,import-error
+import pathlib
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import migrations
 
@@ -25,10 +26,13 @@ REPOSITORY_UUID_KEY = 'repository|uuid'
 
 def migrate_repository(apps, schema_editor):
     """Migrate the repository."""
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     import json
     from tempfile import NamedTemporaryFile
-    from aiida.common.progress_reporter import set_progress_bar_tqdm, get_progress_reporter
+    from disk_objectstore import Container
+
+    from aiida.common import exceptions
+    from aiida.common.progress_reporter import set_progress_bar_tqdm, get_progress_reporter, set_progress_reporter
     from aiida.manage.configuration import get_profile
 
     DbNode = apps.get_model('db', 'DbNode')
@@ -39,7 +43,31 @@ def migrate_repository(apps, schema_editor):
     missing_repo_folder = []
     shard_count = 256
 
-    set_progress_bar_tqdm()
+    basepath = pathlib.Path(profile.repository_path) / 'repository' / 'node'
+    filepath = pathlib.Path(profile.repository_path) / 'container'
+    container = Container(filepath)
+
+    if not profile.is_test_profile and (node_count > 0 and not basepath.is_dir()):
+        raise exceptions.DatabaseMigrationError(
+            f'the file repository `{basepath}` does not exist but the database is not empty, it contains {node_count} '
+            'nodes. Aborting the migration.'
+        )
+
+    if not profile.is_test_profile and container.is_initialised:
+        raise exceptions.DatabaseMigrationError(
+            f'the container {filepath} already exists. If you ran this migration before and it failed simply '
+            'delete this directory and restart the migration.'
+        )
+
+    container.init_container(clear=True, **profile.defaults['repository'])
+
+    # Only show the progress bar if there is at least a node in the database. Note that we cannot simply make the entire
+    # next block under the context manager optional, since it performs checks on whether the repository contains files
+    # that are not in the database that are still important to perform even if the database is empty.
+    if node_count > 0:
+        set_progress_bar_tqdm()
+    else:
+        set_progress_reporter(None)
 
     with get_progress_reporter()(total=shard_count, desc='Migrating file repository') as progress:
         for i in range(shard_count):
@@ -47,9 +75,7 @@ def migrate_repository(apps, schema_editor):
             shard = '%.2x' % i  # noqa flynt
             progress.set_description_str(f'Migrating file repository: shard {shard}')
 
-            mapping_node_repository_metadata, missing_sub_repo_folder = utils.migrate_legacy_repository(
-                node_count, shard
-            )
+            mapping_node_repository_metadata, missing_sub_repo_folder = utils.migrate_legacy_repository(shard)
 
             if missing_sub_repo_folder:
                 missing_repo_folder.extend(missing_sub_repo_folder)
@@ -112,7 +138,6 @@ def migrate_repository(apps, schema_editor):
 
         # If there were no nodes, most likely a new profile, there is not need to print the warning
         if node_count:
-            import pathlib
             echo.echo_warning(
                 '\nMigrated file repository to the new disk object store. The old repository has not been deleted '
                 f'out of safety and can be found at {pathlib.Path(profile.repository_path, "repository")}.'

--- a/aiida/backends/general/migrations/utils.py
+++ b/aiida/backends/general/migrations/utils.py
@@ -126,8 +126,10 @@ class NoopRepositoryBackend(AbstractRepositoryBackend):
         raise NotImplementedError()
 
 
-def migrate_legacy_repository(node_count, shard=None):
+def migrate_legacy_repository(shard=None):
     """Migrate the legacy file repository to the new disk object store and return mapping of repository metadata.
+
+    .. warning:: this method assumes that the new disk object store container has been initialized.
 
     The format of the return value will be a dictionary where the keys are the UUIDs of the nodes whose repository
     folder has contents have been migrated to the disk object store. The values are the repository metadata that contain
@@ -141,8 +143,6 @@ def migrate_legacy_repository(node_count, shard=None):
     have to be adapted and the significant parts of the implementation will have to be copy pasted here.
 
     :return: mapping of node UUIDs onto the new repository metadata.
-    :raises `~aiida.common.exceptions.DatabaseMigrationError`: in case the container of the migrated repository already
-        exists or if the repository does not exist but the database contains at least one node.
     """
     # pylint: disable=too-many-locals
     from aiida.manage.configuration import get_profile
@@ -151,33 +151,12 @@ def migrate_legacy_repository(node_count, shard=None):
     backend = NoopRepositoryBackend()
     repository = MigrationRepository(backend=backend)
 
-    # Initialize the new container: don't go through the profile, because that will not check if it already exists
-    filepath = pathlib.Path(profile.repository_path) / 'container'
     basepath = pathlib.Path(profile.repository_path) / 'repository' / 'node'
+    filepath = pathlib.Path(profile.repository_path) / 'container'
     container = Container(filepath)
 
-    # The new container needs to be initialised. Since this function can be called multiple times, it shouldn't
-    # initialise the repository each time since it will delete all content. By checking the value of the shard, we
-    # should just initialise it for the first iteration.
-    if shard is None or shard == '00':
-        if container.is_initialised and not profile.is_test_profile:
-            raise exceptions.DatabaseMigrationError(
-                f'the container {filepath} already exists. If you ran this migration before and it failed simply '
-                'delete this directory and restart the migration.'
-            )
-
-        container.init_container(clear=True, **profile.defaults['repository'])
-
-    if not basepath.is_dir():
-        # If the database is empty, this is a new profile and so it is normal the repo folder doesn't exist. We simply
-        # return as there is nothing to migrate.
-        if profile.is_test_profile or node_count == 0:
-            return None, None
-
-        raise exceptions.DatabaseMigrationError(
-            f'the file repository `{basepath}` does not exist but the database is not empty, it contains {node_count} '
-            'nodes. Aborting the migration.'
-        )
+    if not basepath.exists():
+        return None, None
 
     node_repository_dirpaths, missing_sub_repo_folder = get_node_repository_dirpaths(basepath, shard)
 


### PR DESCRIPTION
Fixes #4904 

The migration of the legacy file repository to the new disk object store
includes a progress bar counting the shards of the repository as they
are being migrated. This is useful for typical production databases for
which this can take some time, however, it was also showing for empty
databases. This output was unnecessarily noisy and on CI platforms would
give a lot of output since each iteration of the progress bar is kept
on a single line. Therefore the migration is updated to only show the
progress bar as long as the database contains at least one node.

To make this possible the code had to be refactored because if the
database is empty, now the call to `utils.migrate_legacy_repository` is
skipped entirely, since that just migrates the files of existing nodes,
however, this function was also doing other important actions, such as
initializing the new repository and checking the old repository exists,
which should definitely not be skipped. These operations are therefore
moved to the backend specific migration files themselves.

Even for empty databases, the `migrate_legacy_repository` is still
called the same as it would be for non-empty databases and it is not
skipped entirely within a simple conditional. The reason is to keep the
logic as close as possible for empty and non-empty databases since there
might be subtle differences if we skip it entirely for the one and not
the other.