### PR TITLE
👌 IMPROVE: `Repository.hash()` speed

### DIFF
--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -13,6 +13,7 @@ import hashlib
 import numbers
 import random
 import time
+import typing
 import uuid
 from collections import abc, OrderedDict
 from functools import singledispatch
@@ -80,6 +81,31 @@ BLAKE2B_OPTIONS = {
     'digest_size': 32,  # we do not need a cryptographically relevant digest
     'inner_size': 64,  # ... but still use 64 as the inner size
 }
+
+
+def chunked_file_hash(
+    handle: typing.BinaryIO, hash_cls: typing.Any, chunksize: int = 524288, **kwargs: typing.Any
+) -> str:
+    """Return the hash for the given file handle
+
+    Will read the file in chunks, which should be opened in 'rb' mode.
+
+    :param handle: a file handle, opened in 'rb' mode.
+    :param hash_cls: a class implementing hashlib._Hash
+    :param chunksize: number of bytes to chunk the file read in
+    :param kwargs: arguments to pass to the hasher initialisation
+    :return: the hash hexdigest (the hash key)
+    """
+    hasher = hash_cls(**kwargs)
+    while True:
+        chunk = handle.read(chunksize)
+        hasher.update(chunk)
+
+        if not chunk:
+            # Empty returned value: EOF
+            break
+
+    return hasher.hexdigest()
 
 
 def make_hash(object_to_hash, **kwargs):

--- a/aiida/repository/backend/abstract.py
+++ b/aiida/repository/backend/abstract.py
@@ -7,6 +7,7 @@ This key should then be able to be used to retrieve the bytes of the correspondi
 """
 import abc
 import contextlib
+import hashlib
 import io
 import pathlib
 import typing
@@ -104,6 +105,21 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         """
         with self.open(key) as handle:
             return handle.read()
+
+    def get_object_hash(self, key: str) -> str:
+        """Return the hash of a object identified by key.
+
+        .. note::
+            This hash value is dependant on the repository implementation
+            and so may change for different repositories.
+            By default the algorithm is SHA-256
+
+        :param key: fully qualified identifier for the object within the repository.
+        :raise FileNotFoundError: if the file does not exist.
+        :raise OSError: if the file could not be opened.
+        """
+        with self.open(key) as handle:
+            return hashlib.sha256(handle.read()).hexdigest()
 
     def delete_object(self, key: str):
         """Delete the object from the repository.

--- a/aiida/repository/backend/abstract.py
+++ b/aiida/repository/backend/abstract.py
@@ -12,6 +12,8 @@ import io
 import pathlib
 import typing
 
+from aiida.common.hashing import chunked_file_hash
+
 __all__ = ('AbstractRepositoryBackend',)
 
 
@@ -107,19 +109,18 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
             return handle.read()
 
     def get_object_hash(self, key: str) -> str:
-        """Return the hash of a object identified by key.
+        """Return the SHA-256 hash of an object stored under the given key.
 
-        .. note::
-            This hash value is dependant on the repository implementation
-            and so may change for different repositories.
-            By default the algorithm is SHA-256
+        .. important::
+            A SHA-256 hash should always be returned,
+            to ensure consistency across different repository implementations.
 
         :param key: fully qualified identifier for the object within the repository.
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
         with self.open(key) as handle:
-            return hashlib.sha256(handle.read()).hexdigest()
+            return chunked_file_hash(handle, hashlib.sha256)
 
     def delete_object(self, key: str):
         """Delete the object from the repository.

--- a/aiida/repository/backend/disk_object_store.py
+++ b/aiida/repository/backend/disk_object_store.py
@@ -101,17 +101,18 @@ class DiskObjectStoreRepositoryBackend(AbstractRepositoryBackend):
         self.container.delete_objects([key])
 
     def get_object_hash(self, key: str) -> str:
-        """Return the hash of a object identified by key.
+        """Return the SHA-256 hash of an object stored under the given key.
 
-        .. note::
-            This hash value is dependant on the repository implementation
-            and so may change for different repositories.
-            By default the algorithm is SHA-256
+        .. important::
+            A SHA-256 hash should always be returned,
+            to ensure consistency across different repository implementations.
 
         :param key: fully qualified identifier for the object within the repository.
         :raise FileNotFoundError: if the file does not exist.
 
         """
+        if not self.has_object(key):
+            raise FileNotFoundError(key)
         if self.container.hash_type != 'sha256':
             return super().get_object_hash(key)
         return key

--- a/aiida/repository/backend/disk_object_store.py
+++ b/aiida/repository/backend/disk_object_store.py
@@ -99,3 +99,19 @@ class DiskObjectStoreRepositoryBackend(AbstractRepositoryBackend):
         """
         super().delete_object(key)
         self.container.delete_objects([key])
+
+    def get_object_hash(self, key: str) -> str:
+        """Return the hash of a object identified by key.
+
+        .. note::
+            This hash value is dependant on the repository implementation
+            and so may change for different repositories.
+            By default the algorithm is SHA-256
+
+        :param key: fully qualified identifier for the object within the repository.
+        :raise FileNotFoundError: if the file does not exist.
+
+        """
+        if self.container.hash_type != 'sha256':
+            return super().get_object_hash(key)
+        return key

--- a/aiida/repository/repository.py
+++ b/aiida/repository/repository.py
@@ -104,8 +104,8 @@ class Repository:
         for root, dirnames, filenames in self.walk():
             objects['__dirnames__'] = dirnames
             for filename in filenames:
-                with self.open(root / filename) as handle:
-                    objects[str(root / filename)] = handle.read()
+                key = self.get_file(root / filename).key
+                objects[str(root / filename)] = self.backend.get_object_hash(key)
 
         return make_hash(objects)
 

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -9,7 +9,10 @@
 ###########################################################################
 """Translator for node"""
 import pkgutil
-import imp
+import importlib.util
+import importlib.machinery
+from importlib._bootstrap import _exec, _load
+import sys
 import inspect
 import os
 
@@ -341,17 +344,36 @@ class NodeTranslator(BaseTranslator):
         results = {}
 
         for _, name, is_pkg in pkgutil.walk_packages([package_path]):
-            # N.B. pkgutil.walk_package requires a LIST of paths.
+            # N.B. pkgutil.walk_packages requires a LIST of paths
 
             full_path_base = os.path.join(package_path, name)
-
             if is_pkg:
-                app_module = imp.load_package(full_path_base, full_path_base)
+                # re-implementation of deprecated `imp.load_package`
+                if os.path.isdir(full_path_base):
+                    #Adds an extension to check for __init__ file in the package directory
+                    extensions = (importlib.machinery.SOURCE_SUFFIXES[:] + importlib.machinery.BYTECODE_SUFFIXES[:])
+                    for extension in extensions:
+                        init_path = os.path.join(full_path_base, '__init__' + extension)
+                        if os.path.exists(init_path):
+                            path = init_path
+                            break
+                    else:
+                        raise ValueError(f'{full_path_base!r} is not a package')
+                #passing [] to submodule_search_locations indicates its a package and python searches for sub-modules
+                spec = importlib.util.spec_from_file_location(full_path_base, path, submodule_search_locations=[])
+                if full_path_base in sys.modules:
+                    #executes from sys.modules
+                    app_module = _exec(spec, sys.modules[full_path_base])
+                else:
+                    #loads and executes the module
+                    app_module = _load(spec)
             else:
                 full_path = f'{full_path_base}.py'
-                # I could use load_module but it takes lots of arguments,
-                # then I use load_source
-                app_module = imp.load_source(f'rst{name}', full_path)
+                # reimplementation of deprecated `imp.load_source`
+                spec = importlib.util.spec_from_file_location(name, full_path)
+                app_module = importlib.util.module_from_spec(spec)
+                sys.modules[name] = app_module
+                spec.loader.exec_module(app_module)
 
             # Go through the content of the module
             if not is_pkg:

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -25,6 +25,7 @@ py:class function
 py:class IO
 py:class traceback
 py:class _io.BufferedReader
+py:class BinaryIO
 
 ### AiiDA
 

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -11,9 +11,10 @@
 Unittests for aiida.common.hashing:make_hash with hardcoded hash values
 """
 
-import itertools
 import collections
+import itertools
 from datetime import datetime
+import hashlib
 import uuid
 
 import numpy as np
@@ -25,7 +26,7 @@ except ImportError:
     import unittest
 
 from aiida.common.exceptions import HashingError
-from aiida.common.hashing import make_hash, float_to_text
+from aiida.common.hashing import make_hash, float_to_text, chunked_file_hash
 from aiida.common.folders import SandboxFolder
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm import Dict
@@ -257,3 +258,11 @@ class CheckDBRoundTrip(AiidaTestCase):
             recomputed_hash = node.get_hash()
 
             self.assertEqual(first_hash, recomputed_hash)
+
+
+def test_chunked_file_hash(tmp_path):
+    """Test the ``chunked_file_hash`` function."""
+    (tmp_path / 'afile').write_bytes(b'content')
+    with (tmp_path / 'afile').open('rb') as handle:
+        key = chunked_file_hash(handle, hashlib.sha256)
+    assert key == 'ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73'

--- a/tests/repository/backend/test_disk_object_store.py
+++ b/tests/repository/backend/test_disk_object_store.py
@@ -134,3 +134,14 @@ def test_erase(repository, generate_directory):
 
     assert not dirpath.exists()
     assert not repository.is_initialised
+
+
+def test_get_object_hash(repository, generate_directory):
+    """Test the ``Repository.get_object_hash`` returns the expected value."""
+    repository.initialise()
+    directory = generate_directory({'file_a': b'content'})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert repository.get_object_hash(key) == 'ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73'

--- a/tests/repository/backend/test_sandbox.py
+++ b/tests/repository/backend/test_sandbox.py
@@ -134,3 +134,14 @@ def test_cleanup():
     assert dirpath.exists()
     del repository
     assert not dirpath.exists()
+
+
+def test_get_object_hash(repository, generate_directory):
+    """Test the ``Repository.get_object_hash`` returns the expected value."""
+    repository.initialise()
+    directory = generate_directory({'file_a': b'content'})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert repository.get_object_hash(key) == 'ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73'


### PR DESCRIPTION
closes #4918

Uses `hashlib.sha256` by default then, to be super safe, only uses the key for the object-store if `self.container.hash_type == 'sha256'`

before:

```
--------------------------------------------- benchmark 'node': 1 tests ---------------------------------------------
Name (time in ms)              Min       Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------
test_store_with_object     10.4047  105.4098  14.0552  9.3613  13.0171  1.9786       1;4  71.1483     100           1
---------------------------------------------------------------------------------------------------------------------
```

after:

```
------------------------------------------- benchmark 'node': 1 tests -------------------------------------------
Name (time in ms)             Min     Max    Mean  StdDev  Median     IQR  Outliers       OPS  Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------
test_store_with_object     5.8858  9.1815  6.8171  0.7261  6.5448  0.9458      22;3  146.6907     100           1
-----------------------------------------------------------------------------------------------------------------
```