### PR TITLE
👌 IMPROVE: add `DaemonClient.lock()`

### DIFF
--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -260,3 +260,9 @@ class HashingError(AiidaException):
     """
     Raised when an attempt to hash an object fails via a known failure mode
     """
+
+
+class DaemonLock(AiidaException):
+    """
+    Raised when an attempt to instatiate the daemon is made, when it is locked for use
+    """

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -26,6 +26,7 @@ __all__ = ('Profile',)
 
 CIRCUS_PID_FILE_TEMPLATE = os.path.join(DAEMON_DIR, 'circus-{}.pid')
 DAEMON_PID_FILE_TEMPLATE = os.path.join(DAEMON_DIR, 'aiida-{}.pid')
+DAEMON_LOCK_FILE_TEMPLATE = os.path.join(DAEMON_DIR, 'lock-{}.pid')
 CIRCUS_LOG_FILE_TEMPLATE = os.path.join(DAEMON_LOG_DIR, 'circus-{}.log')
 DAEMON_LOG_FILE_TEMPLATE = os.path.join(DAEMON_LOG_DIR, 'aiida-{}.log')
 CIRCUS_PORT_FILE_TEMPLATE = os.path.join(DAEMON_DIR, 'circus-{}.port')
@@ -399,5 +400,6 @@ class Profile:  # pylint: disable=too-many-public-methods
             'daemon': {
                 'log': DAEMON_LOG_FILE_TEMPLATE.format(self.name),
                 'pid': DAEMON_PID_FILE_TEMPLATE.format(self.name),
+                'lock': DAEMON_LOCK_FILE_TEMPLATE.format(self.name),
             }
         }


### PR DESCRIPTION
This is a proposal for part of the solution to #4321, in order to provide a basic locking mechanism for the daemon; to "ensure" that it can not be running or started from another process:

```python
In [29]: from aiida.engine.daemon.client import get_daemon_client
    ...: client = get_daemon_client()
    ...: with client.lock():
    ...:     # try to get another client
    ...:     get_daemon_client()
    ...: 
---------------------------------------------------------------------------
DaemonLock                                Traceback (most recent call last)
<ipython-input-29-58ecd1c03adb> in <module>
      3 with client.lock():
      4     # try to get another client
----> 5     get_daemon_client()
      6 

~/Documents/GitHub/aiida-core-origin/aiida/engine/daemon/client.py in get_daemon_client(profile_name)
     61         profile = config.current_profile
     62 
---> 63     return DaemonClient(profile)
     64 
     65 

~/Documents/GitHub/aiida-core-origin/aiida/engine/daemon/client.py in __init__(self, profile)
     87         self._DAEMON_TIMEOUT: int = config.get_option('daemon.timeout')  # pylint: disable=invalid-name
     88         if Path(self.daemon_lock_file).exists():
---> 89             raise DaemonLock(
     90                 f"The '{self.profile.name}' daemon is locked for use. "
     91                 'Use `verdi daemon unlock` if this is unexpected.'

DaemonLock: The quicksetup daemon is locked for use. Use `verdi daemon unlock` if this is unexpected.
```

cc @giovannipizzi, @sphuber for comment

(if you think its ok, I'll add tests and was also thinking of adding `verdi daemon unlock`, in case for whatever reason the lock file is not removed)