### PR TITLE
Migrations: fix the rename of `name` to `label` for `DbComputer`

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/versions/535039300e4a_computer_name_to_label.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/535039300e4a_computer_name_to_label.py
@@ -8,7 +8,6 @@ Create Date: 2021-04-28 14:11:40.728240
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '535039300e4a'
@@ -19,15 +18,13 @@ depends_on = None
 
 def upgrade():
     """Migrations for the upgrade."""
-    op.add_column('db_dbcomputer', sa.Column('label', sa.String(length=255), nullable=False))
-    op.drop_constraint('db_dbcomputer_name_key', 'db_dbcomputer', type_='unique')
+    op.drop_constraint('db_dbcomputer_name_key', 'db_dbcomputer')
+    op.alter_column('db_dbcomputer', 'name', new_column_name='label')  # pylint: disable=no-member
     op.create_unique_constraint('db_dbcomputer_label_key', 'db_dbcomputer', ['label'])
-    op.drop_column('db_dbcomputer', 'name')
 
 
 def downgrade():
     """Migrations for the downgrade."""
-    op.add_column('db_dbcomputer', sa.Column('name', sa.VARCHAR(length=255), autoincrement=False, nullable=False))
-    op.drop_constraint('db_dbcomputer_label_key', 'db_dbcomputer', type_='unique')
+    op.drop_constraint('db_dbcomputer_label_key', 'db_dbcomputer')
+    op.alter_column('db_dbcomputer', 'label', new_column_name='name')  # pylint: disable=no-member
     op.create_unique_constraint('db_dbcomputer_name_key', 'db_dbcomputer', ['name'])
-    op.drop_column('db_dbcomputer', 'label')

--- a/tests/backends/aiida_django/migrations/test_migrations_0048_computer_name_to_label.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_0048_computer_name_to_label.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=import-error,no-name-in-module,invalid-name
+"""Test migration that renames the ``name`` column of the ``Computer`` entity to ``label``."""
+from .test_migrations_common import TestMigrations
+
+
+class TestMigration(TestMigrations):
+    """Test migration that renames the ``name`` column of the ``Computer`` entity to ``label``."""
+
+    migrate_from = '0047_migrate_repository'
+    migrate_to = '0048_computer_name_to_label'
+
+    def setUpBeforeMigration(self):
+        DbComputer = self.apps.get_model('db', 'DbComputer')
+
+        computer = DbComputer(name='testing')
+        computer.save()
+        self.computer_pk = computer.pk
+
+    def test_migration(self):
+        """Test that the migration was performed correctly."""
+        DbComputer = self.apps.get_model('db', 'DbComputer')
+
+        computer = DbComputer.objects.get(pk=self.computer_pk)
+        assert computer.label == 'testing'


### PR DESCRIPTION
Fixes #4925 

The migration was broken for SqlAlchemy and wasn't detected because
there were no tests. The migration of new profiles still worked because
it only failed for databases that have at least one computer.

The new migration properly uses `alter_column` to change the column
name, instead of creating a new one and dropping the old one. Not only
does this incur the exception that the new column will have null values,
which is not allowed since it is not nullable, but it would also have
lost all the data.

Finally, the `label` column has a uniqueness constraint and the name
should technically also be changed, so the constraint is dropped and
added with the new name based on `label`.