### PR TITLE
♻️ REFACTOR: `Repository.get_hash_keys` -> `Repository.get_file_keys`

### DIFF
--- a/aiida/repository/common.py
+++ b/aiida/repository/common.py
@@ -30,7 +30,17 @@ class File():
         file_type: FileType = FileType.DIRECTORY,
         key: typing.Union[str, None] = None,
         objects: typing.Dict[str, 'File'] = None
-    ):
+    ) -> None:
+        """Construct a new instance.
+
+        :param name: The final element of the file path
+        :param file_type: Identifies whether the File is a file or a directory 
+        :param key: A key to map the file to an object in the repository (file only)
+        :param objects: Mapping of child names to child Files (directory only)
+
+        :raises ValueError: If a key is defined for a directory,
+            or objects are defined for a file
+        """
         if not isinstance(name, str):
             raise TypeError('name should be a string.')
 

--- a/aiida/repository/repository.py
+++ b/aiida/repository/repository.py
@@ -181,24 +181,24 @@ class Repository:
 
         return directory
 
-    def get_hash_keys(self) -> List[str]:
-        """Return the hash keys of all file objects contained within this repository.
+    def get_file_keys(self) -> List[str]:
+        """Return the keys of all file objects contained within this repository.
 
-        :return: list of file object hash keys.
+        :return: list of keys, which map a file to its content in the backend repository.
         """
-        hash_keys: List[str] = []
+        file_keys: List[str] = []
 
-        def add_hash_keys(keys, objects):
+        def _add_file_keys(keys, objects):
             """Recursively add keys of all file objects to the keys list."""
             for obj in objects.values():
                 if obj.file_type == FileType.FILE and obj.key is not None:
                     keys.append(obj.key)
                 elif obj.file_type == FileType.DIRECTORY:
-                    add_hash_keys(keys, obj.objects)
+                    _add_file_keys(keys, obj.objects)
 
-        add_hash_keys(hash_keys, self._directory.objects)
+        _add_file_keys(file_keys, self._directory.objects)
 
-        return hash_keys
+        return file_keys
 
     def get_object(self, path: FilePath = None) -> File:
         """Return the object at the given path.
@@ -435,8 +435,8 @@ class Repository:
             nodes. Therefore, we manually delete all file objects and then simply reset the internal file hierarchy.
 
         """
-        for hash_key in self.get_hash_keys():
-            self.backend.delete_object(hash_key)
+        for file_key in self.get_file_keys():
+            self.backend.delete_object(file_key)
         self.reset()
 
     def clone(self, source: 'Repository') -> None:

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -126,11 +126,11 @@ def test_create_directory(repository):
     assert repository.list_object_names('nested') == ['dir']
 
 
-def test_get_hash_keys(repository, generate_directory):
-    """Test the ``Repository.get_hash_keys`` method."""
+def test_get_file_keys(repository, generate_directory):
+    """Test the ``Repository.get_file_keys`` method."""
     directory = generate_directory({'file_a': b'content_a', 'relative': {'file_b': b'content_b'}})
 
-    assert repository.get_hash_keys() == []
+    assert repository.get_file_keys() == []
 
     with open(directory / 'file_a', 'rb') as handle:
         repository.put_object_from_filelike(handle, 'file_a')
@@ -138,9 +138,9 @@ def test_get_hash_keys(repository, generate_directory):
     with open(directory / 'relative/file_b', 'rb') as handle:
         repository.put_object_from_filelike(handle, 'relative/file_b')
 
-    hash_keys = [repository.get_object('file_a').key, repository.get_object('relative/file_b').key]
+    file_keys = [repository.get_object('file_a').key, repository.get_object('relative/file_b').key]
 
-    assert sorted(repository.get_hash_keys()) == sorted(hash_keys)
+    assert sorted(repository.get_file_keys()) == sorted(file_keys)
 
 
 def test_get_object_raises(repository):


### PR DESCRIPTION
I feel that this make it clearer what this method is returning.
When we refer to a hash, in the context of the repository, we are refering to the (hexidecimal) hash of a file's contents.
By contrast, the key to the file's contents does not have to be a hash of its contents, as is the case for `SandboxRepositoryBackend`, which uses a UUID.