### PR TITLE
`Config`: write config to disk at end of `delete_profile`

### DIFF
--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -372,6 +372,7 @@ class Config:  # pylint: disable=too-many-public-methods
             postgres.drop_dbuser(profile.database_username)
 
         self.remove_profile(name)
+        self.store()
 
     def set_default_profile(self, name, overwrite=False):
         """Set the given profile as the new default.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,14 +182,15 @@ def empty_config(tmp_path) -> Config:
     with Capturing():
         configuration.CONFIG = configuration.load_config(create=True)
 
-    yield get_config()
-
-    # Reset the config folder path and the config instance. Note this will always be executed after the yield no
-    # matter what happened in the test that used this fixture.
-    reset_profile()
-    settings.AIIDA_CONFIG_FOLDER = current_config_path
-    configuration.CONFIG = current_config
-    load_profile(current_profile_name)
+    try:
+        yield get_config()
+    finally:
+        # Reset the config folder path and the config instance. Note this will always be executed after the yield no
+        # matter what happened in the test that used this fixture.
+        reset_profile()
+        settings.AIIDA_CONFIG_FOLDER = current_config_path
+        configuration.CONFIG = current_config
+        load_profile(current_profile_name)
 
 
 @pytest.fixture
@@ -199,7 +200,7 @@ def profile_factory() -> Profile:
     :return: the profile instance.
     """
 
-    def _create_profile(name, **kwargs):
+    def _create_profile(name='test-profile', **kwargs):
 
         repository_dirpath = kwargs.pop('repository_dirpath', get_config().dirpath)
 

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -7,421 +7,380 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for the Config class."""
+"""Tests for the ``Config`` class."""
 import os
 import pathlib
-import shutil
-import tempfile
 
 import pytest
 
-from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions, json
 from aiida.manage.configuration import Config, Profile, settings
 from aiida.manage.configuration.migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
 from aiida.manage.configuration.options import get_option
 
-from tests.utils.configuration import create_mock_profile
 
-
-class TestConfigDirectory(AiidaTestCase):
-    """Tests to make sure that the detection and creation of configuration folder is done correctly."""
-
-    @classmethod
-    def setUpClass(cls, *args, **kwargs):
-        """Save the current environment variable settings."""
-        super().setUpClass(*args, **kwargs)
-        cls.aiida_path_original = os.environ.get(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
-
-    @classmethod
-    def tearDownClass(cls, *args, **kwargs):
-        """Restore the original environment variable settings."""
-        super().tearDownClass(*args, **kwargs)
-        if cls.aiida_path_original is not None:
-            os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = cls.aiida_path_original
+@pytest.fixture
+def cache_aiida_path_variable():
+    """Fixture that will store the ``AIIDA_PATH`` environment variable and restore it after the yield."""
+    aiida_path_original = os.environ.get(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
+    try:
+        yield
+    finally:
+        if aiida_path_original is not None:
+            os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = aiida_path_original
         else:
             try:
                 del os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE]
             except KeyError:
                 pass
 
-    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
-    def test_environment_variable_not_set(self):
-        """Check that if the environment variable is not set, config folder will be created in `DEFAULT_AIIDA_PATH`.
-
-        To make sure we do not mess with the actual default `.aiida` folder, which often lives in the home folder
-        we create a temporary directory and set the `DEFAULT_AIIDA_PATH` to it.
-        """
-        try:
-            directory = tempfile.mkdtemp()
-
-            # Change the default configuration folder path to temp folder instead of probably `~`.
-            settings.DEFAULT_AIIDA_PATH = directory
-
-            # Make sure that the environment variable is not set
-            try:
-                del os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE]
-            except KeyError:
-                pass
-            settings.set_configuration_directory()
-
-            config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
-            self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
-        finally:
-            shutil.rmtree(directory)
-
-    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
-    def test_environment_variable_set_single_path_without_config_folder(self):  # pylint: disable=invalid-name
-        """If `AIIDA_PATH` is set but does not contain a configuration folder, it should be created."""
-        try:
-            directory = tempfile.mkdtemp()
-
-            # Set the environment variable and call configuration initialization
-            env_variable = f'{directory}'
-            os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = env_variable
-            settings.set_configuration_directory()
-
-            # This should have created the configuration directory in the path
-            config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
-            self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
-
-        finally:
-            shutil.rmtree(directory)
-
-    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
-    def test_environment_variable_set_single_path_with_config_folder(self):  # pylint: disable=invalid-name
-        """If `AIIDA_PATH` is set and already contains a configuration folder it should simply be used."""
-        try:
-            directory = tempfile.mkdtemp()
-            os.makedirs(os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME))
-
-            # Set the environment variable and call configuration initialization
-            env_variable = f'{directory}'
-            os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = env_variable
-            settings.set_configuration_directory()
-
-            # This should have created the configuration directory in the pathpath
-            config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
-            self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
-        finally:
-            shutil.rmtree(directory)
-
-    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
-    def test_environment_variable_path_including_config_folder(self):  # pylint: disable=invalid-name
-        """If `AIIDA_PATH` is set and the path contains the base name of the config folder, it should work, i.e:
-
-            `/home/user/.virtualenvs/dev/`
-            `/home/user/.virtualenvs/dev/.aiida`
-
-        Are both legal and will both result in the same configuration folder path.
-        """
-        try:
-            directory = tempfile.mkdtemp()
-
-            # Set the environment variable with a path that include base folder name and call config initialization
-            env_variable = f'{os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)}'
-            os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = env_variable
-            settings.set_configuration_directory()
-
-            # This should have created the configuration directory in the pathpath
-            config_folder = os.path.join(directory, settings.DEFAULT_CONFIG_DIR_NAME)
-            self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
-
-        finally:
-            shutil.rmtree(directory)
-
-    @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
-    def test_environment_variable_set_multiple_path(self):  # pylint: disable=invalid-name
-        """If `AIIDA_PATH` is set with multiple paths without actual config folder, one is created in the last."""
-        try:
-            directory_a = tempfile.mkdtemp()
-            directory_b = tempfile.mkdtemp()
-            directory_c = tempfile.mkdtemp()
-
-            # Set the environment variable to contain three paths and call configuration initialization
-            env_variable = f'{directory_a}:{directory_b}:{directory_c}'
-            os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = env_variable
-            settings.set_configuration_directory()
-
-            # This should have created the configuration directory in the last path
-            config_folder = os.path.join(directory_c, settings.DEFAULT_CONFIG_DIR_NAME)
-            self.assertTrue(os.path.isdir(config_folder))
-            self.assertEqual(settings.AIIDA_CONFIG_FOLDER, pathlib.Path(config_folder))
-
-        finally:
-            shutil.rmtree(directory_a)
-            shutil.rmtree(directory_b)
-            shutil.rmtree(directory_c)
-
-
-class TestConfig(AiidaTestCase):
-    """Tests for the Config class."""
-
-    def setUp(self):
-        """Setup a mock config."""
-        super().setUp()
-        self.profile_name = 'test_profile'
-        self.profile = create_mock_profile(self.profile_name)
-        self.config_filebase = tempfile.mkdtemp()
-        self.config_filename = 'config.json'
-        self.config_filepath = os.path.join(self.config_filebase, self.config_filename)
-        self.config_dictionary = {
-            Config.KEY_VERSION: {
-                Config.KEY_VERSION_CURRENT: CURRENT_CONFIG_VERSION,
-                Config.KEY_VERSION_OLDEST_COMPATIBLE: OLDEST_COMPATIBLE_CONFIG_VERSION,
-            },
-            Config.KEY_PROFILES: {
-                self.profile_name: self.profile.dictionary
-            },
-        }
-
-    def tearDown(self):
-        """Clean the temporary folder."""
-        super().tearDown()
-        if self.config_filebase and os.path.isdir(self.config_filebase):
-            shutil.rmtree(self.config_filebase)
-
-    def compare_config_in_memory_and_on_disk(self, config, filepath):
-        """Verify that the contents of `config` are identical to the contents of the file with path `filepath`.
-
-        :param config: instance of `Config`
-        :param filepath: absolute filepath to a configuration file
-        :raises AssertionError: if content of `config` is not equal to that of file on disk
-        """
-        from aiida.manage.configuration.settings import DEFAULT_CONFIG_INDENT_SIZE
 
-        in_memory = json.dumps(config.dictionary, indent=DEFAULT_CONFIG_INDENT_SIZE)
-
-        # Read the content stored on disk
-        with open(filepath, 'r') as handle:
-            on_disk = handle.read()
-
-        # Compare content of in memory config and the one on disk
-        self.assertEqual(in_memory, on_disk)
-
-    def test_from_file_no_migrate(self):
-        """Test that ``Config.from_file`` does not overwrite if the content was not migrated."""
-        from time import sleep
-
-        # Construct the ``Config`` instance and write it to disk
-        Config(self.config_filepath, self.config_dictionary).store()
-
-        timestamp = os.path.getmtime(self.config_filepath)
-        Config.from_file(self.config_filepath)
-
-        # Sleep a second, because for some operating systems the time resolution is of the order of a second
-        sleep(1)
-
-        assert os.path.getmtime(self.config_filepath) == timestamp
-
-    def test_from_file(self):
-        """Test the `Config.from_file` class method.
-
-        Regression test for #3790: make sure configuration is written to disk after it is loaded and migrated.
-        """
-
-        # If the config file does not exist, a completely new file is created with a migrated config
-        filepath_nonexisting = os.path.join(self.config_filebase, 'config_nonexisting.json')
-        config = Config.from_file(filepath_nonexisting)
-
-        # Make sure that the migrated config is written to disk, by loading it from disk and comparing to the content
-        # of the in memory config object.
-        self.compare_config_in_memory_and_on_disk(config, filepath_nonexisting)
-
-        # Now repeat the test for an existing file. The previous filepath now *does* exist and is migrated
-        filepath_existing = filepath_nonexisting
-        config = Config.from_file(filepath_existing)
-
-        self.compare_config_in_memory_and_on_disk(config, filepath_existing)
-
-        # Finally, we test that an existing configuration file with an outdated schema is migrated and written to disk
-        with tempfile.NamedTemporaryFile() as handle:
-
-            # Write content of configuration with old schema to disk
-            filepath = os.path.join(os.path.dirname(__file__), 'migrations', 'test_samples', 'input', '0.json')
-            with open(filepath, 'rb') as source:
-                handle.write(source.read())
-                handle.flush()
-
-            config = Config.from_file(handle.name)
-            self.compare_config_in_memory_and_on_disk(config, handle.name)
-
-    def test_basic_properties(self):
-        """Test the basic properties of the Config class."""
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        self.assertEqual(config.filepath, self.config_filepath)
-        self.assertEqual(config.dirpath, self.config_filebase)
-        self.assertEqual(config.version, CURRENT_CONFIG_VERSION)
-        self.assertEqual(config.version_oldest_compatible, OLDEST_COMPATIBLE_CONFIG_VERSION)
-        self.assertEqual(config.dictionary, self.config_dictionary)
-
-    def test_setting_versions(self):
-        """Test the version setters."""
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        self.assertEqual(config.version, CURRENT_CONFIG_VERSION)
-        self.assertEqual(config.version_oldest_compatible, OLDEST_COMPATIBLE_CONFIG_VERSION)
-
-        new_config_version = 1000
-        new_compatible_version = 999
-
-        config.version = new_config_version
-        config.version_oldest_compatible = new_compatible_version
-
-        self.assertEqual(config.version, new_config_version)
-        self.assertEqual(config.version_oldest_compatible, new_compatible_version)
-
-    def test_construct_empty_dictionary(self):
-        """Constructing with empty dictionary should create basic skeleton."""
-        config = Config(self.config_filepath, {})
-
-        self.assertTrue(Config.KEY_PROFILES in config.dictionary)
-        self.assertTrue(Config.KEY_VERSION in config.dictionary)
-        self.assertTrue(Config.KEY_VERSION_CURRENT in config.dictionary[Config.KEY_VERSION])
-        self.assertTrue(Config.KEY_VERSION_OLDEST_COMPATIBLE in config.dictionary[Config.KEY_VERSION])
-
-    def test_default_profile(self):
-        """Test setting and getting default profile."""
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        # If not set should return None
-        self.assertEqual(config.default_profile_name, None)
-
-        # Setting it to a profile that does not exist should raise
-        with self.assertRaises(exceptions.ProfileConfigurationError):
-            config.set_default_profile('non_existing_profile')
-
-        # After setting a default profile, it should return the right name
-        config.add_profile(create_mock_profile(self.profile_name))
-        config.set_default_profile(self.profile_name)
-        self.assertTrue(config.default_profile_name, self.profile_name)
-
-        # Setting it when a default is already set, should not overwrite by default
-        alternative_profile_name = 'alternative_profile_name'
-        config.add_profile(create_mock_profile(alternative_profile_name))
-        config.set_default_profile(self.profile_name)
-        self.assertTrue(config.default_profile_name, self.profile_name)
-
-        # But with overwrite=True it should
-        config.set_default_profile(self.profile_name, overwrite=True)
-        self.assertTrue(config.default_profile_name, alternative_profile_name)
-
-    def test_profiles(self):
-        """Test the properties related to retrieving, creating, updating and removing profiles."""
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        # Each item returned by config.profiles should be a Profile instance
-        for profile in config.profiles:
-            self.assertIsInstance(profile, Profile)
-            self.assertTrue(profile.dictionary, self.config_dictionary[Config.KEY_PROFILES][profile.name])
-
-        # The profile_names property should return the keys of the profiles dictionary
-        self.assertEqual(config.profile_names, list(self.config_dictionary[Config.KEY_PROFILES]))
-
-        # Test get_profile
-        self.assertEqual(config.get_profile(self.profile_name).dictionary, self.profile.dictionary)
-
-        # Update a profile
-        updated_profile = create_mock_profile(self.profile_name)
-        config.update_profile(updated_profile)
-        self.assertEqual(config.get_profile(self.profile_name).dictionary, updated_profile.dictionary)
-
-        # Removing an unexisting profile should raise
-        with self.assertRaises(exceptions.ProfileConfigurationError):
-            config.remove_profile('non_existing_profile')
-
-        # Removing an existing should work and in this test case none should remain
-        config.remove_profile(self.profile_name)
-        self.assertEqual(config.profiles, [])
-        self.assertEqual(config.profile_names, [])
-
-    def test_option(self):
-        """Test the setter, unsetter and getter of configuration options."""
-        option_value = 131
-        option_name = 'daemon.timeout'
-        option = get_option(option_name)
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        # Getting option that does not exist, should simply return the option default
-        self.assertEqual(config.get_option(option_name, scope=self.profile_name), option.default)
-        self.assertEqual(config.get_option(option_name, scope=None), option.default)
-
-        # Unless we set default=False, in which case it should return None
-        self.assertEqual(config.get_option(option_name, scope=self.profile_name, default=False), None)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), None)
-
-        # Setting an option profile configuration wide
-        config.set_option(option_name, option_value)
-
-        # Getting configuration wide should get new value but None for profile specific
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value)
-        self.assertEqual(config.get_option(option_name, scope=self.profile_name, default=False), None)
-
-        # Setting an option profile specific
-        config.set_option(option_name, option_value, scope=self.profile_name)
-        self.assertEqual(config.get_option(option_name, scope=self.profile_name), option_value)
-
-        # Unsetting profile specific
-        config.unset_option(option_name, scope=self.profile_name)
-        self.assertEqual(config.get_option(option_name, scope=self.profile_name, default=False), None)
-
-        # Unsetting configuration wide
-        config.unset_option(option_name, scope=None)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), None)
-        self.assertEqual(config.get_option(option_name, scope=None, default=True), option.default)
-
-        # Setting a `None` like option
-        option_value = 0
-        config.set_option(option_name, option_value)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value)
-
-    def test_option_global_only(self):
-        """Test that `global_only` options are only set globally even if a profile specific scope is set."""
-        option_name = 'autofill.user.email'
-        option_value = 'some@email.com'
-
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        # Setting an option globally should be fine
-        config.set_option(option_name, option_value, scope=None)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value)
-
-        # Setting an option profile specific should actually not set it on the profile since it is `global_only`
-        config.set_option(option_name, option_value, scope=None)
-        self.assertEqual(config.get_option(option_name, scope=self.profile_name, default=False), None)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value)
-
-    def test_set_option_override(self):
-        """Test that `global_only` options are only set globally even if a profile specific scope is set."""
-        option_name = 'autofill.user.email'
-        option_value_one = 'first@email.com'
-        option_value_two = 'second@email.com'
-
-        config = Config(self.config_filepath, self.config_dictionary)
-
-        # Setting an option if it does not exist should work
-        config.set_option(option_name, option_value_one)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value_one)
-
-        # Setting it again will override it by default
-        config.set_option(option_name, option_value_two)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value_two)
-
-        # If we set override to False, it should not override, big surprise
-        config.set_option(option_name, option_value_one, override=False)
-        self.assertEqual(config.get_option(option_name, scope=None, default=False), option_value_two)
-
-    def test_store(self):
-        """Test that the store method writes the configuration properly to disk."""
-        config = Config(self.config_filepath, self.config_dictionary)
-        config.store()
-
-        with open(config.filepath, 'r') as handle:
-            config_recreated = Config(config.filepath, json.load(handle))
-
-            self.assertEqual(config.dictionary, config_recreated.dictionary)
+@pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_environment_variable_not_set(tmp_path):
+    """Check that if the environment variable is not set, config folder will be created in `DEFAULT_AIIDA_PATH`.
+
+    To make sure we do not mess with the actual default `.aiida` folder, which often lives in the home folder
+    we create a temporary directory and set the `DEFAULT_AIIDA_PATH` to it.
+    """
+    # Change the default configuration folder path to temp folder instead of probably `~`.
+    settings.DEFAULT_AIIDA_PATH = tmp_path
+
+    # Make sure that the environment variable is not set
+    try:
+        del os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE]
+    except KeyError:
+        pass
+    settings.set_configuration_directory()
+
+    config_folder = os.path.join(tmp_path, settings.DEFAULT_CONFIG_DIR_NAME)
+    assert os.path.isdir(config_folder)
+    assert settings.AIIDA_CONFIG_FOLDER == pathlib.Path(config_folder)
+
+
+@pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_environment_variable_set_single_path_without_config_folder(tmp_path):  # pylint: disable=invalid-name
+    """If `AIIDA_PATH` is set but does not contain a configuration folder, it should be created."""
+    # Set the environment variable and call configuration initialization
+    os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(tmp_path)
+    settings.set_configuration_directory()
+
+    # This should have created the configuration directory in the path
+    config_folder = tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
+    assert config_folder.is_dir()
+    assert settings.AIIDA_CONFIG_FOLDER == config_folder
+
+
+@pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_environment_variable_set_single_path_with_config_folder(tmp_path):  # pylint: disable=invalid-name
+    """If `AIIDA_PATH` is set and already contains a configuration folder it should simply be used."""
+    (tmp_path / settings.DEFAULT_CONFIG_DIR_NAME).mkdir()
+
+    # Set the environment variable and call configuration initialization
+    os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(tmp_path)
+    settings.set_configuration_directory()
+
+    # This should have created the configuration directory in the path
+    config_folder = tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
+    assert config_folder.is_dir()
+    assert settings.AIIDA_CONFIG_FOLDER == config_folder
+
+
+@pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_environment_variable_path_including_config_folder(tmp_path):  # pylint: disable=invalid-name
+    """If `AIIDA_PATH` is set and the path contains the base name of the config folder, it should work, i.e:
+
+        `/home/user/.virtualenvs/dev/`
+        `/home/user/.virtualenvs/dev/.aiida`
+
+    Are both legal and will both result in the same configuration folder path.
+    """
+    # Set the environment variable with a path that include base folder name and call config initialization
+    os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(tmp_path / settings.DEFAULT_CONFIG_DIR_NAME)
+    settings.set_configuration_directory()
+
+    # This should have created the configuration directory in the pathpath
+    config_folder = tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
+    assert config_folder.is_dir()
+    assert settings.AIIDA_CONFIG_FOLDER == config_folder
+
+
+@pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_environment_variable_set_multiple_path(tmp_path):  # pylint: disable=invalid-name
+    """If `AIIDA_PATH` is set with multiple paths without actual config folder, one is created in the last."""
+    directory_a = tmp_path / 'a'
+    directory_b = tmp_path / 'b'
+    directory_c = tmp_path / 'c'
+
+    directory_a.mkdir()
+    directory_b.mkdir()
+    directory_c.mkdir()
+
+    # Set the environment variable to contain three paths and call configuration initialization
+    env_variable = f'{directory_a}:{directory_b}:{directory_c}'
+    os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = env_variable
+    settings.set_configuration_directory()
+
+    # This should have created the configuration directory in the last path
+    config_folder = directory_c / settings.DEFAULT_CONFIG_DIR_NAME
+    assert os.path.isdir(config_folder)
+    assert settings.AIIDA_CONFIG_FOLDER == config_folder
+
+
+def compare_config_in_memory_and_on_disk(config, filepath):
+    """Verify that the contents of `config` are identical to the contents of the file with path `filepath`.
+
+    :param config: instance of `Config`
+    :param filepath: absolute filepath to a configuration file
+    :raises AssertionError: if content of `config` is not equal to that of file on disk
+    """
+    from aiida.manage.configuration.settings import DEFAULT_CONFIG_INDENT_SIZE
+
+    in_memory = json.dumps(config.dictionary, indent=DEFAULT_CONFIG_INDENT_SIZE)
+
+    # Read the content stored on disk
+    with open(filepath, 'r') as handle:
+        on_disk = handle.read()
+
+    # Compare content of in memory config and the one on disk
+    assert in_memory == on_disk
+
+
+def test_from_file(tmp_path):
+    """Test the `Config.from_file` class method.
+
+    Regression test for #3790: make sure configuration is written to disk after it is loaded and migrated.
+    """
+
+    # If the config file does not exist, a completely new file is created with a migrated config
+    filepath_nonexisting = tmp_path / 'config_nonexisting.json'
+    config = Config.from_file(filepath_nonexisting)
+
+    # Make sure that the migrated config is written to disk, by loading it from disk and comparing to the content
+    # of the in memory config object.
+    compare_config_in_memory_and_on_disk(config, filepath_nonexisting)
+
+    # Now repeat the test for an existing file. The previous filepath now *does* exist and is migrated
+    filepath_existing = filepath_nonexisting
+    config = Config.from_file(filepath_existing)
+
+    compare_config_in_memory_and_on_disk(config, filepath_existing)
+
+    # Finally, we test that an existing configuration file with an outdated schema is migrated and written to disk
+    with (tmp_path / 'config.json').open('wb') as handle:
+
+        # Write content of configuration with old schema to disk
+        filepath = pathlib.Path(__file__).parent.absolute() / 'migrations' / 'test_samples' / 'input' / '0.json'
+        with filepath.open('rb') as source:
+            handle.write(source.read())
+            handle.flush()
+
+        config = Config.from_file(handle.name)
+        compare_config_in_memory_and_on_disk(config, handle.name)
+
+
+def test_from_file_no_migrate(config_with_profile):
+    """Test that ``Config.from_file`` does not overwrite if the content was not migrated."""
+    from time import sleep
+
+    # Construct the ``Config`` instance and write it to disk
+    config = config_with_profile
+    config.store()
+
+    timestamp = os.path.getmtime(config.filepath)
+    Config.from_file(config.filepath)
+
+    # Sleep a second, because for some operating systems the time resolution is of the order of a second
+    sleep(1)
+
+    assert os.path.getmtime(config.filepath) == timestamp
+
+
+def test_basic_properties(config_with_profile):
+    """Test the basic properties of the Config class."""
+    config = config_with_profile
+
+    assert isinstance(config.filepath, str)
+    assert isinstance(config.dirpath, str)
+    assert config.version == CURRENT_CONFIG_VERSION
+    assert config.version_oldest_compatible == OLDEST_COMPATIBLE_CONFIG_VERSION
+    assert isinstance(config.dictionary, dict)
+
+
+def test_setting_versions(config_with_profile):
+    """Test the version setters."""
+    config = config_with_profile
+
+    assert config.version == CURRENT_CONFIG_VERSION
+    assert config.version_oldest_compatible == OLDEST_COMPATIBLE_CONFIG_VERSION
+
+    new_config_version = 1000
+    new_compatible_version = 999
+
+    config.version = new_config_version
+    config.version_oldest_compatible = new_compatible_version
+
+    assert config.version == new_config_version
+    assert config.version_oldest_compatible == new_compatible_version
+
+
+def test_construct_empty_dictionary(tmp_path):
+    """Constructing with empty dictionary should create basic skeleton."""
+    config = Config(tmp_path, {})
+
+    assert Config.KEY_PROFILES in config.dictionary
+    assert Config.KEY_VERSION in config.dictionary
+    assert Config.KEY_VERSION_CURRENT in config.dictionary[Config.KEY_VERSION]
+    assert Config.KEY_VERSION_OLDEST_COMPATIBLE in config.dictionary[Config.KEY_VERSION]
+
+
+def test_default_profile(empty_config, profile_factory):
+    """Test setting and getting default profile."""
+    config = empty_config
+
+    # If not set should return None
+    assert config.default_profile_name is None
+
+    # Setting it to a profile that does not exist should raise
+    with pytest.raises(exceptions.ProfileConfigurationError):
+        config.set_default_profile('non_existing_profile')
+
+    # After setting a default profile, it should return the right name
+    profile = profile_factory()
+    config.add_profile(profile)
+    config.set_default_profile(profile.name)
+    assert config.default_profile_name == profile.name
+
+    # Setting it when a default is already set, should not overwrite by default
+    alternative_profile_name = 'alternative_profile_name'
+    alternative_profile = profile_factory(name=alternative_profile_name)
+    config.add_profile(alternative_profile)
+    config.set_default_profile(profile.name)
+    assert config.default_profile_name == profile.name
+
+    # But with overwrite=True it should
+    config.set_default_profile(alternative_profile.name, overwrite=True)
+    assert config.default_profile_name == alternative_profile_name
+
+
+def test_profiles(config_with_profile, profile_factory):
+    """Test the properties related to retrieving, creating, updating and removing profiles."""
+    config = config_with_profile
+    profile = config.get_profile()
+
+    # Each item returned by config.profiles should be a Profile instance
+    for profile in config.profiles:
+        assert isinstance(profile, Profile)
+
+    # The profile_names property should return the keys of the profiles dictionary
+    assert config.profile_names == [profile.name]
+
+    # Update a profile
+    updated_profile = profile_factory(profile.name)
+    config.update_profile(updated_profile)
+    assert config.get_profile(updated_profile.name).dictionary == updated_profile.dictionary
+
+    # Removing an unexisting profile should raise
+    with pytest.raises(exceptions.ProfileConfigurationError):
+        config.remove_profile('non_existing_profile')
+
+    # Removing an existing should work and in this test case none should remain
+    config.remove_profile(profile.name)
+    assert config.profiles == []
+    assert config.profile_names == []
+
+
+def test_option(config_with_profile):
+    """Test the setter, unsetter and getter of configuration options."""
+    option_value = 131
+    option_name = 'daemon.timeout'
+    option = get_option(option_name)
+    config = config_with_profile
+    profile = config.get_profile()
+
+    # Getting option that does not exist, should simply return the option default
+    assert config.get_option(option_name, scope=profile.name) == option.default
+    assert config.get_option(option_name, scope=None) == option.default
+
+    # Unless we set default=False, in which case it should return None
+    assert config.get_option(option_name, scope=profile.name, default=False) is None
+    assert config.get_option(option_name, scope=None, default=False) is None
+
+    # Setting an option profile configuration wide
+    config.set_option(option_name, option_value)
+
+    # Getting configuration wide should get new value but None for profile specific
+    assert config.get_option(option_name, scope=None, default=False) == option_value
+    assert config.get_option(option_name, scope=profile.name, default=False) is None
+
+    # Setting an option profile specific
+    config.set_option(option_name, option_value, scope=profile.name)
+    assert config.get_option(option_name, scope=profile.name) == option_value
+
+    # Unsetting profile specific
+    config.unset_option(option_name, scope=profile.name)
+    assert config.get_option(option_name, scope=profile.name, default=False) is None
+
+    # Unsetting configuration wide
+    config.unset_option(option_name, scope=None)
+    assert config.get_option(option_name, scope=None, default=False) is None
+    assert config.get_option(option_name, scope=None, default=True) == option.default
+
+    # Setting a `None` like option
+    option_value = 0
+    config.set_option(option_name, option_value)
+    assert config.get_option(option_name, scope=None, default=False) == option_value
+
+
+def test_option_global_only(config_with_profile):
+    """Test that `global_only` options are only set globally even if a profile specific scope is set."""
+    option_name = 'autofill.user.email'
+    option_value = 'some@email.com'
+
+    config = config_with_profile
+    profile = config.get_profile()
+
+    # Setting an option globally should be fine
+    config.set_option(option_name, option_value, scope=None)
+    assert config.get_option(option_name, scope=None, default=False) == option_value
+
+    # Setting an option profile specific should actually not set it on the profile since it is `global_only`
+    config.set_option(option_name, option_value, scope=None)
+    assert config.get_option(option_name, scope=profile.name, default=False) is None
+    assert config.get_option(option_name, scope=None, default=False) == option_value
+
+
+def test_set_option_override(config_with_profile):
+    """Test that `global_only` options are only set globally even if a profile specific scope is set."""
+    option_name = 'autofill.user.email'
+    option_value_one = 'first@email.com'
+    option_value_two = 'second@email.com'
+
+    config = config_with_profile
+
+    # Setting an option if it does not exist should work
+    config.set_option(option_name, option_value_one)
+    assert config.get_option(option_name, scope=None, default=False) == option_value_one
+
+    # Setting it again will override it by default
+    config.set_option(option_name, option_value_two)
+    assert config.get_option(option_name, scope=None, default=False) == option_value_two
+
+    # If we set override to False, it should not override, big surprise
+    config.set_option(option_name, option_value_one, override=False)
+    assert config.get_option(option_name, scope=None, default=False) == option_value_two
+
+
+def test_store(config_with_profile):
+    """Test that the store method writes the configuration properly to disk."""
+    config = config_with_profile
+    config.store()
+
+    with open(config.filepath, 'r') as handle:
+        config_recreated = Config(config.filepath, json.load(handle))
+
+        assert config.dictionary == config_recreated.dictionary

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -384,3 +384,23 @@ def test_store(config_with_profile):
         config_recreated = Config(config.filepath, json.load(handle))
 
         assert config.dictionary == config_recreated.dictionary
+
+
+def test_delete_profile(config_with_profile, profile_factory):
+    """Test the ``delete_profile`` method."""
+    config = config_with_profile
+    profile_name = 'to-be-deleted'
+    profile = profile_factory(name=profile_name)
+
+    config.add_profile(profile)
+    assert config.get_profile(profile_name) == profile
+
+    # Write the contents to disk so that the to-be-deleted profile is in the config file on disk
+    config.store()
+
+    config.delete_profile(profile_name)
+    assert profile_name not in config.profile_names
+
+    # Now reload the config from disk to make sure the changes after deletion were persisted to disk
+    config_on_disk = Config.from_file(config.filepath)
+    assert profile_name not in config_on_disk.profile_names


### PR DESCRIPTION
Fixes #4921 

The `delete_profile` would successfully remove the profile from the
`Config` instance in memory, however, the changes would not be persisted
to disk. After reloading the config from disk, the deleted profile would
be back. A regression test is added for this behavior and the behavior
is fixed by calling `store` explictly at the end of the method, to
persist the new state to disk.

This PR also adds a separate commit that first refactors the tests
for the `Config` class to use `pytest` straight up. For clarity, these
commits should be merged separately.