### PR TITLE
🔧 MAINTAIN: Remove psycopg2 Conda mapping

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 - plumpy~=0.19.0
 - pgsu~=0.2.0
 - psutil~=5.6
-- psycopg2>=2.8.3,~=2.8
+- psycopg2-binary>=2.8.3,~=2.8
 - python-dateutil~=2.8
 - pytz~=2019.3
 - pyyaml~=5.1.2

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -26,7 +26,6 @@ import tomlkit as toml
 ROOT = Path(__file__).resolve().parent.parent  # repository root
 
 SETUPTOOLS_CONDA_MAPPINGS = {
-    'psycopg2-binary': 'psycopg2',
     'graphviz': 'python-graphviz',
 }
 


### PR DESCRIPTION
See: https://github.com/conda-forge/aiida-core-feedstock/pull/54, critically it means that conda environments now pass `pip check` (they didn't before)