### PR TITLE
suggest running reentry scan for unstorable Node

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -197,11 +197,11 @@ class Node(Entity, NodeRepositoryMixin, EntityAttributesMixin, EntityExtrasMixin
             raise exceptions.StoringNotAllowed(self._unstorable_message)
 
         if not is_registered_entry_point(self.__module__, self.__class__.__name__, groups=('aiida.node', 'aiida.data')):
-            msg = f'class `{self.__module__}:{self.__class__.__name__}` does not have a registered entry point.' \
-             + ' Consider running `reentry scan`.' \
-             + ' If the issue persists, check that the corresponding plugin is installed ' \
-             + 'and that the entry point shows up in `verdi plugin list`.'
-            raise exceptions.StoringNotAllowed(msg)
+            raise exceptions.StoringNotAllowed(
+                f'class `{self.__module__}:{self.__class__.__name__}` does not have a registered entry point. '
+                'Consider running `reentry scan`. If the issue persists, check that the corresponding plugin is '
+                'installed and that the entry point shows up in `verdi plugin list`.'
+            )
 
     @classproperty
     def class_node_type(cls) -> str:

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -197,7 +197,8 @@ class Node(Entity, NodeRepositoryMixin, EntityAttributesMixin, EntityExtrasMixin
             raise exceptions.StoringNotAllowed(self._unstorable_message)
 
         if not is_registered_entry_point(self.__module__, self.__class__.__name__, groups=('aiida.node', 'aiida.data')):
-            msg = f'class `{self.__module__}:{self.__class__.__name__}` does not have registered entry point'
+            msg = f'class `{self.__module__}:{self.__class__.__name__}` does not have a registered entry point.' \
+             + ' Consider running `reentry scan`.'
             raise exceptions.StoringNotAllowed(msg)
 
     @classproperty

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -198,7 +198,9 @@ class Node(Entity, NodeRepositoryMixin, EntityAttributesMixin, EntityExtrasMixin
 
         if not is_registered_entry_point(self.__module__, self.__class__.__name__, groups=('aiida.node', 'aiida.data')):
             msg = f'class `{self.__module__}:{self.__class__.__name__}` does not have a registered entry point.' \
-             + ' Consider running `reentry scan`.'
+             + ' Consider running `reentry scan`.' \
+             + ' If the issue persists, check that the corresponding plugin is installed ' \
+             + 'and that the entry point shows up in `verdi plugin list`.'
             raise exceptions.StoringNotAllowed(msg)
 
     @classproperty


### PR DESCRIPTION
When encountering a Node that isn't storable because of an entry point
that isn't registered, suggest to run `reentry scan`.
We got a user question regarding this, apparently this was not obvious.