### PR TITLE
Disregard old test repository quirks for migration

### DIFF
--- a/aiida/backends/general/migrations/utils.py
+++ b/aiida/backends/general/migrations/utils.py
@@ -252,12 +252,16 @@ def get_node_repository_dirpaths(basepath, shard=None):
                 path = None
 
                 if 'path' in subdirs and 'raw_input' in subdirs:
-                    # If the `path` is empty, we simply ignore and set `raw_input` to be migrated, otherwise we add
-                    # the entry to `contains_both` which will cause the migration to fail.
-                    if os.listdir(dirpath / 'path'):
-                        contains_both.append(str(dirpath))
-                    else:
+                    # If the `path` folder is empty OR it contains *only* a `.gitignore`, we simply ignore and set
+                    # `raw_input` to be migrated, otherwise we add the entry to `contains_both` which will cause the
+                    # migration to fail.
+                    # See issue #4910 (https://github.com/aiidateam/aiida-core/issues/4910) for more information on the
+                    # `.gitignore` case.
+                    path_contents = os.listdir(dirpath / 'path')
+                    if not path_contents or path_contents == ['.gitignore']:
                         path = dirpath / 'raw_input'
+                    else:
+                        contains_both.append(str(dirpath))
                 elif 'path' in subdirs:
                     path = dirpath / 'path'
                 elif 'raw_input' in subdirs:

--- a/tests/backends/aiida_django/migrations/test_migrations_0047_migrate_repository.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_0047_migrate_repository.py
@@ -10,6 +10,7 @@
 # pylint: disable=import-error,no-name-in-module,invalid-name
 """Test migration of the old file repository to the disk object store."""
 import hashlib
+import os
 
 from aiida.backends.general.migrations import utils
 from .test_migrations_common import TestMigrations
@@ -33,14 +34,25 @@ class TestRepositoryMigration(TestMigrations):
         dbnode_02.save()
         dbnode_03 = DbNode(user_id=self.default_user.id)
         dbnode_03.save()
+        dbnode_04 = DbNode(user_id=self.default_user.id)
+        dbnode_04.save()
 
         self.node_01_pk = dbnode_01.pk
         self.node_02_pk = dbnode_02.pk
         self.node_03_pk = dbnode_03.pk
+        self.node_04_pk = dbnode_04.pk
 
         utils.put_object_from_string(dbnode_01.uuid, 'sub/path/file_b.txt', 'b')
         utils.put_object_from_string(dbnode_01.uuid, 'sub/file_a.txt', 'a')
         utils.put_object_from_string(dbnode_02.uuid, 'output.txt', 'output')
+        utils.put_object_from_string(dbnode_04.uuid, '.gitignore', 'test')
+
+        # If both `path` and `raw_input` subfolders are present and `.gitignore` is in `path`, it should be ignored.
+        # Cannot use `put_object_from_string` here as it statically writes under the `path` folder.
+        raw_input_sub_folder = utils.get_node_repository_sub_folder(dbnode_04.uuid, subfolder='raw_input')
+        os.makedirs(raw_input_sub_folder, exist_ok=True)
+        with open(os.path.join(raw_input_sub_folder, 'input.txt'), 'w', encoding='utf-8') as handle:
+            handle.write('input')
 
         # When multiple migrations are ran, it is possible that migration 0047 is run at a point where the repository
         # container does not have a UUID (at that point in the migration) and so the setting gets set to `None`. This
@@ -56,6 +68,7 @@ class TestRepositoryMigration(TestMigrations):
         node_01 = DbNode.objects.get(pk=self.node_01_pk)
         node_02 = DbNode.objects.get(pk=self.node_02_pk)
         node_03 = DbNode.objects.get(pk=self.node_03_pk)
+        node_04 = DbNode.objects.get(pk=self.node_04_pk)
 
         assert node_01.repository_metadata == {
             'o': {
@@ -83,11 +96,19 @@ class TestRepositoryMigration(TestMigrations):
             }
         }
         assert node_03.repository_metadata == {}
+        assert node_04.repository_metadata == {
+            'o': {
+                'input.txt': {
+                    'k': hashlib.sha256('input'.encode('utf-8')).hexdigest()
+                }
+            }
+        }
 
         for hashkey, content in (
             (node_01.repository_metadata['o']['sub']['o']['path']['o']['file_b.txt']['k'], b'b'),
             (node_01.repository_metadata['o']['sub']['o']['file_a.txt']['k'], b'a'),
             (node_02.repository_metadata['o']['output.txt']['k'], b'output'),
+            (node_04.repository_metadata['o']['input.txt']['k'], b'input'),
         ):
             assert utils.get_repository_object(hashkey) == content
 


### PR DESCRIPTION
An old test created a `.gitignore` file in the Node repository folder
`path`, while also creating files under a `raw_input` folder.
This adds a logic test for this specific edge-case, migrating the
`raw_input` folder and ignoring the `path` folder for the specific Node.

Fixes #4910.