### PR TITLE
BaseRestartWorkChain: deal with namespaced outputs

### DIFF
--- a/aiida/engine/processes/workchains/restart.py
+++ b/aiida/engine/processes/workchains/restart.py
@@ -303,11 +303,13 @@ class BaseRestartWorkChain(WorkChain):
 
         self.report(f'work chain completed after {self.ctx.iteration} iterations')
 
+        exposed_outputs = self.exposed_outputs(node, self.process_class)
+
         for name, port in self.spec().outputs.items():
 
             try:
-                output = node.get_outgoing(link_label_filter=name).one().node
-            except ValueError:
+                output = exposed_outputs[name]
+            except KeyError:
                 if port.required:
                     self.report(f"required output '{name}' was not an output of {self.ctx.process_name}<{node.pk}>")
             else:

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -11,7 +11,7 @@
 # pylint: disable=invalid-name,no-self-use,no-member
 import pytest
 
-from aiida import engine
+from aiida import engine, orm
 from aiida.engine.processes.workchains.awaitable import Awaitable
 
 
@@ -146,3 +146,48 @@ def test_run_process(generate_work_chain, generate_calculation_node, monkeypatch
     assert isinstance(result, engine.ToContext)
     assert isinstance(result['children'], Awaitable)
     assert process.node.get_extra(SomeWorkChain._considered_handlers_extra) == [[]]  # pylint: disable=protected-access
+
+
+class OutputNamespaceWorkChain(engine.WorkChain):
+    """A WorkChain has namespaced output"""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.output_namespace('sub', valid_type=orm.Int, dynamic=True)
+        spec.outline(cls.finalize)
+
+    def finalize(self):
+        self.out('sub.result', orm.Int(1).store())
+
+
+class CustomBRWorkChain(engine.BaseRestartWorkChain):
+    """`BaseRestartWorkChain` of `OutputNamespaceWorkChain`"""
+
+    _process_class = OutputNamespaceWorkChain
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.expose_outputs(cls._process_class)
+        spec.output('extra', valid_type=orm.Int)
+
+        spec.outline(
+            cls.setup,
+            engine.while_(cls.should_run_process)(
+                cls.run_process,
+                cls.inspect_process,
+            ),
+            cls.results,
+        )
+
+    def setup(self):
+        super().setup()
+        self.ctx.inputs = {}
+
+
+@pytest.mark.requires_rmq
+def test_results():
+    res, node = engine.launch.run_get_node(CustomBRWorkChain)
+    assert res['sub'].result.value == 1
+    assert node.exit_status == 11


### PR DESCRIPTION
Fixes #4623 

To also output the namespace of `BaseRestartWorkChain`. Instead of using `out_many` to dump all outputs from inner process, here I compare the outputs of sub process with the required port.  The details are mentioned in https://github.com/aiidateam/aiida-core/issues/4623. 
