### PR TITLE
fix verdi computer show tab completion

### DIFF
--- a/aiida/cmdline/params/types/computer.py
+++ b/aiida/cmdline/params/types/computer.py
@@ -41,7 +41,7 @@ class ComputerParamType(IdentifierParamType):
 
         :returns: list of tuples of valid entry points (matching incomplete) and a description
         """
-        return [(option, '') for option, in self.orm_class_loader.get_options(incomplete, project='name')]
+        return [(option, '') for option, in self.orm_class_loader.get_options(incomplete, project='label')]
 
 
 class ShebangParamType(StringParamType):


### PR DESCRIPTION
Got the following error when doing `verdi computer show <tab>`. This is a quick fix but just thinking when this change made in `DbComputer`, maybe other places also need to be take care of?

```
Traceback (most recent call last):                                                                                      
  File "/home/unkcpz/Projects/python-code/aiida_core/aiida/orm/implementation/querybuilder.py", line 399, in get_column 
    return getattr(alias, colname)                                                                                      
  File "/home/unkcpz/miniconda3/envs/aiida-core-dev/lib/python3.8/site-packages/sqlalchemy/orm/util.py", line 506, in __
getattr__                                                                                                               
    attr = getattr(target, key)                                                                                         
AttributeError: type object 'DbComputer' has no attribute 'name'
...
...
  File "/home/unkcpz/Projects/python-code/aiida_core/aiida/orm/querybuilder.py", line 1225, in _add_to_projections
    entity_to_project = self._get_projectable_entity(alias, column_name, attr_key, cast=cast)
  File "/home/unkcpz/Projects/python-code/aiida_core/aiida/orm/querybuilder.py", line 1199, in _get_projectable_entity
    entity = self._impl.get_column(column_name, alias)
  File "/home/unkcpz/Projects/python-code/aiida_core/aiida/orm/implementation/querybuilder.py", line 401, in get_column
    raise ValueError(
ValueError: name is not a column of aliased(DbComputer)
Valid columns are:
id
uuid
label
hostname
description
scheduler_type
transport_type
metadata
```