### PR TITLE
RFC: permit class member functions as calcfunctions

### DIFF
--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -280,9 +280,10 @@ class FunctionProcess(Process):
             spec.outputs.valid_type = (Data, dict)
 
         return type(
-            func.__name__, (FunctionProcess,), {
+            func.__qualname__, (FunctionProcess,), {
                 '__module__': func.__module__,
                 '__name__': func.__name__,
+                '__qualname__': func.__qualname__,
                 '_func': staticmethod(func),
                 Process.define.__name__: classmethod(_define),
                 '_func_args': args,

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -220,7 +220,7 @@ class ProcessNode(Sealable, Node):
             raise ValueError(
                 f'could not load process class for entry point `{self.process_type}` for Node<{self.pk}>: {exception}'
             ) from exception
-        except ValueError:
+        except ValueError as exception:
             import importlib
 
             def str_rsplit_iter(string, sep='.'):
@@ -239,8 +239,8 @@ class ProcessNode(Sealable, Node):
                     pass
             else:
                 raise ValueError(
-                    f'could not load process class from `{self.process_type}` for Node<{self.pk}>: {exception}'
-                )
+                    f'could not load process class from `{self.process_type}` for Node<{self.pk}>'
+                ) from exception
 
         return process_class
 

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -162,8 +162,8 @@ def parse_entry_point_string(entry_point_string: str) -> Tuple[str, str]:
 
     try:
         group, name = entry_point_string.split(ENTRY_POINT_STRING_SEPARATOR)
-    except ValueError:
-        raise ValueError('invalid entry_point_string format')
+    except ValueError as exc:
+        raise ValueError(f'invalid entry_point_string format: {entry_point_string}') from exc
 
     return group, name
 

--- a/docs/source/topics/processes/functions.rst
+++ b/docs/source/topics/processes/functions.rst
@@ -212,6 +212,39 @@ The question you should ask yourself is whether a potential problem merits throw
 Or maybe, as in the example above, the problem is easily foreseeable and classifiable with a well defined exit status, in which case it might make more sense to return the exit code.
 At the end one should think which solution makes it easier for a workflow calling the function to respond based on the result and what makes it easier to query for these specific failure modes.
 
+As class member methods
+=======================
+
+.. versionadded:: 2.3
+
+Process functions can also be declared as class member methods, for example as part of a :class:`~aiida.engine.processes.workchains.workchain.WorkChain`:
+
+.. code-block:: python
+
+    class CalcFunctionWorkChain(WorkChain):
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input('x')
+        spec.input('y')
+        spec.output('sum')
+        spec.outline(
+            cls.run_compute_sum,
+        )
+
+    @staticmethod
+    @calcfunction
+    def compute_sum(x, y):
+        return x + y
+
+    def run_compute_sum(self):
+        self.out('sum', self.compute_sum(self.inputs.x, self.inputs.y))
+
+In this example, the work chain declares a class method called ``compute_sum`` which is decorated with the ``calcfunction`` decorator to turn it into a calculation function.
+It is important that the method is also decorated with the ``staticmethod`` (see the `Python documentation <https://docs.python.org/3/library/functions.html#staticmethod>`_) such that the work chain instance is not passed when the method is invoked.
+The calcfunction can be called from a work chain step like any other class method, as is shown in the last line.
+
 
 Provenance
 ==========

--- a/tests/engine/calcfunctions.py
+++ b/tests/engine/calcfunctions.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Definition of a calculation function used in ``test_calcfunctions.py``."""
+from aiida.engine import calcfunction
+from aiida.orm import Int
+
+
+@calcfunction
+def add_calcfunction(data):
+    """Calcfunction mirroring a ``test_calcfunctions`` calcfunction but has a slightly different implementation."""
+    return Int(data.value + 2)

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -100,23 +100,27 @@ class TestCalcFunction:
             assert cached.base.links.get_incoming().one().node.uuid == input_node.uuid
 
     def test_calcfunction_caching_change_code(self):
-        """Verify that changing the source codde of a calcfunction invalidates any existing cached nodes."""
-        result_original = self.test_calcfunction(self.default_int)
+        """Verify that changing the source code of a calcfunction invalidates any existing cached nodes.
 
-        # Intentionally using the same name, to check that caching anyway
-        # distinguishes between the calcfunctions.
-        @calcfunction
-        def add_calcfunction(data):  # pylint: disable=redefined-outer-name
-            """This calcfunction has a different source code from the one created at the module level."""
-            return Int(data.value + 2)
+        The ``add_calcfunction`` of the ``calcfunctions`` module uses the exact same name as the one defined in this
+        test module, however, it has a slightly different implementation. Note that we have to define the duplicate in
+        a different module, because we cannot define it in the same module (as the name clashes, on purpose) and we
+        cannot inline the calcfunction in this test, since inlined process functions are not valid cache sources.
+        """
+        from .calcfunctions import add_calcfunction  # pylint: disable=redefined-outer-name
+
+        result_original = self.test_calcfunction(self.default_int)
 
         with enable_caching(identifier='*.add_calcfunction'):
             result_cached, cached = add_calcfunction.run_get_node(self.default_int)
             assert result_original != result_cached
             assert not cached.base.caching.is_created_from_cache
+            assert cached.is_valid_cache
+
             # Test that the locally-created calcfunction can be cached in principle
             result2_cached, cached2 = add_calcfunction.run_get_node(self.default_int)
-            assert result_original != result2_cached
+            assert result2_cached != result_original
+            assert result2_cached == result_cached
             assert cached2.base.caching.is_created_from_cache
 
     def test_calcfunction_do_not_store_provenance(self):


### PR DESCRIPTION
It is already possible to specify a class member function as a "calcfunction"
and use it when not running via the daemon (and not with caching enabled):

    class MyWorkChain(WorkChain):
        @calcfunction
        def mysum(a, b):
            return a+b

        def workfunc(self):
            self.ctx.sum = MyWorkChain.mysum(self.inputs.x, self.inputs.y)

Here I simply extend the loading to unbreak caching and running via the daemon,
while brushing up error handling a bit (catch one exception more and cleanup the traceback).
