### PR TITLE
Additional info printing

### DIFF
--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -153,7 +153,7 @@ class Node(Entity, NodeRepositoryMixin, EntityAttributesMixin, EntityExtrasMixin
         if not self.is_stored:
             return f'uuid: {self.uuid} (unstored)'
 
-        return f'uuid: {self.uuid} (pk: {self.pk})'
+        return f'uuid: {self.uuid}\n\tpk: {self.pk}'
 
     def __copy__(self):
         """Copying a Node is not supported in general, but only for the Data sub class."""

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -55,11 +55,21 @@ class ProcessNode(Sealable, Node):
     _unstorable_message = 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
     def __str__(self) -> str:
-        base = super().__str__()
-        if self.process_type:
-            return f'{base} ({self.process_type})'
+        base = f'{super().__str__()}\n\ttype: {self.process_type}' if self.process_type else f'{super().__str__()}'
+        out =  f"""
+        {base}
+        process_state: {self.process_state}
+        exit_state: {self.exit_status}
+        exit_message: {self.exit_message}\n"""
+        if self.caller:
+            out += f'\tcaller: {self.caller.pk}, {self.caller.process_class}\n'
 
-        return f'{base}'
+        if self.called_descendants:
+            out += f'\t{len(self.called_descendants)} called descendants:\n'
+            for d in self.called_descendants:
+                out += f'\t\t{d.pk}, {d.process_class}'
+        
+        return out
 
     @classproperty
     def _updatable_attributes(cls) -> Tuple[str, ...]:


### PR DESCRIPTION
Following my show & tell and the small discussion we had after, I thought I'd make a quick example case of the additional information that could be printed to help users find their way.

The main goals would be to:
1. immediately show some helpful information
2. guide users to where they might find additional information/what they are looking for
3. Keep things uniform, i.e. ordering of certain things etc (not a huge deal)

As shown by the example, very little needs to be done to supply already a lot of information that's useful, I think this would be a very easy way to increase interactivity of the basic AiiDA use.

Would be great if we can start adding these small QOL improvements asap, and to also have some feedback.
@giovannipizzi @ramirezfranciscof  @mbercx @chrisjsewell @ltalirz  

PS: There's the crayons package that would also be nice to use, i.e. make all the PK numbers green, node types yellow, if errors are present color them red, or something along those lines.

Cheers!