### PR TITLE
FIX: daemon hang when passing `None` as `job_id`

### DIFF
--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -256,6 +256,10 @@ async def task_retrieve_job(
             scheduler = node.computer.get_scheduler()  # type: ignore[union-attr]
             scheduler.set_transport(transport)
 
+            if node.get_job_id() is None:
+                logger.warning(f'there is no job id for CalcJobNoe<{node.pk}>: skipping `get_detailed_job_info`')
+                return execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder)
+
             try:
                 detailed_job_info = scheduler.get_detailed_job_info(node.get_job_id())
             except FeatureNotAvailable:


### PR DESCRIPTION
Will fix #4752.

### The behaviour fix

I implemented the catch in the `get_detailed_job_info` method of the abstract `Scheduler` class. If I'm not mistaken, this alone was enough to fix the problem. @atztogo can you please check that I understood correctly and this branch solves your issue?

I didn't add any raising mechanism on the specific implementation of `_get_detailed_job_info_command` inside the `SgeScheduler` class because it seemed too specific a fix (why are we not adding checks in the implementations of this method in other plugins? why are we not adding checks for type or explicit typing in the other methods of the plugin?), but I can open an issue to deal with this in a more holistic/complete way.

### Unit testing an abstract class

I also added the test for both the new and the typical behaviours of `get_detailed_job_info`. I couldn't find any solid agreed upon way of easily unit testing abstract classes. In the end I decided to go with [this way](https://stackoverflow.com/a/36414551) of fully overriding all `__abstractmethods__` because it was the simpler one for this case, although it might be less ideal for more complex situations (it was already a bit annoying having to `lamdba` inline override the `__init__` and mock the transport).

I didn't want to define a full manual "mock" class with an implementation for each abstract method of the `Scheduler` (even if it was just a `pass`), and I couldn't find any satisfying explanation for the mocking features/classes/methods of `unittest` (meaning nothing that allowed me to understand it deep enough to be comfortable using it, but without having to go through the full documentation, which could be worth it but would require more time). Also I wasn't sure if it was fair play to keep adding stuff from that module or if we should be favouring `pytest` only solutions for unit testing (such as subclassing `TestCase`).

I call upon thee higher beings of python if you have any feedback/advice on this topic ( @sphuber @dev-zero @greschd @chrisjsewell ).