### PR TITLE
🐛 FIX: Initialising a Node with a User

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -70,6 +70,13 @@ def clear_database_before_test(aiida_profile):
     yield
 
 
+@pytest.fixture(scope='class')
+def clear_database_before_test_class(aiida_profile):
+    """Clear the database before a test class."""
+    aiida_profile.reset_db()
+    yield
+
+
 @pytest.fixture(scope='function')
 def temporary_event_loop():
     """Create a temporary loop for independent test case"""

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -122,7 +122,7 @@ class Node(Entity, NodeRepositoryMixin, EntityAttributesMixin, EntityExtrasMixin
             raise ValueError('the computer is not stored')
 
         computer = computer.backend_entity if computer else None
-        user = user.backend_entity if user else User.objects(backend).get_default()
+        user = user if user else User.objects(backend).get_default()
 
         if user is None:
             raise ValueError('the user cannot be None')

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-public-methods,no-self-use
+# pylint: disable=attribute-defined-outside-init,no-self-use,too-many-public-methods
 """Tests for the Node ORM class."""
 import logging
 import os
@@ -15,36 +15,55 @@ import tempfile
 
 import pytest
 
-from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions, LinkType
-from aiida.orm import Data, Log, Node, User, CalculationNode, WorkflowNode, load_node
+from aiida.orm import Computer, Data, Log, Node, User, CalculationNode, WorkflowNode, load_node
 from aiida.orm.utils.links import LinkTriple
 
 
-class TestNode(AiidaTestCase):
+@pytest.mark.usefixtures('clear_database_before_test_class')
+class TestNode:
     """Tests for generic node functionality."""
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        """Setup for methods."""
         self.user = User.objects.get_default()
+        _, self.computer = Computer.objects.get_or_create(
+            label='localhost',
+            description='localhost computer set up by test manager',
+            hostname='localhost',
+            transport_type='local',
+            scheduler_type='direct'
+        )
+        self.computer.store()
+
+    def test_instantiate_with_user(self):
+        """Test a Node can be instantiated with a specific user."""
+        new_user = User(email='a@b.com').store()
+        node = Data(user=new_user).store()
+        assert node.user.pk == new_user.pk
+
+    def test_instantiate_with_computer(self):
+        """Test a Node can be instantiated with a specific computer."""
+        node = Data(computer=self.computer).store()
+        assert node.computer.pk == self.computer.pk
 
     def test_repository_garbage_collection(self):
         """Verify that the repository sandbox folder is cleaned after the node instance is garbage collected."""
         node = Data()
         dirpath = node._repository.backend.sandbox.abspath  # pylint: disable=protected-access
 
-        self.assertTrue(os.path.isdir(dirpath))
+        assert os.path.isdir(dirpath)
         del node
-        self.assertFalse(os.path.isdir(dirpath))
+        assert not os.path.isdir(dirpath)
 
     def test_computer_user_immutability(self):
         """Test that computer and user of a node are immutable after storing."""
         node = Data().store()
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             node.computer = self.computer
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             node.user = self.user
 
     @staticmethod
@@ -66,11 +85,12 @@ class TestNode(AiidaTestCase):
         assert node.repository_metadata != repository_metadata
 
 
-class TestNodeAttributesExtras(AiidaTestCase):
+@pytest.mark.usefixtures('clear_database_before_test_class')
+class TestNodeAttributesExtras:
     """Test for node attributes and extras."""
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        """Setup for methods."""
         self.node = Data()
 
     def test_attributes(self):
@@ -79,10 +99,10 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         self.node.set_attribute('key', original_attribute)
         node_attributes = self.node.attributes
-        self.assertEqual(node_attributes['key'], original_attribute)
+        assert node_attributes['key'] == original_attribute
         node_attributes['key']['nested']['a'] = 2
 
-        self.assertEqual(original_attribute['nested']['a'], 2)
+        assert original_attribute['nested']['a'] == 2
 
         # Now store the node and verify that `attributes` then returns a deep copy
         self.node.store()
@@ -90,7 +110,7 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         # We change the returned node attributes but the original attribute should remain unchanged
         node_attributes['key']['nested']['a'] = 3
-        self.assertEqual(original_attribute['nested']['a'], 2)
+        assert original_attribute['nested']['a'] == 2
 
     def test_get_attribute(self):
         """Test the `Node.get_attribute` method."""
@@ -98,14 +118,14 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         self.node.set_attribute('key', original_attribute)
         node_attribute = self.node.get_attribute('key')
-        self.assertEqual(node_attribute, original_attribute)
+        assert node_attribute == original_attribute
         node_attribute['nested']['a'] = 2
 
-        self.assertEqual(original_attribute['nested']['a'], 2)
+        assert original_attribute['nested']['a'] == 2
 
         default = 'default'
-        self.assertEqual(self.node.get_attribute('not_existing', default=default), default)
-        with self.assertRaises(AttributeError):
+        assert self.node.get_attribute('not_existing', default=default) == default
+        with pytest.raises(AttributeError):
             self.node.get_attribute('not_existing')
 
         # Now store the node and verify that `get_attribute` then returns a deep copy
@@ -114,11 +134,11 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         # We change the returned node attributes but the original attribute should remain unchanged
         node_attribute['nested']['a'] = 3
-        self.assertEqual(original_attribute['nested']['a'], 2)
+        assert original_attribute['nested']['a'] == 2
 
         default = 'default'
-        self.assertEqual(self.node.get_attribute('not_existing', default=default), default)
-        with self.assertRaises(AttributeError):
+        assert self.node.get_attribute('not_existing', default=default) == default
+        with pytest.raises(AttributeError):
             self.node.get_attribute('not_existing')
 
     def test_get_attribute_many(self):
@@ -127,10 +147,10 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         self.node.set_attribute('key', original_attribute)
         node_attribute = self.node.get_attribute_many(['key'])[0]
-        self.assertEqual(node_attribute, original_attribute)
+        assert node_attribute == original_attribute
         node_attribute['nested']['a'] = 2
 
-        self.assertEqual(original_attribute['nested']['a'], 2)
+        assert original_attribute['nested']['a'] == 2
 
         # Now store the node and verify that `get_attribute` then returns a deep copy
         self.node.store()
@@ -138,28 +158,28 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         # We change the returned node attributes but the original attribute should remain unchanged
         node_attribute['nested']['a'] = 3
-        self.assertEqual(original_attribute['nested']['a'], 2)
+        assert original_attribute['nested']['a'] == 2
 
     def test_set_attribute(self):
         """Test the `Node.set_attribute` method."""
-        with self.assertRaises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             self.node.set_attribute('illegal.key', 'value')
 
         self.node.set_attribute('valid_key', 'value')
         self.node.store()
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             self.node.set_attribute('valid_key', 'value')
 
     def test_set_attribute_many(self):
         """Test the `Node.set_attribute` method."""
-        with self.assertRaises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             self.node.set_attribute_many({'illegal.key': 'value', 'valid_key': 'value'})
 
         self.node.set_attribute_many({'valid_key': 'value'})
         self.node.store()
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             self.node.set_attribute_many({'valid_key': 'value'})
 
     def test_reset_attribute(self):
@@ -169,32 +189,32 @@ class TestNodeAttributesExtras(AiidaTestCase):
         attributes_illegal = {'attribute.illegal': 'value', 'attribute_four': 'value'}
 
         self.node.set_attribute_many(attributes_before)
-        self.assertEqual(self.node.attributes, attributes_before)
+        assert self.node.attributes == attributes_before
         self.node.reset_attributes(attributes_after)
-        self.assertEqual(self.node.attributes, attributes_after)
+        assert self.node.attributes == attributes_after
 
-        with self.assertRaises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             self.node.reset_attributes(attributes_illegal)
 
         self.node.store()
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             self.node.reset_attributes(attributes_after)
 
     def test_delete_attribute(self):
         """Test the `Node.delete_attribute` method."""
         self.node.set_attribute('valid_key', 'value')
-        self.assertEqual(self.node.get_attribute('valid_key'), 'value')
+        assert self.node.get_attribute('valid_key') == 'value'
         self.node.delete_attribute('valid_key')
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             self.node.delete_attribute('valid_key')
 
         # Repeat with stored node
         self.node.set_attribute('valid_key', 'value')
         self.node.store()
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             self.node.delete_attribute('valid_key')
 
     def test_delete_attribute_many(self):
@@ -204,28 +224,28 @@ class TestNodeAttributesExtras(AiidaTestCase):
         """Test the `Node.clear_attributes` method."""
         attributes = {'attribute_one': 'value', 'attribute_two': 'value'}
         self.node.set_attribute_many(attributes)
-        self.assertEqual(self.node.attributes, attributes)
+        assert self.node.attributes == attributes
 
         self.node.clear_attributes()
-        self.assertEqual(self.node.attributes, {})
+        assert self.node.attributes == {}
 
         # Repeat for stored node
         self.node.store()
 
-        with self.assertRaises(exceptions.ModificationNotAllowed):
+        with pytest.raises(exceptions.ModificationNotAllowed):
             self.node.clear_attributes()
 
     def test_attributes_items(self):
         """Test the `Node.attributes_items` generator."""
         attributes = {'attribute_one': 'value', 'attribute_two': 'value'}
         self.node.set_attribute_many(attributes)
-        self.assertEqual(dict(self.node.attributes_items()), attributes)
+        assert dict(self.node.attributes_items()) == attributes
 
     def test_attributes_keys(self):
         """Test the `Node.attributes_keys` generator."""
         attributes = {'attribute_one': 'value', 'attribute_two': 'value'}
         self.node.set_attribute_many(attributes)
-        self.assertEqual(set(self.node.attributes_keys()), set(attributes))
+        assert set(self.node.attributes_keys()) == set(attributes)
 
     def test_extras(self):
         """Test the `Node.extras` property."""
@@ -233,10 +253,10 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         self.node.set_extra('key', original_extra)
         node_extras = self.node.extras
-        self.assertEqual(node_extras['key'], original_extra)
+        assert node_extras['key'] == original_extra
         node_extras['key']['nested']['a'] = 2
 
-        self.assertEqual(original_extra['nested']['a'], 2)
+        assert original_extra['nested']['a'] == 2
 
         # Now store the node and verify that `extras` then returns a deep copy
         self.node.store()
@@ -244,7 +264,7 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         # We change the returned node extras but the original extra should remain unchanged
         node_extras['key']['nested']['a'] = 3
-        self.assertEqual(original_extra['nested']['a'], 2)
+        assert original_extra['nested']['a'] == 2
 
     def test_get_extra(self):
         """Test the `Node.get_extra` method."""
@@ -252,14 +272,14 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         self.node.set_extra('key', original_extra)
         node_extra = self.node.get_extra('key')
-        self.assertEqual(node_extra, original_extra)
+        assert node_extra == original_extra
         node_extra['nested']['a'] = 2
 
-        self.assertEqual(original_extra['nested']['a'], 2)
+        assert original_extra['nested']['a'] == 2
 
         default = 'default'
-        self.assertEqual(self.node.get_extra('not_existing', default=default), default)
-        with self.assertRaises(AttributeError):
+        assert self.node.get_extra('not_existing', default=default) == default
+        with pytest.raises(AttributeError):
             self.node.get_extra('not_existing')
 
         # Now store the node and verify that `get_extra` then returns a deep copy
@@ -268,11 +288,11 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         # We change the returned node extras but the original extra should remain unchanged
         node_extra['nested']['a'] = 3
-        self.assertEqual(original_extra['nested']['a'], 2)
+        assert original_extra['nested']['a'] == 2
 
         default = 'default'
-        self.assertEqual(self.node.get_extra('not_existing', default=default), default)
-        with self.assertRaises(AttributeError):
+        assert self.node.get_extra('not_existing', default=default) == default
+        with pytest.raises(AttributeError):
             self.node.get_extra('not_existing')
 
     def test_get_extra_many(self):
@@ -281,10 +301,10 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         self.node.set_extra('key', original_extra)
         node_extra = self.node.get_extra_many(['key'])[0]
-        self.assertEqual(node_extra, original_extra)
+        assert node_extra == original_extra
         node_extra['nested']['a'] = 2
 
-        self.assertEqual(original_extra['nested']['a'], 2)
+        assert original_extra['nested']['a'] == 2
 
         # Now store the node and verify that `get_extra` then returns a deep copy
         self.node.store()
@@ -292,29 +312,29 @@ class TestNodeAttributesExtras(AiidaTestCase):
 
         # We change the returned node extras but the original extra should remain unchanged
         node_extra['nested']['a'] = 3
-        self.assertEqual(original_extra['nested']['a'], 2)
+        assert original_extra['nested']['a'] == 2
 
     def test_set_extra(self):
         """Test the `Node.set_extra` method."""
-        with self.assertRaises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             self.node.set_extra('illegal.key', 'value')
 
         self.node.set_extra('valid_key', 'value')
         self.node.store()
 
         self.node.set_extra('valid_key', 'changed')
-        self.assertEqual(load_node(self.node.pk).get_extra('valid_key'), 'changed')
+        assert load_node(self.node.pk).get_extra('valid_key') == 'changed'
 
     def test_set_extra_many(self):
         """Test the `Node.set_extra` method."""
-        with self.assertRaises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             self.node.set_extra_many({'illegal.key': 'value', 'valid_key': 'value'})
 
         self.node.set_extra_many({'valid_key': 'value'})
         self.node.store()
 
         self.node.set_extra_many({'valid_key': 'changed'})
-        self.assertEqual(load_node(self.node.pk).get_extra('valid_key'), 'changed')
+        assert load_node(self.node.pk).get_extra('valid_key') == 'changed'
 
     def test_reset_extra(self):
         """Test the `Node.reset_extra` method."""
@@ -323,25 +343,25 @@ class TestNodeAttributesExtras(AiidaTestCase):
         extras_illegal = {'extra.illegal': 'value', 'extra_four': 'value'}
 
         self.node.set_extra_many(extras_before)
-        self.assertEqual(self.node.extras, extras_before)
+        assert self.node.extras == extras_before
         self.node.reset_extras(extras_after)
-        self.assertEqual(self.node.extras, extras_after)
+        assert self.node.extras == extras_after
 
-        with self.assertRaises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             self.node.reset_extras(extras_illegal)
 
         self.node.store()
 
         self.node.reset_extras(extras_after)
-        self.assertEqual(load_node(self.node.pk).extras, extras_after)
+        assert load_node(self.node.pk).extras == extras_after
 
     def test_delete_extra(self):
         """Test the `Node.delete_extra` method."""
         self.node.set_extra('valid_key', 'value')
-        self.assertEqual(self.node.get_extra('valid_key'), 'value')
+        assert self.node.get_extra('valid_key') == 'value'
         self.node.delete_extra('valid_key')
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             self.node.delete_extra('valid_key')
 
         # Repeat with stored node
@@ -349,16 +369,16 @@ class TestNodeAttributesExtras(AiidaTestCase):
         self.node.store()
 
         self.node.delete_extra('valid_key')
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             load_node(self.node.pk).get_extra('valid_key')
 
     def test_delete_extra_many(self):
         """Test the `Node.delete_extra_many` method."""
         self.node.set_extra('valid_key', 'value')
-        self.assertEqual(self.node.get_extra('valid_key'), 'value')
+        assert self.node.get_extra('valid_key') == 'value'
         self.node.delete_extra('valid_key')
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             self.node.delete_extra('valid_key')
 
         # Repeat with stored group
@@ -366,42 +386,43 @@ class TestNodeAttributesExtras(AiidaTestCase):
         self.node.store()
 
         self.node.delete_extra('valid_key')
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             load_node(self.node.pk).get_extra('valid_key')
 
     def test_clear_extras(self):
         """Test the `Node.clear_extras` method."""
         extras = {'extra_one': 'value', 'extra_two': 'value'}
         self.node.set_extra_many(extras)
-        self.assertEqual(self.node.extras, extras)
+        assert self.node.extras == extras
 
         self.node.clear_extras()
-        self.assertEqual(self.node.extras, {})
+        assert self.node.extras == {}
 
         # Repeat for stored node
         self.node.store()
 
         self.node.clear_extras()
-        self.assertEqual(load_node(self.node.pk).extras, {})
+        assert load_node(self.node.pk).extras == {}
 
     def test_extras_items(self):
         """Test the `Node.extras_items` generator."""
         extras = {'extra_one': 'value', 'extra_two': 'value'}
         self.node.set_extra_many(extras)
-        self.assertEqual(dict(self.node.extras_items()), extras)
+        assert dict(self.node.extras_items()) == extras
 
     def test_extras_keys(self):
         """Test the `Node.extras_keys` generator."""
         extras = {'extra_one': 'value', 'extra_two': 'value'}
         self.node.set_extra_many(extras)
-        self.assertEqual(set(self.node.extras_keys()), set(extras))
+        assert set(self.node.extras_keys()) == set(extras)
 
 
-class TestNodeLinks(AiidaTestCase):
+@pytest.mark.usefixtures('clear_database_before_test_class')
+class TestNodeLinks:
     """Test for linking from and to Node."""
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        """Setup for methods."""
         self.node_source = CalculationNode()
         self.node_target = Data()
 
@@ -414,21 +435,21 @@ class TestNodeLinks(AiidaTestCase):
         calculation.store()
         stored_triples = calculation.get_stored_link_triples()
 
-        self.assertEqual(len(stored_triples), 1)
+        assert len(stored_triples) == 1
 
         link_triple = stored_triples[0]
 
         # Verify the type and value of the tuple elements
-        self.assertTrue(isinstance(link_triple, LinkTriple))
-        self.assertTrue(isinstance(link_triple.node, Node))
-        self.assertTrue(isinstance(link_triple.link_type, LinkType))
-        self.assertEqual(link_triple.node.uuid, data.uuid)
-        self.assertEqual(link_triple.link_type, LinkType.INPUT_CALC)
-        self.assertEqual(link_triple.link_label, 'input')
+        assert isinstance(link_triple, LinkTriple)
+        assert isinstance(link_triple.node, Node)
+        assert isinstance(link_triple.link_type, LinkType)
+        assert link_triple.node.uuid == data.uuid
+        assert link_triple.link_type == LinkType.INPUT_CALC
+        assert link_triple.link_label == 'input'
 
     def test_validate_incoming_ipsum(self):
         """Test the `validate_incoming` method with respect to linking ourselves."""
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.node_target.validate_incoming(self.node_target, LinkType.CREATE, 'link_label')
 
     def test_validate_incoming(self):
@@ -437,13 +458,13 @@ class TestNodeLinks(AiidaTestCase):
         For a generic Node all incoming link types are valid as long as the source is also of type Node and the link
         type is a valid LinkType enum value.
         """
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.node_target.validate_incoming(self.node_source, None, 'link_label')
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.node_target.validate_incoming(None, LinkType.CREATE, 'link_label')
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.node_target.validate_incoming(self.node_source, LinkType.CREATE.value, 'link_label')
 
     def test_add_incoming_create(self):
@@ -455,15 +476,15 @@ class TestNodeLinks(AiidaTestCase):
         target.add_incoming(source_one, LinkType.CREATE, 'link_label')
 
         # Can only have a single incoming CREATE link
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.CREATE, 'link_label')
 
         # Even when the source node is different
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_two, LinkType.CREATE, 'link_label')
 
         # Or when the link label is different
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.CREATE, 'other_label')
 
     def test_add_incoming_call_calc(self):
@@ -475,15 +496,15 @@ class TestNodeLinks(AiidaTestCase):
         target.add_incoming(source_one, LinkType.CALL_CALC, 'link_label')
 
         # Can only have a single incoming CALL_CALC link
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.CALL_CALC, 'link_label')
 
         # Even when the source node is different
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_two, LinkType.CALL_CALC, 'link_label')
 
         # Or when the link label is different
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.CALL_CALC, 'other_label')
 
     def test_add_incoming_call_work(self):
@@ -495,15 +516,15 @@ class TestNodeLinks(AiidaTestCase):
         target.add_incoming(source_one, LinkType.CALL_WORK, 'link_label')
 
         # Can only have a single incoming CALL_WORK link
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.CALL_WORK, 'link_label')
 
         # Even when the source node is different
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_two, LinkType.CALL_WORK, 'link_label')
 
         # Or when the link label is different
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.CALL_WORK, 'other_label')
 
     def test_add_incoming_input_calc(self):
@@ -515,14 +536,14 @@ class TestNodeLinks(AiidaTestCase):
         target.add_incoming(source_one, LinkType.INPUT_CALC, 'link_label')
 
         # Can only have a single incoming INPUT_CALC link from each source node if the label is not unique
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.INPUT_CALC, 'link_label')
 
         # Using another link label is fine
         target.validate_incoming(source_one, LinkType.INPUT_CALC, 'other_label')
 
         # However, using the same link, even from another node is illegal
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_two, LinkType.INPUT_CALC, 'link_label')
 
     def test_add_incoming_input_work(self):
@@ -534,14 +555,14 @@ class TestNodeLinks(AiidaTestCase):
         target.add_incoming(source_one, LinkType.INPUT_WORK, 'link_label')
 
         # Can only have a single incoming INPUT_WORK link from each source node if the label is not unique
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.INPUT_WORK, 'link_label')
 
         # Using another link label is fine
         target.validate_incoming(source_one, LinkType.INPUT_WORK, 'other_label')
 
         # However, using the same link, even from another node is illegal
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_two, LinkType.INPUT_WORK, 'link_label')
 
     def test_add_incoming_return(self):
@@ -553,7 +574,7 @@ class TestNodeLinks(AiidaTestCase):
         target.add_incoming(source_one, LinkType.RETURN, 'link_label')
 
         # Can only have a single incoming RETURN link from each source node if the label is not unique
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.validate_incoming(source_one, LinkType.RETURN, 'link_label')
 
         # From another source node or using another label is fine
@@ -570,7 +591,7 @@ class TestNodeLinks(AiidaTestCase):
         source = WorkflowNode()
         target = Data()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             target.add_incoming(source, LinkType.RETURN, 'link_label')
 
     def test_get_incoming(self):
@@ -585,17 +606,17 @@ class TestNodeLinks(AiidaTestCase):
         # Without link type
         incoming_nodes = target.get_incoming().all()
         incoming_uuids = sorted([neighbor.node.uuid for neighbor in incoming_nodes])
-        self.assertEqual(incoming_uuids, sorted([source_one.uuid, source_two.uuid]))
+        assert incoming_uuids == sorted([source_one.uuid, source_two.uuid])
 
         # Using a single link type
         incoming_nodes = target.get_incoming(link_type=LinkType.INPUT_CALC).all()
         incoming_uuids = sorted([neighbor.node.uuid for neighbor in incoming_nodes])
-        self.assertEqual(incoming_uuids, sorted([source_one.uuid, source_two.uuid]))
+        assert incoming_uuids == sorted([source_one.uuid, source_two.uuid])
 
         # Using a link type tuple
         incoming_nodes = target.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)).all()
         incoming_uuids = sorted([neighbor.node.uuid for neighbor in incoming_nodes])
-        self.assertEqual(incoming_uuids, sorted([source_one.uuid, source_two.uuid]))
+        assert incoming_uuids == sorted([source_one.uuid, source_two.uuid])
 
     def test_node_indegree_unique_pair(self):
         """Test that the validation of links with indegree `unique_pair` works correctly
@@ -614,7 +635,7 @@ class TestNodeLinks(AiidaTestCase):
 
         uuids_incoming = set(node.uuid for node in called.get_incoming().all_nodes())
         uuids_expected = set([caller.uuid, data.uuid])
-        self.assertEqual(uuids_incoming, uuids_expected)
+        assert uuids_incoming == uuids_expected
 
     def test_node_indegree_unique_triple(self):
         """Test that the validation of links with indegree `unique_triple` works correctly
@@ -632,7 +653,7 @@ class TestNodeLinks(AiidaTestCase):
 
         uuids_incoming = set(node.uuid for node in data.get_incoming().all_nodes())
         uuids_expected = set([return_one.uuid, return_two.uuid])
-        self.assertEqual(uuids_incoming, uuids_expected)
+        assert uuids_incoming == uuids_expected
 
     def test_node_outdegree_unique_triple(self):
         """Test that the validation of links with outdegree `unique_triple` works correctly
@@ -653,7 +674,7 @@ class TestNodeLinks(AiidaTestCase):
 
         uuids_outgoing = set(node.uuid for node in creator.get_outgoing().all_nodes())
         uuids_expected = set([data_one.uuid, data_two.uuid])
-        self.assertEqual(uuids_outgoing, uuids_expected)
+        assert uuids_outgoing == uuids_expected
 
     def test_get_node_by_label(self):
         """Test the get_node_by_label() method of the `LinkManager`
@@ -678,12 +699,12 @@ class TestNodeLinks(AiidaTestCase):
 
         # Retrieve a link when the label is unique
         output_the_input = data.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('the_input')
-        self.assertEqual(output_the_input.pk, calc_two.pk)
+        assert output_the_input.pk == calc_two.pk
 
-        with self.assertRaises(exceptions.MultipleObjectsError):
+        with pytest.raises(exceptions.MultipleObjectsError):
             data.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('input')
 
-        with self.assertRaises(exceptions.NotExistent):
+        with pytest.raises(exceptions.NotExistent):
             data.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('some_weird_label')
 
     def test_tab_completable_properties(self):
@@ -727,42 +748,42 @@ class TestNodeLinks(AiidaTestCase):
         output2.add_incoming(top_workflow, link_type=LinkType.RETURN, link_label='result_b')
 
         # creator
-        self.assertEqual(output1.creator.pk, calc1.pk)
-        self.assertEqual(output2.creator.pk, calc2.pk)
+        assert output1.creator.pk == calc1.pk
+        assert output2.creator.pk == calc2.pk
 
         # caller (for calculations)
-        self.assertEqual(calc1.caller.pk, workflow.pk)
-        self.assertEqual(calc2.caller.pk, workflow.pk)
+        assert calc1.caller.pk == workflow.pk
+        assert calc2.caller.pk == workflow.pk
 
         # caller (for workflows)
-        self.assertEqual(workflow.caller.pk, top_workflow.pk)
+        assert workflow.caller.pk == top_workflow.pk
 
         # .inputs for calculations
-        self.assertEqual(calc1.inputs.input_value.pk, input1.pk)
-        self.assertEqual(calc2.inputs.input_value.pk, input2.pk)
-        with self.assertRaises(AttributeError):
+        assert calc1.inputs.input_value.pk == input1.pk
+        assert calc2.inputs.input_value.pk == input2.pk
+        with pytest.raises(AttributeError):
             _ = calc1.inputs.some_label
 
         # .inputs for workflows
-        self.assertEqual(top_workflow.inputs.a.pk, input1.pk)
-        self.assertEqual(top_workflow.inputs.b.pk, input2.pk)
-        self.assertEqual(workflow.inputs.a.pk, input1.pk)
-        self.assertEqual(workflow.inputs.b.pk, input2.pk)
-        with self.assertRaises(AttributeError):
+        assert top_workflow.inputs.a.pk == input1.pk
+        assert top_workflow.inputs.b.pk == input2.pk
+        assert workflow.inputs.a.pk == input1.pk
+        assert workflow.inputs.b.pk == input2.pk
+        with pytest.raises(AttributeError):
             _ = workflow.inputs.some_label
 
         # .outputs for calculations
-        self.assertEqual(calc1.outputs.result.pk, output1.pk)
-        self.assertEqual(calc2.outputs.result.pk, output2.pk)
-        with self.assertRaises(AttributeError):
+        assert calc1.outputs.result.pk == output1.pk
+        assert calc2.outputs.result.pk == output2.pk
+        with pytest.raises(AttributeError):
             _ = calc1.outputs.some_label
 
         # .outputs for workflows
-        self.assertEqual(top_workflow.outputs.result_a.pk, output1.pk)
-        self.assertEqual(top_workflow.outputs.result_b.pk, output2.pk)
-        self.assertEqual(workflow.outputs.result_a.pk, output1.pk)
-        self.assertEqual(workflow.outputs.result_b.pk, output2.pk)
-        with self.assertRaises(AttributeError):
+        assert top_workflow.outputs.result_a.pk == output1.pk
+        assert top_workflow.outputs.result_b.pk == output2.pk
+        assert workflow.outputs.result_a.pk == output1.pk
+        assert workflow.outputs.result_b.pk == output2.pk
+        with pytest.raises(AttributeError):
             _ = workflow.outputs.some_label
 
 


### PR DESCRIPTION
So it appears that no one has ever tried to specifically set a user for a node (e.g. `Data(user=another_user)`) because, as you see from the diff, it would then try to call `.backend_entity` on the backend entity and fail.
Disappointing that mypy didn't pick this up in the type checking (perhaps there is a stricter setting that I haven't added)

cc @ltalirz as this came up with respect to the REST API (i.e. if we want to create a node for a specific user)