### PR TITLE
🐛 FIX: Pin psycopg2-binary to 2.8.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
 - plumpy~=0.19.0
 - pgsu~=0.2.0
 - psutil~=5.6
-- psycopg2-binary>=2.8.3,~=2.8
+- psycopg2-binary~=2.8.3
 - python-dateutil~=2.8
 - pytz~=2019.3
 - pyyaml~=5.1

--- a/setup.json
+++ b/setup.json
@@ -42,7 +42,7 @@
         "plumpy~=0.19.0",
         "pgsu~=0.2.0",
         "psutil~=5.6",
-        "psycopg2-binary~=2.8,>=2.8.3",
+        "psycopg2-binary~=2.8.3",
         "python-dateutil~=2.8",
         "pytz~=2019.3",
         "pyyaml~=5.1",


### PR DESCRIPTION
I think psycopg2 2.9 (released yesterday: https://github.com/psycopg/psycopg2/commit/50145014e8abdda2859ed65329ecc3e7b6699521) has just broken all the testing 😬 

See: https://github.com/aiidaplugins/aiida-lammps/pull/26/checks?check_run_id=2848451163

```python
    @pytest.fixture(scope='session', autouse=True)
    def aiida_profile():
        """Set up AiiDA test profile for the duration of the tests.
    
        Note: scope='session' limits this fixture to run once per session. Thanks to ``autouse=True``, you don't actually
         need to depend on it explicitly - it will activate as soon as you import it in your ``conftest.py``.
        """
>       with test_manager(backend=get_test_backend_name(), profile_name=get_test_profile_name()) as manager:

...

command = 'CREATE DATABASE "aiida_db" OWNER "aiida" ENCODING \'UTF8\' LC_COLLATE=\'en_US.UTF-8\' LC_CTYPE=\'en_US.UTF-8\' TEMPLATE=template0'
dsn = {'database': 'postgres', 'host': 'localhost', 'password': None, 'port': 58049, ...}

    def _execute_psyco(command, dsn):
        """
        executes a postgres commandline through psycopg2
    
        :param command: A psql command line as a str
        :param dsn: will be forwarded to psycopg2.connect
        """
        import psycopg2  # pylint: disable=import-outside-toplevel
    
        output = None
        with psycopg2.connect(**dsn) as conn:
            conn.autocommit = True
            with conn.cursor() as cursor:
>               cursor.execute(command)
E               psycopg2.errors.ActiveSqlTransaction: CREATE DATABASE cannot run inside a transaction block
```

related:

- https://stackoverflow.com/questions/34484066/create-a-postgres-database-using-python

cc @csadorf @giovannipizzi @sphuber @ltalirz 