### PR TITLE
Exception not raise properly when number of codes>2 in calc_info 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,15 @@ repos:
     hooks:
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
+        exclude: &exclude_pre_commit_hooks >
+            (?x)^(
+                tests/.*(?<!\.py)$
+            )$
     -   id: fix-encoding-pragma
     -   id: mixed-line-ending
     -   id: trailing-whitespace
+        exclude: *exclude_pre_commit_hooks
+
 
 -   repo: https://github.com/ikamensh/flynt/
     rev: '0.55'

--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -80,7 +80,8 @@ class CalcInfo(DefaultFieldsAttributeDict):
         either, for example, because they contain proprietary information or because they are big and their content is
         already indirectly present in the repository through one of the data nodes passed as input to the calculation.
     * codes_info: a list of dictionaries used to pass the info of the execution of a code
-    * codes_run_mode: a string used to specify the order in which multi codes can be executed
+    * codes_run_mode: the mode of execution in which the codes will be run (`CodeRunMode.SERIAL` by default,
+        but can also be `CodeRunMode.PARALLEL`)
     * skip_submit: a flag that, when set to True, orders the engine to skip the submit/update steps (so no code will
         run, it will only upload the files and then retrieve/parse).
     """

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -183,6 +183,12 @@ In our example, the two input files are already stored in the AiiDA file reposit
 The ``retrieve_list`` on the other hand tells the engine which files to retrieve from the directory where the job ran after it has finished.
 All files listed here will be store in a |FolderData| node that is attached as an output node to the calculation with the label ``retrieved``.
 
+Finally, we pass the |CodeInfo| to a |CalcInfo| object.
+One calculation job can involve more than one executable, so ``codes_info`` is a list.
+If you have more than one executable in your ``codes_info``, you can set ``codes_run_mode`` to specify the mode with which these will be executed (`CodeRunMode.SERIAL` by default).
+We define the ``retrieve_list`` of filenames that the engine should retrieve from the directory where the job ran after it has finished.
+The engine will store these files in a |FolderData| node that will be attached as an output node to the calculation with the label ``retrieved``.
+
 .. admonition:: Further reading
 
     There are :ref:`other file lists available<topics:calculations:usage:calcjobs:file_lists>` that allow you to easily customize how to move files to and from the remote working directory in order to prevent the creation of unnecessary copies.

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -112,6 +112,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.10.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
+pytest-regressions==2.2.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -111,6 +111,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.10.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
+pytest-regressions==2.2.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -111,6 +111,7 @@ pytest-benchmark==3.2.3
 pytest-cov==2.10.1
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
+pytest-regressions==2.2.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-memcached==1.59

--- a/setup.json
+++ b/setup.json
@@ -112,6 +112,7 @@
             "pytest-cov~=2.7,<2.11",
             "pytest-rerunfailures~=9.1,>=9.1.1",
             "pytest-benchmark~=3.2",
+            "pytest-regressions~=2.2",
             "pympler~=0.9",
             "coverage<5.0",
             "sqlalchemy-diff~=0.1.3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,3 +365,11 @@ def with_daemon():
 
     # Note this will always be executed after the yield no matter what happened in the test that used this fixture.
     os.kill(daemon.pid, signal.SIGTERM)
+
+
+@pytest.fixture(scope='function')
+def dry_run_in_tmp(request, tmpdir):
+    """change to the tmp directory to do the dry run, then change back to the calling directory to avoid side-effects"""
+    os.chdir(tmpdir)
+    yield
+    os.chdir(request.config.invocation_dir)

--- a/tests/engine/test_calc_job/test_multi_codes_run_parallel_False_.sh
+++ b/tests/engine/test_calc_job/test_multi_codes_run_parallel_False_.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'/bin/bash'   
+
+'/bin/bash'   

--- a/tests/engine/test_calc_job/test_multi_codes_run_parallel_True_.sh
+++ b/tests/engine/test_calc_job/test_multi_codes_run_parallel_True_.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'/bin/bash'    &
+
+'/bin/bash'    &
+
+wait
+

--- a/tests/engine/test_calc_job/test_multi_codes_run_withmpi_False_.sh
+++ b/tests/engine/test_calc_job/test_multi_codes_run_withmpi_False_.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'/bin/bash'   
+
+'/bin/bash'   

--- a/tests/engine/test_calc_job/test_multi_codes_run_withmpi_True_.sh
+++ b/tests/engine/test_calc_job/test_multi_codes_run_withmpi_True_.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'/bin/bash'   
+
+'mpirun' '-np' '1' '/bin/bash'   


### PR DESCRIPTION
If `calc_info.codes_run_mode` is not set when using more than one code in a calc_info, the `PluginInternalError` is not properly raised. `calc_info.codes_run_mode` will be a `None`, and the exception never raised here.