### PR TITLE
👌 IMPROVE: Make `verdi group` messages consistent

### DIFF
--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -124,8 +124,9 @@ def group_delete(group, delete_nodes, dry_run, force, verbose, **traversal_rules
             return
 
     if not dry_run:
+        group_str = str(group)
         orm.Group.objects.delete(group.pk)
-        echo.echo_success(f'{group} deleted.')
+        echo.echo_success(f'{group_str} deleted.')
 
 
 @verdi_group.command('relabel')

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -136,8 +136,8 @@ class Group(entities.Entity, entities.EntityExtrasMixin, metaclass=GroupMeta):
 
     def __repr__(self):
         return (
-            f'{self.__class__.__name__}(label={self.label}, user={self.user}, description={self.description}, '
-            f'type_string={self.type_string}, backend={self.backend})'
+            f'<{self.__class__.__name__}: {self.label!r} '
+            f'[{"type " + self.type_string if self.type_string else "user-defined"}], of user {self.user.email}>'
         )
 
     def __str__(self):

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -138,10 +138,7 @@ class Group(entities.Entity, entities.EntityExtrasMixin, metaclass=GroupMeta):
         return f'<{self.__class__.__name__}: {str(self)}>'
 
     def __str__(self):
-        if self.type_string:
-            return f'"{self.label}" [type {self.type_string}], of user {self.user.email}'
-
-        return f'"{self.label}" [user-defined], of user {self.user.email}'
+        return f'"{self.label}" [{"type " + self.type_string if self.type_string else "user-defined"}]'
 
     def store(self):
         """Verify that the group is allowed to be stored, which is the case along as `type_string` is set."""

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -135,10 +135,13 @@ class Group(entities.Entity, entities.EntityExtrasMixin, metaclass=GroupMeta):
         super().__init__(model)
 
     def __repr__(self):
-        return f'<{self.__class__.__name__}: {str(self)}>'
+        return (
+            f'{self.__class__.__name__}(label={self.label}, user={self.user}, description={self.description}, '
+            f'type_string={self.type_string}, backend={self.backend})'
+        )
 
     def __str__(self):
-        return f'"{self.label}" [{"type " + self.type_string if self.type_string else "user-defined"}]'
+        return f'{self.__class__.__name__}<{self.label}>'
 
     def store(self):
         """Verify that the group is allowed to be stored, which is the case along as `type_string` is set."""

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -246,7 +246,7 @@ Below is a list with all available subcommands.
     Commands:
       add-nodes     Add nodes to a group.
       copy          Duplicate a group.
-      create        Create an empty group with a given name.
+      create        Create an empty group with a given label.
       delete        Delete a group and (optionally) the nodes it contains.
       description   Change the description of a group.
       list          Show a list of existing groups.

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -325,10 +325,10 @@ class TestVerdiGroup(AiidaTestCase):
         options = [source_label, dest_label]
         result = self.cli_runner.invoke(cmd_group.group_copy, options)
         self.assertClickResultNoException(result)
-        self.assertIn((
-            f'Success: Nodes copied from {source_group} to "{dest_label}" '
-            f'[{"type " + source_group.type_string if source_group.type_string else "user-defined"}].'
-        ), result.output, result.exception)
+        self.assertIn(
+            f'Success: Nodes copied from {source_group} to {source_group.__class__.__name__}<{dest_label}>.',
+            result.output, result.exception
+        )
 
         # Check destination group exists with source group's nodes
         dest_group = orm.load_group(label=dest_label)

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -326,8 +326,8 @@ class TestVerdiGroup(AiidaTestCase):
         result = self.cli_runner.invoke(cmd_group.group_copy, options)
         self.assertClickResultNoException(result)
         self.assertIn((
-            f'Success: Nodes copied from {source_group.__class__.__name__}<{source_label}> to '
-            f'{source_group.__class__.__name__}<{dest_label}>.'
+            f'Success: Nodes copied from {source_group} to "{dest_label}" '
+            f'[{"type " + source_group.type_string if source_group.type_string else "user-defined"}].'
         ), result.output, result.exception)
 
         # Check destination group exists with source group's nodes
@@ -340,8 +340,7 @@ class TestVerdiGroup(AiidaTestCase):
         result = self.cli_runner.invoke(cmd_group.group_copy, options)
         self.assertIsNotNone(result.exception, result.output)
         self.assertIn(
-            f'Warning: Destination {dest_group.__class__.__name__}<{dest_label}> already exists and is not empty.',
-            result.output, result.exception
+            f'Warning: Destination {dest_group} already exists and is not empty.', result.output, result.exception
         )
 
         # Check destination group is unchanged

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -325,9 +325,10 @@ class TestVerdiGroup(AiidaTestCase):
         options = [source_label, dest_label]
         result = self.cli_runner.invoke(cmd_group.group_copy, options)
         self.assertClickResultNoException(result)
-        self.assertIn(
-            f'Success: Nodes copied from group<{source_label}> to group<{dest_label}>', result.output, result.exception
-        )
+        self.assertIn((
+            f'Success: Nodes copied from {source_group.__class__.__name__}<{source_label}> to '
+            f'{source_group.__class__.__name__}<{dest_label}>.'
+        ), result.output, result.exception)
 
         # Check destination group exists with source group's nodes
         dest_group = orm.load_group(label=dest_label)
@@ -339,8 +340,8 @@ class TestVerdiGroup(AiidaTestCase):
         result = self.cli_runner.invoke(cmd_group.group_copy, options)
         self.assertIsNotNone(result.exception, result.output)
         self.assertIn(
-            f'Warning: Destination group<{dest_label}> already exists and is not empty.', result.output,
-            result.exception
+            f'Warning: Destination {dest_group.__class__.__name__}<{dest_label}> already exists and is not empty.',
+            result.output, result.exception
         )
 
         # Check destination group is unchanged


### PR DESCRIPTION
Closes #4998.

- Use `label` instead of `name`.
- Use `group.__class__.__name__` always.
- Minor syntax fixes.

**Edit**: This PR has been updated according to the discussion below.