### PR TITLE
🐛 FIX: `BandsData` matplotlib with NaN values

### DIFF
--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -784,9 +784,9 @@ class BandsData(KpointsData):
 
         # axis limits
         if y_max_lim is None:
-            y_max_lim = numpy.array(bands).max()
+            y_max_lim = numpy.nanmax(bands)
         if y_min_lim is None:
-            y_min_lim = numpy.array(bands).min()
+            y_min_lim = numpy.nanmin(bands)
         x_min_lim = min(x)  # this isn't a numpy array, but a list
         x_max_lim = max(x)
         all_data['x_min_lim'] = x_min_lim


### PR DESCRIPTION
The `BandsData` supports using `numpy.NaN` values in the bands array which can be used to remove some parts of the bands or to fill up parts which might be out of a certain energy window.

The matplotlib plotting functionality (`BandsData.show_mpl()`) however does not work with NaN values when the limits for the plot are found.  

With `nanmin` and `nanmax` instead of the simple `min/max` ignores NaN values in the bands array and makes the matplotlib plotter work for incomplete bands.