### PR TITLE
Add the `ElectronicBandsData` data plugin

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -208,7 +208,7 @@ def _show_xmgrace(exec_name, list_bands):
     import sys
     import subprocess
     import tempfile
-    from aiida.orm.nodes.data.array.bands import MAX_NUM_AGR_COLORS
+    from aiida.orm.nodes.data.array.bands.bands import MAX_NUM_AGR_COLORS
 
     list_files = []
     current_band_number = 0

--- a/aiida/orm/nodes/data/array/bands/__init__.py
+++ b/aiida/orm/nodes/data/array/bands/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Module with `Node` sub classes for band structure data types."""
+from .bands import BandsData, find_bandgap, prepare_header_comment
+from .electronic import ElectronicBandsData
+
+__all__ = ('BandsData', 'find_bandgap', 'prepare_header_comment', 'ElectronicBandsData')

--- a/aiida/orm/nodes/data/array/bands/bands.py
+++ b/aiida/orm/nodes/data/array/bands/bands.py
@@ -18,7 +18,9 @@ import numpy
 
 from aiida.common.exceptions import ValidationError
 from aiida.common.utils import prettify_labels, join_labels
-from .kpoints import KpointsData
+from ..kpoints import KpointsData
+
+__all__ = ('BandsData',)
 
 
 def prepare_header_comment(uuid, plot_info, comment_char='#'):

--- a/aiida/orm/nodes/data/array/bands/electronic.py
+++ b/aiida/orm/nodes/data/array/bands/electronic.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Data plugin to represent an electronic band structure."""
+from typing import Optional
+
+from numpy.typing import ArrayLike
+
+from aiida.common.lang import type_check
+from ..kpoints import KpointsData
+from .bands import BandsData
+
+__all__ = ('ElectronicBandsData',)
+
+
+class ElectronicBandsData(BandsData):
+    """Data plugin to represent an electronic band structure.
+
+    It subclasses the ``BandsData`` plugin and adds the ``fermi_level`` attribute.
+    """
+
+    KEY_FERMI_LEVEL = 'fermi_level'
+
+    def __init__(self, kpoints: KpointsData, bands: ArrayLike, fermi_level: Optional[float] = None, **kwargs):
+        """Construct a new instance.
+
+        The arguments ``kpoints``, ``bands`` and ``fermi_level`` can be set through the constructor but have to be
+        provided as positional arguments.
+
+        .. note:: Since we are currently still supporting Python 3.7, we cannot yet use the ``/`` positional argument
+            which was added to Python 3.8. Once support for Python 3.7 is dropped we can enforce the correct usage of
+            the arguments through that operator.
+
+        """
+        super().__init__(**kwargs)
+
+        self.set_kpointsdata(kpoints)
+        self.set_bands(bands)
+
+        if fermi_level is not None:
+            self.fermi_level = fermi_level
+
+    @property
+    def fermi_level(self) -> Optional[float]:
+        """Return the fermi level or ``None`` if one is not defined."""
+        return self.get_attribute(self.KEY_FERMI_LEVEL, None)
+
+    @fermi_level.setter
+    def fermi_level(self, value: float):
+        """Set the fermi level."""
+        type_check(value, float)
+        self.set_attribute(self.KEY_FERMI_LEVEL, value)

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -93,6 +93,8 @@ py:class sphinx.util.docutils.SphinxDirective
 py:class frozenset
 
 py:class numpy.bool_
+py:class numpy.dtype
+py:class numpy.typing._array_like._SupportsArray
 
 py:class paramiko.proxy.ProxyCommand
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 # Global options
 
 [mypy]
+plugins = numpy.typing.mypy_plugin
 
 show_error_codes = True
 

--- a/setup.json
+++ b/setup.json
@@ -151,7 +151,8 @@
         ],
         "aiida.data": [
             "array = aiida.orm.nodes.data.array.array:ArrayData",
-            "array.bands = aiida.orm.nodes.data.array.bands:BandsData",
+            "array.bands = aiida.orm.nodes.data.array.bands.bands:BandsData",
+            "array.bands.electronic = aiida.orm.nodes.data.array.bands.electronic:ElectronicBandsData",
             "array.kpoints = aiida.orm.nodes.data.array.kpoints:KpointsData",
             "array.projection = aiida.orm.nodes.data.array.projection:ProjectionData",
             "array.trajectory = aiida.orm.nodes.data.array.trajectory:TrajectoryData",

--- a/tests/orm/data/test_data.py
+++ b/tests/orm/data/test_data.py
@@ -7,14 +7,15 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=too-many-return-statements
 """Tests for the `Data` base class."""
-
 import os
 import numpy
 import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
+from aiida.orm.nodes.data.array.bands import ElectronicBandsData
 from tests.static import STATIC_DIR
 
 
@@ -44,6 +45,13 @@ class TestData(AiidaTestCase):
             instance = data_class()
             instance.set_kpointsdata(kpoints)
             instance.set_bands([[1.0, 2.0], [3.0, 4.0]])
+            return instance
+
+        if data_class is ElectronicBandsData:
+            kpoints = orm.KpointsData()
+            kpoints.set_cell([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+            kpoints.set_kpoints([[0., 0., 0.], [0.1, 0.1, 0.1]])
+            instance = data_class(kpoints, [[1.0, 2.0], [3.0, 4.0]])
             return instance
 
         if data_class is orm.TrajectoryData:

--- a/tests/orm/data/test_electronic_bands.py
+++ b/tests/orm/data/test_electronic_bands.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`~aiida.orm.node.data.array.bands.electronic.ElectronicBandsData`."""
+import numpy
+import pytest
+
+from aiida.common.exceptions import ModificationNotAllowed
+from aiida.orm.nodes.data.array.kpoints import KpointsData
+from aiida.orm.nodes.data.array.bands.electronic import ElectronicBandsData
+
+
+@pytest.fixture
+def bands():
+    """Return a numpy array with arbitrary bands data."""
+    return numpy.array([[0, 1], [1, 1]])
+
+
+@pytest.fixture
+def kpoints():
+    """Return a numpy array with arbitrary bands data."""
+    kpoints = KpointsData()
+    kpoints.set_kpoints([[0., 0., 0.], [0.1, 0.1, 0.1]])
+    return kpoints
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_constructor(kpoints, bands):
+    """Test the constructor."""
+    node = ElectronicBandsData(kpoints, bands)
+    assert isinstance(node, ElectronicBandsData)
+    assert not node.is_stored
+
+    fermi_level = 2.3
+    node = ElectronicBandsData(kpoints, bands, fermi_level)
+    assert isinstance(node, ElectronicBandsData)
+    assert not node.is_stored
+    assert node.fermi_level == fermi_level
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_store(kpoints, bands):
+    """Test storing an instance."""
+    node = ElectronicBandsData(kpoints, bands)
+    node.store()
+    assert isinstance(node, ElectronicBandsData)
+    assert node.is_stored
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_fermi_level(kpoints, bands):
+    """Test the ``fermi_level`` property."""
+    node = ElectronicBandsData(kpoints, bands)
+    assert node.fermi_level is None
+
+    fermi_level = 2.3
+    node.fermi_level = fermi_level
+    assert node.fermi_level == fermi_level
+
+    node.store()
+    assert node.is_stored
+
+    with pytest.raises(ModificationNotAllowed):
+        node.fermi_level = 1.0


### PR DESCRIPTION
Fixes #5032 

This data plugin is a subclass of the `BandsData` plugin. It adds
support to define a fermi energy, which is set as an attribute. This is
a typical use case for electronic band structures, which so far were
using the `BandsData` type, but the latter was also being used for other
band structures, such as phonons, which do not share this property.

By making it a subclass, existing processes that accept `BandsData`
instances will automatically also accept `ElectronicBandsData` instances
and queries for `BandsData` will also match the subclasses, unless the
user turns of subclassing explicitly.