### PR TITLE
REST API: make the profile configurable as request parameter

### DIFF
--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -45,7 +45,8 @@ from aiida.restapi.common import config
     help='Enable POST endpoints (currently only /querybuilder).',
     hidden=True,
 )
-def restapi(hostname, port, config_dir, debug, wsgi_profile, posting):
+@click.pass_context
+def restapi(ctx, hostname, port, config_dir, debug, wsgi_profile, posting):
     """
     Run the AiiDA REST API server.
 
@@ -58,6 +59,7 @@ def restapi(hostname, port, config_dir, debug, wsgi_profile, posting):
     # Invoke the runner
     try:
         run_api(
+            profile=ctx.obj['profile'].name,
             hostname=hostname,
             port=port,
             config=config_dir,

--- a/aiida/manage/configuration/schema/config-v9.schema.json
+++ b/aiida/manage/configuration/schema/config-v9.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "description": "Schema for AiiDA configuration files, format version 8",
+  "description": "Schema for AiiDA configuration files, format version 9",
   "type": "object",
   "definitions": {
     "options": {
@@ -123,6 +123,12 @@
           "default": 5,
           "minimum": 1,
           "description": "Maximum number of transport task attempts before a Process is Paused."
+        },
+        "rest_api.profile_switching": {
+          "type": "boolean",
+          "default": false,
+          "description": "Toggle whether the profile can be specified in requests submitted to the REST API",
+          "global_only": true
         },
         "rmq.task_timeout": {
           "type": "integer",

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -486,6 +486,7 @@ class Utils:
         extras = None
         extras_filter = None
         full_type = None
+        profile = None
 
         # io tree limit parameters
         tree_in_limit = None
@@ -539,10 +540,17 @@ class Utils:
             raise RestInputValidationError('You cannot specify extras_filter more than once')
         if 'full_type' in field_counts and field_counts['full_type'] > 1:
             raise RestInputValidationError('You cannot specify full_type more than once')
+        if 'profile' in field_counts and field_counts['profile'] > 1:
+            raise RestInputValidationError('You cannot specify profile more than once')
 
         ## Extract results
         for field in field_list:
-            if field[0] == 'limit':
+            if field[0] == 'profile':
+                if field[1] == '=':
+                    profile = field[2]
+                else:
+                    raise RestInputValidationError("only assignment operator '=' is permitted after 'profile'")
+            elif field[0] == 'limit':
                 if field[1] == '=':
                     limit = field[2]
                 else:
@@ -658,7 +666,7 @@ class Utils:
 
         return (
             limit, offset, perpage, orderby, filters, download_format, download, filename, tree_in_limit,
-            tree_out_limit, attributes, attributes_filter, extras, extras_filter, full_type
+            tree_out_limit, attributes, attributes_filter, extras, extras_filter, full_type, profile
         )
 
     def parse_query_string(self, query_string):
@@ -680,7 +688,7 @@ class Utils:
 
         ## Define grammar
         # key types
-        key = Word(f'{alphas}_', f'{alphanums}_')
+        key = Word(f'{alphas}_', f'{alphanums}_-')
         # operators
         operator = (
             Literal('=like=') | Literal('=ilike=') | Literal('=in=') | Literal('=notin=') | Literal('=') |

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -14,7 +14,7 @@ from flask import make_response, request
 from flask_restful import Resource
 
 from aiida.common.lang import classproperty
-from aiida.manage import load_profile
+from aiida.manage import get_config_option, load_profile
 from aiida.restapi.common.exceptions import RestInputValidationError
 from aiida.restapi.common.utils import Utils, close_thread_connection
 from aiida.restapi.translator.nodes.node import NodeTranslator
@@ -153,13 +153,18 @@ class BaseResource(Resource):
 
         return node
 
-    def load_profile(self, profile):
+    def load_profile(self, profile=None):
         """Load the required profile.
 
         This will load the profile specified by the ``profile`` keyword in the query parameters, and if not specified it
         will default to the profile defined in the constructor.
         """
-        load_profile(profile, allow_switch=True)
+        profile_switching_enabled = get_config_option('rest_api.profile_switching')
+
+        if profile is not None and not profile_switching_enabled:
+            raise RestInputValidationError('specifying an explicit profile is not enabled for this REST API.')
+
+        load_profile(profile or self.profile, allow_switch=True)
 
     def get(self, id=None, page=None):  # pylint: disable=redefined-builtin,invalid-name,unused-argument
         # pylint: disable=too-many-locals

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -14,6 +14,7 @@ from flask import make_response, request
 from flask_restful import Resource
 
 from aiida.common.lang import classproperty
+from aiida.manage import load_profile
 from aiida.restapi.common.exceptions import RestInputValidationError
 from aiida.restapi.common.utils import Utils, close_thread_connection
 from aiida.restapi.translator.nodes.node import NodeTranslator
@@ -33,11 +34,10 @@ class ServerInfo(Resource):
         It returns the general info about the REST API
         :return: returns current AiiDA version defined in aiida/__init__.py
         """
-        # Decode url parts
         path = unquote(request.path)
         url = unquote(request.url)
         url_root = unquote(request.url_root)
-
+        query_string = unquote(request.query_string.decode('utf-8'))
         subpath = self.utils.strip_api_prefix(path).strip('/')
         pathlist = self.utils.split_path(subpath)
 
@@ -81,7 +81,7 @@ class ServerInfo(Resource):
             url=url,
             url_root=url_root,
             path=path,
-            query_string=request.query_string.decode('utf-8'),
+            query_string=query_string,
             resource_type='Info',
             data=response
         )
@@ -103,8 +103,10 @@ class BaseResource(Resource):
 
     ## TODO add the caching support. I cache total count, results, and possibly
 
-    def __init__(self, **kwargs):
+    def __init__(self, profile, **kwargs):
+        """Construct the resource."""
         self.trans = self._translator_class(**kwargs)
+        self.profile = profile
 
         # Configure utils
         utils_conf_keys = ('PREFIX', 'PERPAGE_DEFAULT', 'LIMIT_DEFAULT')
@@ -114,6 +116,26 @@ class BaseResource(Resource):
         # HTTP Request method decorators
         if 'get_decorators' in kwargs and isinstance(kwargs['get_decorators'], (tuple, list, set)):
             self.method_decorators = {'get': list(kwargs['get_decorators'])}
+
+    @staticmethod
+    def unquote_request():
+        """Unquote and return various parts of the request.
+
+        :returns: Tuple of the request path, url, url root and query string.
+        """
+        path = unquote(request.path)
+        url = unquote(request.url)
+        url_root = unquote(request.url_root)
+        query_string = unquote(request.query_string.decode('utf-8'))
+        return path, url, url_root, query_string
+
+    def parse_path(self, path):
+        """Parse the request path."""
+        return self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
+
+    def parse_query_string(self, query_string):
+        """Parse the request query string."""
+        return self.utils.parse_query_string(query_string)
 
     @classproperty
     def parse_pk_uuid(cls):  # pylint: disable=no-self-argument
@@ -131,6 +153,14 @@ class BaseResource(Resource):
 
         return node
 
+    def load_profile(self, profile):
+        """Load the required profile.
+
+        This will load the profile specified by the ``profile`` keyword in the query parameters, and if not specified it
+        will default to the profile defined in the constructor.
+        """
+        load_profile(profile, allow_switch=True)
+
     def get(self, id=None, page=None):  # pylint: disable=redefined-builtin,invalid-name,unused-argument
         # pylint: disable=too-many-locals
         """
@@ -139,21 +169,34 @@ class BaseResource(Resource):
         :param page: page no, used for pagination
         :return: http response
         """
+        path, url, url_root, query_string = self.unquote_request()
+        resource_type, page, node_id, query_type = self.parse_path(path)
+        parameters = self.parse_query_string(query_string)
+        limit = parameters[0]
+        offset = parameters[1]
+        perpage = parameters[2]
+        orderby = parameters[3]
+        filters = parameters[4]
+        profile = parameters[-1]
 
-        ## Decode url parts
-        path = unquote(request.path)
-        query_string = unquote(request.query_string.decode('utf-8'))
-        url = unquote(request.url)
-        url_root = unquote(request.url_root)
-
-        ## Parse request
-        (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
-
-        # pylint: disable=unused-variable
-        (
-            limit, offset, perpage, orderby, filters, download_format, download, filename, tree_in_limit,
-            tree_out_limit, attributes, attributes_filter, extras, extras_filter, full_type
-        ) = self.utils.parse_query_string(query_string)
+        try:
+            self.load_profile(profile)
+        except RestInputValidationError as exception:
+            return self.utils.build_response(
+                status=400,
+                headers=self.utils.build_headers(url=request.url, total_count=0),
+                data={
+                    'method': request.method,
+                    'url': url,
+                    'url_root': url_root,
+                    'path': path,
+                    'query_string': query_string,
+                    'resource_type': self.__class__.__name__,
+                    'data': {
+                        'message': str(exception)
+                    },
+                }
+            )
 
         ## Validate request
         self.utils.validate_request(
@@ -175,6 +218,7 @@ class BaseResource(Resource):
             headers = self.utils.build_headers(url=request.url, total_count=1)
 
         else:
+
             ## Set the query, and initialize qb object
             self.trans.set_query(filters=filters, orders=orderby, node_id=node_id)
 
@@ -200,7 +244,7 @@ class BaseResource(Resource):
             url_root=url_root,
             path=request.path,
             id=node_id,
-            query_string=request.query_string.decode('utf-8'),
+            query_string=query_string,
             resource_type=resource_type,
             data=results
         )
@@ -234,16 +278,17 @@ class QueryBuilder(BaseResource):
 
     def get(self):  # pylint: disable=arguments-differ
         """Static return to state information about this endpoint."""
+        path, url, url_root, query_string = self.unquote_request()
         headers = self.utils.build_headers(url=request.url, total_count=1)
         return self.utils.build_response(
             status=405,  # Method Not Allowed
             headers=headers,
             data={
                 'method': request.method,
-                'url': unquote(request.url),
-                'url_root': unquote(request.url_root),
-                'path': unquote(request.path),
-                'query_string': request.query_string.decode('utf-8'),
+                'url': url,
+                'url_root': url_root,
+                'path': path,
+                'query_string': query_string,
                 'resource_type': self.__class__.__name__,
                 'data': {'message': self.GET_MESSAGE},
             },
@@ -262,6 +307,28 @@ class QueryBuilder(BaseResource):
         :return: QueryBuilder result of AiiDA entities in "standard" REST API format.
         """
         # pylint: disable=protected-access
+        path, url, url_root, query_string = self.unquote_request()
+        profile = self.parse_query_string(query_string)[-1]
+
+        try:
+            self.load_profile(profile)
+        except RestInputValidationError as exception:
+            return self.utils.build_response(
+                status=400,
+                headers=self.utils.build_headers(url=request.url, total_count=0),
+                data={
+                    'method': request.method,
+                    'url': url,
+                    'url_root': url_root,
+                    'path': path,
+                    'query_string': query_string,
+                    'resource_type': self.__class__.__name__,
+                    'data': {
+                        'message': str(exception)
+                    },
+                }
+            )
+
         self.trans._query_help = request.get_json(force=True)
         # While the data may be correct JSON, it MUST be a single JSON Object,
         # equivalent of a QueryBuilder.as_dict() dictionary.
@@ -350,20 +417,31 @@ class Node(BaseResource):
         :param page: page no, used for pagination
         :return: http response
         """
-
-        ## Decode url parts
-        path = unquote(request.path)
-        query_string = unquote(request.query_string.decode('utf-8'))
-        url = unquote(request.url)
-        url_root = unquote(request.url_root)
-
-        ## Parse request
-        (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
-
+        path, url, url_root, query_string = self.unquote_request()
+        (resource_type, page, node_id, query_type) = self.parse_path(path)
         (
             limit, offset, perpage, orderby, filters, download_format, download, filename, tree_in_limit,
-            tree_out_limit, attributes, attributes_filter, extras, extras_filter, full_type
-        ) = self.utils.parse_query_string(query_string)
+            tree_out_limit, attributes, attributes_filter, extras, extras_filter, full_type, profile
+        ) = self.parse_query_string(query_string)
+
+        try:
+            self.load_profile(profile)
+        except RestInputValidationError as exception:
+            return self.utils.build_response(
+                status=400,
+                headers=self.utils.build_headers(url=request.url, total_count=0),
+                data={
+                    'method': request.method,
+                    'url': url,
+                    'url_root': url_root,
+                    'path': path,
+                    'query_string': query_string,
+                    'resource_type': self.__class__.__name__,
+                    'data': {
+                        'message': str(exception)
+                    },
+                }
+            )
 
         ## Validate request
         self.utils.validate_request(
@@ -495,7 +573,7 @@ class Node(BaseResource):
             url_root=url_root,
             path=path,
             id=node_id,
-            query_string=request.query_string.decode('utf-8'),
+            query_string=query_string,
             resource_type=resource_type,
             data=results
         )
@@ -540,13 +618,30 @@ class ProcessNode(Node):
         :param id: node identifier
         :return: http response
         """
+        path, url, url_root, query_string = self.unquote_request()
+        resource_type, page, node_id, query_type = self.parse_path(path)
+        profile = self.parse_query_string(query_string)[-1]
+
+        try:
+            self.load_profile(profile)
+        except RestInputValidationError as exception:
+            return self.utils.build_response(
+                status=400,
+                headers=self.utils.build_headers(url=request.url, total_count=0),
+                data={
+                    'method': request.method,
+                    'url': url,
+                    'url_root': url_root,
+                    'path': path,
+                    'query_string': query_string,
+                    'resource_type': self.__class__.__name__,
+                    'data': {
+                        'message': str(exception)
+                    },
+                }
+            )
 
         headers = self.utils.build_headers(url=request.url, total_count=1)
-
-        path = unquote(request.path)
-
-        ## Parse request
-        (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
 
         results = None
         if query_type == 'report':
@@ -562,11 +657,11 @@ class ProcessNode(Node):
         ## Build response
         data = dict(
             method=request.method,
-            url=unquote(request.url),
-            url_root=unquote(request.url_root),
+            url=url,
+            url_root=url_root,
             path=path,
             id=node_id,
-            query_string=request.query_string.decode('utf-8'),
+            query_string=query_string,
             resource_type=resource_type,
             data=results
         )
@@ -587,14 +682,28 @@ class CalcJobNode(ProcessNode):
         :param id: node identifier
         :return: http response
         """
+        path, url, url_root, query_string = self.unquote_request()
+        resource_type, page, node_id, query_type = self.parse_path(path)
+        profile = self.parse_query_string(query_string)[-1]
 
-        ## Decode url parts
-        path = unquote(request.path)
-        url = unquote(request.url)
-        url_root = unquote(request.url_root)
-
-        ## Parse request
-        (resource_type, page, node_id, query_type) = self.utils.parse_path(path, parse_pk_uuid=self.parse_pk_uuid)
+        try:
+            self.load_profile(profile)
+        except RestInputValidationError as exception:
+            return self.utils.build_response(
+                status=400,
+                headers=self.utils.build_headers(url=request.url, total_count=0),
+                data={
+                    'method': request.method,
+                    'url': url,
+                    'url_root': url_root,
+                    'path': path,
+                    'query_string': query_string,
+                    'resource_type': self.__class__.__name__,
+                    'data': {
+                        'message': str(exception)
+                    },
+                }
+            )
 
         node = self._load_and_verify(node_id)
         results = None
@@ -617,7 +726,7 @@ class CalcJobNode(ProcessNode):
             url_root=url_root,
             path=path,
             id=node_id,
-            query_string=request.query_string.decode('utf-8'),
+            query_string=query_string,
             resource_type=resource_type,
             data=results
         )

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -68,8 +68,8 @@ def configure_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **k
     :returns: Flask RESTful API
     :rtype: :py:class:`flask_restful.Api`
     """
-
     # Unpack parameters
+    profile = kwargs.pop('profile', None)
     config = kwargs.pop('config', CLI_DEFAULTS['CONFIG_DIR'])
     catch_internal_server = kwargs.pop('catch_internal_server', CLI_DEFAULTS['CATCH_INTERNAL_SERVER'])
     wsgi_profile = kwargs.pop('wsgi_profile', CLI_DEFAULTS['WSGI_PROFILE'])
@@ -106,4 +106,4 @@ def configure_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **k
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
     # Instantiate and return a Flask RESTful API by associating its app
-    return flask_api(app, posting=posting, **config_module.API_CONFIG)
+    return flask_api(app, posting=posting, **config_module.API_CONFIG, profile=profile)

--- a/docs/source/howto/share_data.rst
+++ b/docs/source/howto/share_data.rst
@@ -277,6 +277,29 @@ Here are some examples to try::
 
 For an extensive user documentation of the endpoints, the query string as well as the format of the responses, see the :ref:`AiiDA REST API reference <reference:rest-api>`.
 
+.. versionadded:: 2.1.0
+
+It is possible to allow a request to declare a specific profile for which to run the profile.
+This makes it possible to use a single REST API to serve the content of all configured profiles.
+The profile switching functionality is disabled by default but can be enabled through the config:
+
+.. code-block:: console
+
+    verdi config set rest_api.profile_switching True
+
+After the REST API is restarted, it will now accept the `profile` query parameter, for example:
+
+.. code-block:: console
+
+    http://127.0.0.1:5000/api/v4/computers?profile=some-profile-name
+
+If the specified is already loaded, the REST API functions exactly as without profile switching enabled.
+If another profile is specified, the REST API will first switch profiles before executing the request.
+
+.. note::
+
+    If the profile parameter is specified in a request and the REST API does not have profile switching enabled, a 400 response is returned.
+
 .. _how-to:share:serve:deploy:
 
 Deploying a REST API server


### PR DESCRIPTION
Fixes #5052 

To make this possible, after parsing the query string but before
performing the request, the desired profile needs to be loaded. If any
other profile is already loaded, that first needs to be properly
unloaded, properly unloading the database backend and the manager with
all it resources.