### PR TITLE
👌 IMPROVE: `MultipleEntryPointError` message

### DIFF
--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -264,7 +264,7 @@ def get_entry_point(group: str, name: str) -> EntryPoint:
     if name not in found.names:
         raise MissingEntryPointError(f"Entry point '{name}' not found in group '{group}'")
     if len(found.names) > 1:
-        raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}'.")
+        raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}': {found}")
     return found[name]
 
 


### PR DESCRIPTION
Include the actual entry-points object in the exception message,
to allow debugging of what packages are causing the clash.

fixes #696

for example, an error message would be:

```
MultipleEntryPointError: Multiple entry points 'name' found in group 'aiida.groups': (EntryPoint(name='name', value='aiida.orm.groups:Group', group='aiida.groups'), EntryPoint(name='name', value='other.groups:Group', group='aiida.groups'))
```