### PR TITLE
Release v1.5.3

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -54,7 +54,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres
         env:
           POSTGRES_DB: test_${{ matrix.backend }}
           POSTGRES_PASSWORD: ''
@@ -83,7 +83,7 @@ jobs:
       run: |
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install postgresql-10 graphviz
+        sudo apt install postgresql graphviz
 
     - name: Upgrade pip
       run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -123,7 +123,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres
         env:
           POSTGRES_DB: test_${{ matrix.backend }}
           POSTGRES_PASSWORD: ''
@@ -152,7 +152,7 @@ jobs:
       run: |
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install postgresql-10 graphviz
+        sudo apt install postgresql graphviz
 
     - run: pip install --upgrade pip
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## v1.5.2
+## v1.5.3 - 2021-08-13
+
+### Dependencies
+
+- Pin `sqlalchemy` to minor version 1.3 since `sqlalchemy==1.4` breaks our compatibility
+- Put upper limit on `psycopg2-binary` since `psycopg2-binary==2.9` breaks out test environment
+- Fix `pymatgen` imports since top-level imports were removed in v2021.3.4
+
+### Developers
+
+- CI: switch from `postgresql-10` to the default
+- Docs: add statements to nitpick-ignore
+- Dependencies: put upper limit for `pylint-django`
+
+
+## v1.5.2 - 2020-12-07
 
 Note: release `v1.5.1` was skipped due to a problem with the uploaded files to PyPI.
 
@@ -16,7 +31,7 @@ Note: release `v1.5.1` was skipped due to a problem with the uploaded files to P
 - CI: manually install `numpy` to prevent incompatible releases [[#4615]](https://github.com/aiidateam/aiida-core/pull/4615)
 
 
-## v1.5.0
+## v1.5.0 - 2020-11-13
 
 In this minor version release, support for Python 3.9 is added [[#4301]](https://github.com/aiidateam/aiida-core/pull/4301), while support for Python 3.5 is dropped [[#4386]](https://github.com/aiidateam/aiida-core/pull/4386).
 This version is compatible with all current Python versions that are not end-of-life:

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -31,7 +31,7 @@ __copyright__ = (
     'For further information please visit http://www.aiida.net/. All rights reserved.'
 )
 __license__ = 'MIT license, see LICENSE.txt file.'
-__version__ = '1.5.2'
+__version__ = '1.5.3'
 __authors__ = 'The AiiDA team.'
 __paper__ = (
     'G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky,'

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -289,7 +289,7 @@ def tree(nodes, depth):
     from aiida.cmdline.utils.ascii_vis import NodeTreePrinter
 
     for node in nodes:
-        NodeTreePrinter.print_node_tree(node, depth, tuple(LinkType.__members__.values()))
+        NodeTreePrinter.print_node_tree(node, depth, tuple(LinkType.__members__.values()))  # pylint: disable=no-member
 
         if len(nodes) > 1:
             echo.echo('')

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -88,7 +88,7 @@ class InterruptableFuture(concurrent.Future):
         # Wait for one of the two to finish, if it's us that finishes we expect that it was
         # because of an exception that will have been raised automatically
         wait_iterator = gen.WaitIterator(yieldable, self)
-        result = yield wait_iterator.next()  # pylint: disable=stop-iteration-return
+        result = yield wait_iterator.next()  # pylint: disable=stop-iteration-return,not-callable
         if not wait_iterator.current_index == 0:
             raise RuntimeError(f"This interruptible future had it's result set unexpectedly to {result}")
 

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -703,7 +703,7 @@ class TrajectoryData(ArrayData):
             point given results in the point being given as a multiples of lattice vectors
             Than take the integer of the rows to find how many times you have to shift
             the point back"""
-            invcell = np.matrix(cell).T.I
+            invcell = np.matrix(cell).T.I  # pylint: disable=no-member
             # point in crystal coordinates
             points_in_crystal = np.dot(invcell, point).tolist()[0]
             #point collapsed into unit cell

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -116,7 +116,12 @@ def get_pymatgen_version():
     if not has_pymatgen():
         return None
     import pymatgen
-    return pymatgen.__version__
+    try:
+        return pymatgen.__version__
+    except AttributeError:
+        # This is the structure for newer versions
+        from pymatgen.core import __version__
+        return __version__
 
 
 def has_spglib():
@@ -1852,7 +1857,7 @@ class StructureData(Data):
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors)
         """
-        from pymatgen import Structure
+        from pymatgen.core.structure import Structure
 
         if self.pbc != (True, True, True):
             raise ValueError('Periodic boundary conditions must apply in all three dimensions of real space')
@@ -1862,7 +1867,7 @@ class StructureData(Data):
 
         if (kwargs.pop('add_spin', False) and any([n.endswith('1') or n.endswith('2') for n in self.get_kind_names()])):
             # case when spins are defined -> no partial occupancy allowed
-            from pymatgen import Specie
+            from pymatgen.core.periodic_table import Specie
             oxidation_state = 0  # now I always set the oxidation_state to zero
             for site in self.sites:
                 kind = self.get_kind(site.kind_name)
@@ -1907,7 +1912,7 @@ class StructureData(Data):
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors)
         """
-        from pymatgen import Molecule
+        from pymatgen.core.structure import Molecule
 
         if kwargs:
             raise ValueError(f'Unrecognized parameters passed to pymatgen converter: {kwargs.keys()}')

--- a/aiida/tools/dbimporters/plugins/materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/materialsproject.py
@@ -12,7 +12,7 @@ import datetime
 import os
 import requests
 
-from pymatgen import MPRester
+from pymatgen.ext.matproj import MPRester
 
 from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -26,8 +26,14 @@ py:class IO
 
 # issues with order of object processing and type hinting
 py:class WorkChainSpec
+py:class aiida.engine.processes.workchains.workchain.WorkChainSpec
 py:class aiida.tools.importexport.dbexport.ExportReport
 py:class aiida.tools.importexport.dbexport.ArchiveData
+py:obj aiida.orm.entities.EntityType
+py:obj aiida.orm.implementation.entities.EntityType
+py:obj aiida.orm.implementation.django.entities.ModelType
+py:obj aiida.orm.implementation.sql.backends.ModelType
+py:obj aiida.orm.implementation.sqlalchemy.entities.ModelType
 
 py:class EntityType
 py:class aiida.tools.groups.paths.WalkNodeResult

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
 - plumpy~=0.15.1
 - pgsu~=0.1.0
 - psutil~=5.6
-- psycopg2>=2.8.3,~=2.8
+- psycopg2<2.9,>=2.8.3
 - python-dateutil~=2.8
 - pytz~=2019.3
 - pyyaml~=5.1.2

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
 - reentry~=1.3
 - simplejson~=3.16
 - sqlalchemy-utils~=0.34.2
-- sqlalchemy>=1.3.10,~=1.3
+- sqlalchemy~=1.3.10
 - tabulate~=0.8.5
 - tornado<5.0
 - topika~=0.2.2

--- a/setup.json
+++ b/setup.json
@@ -42,7 +42,7 @@
         "plumpy~=0.15.1",
         "pgsu~=0.1.0",
         "psutil~=5.6",
-        "psycopg2-binary~=2.8,>=2.8.3",
+        "psycopg2-binary>=2.8.3,<2.9",
         "python-dateutil~=2.8",
         "pytz~=2019.3",
         "pyyaml~=5.1.2",

--- a/setup.json
+++ b/setup.json
@@ -99,7 +99,7 @@
             "packaging==20.3",
             "pre-commit~=2.2",
             "pylint~=2.5.0",
-            "pylint-django~=2.0",
+            "pylint-django>=2.0,<2.4.0",
             "tomlkit~=0.7.0"
         ],
         "tests": [

--- a/setup.json
+++ b/setup.json
@@ -49,7 +49,7 @@
         "reentry~=1.3",
         "simplejson~=3.16",
         "sqlalchemy-utils~=0.34.2",
-        "sqlalchemy~=1.3,>=1.3.10",
+        "sqlalchemy~=1.3.10",
         "tabulate~=0.8.5",
         "tornado<5.0",
         "topika~=0.2.2",

--- a/setup.json
+++ b/setup.json
@@ -1,6 +1,6 @@
 {
     "name": "aiida-core",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "url": "http://www.aiida.net/",
     "license": "MIT License",
     "author": "The AiiDA team",

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,missing-function-docstring,invalid-name,missing-class-docstring,no-self-use
+# pylint: disable=too-many-lines,missing-function-docstring,invalid-name,missing-class-docstring,no-self-use,no-member
 """Tests for the `WorkChain` class."""
 import inspect
 import unittest
@@ -827,8 +827,8 @@ class TestWorkchain(AiidaTestCase):
         wc = ExitCodeWorkChain()
 
         # The exit code can be gotten by calling it with the status or label, as well as using attribute dereferencing
-        self.assertEqual(wc.exit_codes(status).status, status)
-        self.assertEqual(wc.exit_codes(label).status, status)
+        self.assertEqual(wc.exit_codes(status).status, status)  # pylint: disable=too-many-function-args
+        self.assertEqual(wc.exit_codes(label).status, status)  # pylint: disable=too-many-function-args
         self.assertEqual(wc.exit_codes.SOME_EXIT_CODE.status, status)
 
         with self.assertRaises(AttributeError):

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods,no-member
 """Tests for the Node ORM class."""
 import io
 import os

--- a/tests/restapi/test_threaded_restapi.py
+++ b/tests/restapi/test_threaded_restapi.py
@@ -62,8 +62,7 @@ def test_run_threaded_server(restapi_server, server_url, aiida_localhost):
             pytest.fail('Thread did not close/join within 1 min after REST API server was called to shutdown')
 
 
-# Tracked in issue #4281
-@pytest.mark.flaky(reruns=2)
+@pytest.mark.skip('Tracked in issue #4281')
 @pytest.mark.usefixtures('clear_database_before_test', 'restrict_sqlalchemy_queuepool')
 def test_run_without_close_session(restapi_server, server_url, aiida_localhost, capfd):
     """Run AiiDA REST API threaded in a separate thread and perform many sequential requests"""

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,invalid-name
+# pylint: disable=too-many-lines,invalid-name,no-member
 """Tests for specific subclasses of Data."""
 import os
 import tempfile

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2220,15 +2220,17 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests pymatgen -> StructureData, with partial occupancies and spins.
         This should raise a ValueError.
         """
-        import pymatgen
+        from pymatgen.core.periodic_table import Specie
+        from pymatgen.core.composition import Composition
+        from pymatgen.core.structure import Structure
 
-        Fe_spin_up = pymatgen.Specie('Fe', 0, properties={'spin': 1})
-        Mn_spin_up = pymatgen.Specie('Mn', 0, properties={'spin': 1})
-        Fe_spin_down = pymatgen.Specie('Fe', 0, properties={'spin': -1})
-        Mn_spin_down = pymatgen.Specie('Mn', 0, properties={'spin': -1})
-        FeMn1 = pymatgen.Composition({Fe_spin_up: 0.5, Mn_spin_up: 0.5})
-        FeMn2 = pymatgen.Composition({Fe_spin_down: 0.5, Mn_spin_down: 0.5})
-        a = pymatgen.Structure(
+        Fe_spin_up = Specie('Fe', 0, properties={'spin': 1})
+        Mn_spin_up = Specie('Mn', 0, properties={'spin': 1})
+        Fe_spin_down = Specie('Fe', 0, properties={'spin': -1})
+        Mn_spin_down = Specie('Mn', 0, properties={'spin': -1})
+        FeMn1 = Composition({Fe_spin_up: 0.5, Mn_spin_up: 0.5})
+        FeMn2 = Composition({Fe_spin_down: 0.5, Mn_spin_down: 0.5})
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[FeMn1, FeMn2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
         )
 
@@ -2236,9 +2238,9 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
             StructureData(pymatgen=a)
 
         # same, with vacancies
-        Fe1 = pymatgen.Composition({Fe_spin_up: 0.5})
-        Fe2 = pymatgen.Composition({Fe_spin_down: 0.5})
-        a = pymatgen.Structure(
+        Fe1 = Composition({Fe_spin_up: 0.5})
+        Fe2 = Composition({Fe_spin_down: 0.5})
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[Fe1, Fe2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
         )
 
@@ -2250,12 +2252,13 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
     def test_multiple_kinds_partial_occupancies():
         """Tests that a structure with multiple sites with the same element but different
         partial occupancies, get their own unique kind name."""
-        import pymatgen
+        from pymatgen.core.composition import Composition
+        from pymatgen.core.structure import Structure
 
-        Mg1 = pymatgen.Composition({'Mg': 0.50})
-        Mg2 = pymatgen.Composition({'Mg': 0.25})
+        Mg1 = Composition({'Mg': 0.50})
+        Mg2 = Composition({'Mg': 0.25})
 
-        a = pymatgen.Structure(
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[Mg1, Mg2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
         )
 
@@ -2268,12 +2271,13 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests that a structure with multiple sites with the same alloy symbols but different
         weights, get their own unique kind name
         """
-        import pymatgen
+        from pymatgen.core.composition import Composition
+        from pymatgen.core.structure import Structure
 
-        alloy_one = pymatgen.Composition({'Mg': 0.25, 'Al': 0.75})
-        alloy_two = pymatgen.Composition({'Mg': 0.45, 'Al': 0.55})
+        alloy_one = Composition({'Mg': 0.25, 'Al': 0.75})
+        alloy_two = Composition({'Mg': 0.45, 'Al': 0.55})
 
-        a = pymatgen.Structure(
+        a = Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]],
             species=[alloy_one, alloy_two],
             coords=[[0, 0, 0], [0.5, 0.5, 0.5]]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,invalid-name,protected-access
+# pylint: disable=too-many-lines,invalid-name,protected-access,no-member
 # pylint: disable=missing-docstring,too-many-locals,too-many-statements
 # pylint: disable=too-many-public-methods
 import copy


### PR DESCRIPTION
Patch release for v1.5 series to make sure `aiida-core` is installable on Python 3.6, support for which was dropped in `aiida-core==1.6`.

@ramirezfranciscof @chrisjsewell only need to review and accept. No need to merge, I will take care of this.