### PR TITLE
👌 IMPROVE: CLI responsiveness

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -541,9 +541,6 @@ def computer_delete(computer):
 class LazyConfigureGroup(click.Group):
     """A click group that will lazily load the subcommands for each transport plugin."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def list_commands(self, ctx):
         return list(get_entry_point_names('aiida.transports'))
 

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -540,6 +540,7 @@ def computer_delete(computer):
 
 class LazyConfigureGroup(click.Group):
     """A click group that will lazily load the subcommands for each transport plugin."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -547,7 +547,7 @@ class LazyConfigureGroup(click.Group):
     def list_commands(self, ctx):
         return list(get_entry_point_names('aiida.transports'))
 
-    def get_command(self, ctx, name):
+    def get_command(self, ctx, name):  # pylint: disable=arguments-differ
         from aiida.transports import cli as transport_cli
         return transport_cli.create_configure_cmd(name)
 
@@ -569,6 +569,7 @@ def computer_configure():
 def computer_config_show(computer, user, defaults, as_option_string):
     """Show the current configuration for a computer."""
     from aiida.common.escaping import escape_for_bash
+    from aiida.transports import cli as transport_cli
 
     transport_cls = computer.get_transport_class()
     option_list = [

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -33,13 +33,21 @@ def devel_check_load_time():
     """
     from aiida.manage.manager import get_manager
 
+    aiida_modules = [key for key in sys.modules.keys() if key.startswith("aiida.")]
+    aiida_modules_str = "\n- ".join(sorted(aiida_modules))
+    echo.echo(f"aiida modules loaded:\n- {aiida_modules_str}")
+
     manager = get_manager()
 
     if manager.backend_loaded:
         echo.echo_critical('potential `verdi` speed problem: database backend is loaded.')
 
-    if 'aiida.orm' in sys.modules:
-        echo.echo_critical('potential `verdi` speed problem: `aiida.orm` module is imported.')
+    allowed = ("aiida.backends", "aiida.cmdline", "aiida.common", "aiida.manage", "aiida.plugins", "aiida.restapi")
+    for loaded in aiida_modules:
+        if not any(loaded.startswith(mod) for mod in allowed):
+            echo.echo_critical(
+                f'potential `verdi` speed problem: `{loaded}` module is imported which is not in: {allowed}'
+            )
 
     echo.echo_success('no issues detected')
 

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -37,8 +37,8 @@ def devel_check_load_time(verbose):
     from aiida.manage.manager import get_manager
 
     aiida_modules = [key for key in sys.modules if key.startswith('aiida.')]
+    aiida_modules_str = '\n- '.join(sorted(aiida_modules))
     if verbose:
-        aiida_modules_str = '\n- '.join(sorted(aiida_modules))
         echo.echo(f'aiida modules loaded:\n- {aiida_modules_str}')
 
     manager = get_manager()

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -36,7 +36,7 @@ def devel_check_load_time(verbose):
     """
     from aiida.manage.manager import get_manager
 
-    aiida_modules = [key for key in sys.modules.keys() if key.startswith('aiida.')]
+    aiida_modules = [key for key in sys.modules if key.startswith('aiida.')]
     if verbose:
         aiida_modules_str = '\n- '.join(sorted(aiida_modules))
         echo.echo(f'aiida modules loaded:\n- {aiida_modules_str}')

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -30,7 +30,7 @@ def devel_check_load_time(verbose):
     Known pathways that increase load time:
 
         * the database environment is loaded when it doesn't need to be
-        * the `aiida.orm` module is imported when it doesn't need to be
+        * Only expected `aiida.*` modules are imported
 
     If either of these conditions are true, the command will raise a critical error
     """

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -10,8 +10,6 @@
 """`verdi devel` commands."""
 import sys
 
-import click
-
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators, echo

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -10,6 +10,8 @@
 """`verdi devel` commands."""
 import sys
 
+import click
+
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators, echo
 
@@ -20,7 +22,8 @@ def verdi_devel():
 
 
 @verdi_devel.command('check-load-time')
-def devel_check_load_time():
+@click.option('-v', '--verbose', is_flag=True, help='Increase verbosity')
+def devel_check_load_time(verbose):
     """Check for common indicators that slowdown `verdi`.
 
     Check for environment properties that negatively affect the responsiveness of the `verdi` command line interface.
@@ -33,9 +36,10 @@ def devel_check_load_time():
     """
     from aiida.manage.manager import get_manager
 
-    aiida_modules = [key for key in sys.modules.keys() if key.startswith('aiida.')]
-    aiida_modules_str = '\n- '.join(sorted(aiida_modules))
-    echo.echo(f'aiida modules loaded:\n- {aiida_modules_str}')
+    aiida_modules = [key for key in sys.modules.keys() if key.startswith("aiida.")]
+    if verbose:
+        aiida_modules_str = "\n- ".join(sorted(aiida_modules))
+        echo.echo(f"aiida modules loaded:\n- {aiida_modules_str}")
 
     manager = get_manager()
 

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -36,10 +36,10 @@ def devel_check_load_time(verbose):
     """
     from aiida.manage.manager import get_manager
 
-    aiida_modules = [key for key in sys.modules.keys() if key.startswith("aiida.")]
+    aiida_modules = [key for key in sys.modules.keys() if key.startswith('aiida.')]
     if verbose:
-        aiida_modules_str = "\n- ".join(sorted(aiida_modules))
-        echo.echo(f"aiida modules loaded:\n- {aiida_modules_str}")
+        aiida_modules_str = '\n- '.join(sorted(aiida_modules))
+        echo.echo(f'aiida modules loaded:\n- {aiida_modules_str}')
 
     manager = get_manager()
 

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -13,6 +13,7 @@ import sys
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators, echo
 
 
@@ -22,7 +23,7 @@ def verdi_devel():
 
 
 @verdi_devel.command('check-load-time')
-@click.option('-v', '--verbose', is_flag=True, help='Increase verbosity')
+@options.VERBOSE()
 def devel_check_load_time(verbose):
     """Check for common indicators that slowdown `verdi`.
 
@@ -30,14 +31,14 @@ def devel_check_load_time(verbose):
     Known pathways that increase load time:
 
         * the database environment is loaded when it doesn't need to be
-        * Only expected `aiida.*` modules are imported
+        * Unexpected `aiida.*` modules are imported
 
     If either of these conditions are true, the command will raise a critical error
     """
     from aiida.manage.manager import get_manager
 
-    aiida_modules = [key for key in sys.modules if key.startswith('aiida.')]
-    aiida_modules_str = '\n- '.join(sorted(aiida_modules))
+    loaded_aiida_modules = [key for key in sys.modules if key.startswith('aiida.')]
+    aiida_modules_str = '\n- '.join(sorted(loaded_aiida_modules))
     if verbose:
         echo.echo(f'aiida modules loaded:\n- {aiida_modules_str}')
 
@@ -47,7 +48,7 @@ def devel_check_load_time(verbose):
         echo.echo_critical('potential `verdi` speed problem: database backend is loaded.')
 
     allowed = ('aiida.backends', 'aiida.cmdline', 'aiida.common', 'aiida.manage', 'aiida.plugins', 'aiida.restapi')
-    for loaded in aiida_modules:
+    for loaded in loaded_aiida_modules:
         if not any(loaded.startswith(mod) for mod in allowed):
             echo.echo_critical(
                 f'potential `verdi` speed problem: `{loaded}` module is imported which is not in: {allowed}'

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -33,16 +33,16 @@ def devel_check_load_time():
     """
     from aiida.manage.manager import get_manager
 
-    aiida_modules = [key for key in sys.modules.keys() if key.startswith("aiida.")]
-    aiida_modules_str = "\n- ".join(sorted(aiida_modules))
-    echo.echo(f"aiida modules loaded:\n- {aiida_modules_str}")
+    aiida_modules = [key for key in sys.modules.keys() if key.startswith('aiida.')]
+    aiida_modules_str = '\n- '.join(sorted(aiida_modules))
+    echo.echo(f'aiida modules loaded:\n- {aiida_modules_str}')
 
     manager = get_manager()
 
     if manager.backend_loaded:
         echo.echo_critical('potential `verdi` speed problem: database backend is loaded.')
 
-    allowed = ("aiida.backends", "aiida.cmdline", "aiida.common", "aiida.manage", "aiida.plugins", "aiida.restapi")
+    allowed = ('aiida.backends', 'aiida.cmdline', 'aiida.common', 'aiida.manage', 'aiida.plugins', 'aiida.restapi')
     for loaded in aiida_modules:
         if not any(loaded.startswith(mod) for mod in allowed):
             echo.echo_critical(

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -167,3 +167,4 @@ py:class Session
 py:class Query
 py:class BackendQueryBuilder
 py:class importlib_metadata.EntryPoint
+py:class Command


### PR DESCRIPTION
This commit improves the CLI loading speed,
by loading the `verdi computer configure` commands
(which in-turn load Transport plugins)
only when necessary.

The strictness of the `verdi devel check-load-time`
is also increased, to only allow loading of specific aiida modules.

closes #5070