### PR TITLE
CI: Update/maintain test-install GA workflow

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -73,6 +73,32 @@ jobs:
         pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
         pip freeze
 
+  create-conda-environment:
+    # Verify that we can create a valid conda environment from the environment.yml file.
+
+    needs: [validate-dependency-specification]
+    if: github.repository == 'aiidateam/aiida-core'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        python-version: 3.9
+        update-conda: false
+        conda-channels: conda-forge
+
+    - run: conda --version
+    - run: python --version
+    - run: which python
+
+    - name: Test conda environment
+      run: |
+        conda env create --dry-run -f environment.yml -n test-environment
+
   install-with-pip:
 
     if: github.repository == 'aiidateam/aiida-core'
@@ -107,12 +133,18 @@ jobs:
         python -c "import aiida"
 
   install-with-conda:
+    # Verify that we can install AiiDA with conda.
 
     if: github.repository == 'aiidateam/aiida-core'
-    runs-on: ubuntu-latest
-    name: install-with-conda
+    # Currently the installation for Python 3.7 fails in combination with
+    # ubuntu-20.04 due to an incompatibility with glibc.
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
 
-    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +152,7 @@ jobs:
     - name: Setup Conda
       uses: s-weigand/setup-conda@v1
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
         update-conda: false
         conda-channels: conda-forge
     - run: conda --version
@@ -129,20 +161,11 @@ jobs:
 
     - name: Test direct installation
       run: |
-        conda create -n test-install aiida-core
-        source activate test-install
-        python -c "import aiida"
-
-    - name: Test conda environment
-      run: |
-        conda env create -f environment.yml -n test-environment
-        source activate test-environment
-        python -m pip install --no-deps -e .
-        python -c "import aiida"
+        conda create --dry-run -n test-install aiida-core python=${{ matrix.python-version }}
 
   tests:
 
-    needs: [install-with-pip, install-with-conda]
+    needs: [install-with-pip]
     runs-on: ubuntu-latest
     timeout-minutes: 35
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -34,7 +34,44 @@ jobs:
       run: pip install -r utils/requirements.txt
 
     - name: Validate
-      run: python ./utils/dependency_management.py validate-all
+      run: |
+        python ./utils/dependency_management.py check-requirements
+        python ./utils/dependency_management.py validate-all
+
+  resolve-pip-dependencies:
+    # Check whether the environments defined in the requirements/* files are
+    # resolvable.
+    #
+    # This job should use the planned `pip resolve` command once released:
+    # https://github.com/pypa/pip/issues/7819
+
+    needs: [validate-dependency-specification]
+    if: github.repository == 'aiidateam/aiida-core'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Upgrade pip and setuptools
+      run: |
+        pip install --upgrade pip setuptools
+        pip --version
+
+    - name: Create environment from requirements file.
+      run: |
+        pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
+        pip freeze
 
   install-with-pip:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
         exclude: *exclude_pre_commit_hooks
+    -   id: check-yaml
 
 
 -   repo: https://github.com/ikamensh/flynt/

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -122,7 +122,7 @@ python-memcached==1.59
 pytray==0.3.2
 pytz==2021.1
 PyYAML==5.4.1
-pyzmq==22.1.1
+pyzmq==22.2.1
 qtconsole==5.1.1
 QtPy==1.9.0
 requests==2.26.0


### PR DESCRIPTION
Related to: https://github.com/aiidateam/aiida-core/pull/5046#issuecomment-898386064

- MAINTAIN: Add 'check-yaml' to pre-commit hooks.
  Should catch issues with the definition of workflow files in the future.
- Dependencies: Fix the pyzmq requirement specification for Python 3.9.
  I have verified that the `resolve-pip-dependencies` job (see below) fails without this change.
- CI: Implement _resolve-pip-dependencies_ job.
  Checks whether environments defined in the requirements/ files are resolvable.
- CI: Separate the direct conda installation test into separate job.
  The test whether we can actually install aiida with `conda install aiida-core ...` is run as a dedicated job only after we checked that we can create a conda environment from the `environment.yml` file.
- CI: Run _install-with-conda_ job for all supported Python versions.
  To test whether `conda install aiida-core ...` actually works for all supported Python versions.

Checklist before merge:
- [ ] Restore deleted GA workflows.
- [ ] Re-enable test suite