### PR TITLE
🔧 MAINTAIN: Update pylint version (& fix new issues)

### DIFF
--- a/.github/system_tests/test_daemon.py
+++ b/.github/system_tests/test_daemon.py
@@ -16,6 +16,11 @@ import sys
 import tempfile
 import time
 
+from workchains import (
+    ArithmeticAddBaseWorkChain, CalcFunctionRunnerWorkChain, DynamicDbInput, DynamicMixedInput, DynamicNonDbInput,
+    ListEcho, NestedInputNamespace, NestedWorkChain, SerializeWorkChain, WorkFunctionRunnerWorkChain
+)
+
 from aiida.common import exceptions, StashMode
 from aiida.engine import run, submit
 from aiida.engine.daemon.client import get_daemon_client
@@ -25,10 +30,6 @@ from aiida.engine.processes import Process
 from aiida.orm import CalcJobNode, load_node, Int, Str, List, Dict, load_code
 from aiida.plugins import CalculationFactory, WorkflowFactory
 from aiida.workflows.arithmetic.add_multiply import add_multiply, add
-from workchains import (
-    NestedWorkChain, DynamicNonDbInput, DynamicDbInput, DynamicMixedInput, ListEcho, CalcFunctionRunnerWorkChain,
-    WorkFunctionRunnerWorkChain, NestedInputNamespace, SerializeWorkChain, ArithmeticAddBaseWorkChain
-)
 
 from tests.utils.memory import get_instances  # pylint: disable=import-error
 

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -16,7 +16,7 @@ from django.db import models as m
 from django.db.models.query import QuerySet
 from pytz import UTC
 
-import aiida.backends.djsite.db.migrations as migrations
+from aiida.backends.djsite.db import migrations
 from aiida.common import timezone
 from aiida.common.json import JSONEncoder
 from aiida.common.utils import get_new_uuid
@@ -413,7 +413,7 @@ def suppress_auto_now(list_of_models_fields):
     try:
         yield
     finally:
-        for model in _original_model_values:
-            for field in _original_model_values[model]:
-                field.auto_now = _original_model_values[model][field]['auto_now']
-                field.editable = _original_model_values[model][field]['editable']
+        for model, data in _original_model_values.items():
+            for field, value in data.items():
+                field.auto_now = value['auto_now']
+                field.editable = value['editable']

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -137,12 +137,12 @@ class AbstractQueryManager(abc.ABC):
 
         if args.element is not None:
             all_symbols = [_['symbols'][0] for _ in akinds]
-            if not any([s in args.element for s in all_symbols]):
+            if not any(s in args.element for s in all_symbols):
                 return None
 
         if args.element_only is not None:
             all_symbols = [_['symbols'][0] for _ in akinds]
-            if not all([s in all_symbols for s in args.element_only]):
+            if not all(s in all_symbols for s in args.element_only):
                 return None
 
         # We want only the StructureData that have attributes

--- a/aiida/backends/general/migrations/utils.py
+++ b/aiida/backends/general/migrations/utils.py
@@ -55,7 +55,7 @@ class LazyFile(File):
         if key is not None and not isinstance(key, (str, LazyOpener)):
             raise TypeError('key should be `None` or a string.')
 
-        if objects is not None and any([not isinstance(obj, self.__class__) for obj in objects.values()]):
+        if objects is not None and any(not isinstance(obj, self.__class__) for obj in objects.values()):
             raise TypeError('objects should be `None` or a dictionary of `File` instances.')
 
         if file_type == FileType.DIRECTORY and key is not None:

--- a/aiida/cmdline/commands/cmd_archive.py
+++ b/aiida/cmdline/commands/cmd_archive.py
@@ -436,10 +436,11 @@ def _import_archive(archive: str, web_based: bool, import_kwargs: dict, try_migr
         if web_based:
             echo.echo_info(f'downloading archive: {archive}')
             try:
-                response = urllib.request.urlopen(archive)
+                with urllib.request.urlopen(archive) as response:
+                    temp_folder.create_file_from_filelike(response, 'downloaded_archive.zip')
             except Exception as exception:
                 _echo_exception(f'downloading archive {archive} failed', exception)
-            temp_folder.create_file_from_filelike(response, 'downloaded_archive.zip')
+
             archive_path = temp_folder.get_abs_path('downloaded_archive.zip')
             echo.echo_success('archive downloaded, proceeding with import')
 

--- a/aiida/cmdline/commands/cmd_archive.py
+++ b/aiida/cmdline/commands/cmd_archive.py
@@ -254,6 +254,7 @@ def migrate(input_file, output_file, force, in_place, archive_format, version, v
 
 class ExtrasImportCode(Enum):
     """Exit codes for the verdi command line."""
+    # pylint: disable=invalid-name
     keep_existing = 'kcl'
     update_existing = 'kcu'
     mirror = 'ncu'

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -546,7 +546,7 @@ class LazyConfigureGroup(click.Group):
         subcommands.extend(get_entry_point_names('aiida.transports'))
         return subcommands
 
-    def get_command(self, ctx, name):  # pylint: disable=arguments-differ
+    def get_command(self, ctx, name):  # pylint: disable=arguments-renamed
         from aiida.transports import cli as transport_cli
         try:
             command = transport_cli.create_configure_cmd(name)

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -158,7 +158,7 @@ def logshow():
 
     try:
         currenv = get_env_with_venv_bin()
-        process = subprocess.Popen(['tail', '-f', client.daemon_log_file], env=currenv)
+        process = subprocess.Popen(['tail', '-f', client.daemon_log_file], env=currenv)  # pylint: disable=consider-using-with
         process.wait()
     except KeyboardInterrupt:
         process.kill()

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -220,7 +220,7 @@ def _show_xmgrace(exec_name, list_bands):
             'agr', setnumber_offset=current_band_number, color_number=(iband + 1 % MAX_NUM_AGR_COLORS)
         )
         # write a tempfile
-        tempf = tempfile.NamedTemporaryFile('w+b', suffix='.agr')
+        tempf = tempfile.NamedTemporaryFile('w+b', suffix='.agr')  # pylint: disable=consider-using-with
         tempf.write(text)
         tempf.flush()
         list_files.append(tempf)

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -72,7 +72,7 @@ def structure_list(elements, raw, formula_mode, past_days, groups, all_users):
         # it will be pushed in the query.
         if elements is not None:
             all_symbols = [_['symbols'][0] for _ in akinds]
-            if not any([s in elements for s in all_symbols]):
+            if not any(s in elements for s in all_symbols):
                 continue
 
             if elements_only:

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -121,7 +121,7 @@ def profile_delete(force, include_config, include_database, include_database_use
         }
 
         if not all(includes.values()):
-            excludes = [label for label in includes if not includes[label]]
+            excludes = [label for label, value in includes.items() if not value]
             message_suffix = f' excluding: {", ".join(excludes)}.'
         else:
             message_suffix = '.'

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -114,7 +114,7 @@ def run(scriptname, varargs, auto_group, auto_group_label_prefix, exclude, inclu
 
     try:
         # Here we use a standard open and not open, as exec will later fail if passed a unicode type string.
-        handle = open(scriptname, 'r')
+        handle = open(scriptname, 'r')  # pylint: disable=consider-using-with
     except IOError:
         echo.echo_critical(f"Unable to load file '{scriptname}'")
     else:

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -130,7 +130,7 @@ def verdi_status(print_traceback, no_rmq):
         delete_stale_pid_file(client)
         daemon_status = get_daemon_status(client)
 
-        daemon_status = daemon_status.split('\n')[0]  # take only the first line
+        daemon_status = daemon_status.split('\n', maxsplit=1)[0]  # take only the first line
         if client.is_daemon_running:
             print_status(ServiceStatus.UP, 'daemon', daemon_status)
         else:

--- a/aiida/cmdline/params/options/multivalue.py
+++ b/aiida/cmdline/params/options/multivalue.py
@@ -24,7 +24,7 @@ def collect_usage_pieces(self, ctx):
 
     # If the command contains a `MultipleValueOption` make sure to add `[--]` to the help string before the
     # arguments, which hints the use of the optional `endopts` marker
-    if any([isinstance(param, MultipleValueOption) for param in self.get_params(ctx)]):
+    if any(isinstance(param, MultipleValueOption) for param in self.get_params(ctx)):
         result.append('[--]')
 
     for param in self.get_params(ctx):

--- a/aiida/cmdline/params/types/identifier.py
+++ b/aiida/cmdline/params/types/identifier.py
@@ -10,7 +10,7 @@
 """
 Module for custom click param type identifier
 """
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 import click
 
@@ -65,7 +65,8 @@ class IdentifierParamType(click.ParamType, ABC):
                 else:
                     self._entry_points.append(entry_point)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     @with_dbenv()
     def orm_class_loader(self):
         """

--- a/aiida/cmdline/params/types/multiple.py
+++ b/aiida/cmdline/params/types/multiple.py
@@ -37,6 +37,6 @@ class MultipleValueParamType(click.ParamType):
 
     def convert(self, value, param, ctx):
         try:
-            return tuple([self._param_type(entry) for entry in value])
+            return tuple(self._param_type(entry) for entry in value)
         except ValueError:
             self.fail(f'could not convert {value} into type {self._param_type}')

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -99,7 +99,8 @@ class PathOrUrl(click.Path):
     def checks_url(self, url, param, ctx):
         """Check whether URL is reachable within timeout."""
         try:
-            urllib.request.urlopen(url, timeout=self.timeout_seconds)  # pylint: disable=consider-using-with
+            with urllib.request.urlopen(url, timeout=self.timeout_seconds):
+                pass
         except (urllib.error.URLError, urllib.error.HTTPError, timeout):
             self.fail(
                 '{0} "{1}" could not be reached within {2} s.\n'

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -99,7 +99,7 @@ class PathOrUrl(click.Path):
     def checks_url(self, url, param, ctx):
         """Check whether URL is reachable within timeout."""
         try:
-            urllib.request.urlopen(url, timeout=self.timeout_seconds)
+            urllib.request.urlopen(url, timeout=self.timeout_seconds)  # pylint: disable=consider-using-with
         except (urllib.error.URLError, urllib.error.HTTPError, timeout):
             self.fail(
                 '{0} "{1}" could not be reached within {2} s.\n'
@@ -143,7 +143,7 @@ class FileOrUrl(click.File):
     def get_url(self, url, param, ctx):
         """Retrieve file from URL."""
         try:
-            return urllib.request.urlopen(url, timeout=self.timeout_seconds)
+            return urllib.request.urlopen(url, timeout=self.timeout_seconds)  # pylint: disable=consider-using-with
         except (urllib.error.URLError, urllib.error.HTTPError, timeout):
             self.fail(
                 '"{0}" could not be reached within {1} s.\n'

--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -32,7 +32,7 @@ class Pluginable(click.Group):
 
         return subcommands
 
-    def get_command(self, ctx, name):  # pylint: disable=arguments-differ
+    def get_command(self, ctx, name):  # pylint: disable=arguments-renamed
         """Try to load a subcommand from entry points, else defer to super."""
         command = None
         if not self._exclude_external_plugins:

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -282,7 +282,7 @@ class Folder:
         if 'b' in mode:
             encoding = None
 
-        return open(  # pytest: disable=consider-using-with
+        return open(  # pylint: disable=consider-using-with
             self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding
         )
 

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -282,7 +282,9 @@ class Folder:
         if 'b' in mode:
             encoding = None
 
-        return open(self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding)
+        return open(  # pytest: disable=consider-using-with
+            self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding
+        )
 
     @property
     def abspath(self):

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -129,8 +129,7 @@ def str_timedelta(dt, max_num_fields=3, short=False, negative_to_zero=False):  #
     s_tot = int(s_tot)
 
     if negative_to_zero:
-        if s_tot < 0:
-            s_tot = 0
+        s_tot = max(s_tot, 0)
 
     negative = (s_tot < 0)
     s_tot = abs(s_tot)

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -189,7 +189,7 @@ class PortNamespace(WithNonDb, ports.PortNamespace):
         # `('___', '_')`, where the first element is the matched group of consecutive underscores.
         consecutive_underscores = [match[0] for match in re.findall(r'((_)\2+)', port_name)]
 
-        if any([len(entry) > PORT_NAME_MAX_CONSECUTIVE_UNDERSCORES for entry in consecutive_underscores]):
+        if any(len(entry) > PORT_NAME_MAX_CONSECUTIVE_UNDERSCORES for entry in consecutive_underscores):
             raise ValueError(f'invalid port name `{port_name}`: more than two consecutive underscores')
 
     def serialize(self, mapping: Optional[Dict[str, Any]], breadcrumbs: Sequence[str] = ()) -> Optional[Dict[str, Any]]:

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -109,7 +109,7 @@ class InputPort(WithSerialize, WithNonDb, ports.InputPort):
                     ' It is advised to use a lambda instead, e.g.: `default=lambda: orm.Int(5)`.'.format(args[0])
                 warnings.warn(UserWarning(message))  # pylint: disable=no-member
 
-        super(InputPort, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_description(self) -> Dict[str, str]:
         """

--- a/aiida/engine/processes/workchains/utils.py
+++ b/aiida/engine/processes/workchains/utils.py
@@ -90,7 +90,7 @@ def process_handler(
     if exit_codes is not None and not isinstance(exit_codes, list):
         exit_codes = [exit_codes]
 
-    if exit_codes and any([not isinstance(exit_code, ExitCode) for exit_code in exit_codes]):
+    if exit_codes and any(not isinstance(exit_code, ExitCode) for exit_code in exit_codes):
         raise TypeError('`exit_codes` keyword should be an instance of `ExitCode` or list thereof.')
 
     if not isinstance(enabled, bool):

--- a/aiida/manage/database/integrity/sql/links.py
+++ b/aiida/manage/database/integrity/sql/links.py
@@ -12,7 +12,7 @@
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.links import LinkType
 
-VALID_LINK_TYPES = tuple([link_type.value for link_type in LinkType])
+VALID_LINK_TYPES = tuple(link_type.value for link_type in LinkType)
 
 SELECT_CALCULATIONS_WITH_OUTGOING_CALL = """
     SELECT link.id, node_in.uuid, node_out.uuid, link.type, link.label

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -30,6 +30,7 @@ class BackendAuthInfo(BackendEntity):
         """
 
     @enabled.setter
+    @abc.abstractmethod
     def enabled(self, value):
         """Set the enabled state
 

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -21,7 +21,8 @@ class BackendAuthInfo(BackendEntity):
 
     METADATA_WORKDIR = 'workdir'
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def enabled(self):
         """Return whether this instance is enabled.
 
@@ -35,14 +36,16 @@ class BackendAuthInfo(BackendEntity):
         :param enabled: boolean, True to enable the instance, False to disable it
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def computer(self):
         """Return the computer associated with this instance.
 
         :return: :class:`aiida.orm.implementation.computers.BackendComputer`
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def user(self):
         """Return the user associated with this instance.
 

--- a/aiida/orm/implementation/backends.py
+++ b/aiida/orm/implementation/backends.py
@@ -30,31 +30,38 @@ class Backend(abc.ABC):
     def migrate(self):
         """Migrate the database to the latest schema generation or version."""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def authinfos(self) -> 'BackendAuthInfoCollection':
         """Return the collection of authorisation information objects"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def comments(self) -> 'BackendCommentCollection':
         """Return the collection of comments"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def computers(self) -> 'BackendComputerCollection':
         """Return the collection of computers"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def groups(self) -> 'BackendGroupCollection':
         """Return the collection of groups"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def logs(self) -> 'BackendLogCollection':
         """Return the collection of logs"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def nodes(self) -> 'BackendNodeCollection':
         """Return the collection of nodes"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def query_manager(self) -> 'AbstractQueryManager':
         """Return the query manager for the objects stored in the backend"""
 
@@ -62,7 +69,8 @@ class Backend(abc.ABC):
     def query(self) -> 'BackendQueryBuilder':
         """Return an instance of a query builder implementation for this backend"""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def users(self) -> 'BackendUserCollection':
         """Return the collection of users"""
 

--- a/aiida/orm/implementation/comments.py
+++ b/aiida/orm/implementation/comments.py
@@ -23,11 +23,13 @@ class BackendComment(BackendEntity):
     def uuid(self):
         return str(self._dbmodel.uuid)
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def ctime(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def mtime(self):
         pass
 
@@ -35,11 +37,13 @@ class BackendComment(BackendEntity):
     def set_mtime(self, value):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def node(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def user(self):
         pass
 
@@ -47,7 +51,8 @@ class BackendComment(BackendEntity):
     def set_user(self, value):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def content(self):
         pass
 

--- a/aiida/orm/implementation/computers.py
+++ b/aiida/orm/implementation/computers.py
@@ -35,7 +35,8 @@ class BackendComputer(BackendEntity):
 
     _logger = logging.getLogger(__name__)
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_stored(self):
         """
         Is the computer stored?
@@ -44,15 +45,18 @@ class BackendComputer(BackendEntity):
         :rtype: bool
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def label(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def description(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def hostname(self):
         pass
 

--- a/aiida/orm/implementation/entities.py
+++ b/aiida/orm/implementation/entities.py
@@ -39,7 +39,8 @@ class BackendEntity(abc.ABC):
     def dbmodel(self):
         return self._dbmodel
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def id(self):  # pylint: disable=invalid-name
         """Return the id for this entity.
 
@@ -65,7 +66,8 @@ class BackendEntity(abc.ABC):
         Whether it is possible to call store more than once is delegated to the object itself
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_stored(self):
         """Return whether the entity is stored.
 
@@ -274,7 +276,8 @@ class BackendEntityAttributesMixin(abc.ABC):
         for key in self._dbmodel.attributes.keys():
             yield key
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_stored(self):
         """Return whether the entity is stored.
 
@@ -439,7 +442,8 @@ class BackendEntityExtrasMixin(abc.ABC):
         for key in self._dbmodel.extras.keys():
             yield key
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_stored(self):
         """Return whether the entity is stored.
 

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -164,7 +164,7 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
         if not isinstance(nodes, (list, tuple)):
             raise TypeError('nodes has to be a list or tuple')
 
-        if any([not isinstance(node, BackendNode) for node in nodes]):
+        if any(not isinstance(node, BackendNode) for node in nodes):
             raise TypeError(f'nodes have to be of type {BackendNode}')
 
     def remove_nodes(self, nodes):
@@ -180,7 +180,7 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
         if not isinstance(nodes, (list, tuple)):
             raise TypeError('nodes has to be a list or tuple')
 
-        if any([not isinstance(node, BackendNode) for node in nodes]):
+        if any(not isinstance(node, BackendNode) for node in nodes):
             raise TypeError(f'nodes have to be of type {BackendNode}')
 
     def __repr__(self):

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -24,7 +24,8 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
     An AiiDA ORM implementation of group of nodes.
     """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def label(self):
         """
         :return: the name of the group as a string
@@ -42,7 +43,8 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
         :raises aiida.common.UniquenessError: if another group of same type and name already exists
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def description(self):
         """
         :return: the description of the group as a string
@@ -55,26 +57,30 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
         :return: the description of the group as a string
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def type_string(self):
         """
         :return: the string defining the type of the group
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def user(self):
         """
         :return: a backend user object, representing the user associated to this group.
         :rtype: :class:`aiida.orm.implementation.BackendUser`
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def id(self):  # pylint: disable=invalid-name
         """
         :return: the principal key (the ID) as an integer, or None if the node was not stored yet
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def uuid(self):
         """
         :return: a string with the uuid
@@ -121,7 +127,8 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
         :return: the integer pk of the node or None if not stored.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_stored(self):
         """Return whether the group is stored.
 
@@ -132,7 +139,8 @@ class BackendGroup(BackendEntity, BackendEntityExtrasMixin):
     def store(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def nodes(self):
         """
         Return a generator/iterator that iterates over all nodes and returns

--- a/aiida/orm/implementation/logs.py
+++ b/aiida/orm/implementation/logs.py
@@ -20,7 +20,8 @@ class BackendLog(BackendEntity):
     Backend Log interface
     """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def uuid(self):
         """
         Get the UUID of the log entry
@@ -29,7 +30,8 @@ class BackendLog(BackendEntity):
         :rtype: uuid.UUID
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def time(self):
         """
         Get the time corresponding to the entry
@@ -38,7 +40,8 @@ class BackendLog(BackendEntity):
         :rtype: :class:`!datetime.datetime`
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def loggername(self):
         """
         The name of the logger that created this entry
@@ -47,7 +50,8 @@ class BackendLog(BackendEntity):
         :rtype: str
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def levelname(self):
         """
         The name of the log level
@@ -56,7 +60,8 @@ class BackendLog(BackendEntity):
         :rtype: str
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def dbnode_id(self):
         """
         Get the id of the object that created the log entry
@@ -65,7 +70,8 @@ class BackendLog(BackendEntity):
         :rtype: int
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def message(self):
         """
         Get the message corresponding to the entry
@@ -74,7 +80,8 @@ class BackendLog(BackendEntity):
         :rtype: str
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def metadata(self):
         """
         Get the metadata corresponding to the entry

--- a/aiida/orm/implementation/nodes.py
+++ b/aiida/orm/implementation/nodes.py
@@ -112,7 +112,8 @@ class BackendNode(BackendEntity, BackendEntityExtrasMixin, BackendEntityAttribut
         """
         self._dbmodel.repository_metadata = value
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def computer(self):
         """Return the computer of this node.
 
@@ -128,7 +129,8 @@ class BackendNode(BackendEntity, BackendEntityExtrasMixin, BackendEntityAttribut
         :param computer: a `BackendComputer`
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def user(self):
         """Return the user of this node.
 

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -50,7 +50,8 @@ class BackendQueryBuilder:
         self.inner_to_outer_schema = dict()
         self.outer_to_inner_schema = dict()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def Node(self):
         """
         Decorated as a property, returns the implementation for DbNode.
@@ -58,49 +59,57 @@ class BackendQueryBuilder:
         a corresponding dummy-model  must be written.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def Link(self):
         """
         A property, decorated with @property. Returns the implementation for the DbLink
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def Computer(self):
         """
         A property, decorated with @property. Returns the implementation for the Computer
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def User(self):
         """
         A property, decorated with @property. Returns the implementation for the User
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def Group(self):
         """
         A property, decorated with @property. Returns the implementation for the Group
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def AuthInfo(self):
         """
         A property, decorated with @property. Returns the implementation for the AuthInfo
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def Comment(self):
         """
         A property, decorated with @property. Returns the implementation for the Comment
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def Log(self):
         """
         A property, decorated with @property. Returns the implementation for the Log
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def table_groups_nodes(self):
         """
         A property, decorated with @property. Returns the implementation for the many-to-many
@@ -128,7 +137,8 @@ class BackendQueryBuilder:
         This is important for the schema having attributes in a different table.
         """
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def get_filter_expr_from_attributes(cls, operator, value, attr_key, column=None, column_name=None, alias=None):  # pylint: disable=too-many-arguments
         """
         Returns an valid SQLAlchemy expression.
@@ -385,7 +395,8 @@ class BackendQueryBuilder:
             self.get_session().close()
             raise
 
-    @abc.abstractstaticmethod
+    @staticmethod
+    @abc.abstractmethod
     def get_table_name(aliased_class):
         """Returns the table name given an Aliased class."""
 

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -362,7 +362,7 @@ class SqlaGroupCollection(BackendGroupCollection):
             _LOGGER.warning("SQLA query doesn't support additional filters, ignoring '%s'", kwargs)
         groups = (session.query(DbGroup).filter(*filters).order_by(DbGroup.id).distinct().all())
 
-        return [SqlaGroup.from_dbmodel(group, self._backend) for group in groups]
+        return [SqlaGroup.from_dbmodel(group, self._backend) for group in groups]  # pylint: disable=no-member
 
     def delete(self, id):  # pylint: disable=redefined-builtin
         session = sa.get_scoped_session()

--- a/aiida/orm/implementation/users.py
+++ b/aiida/orm/implementation/users.py
@@ -42,8 +42,8 @@ class BackendUser(BackendEntity):
         :return: the email address
         """
 
-    @abc.abstractmethod
     @email.setter
+    @abc.abstractmethod
     def email(self, val):
         """
         Set the email address of the user
@@ -61,8 +61,8 @@ class BackendUser(BackendEntity):
         :rtype: str
         """
 
-    @abc.abstractmethod
     @first_name.setter
+    @abc.abstractmethod
     def first_name(self, val):
         """
         Set the user's first name
@@ -80,8 +80,8 @@ class BackendUser(BackendEntity):
         :rtype: str
         """
 
-    @abc.abstractmethod
     @last_name.setter
+    @abc.abstractmethod
     def last_name(self, val):
         """
         Set the user's last name
@@ -100,8 +100,8 @@ class BackendUser(BackendEntity):
         :rtype: str
         """
 
-    @abc.abstractmethod
     @institution.setter
+    @abc.abstractmethod
     def institution(self, val):
         """
         Set the user's institution

--- a/aiida/orm/implementation/users.py
+++ b/aiida/orm/implementation/users.py
@@ -33,7 +33,8 @@ class BackendUser(BackendEntity):
         """
         return None
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def email(self):
         """
         Get the email address of the user
@@ -50,7 +51,8 @@ class BackendUser(BackendEntity):
         :param val: the new email address
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def first_name(self):
         """
         Get the user's first name
@@ -68,7 +70,8 @@ class BackendUser(BackendEntity):
         :param val: the new first name
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def last_name(self):
         """
         Get the user's last name
@@ -87,7 +90,8 @@ class BackendUser(BackendEntity):
         :type val: str
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def institution(self):
         """
         Get the user's institution

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -305,7 +305,7 @@ class BandsData(KpointsData):
         if labels is not None:
             if isinstance(labels, str):
                 the_labels = [str(labels)]
-            elif isinstance(labels, (tuple, list)) and all([isinstance(_, str) for _ in labels]):
+            elif isinstance(labels, (tuple, list)) and all(isinstance(_, str) for _ in labels):
                 the_labels = [str(_) for _ in labels]
             else:
                 raise ValidationError(

--- a/aiida/orm/nodes/data/array/kpoints.py
+++ b/aiida/orm/nodes/data/array/kpoints.py
@@ -152,7 +152,7 @@ class KpointsData(ArrayData):
             raise ValueError('The input must contain an integer index, to map the labels into the kpoint list')
         labels = [str(i[1]) for i in value]
 
-        if any([i > len(self.get_kpoints()) - 1 for i in label_numbers]):
+        if any(i > len(self.get_kpoints()) - 1 for i in label_numbers):
             raise ValueError('Index of label exceeding the list of kpoints')
 
         self.set_attribute('label_numbers', label_numbers)

--- a/aiida/orm/nodes/data/array/projection.py
+++ b/aiida/orm/nodes/data/array/projection.py
@@ -220,7 +220,7 @@ class ProjectionData(OrbitalData, ArrayData):
             required_length, raises exception using array_name if there is
             a failure
             """
-            if not all([isinstance(_, np.ndarray) for _ in array_list]):
+            if not all(isinstance(_, np.ndarray) for _ in array_list):
                 raise exceptions.ValidationError(f'{array_name} was not composed entirely of ndarrays')
             if len(array_list) != orb_length:
                 raise exceptions.ValidationError(f'{array_name} did not have the same length as the list of orbitals')
@@ -285,7 +285,7 @@ class ProjectionData(OrbitalData, ArrayData):
             except IndexError:
                 return exceptions.ValidationError('tags must be a list')
 
-            if not all([isinstance(_, str) for _ in tags]):
+            if not all(isinstance(_, str) for _ in tags):
                 raise exceptions.ValidationError('Tags must set a list of strings')
             self.set_attribute('tags', tags)
 

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -704,7 +704,7 @@ class TrajectoryData(ArrayData):
             point given results in the point being given as a multiples of lattice vectors
             Than take the integer of the rows to find how many times you have to shift
             the point back"""
-            invcell = np.matrix(cell).T.I
+            invcell = np.matrix(cell).T.I  # pylint: disable=no-member
             # point in crystal coordinates
             points_in_crystal = np.dot(invcell, point).tolist()[0]
             #point collapsed into unit cell

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -39,7 +39,7 @@ class TrajectoryData(ArrayData):
 
         if not isinstance(symbols, collections.abc.Iterable):
             raise TypeError('TrajectoryData.symbols must be of type list')
-        if any([not isinstance(i, str) for i in symbols]):
+        if any(not isinstance(i, str) for i in symbols):
             raise TypeError('TrajectoryData.symbols must be a 1d list of strings')
         if not isinstance(positions, numpy.ndarray) or positions.dtype != float:
             raise TypeError('TrajectoryData.positions must be a numpy array of floats')

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -708,7 +708,7 @@ class CifData(SinglefileData):
                 if tag in self.values[datablock].keys():
                     coords.extend(self.values[datablock][tag])
 
-        return not all([coord == '?' for coord in coords])
+        return not all(coord == '?' for coord in coords)
 
     @property
     def has_unknown_species(self):
@@ -733,7 +733,7 @@ class CifData(SinglefileData):
                 return None
 
             species = parse_formula(formula).keys()
-            if any([specie not in known_species for specie in species]):
+            if any(specie not in known_species for specie in species):
                 return True
 
         return False

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -59,6 +59,7 @@ class Data(Node):
 
         :returns: an unstored clone of this Data node
         """
+        # pylint: disable=no-member
         import copy
 
         backend_clone = self.backend_entity.clone()

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -59,13 +59,12 @@ class Data(Node):
 
         :returns: an unstored clone of this Data node
         """
-        # pylint: disable=no-member
         import copy
 
         backend_clone = self.backend_entity.clone()
         clone = self.__class__.from_backend_entity(backend_clone)
-        clone.reset_attributes(copy.deepcopy(self.attributes))
-        clone._repository.clone(self._repository)  # pylint: disable=protected-access
+        clone.reset_attributes(copy.deepcopy(self.attributes))  # pylint: disable=no-member
+        clone._repository.clone(self._repository)  # pylint: disable=no-member,protected-access
 
         return clone
 

--- a/aiida/orm/nodes/data/list.py
+++ b/aiida/orm/nodes/data/list.py
@@ -61,13 +61,13 @@ class List(Data, MutableSequence):
         if not self._using_list_reference():
             self.set_list(data)
 
-    def extend(self, value):  # pylint: disable=arguments-differ
+    def extend(self, value):  # pylint: disable=arguments-renamed
         data = self.get_list()
         data.extend(value)
         if not self._using_list_reference():
             self.set_list(data)
 
-    def insert(self, i, value):  # pylint: disable=arguments-differ
+    def insert(self, i, value):  # pylint: disable=arguments-renamed
         data = self.get_list()
         data.insert(i, value)
         if not self._using_list_reference():

--- a/aiida/orm/nodes/data/orbital.py
+++ b/aiida/orm/nodes/data/orbital.py
@@ -49,8 +49,8 @@ class OrbitalData(Data):
         filter_dict = {}
         filter_dict.update(kwargs)
         # prevents KeyError from occuring
-        orbital_dicts = [x for x in orbital_dicts if all([y in x for y in filter_dict])]
-        orbital_dicts = [x for x in orbital_dicts if all([x[y] == z for y, z in filter_dict.items()])]
+        orbital_dicts = [x for x in orbital_dicts if all(y in x for y in filter_dict)]
+        orbital_dicts = [x for x in orbital_dicts if all(x[y] == z for y, z in filter_dict.items())]
 
         list_of_outputs = []
         for orbital_dict in orbital_dicts:

--- a/aiida/orm/nodes/data/orbital.py
+++ b/aiida/orm/nodes/data/orbital.py
@@ -50,7 +50,7 @@ class OrbitalData(Data):
         filter_dict.update(kwargs)
         # prevents KeyError from occuring
         orbital_dicts = [x for x in orbital_dicts if all([y in x for y in filter_dict])]
-        orbital_dicts = [x for x in orbital_dicts if all([x[y] == filter_dict[y] for y in filter_dict])]
+        orbital_dicts = [x for x in orbital_dicts if all([x[y] == z for y, z in filter_dict.items()])]
 
         list_of_outputs = []
         for orbital_dict in orbital_dicts:

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -741,7 +741,7 @@ class StructureData(Data):
 
         super().__init__(**kwargs)
 
-        if any([ext is not None for ext in [ase, pymatgen, pymatgen_structure, pymatgen_molecule]]):
+        if any(ext is not None for ext in [ase, pymatgen, pymatgen_structure, pymatgen_molecule]):
 
             if ase is not None:
                 self.set_ase(ase)
@@ -1864,7 +1864,7 @@ class StructureData(Data):
         species = []
         additional_kwargs = {}
 
-        if (kwargs.pop('add_spin', False) and any([n.endswith('1') or n.endswith('2') for n in self.get_kind_names()])):
+        if (kwargs.pop('add_spin', False) and any(n.endswith('1') or n.endswith('2') for n in self.get_kind_names())):
             # case when spins are defined -> no partial occupancy allowed
             from pymatgen.core.periodic_table import Specie
             oxidation_state = 0  # now I always set the oxidation_state to zero
@@ -1884,10 +1884,10 @@ class StructureData(Data):
             for site in self.sites:
                 kind = self.get_kind(site.kind_name)
                 species.append(dict(zip(kind.symbols, kind.weights)))
-            if any([
+            if any(
                 create_automatic_kind_name(self.get_kind(name).symbols,
                                            self.get_kind(name).weights) != name for name in self.get_site_kindnames()
-            ]):
+            ):
                 # add "kind_name" as a properties to each site, whenever
                 # the kind_name cannot be automatically obtained from the symbols
                 additional_kwargs['site_properties'] = {'kind_name': self.get_site_kindnames()}

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -2145,18 +2145,14 @@ class Kind:
             return (False, 'Different length of symbols list')
 
         # Check list of symbols
-        for i in range(len(self.symbols)):
-            if self.symbols[i] != other_kind.symbols[i]:
-                return (
-                    False, f'Symbol at position {i + 1:d} are different ({self.symbols[i]} vs. {other_kind.symbols[i]})'
-                )
+        for i, symbol in enumerate(self.symbols):
+            if symbol != other_kind.symbols[i]:
+                return (False, f'Symbol at position {i + 1:d} are different ({symbol} vs. {other_kind.symbols[i]})')
         # Check weights (assuming length of weights and of symbols have same
         # length, which should be always true
-        for i in range(len(self.weights)):
-            if self.weights[i] != other_kind.weights[i]:
-                return (
-                    False, f'Weight at position {i + 1:d} are different ({self.weights[i]} vs. {other_kind.weights[i]})'
-                )
+        for i, weight in enumerate(self.weights):
+            if weight != other_kind.weights[i]:
+                return (False, f'Weight at position {i + 1:d} are different ({weight} vs. {other_kind.weights[i]})')
         # Check masses
         if abs(self.mass - other_kind.mass) > _MASS_THRESHOLD:
             return (False, f'Masses are different ({self.mass} vs. {other_kind.mass})')

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -510,7 +510,7 @@ class Node(Entity, NodeRepositoryMixin, EntityAttributesMixin, EntityExtrasMixin
         if not isinstance(link_type, tuple):
             link_type = (link_type,)
 
-        if link_type and not all([isinstance(t, LinkType) for t in link_type]):
+        if link_type and not all(isinstance(t, LinkType) for t in link_type):
             raise TypeError(f'link_type should be a LinkType or tuple of LinkType: got {link_type}')
 
         node_class = node_class or Node

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -1923,7 +1923,7 @@ class QueryBuilder:
                 # if so, I instruct the recursive function to build the path on the fly!
                 # The default is False, cause it's super expensive
                 expand_path = ((self._filters[edge_tag].get('path', None) is not None) or
-                               any(['path' in d.keys() for d in self._projections[edge_tag]]))
+                               any('path' in d.keys() for d in self._projections[edge_tag]))
                 aliased_edge = connection_func(
                     toconnectwith, alias, isouterjoin=isouterjoin, filter_dict=filter_dict, expand_path=expand_path
                 )

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module with `OrmEntityLoader` and its sub classes that simplify loading entities through their identifiers."""
-from abc import abstractclassmethod
+from abc import abstractmethod
 from enum import Enum
 
 from aiida.common.exceptions import MultipleObjectsError, NotExistent
@@ -261,7 +261,8 @@ class OrmEntityLoader:
         """
         raise NotImplementedError
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def _get_query_builder_label_identifier(cls, identifier, classes, operator='==', project='*'):
         """
         Return the query builder instance that attempts to map the identifier onto an entity of the orm class,

--- a/aiida/repository/backend/abstract.py
+++ b/aiida/repository/backend/abstract.py
@@ -28,7 +28,8 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
     and persistent. Persisting the key or mapping it onto a virtual file hierarchy is again up to the client upstream.
     """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def uuid(self) -> typing.Optional[str]:
         """Return the unique identifier of the repository."""
 
@@ -39,7 +40,8 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :param kwargs: parameters for the initialisation.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_initialised(self) -> bool:
         """Return whether the repository has been initialised."""
 

--- a/aiida/repository/backend/abstract.py
+++ b/aiida/repository/backend/abstract.py
@@ -111,7 +111,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
-        with self.open(key) as handle:
+        with self.open(key) as handle:  # pylint: disable=not-context-manager
             return handle.read()
 
     def get_object_hash(self, key: str) -> str:
@@ -125,7 +125,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
-        with self.open(key) as handle:
+        with self.open(key) as handle:  # pylint: disable=not-context-manager
             return chunked_file_hash(handle, hashlib.sha256)
 
     def delete_object(self, key: str):

--- a/aiida/repository/common.py
+++ b/aiida/repository/common.py
@@ -50,7 +50,7 @@ class File():
         if key is not None and not isinstance(key, str):
             raise TypeError('key should be `None` or a string.')
 
-        if objects is not None and any([not isinstance(obj, self.__class__) for obj in objects.values()]):
+        if objects is not None and any(not isinstance(obj, self.__class__) for obj in objects.values()):
             raise TypeError('objects should be `None` or a dictionary of `File` instances.')
 
         if file_type == FileType.DIRECTORY and key is not None:
@@ -122,9 +122,9 @@ class File():
         if not isinstance(other, self.__class__):
             return False
 
-        equal_attributes = all([getattr(self, key) == getattr(other, key) for key in ['name', 'file_type', 'key']])
+        equal_attributes = all(getattr(self, key) == getattr(other, key) for key in ['name', 'file_type', 'key'])
         equal_object_keys = sorted(self.objects) == sorted(other.objects)
-        equal_objects = equal_object_keys and all([obj == other.objects[key] for key, obj in self.objects.items()])
+        equal_objects = equal_object_keys and all(obj == other.objects[key] for key, obj in self.objects.items())
 
         return equal_attributes and equal_objects
 

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -62,7 +62,8 @@ class JobResource(DefaultFieldsAttributeDict, metaclass=abc.ABCMeta):
     """
     _default_fields = tuple()
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def validate_resources(cls, **kwargs):
         """Validate the resources against the job resource class of this scheduler.
 
@@ -76,7 +77,8 @@ class JobResource(DefaultFieldsAttributeDict, metaclass=abc.ABCMeta):
         """Return a list of valid keys to be passed to the constructor."""
         return list(cls._default_fields)
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
 

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -151,6 +151,15 @@ class LsfJobResource(JobResource):
         """
         return False
 
+    @classmethod
+    def validate_resources(cls, **kwargs):
+        """Validate the resources against the job resource class of this scheduler.
+
+        :param kwargs: dictionary of values to define the job resources
+        :return: attribute dictionary with the parsed parameters populated
+        :raises ValueError: if the resources are invalid or incomplete
+        """
+
 
 class LsfScheduler(aiida.schedulers.Scheduler):
     """

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -114,7 +114,7 @@ class LsfJobResource(JobResource):
         :raises ValueError: if the resources are invalid or incomplete
         """
         from aiida.common.exceptions import ConfigurationError
-        
+
         resources = AttributeDict()
 
         resources.parallel_env = kwargs.pop('parallel_env', '')
@@ -136,9 +136,9 @@ class LsfJobResource(JobResource):
 
         if resources.tot_num_mpiprocs <= 0:
             raise ValueError('tot_num_mpiprocs must be >= 1')
-            
+
         return resources
-  
+
     def __init__(self, **kwargs):
         """
         Initialize the job resources from the passed arguments (the valid keys can be

--- a/aiida/schedulers/plugins/sge.py
+++ b/aiida/schedulers/plugins/sge.py
@@ -323,7 +323,7 @@ class SgeScheduler(aiida.schedulers.Scheduler):
             raise SchedulerError('Error during joblist retrieval, no stdout produced')
 
         try:
-            first_child = xmldata.firstChild
+            first_child = xmldata.firstChild  # pylint: disable=no-member
             second_childs = first_child.childNodes
             tag_names_sec = [elem.tagName for elem in second_childs \
                              if elem.nodeType == 1]

--- a/aiida/tools/data/array/kpoints/legacy.py
+++ b/aiida/tools/data/array/kpoints/legacy.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tool to automatically determine k-points for a given structure using legacy custom implementation."""
-# pylint: disable=too-many-lines,fixme,invalid-name,too-many-arguments,too-many-locals,eval-used
+# pylint: disable=too-many-lines,fixme,invalid-name,too-many-arguments,too-many-locals,eval-used,use-a-generator
 import numpy
 
 _default_epsilon_length = 1e-5

--- a/aiida/tools/data/array/kpoints/legacy.py
+++ b/aiida/tools/data/array/kpoints/legacy.py
@@ -1950,17 +1950,15 @@ def get_kpoints_path(
         return [x[int(p)] for p in permutation]
 
     the_special_points = {}
-    for key in special_points:
+    for key, value in special_points.items():
         # NOTE: this originally returned the inverse of the permutation, but was later changed to permutation
-        the_special_points[key] = permute(special_points[key], permutation)
+        the_special_points[key] = permute(value, permutation)
 
     # output crystal or cartesian
     if cartesian:
         the_abs_special_points = {}
-        for key in the_special_points:
-            the_abs_special_points[key] = change_reference(
-                reciprocal_cell, numpy.array(the_special_points[key]), to_cartesian=True
-            )
+        for key, value in the_special_points.items():
+            the_abs_special_points[key] = change_reference(reciprocal_cell, numpy.array(value), to_cartesian=True)
 
         return the_abs_special_points, path, bravais_info
 

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -162,6 +162,7 @@ def refine_inline(node):
 
     .. note:: can be used as inline calculation.
     """
+    # pylint: disable=unsubscriptable-object
     from aiida.orm.nodes.data.structure import StructureData, ase_refine_cell
 
     if len(node.values.keys()) > 1:

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -162,7 +162,6 @@ def refine_inline(node):
 
     .. note:: can be used as inline calculation.
     """
-    # pylint: disable=unsubscriptable-object
     from aiida.orm.nodes.data.structure import StructureData, ase_refine_cell
 
     if len(node.values.keys()) > 1:
@@ -192,15 +191,15 @@ def refine_inline(node):
 
     # Remove all existing symmetry tags before overwriting:
     for tag in symmetry_tags:
-        cif.values[name].RemoveCifItem(tag)
+        cif.values[name].RemoveCifItem(tag)  # pylint: disable=unsubscriptable-object
 
-    cif.values[name]['_symmetry_space_group_name_H-M'] = symmetry['hm']
-    cif.values[name]['_symmetry_space_group_name_Hall'] = symmetry['hall']
-    cif.values[name]['_symmetry_Int_Tables_number'] = symmetry['tables']
-    cif.values[name]['_symmetry_equiv_pos_as_xyz'] = \
-        [symop_string_from_symop_matrix_tr(symmetry['rotations'][i],
-                                           symmetry['translations'][i])
-         for i in range(len(symmetry['rotations']))]
+    cif.values[name]['_symmetry_space_group_name_H-M'] = symmetry['hm']  # pylint: disable=unsubscriptable-object
+    cif.values[name]['_symmetry_space_group_name_Hall'] = symmetry['hall']  # pylint: disable=unsubscriptable-object
+    cif.values[name]['_symmetry_Int_Tables_number'] = symmetry['tables']  # pylint: disable=unsubscriptable-object
+    cif.values[name]['_symmetry_equiv_pos_as_xyz'] = [  # pylint: disable=unsubscriptable-object
+        symop_string_from_symop_matrix_tr(symmetry['rotations'][i], symmetry['translations'][i])
+        for i in range(len(symmetry['rotations']))
+    ]
 
     # Summary formula has to be calculated from non-reduced set of atoms.
     cif.values[name]['_chemical_formula_sum'] = \

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -202,8 +202,9 @@ def refine_inline(node):
     ]
 
     # Summary formula has to be calculated from non-reduced set of atoms.
-    cif.values[name]['_chemical_formula_sum'] = \
+    cif.values[name]['_chemical_formula_sum'] = (  # pylint: disable=unsubscriptable-object
         StructureData(ase=original_atoms).get_formula(mode='hill', separator=' ')
+    )
 
     # If the number of reduced atoms multiplies the number of non-reduced
     # atoms, the new Z value can be calculated.
@@ -211,6 +212,6 @@ def refine_inline(node):
         old_Z = node.values[name]['_cell_formula_units_Z']
         if len(original_atoms) % len(refined_atoms):
             new_Z = old_Z * len(original_atoms) // len(refined_atoms)
-            cif.values[name]['_cell_formula_units_Z'] = new_Z
+            cif.values[name]['_cell_formula_units_Z'] = new_Z  # pylint: disable=unsubscriptable-object
 
     return {'cif': cif}

--- a/aiida/tools/data/orbital/realhydrogen.py
+++ b/aiida/tools/data/orbital/realhydrogen.py
@@ -351,8 +351,8 @@ class RealhydrogenOrbital(Orbital):
         angular_momentum=1 and magnetic_number=1 will return "Px"
         """
         orbital_name = [
-            x for x in CONVERSION_DICT
-            if any([CONVERSION_DICT[x][y]['angular_momentum'] == angular_momentum for y in CONVERSION_DICT[x]])
+            orbital for orbital, data in CONVERSION_DICT.items()
+            if any([values['angular_momentum'] == angular_momentum for values in data.values()])
         ]
         if not orbital_name:
             raise ValueError(f'No orbital name corresponding to the angular_momentum {angular_momentum} could be found')
@@ -379,7 +379,10 @@ class RealhydrogenOrbital(Orbital):
         of quantum numbers, the ones associated with "Px"
         """
         name = name.upper()
-        list_of_dicts = [CONVERSION_DICT[x][y] for x in CONVERSION_DICT for y in CONVERSION_DICT[x] if name in (y, x)]
+        list_of_dicts = [
+            subdata for orbital, data in CONVERSION_DICT.items() for suborbital, subdata in data.items()
+            if name in (suborbital, orbital)
+        ]
         if not list_of_dicts:
             raise ValueError('Invalid choice of projection name')
         return list_of_dicts

--- a/aiida/tools/data/orbital/realhydrogen.py
+++ b/aiida/tools/data/orbital/realhydrogen.py
@@ -352,7 +352,7 @@ class RealhydrogenOrbital(Orbital):
         """
         orbital_name = [
             orbital for orbital, data in CONVERSION_DICT.items()
-            if any([values['angular_momentum'] == angular_momentum for values in data.values()])
+            if any(values['angular_momentum'] == angular_momentum for values in data.values())
         ]
         if not orbital_name:
             raise ValueError(f'No orbital name corresponding to the angular_momentum {angular_momentum} could be found')

--- a/aiida/tools/data/structure.py
+++ b/aiida/tools/data/structure.py
@@ -41,6 +41,7 @@ def _get_cif_ase_inline(struct, parameters):
     cif = CifData(ase=struct.get_ase(**kwargs))
     formula = struct.get_formula(mode='hill', separator=' ')
     for i in cif.values.keys():
+        # pylint: disable=unsubscriptable-object
         cif.values[i]['_symmetry_space_group_name_H-M'] = 'P 1'
         cif.values[i]['_symmetry_space_group_name_Hall'] = 'P 1'
         cif.values[i]['_symmetry_Int_Tables_number'] = 1

--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -223,7 +223,8 @@ class DbEntry:
             from urllib.request import urlopen
             from hashlib import md5
 
-            self._contents = urlopen(self.source['uri']).read().decode('utf-8')
+            with urlopen(self.source['uri']) as handle:
+                self._contents = handle.read().decode('utf-8')
             self.source['source_md5'] = md5(self._contents.encode('utf-8')).hexdigest()
         return self._contents
 

--- a/aiida/tools/dbimporters/plugins/icsd.py
+++ b/aiida/tools/dbimporters/plugins/icsd.py
@@ -586,9 +586,10 @@ class IcsdSearchResults(DbSearchResults):  # pylint: disable=abstract-method,too
             from urllib.request import urlopen
             import re
 
-            self.html = urlopen(
+            with urlopen(
                 self.db_parameters['server'] + self.db_parameters['db'] + '/' + self.query.format(str(self.page))
-            ).read()
+            ) as handle:
+                self.html = handle.read()
 
             self.soup = BeautifulSoup(self.html)
 
@@ -669,7 +670,8 @@ class IcsdEntry(CifEntry):  # pylint: disable=abstract-method
 
         if self._contents is None:
             from hashlib import md5
-            self._contents = urllib.request.urlopen(self.source['uri']).read()
+            with urllib.request.urlopen(self.source['uri']) as handle:
+                self._contents = handle.read()
             self._contents = self._contents.decode('iso-8859-1').encode('utf8')
             self.source['source_md5'] = md5(self._contents).hexdigest()
 

--- a/aiida/tools/dbimporters/plugins/mpod.py
+++ b/aiida/tools/dbimporters/plugins/mpod.py
@@ -54,10 +54,10 @@ class MpodDbImporter(DbImporter):
             elements = [elements]
 
         get_parts = []
-        for key in self._keywords:
+        for key, value in self._keywords.items():
             if key in kwargs:
                 values = kwargs.pop(key)
-                get_parts.append(self._keywords[key][1](self, self._keywords[key][0], key, values))
+                get_parts.append(value[1](self, value[0], key, values))
 
         if kwargs:
             raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")

--- a/aiida/tools/dbimporters/plugins/mpod.py
+++ b/aiida/tools/dbimporters/plugins/mpod.py
@@ -85,7 +85,8 @@ class MpodDbImporter(DbImporter):
         query_statements = self.query_get(**kwargs)
         results = None
         for query in query_statements:
-            response = urlopen(query).read()
+            with urlopen(query) as handle:
+                response = handle.read()
             this_results = re.findall(r'/datafiles/(\d+)\.mpod', response)
             if results is None:
                 results = this_results

--- a/aiida/tools/dbimporters/plugins/nninc.py
+++ b/aiida/tools/dbimporters/plugins/nninc.py
@@ -70,7 +70,8 @@ class NnincDbImporter(DbImporter):
         import re
 
         query = self.query_get(**kwargs)
-        response = urlopen(query).read()
+        with urlopen(query) as handle:
+            response = handle.read()
         results = re.findall(r'psp_files/([^\']+)\.UPF', response)
 
         elements = kwargs.get('element', None)

--- a/aiida/tools/dbimporters/plugins/nninc.py
+++ b/aiida/tools/dbimporters/plugins/nninc.py
@@ -47,11 +47,11 @@ class NnincDbImporter(DbImporter):
         :return: a string with HTTP GET statement.
         """
         get_parts = []
-        for key in self._keywords:
+        for key, value in self._keywords.items():
             if key in kwargs:
                 values = kwargs.pop(key)
-                if self._keywords[key][1] is not None:
-                    get_parts.append(self._keywords[key][1](self, self._keywords[key][0], key, values))
+                if value[1] is not None:
+                    get_parts.append(value[1](self, value[0], key, values))
 
         if kwargs:
             raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")

--- a/aiida/tools/dbimporters/plugins/oqmd.py
+++ b/aiida/tools/dbimporters/plugins/oqmd.py
@@ -57,12 +57,14 @@ class OqmdDbImporter(DbImporter):
         import re
 
         query_statement = self.query_get(**kwargs)
-        response = urlopen(query_statement).read()
+        with urlopen(query_statement) as handle:
+            response = handle.read()
         entries = re.findall(r'(/materials/entry/\d+)', response)
 
         results = []
         for entry in entries:
-            response = urlopen(f'{self._query_url}{entry}').read()
+            with urlopen(f'{self._query_url}{entry}') as handle:
+                response = handle.read()
             structures = re.findall(r'/materials/export/conventional/cif/(\d+)', response)
             for struct in structures:
                 results.append({'id': struct})

--- a/aiida/tools/dbimporters/plugins/pcod.py
+++ b/aiida/tools/dbimporters/plugins/pcod.py
@@ -45,12 +45,12 @@ class PcodDbImporter(CodDbImporter):
         :return: string containing a SQL statement.
         """
         sql_parts = []
-        for key in self._keywords:
+        for key, value in self._keywords.items():
             if key in kwargs:
                 values = kwargs.pop(key)
                 if not isinstance(values, list):
                     values = [values]
-                sql_parts.append(f'({self._keywords[key][1](self, self._keywords[key][0], key, values)})')
+                sql_parts.append(f'({value[1](self, value[0], key, values)})')
         if kwargs:
             raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
 

--- a/aiida/tools/graph/age_entities.py
+++ b/aiida/tools/graph/age_entities.py
@@ -414,8 +414,8 @@ class Basket():
 
     def __add__(self, other):
         new_dict = {}
-        for key in self._dict:
-            new_dict[key] = self._dict[key] + other.dict[key]
+        for key, value in self._dict.items():
+            new_dict[key] = value + other.dict[key]
         return Basket(**new_dict)
 
     def __iadd__(self, other):

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -230,7 +230,7 @@ def traverse_graph(
     if not isinstance(starting_pks, Iterable):  # pylint: disable=isinstance-second-argument-not-valid-type
         raise TypeError(f'starting_pks must be an iterable\ninstead, it is {type(starting_pks)}')
 
-    if any([not isinstance(pk, int) for pk in starting_pks]):
+    if any(not isinstance(pk, int) for pk in starting_pks):
         raise TypeError(f'one of the starting_pks is not of type int:\n {starting_pks}')
     operational_set = set(starting_pks)
 

--- a/aiida/tools/importexport/common/utils.py
+++ b/aiida/tools/importexport/common/utils.py
@@ -85,9 +85,9 @@ def get_valid_import_links(url):
     Open the given URL, parse the HTML and return a list of valid links where
     the link file has a .aiida extension.
     """
-    request = urllib.request.urlopen(url)
-    parser = HTMLGetLinksParser(filter_extension='aiida')
-    parser.feed(request.read().decode('utf8'))
+    with urllib.request.urlopen(url) as request:
+        parser = HTMLGetLinksParser(filter_extension='aiida')
+        parser.feed(request.read().decode('utf8'))
 
     return_urls = []
 

--- a/aiida/tools/importexport/dbimport/backends/django.py
+++ b/aiida/tools/importexport/dbimport/backends/django.py
@@ -458,7 +458,7 @@ def _store_entity_data(
                     import_entry_uuid = str(node.uuid)
                     import_entry_pk = import_existing_entry_pks[import_entry_uuid]
 
-                    pbar_node_base_str = f"{pbar_base_str}UUID={import_entry_uuid.split('-')[0]} - "
+                    pbar_node_base_str = f"{pbar_base_str}UUID={import_entry_uuid.split('-', maxsplit=1)[0]} - "
                     progress.set_description_str(f'{pbar_node_base_str}Extras', refresh=False)
                     progress.update()
 

--- a/aiida/tools/importexport/dbimport/backends/sqla.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla.py
@@ -523,7 +523,7 @@ def _store_entity_data(
                     import_entry_uuid = str(node.uuid)
                     import_entry_pk = import_existing_entry_pks[import_entry_uuid]
 
-                    pbar_node_base_str = f"{pbar_base_str}UUID={import_entry_uuid.split('-')[0]} - "
+                    pbar_node_base_str = f"{pbar_base_str}UUID={import_entry_uuid.split('-', maxsplit=1)[0]} - "
                     progress.set_description_str(f'{pbar_node_base_str}Extras', refresh=False)
                     progress.update()
 

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -510,7 +510,7 @@ class Graph:
             return None
         if isinstance(link_types, str):
             link_types = [link_types]
-        link_types = tuple([getattr(LinkType, l.upper()) if isinstance(l, str) else l for l in link_types])
+        link_types = tuple(getattr(LinkType, l.upper()) if isinstance(l, str) else l for l in link_types)
         return link_types
 
     def add_incoming(self, node, link_types=(), annotate_links=None, return_pks=True):

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -747,7 +747,7 @@ class LocalTransport(Transport):
 
         command = bash_commmand + escape_for_bash(command)
 
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # pylint: disable=consider-using-with
             command,
             shell=True,
             stdin=subprocess.PIPE,

--- a/aiida/transports/util.py
+++ b/aiida/transports/util.py
@@ -41,7 +41,7 @@ class _DetachedProxyCommand(ProxyCommand):
         from shlex import split as shlsplit
 
         self.cmd = shlsplit(command_line)
-        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, start_new_session=True)
+        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, start_new_session=True)  # pylint: disable=consider-using-with
         self.timeout = None
 
     def close(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ disable = [
     # added in pylint v2.9.4
     "deprecated-decorator",
     "raise-missing-from",
-    "use-a-generator",
-    "use-maxsplit-arg"
+    "use-a-generator"
 ]
 
 [tool.pylint.basic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ disable = [
     "too-many-arguments",
     "too-many-instance-attributes",
     # added in pylint v2.9.4
-    "consider-using-with",
     "deprecated-decorator",
     "raise-missing-from",
     "use-a-generator",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.master]
 load-plugins = "pylint_django"
+# this currently fails with aiida.common.exceptions.ProfileConfigurationError: no profile has been loaded
+# we woud need a static settings module to use this
+# django-settings-module = "aiida.backends.djsite.settings"
 
 [tool.pylint.format]
 max-line-length = 120
@@ -13,7 +16,7 @@ disable = [
     "bad-continuation",
     "bad-option-value",
     "cyclic-import",
-    "django-not-available",
+    "django-not-configured",
     "duplicate-code",
     "import-outside-toplevel",
     "inconsistent-return-statements",
@@ -24,7 +27,12 @@ disable = [
     "too-many-ancestors",
     "too-many-arguments",
     "too-many-instance-attributes",
-    "useless-suppression",
+    # added in pylint v2.9.4
+    "consider-using-with",
+    "deprecated-decorator",
+    "raise-missing-from",
+    "use-a-generator",
+    "use-maxsplit-arg"
 ]
 
 [tool.pylint.basic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ disable = [
     "too-many-instance-attributes",
     # added in pylint v2.9.4
     "deprecated-decorator",
-    "raise-missing-from",
-    "use-a-generator"
+    "raise-missing-from"
 ]
 
 [tool.pylint.basic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,11 @@ disable = [
     "locally-disabled",
     "logging-fstring-interpolation",
     "no-else-raise",
+    "raise-missing-from",
     "too-few-public-methods",
     "too-many-ancestors",
     "too-many-arguments",
-    "too-many-instance-attributes",
-    # added in pylint v2.9.4
-    "deprecated-decorator",
-    "raise-missing-from"
+    "too-many-instance-attributes"
 ]
 
 [tool.pylint.basic]

--- a/setup.json
+++ b/setup.json
@@ -95,12 +95,11 @@
             "notebook~=6.1,>=6.1.5"
         ],
         "pre-commit": [
-            "astroid<2.5",
             "mypy==0.910",
             "packaging==20.3",
             "pre-commit~=2.2",
-            "pylint~=2.5.0",
-            "pylint-django>=2.0,<2.4.0"
+            "pylint~=2.9.4",
+            "pylint-django"
         ],
         "tests": [
             "aiida-export-migration-tests==0.9.0",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 
     setup(
         packages=find_packages(include=['aiida', 'aiida.*']),
-        long_description=open(os.path.join(THIS_FOLDER, 'README.md')).read(),
+        long_description=open(os.path.join(THIS_FOLDER, 'README.md')).read(),  # pylint: disable=consider-using-with
         long_description_content_type='text/markdown',
         **SETUP_JSON
     )

--- a/tests/backends/aiida_sqlalchemy/test_migrations.py
+++ b/tests/backends/aiida_sqlalchemy/test_migrations.py
@@ -961,9 +961,9 @@ class TestDbLogMigrationBackward(TestBackwardMigrationsSQLA):
             try:
                 session = Session(connection.engine)
 
-                for log_pk in self.to_check:
+                for log_pk, to_check_value in self.to_check.items():
                     log_entry = session.query(DbLog).filter(DbLog.id == log_pk).one()
-                    log_dbnode_id, node_type = self.to_check[log_pk]
+                    log_dbnode_id, node_type = to_check_value
 
                     self.assertEqual(
                         log_dbnode_id, log_entry.objpk,

--- a/tests/cmdline/commands/test_archive_export.py
+++ b/tests/cmdline/commands/test_archive_export.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=consider-using-with
 """Tests for `verdi export`."""
 import errno
 import os

--- a/tests/cmdline/commands/test_archive_export.py
+++ b/tests/cmdline/commands/test_archive_export.py
@@ -145,7 +145,7 @@ class TestVerdiExport(AiidaTestCase):
     def test_migrate_versions_old(self):
         """Migrating archives with a version older than the current should work."""
         archives = []
-        for version in range(1, int(EXPORT_VERSION.split('.')[-1]) - 1):
+        for version in range(1, int(EXPORT_VERSION.rsplit('.', maxsplit=1)[-1]) - 1):
             archives.append(f'export_v0.{version}_simple.aiida')
 
         for archive in archives:
@@ -271,7 +271,7 @@ class TestVerdiExport(AiidaTestCase):
     def test_inspect(self):
         """Test the functionality of `verdi export inspect`."""
         archives = []
-        for version in range(1, int(EXPORT_VERSION.split('.')[-1])):
+        for version in range(1, int(EXPORT_VERSION.rsplit('.', maxsplit=1)[-1])):
             archives.append((f'export_v0.{version}_simple.aiida', f'0.{version}'))
 
         for archive, version_number in archives:

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -154,7 +154,7 @@ class TestVerdiImport(AiidaTestCase):
             result = self.cli_runner.invoke(cmd_archive.import_archive, options)
             self.assertIsNone(result.exception, result.output)
             self.assertTrue(
-                any([re.fullmatch(r'Comment rules[\s]*{}'.format(mode), line) for line in result.output.split('\n')]),
+                any(re.fullmatch(r'Comment rules[\s]*{}'.format(mode), line) for line in result.output.split('\n')),
                 msg=f'Mode: {mode}. Output: {result.output}'
             )
             self.assertEqual(result.exit_code, 0, result.output)

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -164,7 +164,7 @@ class TestVerdiImport(AiidaTestCase):
         Expected behavior: Automatically migrate to newest version and import correctly.
         """
         archives = []
-        for version in range(1, int(EXPORT_VERSION.split('.')[-1]) - 1):
+        for version in range(1, int(EXPORT_VERSION.rsplit('.', maxsplit=1)[-1]) - 1):
             archives.append((f'export_v0.{version}_simple.aiida', f'0.{version}'))
 
         for archive, version in archives:

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -315,7 +315,7 @@ def test_list_worker_slot_warning(run_cli_command, monkeypatch):
     # Default cmd should not throw the warning as we are below the limit
     result = run_cli_command(cmd_process.process_list)
     warning_phrase = 'of the available daemon worker slots have been used!'
-    assert all([warning_phrase not in line for line in result.output_lines])
+    assert all(warning_phrase not in line for line in result.output_lines)
 
     # Add one more running node to put us over the limit
     calc = WorkFunctionNode()
@@ -325,7 +325,7 @@ def test_list_worker_slot_warning(run_cli_command, monkeypatch):
     # Now the warning should fire
     result = run_cli_command(cmd_process.process_list)
     warning_phrase = '% of the available daemon worker slots have been used!'
-    assert any([warning_phrase in line for line in result.output_lines])
+    assert any(warning_phrase in line for line in result.output_lines)
 
 
 class TestVerdiProcessCallRoot(AiidaTestCase):

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -36,9 +36,9 @@ class TestVerdiUserCommand(AiidaTestCase):
         super().setUp()
 
         created, user = orm.User.objects.get_or_create(email=USER_1['email'])
-        for key, _ in USER_1.items():
+        for key, value in USER_1.items():
             if key != 'email':
-                setattr(user, key, USER_1[key])
+                setattr(user, key, value)
         if created:
             orm.User(**USER_1).store()
         self.cli_runner = CliRunner()

--- a/tests/common/test_timezone.py
+++ b/tests/common/test_timezone.py
@@ -13,7 +13,7 @@ import datetime
 import unittest
 import time
 
-import aiida.common.timezone as timezone
+from aiida.common import timezone
 
 
 class TimezoneTest(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def non_interactive_editor(request):
         else:
             environ = None
         try:
-            process = subprocess.Popen(
+            process = subprocess.Popen(  # pylint: disable=consider-using-with
                 f'{editor} {filename}',  # This is the line that we change removing `shlex_quote`
                 env=environ,
                 shell=True,
@@ -354,7 +354,7 @@ def with_daemon():
     env['PYTHONPATH'] = ':'.join(sys.path)
 
     profile = get_config().current_profile
-    daemon = subprocess.Popen(
+    daemon = subprocess.Popen(  # pylint: disable=consider-using-with
         DaemonClient(profile).cmd_string.split(),
         stderr=sys.stderr,
         stdout=sys.stdout,

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -1014,12 +1014,12 @@ class TestWorkchain(AiidaTestCase):
         wc = ExitCodeWorkChain()
 
         # The exit code can be gotten by calling it with the status or label, as well as using attribute dereferencing
-        self.assertEqual(wc.exit_codes(status).status, status)
-        self.assertEqual(wc.exit_codes(label).status, status)
-        self.assertEqual(wc.exit_codes.SOME_EXIT_CODE.status, status)
+        self.assertEqual(wc.exit_codes(status).status, status)  # pylint: disable=too-many-function-args
+        self.assertEqual(wc.exit_codes(label).status, status)  # pylint: disable=too-many-function-args
+        self.assertEqual(wc.exit_codes.SOME_EXIT_CODE.status, status)  # pylint: disable=no-member
 
         with self.assertRaises(AttributeError):
-            wc.exit_codes.NON_EXISTENT_ERROR  # pylint: disable=pointless-statement
+            wc.exit_codes.NON_EXISTENT_ERROR  # pylint: disable=no-member,pointless-statement
 
         self.assertEqual(ExitCodeWorkChain.exit_codes.SOME_EXIT_CODE.status, status)  # pylint: disable=no-member
         self.assertEqual(ExitCodeWorkChain.exit_codes.SOME_EXIT_CODE.message, message)  # pylint: disable=no-member

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=attribute-defined-outside-init,no-self-use,too-many-public-methods
+# pylint: disable=attribute-defined-outside-init,no-member,no-self-use,too-many-public-methods
 """Tests for the Node ORM class."""
 import logging
 import os

--- a/tests/orm/node/test_repository.py
+++ b/tests/orm/node/test_repository.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name,protected-access
+# pylint: disable=redefined-outer-name,protected-access,no-member
 """Tests for the :mod:`aiida.orm.nodes.repository` module."""
 import io
 import pathlib

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -81,8 +81,8 @@ class TestGroups(AiidaTestCase):
         nodes_sliced = group.nodes[1:3]
         self.assertTrue(isinstance(nodes_sliced, list))
         self.assertEqual(len(nodes_sliced), 2)
-        self.assertTrue(all([isinstance(node, orm.Data) for node in nodes_sliced]))
-        self.assertTrue(all([node.uuid in set(node.uuid for node in nodes) for node in nodes_sliced]))
+        self.assertTrue(all(isinstance(node, orm.Data) for node in nodes_sliced))
+        self.assertTrue(all(node.uuid in set(node.uuid for node in nodes) for node in nodes_sliced))
 
     def test_description(self):
         """Test the update of the description both for stored and unstored groups."""

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -281,17 +281,17 @@ def test_list_objects(repository, generate_directory):
 
     objects = repository.list_objects()
     assert len(objects) == 3
-    assert all([isinstance(obj, File) for obj in objects])
+    assert all(isinstance(obj, File) for obj in objects)
     assert [obj.name for obj in objects] == ['file_a', 'path', 'relative']
 
     objects = repository.list_objects('path')
     assert len(objects) == 1
-    assert all([isinstance(obj, File) for obj in objects])
+    assert all(isinstance(obj, File) for obj in objects)
     assert [obj.name for obj in objects] == ['sub']
 
     objects = repository.list_objects('relative')
     assert len(objects) == 1
-    assert all([isinstance(obj, File) for obj in objects])
+    assert all(isinstance(obj, File) for obj in objects)
     assert [obj.name for obj in objects] == ['file_b']
 
 

--- a/tests/schedulers/test_pbspro.py
+++ b/tests/schedulers/test_pbspro.py
@@ -945,7 +945,7 @@ class TestSubmitScript(unittest.TestCase):
             submit_script_text = scheduler.get_submit_script(job_tmpl)
 
             # This tests if the implementation correctly chooses the default:
-            self.assertEqual(submit_script_text.split('\n')[0], expected_first_line)
+            self.assertEqual(submit_script_text.split('\n', maxsplit=1)[0], expected_first_line)
 
     def test_submit_script_with_num_cores_per_machine(self):
         """

--- a/tests/schedulers/test_slurm.py
+++ b/tests/schedulers/test_slurm.py
@@ -244,7 +244,7 @@ class TestSubmitScript:
             submit_script_text = scheduler.get_submit_script(job_tmpl)
 
             # This tests if the implementation correctly chooses the default:
-            assert submit_script_text.split('\n')[0] == expected_first_line
+            assert submit_script_text.split('\n', maxsplit=1)[0] == expected_first_line
 
     def test_submit_script_with_num_cores_per_machine(self):  # pylint: disable=invalid-name
         """

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,invalid-name
+# pylint: disable=too-many-lines,invalid-name,no-member
 """Tests for specific subclasses of Data."""
 import os
 import tempfile

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=too-many-lines,invalid-name,protected-access
 # pylint: disable=missing-docstring,too-many-locals,too-many-statements
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods,no-member
 import copy
 import io
 import tempfile

--- a/tests/tools/dbimporters/test_icsd.py
+++ b/tests/tools/dbimporters/test_icsd.py
@@ -74,7 +74,8 @@ class TestIcsd(AiidaTestCase):
         """
         Test Icsd intranet webinterface
         """
-        urllib.request.urlopen(f'{self.server}icsd/').read()
+        with urllib.request.urlopen(f'{self.server}icsd/') as handle:
+            handle.read()
 
     def test_mysqldb(self):
         """

--- a/tests/tools/importexport/migration/test_v06_to_v07.py
+++ b/tests/tools/importexport/migration/test_v06_to_v07.py
@@ -29,10 +29,10 @@ def test_migrate_external(migrate_from_func):
                 )
 
             # Check new attributes were added successfully
-            for attr in new_attrs:
+            for attr, attr_value in new_attrs.items():
                 assert attr in attrs, f"key '{attr}' was not added to attributes for Node <pk={node_pk}>"
-                assert attrs[attr] == new_attrs[attr], (
-                    f"key '{attr}' should have had the value {new_attrs[attr]}, but did instead have {attrs[attr]}"
+                assert attrs[attr] == attr_value, (
+                    f"key '{attr}' should have had the value {attr_value}, but did instead have {attrs[attr]}"
                 )
 
     # Check Attribute and Link have been removed

--- a/tests/tools/importexport/test_simple.py
+++ b/tests/tools/importexport/test_simple.py
@@ -88,10 +88,10 @@ def test_calc_of_structuredata(aiida_profile, tmp_path, file_format):
     aiida_profile.reset_db()
 
     import_data(filename)
-    for uuid in attrs:
+    for uuid, value in attrs.items():
         node = orm.load_node(uuid)
-        for k in attrs[uuid].keys():
-            assert attrs[uuid][k] == node.get_attribute(k)
+        for k in value.keys():
+            assert value[k] == node.get_attribute(k)
 
 
 def test_check_for_export_format_version(aiida_profile, tmp_path):

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,fixme
+# pylint: disable=too-many-lines,fixme,consider-using-with
 """
 This module contains a set of unittest test classes that can be loaded from
 the plugin.


### PR DESCRIPTION
Update pylint pinning to v2.9 and remove restrictions on astroid and pylint-django.

- `django-not-available` -> `django-not-configured`
- Fix new categories: `consider-using-dict-items`, `consider-using-enumerate`, `too-many-function-args`, `consider-using-from-import`, `consider-using-max-builtin`, `arguments-renamed`, `consider-using-with`, `use-maxsplit-arg`, `use-a-generator`, `deprecated-decorator`
- extra disables required for `no-member` (pylint seems to be getting worse at identifying members, or at least more strict)
- disable `unsubscriptable-object` for `cif.values`

closes #4647