### PR TITLE
CI: run certain workflows only on main repo, not on forks

### DIFF
--- a/.github/workflows/build_and_test_docker_on_pr.yml
+++ b/.github/workflows/build_and_test_docker_on_pr.yml
@@ -16,6 +16,9 @@ jobs:
 
   build-and-test:
 
+    # Only run this job on the main repository and not on forks
+    if: github.repository == 'aiidateam/aiida-core'
+
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -11,6 +11,9 @@ jobs:
     # upload the latest pot files to transifex services for team transilation.
     # https://www.transifex.com/aiidateam/aiida-core/dashboard/
 
+    # Only run this job on the main repository and not on forks
+    if: github.repository == 'aiidateam/aiida-core'
+
     name: Upload pot files to transifex
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/push_image_to_dockerhub.yml
+++ b/.github/workflows/push_image_to_dockerhub.yml
@@ -15,6 +15,9 @@ jobs:
 
   build-and-push:
 
+    # Only run this job on the main repository and not on forks
+    if: github.repository == 'aiidateam/aiida-core'
+
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
 
   check-release-tag:
 
+    # Only run this job on the main repository and not on forks
+    if: github.repository == 'aiidateam/aiida-core'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #5068

The following workflows should only be run on the main repo:

 * `build_and_test_docker_on_pr.yml`
 * `post-release.yml`
 * `push_image_to_dockerhub.yml`
 * `release.yml`