### PR TITLE
CI: do not run the benchmark on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,8 @@ jobs:
 
   run-and-upload:
 
-    if: ${{ github.event_name == 'push' }}
+    # Only run on pushes and when the job is on the main repository and not on forks
+    if: ${{ github.event_name == 'push' && github.repository == 'aiidateam/aiida-core' }}
 
     strategy:
       fail-fast: false

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -71,12 +71,16 @@ class CalcJobNode(CalculationNode):
                 entry_point = get_entry_point_from_string(entry_point_string)
 
                 try:
-                    tools_class = load_entry_point('aiida.tools.calculations', entry_point.name)
+                    tools_class = load_entry_point(
+                        'aiida.tools.calculations',
+                        entry_point.name  # type: ignore[attr-defined]
+                    )
                     self._tools = tools_class(self)
                 except exceptions.EntryPointError as exception:
                     self._tools = CalculationTools(self)
+                    entry_point_name = entry_point.name  # type: ignore[attr-defined]
                     self.logger.warning(
-                        f'could not load the calculation tools entry point {entry_point.name}: {exception}'
+                        f'could not load the calculation tools entry point {entry_point_name}: {exception}'
                     )
 
         return self._tools

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -309,7 +309,7 @@ def get_entry_point_string_from_class(class_module: str, class_name: str) -> Opt
     group, entry_point = get_entry_point_from_class(class_module, class_name)
 
     if group and entry_point:
-        return ENTRY_POINT_STRING_SEPARATOR.join([group, entry_point.name])
+        return ENTRY_POINT_STRING_SEPARATOR.join([group, entry_point.name])  # type: ignore[attr-defined]
     return None
 
 


### PR DESCRIPTION
If done, it would fail anyway because it cannot find the `gh-pages`
branch to push the results to.

For example, see: https://github.com/sphuber/aiida-core/runs/3421686169