### PR TITLE
Docs: add topics section on repository usage

### DIFF
--- a/aiida/orm/nodes/repository.py
+++ b/aiida/orm/nodes/repository.py
@@ -130,6 +130,16 @@ class NodeRepositoryMixin:
             else:
                 yield handle
 
+    def get_object(self, path: FilePath = None) -> File:
+        """Return the object at the given path.
+
+        :param path: the relative path where to store the object in the repository.
+        :return: the `File` representing the object located at the given relative path.
+        :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+        :raises FileNotFoundError: if no object exists for the given path.
+        """
+        return self._repository.get_object(path)
+
     def get_object_content(self, path: str, mode='r') -> Union[str, bytes]:
         """Return the content of a object identified by key.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,7 +101,6 @@ exclude_patterns = [
     'internals/orm.rst',
     'scheduler/index.rst',
     'topics/daemon.rst',
-    'topics/repository.rst',
     'working_with_aiida/**',
 ]
 

--- a/docs/source/topics/index.rst
+++ b/docs/source/topics/index.rst
@@ -12,6 +12,7 @@ Topics
    provenance/index
    data_types
    database
+   repository
    plugins
    schedulers
    transport
@@ -19,4 +20,3 @@ Topics
 .. todo::
 
     daemon  // after provenance
-    repository // after database

--- a/docs/source/topics/repository.rst
+++ b/docs/source/topics/repository.rst
@@ -1,12 +1,169 @@
-.. todo::
+.. _topics:repository:
 
-    .. _topics:repository:
+**********
+Repository
+**********
 
-    **********
-    Repository
-    **********
+In addition to the :ref:`database <topics:database>`, AiiDA also stores information in the *repository* in the form of files.
+The repository is optimized to store large amounts of files, which allows AiiDA to scale to high-throughput loads.
+As a result, the files cannot be accessed directly using file system tools, despite the fact that they are stored somewhere on the local file system.
+Instead, you should interact with the repository through the API.
 
-    `#4020`_
+Since each node can have its own *virtual* file hierarchy, the repository contents of a node are accessed through the :class:`~aiida.orm.nodes.node.Node` class.
+The hierarchy is virtual because the files may not actually be written to disk with the same hierarchy.
+For more technical information on the implementation, please refer to the :ref:`repository internals section <internal-architecture:repository>`.
 
 
-.. _#4020: https://github.com/aiidateam/aiida-core/issues/4020
+.. _topics:repository:writing:
+
+Writing to the repository
+=========================
+
+To write files to a node, you can use one of the following three methods:
+
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.put_object_from_file`
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.put_object_from_filelike`
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.put_object_from_tree`
+
+Let's assume that you have a file on your local file system called `/some/path/file.txt` that you want to copy to a node.
+The most straightforward solution is the following:
+
+.. code:: python
+
+    node = Node()
+    node.put_object_from_file('/some/path/file.txt', 'file.txt')
+
+Note that the first argument should be an absolute filepath.
+The second argument is the filename with which the file will be written to the repository of the node.
+It can be any valid filename as long as it is relative.
+The target filename can contain nested subdirectories, for example `some/relative/path/file.txt`.
+The nested directories do not have to exist.
+
+Alternatively, it is also possible to write a file to a node from a stream or filelike-object.
+This is useful when the content of the file is already in memory and prevents having to write it to the local filesystem first.
+For example, one can do the following:
+
+.. code:: python
+
+    with open('/some/path/file.txt') as handle:
+        node = Node()
+        node.put_object_from_filelike(handle, 'file.txt')
+
+which is the same as the previous example, except the file is opened first in a context manager and then the filelike-object is passed in.
+The :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.put_object_from_filelike` method should work with any filelike-object, for example also byte- and textstreams:
+
+.. code:: python
+
+    import io
+    node = Node()
+    node.put_object_from_filelike(io.BytesIO(b'some content'), 'file.txt')
+
+Finally, instead of writing one file at a time, you can write the contents of an entire directory to the node's repository:
+
+.. code:: python
+
+    node = Node()
+    node.put_object_from_tree('/some/directory')
+
+The contents of the entire directory will be recursively written to the node's repository.
+Optionally, you can write the content to a subdirectory in the repository:
+
+.. code:: python
+
+    node = Node()
+    node.put_object_from_tree('/some/directory', 'some/sub/path')
+
+As with :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.put_object_from_file`, the sub directories do not have to be explicitly created first.
+
+
+.. _topics:repository:listing:
+
+Listing repository content
+==========================
+
+To determine the contents of a node's repository, you can use the following methods:
+
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.list_object_names`
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.list_objects`
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.walk`
+
+The first method will return a list of file objects contained within the node's repository, where an object can be either a directory or a file:
+
+.. code:: ipython
+
+    In [1]: node.list_object_names()
+    Out[1]: ['sub', 'file.txt']
+
+To determine the contents of a subdirectory, simply pass the path as an argument:
+
+.. code:: ipython
+
+    In [1]: node.list_object_names('sub/directory')
+    Out[1]: ['nested.txt']
+
+Note that the elements in the returned list are simple strings and so one cannot tell if they correspond to a directory or a file.
+If this information is needed, use :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.list_objects` instead.
+This method returns a list of :class:`~aiida.repository.common.File` objects.
+These objects have a :meth:`~aiida.repository.common.File.file_type` and :meth:`~aiida.repository.common.File.name` property which returns the type and name of the file object, respectively.
+An example usage would be the following:
+
+.. code:: python
+
+    from aiida.repository.common import FileType
+
+    for obj in node.list_objects():
+        if obj.file_type == FileType.DIRECTORY:
+            print(f'{obj.name} is a directory.)
+        elif obj.file_type == FileType.FILE:
+            print(f'{obj.name} is a file.)
+
+To retrieve a specific file object with a particular relative path, use :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.get_object`:
+
+.. code:: ipython
+
+    In [1]: node.get_object('sub/directory/nested.txt')
+    Out[1]: File(file_type=FileType.FILE, name='nested.txt')
+
+Finally, if you want to recursively iterate over the contents of a node's repository, you can use the :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.walk` method.
+It operates exactly as the |os.walk|_:
+
+.. code:: ipython
+
+    In [1]: for root, dirnames, filenames in node.walk():
+                print(root, dirnames, filenames)
+    Out[1]: '.', ['sub'], ['file.txt']
+            'sub', ['directory'], []
+            'sub/directory', [], ['nested.txt']
+
+
+.. _topics:repository:reading:
+
+Reading from the repository
+===========================
+
+To retrieve the content of files stored in a node's repository, you can use the following methods:
+
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.open`
+ * :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.get_object_content`
+
+The first method functions exactly as Python's ``open`` built-in function:
+
+.. code:: python
+
+    with node.open('some/file.txt', 'r') as handle:
+        content = handle.read()
+
+The :meth:`~aiida.orm.nodes.repository.NodeRepositoryMixin.get_object_content` method provides a short-cut for this operation in case you want to directly read the content into memory:
+
+.. code:: python
+
+    content node.get_object_content('some/file.txt', 'r')
+
+Both methods accept a second argument to determine whether the file should be opened in text- or binary-mode.
+The valid values are ``'r'`` and ``'rb'``, respectively.
+Note that these methods can only be used to read content from the repository and so any other read modes, such as ``'wb'``, will result in an exception.
+To write files to the repository, use the methods that are described in the section on :ref:`writing to the repository <topics:repository:writing>`.
+
+
+.. |os.walk| replace:: ``os.walk`` method of the Python standard library
+.. _os.walk: https://docs.python.org/3/library/os.html#os.walk


### PR DESCRIPTION
Fixes #4020 

This adds a badly needed section on how to interact with the file
repository through the `Node` interface. So far there was not a single
place dedicated to showing all repository related methods.

Also expose the `Repository.get_object` method on the level of the
`NodeRepositoryMixin` such that it is available from the `Node`
interface.