### PR TITLE
`Node`: add the `copy_tree` method 

### DIFF
--- a/aiida/orm/nodes/repository.py
+++ b/aiida/orm/nodes/repository.py
@@ -216,6 +216,14 @@ class NodeRepositoryMixin:
         """
         yield from self._repository.walk(path)
 
+    def copy_tree(self, target: Union[str, pathlib.Path], path: FilePath = None) -> None:
+        """Copy the contents of the entire node repository to another location on the local file system.
+
+        :param target: absolute path of the directory where to copy the contents to.
+        :param path: optional relative path whose contents to copy.
+        """
+        self._repository.copy_tree(target, path)
+
     def delete_object(self, path: str):
         """Delete the object from the repository.
 

--- a/tests/orm/node/test_repository.py
+++ b/tests/orm/node/test_repository.py
@@ -213,3 +213,18 @@ def test_walk():
         (pathlib.Path('.'), ['relative'], []),
         (pathlib.Path('relative'), [], ['path']),
     ]
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_copy_tree(tmp_path):
+    """Test the ``Repository.copy_tree`` method."""
+    node = Data()
+    node.put_object_from_filelike(io.BytesIO(b'content'), 'relative/path')
+
+    node.copy_tree(tmp_path)
+    dirpath = pathlib.Path(tmp_path / 'relative')
+    filepath = dirpath / 'path'
+    assert dirpath.is_dir()
+    assert filepath.is_file()
+    with node.open('relative/path', 'rb') as handle:
+        assert filepath.read_bytes() == handle.read()

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -4,6 +4,7 @@
 import contextlib
 import io
 import pathlib
+import typing as t
 
 import pytest
 
@@ -55,6 +56,20 @@ def repository_uninitialised(request, tmp_path_factory) -> Repository:
     with request.param(tmp_path_factory.mktemp('container')) as backend:
         repository = Repository(backend=backend)
         yield repository
+
+
+@pytest.fixture(scope='function', params=[True, False])
+def tmp_path_parametrized(request, tmp_path_factory) -> t.Union[str, pathlib.Path]:
+    """Indirect parametrized fixture that returns temporary path both as ``str`` and as ``pathlib.Path``.
+
+    This is a useful fixture to automatically parametrize a test for a method that accepts both types.
+    """
+    tmp_path = tmp_path_factory.mktemp('target')
+
+    if request.param:
+        tmp_path = str(tmp_path)
+
+    yield tmp_path
 
 
 def test_uuid(repository_uninitialised):
@@ -564,6 +579,42 @@ def test_walk(repository, generate_directory):
         (pathlib.Path('relative'), ['sub'], ['file_b']),
         (pathlib.Path('relative/sub'), [], ['file_c']),
     ]
+
+
+@pytest.mark.parametrize('path', ('.', 'relative'))
+def test_copy_tree(repository, generate_directory, tmp_path_parametrized, path):
+    """Test the ``Repository.copy_tree`` method."""
+    directory = generate_directory({'file_a': None, 'relative': {'file_b': None, 'sub': {'file_c': None}}})
+    repository.put_object_from_tree(str(directory))
+
+    repository.copy_tree(tmp_path_parametrized, path=path)
+    for root, dirnames, filenames in repository.walk(path):
+        for dirname in dirnames:
+            assert pathlib.Path(tmp_path_parametrized / root / dirname).is_dir()
+        for filename in filenames:
+            filepath = pathlib.Path(tmp_path_parametrized / root / filename)
+            assert filepath.is_file()
+            with repository.open(root / filename) as handle:
+                assert filepath.read_bytes() == handle.read()
+
+
+@pytest.mark.parametrize(('argument', 'value', 'exception', 'match'), (
+    ('target', None, TypeError, r'path .* is not of type `str` nor `pathlib.Path`.'),
+    ('target', 'relative/path', TypeError, r'provided target `.*` is not an absolute path.'),
+    ('target', pathlib.Path('.'), TypeError, r'provided target `.*` is not an absolute path.'),
+    ('path', pathlib.Path('file_a'), NotADirectoryError, r'object with path `.*` is not a directory.'),
+))
+def test_copy_tree_invalid(tmp_path, repository, generate_directory, argument, value, exception, match):
+    """Test the ``Repository.copy_tree`` method for invalid input."""
+    directory = generate_directory({'file_a': None})
+    repository.put_object_from_tree(str(directory))
+
+    if argument == 'target':
+        with pytest.raises(exception, match=match):
+            repository.copy_tree(target=value)
+    else:
+        with pytest.raises(exception, match=match):
+            repository.copy_tree(target=tmp_path, path=value)
 
 
 def test_clone(repository, generate_directory):


### PR DESCRIPTION
Fixes #4928 

This method allows to easily copy the entire repository tree, or a
subdirectory, of a `Node` to a place on the local file system. The
method simply forwards to the `aiida.repository.Repository` class, where
the functionality is actually implemented using the `Repository.walk`
method, recursively looping over all the files contained within the
node's repository.