### PR TITLE
🔧 MAINTAIN: Pin setuptools<58.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "fastentrypoints~=0.12"]
+requires = ["setuptools>=40.8.0,<58.0.2", "wheel", "fastentrypoints~=0.12"]
 build-backend = "setuptools.build_meta"
 
 [tool.pylint.master]


### PR DESCRIPTION
The installation of the coverage package fails
(a dependency of pytest-cov),
due to this breaking change: https://github.com/pypa/setuptools/issues/2775