### PR TITLE
`DirectScheduler`: use `num_cores_per_mpiproc` if defined in resources

### DIFF
--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -150,19 +150,29 @@ class DirectScheduler(aiida.schedulers.Scheduler):
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
 
+        env_lines = []
+
+        if job_tmpl.job_resource and job_tmpl.job_resource.num_cores_per_mpiproc:
+            # since this was introduced after the environment injection below,
+            # it is intentionally put before it to avoid breaking current users script by overruling
+            # any explicit OMP_NUM_THREADS they may have set in their job_environment
+            env_lines.append(f'export OMP_NUM_THREADS={job_tmpl.job_resource.num_cores_per_mpiproc}')
+
         # Job environment variables are to be set on one single line.
         # This is a tough job due to the escaping of commas, etc.
         # moreover, I am having issues making it work.
         # Therefore, I assume that this is bash and export variables by
         # and.
-
         if job_tmpl.job_environment:
-            lines.append(empty_line)
-            lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
             if not isinstance(job_tmpl.job_environment, dict):
                 raise ValueError('If you provide job_environment, it must be a dictionary')
             for key, value in job_tmpl.job_environment.items():
-                lines.append(f'export {key.strip()}={escape_for_bash(value)}')
+                env_lines.append(f'export {key.strip()}={escape_for_bash(value)}')
+
+        if env_lines:
+            lines.append(empty_line)
+            lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
+            lines += env_lines
             lines.append('# ENVIRONMENT VARIABLES  END  ###')
             lines.append(empty_line)
 


### PR DESCRIPTION
If `num_cores_per_mpiproc` is specified in the job resources, the value
will now be exported as the `OMP_NUM_THREADS` variable.

Supersedes #5051 