### PR TITLE
🧪 TESTS: Add `CREATEDB` priviliges for DB user

### DIFF
--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -91,7 +91,7 @@ class Postgres(PGSU):
         """
         return bool(self.execute(_USER_EXISTS_COMMAND.format(dbuser)))
 
-    def create_dbuser(self, dbuser, dbpass, priviliges=""):
+    def create_dbuser(self, dbuser, dbpass, priviliges=''):
         """
         Create a database user in postgres
 

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -22,6 +22,7 @@ from aiida.cmdline.utils import echo
 
 __all__ = ('Postgres', 'PostgresConnectionMode', 'DEFAULT_DBINFO')
 
+# The last placeholder is for adding privileges of the user
 _CREATE_USER_COMMAND = 'CREATE USER "{}" WITH PASSWORD \'{}\' {}'
 _DROP_USER_COMMAND = 'DROP USER "{}"'
 _CREATE_DB_COMMAND = (
@@ -91,7 +92,7 @@ class Postgres(PGSU):
         """
         return bool(self.execute(_USER_EXISTS_COMMAND.format(dbuser)))
 
-    def create_dbuser(self, dbuser, dbpass, priviliges=''):
+    def create_dbuser(self, dbuser, dbpass, privileges=''):
         """
         Create a database user in postgres
 
@@ -100,7 +101,7 @@ class Postgres(PGSU):
         :raises: psycopg2.errors.DuplicateObject if user already exists and
             self.connection_mode == PostgresConnectionMode.PSYCOPG
         """
-        self.execute(_CREATE_USER_COMMAND.format(dbuser, dbpass, priviliges))
+        self.execute(_CREATE_USER_COMMAND.format(dbuser, dbpass, privileges))
 
     def drop_dbuser(self, dbuser):
         """

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -22,7 +22,7 @@ from aiida.cmdline.utils import echo
 
 __all__ = ('Postgres', 'PostgresConnectionMode', 'DEFAULT_DBINFO')
 
-_CREATE_USER_COMMAND = 'CREATE USER "{}" WITH PASSWORD \'{}\''
+_CREATE_USER_COMMAND = 'CREATE USER "{}" WITH PASSWORD \'{}\' {}'
 _DROP_USER_COMMAND = 'DROP USER "{}"'
 _CREATE_DB_COMMAND = (
     'CREATE DATABASE "{}" OWNER "{}" ENCODING \'UTF8\' '
@@ -91,7 +91,7 @@ class Postgres(PGSU):
         """
         return bool(self.execute(_USER_EXISTS_COMMAND.format(dbuser)))
 
-    def create_dbuser(self, dbuser, dbpass):
+    def create_dbuser(self, dbuser, dbpass, priviliges=""):
         """
         Create a database user in postgres
 
@@ -100,7 +100,7 @@ class Postgres(PGSU):
         :raises: psycopg2.errors.DuplicateObject if user already exists and
             self.connection_mode == PostgresConnectionMode.PSYCOPG
         """
-        self.execute(_CREATE_USER_COMMAND.format(dbuser, dbpass))
+        self.execute(_CREATE_USER_COMMAND.format(dbuser, dbpass, priviliges))
 
     def drop_dbuser(self, dbuser):
         """
@@ -220,7 +220,7 @@ def manual_setup_instructions(dbuser, dbname):
         'Run the following commands as a UNIX user with access to PostgreSQL (Ubuntu: $ sudo su postgres):',
         '',
         '\t$ psql template1',
-        f'	==> {_CREATE_USER_COMMAND.format(dbuser, dbpass)}',
+        f'	==> {_CREATE_USER_COMMAND.format(dbuser, dbpass, "")}',
         f'	==> {_CREATE_DB_COMMAND.format(dbname, dbuser)}',
         f'	==> {_GRANT_PRIV_COMMAND.format(dbname, dbuser)}',
     ])

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -319,7 +319,9 @@ class TemporaryProfileManager(ProfileManager):
             self.create_db_cluster()
         self.postgres = Postgres(interactive=False, quiet=True, dbinfo=self.dbinfo)
         # note: not using postgres.create_dbuser_db_safe here since we don't want prompts
-        self.postgres.create_dbuser(self.profile_info['database_username'], self.profile_info['database_password'], 'CREATEDB')
+        self.postgres.create_dbuser(
+            self.profile_info['database_username'], self.profile_info['database_password'], 'CREATEDB'
+        )
         self.postgres.create_db(self.profile_info['database_username'], self.profile_info['database_name'])
         self.dbinfo = self.postgres.dbinfo
         self.profile_info['database_hostname'] = self.postgres.host_for_psycopg2

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -318,7 +318,7 @@ class TemporaryProfileManager(ProfileManager):
         if self.pg_cluster is None:
             self.create_db_cluster()
         self.postgres = Postgres(interactive=False, quiet=True, dbinfo=self.dbinfo)
-        # note: not using postgres.create_dbuser_db_safe here since we don't want prompts
+        # Note: We give the user CREATEDB privileges here, only since they are required for the migration tests
         self.postgres.create_dbuser(
             self.profile_info['database_username'], self.profile_info['database_password'], 'CREATEDB'
         )

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -319,7 +319,7 @@ class TemporaryProfileManager(ProfileManager):
             self.create_db_cluster()
         self.postgres = Postgres(interactive=False, quiet=True, dbinfo=self.dbinfo)
         # note: not using postgres.create_dbuser_db_safe here since we don't want prompts
-        self.postgres.create_dbuser(self.profile_info['database_username'], self.profile_info['database_password'])
+        self.postgres.create_dbuser(self.profile_info['database_username'], self.profile_info['database_password'], 'CREATEDB')
         self.postgres.create_db(self.profile_info['database_username'], self.profile_info['database_name'])
         self.dbinfo = self.postgres.dbinfo
         self.profile_info['database_hostname'] = self.postgres.host_for_psycopg2


### PR DESCRIPTION
Allows for `tests/backends/aiida_sqlalchemy/test_migrations.py`
to run with auto-generated `aiida` users in tests

The tests run on Github Actions are specifially set up with a profile that uses the `postgres` super user: https://github.com/aiidateam/aiida-core/blob/1519278ab57635e1ba26ec95b6747393bd939e51/.github/config/profile.yaml#L12

whereas the default test database user a standard `aiida` user: https://github.com/aiidateam/aiida-core/blob/1519278ab57635e1ba26ec95b6747393bd939e51/aiida/manage/tests/main.py#L45

The `postrges` super user already has all privileges, by default, but the `aiida` user requires `CREATEDB` to carry out the migration tests.