### PR TITLE
`QueryBuilder`: set correct name for the `QUERYBUILDER` logger

### DIFF
--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 __all__ = ('BackendQueryBuilder',)
 
-QUERYBUILD_LOGGER = AIIDA_LOGGER.getChild('export')
+QUERYBUILD_LOGGER = AIIDA_LOGGER.getChild('orm.querybuilder')
 
 
 class EntityTypes(Enum):


### PR DESCRIPTION
The logger had the namespace `aiida.exporter` due to a copy-and-paste error.
It is changed to `aiida.orm.querybuilder`.