### PR TITLE
fix: remove branch restriction for docker push

### DIFF
--- a/.github/workflows/push_image_to_dockerhub.yml
+++ b/.github/workflows/push_image_to_dockerhub.yml
@@ -5,9 +5,6 @@ name: build-and-push-to-dockerhub
 
 on:
   push:
-    branches:
-      - master
-      - develop
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 


### PR DESCRIPTION
fixes #5132 

The push of docker images to dockerhub was limited to the `master` and
`develop` branches, thus excluding maintenance releases on support
branches.

Here we remove the branch limitation, mirroring the corresponding
selector in the `release` workflow.