### PR TITLE
bump aiida-prerequisites

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.3.0
+FROM aiidateam/aiida-prerequisites:0.4.0
 
 # to run the tests
 RUN pip install ansible~=2.10.0 molecule~=3.1.0

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -48,10 +48,10 @@ pipeline {
                     // this folder is mounted from a volume so will have wrong permissions
                     sh 'sudo chown root:root /home/jenkins/.cache'
                     // prepare environment (install python dependencies etc)
-                    sh 'pip install -r requirements/requirements-py-3.7.txt --cache-dir /home/jenkins/.cache/pip'
+                    sh 'pip install -r requirements/requirements-py-3.8.txt --cache-dir /home/jenkins/.cache/pip'
                     sh 'pip install --no-deps .'
                     // for some reason if we don't change permissions here then python can't import the modules
-                    sh 'sudo chmod -R a+rwX /opt/conda/lib/python3.7/site-packages/'
+                    sh 'sudo chmod -R a+rwX /opt/conda/lib/python3.8/site-packages/'
                 }
             }
         stage('Test') {

--- a/.molecule/default/Dockerfile
+++ b/.molecule/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.3.0
+FROM aiidateam/aiida-prerequisites:0.4.0
 
 # allow for collection of query statistics
 # (must also be intialised on each database)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.3.0
+FROM aiidateam/aiida-prerequisites:0.4.0
 
 USER root
 
@@ -14,7 +14,6 @@ ENV AIIDADB_BACKEND django
 # Copy and install AiiDA
 COPY . aiida-core
 RUN pip install ./aiida-core[atomic_tools]
-RUN pip install --upgrade git+https://github.com/unkcpz/circus.git@fix/quit-wait
 
 # Configure aiida for the user
 COPY .docker/opt/configure-aiida.sh /opt/configure-aiida.sh


### PR DESCRIPTION
This includes an upgrade from Ubuntu 18.04 to 20.04.

Also remove installation of custom circus dependency (issue was fixed in
circus 17.0).