### PR TITLE
NEW: Mechanism to lock profile access within AiiDA

### DIFF
--- a/aiida/backends/djsite/manager.py
+++ b/aiida/backends/djsite/manager.py
@@ -84,7 +84,7 @@ class DjangoBackendManager(BackendManager):
         from django.db.utils import ProgrammingError
         from aiida.manage.manager import get_manager
 
-        backend = get_manager()._load_backend(schema_check=False, repository_check=False)  # pylint: disable=protected-access
+        backend = get_manager()._load_backend(schema_check=False, repository_check=False, locking_check=False)  # pylint: disable=protected-access
 
         try:
             result = backend.execute_raw(r"""SELECT val FROM db_dbsetting WHERE key = 'schema_generation';""")

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -58,3 +58,27 @@ def delete_nodes_and_connections(pks):
         raise Exception(f'unknown backend {configuration.PROFILE.database_backend}')
 
     delete_nodes_backend(pks)
+
+
+def list_database_connections():
+    """Lists all other connections to the database (ignores self)"""
+    from aiida.manage.manager import get_manager
+
+    manager = get_manager()
+    backend = manager.get_backend()
+    dbname = manager.get_profile().database_name
+
+    sqlstm = f"SELECT pid, client_port FROM pg_stat_activity WHERE datname='{dbname}' AND pid != pg_backend_pid();"
+    connections = [pid for pid, client_port in backend.execute_raw(sqlstm)]
+
+    return connections
+
+
+def get_database_pid():
+    """Returns the process id of the connection to the database"""
+    from aiida.manage.manager import get_manager
+
+    sqlstm = 'SELECT pg_backend_pid();'
+    process_id = get_manager().get_backend().execute_raw(sqlstm)[0]
+
+    return process_id

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -190,6 +190,14 @@ class DatabaseMigrationError(AiidaException):
     """Raised if a critical error is encountered during a database migration."""
 
 
+class LockedProfileError(AiidaException):
+    """Raised if attempting to load a locked profile."""
+
+
+class LockingProfileError(AiidaException):
+    """Raised if the profile can`t be locked."""
+
+
 class DbContentError(AiidaException):
     """
     Raised when the content of the DB is not valid.

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -99,7 +99,9 @@ class Manager:
         manager.reset_backend_environment()
         self._backend = None
 
-    def _load_backend(self, schema_check: bool = True, repository_check: bool = True) -> 'Backend':
+    def _load_backend(
+        self, schema_check: bool = True, repository_check: bool = True, locking_check: bool = True
+    ) -> 'Backend':
         """Load the backend for the currently configured profile and return it.
 
         .. note:: this will reconstruct the `Backend` instance in `self._backend` so the preferred method to load the
@@ -129,7 +131,7 @@ class Manager:
 
         # Do NOT reload the backend environment if already loaded, simply reload the backend instance after
         if configuration.BACKEND_UUID is None:
-            backend_manager.load_backend_environment(profile, validate_schema=schema_check)
+            backend_manager.load_backend_environment(profile, validate_schema=schema_check, verify_lock=locking_check)
             configuration.BACKEND_UUID = profile.uuid
 
         # Perform the check on the repository compatibility. Since this is new functionality and the stability is not
@@ -173,7 +175,7 @@ class Manager:
         """
         return self._backend is not None
 
-    def get_backend_manager(self) -> 'BackendManager':
+    def get_backend_manager(self, locking_check: bool = True) -> 'BackendManager':
         """Return the database backend manager.
 
         .. note:: this is not the actual backend, but a manager class that is necessary for database operations that
@@ -188,7 +190,7 @@ class Manager:
         if self._backend_manager is None:
 
             if self._backend is None:
-                self._load_backend()
+                self._load_backend(locking_check=locking_check)
 
             profile = self.get_profile()
             if profile is None:

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -362,8 +362,10 @@ Below is a list with all available subcommands.
     Commands:
       delete      Delete one or more profiles.
       list        Display a list of all available profiles.
+      lock        Locks the profile from access through daemons or shells
       setdefault  Set a profile as the default one.
       show        Show details for a profile.
+      unlock      Forces the unlocking of the profile.
 
 
 .. _reference:command-line:verdi-quicksetup:


### PR DESCRIPTION
This adds a safe-guard mechanism to temporarily block access to a profile for other AiiDA entities (daemons, verdi shells, scrip execution via `verdi run`). It implements the solution described by @giovannipizzi in [this comment](https://github.com/aiidateam/aiida-core/pull/4924#issuecomment-834112893) (and so potentially superseding the respective PR #4924).

The original description of the way it works is in the mentioned comment which can be checked if something I say here is unclear, but below in this OP I'll try to keep updated all the important information necessary to understand the content PR. In the comments I'll add some circumstantial information about the current situation, such as some (important) problems I'm still dealing with.

## **Setting the lock**

The lock is set by the context manager `get_locking_context` added to the `BackendManager` class. It performs the following steps in order to lock the profile in a safe way:

1. Checks for other processes connected to the DB and stops if there is any (see SQL query below)
2. Tries to add an entry to `db_dbsettings` with key `locking_pid` and value equal to the process id of the locker. This is what effectively locks the profile since all other processes will now check for this.
3. Now the control is returned back to the caller through a `yield` statement within a `try` wrap that begins the context of the locking. After the control gets back to the process when the context is closed (`finally` clause) which "deletes" the `locking_pid` setting.
    - Before yielding, there is a second check for other processes that may have connected simultaneously between steps 1 and 2. If there was any such processes then it raises and triggers the release of the `finally` clause.

## **Checking the lock**

This has been added to the `load_backend_environment` method of the `BackendManager` class. This is supposed to be called by all processes when trying to access the database of the profile. It simply tries to get the `locking_pid` setting and exits with an error message if it finds it.

All of this had to be wrapped around and optional keyword that allows to load the profile skipping this very check because there is also a new CLI tool to force the unlocking of the profile which has to be able to modify the DB even when it is locked (to remove the `locking_pid` setting): `verdi profile unlock`.

## **Other changes**

The previous text describes the main modifications included in `aiida/backends/manager.py` and the addition of the command in `aiida/cmdline/commands/cmd_profile.py`. A second command `verdi profile lock N` (N number of seconds to wait with the profile locked) was added for testing purposes but would probably be removed in the final version. Then the following changes were also implemented in support of the PR:

**aiida/common/exceptions.py**
Two exceptions were added for when trying to access a locked profile (LockedProfileError) and when trying to lock a profile that is being used (LockingProfileError).

**aiida/manage/manager.py**
**aiida/backends/djsite/manager.py**
Some methods had to be adapted for enabling the option to skip the lock check mentioned above. The option needed to be passed down from when getting the backend manager to the step of loading the profile. The methods affected by this (besides `BackendManager.load_backend_environment`, where the option is used) are:
- `Manager._load_backend`
- `Manager.get_backend_manager`
- `DjangoBackendManager.get_schema_generation_database`

**aiida/backends/utils.py**
Auxiliary functions to get the current pid accessing the DB (`get_database_pid`) and listing the other connections to the DB (`list_database_connections`). I didn’t put these methods in the BackendManager because they are using the backend, but since anyways are called from BackendManager there is some ugly dependency going on here that I'm not sure how to fix.

**aiida/backends/manager.py**
Besides adapting `load_backend_environment` and adding `get_locking_context`, there were also a couple of minor additions worth mentioning for completeness sake:
- the template text for the errors raised.
- the global variables for the name of the key in the db_dbsettings.
- the `get_locking_pid` method (used by the check in `load_backend_environment`).
- the `force_unlock` method (used by `verdi profile unlock`).