### PR TITLE
Command line: allow to not set input plugin for code

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -82,6 +82,8 @@ def setup_code(non_interactive, **kwargs):
     else:
         kwargs['code_type'] = CodeBuilder.CodeType.STORE_AND_UPLOAD
 
+    kwargs.pop('bind_to_input_plugin')
+
     code_builder = CodeBuilder(**kwargs)
 
     try:

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -61,6 +61,7 @@ def set_code_builder(ctx, param, value):
 @verdi_code.command('setup')
 @options_code.LABEL()
 @options_code.DESCRIPTION()
+@options_code.BIND_TO_INPUT_PLUGIN()
 @options_code.INPUT_PLUGIN()
 @options_code.ON_COMPUTER()
 @options_code.COMPUTER()

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -16,6 +16,7 @@ from aiida.cmdline.params.options.overridable import OverridableOption
 
 
 def is_on_computer(ctx):
+    import ipdb; ipdb.set_trace()
     return bool(ctx.params.get('on_computer'))
 
 
@@ -31,6 +32,19 @@ ON_COMPUTER = OverridableOption(
     prompt='Installed on target computer?',
     help='Whether the code is installed on the target computer, or should be copied to the target computer each time '
     'from a local path.'
+)
+
+def is_bind_to_input_plugin(ctx):
+    return bool(ctx.params.get('bind_to_input_plugin'))
+
+BIND_TO_INPUT_PLUGIN = OverridableOption(
+    '--bind-to-input-plugin',
+    is_eager=False,
+    default=True,
+    is_flag=True,
+    cls=InteractiveOption,
+    prompt='Bind to a input plugin?',
+    help="Whether to set a input plugin for the code.",
 )
 
 REMOTE_ABS_PATH = OverridableOption(
@@ -80,6 +94,8 @@ DESCRIPTION = options.DESCRIPTION.clone(
 INPUT_PLUGIN = options.INPUT_PLUGIN.clone(
     prompt='Default calculation input plugin',
     cls=InteractiveOption,
+    required_fn=is_bind_to_input_plugin,
+    prompt_fn=is_bind_to_input_plugin,
     help="Entry point name of the default calculation plugin (as listed in 'verdi plugin list aiida.calculations')."
 )
 

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -16,7 +16,6 @@ from aiida.cmdline.params.options.overridable import OverridableOption
 
 
 def is_on_computer(ctx):
-    import ipdb; ipdb.set_trace()
     return bool(ctx.params.get('on_computer'))
 
 

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -33,8 +33,10 @@ ON_COMPUTER = OverridableOption(
     'from a local path.'
 )
 
+
 def is_bind_to_input_plugin(ctx):
     return bool(ctx.params.get('bind_to_input_plugin'))
+
 
 BIND_TO_INPUT_PLUGIN = OverridableOption(
     '--bind-to-input-plugin',
@@ -43,7 +45,7 @@ BIND_TO_INPUT_PLUGIN = OverridableOption(
     is_flag=True,
     cls=InteractiveOption,
     prompt='Bind to a input plugin?',
-    help="Whether to set a input plugin for the code.",
+    help='Whether to set a input plugin for the code.',
 )
 
 REMOTE_ABS_PATH = OverridableOption(

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -406,6 +406,7 @@ DESCRIPTION = OverridableOption(
 INPUT_PLUGIN = OverridableOption(
     '-P',
     '--input-plugin',
+    required=False,
     type=types.PluginParamType(group='calculations', load=False),
     help='Calculation input plugin string.'
 )

--- a/aiida/cmdline/params/types/plugin.py
+++ b/aiida/cmdline/params/types/plugin.py
@@ -247,3 +247,6 @@ class PluginParamType(EntryPointType):
                 raise click.BadParameter(str(exception))
         else:
             return entry_point
+
+    def __repr__(self):
+        return 'PLUGINPARAM'

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -111,6 +111,7 @@ class TestVerdiCodeSetup(AiidaTestCase):
 
             self.assertClickResultNoException(result)
             self.assertIsInstance(orm.Code.get_from_string(f'{label}'), orm.Code)
+
     def test_from_config_no_input_plugin(self):
         """Test setting up a code from a config file without set the input plugin.
 
@@ -121,7 +122,7 @@ class TestVerdiCodeSetup(AiidaTestCase):
         config_file_template = dedent(
             """
                     ---
-                    label: {label}                    
+                    label: {label}
                     bind_to_input_plugin: no
                     computer: {computer}
                     remote_abs_path: /remote/abs/path


### PR DESCRIPTION
For feature #4991. 

An extra flag option `--bind-to-input-plugin` with default flag to `True` is add to `verdi code setup` to allow not to set the input plugin for the code.
This may increase the configuration complex a bit of code setup. Especially when setting code through config file, if user do not want to bind input plugin to the code they need to set this flag to `false` explicitly like: 

```
---
label: {label}                    
bind_to_input_plugin: no
computer: {computer}
remote_abs_path: /remote/abs/path
```

