### PR TITLE
🔧 MAINTAIN: Add isort pre-commit hook

### DIFF
--- a/.github/system_tests/pytest/test_memory_leaks.py
+++ b/.github/system_tests/pytest/test_memory_leaks.py
@@ -8,11 +8,11 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utilities for testing memory leakage."""
-from tests.utils import processes as test_processes  # pylint: disable=no-name-in-module,import-error
-from tests.utils.memory import get_instances  # pylint: disable=no-name-in-module,import-error
+from aiida import orm
 from aiida.engine import processes, run_get_node
 from aiida.plugins import CalculationFactory
-from aiida import orm
+from tests.utils import processes as test_processes  # pylint: disable=no-name-in-module,import-error
+from tests.utils.memory import get_instances  # pylint: disable=no-name-in-module,import-error
 
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')
 

--- a/.github/system_tests/test_daemon.py
+++ b/.github/system_tests/test_daemon.py
@@ -17,20 +17,27 @@ import tempfile
 import time
 
 from workchains import (
-    ArithmeticAddBaseWorkChain, CalcFunctionRunnerWorkChain, DynamicDbInput, DynamicMixedInput, DynamicNonDbInput,
-    ListEcho, NestedInputNamespace, NestedWorkChain, SerializeWorkChain, WorkFunctionRunnerWorkChain
+    ArithmeticAddBaseWorkChain,
+    CalcFunctionRunnerWorkChain,
+    DynamicDbInput,
+    DynamicMixedInput,
+    DynamicNonDbInput,
+    ListEcho,
+    NestedInputNamespace,
+    NestedWorkChain,
+    SerializeWorkChain,
+    WorkFunctionRunnerWorkChain,
 )
 
-from aiida.common import exceptions, StashMode
+from aiida.common import StashMode, exceptions
 from aiida.engine import run, submit
 from aiida.engine.daemon.client import get_daemon_client
 from aiida.engine.persistence import ObjectLoader
-from aiida.manage.caching import enable_caching
 from aiida.engine.processes import Process
-from aiida.orm import CalcJobNode, load_node, Int, Str, List, Dict, load_code
+from aiida.manage.caching import enable_caching
+from aiida.orm import CalcJobNode, Dict, Int, List, Str, load_code, load_node
 from aiida.plugins import CalculationFactory, WorkflowFactory
-from aiida.workflows.arithmetic.add_multiply import add_multiply, add
-
+from aiida.workflows.arithmetic.add_multiply import add, add_multiply
 from tests.utils.memory import get_instances  # pylint: disable=import-error
 
 CODENAME_ADD = 'add@localhost'

--- a/.github/system_tests/test_ipython_magics.py
+++ b/.github/system_tests/test_ipython_magics.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Test the AiiDA iPython magics."""
 from IPython.testing.globalipapp import get_ipython
+
 from aiida.tools.ipython.ipython_magics import register_ipython_extension
 
 

--- a/.github/system_tests/test_plugin_testcase.py
+++ b/.github/system_tests/test_plugin_testcase.py
@@ -14,10 +14,10 @@ This must be in a standalone script because it would clash with other tests,
 Since the dbenv gets loaded on the temporary profile.
 """
 
-import sys
-import unittest
-import tempfile
 import shutil
+import sys
+import tempfile
+import unittest
 
 from aiida.manage.tests.unittest_classes import PluginTestCase, TestRunner
 

--- a/.github/system_tests/test_profile_manager.py
+++ b/.github/system_tests/test_profile_manager.py
@@ -9,15 +9,15 @@
 ###########################################################################
 """Unittests for TestManager"""
 import os
+import sys
 import unittest
 import warnings
-import sys
 
 from pgtest import pgtest
 import pytest
 
-from aiida.manage.tests import TemporaryProfileManager, TestManagerError, get_test_backend_name
 from aiida.common.utils import Capturing
+from aiida.manage.tests import TemporaryProfileManager, TestManagerError, get_test_backend_name
 
 
 class TemporaryProfileManagerTestCase(unittest.TestCase):

--- a/.github/system_tests/test_test_manager.py
+++ b/.github/system_tests/test_test_manager.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Unittests for TestManager"""
+import sys
 import unittest
 import warnings
-import sys
 
 import pytest
 

--- a/.github/system_tests/workchains.py
+++ b/.github/system_tests/workchains.py
@@ -10,8 +10,18 @@
 # pylint: disable=invalid-name
 """Work chain implementations for testing purposes."""
 from aiida.common import AttributeDict
-from aiida.engine import calcfunction, workfunction, WorkChain, ToContext, append_, while_, ExitCode
-from aiida.engine import BaseRestartWorkChain, process_handler, ProcessHandlerReport
+from aiida.engine import (
+    BaseRestartWorkChain,
+    ExitCode,
+    ProcessHandlerReport,
+    ToContext,
+    WorkChain,
+    append_,
+    calcfunction,
+    process_handler,
+    while_,
+    workfunction,
+)
 from aiida.engine.persistence import ObjectLoader
 from aiida.orm import Int, List, Str
 from aiida.plugins import CalculationFactory

--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -107,8 +107,8 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
     If no expression is specified, a random one will be generated that adheres to these rules
     """
     # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-branches
-    from aiida.orm import Code, Int, Str
     from aiida.engine import run_get_node
+    from aiida.orm import Code, Int, Str
 
     lib_expression = importlib.import_module('lib.expression')
     lib_workchain = importlib.import_module('lib.workchain')

--- a/.molecule/default/files/polish/lib/workchain.py
+++ b/.molecule/default/files/polish/lib/workchain.py
@@ -13,8 +13,8 @@ import collections
 import hashlib
 import os
 from pathlib import Path
-
 from string import Template
+
 from .expression import OPERATORS  # pylint: disable=relative-beyond-top-level
 
 INDENTATION_WIDTH = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,6 @@ repos:
     rev: 5.9.3
     hooks:
     - id: isort
-      files: >-
-         (?x)^(
-            aiida/common/.*py|
-         )$
 
 -   repo: https://github.com/ikamensh/flynt/
     rev: '0.66'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
          (?x)^(
             aiida/tools/groups/paths.py
          )$
-            
+
 -   repo: https://github.com/ikamensh/flynt/
     rev: '0.66'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,10 @@ repos:
     rev: 5.9.3
     hooks:
     - id: isort
-       files: >-
-          (?x)^(
+      files: >-
+         (?x)^(
             aiida/tools/groups/paths.py
-          )$
+         )$
             
 -   repo: https://github.com/ikamensh/flynt/
     rev: '0.66'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,15 @@ repos:
     -   id: check-yaml
 
 
+-   repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+    - id: isort
+       files: >-
+          (?x)^(
+            aiida/tools/groups/paths.py
+          )$
+            
 -   repo: https://github.com/ikamensh/flynt/
     rev: '0.66'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: isort
       files: >-
          (?x)^(
-            aiida/tools/groups/paths.py
+            aiida/common/.*py|
          )$
 
 -   repo: https://github.com/ikamensh/flynt/

--- a/aiida/backends/djsite/__init__.py
+++ b/aiida/backends/djsite/__init__.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=global-statement
 """Module with implementation of the database backend using Django."""
-from aiida.backends.utils import create_sqlalchemy_engine, create_scoped_session_factory
+from aiida.backends.utils import create_scoped_session_factory, create_sqlalchemy_engine
 
 ENGINE = None
 SESSION_FACTORY = None

--- a/aiida/backends/djsite/db/migrations/0001_initial.py
+++ b/aiida/backends/djsite/db/migrations/0001_initial.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models, migrations
+from django.db import migrations, models
 import django.db.models.deletion
 import django.utils.timezone
 

--- a/aiida/backends/djsite/db/migrations/0002_db_state_change.py
+++ b/aiida/backends/djsite/db/migrations/0002_db_state_change.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models, migrations
+from django.db import migrations, models
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 

--- a/aiida/backends/djsite/db/migrations/0003_add_link_type.py
+++ b/aiida/backends/djsite/db/migrations/0003_add_link_type.py
@@ -9,9 +9,10 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models, migrations
-import aiida.common.timezone
+from django.db import migrations, models
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
+import aiida.common.timezone
 
 REVISION = '1.0.3'
 DOWN_REVISION = '1.0.2'

--- a/aiida/backends/djsite/db/migrations/0004_add_daemon_and_uuid_indices.py
+++ b/aiida/backends/djsite/db/migrations/0004_add_daemon_and_uuid_indices.py
@@ -9,8 +9,7 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models
-from django.db import migrations
+from django.db import migrations, models
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 

--- a/aiida/backends/djsite/db/migrations/0005_add_cmtime_indices.py
+++ b/aiida/backends/djsite/db/migrations/0005_add_cmtime_indices.py
@@ -9,9 +9,10 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models, migrations
-import aiida.common.timezone
+from django.db import migrations, models
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
+import aiida.common.timezone
 
 REVISION = '1.0.5'
 DOWN_REVISION = '1.0.4'

--- a/aiida/backends/djsite/db/migrations/0006_delete_dbpath.py
+++ b/aiida/backends/djsite/db/migrations/0006_delete_dbpath.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.6'

--- a/aiida/backends/djsite/db/migrations/0007_update_linktypes.py
+++ b/aiida/backends/djsite/db/migrations/0007_update_linktypes.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.8'

--- a/aiida/backends/djsite/db/migrations/0008_code_hidden_to_extra.py
+++ b/aiida/backends/djsite/db/migrations/0008_code_hidden_to_extra.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.8'

--- a/aiida/backends/djsite/db/migrations/0009_base_data_plugin_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0009_base_data_plugin_type_string.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.9'

--- a/aiida/backends/djsite/db/migrations/0010_process_type.py
+++ b/aiida/backends/djsite/db/migrations/0010_process_type.py
@@ -9,7 +9,8 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models, migrations
+from django.db import migrations, models
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.10'

--- a/aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py
+++ b/aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.11'

--- a/aiida/backends/djsite/db/migrations/0012_drop_dblock.py
+++ b/aiida/backends/djsite/db/migrations/0012_drop_dblock.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.12'

--- a/aiida/backends/djsite/db/migrations/0013_django_1_8.py
+++ b/aiida/backends/djsite/db/migrations/0013_django_1_8.py
@@ -9,7 +9,8 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Database migration."""
-from django.db import models, migrations
+from django.db import migrations, models
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.13'

--- a/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
@@ -11,6 +11,7 @@
 """Add a uniqueness constraint to the uuid column of DbNode table."""
 
 from django.db import migrations, models
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.common.utils import get_new_uuid
 

--- a/aiida/backends/djsite/db/migrations/0015_invalidating_node_hash.py
+++ b/aiida/backends/djsite/db/migrations/0015_invalidating_node_hash.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.15'

--- a/aiida/backends/djsite/db/migrations/0016_code_sub_class_of_data.py
+++ b/aiida/backends/djsite/db/migrations/0016_code_sub_class_of_data.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.16'

--- a/aiida/backends/djsite/db/migrations/0017_drop_dbcalcstate.py
+++ b/aiida/backends/djsite/db/migrations/0017_drop_dbcalcstate.py
@@ -10,6 +10,7 @@
 # pylint: disable=invalid-name
 """Database migration."""
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.17'

--- a/aiida/backends/djsite/db/migrations/0018_django_1_11.py
+++ b/aiida/backends/djsite/db/migrations/0018_django_1_11.py
@@ -14,8 +14,9 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations, models
-import aiida.common.utils
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
+import aiida.common.utils
 
 REVISION = '1.0.18'
 DOWN_REVISION = '1.0.17'

--- a/aiida/backends/djsite/db/migrations/0020_provenance_redesign.py
+++ b/aiida/backends/djsite/db/migrations/0020_provenance_redesign.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.20'

--- a/aiida/backends/djsite/db/migrations/0021_dbgroup_name_to_label_type_to_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0021_dbgroup_name_to_label_type_to_type_string.py
@@ -12,6 +12,7 @@
 
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.21'

--- a/aiida/backends/djsite/db/migrations/0022_dbgroup_type_string_change_content.py
+++ b/aiida/backends/djsite/db/migrations/0022_dbgroup_type_string_change_content.py
@@ -12,6 +12,7 @@
 
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.22'

--- a/aiida/backends/djsite/db/migrations/0024_dblog_update.py
+++ b/aiida/backends/djsite/db/migrations/0024_dblog_update.py
@@ -11,15 +11,16 @@
 # pylint: disable=invalid-name
 """Migration for the update of the DbLog table. Addition of uuids"""
 import sys
-import click
 
+import click
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations, models
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.backends.general.migrations.utils import dumps_json
-from aiida.common.utils import get_new_uuid
 from aiida.cmdline.utils import echo
+from aiida.common.utils import get_new_uuid
 from aiida.manage import configuration
 
 REVISION = '1.0.24'

--- a/aiida/backends/djsite/db/migrations/0025_move_data_within_node_module.py
+++ b/aiida/backends/djsite/db/migrations/0025_move_data_within_node_module.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.25'

--- a/aiida/backends/djsite/db/migrations/0026_trajectory_symbols_to_attribute.py
+++ b/aiida/backends/djsite/db/migrations/0026_trajectory_symbols_to_attribute.py
@@ -19,6 +19,7 @@ from django.db import migrations
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.backends.general.migrations.utils import load_numpy_array_from_repository
+
 from . import ModelModifierV0025
 
 REVISION = '1.0.26'

--- a/aiida/backends/djsite/db/migrations/0027_delete_trajectory_symbols_array.py
+++ b/aiida/backends/djsite/db/migrations/0027_delete_trajectory_symbols_array.py
@@ -19,6 +19,7 @@ from django.db import migrations
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.backends.general.migrations import utils
+
 from . import ModelModifierV0025
 
 REVISION = '1.0.27'

--- a/aiida/backends/djsite/db/migrations/0028_remove_node_prefix.py
+++ b/aiida/backends/djsite/db/migrations/0028_remove_node_prefix.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.28'

--- a/aiida/backends/djsite/db/migrations/0029_rename_parameter_data_to_dict.py
+++ b/aiida/backends/djsite/db/migrations/0029_rename_parameter_data_to_dict.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.29'

--- a/aiida/backends/djsite/db/migrations/0030_dbnode_type_to_dbnode_node_type.py
+++ b/aiida/backends/djsite/db/migrations/0030_dbnode_type_to_dbnode_node_type.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.30'

--- a/aiida/backends/djsite/db/migrations/0031_remove_dbcomputer_enabled.py
+++ b/aiida/backends/djsite/db/migrations/0031_remove_dbcomputer_enabled.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.31'

--- a/aiida/backends/djsite/db/migrations/0032_remove_legacy_workflows.py
+++ b/aiida/backends/djsite/db/migrations/0032_remove_legacy_workflows.py
@@ -11,16 +11,16 @@
 """Remove legacy workflow."""
 
 import sys
-import click
 
+import click
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.core import serializers
 from django.db import migrations
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
-from aiida.common import json
 from aiida.cmdline.utils import echo
+from aiida.common import json
 from aiida.manage import configuration
 
 REVISION = '1.0.32'

--- a/aiida/backends/djsite/db/migrations/0037_attributes_extras_settings_json.py
+++ b/aiida/backends/djsite/db/migrations/0037_attributes_extras_settings_json.py
@@ -14,8 +14,7 @@ import math
 
 import click
 import django.contrib.postgres.fields.jsonb
-from django.db import migrations, models
-from django.db import transaction
+from django.db import migrations, models, transaction
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.cmdline.utils import echo

--- a/aiida/backends/djsite/db/migrations/0038_data_migration_legacy_job_calculations.py
+++ b/aiida/backends/djsite/db/migrations/0038_data_migration_legacy_job_calculations.py
@@ -43,6 +43,7 @@ their `process_label` which is one of the default columns of `verdi process list
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.38'

--- a/aiida/backends/djsite/db/migrations/0039_reset_hash.py
+++ b/aiida/backends/djsite/db/migrations/0039_reset_hash.py
@@ -15,6 +15,7 @@ Invalidating node hash - User should rehash nodes for caching
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.cmdline.utils import echo
 

--- a/aiida/backends/djsite/db/migrations/0040_data_migration_legacy_process_attributes.py
+++ b/aiida/backends/djsite/db/migrations/0040_data_migration_legacy_process_attributes.py
@@ -30,6 +30,7 @@ it set to `True`. Excluding the nodes that have a `process_state` attribute of o
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.40'

--- a/aiida/backends/djsite/db/migrations/0041_seal_unsealed_processes.py
+++ b/aiida/backends/djsite/db/migrations/0041_seal_unsealed_processes.py
@@ -23,6 +23,7 @@ them will be unsealed.
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.41'

--- a/aiida/backends/djsite/db/migrations/0042_prepare_schema_reset.py
+++ b/aiida/backends/djsite/db/migrations/0042_prepare_schema_reset.py
@@ -13,6 +13,7 @@
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.42'

--- a/aiida/backends/djsite/db/migrations/0043_default_link_label.py
+++ b/aiida/backends/djsite/db/migrations/0043_default_link_label.py
@@ -17,6 +17,7 @@ and underscore are illegal because they are used for namespacing.
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.43'

--- a/aiida/backends/djsite/db/migrations/0044_dbgroup_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0044_dbgroup_type_string.py
@@ -12,6 +12,7 @@
 
 # pylint: disable=no-name-in-module,import-error
 from django.db import migrations
+
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 REVISION = '1.0.44'

--- a/aiida/backends/djsite/db/migrations/0047_migrate_repository.py
+++ b/aiida/backends/djsite/db/migrations/0047_migrate_repository.py
@@ -29,10 +29,11 @@ def migrate_repository(apps, schema_editor):
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     import json
     from tempfile import NamedTemporaryFile
+
     from disk_objectstore import Container
 
     from aiida.common import exceptions
-    from aiida.common.progress_reporter import set_progress_bar_tqdm, get_progress_reporter, set_progress_reporter
+    from aiida.common.progress_reporter import get_progress_reporter, set_progress_bar_tqdm, set_progress_reporter
     from aiida.manage.configuration import get_profile
 
     DbNode = apps.get_model('db', 'DbNode')

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -67,6 +67,7 @@ def _upgrade_schema_generation(version, apps, _):
 
 
 def upgrade_schema_version(up_revision, down_revision):
+    """Run migrations, to translate the database schema."""
     from functools import partial
 
     from django.db import migrations

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -11,8 +11,12 @@
 """Module that contains the db migrations."""
 from django.core.exceptions import ObjectDoesNotExist
 
-from aiida.backends.manager import SCHEMA_VERSION_KEY, SCHEMA_VERSION_DESCRIPTION
-from aiida.backends.manager import SCHEMA_GENERATION_KEY, SCHEMA_GENERATION_DESCRIPTION
+from aiida.backends.manager import (
+    SCHEMA_GENERATION_DESCRIPTION,
+    SCHEMA_GENERATION_KEY,
+    SCHEMA_VERSION_DESCRIPTION,
+    SCHEMA_VERSION_KEY,
+)
 from aiida.common.exceptions import AiidaException, DbContentError
 from aiida.manage.configuration import get_config_option
 
@@ -64,6 +68,7 @@ def _upgrade_schema_generation(version, apps, _):
 
 def upgrade_schema_version(up_revision, down_revision):
     from functools import partial
+
     from django.db import migrations
 
     return migrations.RunPython(
@@ -247,7 +252,7 @@ def _deserialize_attribute(mainitem, subitems, sep, original_class=None, origina
     :raise aiida.backends.djsite.db.migrations.DeserializationException: if an error occurs"""
 
     from aiida.common import json
-    from aiida.common.timezone import (is_naive, make_aware, get_current_timezone)
+    from aiida.common.timezone import get_current_timezone, is_naive, make_aware
 
     if mainitem['datatype'] in ['none', 'bool', 'int', 'float', 'txt']:
         if subitems:
@@ -653,6 +658,7 @@ class ModelModifierV0025:
                 transaction.savepoint_commit(sid)
         except BaseException as exc:  # All exceptions including CTRL+C, ...
             from django.db.utils import IntegrityError
+
             from aiida.common.exceptions import UniquenessError
 
             if with_transaction:
@@ -716,7 +722,7 @@ class ModelModifierV0025:
         import datetime
 
         from aiida.common import json
-        from aiida.common.timezone import is_naive, make_aware, get_current_timezone
+        from aiida.common.timezone import get_current_timezone, is_naive, make_aware
 
         other_attribs = other_attribs if other_attribs is not None else {}
 

--- a/aiida/backends/djsite/manage.py
+++ b/aiida/backends/djsite/manage.py
@@ -20,6 +20,7 @@ from aiida.cmdline.params import options, types
 def main(profile, command):  # pylint: disable=unused-argument
     """Simple wrapper around the Django command line tool that first loads an AiiDA profile."""
     from django.core.management import execute_from_command_line  # pylint: disable=import-error,no-name-in-module
+
     from aiida.manage.manager import get_manager
 
     manager = get_manager()

--- a/aiida/backends/djsite/manager.py
+++ b/aiida/backends/djsite/manager.py
@@ -11,10 +11,12 @@
 """Utilities and configuration of the Django database schema."""
 
 import os
+
 import django
 
 from aiida.common import NotExistent
-from ..manager import BackendManager, SettingsManager, Setting, SCHEMA_VERSION_KEY, SCHEMA_VERSION_DESCRIPTION
+
+from ..manager import SCHEMA_VERSION_DESCRIPTION, SCHEMA_VERSION_KEY, BackendManager, Setting, SettingsManager
 
 # The database schema version required to perform schema reset for a given code schema generation
 SCHEMA_VERSION_RESET = {'1': None}
@@ -82,6 +84,7 @@ class DjangoBackendManager(BackendManager):
         :return: `distutils.version.StrictVersion` with schema version of the database
         """
         from django.db.utils import ProgrammingError
+
         from aiida.manage.manager import get_manager
 
         backend = get_manager()._load_backend(schema_check=False, repository_check=False)  # pylint: disable=protected-access
@@ -104,6 +107,7 @@ class DjangoBackendManager(BackendManager):
         :return: `distutils.version.StrictVersion` with schema version of the database
         """
         from django.db.utils import ProgrammingError
+
         from aiida.manage.manager import get_manager
 
         backend = get_manager()._load_backend(schema_check=False, repository_check=False)  # pylint: disable=protected-access

--- a/aiida/backends/djsite/settings.py
+++ b/aiida/backends/djsite/settings.py
@@ -9,8 +9,7 @@
 ###########################################################################
 # pylint: disable=import-error, no-name-in-module
 """ Django settings for the AiiDA project. """
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from aiida.common import exceptions
 from aiida.common.timezone import get_current_timezone

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -18,6 +18,7 @@ def delete_nodes_and_connections_django(pks_to_delete):  # pylint: disable=inval
     # pylint: disable=no-member,import-error,no-name-in-module
     from django.db import transaction
     from django.db.models import Q
+
     from aiida.backends.djsite.db import models
     with transaction.atomic():
         # This is fixed in pylint-django>=2, but this supports only py3

--- a/aiida/backends/general/migrations/duplicate_uuids.py
+++ b/aiida/backends/general/migrations/duplicate_uuids.py
@@ -74,10 +74,11 @@ def deduplicate_uuids(table=None, dry_run=True):
     :return: list of strings denoting the performed operations
     :raises ValueError: if the specified table is invalid
     """
-    import distutils.dir_util
     from collections import defaultdict
+    import distutils.dir_util
 
     from aiida.common.utils import get_new_uuid
+
     from .utils import get_node_repository_sub_folder
 
     if table not in TABLES_UUID_DEDUPLICATION:

--- a/aiida/backends/general/migrations/utils.py
+++ b/aiida/backends/general/migrations/utils.py
@@ -17,9 +17,9 @@ import pathlib
 import re
 import typing
 
-import numpy
 from disk_objectstore import Container
 from disk_objectstore.utils import LazyOpener
+import numpy
 
 from aiida.common import exceptions, json
 from aiida.repository.backend import AbstractRepositoryBackend

--- a/aiida/backends/sqlalchemy/__init__.py
+++ b/aiida/backends/sqlalchemy/__init__.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=global-statement
 """Module with implementation of the database backend using SqlAlchemy."""
-from aiida.backends.utils import create_sqlalchemy_engine, create_scoped_session_factory
+from aiida.backends.utils import create_scoped_session_factory, create_sqlalchemy_engine
 
 ENGINE = None
 SESSION_FACTORY = None

--- a/aiida/backends/sqlalchemy/manager.py
+++ b/aiida/backends/sqlalchemy/manager.py
@@ -8,15 +8,16 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utilities and configuration of the SqlAlchemy database schema."""
-import os
 import contextlib
+import os
 
 import sqlalchemy
 from sqlalchemy.orm.exc import NoResultFound
 
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.common import NotExistent
-from ..manager import BackendManager, SettingsManager, Setting
+
+from ..manager import BackendManager, Setting, SettingsManager
 
 ALEMBIC_REL_PATH = 'migrations'
 
@@ -35,8 +36,9 @@ class SqlaBackendManager(BackendManager):
         The current database connection is added in the `attributes` property, through which it can then also be
         retrieved, also in the `env.py` file, which is run when the database is migrated.
         """
-        from . import ENGINE
         from alembic.config import Config
+
+        from . import ENGINE
 
         with ENGINE.begin() as connection:
             dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/aiida/backends/sqlalchemy/migrations/env.py
+++ b/aiida/backends/sqlalchemy/migrations/env.py
@@ -19,6 +19,7 @@ def run_migrations_online():
 
     # pylint: disable=unused-import
     from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
+    from aiida.backends.sqlalchemy.models.base import Base
     from aiida.backends.sqlalchemy.models.comment import DbComment
     from aiida.backends.sqlalchemy.models.computer import DbComputer
     from aiida.backends.sqlalchemy.models.group import DbGroup
@@ -27,7 +28,6 @@ def run_migrations_online():
     from aiida.backends.sqlalchemy.models.settings import DbSetting
     from aiida.backends.sqlalchemy.models.user import DbUser
     from aiida.common.exceptions import DbContentError
-    from aiida.backends.sqlalchemy.models.base import Base
     config = context.config  # pylint: disable=no-member
 
     connection = config.attributes.get('connection', None)

--- a/aiida/backends/sqlalchemy/migrations/versions/041a79fc615f_dblog_cleaning.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/041a79fc615f_dblog_cleaning.py
@@ -20,9 +20,8 @@ Create Date: 2018-12-28 15:53:14.596810
 """
 import sys
 
-import click
-
 from alembic import op
+import click
 import sqlalchemy as sa
 from sqlalchemy.sql import text
 

--- a/aiida/backends/sqlalchemy/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
@@ -21,9 +21,9 @@ Create Date: 2019-01-21 10:15:02.451308
 # pylint: disable=no-member,no-name-in-module,import-error
 
 from alembic import op
-from sqlalchemy import cast, String, Integer
-from sqlalchemy.sql import table, column, select, func, text
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy import Integer, String, cast
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import column, func, select, table, text
 
 from aiida.backends.general.migrations.utils import load_numpy_array_from_repository
 

--- a/aiida/backends/sqlalchemy/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
@@ -16,7 +16,6 @@ Create Date: 2018-12-06 12:42:01.897037
 
 """
 from alembic import op
-
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from sqlalchemy.sql import text

--- a/aiida/backends/sqlalchemy/migrations/versions/162b99bca4a2_drop_dbcalcstate.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/162b99bca4a2_drop_dbcalcstate.py
@@ -16,8 +16,8 @@ Create Date: 2018-11-14 08:37:13.719646
 
 """
 from alembic import op
-from sqlalchemy.dialects import postgresql
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '162b99bca4a2'

--- a/aiida/backends/sqlalchemy/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
@@ -16,17 +16,17 @@ Create Date: 2019-04-03 17:11:44.073582
 
 """
 import sys
-import click
 
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-member,import-error,no-name-in-module
 from alembic import op
+import click
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.sql import table, select, func
+from sqlalchemy.sql import func, select, table
 
-from aiida.common import json
 from aiida.cmdline.utils import echo
+from aiida.common import json
 from aiida.manage import configuration
 
 # revision identifiers, used by Alembic.
@@ -38,7 +38,7 @@ depends_on = None
 
 def json_serializer(obj):
     """JSON serializer for objects not serializable by default json code"""
-    from datetime import datetime, date
+    from datetime import date, datetime
     from uuid import UUID
 
     if isinstance(obj, UUID):

--- a/aiida/backends/sqlalchemy/migrations/versions/1feaea71bd5a_migrate_repository.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/1feaea71bd5a_migrate_repository.py
@@ -11,8 +11,8 @@ import pathlib
 
 from alembic import op
 from sqlalchemy import Integer, cast
-from sqlalchemy.dialects.postgresql import UUID, JSONB
-from sqlalchemy.sql import table, column, select, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import column, func, select, table, text
 
 from aiida.backends.general.migrations import utils
 from aiida.cmdline.utils import echo
@@ -29,10 +29,11 @@ def upgrade():
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     import json
     from tempfile import NamedTemporaryFile
+
     from disk_objectstore import Container
 
     from aiida.common import exceptions
-    from aiida.common.progress_reporter import set_progress_bar_tqdm, get_progress_reporter, set_progress_reporter
+    from aiida.common.progress_reporter import get_progress_reporter, set_progress_bar_tqdm, set_progress_reporter
     from aiida.manage.configuration import get_profile
 
     connection = op.get_bind()

--- a/aiida/backends/sqlalchemy/migrations/versions/239cea6d2452_provenance_redesign.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/239cea6d2452_provenance_redesign.py
@@ -19,9 +19,9 @@ Create Date: 2018-12-04 21:14:15.250247
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from alembic import op
-from sqlalchemy import String, Integer
-from sqlalchemy.sql import table, column, select, text
+from sqlalchemy import Integer, String
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import column, select, table, text
 
 # revision identifiers, used by Alembic.
 revision = '239cea6d2452'

--- a/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -41,6 +41,7 @@ def verify_uuid_uniqueness(table):
     :raises: IntegrityError if database contains nodes with duplicate UUIDS.
     """
     from sqlalchemy.sql import text
+
     from aiida.common.exceptions import IntegrityError
 
     query = text(

--- a/aiida/backends/sqlalchemy/migrations/versions/5d4d844852b6_invalidating_node_hash.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/5d4d844852b6_invalidating_node_hash.py
@@ -16,7 +16,6 @@ Create Date: 2018-10-26 17:14:33.566670
 
 """
 from alembic import op
-
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from sqlalchemy.sql import text

--- a/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
@@ -33,6 +33,7 @@ def verify_node_uuid_uniqueness():
     :raises: IntegrityError if database contains nodes with duplicate UUIDS.
     """
     from sqlalchemy.sql import text
+
     from aiida.common.exceptions import IntegrityError
 
     query = text(

--- a/aiida/backends/sqlalchemy/migrations/versions/70c7d732f1b2_delete_dbpath.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/70c7d732f1b2_delete_dbpath.py
@@ -18,6 +18,7 @@ Create Date: 2017-10-17 10:30:23.327195
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.orm.session import Session
+
 from aiida.backends.sqlalchemy.utils import install_tc
 
 # revision identifiers, used by Alembic.

--- a/aiida/backends/sqlalchemy/migrations/versions/a514d673c163_drop_dblock.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/a514d673c163_drop_dblock.py
@@ -16,8 +16,8 @@ Create Date: 2018-05-10 19:08:51.780194
 
 """
 from alembic import op
-from sqlalchemy.dialects import postgresql
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = 'a514d673c163'

--- a/aiida/backends/sqlalchemy/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
@@ -18,12 +18,11 @@ Create Date: 2019-01-21 15:35:07.280805
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-member,no-name-in-module,import-error
 
-import numpy
-
 from alembic import op
-from sqlalchemy.sql import table, column, select, func, text
-from sqlalchemy import String, Integer, cast
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+import numpy
+from sqlalchemy import Integer, String, cast
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import column, func, select, table, text
 
 from aiida.backends.general.migrations import utils
 

--- a/aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py
@@ -19,6 +19,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm.session import Session
+
 from aiida.backends.sqlalchemy.utils import install_tc
 
 # revision identifiers, used by Alembic.

--- a/aiida/backends/sqlalchemy/migrations/versions/e797afa09270_reset_hash.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e797afa09270_reset_hash.py
@@ -16,10 +16,10 @@ Create Date: 2019-07-01 19:39:33.605457
 
 """
 from alembic import op
-
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error
 from sqlalchemy.sql import text
+
 from aiida.cmdline.utils import echo
 
 # revision identifiers, used by Alembic.

--- a/aiida/backends/sqlalchemy/models/authinfo.py
+++ b/aiida/backends/sqlalchemy/models/authinfo.py
@@ -11,10 +11,10 @@
 """Module to manage authentification information for the SQLA backend."""
 
 from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, UniqueConstraint
-from sqlalchemy.types import Integer, Boolean
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import Boolean, Integer
 
 from .base import Base
 

--- a/aiida/backends/sqlalchemy/models/comment.py
+++ b/aiida/backends/sqlalchemy/models/comment.py
@@ -11,13 +11,13 @@
 """Module to manage comments for the SQLA backend."""
 
 from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column
-from sqlalchemy.types import Integer, DateTime, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import DateTime, Integer, Text
 
-from aiida.common import timezone
 from aiida.backends.sqlalchemy.models.base import Base
+from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
 
 

--- a/aiida/backends/sqlalchemy/models/computer.py
+++ b/aiida/backends/sqlalchemy/models/computer.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=import-error,no-name-in-module
 """Module to manage computers for the SQLA backend."""
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.schema import Column
 from sqlalchemy.types import Integer, String, Text
 

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -11,11 +11,10 @@
 """Module to manage computers for the SQLA backend."""
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import relationship, backref
-from sqlalchemy.schema import Column, Table, UniqueConstraint, Index
-from sqlalchemy.types import Integer, String, DateTime, Text
-
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import backref, relationship
+from sqlalchemy.schema import Column, Index, Table, UniqueConstraint
+from sqlalchemy.types import DateTime, Integer, String, Text
 
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid

--- a/aiida/backends/sqlalchemy/models/log.py
+++ b/aiida/backends/sqlalchemy/models/log.py
@@ -11,10 +11,10 @@
 """Module to manage logs for the SQLA backend."""
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.dialects.postgresql import UUID, JSONB
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import backref, relationship
 from sqlalchemy.schema import Column
-from sqlalchemy.types import Integer, DateTime, String, Text
+from sqlalchemy.types import DateTime, Integer, String, Text
 
 from aiida.backends.sqlalchemy.models.base import Base
 from aiida.common import timezone

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -11,16 +11,16 @@
 """Module to manage nodes for the SQLA backend."""
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import relationship, backref
-from sqlalchemy.schema import Column
-from sqlalchemy.types import Integer, String, DateTime, Text
 # Specific to PGSQL. If needed to be agnostic
 # http://docs.sqlalchemy.org/en/rel_0_9/core/custom_types.html?highlight=guid#backend-agnostic-guid-type
 # Or maybe rely on sqlalchemy-utils UUID type
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import backref, relationship
+from sqlalchemy.schema import Column
+from sqlalchemy.types import DateTime, Integer, String, Text
 
-from aiida.common import timezone
 from aiida.backends.sqlalchemy.models.base import Base
+from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
 
 

--- a/aiida/backends/sqlalchemy/models/settings.py
+++ b/aiida/backends/sqlalchemy/models/settings.py
@@ -10,12 +10,11 @@
 # pylint: disable=import-error,no-name-in-module
 """Module to manage node settings for the SQLA backend."""
 from pytz import UTC
-
 from sqlalchemy import Column
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.schema import UniqueConstraint
-from sqlalchemy.types import Integer, String, DateTime
+from sqlalchemy.types import DateTime, Integer, String
 
 from aiida.backends import sqlalchemy as sa
 from aiida.backends.sqlalchemy.models.base import Base

--- a/aiida/backends/sqlalchemy/testbase.py
+++ b/aiida/backends/sqlalchemy/testbase.py
@@ -23,6 +23,7 @@ class SqlAlchemyTests(AiidaTestImplementation):
 
     def clean_db(self):
         from sqlalchemy.sql import table
+
         # pylint: disable=invalid-name
         DbGroupNodes = table('db_dbgroup_dbnodes')
         DbGroup = table('db_dbgroup')

--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -17,8 +17,8 @@ def delete_nodes_and_connections_sqla(pks_to_delete):  # pylint: disable=invalid
     :param pks_to_delete: A list, tuple or set of pks that should be deleted.
     """
     # pylint: disable=no-value-for-parameter
-    from aiida.backends.sqlalchemy.models.node import DbNode, DbLink
     from aiida.backends.sqlalchemy.models.group import table_groups_nodes
+    from aiida.backends.sqlalchemy.models.node import DbLink, DbNode
     from aiida.manage.manager import get_manager
 
     backend = get_manager().get_backend()
@@ -48,6 +48,7 @@ def flag_modified(instance, key):
     derefence the model instance if the passed instance is actually wrapped in the ModelWrapper.
     """
     from sqlalchemy.orm.attributes import flag_modified as flag_modified_sqla
+
     from aiida.orm.implementation.sqlalchemy.utils import ModelWrapper
 
     if isinstance(instance, ModelWrapper):

--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -9,14 +9,14 @@
 ###########################################################################
 """Basic test classes."""
 import os
-import unittest
 import traceback
+import unittest
 
-from aiida.common.exceptions import ConfigurationError, TestsNotAllowedError, InternalError
+from aiida import orm
+from aiida.common.exceptions import ConfigurationError, InternalError, TestsNotAllowedError
+from aiida.common.lang import classproperty
 from aiida.manage import configuration
 from aiida.manage.manager import get_manager, reset_manager
-from aiida import orm
-from aiida.common.lang import classproperty
 
 TEST_KEYWORD = 'test_'
 
@@ -41,8 +41,8 @@ class AiidaTestCase(unittest.TestCase):
     @classmethod
     def get_backend_class(cls):
         """Get backend class."""
+        from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
         from aiida.backends.testimplbase import AiidaTestImplementation
-        from aiida.backends import BACKEND_SQLA, BACKEND_DJANGO
         from aiida.manage.configuration import PROFILE
 
         # Freeze the __impl_class after the first run
@@ -159,9 +159,10 @@ class AiidaTestCase(unittest.TestCase):
         """
         Cleans up file repository.
         """
-        from aiida.manage.configuration import get_profile
-        from aiida.common.exceptions import InvalidOperation
         import shutil
+
+        from aiida.common.exceptions import InvalidOperation
+        from aiida.manage.configuration import get_profile
 
         dirpath_repository = get_profile().repository_path
 

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Backend-agnostic utility functions"""
-from aiida.backends import BACKEND_SQLA, BACKEND_DJANGO
+from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
 from aiida.manage import configuration
 
 AIIDA_ATTRIBUTE_SEP = '.'
@@ -22,6 +22,7 @@ def create_sqlalchemy_engine(profile, **kwargs):
         more info.
     """
     from sqlalchemy import create_engine
+
     from aiida.common import json
 
     # The hostname may be `None`, which is a valid value in the case of peer authentication for example. In this case

--- a/aiida/calculations/importers/arithmetic/add.py
+++ b/aiida/calculations/importers/arithmetic/add.py
@@ -2,11 +2,11 @@
 """Importer for the :class:`aiida.calculations.arithmetic.add.ArithmeticAddCalculation` plugin."""
 from pathlib import Path
 from re import match
-from typing import Dict, Union
 from tempfile import NamedTemporaryFile
+from typing import Dict, Union
 
 from aiida.engine import CalcJobImporter
-from aiida.orm import Node, Int, RemoteData
+from aiida.orm import Int, Node, RemoteData
 
 
 class ArithmeticAddCalculationImporter(CalcJobImporter):

--- a/aiida/calculations/templatereplacer.py
+++ b/aiida/calculations/templatereplacer.py
@@ -92,8 +92,8 @@ class TemplatereplacerCalculation(CalcJob):
         :param folder: a aiida.common.folders.Folder subclass where the plugin should put all its files.
         """
         # pylint: disable=too-many-locals,too-many-statements,too-many-branches
-        from aiida.common.utils import validate_list_of_string_tuples
         from aiida.common.exceptions import ValidationError
+        from aiida.common.utils import validate_list_of_string_tuples
 
         code = self.inputs.code
         template = self.inputs.template.get_dict()

--- a/aiida/calculations/transfer.py
+++ b/aiida/calculations/transfer.py
@@ -10,9 +10,10 @@
 """Implementation of Transfer CalcJob."""
 
 import os
+
 from aiida import orm
-from aiida.engine import CalcJob
 from aiida.common.datastructures import CalcInfo
+from aiida.engine import CalcJob
 
 
 def validate_instructions(instructions, _):

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -16,7 +16,26 @@ click_completion.init()
 
 # Import to populate the `verdi` sub commands
 from aiida.cmdline.commands import (
-    cmd_archive, cmd_calcjob, cmd_code, cmd_completioncommand, cmd_computer, cmd_config, cmd_data, cmd_database,
-    cmd_daemon, cmd_devel, cmd_group, cmd_help, cmd_node, cmd_plugin, cmd_process, cmd_profile, cmd_restapi, cmd_run,
-    cmd_setup, cmd_shell, cmd_status, cmd_user
+    cmd_archive,
+    cmd_calcjob,
+    cmd_code,
+    cmd_completioncommand,
+    cmd_computer,
+    cmd_config,
+    cmd_daemon,
+    cmd_data,
+    cmd_database,
+    cmd_devel,
+    cmd_group,
+    cmd_help,
+    cmd_node,
+    cmd_plugin,
+    cmd_process,
+    cmd_profile,
+    cmd_restapi,
+    cmd_run,
+    cmd_setup,
+    cmd_shell,
+    cmd_status,
+    cmd_user,
 )

--- a/aiida/cmdline/commands/cmd_archive.py
+++ b/aiida/cmdline/commands/cmd_archive.py
@@ -11,8 +11,8 @@
 """`verdi archive` command."""
 from enum import Enum
 import logging
-from typing import List, Tuple
 import traceback
+from typing import List, Tuple
 import urllib.request
 
 import click
@@ -46,6 +46,7 @@ def inspect(archive, version, meta_data):
     information is displayed.
     """
     import dataclasses
+
     from aiida.tools.importexport import CorruptArchive, detect_archive_type, get_reader
 
     reader_cls = get_reader(detect_archive_type(archive))
@@ -121,7 +122,7 @@ def create(
     """
     # pylint: disable=too-many-branches
     from aiida.common.progress_reporter import set_progress_bar_tqdm, set_progress_reporter
-    from aiida.tools.importexport import export, ExportFileFormat
+    from aiida.tools.importexport import ExportFileFormat, export
     from aiida.tools.importexport.common.exceptions import ArchiveExportError
 
     entities = []
@@ -197,7 +198,7 @@ def create(
 def migrate(input_file, output_file, force, in_place, archive_format, version):
     """Migrate an export archive to a more recent format version."""
     from aiida.common.progress_reporter import set_progress_bar_tqdm, set_progress_reporter
-    from aiida.tools.importexport import detect_archive_type, EXPORT_VERSION
+    from aiida.tools.importexport import EXPORT_VERSION, detect_archive_type
     from aiida.tools.importexport.archive.migrators import get_migrator
 
     if in_place:
@@ -393,7 +394,10 @@ def _import_archive(archive: str, web_based: bool, import_kwargs: dict, try_migr
     """
     from aiida.common.folders import SandboxFolder
     from aiida.tools.importexport import (
-        detect_archive_type, EXPORT_VERSION, import_data, IncompatibleArchiveVersionError
+        EXPORT_VERSION,
+        IncompatibleArchiveVersionError,
+        detect_archive_type,
+        import_data,
     )
     from aiida.tools.importexport.archive.migrators import get_migrator
 

--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -87,9 +87,9 @@ def calcjob_inputcat(calcjob, path):
 
     If PATH is not specified, the default input file path will be used, if defined by the calcjob plugin class.
     """
+    import errno
     from shutil import copyfileobj
     import sys
-    import errno
 
     # Get path from the given CalcJobNode if not defined by user
     if path is None:
@@ -134,9 +134,9 @@ def calcjob_outputcat(calcjob, path):
     If PATH is not specified, the default output file path will be used, if defined by the calcjob plugin class.
     Content can only be shown after the daemon has retrieved the remote files.
     """
+    import errno
     from shutil import copyfileobj
     import sys
-    import errno
 
     try:
         retrieved = calcjob.outputs.retrieved
@@ -236,9 +236,9 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force):
     If both are specified, a logical AND is done between the two, i.e. the calcjobs that will be cleaned have been
     modified AFTER [-p option] days from now, but BEFORE [-o option] days from now.
     """
+    from aiida import orm
     from aiida.orm.utils.loaders import ComputerEntityLoader, IdentifierType
     from aiida.orm.utils.remote import clean_remote, get_calcjob_remote_paths
-    from aiida import orm
 
     if calcjobs:
         if (past_days is not None and older_than is not None):

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -14,7 +14,7 @@ import click
 import tabulate
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.params import options, arguments
+from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.commands import code as options_code
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
@@ -146,8 +146,8 @@ def code_duplicate(ctx, code, non_interactive, **kwargs):
 @with_dbenv()
 def show(code):
     """Display detailed information for a code."""
-    from aiida.repository import FileType
     from aiida.cmdline import is_verbose
+    from aiida.repository import FileType
 
     table = []
     table.append(['PK', code.pk])
@@ -250,8 +250,8 @@ def relabel(code, label):
 @with_dbenv()
 def code_list(computer, input_plugin, all_entries, all_users, show_owner):
     """List the available codes."""
-    from aiida.orm import Code  # pylint: disable=redefined-outer-name
     from aiida import orm
+    from aiida.orm import Code  # pylint: disable=redefined-outer-name
 
     qb_user_filters = dict()
     if not all_users:

--- a/aiida/cmdline/commands/cmd_completioncommand.py
+++ b/aiida/cmdline/commands/cmd_completioncommand.py
@@ -12,6 +12,7 @@
 into the bash script to activate completion.
 """
 import click
+
 from aiida.cmdline.commands.cmd_verdi import verdi
 
 

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -14,12 +14,12 @@ from functools import partial
 import click
 import tabulate
 
-from aiida.cmdline.commands.cmd_verdi import verdi, VerdiCommandGroup
-from aiida.cmdline.params import options, arguments
+from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup, verdi
+from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.commands import computer as options_computer
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
-from aiida.common.exceptions import ValidationError, EntryPointError
+from aiida.common.exceptions import EntryPointError, ValidationError
 from aiida.plugins.entry_point import get_entry_point_names
 
 
@@ -116,9 +116,9 @@ def _computer_create_temp_file(transport, scheduler, authinfo):  # pylint: disab
     :param authinfo: the AuthInfo object (from which one can get computer and aiidauser)
     :return: tuple of boolean indicating success or failure and an optional string message
     """
-    import tempfile
     import datetime
     import os
+    import tempfile
 
     file_content = f"Test from 'verdi computer test' on {datetime.datetime.now().isoformat()}"
     workdir = authinfo.get_workdir().format(username=transport.whoami())
@@ -429,6 +429,7 @@ def computer_test(user, print_traceback, computer):
     to perform other tests.
     """
     import traceback
+
     from aiida import orm
     from aiida.common.exceptions import NotExistent
 
@@ -529,8 +530,8 @@ def computer_delete(computer):
 
     Note that it is not possible to delete the computer if there are calculations that are using it.
     """
-    from aiida.common.exceptions import InvalidOperation
     from aiida import orm
+    from aiida.common.exceptions import InvalidOperation
 
     label = computer.label
 

--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -114,7 +114,7 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
 
     List values are split by whitespace, e.g. "a b" becomes ["a", "b"].
     """
-    from aiida.manage.configuration import Config, Profile, ConfigValidationError
+    from aiida.manage.configuration import Config, ConfigValidationError, Profile
 
     if append and remove:
         echo.echo_critical('Cannot flag both append and remove')
@@ -179,8 +179,8 @@ def verdi_config_unset(ctx, option, globally):
 @click.option('-d', '--disabled', is_flag=True, help='List disabled types instead.')
 def verdi_config_caching(disabled):
     """List caching-enabled process types for the current profile."""
-    from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR, get_entry_point_names
     from aiida.manage.caching import get_use_cache
+    from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR, get_entry_point_names
 
     for group in ['aiida.calculations', 'aiida.workflows']:
         for entry_point in get_entry_point_names(group):

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -11,8 +11,8 @@
 
 import os
 import subprocess
-import time
 import sys
+import time
 
 import click
 from click_spinner import spinner
@@ -20,8 +20,12 @@ from click_spinner import spinner
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.utils.common import get_env_with_venv_bin
-from aiida.cmdline.utils.daemon import get_daemon_status, \
-    print_client_response_status, delete_stale_pid_file, _START_CIRCUS_COMMAND
+from aiida.cmdline.utils.daemon import (
+    _START_CIRCUS_COMMAND,
+    delete_stale_pid_file,
+    get_daemon_status,
+    print_client_response_status,
+)
 from aiida.manage.configuration import get_config
 
 

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -11,8 +11,7 @@
 
 import click
 
-from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.commands.cmd_data import cmd_show
+from aiida.cmdline.commands.cmd_data import cmd_show, verdi_data
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export
 from aiida.cmdline.commands.cmd_data.cmd_list import list_options
 from aiida.cmdline.params import arguments, options, types
@@ -41,8 +40,9 @@ def bands():
 @options.FORMULA_MODE()
 def bands_list(elements, elements_exclusive, raw, formula_mode, past_days, groups, all_users):
     """List BandsData objects."""
-    from tabulate import tabulate
     from argparse import Namespace
+
+    from tabulate import tabulate
 
     from aiida.orm.nodes.data.array.bands import get_bands_and_parents_structure
 

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -11,8 +11,7 @@
 
 import click
 
-from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.commands.cmd_data import cmd_show
+from aiida.cmdline.commands.cmd_data import cmd_show, verdi_data
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_options
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.params import arguments, options, types
@@ -34,8 +33,9 @@ def cif():
 @decorators.with_dbenv()
 def cif_list(raw, formula_mode, past_days, groups, all_users):
     """List store CifData objects."""
-    from aiida.orm import CifData
     from tabulate import tabulate
+
+    from aiida.orm import CifData
 
     elements = None
     elements_only = False

--- a/aiida/cmdline/commands/cmd_data/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_export.py
@@ -12,8 +12,9 @@ This module provides export functionality to all data types
 """
 
 import click
-from aiida.cmdline.utils import echo
+
 from aiida.cmdline.params import options
+from aiida.cmdline.utils import echo
 
 EXPORT_OPTIONS = [
     click.option(

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -12,8 +12,8 @@ This allows to manage showfunctionality to all data types.
 """
 import click
 
-from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.params import options
+from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.utils import echo
 from aiida.common.exceptions import MultipleObjectsError
 
@@ -53,8 +53,8 @@ def _show_jmol(exec_name, trajectory_list, **kwargs):
     """
     Plugin for jmol
     """
-    import tempfile
     import subprocess
+    import tempfile
 
     # pylint: disable=protected-access
     with tempfile.NamedTemporaryFile(mode='w+b') as handle:
@@ -78,8 +78,8 @@ def _show_xcrysden(exec_name, object_list, **kwargs):
     """
     Plugin for xcrysden
     """
-    import tempfile
     import subprocess
+    import tempfile
 
     if len(object_list) > 1:
         raise MultipleObjectsError('Visualization of multiple trajectories is not implemented')
@@ -140,8 +140,8 @@ def _show_vesta(exec_name, structure_list):
     at Kyoto University in the group of Prof. Isao Tanaka's lab
 
     """
-    import tempfile
     import subprocess
+    import tempfile
 
     # pylint: disable=protected-access
     with tempfile.NamedTemporaryFile(mode='w+b', suffix='.cif') as tmpf:
@@ -165,8 +165,8 @@ def _show_vmd(exec_name, structure_list):
     """
     Plugin for vmd
     """
-    import tempfile
     import subprocess
+    import tempfile
 
     if len(structure_list) > 1:
         raise MultipleObjectsError('Visualization of multiple objects is not implemented')
@@ -193,9 +193,10 @@ def _show_xmgrace(exec_name, list_bands):
     """
     Plugin for showing the bands with the XMGrace plotting software.
     """
-    import sys
     import subprocess
+    import sys
     import tempfile
+
     from aiida.orm.nodes.data.array.bands import MAX_NUM_AGR_COLORS
 
     list_files = []

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -11,8 +11,7 @@
 
 import click
 
-from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.commands.cmd_data import cmd_show
+from aiida.cmdline.commands.cmd_data import cmd_show, verdi_data
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_options
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.params import arguments, options, types
@@ -55,8 +54,9 @@ def structure():
 @decorators.with_dbenv()
 def structure_list(elements, raw, formula_mode, past_days, groups, all_users):
     """List StructureData objects."""
-    from aiida.orm.nodes.data.structure import StructureData, get_formula, get_symbols_string
     from tabulate import tabulate
+
+    from aiida.orm.nodes.data.structure import StructureData, get_formula, get_symbols_string
 
     elements_only = False
     lst = data_list(

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -11,8 +11,7 @@
 
 import click
 
-from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.commands.cmd_data import cmd_show
+from aiida.cmdline.commands.cmd_data import cmd_show, verdi_data
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_options
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.commands.cmd_data.cmd_show import show_options
@@ -34,8 +33,9 @@ def trajectory():
 @decorators.with_dbenv()
 def trajectory_list(raw, past_days, groups, all_users):
     """List TrajectoryData objects stored in the database."""
-    from aiida.orm import TrajectoryData
     from tabulate import tabulate
+
+    from aiida.orm import TrajectoryData
 
     elements = None
     elements_only = False

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -10,11 +10,12 @@
 """`verdi data upf` command."""
 
 import os
+
 import click
 
 from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_options
+from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
 
 

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -11,11 +11,11 @@
 
 import click
 
-from aiida.common import exceptions
+from aiida.backends.general.migrations.duplicate_uuids import TABLES_UUID_DEDUPLICATION
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators, echo
-from aiida.backends.general.migrations.duplicate_uuids import TABLES_UUID_DEDUPLICATION
+from aiida.common import exceptions
 
 
 @verdi.group('database')
@@ -45,8 +45,8 @@ def database_version():
 @options.FORCE()
 def database_migrate(force):
     """Migrate the database to the latest schema version."""
-    from aiida.manage.manager import get_manager
     from aiida.engine.daemon.client import get_daemon_client
+    from aiida.manage.manager import get_manager
 
     client = get_daemon_client()
     if client.is_daemon_running:
@@ -200,7 +200,7 @@ def detect_invalid_nodes():
 def database_summary():
     """Summarise the entities in the database."""
     from aiida.cmdline import is_verbose
-    from aiida.orm import QueryBuilder, Node, Group, Computer, Comment, Log, User
+    from aiida.orm import Comment, Computer, Group, Log, Node, QueryBuilder, User
     data = {}
 
     # User

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -10,11 +10,11 @@
 """`verdi group` commands"""
 import click
 
-from aiida.common.exceptions import UniquenessError
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.params import options, arguments
+from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.common.exceptions import UniquenessError
 from aiida.common.links import GraphTraversalRules
 
 
@@ -44,7 +44,7 @@ def group_add_nodes(group, force, nodes):
 @with_dbenv()
 def group_remove_nodes(group, nodes, clear, force):
     """Remove nodes from a group."""
-    from aiida.orm import QueryBuilder, Group, Node
+    from aiida.orm import Group, Node, QueryBuilder
 
     if nodes and clear:
         echo.echo_critical(
@@ -95,8 +95,8 @@ def group_remove_nodes(group, nodes, clear, force):
 @with_dbenv()
 def group_delete(group, delete_nodes, dry_run, force, **traversal_rules):
     """Delete a group and (optionally) the nodes it contains."""
-    from aiida.tools import delete_group_nodes
     from aiida import orm
+    from aiida.tools import delete_group_nodes
 
     if not (force or dry_run):
         click.confirm(f'Are you sure you want to delete {group}?', abort=True)
@@ -168,8 +168,8 @@ def group_show(group, raw, limit, uuid):
     """Show information for a given group."""
     from tabulate import tabulate
 
-    from aiida.common.utils import str_timedelta
     from aiida.common import timezone
+    from aiida.common.utils import str_timedelta
 
     if limit:
         node_iterator = group.nodes[:limit]
@@ -256,10 +256,12 @@ def group_list(
     """Show a list of existing groups."""
     # pylint: disable=too-many-branches,too-many-arguments,too-many-locals,too-many-statements
     import datetime
+
+    from tabulate import tabulate
+
     from aiida import orm
     from aiida.common import timezone
     from aiida.common.escaping import escape_for_sql_like
-    from tabulate import tabulate
 
     builder = orm.QueryBuilder()
     filters = {}

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -8,19 +8,18 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi node` command."""
-import shutil
 import pathlib
+import shutil
 
 import click
 import tabulate
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.params import options, arguments
+from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.types.plugin import PluginParamType
 from aiida.cmdline.utils import decorators, echo, multi_line_input
 from aiida.cmdline.utils.decorators import with_dbenv
-from aiida.common import exceptions
-from aiida.common import timezone
+from aiida.common import exceptions, timezone
 from aiida.common.links import GraphTraversalRules
 
 
@@ -40,9 +39,9 @@ def verdi_node_repo():
 @with_dbenv()
 def repo_cat(node, relative_path):
     """Output the content of a file in the node repository folder."""
+    import errno
     from shutil import copyfileobj
     import sys
-    import errno
 
     try:
         with node.open(relative_path, mode='rb') as fhandle:
@@ -201,9 +200,9 @@ def node_show(nodes, print_groups):
         echo.echo(get_node_info(node))
 
         if print_groups:
-            from aiida.orm.querybuilder import QueryBuilder
-            from aiida.orm.groups import Group
             from aiida.orm import Node  # pylint: disable=redefined-outer-name
+            from aiida.orm.groups import Group
+            from aiida.orm.querybuilder import QueryBuilder
 
             # pylint: disable=invalid-name
             qb = QueryBuilder()

--- a/aiida/cmdline/commands/cmd_plugin.py
+++ b/aiida/cmdline/commands/cmd_plugin.py
@@ -28,8 +28,8 @@ def verdi_plugin():
 @decorators.with_dbenv()
 def plugin_list(entry_point_group, entry_point):
     """Display a list of all available plugins."""
-    from aiida.common import EntryPointError
     from aiida.cmdline.utils.common import print_process_info
+    from aiida.common import EntryPointError
     from aiida.engine import Process
     from aiida.plugins.entry_point import get_entry_point_names, load_entry_point
 

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -10,7 +10,6 @@
 # pylint: disable=too-many-arguments
 """`verdi process` command."""
 import click
-
 from kiwipy import communications
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -53,7 +52,8 @@ def process_list(
     to show also the finished ones."""
     # pylint: disable=too-many-locals
     from tabulate import tabulate
-    from aiida.cmdline.utils.common import print_last_process_state_change, check_worker_load
+
+    from aiida.cmdline.utils.common import check_worker_load, print_last_process_state_change
     from aiida.engine.daemon.client import get_daemon_client
 
     relationships = {}
@@ -144,8 +144,8 @@ def process_call_root(processes):
 @decorators.with_dbenv()
 def process_report(processes, levelname, indent_size, max_depth):
     """Show the log report for one or multiple processes."""
-    from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report, get_process_function_report
-    from aiida.orm import CalcJobNode, WorkChainNode, CalcFunctionNode, WorkFunctionNode
+    from aiida.cmdline.utils.common import get_calcjob_report, get_process_function_report, get_workchain_report
+    from aiida.orm import CalcFunctionNode, CalcJobNode, WorkChainNode, WorkFunctionNode
 
     for process in processes:
         if isinstance(process, CalcJobNode):
@@ -280,6 +280,7 @@ def process_play(processes, all_entries, timeout, wait):
 def process_watch(processes):
     """Watch the state transitions for a process."""
     from time import sleep
+
     from kiwipy import BroadcastFilter
 
     def _print(communicator, body, sender, subject, correlation_id):  # pylint: disable=unused-argument
@@ -341,9 +342,10 @@ def process_actions(futures_map, infinitive, present, past, wait=False, timeout=
     :type timeout: float
     """
     # pylint: disable=too-many-branches
+    from concurrent import futures
+
     import kiwipy
     from plumpy.futures import unwrap_kiwi_future
-    from concurrent import futures
 
     from aiida.manage.external.rmq import CommunicationTimeout
 

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -16,7 +16,7 @@ profiles can be selected at hook-up (-p flag).
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.params.options import HOSTNAME, PORT, DEBUG
+from aiida.cmdline.params.options import DEBUG, HOSTNAME, PORT
 from aiida.restapi.common import config
 
 
@@ -54,6 +54,7 @@ def restapi(hostname, port, config_dir, debug, wsgi_profile, posting):
         verdi -p <profile_name> restapi --hostname 127.0.0.5 --port 6789
     """
     from aiida.restapi.run_api import run_api
+
     # Invoke the runner
     run_api(
         hostname=hostname,

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -9,8 +9,8 @@
 ###########################################################################
 """`verdi run` command."""
 import contextlib
-import os
 import functools
+import os
 import sys
 
 import click

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -10,6 +10,7 @@
 """The verdi shell command"""
 
 import os
+
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -16,8 +16,9 @@ import click
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import echo
-from aiida.common.log import override_log_level
 from aiida.common.exceptions import IncompatibleDatabaseSchema
+from aiida.common.log import override_log_level
+
 from ..utils.echo import ExitCode
 
 
@@ -56,10 +57,10 @@ def verdi_status(print_traceback, no_rmq):
     """Print status of AiiDA services."""
     # pylint: disable=broad-except,too-many-statements,too-many-branches
     from aiida import __version__
-    from aiida.cmdline.utils.daemon import get_daemon_status, delete_stale_pid_file
+    from aiida.cmdline.utils.daemon import delete_stale_pid_file, get_daemon_status
     from aiida.common.utils import Capturing
-    from aiida.manage.manager import get_manager
     from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
+    from aiida.manage.manager import get_manager
 
     exit_code = ExitCode.SUCCESS
 

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -10,6 +10,7 @@
 """`verdi user` command."""
 
 from functools import partial
+
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -16,7 +16,7 @@ import click
 
 from aiida.backends import BACKEND_DJANGO
 from aiida.cmdline.params import options, types
-from aiida.manage.configuration import get_config, get_config_option, Profile
+from aiida.manage.configuration import Profile, get_config, get_config_option
 from aiida.manage.external.postgres import DEFAULT_DBINFO
 from aiida.manage.external.rmq import BROKER_DEFAULTS
 
@@ -61,6 +61,7 @@ def get_repository_uri_default(ctx):
     :return: default repository URI
     """
     import os
+
     from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
 
     validate_profile_parameter(ctx)

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -15,6 +15,7 @@
 import click
 
 from aiida.cmdline.utils import echo
+
 from .conditional import ConditionalOption
 
 

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -14,11 +14,12 @@ from pgsu import DEFAULT_DSN as DEFAULT_DBINFO  # pylint: disable=no-name-in-mod
 from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
 from aiida.common.log import LOG_LEVELS, configure_logging
 from aiida.manage.external.rmq import BROKER_DEFAULTS
-from ...utils import defaults, echo
+
 from .. import types
+from ...utils import defaults, echo
+from .config import ConfigFileOption
 from .multivalue import MultipleValueOption
 from .overridable import OverridableOption
-from .config import ConfigFileOption
 
 __all__ = (
     'ALL', 'ALL_STATES', 'ALL_USERS', 'APPEND_TEXT', 'ARCHIVE_FORMAT', 'BROKER_HOST', 'BROKER_PASSWORD', 'BROKER_PORT',

--- a/aiida/cmdline/params/types/code.py
+++ b/aiida/cmdline/params/types/code.py
@@ -11,6 +11,7 @@
 import click
 
 from aiida.cmdline.utils import decorators
+
 from .identifier import IdentifierParamType
 
 __all__ = ('CodeParamType',)

--- a/aiida/cmdline/params/types/group.py
+++ b/aiida/cmdline/params/types/group.py
@@ -10,8 +10,8 @@
 """Module for custom click param type group."""
 import click
 
-from aiida.common.lang import type_check
 from aiida.cmdline.utils import decorators
+from aiida.common.lang import type_check
 
 from .identifier import IdentifierParamType
 

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -9,10 +9,11 @@
 ###########################################################################
 """Click parameter types for paths."""
 import os
+from socket import timeout
+import urllib.error
 # See https://stackoverflow.com/a/41217363/1069467
 import urllib.request
-import urllib.error
-from socket import timeout
+
 import click
 
 __all__ = ('AbsolutePathParamType', 'FileOrUrl', 'PathOrUrl')

--- a/aiida/cmdline/params/types/plugin.py
+++ b/aiida/cmdline/params/types/plugin.py
@@ -15,9 +15,16 @@ import click
 from aiida.cmdline.utils import decorators
 from aiida.common import exceptions
 from aiida.plugins import factories
-from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR, ENTRY_POINT_GROUP_PREFIX, EntryPointFormat
-from aiida.plugins.entry_point import format_entry_point_string, get_entry_point_string_format
-from aiida.plugins.entry_point import get_entry_point, get_entry_points, get_entry_point_groups
+from aiida.plugins.entry_point import (
+    ENTRY_POINT_GROUP_PREFIX,
+    ENTRY_POINT_STRING_SEPARATOR,
+    EntryPointFormat,
+    format_entry_point_string,
+    get_entry_point,
+    get_entry_point_groups,
+    get_entry_point_string_format,
+    get_entry_points,
+)
 
 from .strings import EntryPointType
 

--- a/aiida/cmdline/params/types/profile.py
+++ b/aiida/cmdline/params/types/profile.py
@@ -32,7 +32,7 @@ class ProfileParamType(LabelStringType):
         """Attempt to match the given value to a valid profile."""
         from aiida.common import extendeddicts
         from aiida.common.exceptions import MissingConfigurationError, ProfileConfigurationError
-        from aiida.manage.configuration import get_config, load_profile, Profile
+        from aiida.manage.configuration import Profile, get_config, load_profile
 
         value = super().convert(value, param, ctx)
 

--- a/aiida/cmdline/params/types/strings.py
+++ b/aiida/cmdline/params/types/strings.py
@@ -12,6 +12,7 @@ Module for various text-based string validation.
 """
 
 import re
+
 from click.types import StringParamType
 
 __all__ = ('EmailType', 'EntryPointType', 'HostnameType', 'NonEmptyStringParamType', 'LabelStringType')

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -90,6 +90,7 @@ def get_node_summary(node):
     :return: a string summary of the node
     """
     from plumpy import ProcessState
+
     from aiida.orm import ProcessNode
 
     table_headers = ['Property', 'Value']
@@ -141,8 +142,8 @@ def get_node_info(node, include_summary=True):
     :param include_summary: boolean, if True, also include a summary of node properties
     :return: a string summary of the node including a description of all its links and log messages
     """
-    from aiida.common.links import LinkType
     from aiida import orm
+    from aiida.common.links import LinkType
 
     if include_summary:
         result = get_node_summary(node)
@@ -205,6 +206,7 @@ def format_nested_links(links, headers):
     :return: nested formatted string
     """
     from collections.abc import Mapping
+
     import tabulate as tb
 
     tb.PRESERVE_WHITESPACE = True
@@ -313,6 +315,7 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
     """
     # pylint: disable=too-many-locals
     import itertools
+
     from aiida import orm
     from aiida.common.log import LOG_LEVELS
 

--- a/aiida/cmdline/utils/daemon.py
+++ b/aiida/cmdline/utils/daemon.py
@@ -115,6 +115,7 @@ def delete_stale_pid_file(client):
     :param client: the `DaemonClient`
     """
     import os
+
     import psutil
 
     class StartCircusNotFound(Exception):

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -191,8 +191,9 @@ def deprecated_command(message):
     @decorator
     def wrapper(wrapped, _, args, kwargs):
         """Echo a deprecation warning before doing anything else."""
-        from aiida.cmdline.utils import templates
         from textwrap import wrap
+
+        from aiida.cmdline.utils import templates
 
         template = templates.env.get_template('deprecated.tpl')
         width = 80

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -11,9 +11,9 @@
 import collections
 import enum
 import sys
-import yaml
 
 import click
+import yaml
 
 from aiida.common.log import AIIDA_LOGGER
 
@@ -212,6 +212,7 @@ def _format_dictionary_json_date(dictionary, sort_keys=True):
     def default_jsondump(data):
         """Function needed to decode datetimes, that would otherwise not be JSON-decodable."""
         import datetime
+
         from aiida.common import timezone
 
         if isinstance(data, datetime.datetime):

--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Plugin aware click command Group."""
-from aiida.common import exceptions
 from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup
-from aiida.plugins.entry_point import load_entry_point, get_entry_point_names
+from aiida.common import exceptions
+from aiida.plugins.entry_point import get_entry_point_names, load_entry_point
 
 
 class Pluginable(VerdiCommandGroup):

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -8,8 +8,8 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """A utility module with a factory of standard QueryBuilder instances for Calculation nodes."""
-from aiida.common.lang import classproperty
 from aiida.cmdline.utils.query.mapping import CalculationProjectionMapper
+from aiida.common.lang import classproperty
 
 
 class CalculationQueryBuilder:

--- a/aiida/cmdline/utils/query/formatting.py
+++ b/aiida/cmdline/utils/query/formatting.py
@@ -17,8 +17,8 @@ def format_relative_time(datetime):
     :param datetime: the datetime to format
     :return: string representation of the relative time since the given datetime
     """
-    from aiida.common.utils import str_timedelta
     from aiida.common import timezone
+    from aiida.common.utils import str_timedelta
 
     timedelta = timezone.delta(datetime, timezone.now())
 

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -15,6 +15,7 @@ import shutil
 import tempfile
 
 from aiida.manage.configuration import get_profile
+
 from . import timezone
 
 # If True, tries to make everything (dirs, files) group-writable.

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -8,24 +8,24 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Common password and hash generation functions."""
+from collections import OrderedDict, abc
 import datetime
+from decimal import Decimal
+from functools import singledispatch
 import hashlib
+from itertools import chain
 import numbers
+from operator import itemgetter
 import random
 import time
 import typing
 import uuid
-from collections import abc, OrderedDict
-from functools import singledispatch
-from itertools import chain
-from operator import itemgetter
-from decimal import Decimal
 
 import pytz
 
-from aiida.common.utils import DatetimePrecision
 from aiida.common.constants import AIIDA_FLOAT_PRECISION
 from aiida.common.exceptions import HashingError
+from aiida.common.utils import DatetimePrecision
 
 from .folders import Folder
 

--- a/aiida/common/timezone.py
+++ b/aiida/common/timezone.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Utility functions to operate on datetime objects."""
 from datetime import datetime
+
 import dateutil.parser
 
 
@@ -33,6 +34,7 @@ def now():
     :return: datetime object represeting current time
     """
     import pytz
+
     from aiida.manage.configuration import settings
 
     if getattr(settings, 'USE_TZ', None):

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Miscellaneous generic utility functions and classes."""
+from datetime import datetime
 import filecmp
 import inspect
 import io
@@ -15,7 +16,7 @@ import os
 import re
 import sys
 from uuid import UUID
-from datetime import datetime
+
 from .lang import classproperty
 
 

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import socket
 import tempfile
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from aiida.manage.configuration import get_config, get_config_option
 from aiida.manage.configuration.profile import Profile

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -19,13 +19,15 @@ import os
 import pathlib
 import shutil
 from tempfile import NamedTemporaryFile
-from typing import Any, List, Optional, Mapping as MappingType, Tuple, Union
+from typing import Any, List
+from typing import Mapping as MappingType
+from typing import Optional, Tuple, Union
 
 from aiida.common import AIIDA_LOGGER, exceptions
 from aiida.common.datastructures import CalcInfo
 from aiida.common.folders import SandboxFolder
 from aiida.common.links import LinkType
-from aiida.orm import load_node, CalcJobNode, Code, FolderData, Node, RemoteData
+from aiida.orm import CalcJobNode, Code, FolderData, Node, RemoteData, load_node
 from aiida.orm.utils.log import get_dblogger_extra
 from aiida.repository.common import FileType
 from aiida.schedulers.datastructures import JobState

--- a/aiida/engine/daemon/runner.py
+++ b/aiida/engine/daemon/runner.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Function that starts a daemon runner."""
+import asyncio
 import logging
 import signal
-import asyncio
 
 from aiida.common.log import configure_logging
 from aiida.engine.daemon.client import get_daemon_client
@@ -22,8 +22,7 @@ LOGGER = logging.getLogger(__name__)
 
 async def shutdown_runner(runner: Runner) -> None:
     """Cleanup tasks tied to the service's shutdown."""
-    from asyncio import all_tasks
-    from asyncio import current_task
+    from asyncio import all_tasks, current_task
 
     LOGGER.info('Received signal to shut down the daemon runner')
     tasks = [task for task in all_tasks() if task is not current_task()]

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -13,9 +13,10 @@ from typing import Any, Dict, Tuple, Type, Union
 from aiida.common import InvalidOperation
 from aiida.manage import manager
 from aiida.orm import ProcessNode
+
 from .processes.functions import FunctionProcess
 from .processes.process import Process, ProcessBuilder
-from .utils import is_process_scoped, instantiate_process
+from .utils import instantiate_process, is_process_scoped
 
 __all__ = ('run', 'run_get_pk', 'run_get_node', 'submit')
 

--- a/aiida/engine/persistence.py
+++ b/aiida/engine/persistence.py
@@ -13,11 +13,11 @@
 import importlib
 import logging
 import traceback
-from typing import Any, Hashable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Hashable, Optional
 
-import plumpy.persistence
-import plumpy.loaders
 from plumpy.exceptions import PersistenceError
+import plumpy.loaders
+import plumpy.persistence
 
 from aiida.orm.utils import serialize
 

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -9,11 +9,11 @@
 ###########################################################################
 """Convenience classes to help building the input dictionaries for Processes."""
 import collections
-from typing import Any, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Type
 from uuid import uuid4
 
-from aiida.orm import Node
 from aiida.engine.processes.ports import PortNamespace
+from aiida.orm import Node
 
 if TYPE_CHECKING:
     from aiida.engine.processes.process import Process

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -17,18 +17,18 @@ import plumpy.ports
 import plumpy.process_states
 
 from aiida import orm
-from aiida.common import exceptions, AttributeDict
+from aiida.common import AttributeDict, exceptions
 from aiida.common.datastructures import CalcInfo
 from aiida.common.folders import Folder
-from aiida.common.lang import override, classproperty
+from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
 
 from ..exit_code import ExitCode
 from ..ports import PortNamespace
 from ..process import Process, ProcessState
 from ..process_spec import CalcJobProcessSpec
-from .tasks import Waiting, UPLOAD_COMMAND
 from .importer import CalcJobImporter
+from .tasks import UPLOAD_COMMAND, Waiting
 
 __all__ = ('CalcJob',)
 
@@ -579,11 +579,11 @@ class CalcJob(Process):
 
         """
         # pylint: disable=too-many-locals,too-many-statements,too-many-branches
-        from aiida.common.exceptions import PluginInternalError, ValidationError, InvalidOperation, InputValidationError
         from aiida.common import json
-        from aiida.common.utils import validate_list_of_string_tuples
         from aiida.common.datastructures import CodeInfo, CodeRunMode
-        from aiida.orm import load_node, Code, Computer
+        from aiida.common.exceptions import InputValidationError, InvalidOperation, PluginInternalError, ValidationError
+        from aiida.common.utils import validate_list_of_string_tuples
+        from aiida.orm import Code, Computer, load_node
         from aiida.schedulers.datastructures import JobTemplate
 
         inputs = self.node.get_incoming(link_type=LinkType.INPUT_CALC)

--- a/aiida/engine/processes/calcjobs/manager.py
+++ b/aiida/engine/processes/calcjobs/manager.py
@@ -13,7 +13,7 @@ import contextlib
 import contextvars
 import logging
 import time
-from typing import Any, Dict, Hashable, Iterator, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Hashable, Iterator, List, Optional
 
 from aiida.common import lang
 from aiida.orm import AuthInfo

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -12,21 +12,21 @@ import asyncio
 import functools
 import logging
 import tempfile
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import plumpy
-import plumpy.process_states
 import plumpy.futures
+import plumpy.process_states
 
 from aiida.common.datastructures import CalcJobState
 from aiida.common.exceptions import FeatureNotAvailable, TransportTaskException
 from aiida.common.folders import SandboxFolder
 from aiida.engine.daemon import execmanager
 from aiida.engine.transports import TransportQueue
-from aiida.engine.utils import exponential_backoff_retry, interruptable_task, InterruptableFuture
+from aiida.engine.utils import InterruptableFuture, exponential_backoff_retry, interruptable_task
+from aiida.manage.configuration import get_config_option
 from aiida.orm.nodes.process.calculation.calcjob import CalcJobNode
 from aiida.schedulers.datastructures import JobState
-from aiida.manage.configuration import get_config_option
 
 from ..process import ProcessState
 

--- a/aiida/engine/processes/exit_code.py
+++ b/aiida/engine/processes/exit_code.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """A namedtuple and namespace for ExitCodes that can be used to exit from Processes."""
 from typing import NamedTuple, Optional
+
 from aiida.common.extendeddicts import AttributeDict
 
 __all__ = ('ExitCode', 'ExitCodesNamespace')

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -13,7 +13,7 @@ import functools
 import inspect
 import logging
 import signal
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Tuple, Type
 
 from aiida.common.lang import override
 from aiida.manage.manager import get_manager

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -14,32 +14,43 @@ from collections.abc import Mapping
 import enum
 import inspect
 import logging
-from uuid import UUID
 import traceback
 from types import TracebackType
 from typing import (
-    Any, cast, Dict, Iterable, Iterator, List, MutableMapping, Optional, Type, Tuple, Union, TYPE_CHECKING
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
 )
+from uuid import UUID
 
 from aio_pika.exceptions import ConnectionClosed
+from kiwipy.communications import UnroutableError
 import plumpy.exceptions
 import plumpy.futures
-import plumpy.processes
 import plumpy.persistence
-from plumpy.process_states import ProcessState, Finished
-from kiwipy.communications import UnroutableError
+from plumpy.process_states import Finished, ProcessState
+import plumpy.processes
 
 from aiida import orm
-from aiida.orm.utils import serialize
 from aiida.common import exceptions
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
+from aiida.orm.utils import serialize
 
-from .exit_code import ExitCode, ExitCodesNamespace
 from .builder import ProcessBuilder
-from .ports import InputPort, OutputPort, PortNamespace, PORT_NAMESPACE_SEPARATOR
+from .exit_code import ExitCode, ExitCodesNamespace
+from .ports import PORT_NAMESPACE_SEPARATOR, InputPort, OutputPort, PortNamespace
 from .process_spec import ProcessSpec
 
 if TYPE_CHECKING:

--- a/aiida/engine/processes/process_spec.py
+++ b/aiida/engine/processes/process_spec.py
@@ -15,7 +15,7 @@ import plumpy.process_spec
 from aiida.orm import Dict
 
 from .exit_code import ExitCode, ExitCodesNamespace
-from .ports import InputPort, PortNamespace, CalcJobOutputPort
+from .ports import CalcJobOutputPort, InputPort, PortNamespace
 
 __all__ = ('ProcessSpec', 'CalcJobProcessSpec')
 

--- a/aiida/engine/processes/workchains/awaitable.py
+++ b/aiida/engine/processes/workchains/awaitable.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Union
 
 from plumpy.utils import AttributesDict
+
 from aiida.orm import ProcessNode
 
 __all__ = ('Awaitable', 'AwaitableTarget', 'AwaitableAction', 'construct_awaitable')

--- a/aiida/engine/processes/workchains/context.py
+++ b/aiida/engine/processes/workchains/context.py
@@ -11,7 +11,8 @@
 from typing import Union
 
 from aiida.orm import ProcessNode
-from .awaitable import construct_awaitable, Awaitable, AwaitableAction
+
+from .awaitable import Awaitable, AwaitableAction, construct_awaitable
 
 __all__ = ('ToContext', 'assign_', 'append_')
 

--- a/aiida/engine/processes/workchains/restart.py
+++ b/aiida/engine/processes/workchains/restart.py
@@ -11,14 +11,14 @@
 import functools
 from inspect import getmembers
 from types import FunctionType
-from typing import Any, Dict, List, Optional, Type, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from aiida import orm
 from aiida.common import AttributeDict
 
 from .context import ToContext, append_
-from .workchain import WorkChain
 from .utils import ProcessHandlerReport, process_handler
+from .workchain import WorkChain
 
 if TYPE_CHECKING:
     from aiida.engine.processes import ExitCode, PortNamespace, Process, ProcessSpec

--- a/aiida/engine/processes/workchains/utils.py
+++ b/aiida/engine/processes/workchains/utils.py
@@ -11,7 +11,8 @@
 from functools import partial
 from inspect import getfullargspec
 from types import FunctionType  # pylint: disable=no-name-in-module
-from typing import List, Optional, Union, NamedTuple
+from typing import List, NamedTuple, Optional, Union
+
 from wrapt import decorator
 
 from ..exit_code import ExitCode

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -11,11 +11,13 @@
 import collections.abc
 import functools
 import logging
-from typing import Any, List, Optional, Sequence, Union, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
 
 from plumpy.persistence import auto_persist
-from plumpy.process_states import Wait, Continue
-from plumpy.workchains import if_, while_, return_, _PropagateReturn, Stepper, WorkChainSpec as PlumpyWorkChainSpec
+from plumpy.process_states import Continue, Wait
+from plumpy.workchains import Stepper
+from plumpy.workchains import WorkChainSpec as PlumpyWorkChainSpec
+from plumpy.workchains import _PropagateReturn, if_, return_, while_
 
 from aiida.common import exceptions
 from aiida.common.extendeddicts import AttributeDict
@@ -24,9 +26,9 @@ from aiida.orm import Node, ProcessNode, WorkChainNode
 from aiida.orm.utils import load_node
 
 from ..exit_code import ExitCode
-from ..process_spec import ProcessSpec
 from ..process import Process, ProcessState
-from .awaitable import Awaitable, AwaitableTarget, AwaitableAction, construct_awaitable
+from ..process_spec import ProcessSpec
+from .awaitable import Awaitable, AwaitableAction, AwaitableTarget, construct_awaitable
 
 if TYPE_CHECKING:
     from aiida.engine.runners import Runner

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -18,19 +18,18 @@ from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Type, Union
 import uuid
 
 import kiwipy
+from plumpy.communications import wrap_communicator
+from plumpy.events import reset_event_loop_policy, set_event_loop_policy
 from plumpy.persistence import Persister
 from plumpy.process_comms import RemoteProcessThreadController
-from plumpy.events import set_event_loop_policy, reset_event_loop_policy
-from plumpy.communications import wrap_communicator
 
 from aiida.common import exceptions
-from aiida.orm import load_node, ProcessNode
+from aiida.orm import ProcessNode, load_node
 from aiida.plugins.utils import PluginVersionProvider
 
-from .processes import futures, Process, ProcessBuilder, ProcessState
+from . import transports, utils
+from .processes import Process, ProcessBuilder, ProcessState, futures
 from .processes.calcjobs import manager
-from . import transports
-from . import utils
 
 __all__ = ('Runner',)
 

--- a/aiida/engine/transports.py
+++ b/aiida/engine/transports.py
@@ -8,12 +8,12 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """A transport queue to batch process multiple tasks that require a Transport."""
+import asyncio
 import contextlib
+import contextvars
 import logging
 import traceback
 from typing import Awaitable, Dict, Hashable, Iterator, Optional
-import asyncio
-import contextvars
 
 from aiida.orm import AuthInfo
 from aiida.transports import Transport

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -14,7 +14,7 @@ import asyncio
 import contextlib
 from datetime import datetime
 import logging
-from typing import Any, Awaitable, Callable, Iterator, List, Optional, Tuple, Type, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator, List, Optional, Tuple, Type, Union
 
 if TYPE_CHECKING:
     from .processes import Process, ProcessBuilder
@@ -257,7 +257,7 @@ def set_process_state_change_timestamp(process: 'Process') -> None:
     from aiida.common import timezone
     from aiida.common.exceptions import UniquenessError
     from aiida.manage.manager import get_manager  # pylint: disable=cyclic-import
-    from aiida.orm import ProcessNode, CalculationNode, WorkflowNode
+    from aiida.orm import CalculationNode, ProcessNode, WorkflowNode
 
     if isinstance(process.node, CalculationNode):
         process_type = 'calculation'

--- a/aiida/manage/caching.py
+++ b/aiida/manage/caching.py
@@ -8,17 +8,16 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Definition of caching mechanism and configuration for calculations."""
-import re
-import keyword
-from enum import Enum
 from collections import namedtuple
 from contextlib import contextmanager, suppress
+from enum import Enum
+import keyword
+import re
 
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.manage.configuration import get_config_option
-
-from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR, ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP
+from aiida.plugins.entry_point import ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP, ENTRY_POINT_STRING_SEPARATOR
 
 __all__ = ('get_use_cache', 'enable_caching', 'disable_caching')
 

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -51,6 +51,7 @@ import shutil
 import warnings
 
 from aiida.common.warnings import AiidaDeprecationWarning
+
 from . import options
 
 CONFIG = None
@@ -115,6 +116,7 @@ def load_config(create=False):
     :raises aiida.common.MissingConfigurationError: if the configuration file could not be found and create=False
     """
     from aiida.common import exceptions
+
     from .config import Config
 
     filepath = get_config_path()
@@ -278,7 +280,9 @@ def load_documentation_profile():
     the documentation to be built without having to install and configure AiiDA nor having an actual database present.
     """
     import tempfile
+
     from aiida.manage.manager import get_manager
+
     from .config import Config
     from .profile import Profile
 

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -21,7 +21,7 @@ from aiida.common import json
 from aiida.common.exceptions import ConfigurationError
 
 from . import schema as schema_module
-from .options import get_option, get_option_names, Option, parse_option, NO_DEFAULT
+from .options import NO_DEFAULT, Option, get_option, get_option_names, parse_option
 from .profile import Profile
 
 __all__ = ('Config', 'config_schema', 'ConfigValidationError')
@@ -77,6 +77,7 @@ class Config:  # pylint: disable=too-many-public-methods
         :return: `Config` instance
         """
         from aiida.cmdline.utils import echo
+
         from .migrations import check_and_migrate_config, config_needs_migrating
 
         try:
@@ -489,7 +490,8 @@ class Config:  # pylint: disable=too-many-public-methods
 
         :return: self
         """
-        from aiida.common.files import md5_from_filelike, md5_file
+        from aiida.common.files import md5_file, md5_from_filelike
+
         from .settings import DEFAULT_CONFIG_INDENT_SIZE
 
         # If the filepath of this configuration does not yet exist, simply write it.
@@ -520,7 +522,7 @@ class Config:  # pylint: disable=too-many-public-methods
 
         :param filepath: optional filepath to write the contents to, if not specified, the default filename is used.
         """
-        from .settings import DEFAULT_UMASK, DEFAULT_CONFIG_INDENT_SIZE
+        from .settings import DEFAULT_CONFIG_INDENT_SIZE, DEFAULT_UMASK
 
         umask = os.umask(DEFAULT_UMASK)
 

--- a/aiida/manage/configuration/migrations/utils.py
+++ b/aiida/manage/configuration/migrations/utils.py
@@ -10,6 +10,7 @@
 """Defines utilities for verifying the version of the configuration file and migrating it when necessary."""
 
 from aiida.common import exceptions
+
 from .migrations import _MIGRATION_LOOKUP, CURRENT_CONFIG_VERSION
 
 __all__ = ('check_and_migrate_config', 'config_needs_migrating', 'get_current_version')

--- a/aiida/manage/configuration/options.py
+++ b/aiida/manage/configuration/options.py
@@ -64,8 +64,9 @@ class Option:
 
         """
         # pylint: disable=too-many-branches
-        from .config import ConfigValidationError
         from aiida.manage.caching import _validate_identifier_pattern
+
+        from .config import ConfigValidationError
 
         if cast:
             try:

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -131,6 +131,7 @@ class Profile:  # pylint: disable=too-many-public-methods
     def get_repository(self) -> 'Repository':
         """Return the repository configured for this profile."""
         from disk_objectstore import Container
+
         from aiida.repository import Repository
         from aiida.repository.backend import DiskObjectStoreRepositoryBackend
         container = Container(self.repository_path / 'container')

--- a/aiida/manage/database/integrity/sql/nodes.py
+++ b/aiida/manage/database/integrity/sql/nodes.py
@@ -10,7 +10,7 @@
 """SQL statements that test the integrity of the database with respect to nodes."""
 
 from aiida.common.extendeddicts import AttributeDict
-from aiida.orm import Data, CalculationNode, WorkflowNode
+from aiida.orm import CalculationNode, Data, WorkflowNode
 
 
 def format_type_string_regex(node_class):

--- a/aiida/manage/database/integrity/utils.py
+++ b/aiida/manage/database/integrity/utils.py
@@ -25,8 +25,9 @@ def write_database_integrity_violation(results, headers, reason_message, action_
     """
     # pylint: disable=duplicate-string-formatting-argument
     from datetime import datetime
-    from tabulate import tabulate
     from tempfile import NamedTemporaryFile
+
+    from tabulate import tabulate
 
     from aiida.cmdline.utils import echo
     from aiida.manage import configuration

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -16,7 +16,8 @@ installed by default on various systems. If the postgres setup is not the
 default installation, additional information needs to be provided.
 """
 import click
-from pgsu import PGSU, PostgresConnectionMode, DEFAULT_DSN as DEFAULT_DBINFO  # pylint: disable=no-name-in-module
+from pgsu import DEFAULT_DSN as DEFAULT_DBINFO  # pylint: disable=no-name-in-module
+from pgsu import PGSU, PostgresConnectionMode
 
 from aiida.cmdline.utils import echo
 

--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 import logging
 import traceback
 
-from kiwipy import communications, Future
+from kiwipy import Future, communications
 import pamqp.encode
 import plumpy
 
@@ -175,7 +175,7 @@ class ProcessLauncher(plumpy.ProcessLauncher):
         """
         from aiida.common import exceptions
         from aiida.engine.exceptions import PastException
-        from aiida.orm import load_node, Data
+        from aiida.orm import Data, load_node
         from aiida.orm.utils import serialize
 
         try:

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -11,7 +11,7 @@
 """AiiDA manager for global settings"""
 import asyncio
 import functools
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from kiwipy.rmq import RmqThreadCommunicator
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 
     from aiida.backends.manager import BackendManager
     from aiida.engine.daemon.client import DaemonClient
+    from aiida.engine.persistence import AiiDAPersister
     from aiida.engine.runners import Runner
     from aiida.manage.configuration.config import Config
     from aiida.manage.configuration.profile import Profile
     from aiida.orm.implementation import Backend
-    from aiida.engine.persistence import AiiDAPersister
 
 __all__ = ('get_manager', 'reset_manager')
 
@@ -246,9 +246,10 @@ class Manager:
         :return: the communicator instance
 
         """
+        import kiwipy.rmq
+
         from aiida.common import ConfigurationError
         from aiida.manage.external import rmq
-        import kiwipy.rmq
 
         profile = self.get_profile()
         if profile is None:
@@ -376,6 +377,7 @@ class Manager:
 
         """
         from plumpy.persistence import LoadSaveContext
+
         from aiida.engine import persistence
         from aiida.manage.external import rmq
 

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -11,16 +11,15 @@
 Testing infrastructure for easy testing of AiiDA plugins.
 
 """
-import tempfile
-import shutil
-import os
 from contextlib import contextmanager
+import os
+import shutil
+import tempfile
 
 from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
 from aiida.common import exceptions
-from aiida.manage import configuration
+from aiida.manage import configuration, manager
 from aiida.manage.configuration.settings import create_instance_directories
-from aiida.manage import manager
 from aiida.manage.external.postgres import Postgres
 
 __all__ = (
@@ -161,8 +160,8 @@ class ProfileManager:
             from aiida.backends.djsite.db.testbase import DjangoTests
             self._test_case = DjangoTests()
         elif backend == BACKEND_SQLA:
-            from aiida.backends.sqlalchemy.testbase import SqlAlchemyTests
             from aiida.backends.sqlalchemy import get_scoped_session
+            from aiida.backends.sqlalchemy.testbase import SqlAlchemyTests
 
             self._test_case = SqlAlchemyTests()
             self._test_case.test_session = get_scoped_session()
@@ -177,8 +176,8 @@ class ProfileManager:
 
         Adds default user if necessary.
         """
-        from aiida.orm import User
         from aiida.cmdline.commands.cmd_user import set_default_user
+        from aiida.orm import User
 
         if not User.objects.get_default():
             user_dict = get_user_dict(_DEFAULT_PROFILE_INFO)
@@ -334,7 +333,7 @@ class TemporaryProfileManager(ProfileManager):
 
         Warning: the AiiDA dbenv must not be loaded when this is called!
         """
-        from aiida.manage.configuration import settings, load_profile, Profile
+        from aiida.manage.configuration import Profile, load_profile, settings
 
         if not self._has_test_db:
             self.create_aiida_db()
@@ -458,8 +457,8 @@ def test_manager(backend=BACKEND_DJANGO, profile_name=None, pgtest=None):
     :param pgtest: a dictionary of arguments to be passed to PGTest() for starting the postgresql cluster,
        e.g. {'pg_ctl': '/somepath/pg_ctl'}. Should usually not be necessary.
     """
-    from aiida.common.utils import Capturing
     from aiida.common.log import configure_logging
+    from aiida.common.utils import Capturing
 
     try:
         if not _GLOBAL_TEST_MANAGER.has_profile_open():

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -20,10 +20,11 @@ Collection of pytest fixtures using the TestManager for easy testing of AiiDA pl
 import asyncio
 import shutil
 import tempfile
+
 import pytest
 
 from aiida.common.log import AIIDA_LOGGER
-from aiida.manage.tests import test_manager, get_test_backend_name, get_test_profile_name
+from aiida.manage.tests import get_test_backend_name, get_test_profile_name, test_manager
 
 
 @pytest.fixture(scope='function')
@@ -122,8 +123,8 @@ def aiida_localhost(temp_dir):
     :return: The computer node
     :rtype: :py:class:`aiida.orm.Computer`
     """
-    from aiida.orm import Computer
     from aiida.common.exceptions import NotExistent
+    from aiida.orm import Computer
 
     label = 'localhost-test'
 

--- a/aiida/manage/tests/unittest_classes.py
+++ b/aiida/manage/tests/unittest_classes.py
@@ -15,7 +15,8 @@ import warnings
 
 from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.manage.manager import get_manager
-from .main import _GLOBAL_TEST_MANAGER, test_manager, get_test_backend_name, get_test_profile_name
+
+from .main import _GLOBAL_TEST_MANAGER, get_test_backend_name, get_test_profile_name, test_manager
 
 __all__ = ('PluginTestCase', 'TestRunner')
 

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -10,10 +10,10 @@
 """Module for the `AuthInfo` ORM class."""
 
 from aiida.common import exceptions
-from aiida.plugins import TransportFactory
 from aiida.manage.manager import get_manager
-from . import entities
-from . import users
+from aiida.plugins import TransportFactory
+
+from . import entities, users
 
 __all__ = ('AuthInfo',)
 

--- a/aiida/orm/comments.py
+++ b/aiida/orm/comments.py
@@ -10,8 +10,8 @@
 """Comment objects and functions"""
 
 from aiida.manage.manager import get_manager
-from . import entities
-from . import users
+
+from . import entities, users
 
 __all__ = ('Comment',)
 

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -16,8 +16,7 @@ from aiida.manage.manager import get_manager
 from aiida.orm.implementation import Backend
 from aiida.plugins import SchedulerFactory, TransportFactory
 
-from . import entities
-from . import users
+from . import entities, users
 
 __all__ = ('Computer',)
 

--- a/aiida/orm/convert.py
+++ b/aiida/orm/convert.py
@@ -9,11 +9,18 @@
 ###########################################################################
 # pylint: disable=cyclic-import
 """Module for converting backend entities into frontend, ORM, entities"""
-from collections.abc import Mapping, Iterator, Sized
+from collections.abc import Iterator, Mapping, Sized
 from functools import singledispatch
 
-from aiida.orm.implementation import BackendComputer, BackendGroup, BackendUser, BackendAuthInfo, BackendComment, \
-    BackendLog, BackendNode
+from aiida.orm.implementation import (
+    BackendAuthInfo,
+    BackendComment,
+    BackendComputer,
+    BackendGroup,
+    BackendLog,
+    BackendNode,
+    BackendUser,
+)
 
 
 @singledispatch

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -8,11 +8,11 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module for all common top level AiiDA entity classes and methods"""
-import typing
 import abc
 import copy
+import typing
 
-from plumpy.base.utils import super_check, call_with_super_check
+from plumpy.base.utils import call_with_super_check, super_check
 
 from aiida.common import datastructures, exceptions
 from aiida.common.lang import classproperty, type_check

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -16,9 +16,7 @@ from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.manage.manager import get_manager
 
-from . import convert
-from . import entities
-from . import users
+from . import convert, entities, users
 
 __all__ = ('Group', 'AutoGroup', 'ImportGroup', 'UpfFamily')
 

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -11,7 +11,7 @@
 
 import abc
 
-from .entities import BackendEntity, BackendCollection
+from .entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendAuthInfo', 'BackendAuthInfoCollection')
 

--- a/aiida/orm/implementation/backends.py
+++ b/aiida/orm/implementation/backends.py
@@ -15,8 +15,14 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
     from aiida.orm.implementation import (
-        BackendAuthInfoCollection, BackendCommentCollection, BackendComputerCollection, BackendGroupCollection,
-        BackendLogCollection, BackendNodeCollection, BackendQueryBuilder, BackendUserCollection
+        BackendAuthInfoCollection,
+        BackendCommentCollection,
+        BackendComputerCollection,
+        BackendGroupCollection,
+        BackendLogCollection,
+        BackendNodeCollection,
+        BackendQueryBuilder,
+        BackendUserCollection,
     )
 
 __all__ = ('Backend',)

--- a/aiida/orm/implementation/comments.py
+++ b/aiida/orm/implementation/comments.py
@@ -11,7 +11,7 @@
 
 import abc
 
-from .entities import BackendEntity, BackendCollection
+from .entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendComment', 'BackendCommentCollection')
 

--- a/aiida/orm/implementation/computers.py
+++ b/aiida/orm/implementation/computers.py
@@ -12,7 +12,7 @@
 import abc
 import logging
 
-from .entities import BackendEntity, BackendCollection
+from .entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendComputer', 'BackendComputerCollection')
 

--- a/aiida/orm/implementation/django/authinfos.py
+++ b/aiida/orm/implementation/django/authinfos.py
@@ -13,9 +13,8 @@ from aiida.backends.djsite.db.models import DbAuthInfo
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 
+from . import entities, utils
 from ..authinfos import BackendAuthInfo, BackendAuthInfoCollection
-from . import entities
-from . import utils
 
 
 class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
@@ -30,8 +29,7 @@ class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
         :param user: a :class:`aiida.orm.implementation.users.BackendUser` instance
         :return: an :class:`aiida.orm.implementation.authinfos.BackendAuthInfo` instance
         """
-        from . import computers
-        from . import users
+        from . import computers, users
         super().__init__(backend)
         type_check(user, users.DjangoUser)
         type_check(computer, computers.DjangoComputer)
@@ -146,7 +144,7 @@ class DjangoAuthInfoCollection(BackendAuthInfoCollection):
         :raise aiida.common.exceptions.MultipleObjectsError: if multiple entries exist for the computer/user pair
         """
         # pylint: disable=import-error,no-name-in-module
-        from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+        from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 
         try:
             authinfo = DbAuthInfo.objects.get(dbcomputer=computer.id, aiidauser=user.id)

--- a/aiida/orm/implementation/django/backend.py
+++ b/aiida/orm/implementation/django/backend.py
@@ -15,16 +15,8 @@ from django.db import models, transaction
 
 from aiida.backends.djsite.manager import DjangoBackendManager
 
+from . import authinfos, comments, computers, convert, groups, logs, nodes, querybuilder, users
 from ..sql.backends import SqlBackend
-from . import authinfos
-from . import comments
-from . import computers
-from . import convert
-from . import groups
-from . import logs
-from . import nodes
-from . import querybuilder
-from . import users
 
 __all__ = ('DjangoBackend',)
 
@@ -133,6 +125,7 @@ class DjangoBackend(SqlBackend[models.Model]):
         """
         # pylint: disable=import-error,no-name-in-module
         from django.db import connection
+
         # For now we just return the global but if we ever support multiple Django backends
         # being loaded this should be specific to this backend
         return connection

--- a/aiida/orm/implementation/django/comments.py
+++ b/aiida/orm/implementation/django/comments.py
@@ -10,17 +10,16 @@
 """Django implementations for the Comment entity and collection."""
 # pylint: disable=import-error,no-name-in-module
 import contextlib
-
 from datetime import datetime
+
 from django.core.exceptions import ObjectDoesNotExist
 
 from aiida.backends.djsite.db import models
 from aiida.common import exceptions, lang
 
+from . import entities, users
 from ..comments import BackendComment, BackendCommentCollection
 from .utils import ModelWrapper
-from . import entities
-from . import users
 
 
 class DjangoComment(entities.DjangoModelEntity[models.DbComment], BackendComment):

--- a/aiida/orm/implementation/django/computers.py
+++ b/aiida/orm/implementation/django/computers.py
@@ -15,9 +15,8 @@ from django.db import IntegrityError, transaction
 from aiida.backends.djsite.db import models
 from aiida.common import exceptions
 
-from ..computers import BackendComputerCollection, BackendComputer
-from . import entities
-from . import utils
+from . import entities, utils
+from ..computers import BackendComputer, BackendComputerCollection
 
 
 class DjangoComputer(entities.DjangoModelEntity[models.DbComputer], BackendComputer):

--- a/aiida/orm/implementation/django/entities.py
+++ b/aiida/orm/implementation/django/entities.py
@@ -14,6 +14,7 @@ import typing
 from django.db.models import Model  # pylint: disable=import-error, no-name-in-module
 
 from aiida.common.lang import type_check
+
 from . import utils
 
 ModelType = typing.TypeVar('ModelType')  # pylint: disable=invalid-name

--- a/aiida/orm/implementation/django/groups.py
+++ b/aiida/orm/implementation/django/groups.py
@@ -19,9 +19,7 @@ from aiida.backends.djsite.db import models
 from aiida.common.lang import type_check
 from aiida.orm.implementation.groups import BackendGroup, BackendGroupCollection
 
-from . import entities
-from . import users
-from . import utils
+from . import entities, users, utils
 
 __all__ = ('DjangoGroup', 'DjangoGroupCollection')
 

--- a/aiida/orm/implementation/django/nodes.py
+++ b/aiida/orm/implementation/django/nodes.py
@@ -11,17 +11,18 @@
 
 # pylint: disable=import-error,no-name-in-module
 from datetime import datetime
+
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import transaction, IntegrityError
+from django.db import IntegrityError, transaction
 
 from aiida.backends.djsite.db import models
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.orm.implementation.utils import clean_value
 
-from .. import BackendNode, BackendNodeCollection
 from . import entities
 from . import utils as dj_utils
+from .. import BackendNode, BackendNodeCollection
 from .computers import DjangoComputer
 from .users import DjangoUser
 
@@ -196,6 +197,7 @@ class DjangoNode(entities.DjangoModelEntity[models.DbNode], BackendNode):
         :param clean: boolean, if True, will clean the attributes and extras before attempting to store
         """
         import contextlib
+
         from aiida.backends.djsite.db.models import suppress_auto_now
 
         if clean:

--- a/aiida/orm/implementation/django/users.py
+++ b/aiida/orm/implementation/django/users.py
@@ -14,8 +14,8 @@ import functools
 from aiida.backends.djsite.db import models
 from aiida.backends.djsite.db.models import DbUser
 from aiida.orm.implementation.users import BackendUser, BackendUserCollection
-from . import entities
-from . import utils
+
+from . import entities, utils
 
 __all__ = ('DjangoUser', 'DjangoUserCollection')
 
@@ -91,6 +91,7 @@ class DjangoUserCollection(BackendUserCollection):
         """
         # Constructing the default query
         import operator
+
         from django.db.models import Q  # pylint: disable=import-error, no-name-in-module
         query_list = []
 

--- a/aiida/orm/implementation/django/utils.py
+++ b/aiida/orm/implementation/django/utils.py
@@ -10,7 +10,7 @@
 """Utilities for the implementation of the Django backend."""
 
 # pylint: disable=import-error,no-name-in-module
-from django.db import transaction, IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models.fields import FieldDoesNotExist
 
 from aiida.common import exceptions

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -12,8 +12,8 @@
 import abc
 
 from aiida.common import exceptions
-from .entities import BackendEntity, BackendCollection, BackendEntityExtrasMixin
 
+from .entities import BackendCollection, BackendEntity, BackendEntityExtrasMixin
 from .nodes import BackendNode
 
 __all__ = ('BackendGroup', 'BackendGroupCollection')

--- a/aiida/orm/implementation/logs.py
+++ b/aiida/orm/implementation/logs.py
@@ -10,7 +10,7 @@
 """Backend group module"""
 import abc
 
-from .entities import BackendEntity, BackendCollection
+from .entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendLog', 'BackendLogCollection')
 

--- a/aiida/orm/implementation/nodes.py
+++ b/aiida/orm/implementation/nodes.py
@@ -11,7 +11,7 @@
 
 import abc
 
-from .entities import BackendEntity, BackendCollection, BackendEntityAttributesMixin, BackendEntityExtrasMixin
+from .entities import BackendCollection, BackendEntity, BackendEntityAttributesMixin, BackendEntityExtrasMixin
 
 __all__ = ('BackendNode', 'BackendNodeCollection')
 

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -10,7 +10,7 @@
 """Abstract `QueryBuilder` definition."""
 import abc
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Set, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
 
 from aiida.common.lang import type_check
 from aiida.common.log import AIIDA_LOGGER

--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -14,9 +14,8 @@ from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 
+from . import entities, utils
 from ..authinfos import BackendAuthInfo, BackendAuthInfoCollection
-from . import entities
-from . import utils
 
 
 class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
@@ -31,8 +30,7 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
         :param user: a :class:`aiida.orm.implementation.users.BackendUser` instance
         :return: an :class:`aiida.orm.implementation.authinfos.BackendAuthInfo` instance
         """
-        from . import computers
-        from . import users
+        from . import computers, users
         super().__init__(backend)
         type_check(user, users.SqlaUser)
         type_check(computer, computers.SqlaComputer)

--- a/aiida/orm/implementation/sqlalchemy/backend.py
+++ b/aiida/orm/implementation/sqlalchemy/backend.py
@@ -10,19 +10,11 @@
 """SqlAlchemy implementation of `aiida.orm.implementation.backends.Backend`."""
 from contextlib import contextmanager
 
-from aiida.backends.sqlalchemy.models import base
 from aiida.backends.sqlalchemy.manager import SqlaBackendManager
+from aiida.backends.sqlalchemy.models import base
 
+from . import authinfos, comments, computers, convert, groups, logs, nodes, querybuilder, users
 from ..sql.backends import SqlBackend
-from . import authinfos
-from . import comments
-from . import computers
-from . import convert
-from . import groups
-from . import logs
-from . import nodes
-from . import querybuilder
-from . import users
 
 __all__ = ('SqlaBackend',)
 

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -11,17 +11,15 @@
 # pylint: disable=import-error,no-name-in-module
 
 from datetime import datetime
+
 from sqlalchemy.orm.exc import NoResultFound
 
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import comment as models
-from aiida.common import exceptions
-from aiida.common import lang
+from aiida.common import exceptions, lang
 
+from . import entities, users, utils
 from ..comments import BackendComment, BackendCommentCollection
-from . import entities
-from . import users
-from . import utils
 
 
 class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -18,10 +18,9 @@ from sqlalchemy.orm.session import make_transient
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models.computer import DbComputer
 from aiida.common import exceptions
-from aiida.orm.implementation.computers import BackendComputerCollection, BackendComputer
+from aiida.orm.implementation.computers import BackendComputer, BackendComputerCollection
 
-from . import utils
-from . import entities
+from . import entities, utils
 
 
 class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):

--- a/aiida/orm/implementation/sqlalchemy/entities.py
+++ b/aiida/orm/implementation/sqlalchemy/entities.py
@@ -13,6 +13,7 @@ import typing
 
 from aiida.backends.sqlalchemy.models.base import Base
 from aiida.common.lang import type_check
+
 from . import utils
 
 ModelType = typing.TypeVar('ModelType')  # pylint: disable=invalid-name

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -18,9 +18,8 @@ from aiida.backends.sqlalchemy.models.node import DbNode
 from aiida.common.exceptions import UniquenessError
 from aiida.common.lang import type_check
 from aiida.orm.implementation.groups import BackendGroup, BackendGroupCollection
-from . import entities
-from . import users
-from . import utils
+
+from . import entities, users, utils
 
 __all__ = ('SqlaGroup', 'SqlaGroupCollection')
 
@@ -182,11 +181,12 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
             to create a direct SQL INSERT statement to the group-node relationship
             table (to improve speed).
         """
-        from sqlalchemy.exc import IntegrityError  # pylint: disable=import-error, no-name-in-module
         from sqlalchemy.dialects.postgresql import insert  # pylint: disable=import-error, no-name-in-module
-        from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode
+        from sqlalchemy.exc import IntegrityError  # pylint: disable=import-error, no-name-in-module
+
         from aiida.backends.sqlalchemy import get_scoped_session
         from aiida.backends.sqlalchemy.models.base import Base
+        from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode
 
         super().add_nodes(nodes)
         skip_orm = kwargs.get('skip_orm', False)
@@ -240,6 +240,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
             DELETE statement to the group-node relationship table in order to improve speed.
         """
         from sqlalchemy import and_
+
         from aiida.backends.sqlalchemy import get_scoped_session
         from aiida.backends.sqlalchemy.models.base import Base
         from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -16,9 +16,8 @@ from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import log as models
 from aiida.common import exceptions
 
+from . import entities, utils
 from .. import BackendLog, BackendLogCollection
-from . import entities
-from . import utils
 
 
 class SqlaLog(entities.SqlaModelEntity[models.DbLog], BackendLog):

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -11,8 +11,9 @@
 
 # pylint: disable=no-name-in-module,import-error
 from datetime import datetime
-from sqlalchemy.orm.exc import NoResultFound
+
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm.exc import NoResultFound
 
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import node as models
@@ -20,9 +21,9 @@ from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.orm.implementation.utils import clean_value
 
-from .. import BackendNode, BackendNodeCollection
 from . import entities
 from . import utils as sqla_utils
+from .. import BackendNode, BackendNodeCollection
 from .computers import SqlaComputer
 from .users import SqlaUser
 

--- a/aiida/orm/implementation/sqlalchemy/querybuilder/joiner.py
+++ b/aiida/orm/implementation/sqlalchemy/querybuilder/joiner.py
@@ -10,9 +10,9 @@
 """A module containing the logic for creating joined queries."""
 from typing import Any, Callable, Dict, NamedTuple, Optional, Type
 
-from sqlalchemy import and_, select, join
+from sqlalchemy import and_, join, select
 from sqlalchemy.dialects.postgresql import array
-from sqlalchemy.orm import aliased, Query
+from sqlalchemy.orm import Query, aliased
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.elements import BooleanClauseList
 from sqlalchemy.sql.expression import cast as type_cast

--- a/aiida/orm/implementation/sqlalchemy/querybuilder/main.py
+++ b/aiida/orm/implementation/sqlalchemy/querybuilder/main.py
@@ -15,23 +15,26 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
 import uuid
 import warnings
 
-from sqlalchemy import and_, or_, not_, func as sa_func
+from sqlalchemy import and_
+from sqlalchemy import func as sa_func
+from sqlalchemy import not_, or_
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import SAWarning
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import aliased
+from sqlalchemy.orm.attributes import InstrumentedAttribute, QueryableAttribute
 from sqlalchemy.orm.query import Query
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.util import AliasedClass
-from sqlalchemy.sql.expression import case, text
 from sqlalchemy.sql.compiler import SQLCompiler, TypeCompiler
-from sqlalchemy.sql.elements import BooleanClauseList, Cast, BinaryExpression, ColumnElement, Label, ColumnClause
+from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList, Cast, ColumnClause, ColumnElement, Label
+from sqlalchemy.sql.expression import case, text
 from sqlalchemy.sql.functions import FunctionElement
-from sqlalchemy.orm.attributes import InstrumentedAttribute, QueryableAttribute
-from sqlalchemy.types import Integer, Float, Boolean, DateTime, String
+from sqlalchemy.types import Boolean, DateTime, Float, Integer, String
 
 from aiida.common.exceptions import NotExistent
-from aiida.orm.implementation.querybuilder import (BackendQueryBuilder, EntityTypes, QueryDictType, QUERYBUILD_LOGGER)
+from aiida.orm.implementation.querybuilder import QUERYBUILD_LOGGER, BackendQueryBuilder, EntityTypes, QueryDictType
+
 from .joiner import SqlaJoiner
 
 

--- a/aiida/orm/implementation/sqlalchemy/users.py
+++ b/aiida/orm/implementation/sqlalchemy/users.py
@@ -10,8 +10,8 @@
 """SQLA user"""
 from aiida.backends.sqlalchemy.models.user import DbUser
 from aiida.orm.implementation.users import BackendUser, BackendUserCollection
-from . import entities
-from . import utils
+
+from . import entities, utils
 
 __all__ = ('SqlaUserCollection', 'SqlaUser')
 

--- a/aiida/orm/implementation/users.py
+++ b/aiida/orm/implementation/users.py
@@ -10,7 +10,7 @@
 """Backend user"""
 import abc
 
-from .entities import BackendEntity, BackendCollection
+from .entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendUser', 'BackendUserCollection')
 

--- a/aiida/orm/implementation/utils.py
+++ b/aiida/orm/implementation/utils.py
@@ -8,11 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utility methods for backend non-specific implementations."""
+from collections.abc import Iterable, Mapping
+from decimal import Decimal
 import math
 import numbers
-from decimal import Decimal
-
-from collections.abc import Iterable, Mapping
 
 from aiida.common import exceptions
 from aiida.common.constants import AIIDA_FLOAT_PRECISION

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -11,6 +11,7 @@
 
 from aiida.common import timezone
 from aiida.manage.manager import get_manager
+
 from . import entities
 
 __all__ = ('Log', 'OrderSpecifier', 'ASCENDING', 'DESCENDING')

--- a/aiida/orm/nodes/data/array/array.py
+++ b/aiida/orm/nodes/data/array/array.py
@@ -149,6 +149,7 @@ class ArrayData(Data):
         """
         import re
         import tempfile
+
         import numpy
 
         if not isinstance(array, numpy.ndarray):

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -17,7 +17,8 @@ from string import Template
 import numpy
 
 from aiida.common.exceptions import ValidationError
-from aiida.common.utils import prettify_labels, join_labels
+from aiida.common.utils import join_labels, prettify_labels
+
 from .kpoints import KpointsData
 
 __all__ = ('BandsData', 'find_bandgap')
@@ -861,9 +862,9 @@ class BandsData(KpointsData):
         :py:meth:`~aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict`
         """
         import os
-        import tempfile
         import subprocess
         import sys
+        import tempfile
 
         from aiida.common import json
 
@@ -912,9 +913,9 @@ class BandsData(KpointsData):
         """
         import json
         import os
-        import tempfile
         import subprocess
         import sys
+        import tempfile
 
         all_data = self._matplotlib_get_dict(*args, **kwargs)
 
@@ -1132,6 +1133,7 @@ class BandsData(KpointsData):
         )
 
         import math
+
         # load the x and y of every set
         if color_number > MAX_NUM_AGR_COLORS:
             raise ValueError(f'Color number is too high (should be less than {MAX_NUM_AGR_COLORS})')
@@ -1811,8 +1813,9 @@ def get_bands_and_parents_structure(args):
     # pylint: disable=too-many-locals,too-many-branches
 
     import datetime
-    from aiida.common import timezone
+
     from aiida import orm
+    from aiida.common import timezone
 
     q_build = orm.QueryBuilder()
     if args.all_users is False:
@@ -1905,7 +1908,7 @@ def _extract_formula(akinds, asites, args):
 
     :return: a string with formula if the formula is found
     """
-    from aiida.orm.nodes.data.structure import (get_formula, get_symbols_string)
+    from aiida.orm.nodes.data.structure import get_formula, get_symbols_string
 
     if args.element is not None:
         all_symbols = [_['symbols'][0] for _ in akinds]

--- a/aiida/orm/nodes/data/array/kpoints.py
+++ b/aiida/orm/nodes/data/array/kpoints.py
@@ -242,6 +242,7 @@ class KpointsData(ArrayData):
             Default = [0.,0.,0.].
         """
         from aiida.common.exceptions import ModificationNotAllowed
+
         # validate
         try:
             the_mesh = [int(i) for i in mesh]

--- a/aiida/orm/nodes/data/array/projection.py
+++ b/aiida/orm/nodes/data/array/projection.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Data plugin to represet arrays of projected wavefunction components."""
 import copy
+
 import numpy as np
 
 from aiida.common import exceptions

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -377,7 +377,7 @@ class TrajectoryData(ArrayData):
           meaning that the strings in the ``symbols`` array must be valid
           chemical symbols.
         """
-        from aiida.orm.nodes.data.structure import StructureData, Kind, Site
+        from aiida.orm.nodes.data.structure import Kind, Site, StructureData
 
         # ignore step, time, and velocities
         _, _, cell, symbols, positions, _ = self.get_step_data(index)
@@ -456,9 +456,8 @@ class TrajectoryData(ArrayData):
         """
         Write the given trajectory to a string of format CIF.
         """
-        from aiida.orm.nodes.data.cif \
-            import ase_loops, cif_from_ase, pycifrw_from_cif
         from aiida.common.utils import Capturing
+        from aiida.orm.nodes.data.cif import ase_loops, cif_from_ase, pycifrw_from_cif
 
         cif = ''
         indices = list(range(self.numsteps))
@@ -525,9 +524,10 @@ class TrajectoryData(ArrayData):
             t.importfile('some-calc/AIIDA-PROJECT-pos-1.xyz', 'xyz_pos')
         """
 
+        from numpy import array
+
         from aiida.common.exceptions import ValidationError
         from aiida.tools.data.structure import xyz_parser_iterator
-        from numpy import array
 
         numsteps = self.numsteps
         if numsteps == 0:
@@ -559,9 +559,10 @@ class TrajectoryData(ArrayData):
             :py:meth:`._parse_xyz_pos`
         """
 
+        from numpy import array
+
         from aiida.common.exceptions import ValidationError
         from aiida.tools.data.structure import xyz_parser_iterator
-        from numpy import array
 
         numsteps = self.numsteps
         if numsteps == 0:
@@ -692,8 +693,8 @@ class TrajectoryData(ArrayData):
                 'and requires that you already installed the python numpy '
                 'package, as well as the vtk package'
             )
-        from ase.data.colors import jmol_colors
         from ase.data import atomic_numbers
+        from ase.data.colors import jmol_colors
 
         # pylint: disable=invalid-name
 

--- a/aiida/orm/nodes/data/array/xy.py
+++ b/aiida/orm/nodes/data/array/xy.py
@@ -13,7 +13,9 @@ collections of y-arrays bound to a single x-array, and the methods to operate
 on them.
 """
 import numpy as np
+
 from aiida.common.exceptions import NotExistent
+
 from .array import ArrayData
 
 __all__ = ('XyData',)

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -11,6 +11,7 @@
 """Tools for handling Crystallographic Information Files (CIF)"""
 
 import re
+
 from aiida.common.utils import Capturing
 
 from .singlefile import SinglefileData
@@ -59,7 +60,7 @@ def cif_from_ase(ase, full_occupancies=False, add_fake_biso=False):
     :param ase: ASE "images"
     :return: array of CIF datablocks
     """
-    from numpy import arccos, pi, dot
+    from numpy import arccos, dot, pi
     from numpy.linalg import norm
 
     if not isinstance(ase, (list, tuple)):
@@ -371,6 +372,7 @@ class CifData(SinglefileData):
             from the DB.
         """
         import os
+
         from aiida.common.files import md5_file
 
         if not os.path.abspath(filename):

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -11,6 +11,7 @@
 import os
 
 from aiida.common import exceptions
+
 from .data import Data
 
 __all__ = ('Code',)
@@ -159,9 +160,9 @@ class Code(Data):
         :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
             a code
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError
-        from aiida.orm.querybuilder import QueryBuilder
+        from aiida.common.exceptions import MultipleObjectsError, NotExistent
         from aiida.orm.computers import Computer
+        from aiida.orm.querybuilder import QueryBuilder
 
         query = QueryBuilder()
         query.append(cls, filters={'label': label}, project='*', tag='code')
@@ -233,7 +234,7 @@ class Code(Data):
         :raise TypeError: if code_string is not of string type
 
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError
+        from aiida.common.exceptions import MultipleObjectsError, NotExistent
 
         try:
             label, _, machinename = code_string.partition('@')

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -9,8 +9,8 @@
 ###########################################################################
 """Module with `Node` sub class `Data` to be used as a base class for data structures."""
 from aiida.common import exceptions
-from aiida.common.links import LinkType
 from aiida.common.lang import override
+from aiida.common.links import LinkType
 
 from ..node import Node
 

--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -12,8 +12,9 @@
 import copy
 
 from aiida.common import exceptions
-from .data import Data
+
 from .base import to_aiida_type
+from .data import Data
 
 __all__ = ('Dict',)
 

--- a/aiida/orm/nodes/data/numeric.py
+++ b/aiida/orm/nodes/data/numeric.py
@@ -9,7 +9,7 @@
 ###########################################################################
 """Module for defintion of base `Data` sub class for numeric based data types."""
 
-from .base import to_aiida_type, BaseType
+from .base import BaseType, to_aiida_type
 
 __all__ = ('NumericType',)
 

--- a/aiida/orm/nodes/data/orbital.py
+++ b/aiida/orm/nodes/data/orbital.py
@@ -12,6 +12,7 @@ import copy
 
 from aiida.common.exceptions import ValidationError
 from aiida.plugins import OrbitalFactory
+
 from .data import Data
 
 __all__ = ('OrbitalData',)

--- a/aiida/orm/nodes/data/remote/base.py
+++ b/aiida/orm/nodes/data/remote/base.py
@@ -11,6 +11,7 @@
 import os
 
 from aiida.orm import AuthInfo
+
 from ..data import Data
 
 __all__ = ('RemoteData',)

--- a/aiida/orm/nodes/data/remote/stash/base.py
+++ b/aiida/orm/nodes/data/remote/stash/base.py
@@ -2,6 +2,7 @@
 """Data plugin that models an archived folder on a remote computer."""
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check
+
 from ...data import Data
 
 __all__ = ('RemoteStashData',)

--- a/aiida/orm/nodes/data/remote/stash/folder.py
+++ b/aiida/orm/nodes/data/remote/stash/folder.py
@@ -4,6 +4,7 @@ import typing
 
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check
+
 from .base import RemoteStashData
 
 __all__ = ('RemoteStashFolderData',)

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -13,6 +13,7 @@ import os
 import pathlib
 
 from aiida.common import exceptions
+
 from .data import Data
 
 __all__ = ('SinglefileData',)

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -18,6 +18,7 @@ import itertools
 
 from aiida.common.constants import elements
 from aiida.common.exceptions import UnsupportedSpeciesError
+
 from .data import Data
 
 __all__ = ('StructureData', 'Kind', 'Site')
@@ -581,6 +582,7 @@ def symop_ortho_from_fract(cell):
     """
     # pylint: disable=invalid-name
     import math
+
     import numpy
 
     a, b, c, alpha, beta, gamma = cell
@@ -605,6 +607,7 @@ def symop_fract_from_ortho(cell):
     """
     # pylint: disable=invalid-name
     import math
+
     import numpy
 
     a, b, c, alpha, beta, gamma = cell
@@ -631,8 +634,8 @@ def ase_refine_cell(aseatoms, **kwargs):
     :return newase: refined cell with reduced set of atoms
     :return symmetry: a dictionary describing the symmetry space group
     """
-    from spglib import refine_cell, get_symmetry_dataset
     from ase.atoms import Atoms
+    from spglib import get_symmetry_dataset, refine_cell
     cell, positions, numbers = refine_cell(aseatoms, **kwargs)
 
     refined_atoms = Atoms(numbers, scaled_positions=positions, cell=cell, pbc=True)
@@ -1009,8 +1012,9 @@ class StructureData(Data):
         Write the given structure to a string of format required by ChemDoodle.
         """
         # pylint: disable=too-many-locals,invalid-name
-        import numpy as np
         from itertools import product
+
+        import numpy as np
 
         from aiida.common import json
 
@@ -1768,8 +1772,9 @@ class StructureData(Data):
             AiiDA database for record. Default False.
         :return: :py:class:`aiida.orm.nodes.data.cif.CifData` node.
         """
-        from .dict import Dict
         from aiida.tools.data import structure as structure_tools
+
+        from .dict import Dict
 
         param = Dict(dict=kwargs)
         try:
@@ -2380,6 +2385,7 @@ class Site:
         """
         # pylint: disable=too-many-branches
         from collections import defaultdict
+
         import ase
 
         # I create the list of tags

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -12,6 +12,7 @@ import json
 import re
 
 from upf_to_json import upf_to_json
+
 from .singlefile import SinglefileData
 
 __all__ = ('UpfData',)
@@ -46,7 +47,7 @@ def get_pseudos_from_structure(structure, family_name):
     :raise aiida.common.MultipleObjectsError: if more than one UPF for the same element is found in the group.
     :raise aiida.common.NotExistent: if no UPF for an element in the group is found in the group.
     """
-    from aiida.common.exceptions import NotExistent, MultipleObjectsError
+    from aiida.common.exceptions import MultipleObjectsError, NotExistent
 
     pseudo_list = {}
     family_pseudos = {}
@@ -188,8 +189,8 @@ def parse_upf(fname, check_filename=True):
     # pylint: disable=too-many-branches
     import os
 
-    from aiida.common.exceptions import ParsingError
     from aiida.common import AIIDA_LOGGER
+    from aiida.common.exceptions import ParsingError
     from aiida.orm.nodes.data.structure import _valid_symbols
 
     parsed_data = {}
@@ -276,6 +277,7 @@ class UpfData(SinglefileData):
         :return: tuple of `UpfData` and boolean indicating whether it was created.
         """
         import os
+
         from aiida.common.files import md5_file
 
         if not os.path.isabs(filepath):
@@ -375,8 +377,7 @@ class UpfData(SinglefileData):
 
     def get_upf_family_names(self):
         """Get the list of all upf family names to which the pseudo belongs."""
-        from aiida.orm import UpfFamily
-        from aiida.orm import QueryBuilder
+        from aiida.orm import QueryBuilder, UpfFamily
 
         query = QueryBuilder()
         query.append(UpfFamily, tag='group', project='label')
@@ -470,9 +471,7 @@ class UpfData(SinglefileData):
             If defined, it should be either a `User` instance or the user email.
         :return: list of `Group` entities of type UPF.
         """
-        from aiida.orm import UpfFamily
-        from aiida.orm import QueryBuilder
-        from aiida.orm import User
+        from aiida.orm import QueryBuilder, UpfFamily, User
 
         builder = QueryBuilder()
         builder.append(UpfFamily, tag='group', project='*')

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -14,24 +14,23 @@ import datetime
 import importlib
 from logging import Logger
 import typing
-from typing import Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union
 from uuid import UUID
 
 from aiida.common import exceptions
 from aiida.common.escaping import sql_string_match
-from aiida.common.hashing import make_hash, _HASH_EXTRA_KEY
+from aiida.common.hashing import _HASH_EXTRA_KEY, make_hash
 from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
 from aiida.manage.manager import get_manager
+from aiida.orm import autogroup
 from aiida.orm.utils.links import LinkManager, LinkTriple
 from aiida.orm.utils.node import AbstractNodeMeta
-from aiida.orm import autogroup
 
 from ..comments import Comment
 from ..computers import Computer
-from ..entities import Entity, EntityExtrasMixin, EntityAttributesMixin
 from ..entities import Collection as EntityCollection
+from ..entities import Entity, EntityAttributesMixin, EntityExtrasMixin
 from ..querybuilder import QueryBuilder
 from ..users import User
 from .repository import NodeRepositoryMixin

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -9,8 +9,7 @@
 ###########################################################################
 """Module with `Node` sub class for calculation job processes."""
 import datetime
-from typing import Any, AnyStr, Dict, List, Optional, Sequence, Tuple, Type, Union
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcJobState
@@ -62,7 +61,7 @@ class CalcJobNode(CalculationNode):
 
         :return: CalculationTools instance
         """
-        from aiida.plugins.entry_point import is_valid_entry_point_string, get_entry_point_from_string, load_entry_point
+        from aiida.plugins.entry_point import get_entry_point_from_string, is_valid_entry_point_string, load_entry_point
         from aiida.tools.calculations import CalculationTools
 
         if self._tools is None:

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -10,13 +10,12 @@
 """Module with `Node` sub class for processes."""
 
 import enum
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 from plumpy.process_states import ProcessState
 
-from aiida.common.links import LinkType
 from aiida.common.lang import classproperty
+from aiida.common.links import LinkType
 from aiida.orm.utils.mixins import Sealable
 
 from ..node import Node

--- a/aiida/orm/nodes/repository.py
+++ b/aiida/orm/nodes/repository.py
@@ -7,7 +7,7 @@ import tempfile
 from typing import BinaryIO, Dict, Iterable, Iterator, List, Tuple, Union
 
 from aiida.common import exceptions
-from aiida.repository import Repository, File
+from aiida.repository import File, Repository
 from aiida.repository.backend import SandboxRepositoryBackend
 
 __all__ = ('NodeRepositoryMixin',)

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -22,29 +22,38 @@ when instantiated by the user.
 from copy import deepcopy
 from inspect import isclass as inspect_isclass
 from typing import (
-    Any, Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple, Type, Union, TYPE_CHECKING, cast
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
 )
 import warnings
 
 from aiida.manage.manager import get_manager
 from aiida.orm.implementation.querybuilder import (
-    BackendQueryBuilder, EntityTypes, EntityRelationships, PathItemType, QueryDictType, GROUP_ENTITY_TYPE_PREFIX
+    GROUP_ENTITY_TYPE_PREFIX,
+    BackendQueryBuilder,
+    EntityRelationships,
+    EntityTypes,
+    PathItemType,
+    QueryDictType,
 )
 
-from . import authinfos
-from . import comments
-from . import computers
-from . import groups
-from . import logs
-from . import nodes
-from . import users
-from . import entities
-from . import convert
+from . import authinfos, comments, computers, convert, entities, groups, logs, nodes, users
 
 if TYPE_CHECKING:
     # pylint: disable=ungrouped-imports
-    from aiida.orm.implementation import Backend
     from aiida.engine import Process
+    from aiida.orm.implementation import Backend
 
 __all__ = ('QueryBuilder',)
 
@@ -1263,8 +1272,8 @@ def _get_node_type_filter(classifiers: Classifier, subclassing: bool) -> dict:
 
     :returns: dictionary in QueryBuilder filter language to pass into {"type": ... }
     """
-    from aiida.orm.utils.node import get_query_type_from_type_string
     from aiida.common.escaping import escape_for_sql_like
+    from aiida.orm.utils.node import get_query_type_from_type_string
     value = classifiers.ormclass_type_string
 
     if not subclassing:

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utilities for dealing with links between nodes."""
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict, namedtuple
 from collections.abc import Mapping
 
 from aiida.common import exceptions
@@ -114,7 +114,7 @@ def validate_link(source, target, link_type, link_label):
     """
     # yapf: disable
     from aiida.common.links import LinkType, validate_link_label
-    from aiida.orm import Node, Data, CalculationNode, WorkflowNode
+    from aiida.orm import CalculationNode, Data, Node, WorkflowNode
 
     type_check(link_type, LinkType, f'link_type should be a LinkType enum but got: {type(link_type)}')
     type_check(source, Node, f'source should be a `Node` but got: {type(source)}')

--- a/aiida/orm/utils/log.py
+++ b/aiida/orm/utils/log.py
@@ -21,8 +21,9 @@ class DBLogHandler(logging.Handler):
             # https://github.com/python/cpython/blob/1c2cb516e49ceb56f76e90645e67e8df4e5df01a/Lib/logging/handlers.py#L590
             self.format(record)
 
-        from aiida import orm
         from django.core.exceptions import ImproperlyConfigured  # pylint: disable=no-name-in-module, import-error
+
+        from aiida import orm
 
         try:
             try:

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -15,8 +15,8 @@ to access members of other classes via TAB-completable attributes
 import warnings
 
 from aiida.common import AttributeDict
-from aiida.common.links import LinkType
 from aiida.common.exceptions import NotExistent, NotExistentAttributeError, NotExistentKeyError
+from aiida.common.links import LinkType
 from aiida.common.warnings import AiidaDeprecationWarning
 
 __all__ = ('NodeLinksManager', 'AttributeManager')

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -13,8 +13,7 @@ import io
 import tempfile
 
 from aiida.common import exceptions
-from aiida.common.lang import override
-from aiida.common.lang import classproperty
+from aiida.common.lang import classproperty, override
 
 
 class FunctionCalculationMixin:

--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -10,7 +10,6 @@
 """Utilities to operate on `Node` classes."""
 from abc import ABCMeta
 import logging
-
 import warnings
 
 from aiida.common import exceptions
@@ -85,7 +84,7 @@ def get_type_string_from_class(class_module, class_name):
     :param class_module: module of the class
     :param class_name: name of the class
     """
-    from aiida.plugins.entry_point import get_entry_point_from_class, ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP
+    from aiida.plugins.entry_point import ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP, get_entry_point_from_class
 
     group, entry_point = get_entry_point_from_class(class_module, class_name)
 

--- a/aiida/orm/utils/remote.py
+++ b/aiida/orm/utils/remote.py
@@ -53,8 +53,8 @@ def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computer
     from datetime import timedelta
 
     from aiida import orm
-    from aiida.orm import CalcJobNode
     from aiida.common import timezone
+    from aiida.orm import CalcJobNode
 
     filters_calc = {}
     filters_computer = {}

--- a/aiida/orm/utils/serialize.py
+++ b/aiida/orm/utils/serialize.py
@@ -15,10 +15,10 @@ checkpoints and messages in the RabbitMQ queue so do so with caution.  It is fin
 for new types though.
 """
 from functools import partial
-import yaml
 
 from plumpy import Bundle
 from plumpy.utils import AttributesFrozendict
+import yaml
 
 from aiida import orm
 from aiida.common import AttributeDict

--- a/aiida/parsers/plugins/diff_tutorial/parsers.py
+++ b/aiida/parsers/plugins/diff_tutorial/parsers.py
@@ -6,9 +6,9 @@ Register parsers via the "aiida.parsers" entry point in the setup.json file.
 """
 # START PARSER HEAD
 from aiida.engine import ExitCode
+from aiida.orm import SinglefileData
 from aiida.parsers.parser import Parser
 from aiida.plugins import CalculationFactory
-from aiida.orm import SinglefileData
 
 DiffCalculation = CalculationFactory('diff-tutorial')
 

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -11,7 +11,7 @@
 import enum
 import functools
 import traceback
-from typing import Any, Optional, List, Sequence, Set, Tuple
+from typing import Any, List, Optional, Sequence, Set, Tuple
 
 # importlib.metadata was introduced into the standard library in python 3.8,
 # but was then updated in python 3.10 to use an improved API.
@@ -19,7 +19,7 @@ from typing import Any, Optional, List, Sequence, Set, Tuple
 from importlib_metadata import EntryPoint, EntryPoints
 from importlib_metadata import entry_points as _eps
 
-from aiida.common.exceptions import MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError
+from aiida.common.exceptions import LoadingEntryPointError, MissingEntryPointError, MultipleEntryPointError
 
 __all__ = ('load_entry_point', 'load_entry_point_from_string', 'parse_entry_point')
 

--- a/aiida/plugins/factories.py
+++ b/aiida/plugins/factories.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,cyclic-import
 """Definition of factories to load classes from the various plugin groups."""
 from inspect import isclass
-from typing import Any, Callable, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
 
 from importlib_metadata import EntryPoint
 
@@ -26,14 +26,15 @@ if TYPE_CHECKING:
     from aiida.orm import Data, Group
     from aiida.parsers import Parser
     from aiida.schedulers import Scheduler
-    from aiida.transports import Transport
-    from aiida.tools.dbimporters import DbImporter
     from aiida.tools.data.orbital import Orbital
+    from aiida.tools.dbimporters import DbImporter
+    from aiida.transports import Transport
 
 
 def warn_deprecated_entry_point(entry_point_name: str, deprecated_entry_points: List[str]) -> str:
     """If the ``entry_point_name`` is part of the list of ``deprecated_entry_points``, raise a warning."""
     from warnings import warn
+
     from aiida.common.warnings import AiidaDeprecationWarning
 
     if entry_point_name in deprecated_entry_points:
@@ -70,7 +71,7 @@ def BaseFactory(group: str, name: str, load: bool = True) -> Union[EntryPoint, A
     :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
     :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
     """
-    from .entry_point import load_entry_point, get_entry_point
+    from .entry_point import get_entry_point, load_entry_point
 
     if load is True:
         return load_entry_point(group, name)

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -32,8 +32,11 @@ class App(Flask):
         super().__init__(*args, **kwargs)
 
         # Error handler
-        from aiida.restapi.common.exceptions import RestInputValidationError, \
-            RestValidationError, RestFeatureNotAvailable
+        from aiida.restapi.common.exceptions import (
+            RestFeatureNotAvailable,
+            RestInputValidationError,
+            RestValidationError,
+        )
 
         if catch_internal_server:
 
@@ -92,7 +95,14 @@ class AiidaApi(Api):
 
         from aiida.restapi.common.config import CLI_DEFAULTS
         from aiida.restapi.resources import (
-            ProcessNode, CalcJobNode, Computer, User, Group, Node, ServerInfo, QueryBuilder
+            CalcJobNode,
+            Computer,
+            Group,
+            Node,
+            ProcessNode,
+            QueryBuilder,
+            ServerInfo,
+            User,
         )
 
         self.app = app

--- a/aiida/restapi/common/exceptions.py
+++ b/aiida/restapi/common/exceptions.py
@@ -21,8 +21,7 @@ Other errors arising at deeper level, e.g. those raised by the QueryBuilder
 or internal errors, are not embedded into the HTTP response.
 """
 
-from aiida.common.exceptions import ValidationError, InputValidationError, \
-    FeatureNotAvailable
+from aiida.common.exceptions import FeatureNotAvailable, InputValidationError, ValidationError
 
 
 class RestValidationError(ValidationError):

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -15,11 +15,10 @@ from flask import jsonify
 from flask.json import JSONEncoder
 from wrapt import decorator
 
-from aiida.common.utils import DatetimePrecision
 from aiida.common.exceptions import InputValidationError, ValidationError
+from aiida.common.utils import DatetimePrecision
 from aiida.manage.manager import get_manager
-from aiida.restapi.common.exceptions import RestValidationError, \
-    RestInputValidationError
+from aiida.restapi.common.exceptions import RestInputValidationError, RestValidationError
 
 # Important to match querybuilder keys
 PK_DBSYNONYM = 'id'
@@ -667,16 +666,15 @@ class Utils:
         :return: parsed values for the querykeys
         """
 
-        from pyparsing import Word, alphas, nums, alphanums, printables, \
-            ZeroOrMore, OneOrMore, Suppress, Optional, Literal, Group, \
-            QuotedString, Combine, \
-            StringStart as SS, StringEnd as SE, \
-            WordEnd as WE, \
-            ParseException
-
-        from pyparsing import pyparsing_common as ppc
         from dateutil import parser as dtparser
         from psycopg2.tz import FixedOffsetTimezone
+        from pyparsing import Combine, Group, Literal, OneOrMore, Optional, ParseException, QuotedString
+        from pyparsing import StringEnd as SE
+        from pyparsing import StringStart as SS
+        from pyparsing import Suppress, Word
+        from pyparsing import WordEnd as WE
+        from pyparsing import ZeroOrMore, alphanums, alphas, nums, printables
+        from pyparsing import pyparsing_common as ppc
 
         ## Define grammar
         # key types

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -10,7 +10,7 @@
 """ Resources for REST API """
 from urllib.parse import unquote
 
-from flask import request, make_response
+from flask import make_response, request
 from flask_restful import Resource
 
 from aiida.common.lang import classproperty
@@ -49,8 +49,8 @@ class ServerInfo(Resource):
 
         response = {}
 
-        from aiida.restapi.common.config import API_CONFIG
         from aiida import __version__
+        from aiida.restapi.common.config import API_CONFIG
 
         if resource_type == 'info':
             response = {}

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -15,8 +15,9 @@ import importlib
 import os
 
 from flask_cors import CORS
-from .common.config import CLI_DEFAULTS, APP_CONFIG, API_CONFIG
+
 from . import api as api_classes
+from .common.config import API_CONFIG, APP_CONFIG, CLI_DEFAULTS
 
 __all__ = ('run_api', 'configure_api')
 

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -11,8 +11,7 @@
 
 from aiida.common.exceptions import InputValidationError, InvalidOperation
 from aiida.orm.querybuilder import QueryBuilder
-from aiida.restapi.common.exceptions import RestValidationError, \
-    RestInputValidationError
+from aiida.restapi.common.exceptions import RestInputValidationError, RestValidationError
 from aiida.restapi.common.utils import PK_DBSYNONYM
 
 

--- a/aiida/restapi/translator/computer.py
+++ b/aiida/restapi/translator/computer.py
@@ -11,8 +11,8 @@
 Translator for computer
 """
 
-from aiida.restapi.translator.base import BaseTranslator
 from aiida import orm
+from aiida.restapi.translator.base import BaseTranslator
 
 
 class ComputerTranslator(BaseTranslator):
@@ -36,8 +36,8 @@ class ComputerTranslator(BaseTranslator):
         Get projectable properties specific for Computer
         :return: dict of projectable properties and column_order list
         """
-        from aiida.plugins.entry_point import get_entry_points
         from aiida.common.exceptions import EntryPointError
+        from aiida.plugins.entry_point import get_entry_points
 
         schedulers = {}
         for entry_point in get_entry_points('aiida.schedulers'):

--- a/aiida/restapi/translator/group.py
+++ b/aiida/restapi/translator/group.py
@@ -11,8 +11,8 @@
 Translator for group
 """
 
-from aiida.restapi.translator.base import BaseTranslator
 from aiida import orm
+from aiida.restapi.translator.base import BaseTranslator
 
 
 class GroupTranslator(BaseTranslator):

--- a/aiida/restapi/translator/nodes/data/__init__.py
+++ b/aiida/restapi/translator/nodes/data/__init__.py
@@ -11,9 +11,9 @@
 Translator for data node
 """
 
-from aiida.restapi.translator.nodes.node import NodeTranslator
-from aiida.restapi.common.exceptions import RestInputValidationError
 from aiida.common.exceptions import LicensingException
+from aiida.restapi.common.exceptions import RestInputValidationError
+from aiida.restapi.translator.nodes.node import NodeTranslator
 
 
 class DataTranslator(NodeTranslator):

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -8,25 +8,33 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Translator for node"""
-import pkgutil
-import importlib.util
-import importlib.machinery
 from importlib._bootstrap import _exec, _load
-import sys
+import importlib.machinery
+import importlib.util
 import inspect
 import os
+import pkgutil
+import sys
 
 from aiida import orm
-from aiida.orm import Node, Data
 from aiida.common.exceptions import (
-    InputValidationError, ValidationError, InvalidOperation, LoadingEntryPointError, EntryPointError
+    EntryPointError,
+    InputValidationError,
+    InvalidOperation,
+    LoadingEntryPointError,
+    ValidationError,
 )
 from aiida.manage.manager import get_manager
-from aiida.plugins.entry_point import load_entry_point, get_entry_point_names
-from aiida.restapi.translator.base import BaseTranslator
-from aiida.restapi.common.identifiers import get_full_type_filters
+from aiida.orm import Data, Node
+from aiida.plugins.entry_point import get_entry_point_names, load_entry_point
 from aiida.restapi.common.exceptions import RestFeatureNotAvailable, RestInputValidationError, RestValidationError
-from aiida.restapi.common.identifiers import get_node_namespace, load_entry_point_from_full_type, construct_full_type
+from aiida.restapi.common.identifiers import (
+    construct_full_type,
+    get_full_type_filters,
+    get_node_namespace,
+    load_entry_point_from_full_type,
+)
+from aiida.restapi.translator.base import BaseTranslator
 
 
 class NodeTranslator(BaseTranslator):

--- a/aiida/restapi/translator/user.py
+++ b/aiida/restapi/translator/user.py
@@ -9,8 +9,8 @@
 ###########################################################################
 """Translator for user"""
 
-from aiida.restapi.translator.base import BaseTranslator
 from aiida import orm
+from aiida.restapi.translator.base import BaseTranslator
 
 
 class UserTranslator(BaseTranslator):

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -460,6 +460,7 @@ class JobInfo(DefaultFieldsAttributeDict):  # pylint: disable=too-many-instance-
         """
 
         import datetime
+
         import pytz
 
         if value is None:
@@ -484,6 +485,7 @@ class JobInfo(DefaultFieldsAttributeDict):  # pylint: disable=too-many-instance-
         :return: The deserialised date
         """
         import datetime
+
         import pytz
 
         if value is None:

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -11,10 +11,10 @@
 Plugin for direct execution.
 """
 
-import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
+import aiida.schedulers
 from aiida.schedulers import SchedulerError
-from aiida.schedulers.datastructures import (JobInfo, JobState, NodeNumberJobResource)
+from aiida.schedulers.datastructures import JobInfo, JobState, NodeNumberJobResource
 
 ## From the ps man page on Mac OS X 10.12
 #     state     The state is given by a sequence of characters, for example,

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -12,11 +12,11 @@ Plugin for LSF.
 This has been tested on the CERN lxplus cluster (LSF 9.1.3)
 """
 
-import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
 from aiida.common.extendeddicts import AttributeDict
+import aiida.schedulers
 from aiida.schedulers import SchedulerError, SchedulerParsingError
-from aiida.schedulers.datastructures import (JobInfo, JobState, JobResource)
+from aiida.schedulers.datastructures import JobInfo, JobResource, JobState
 
 # This maps LSF status codes to our own state list
 #
@@ -308,8 +308,8 @@ class LsfScheduler(aiida.schedulers.Scheduler):
         :param job_tmpl: an JobTemplate instance with relevant parameters set.
         """
         # pylint: disable=too-many-statements,too-many-branches
-        import string
         import re
+        import string
 
         empty_line = ''
 

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -14,7 +14,7 @@ import logging
 
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import Scheduler, SchedulerError, SchedulerParsingError
-from aiida.schedulers.datastructures import (JobInfo, JobState, MachineInfo, NodeNumberJobResource)
+from aiida.schedulers.datastructures import JobInfo, JobState, MachineInfo, NodeNumberJobResource
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -677,8 +677,8 @@ class PbsBaseClass(Scheduler):
         Parse a time string in the format returned from qstat -f and
         returns a datetime object.
         """
-        import time
         import datetime
+        import time
 
         try:
             time_struct = time.strptime(string, fmt)

--- a/aiida/schedulers/plugins/pbspro.py
+++ b/aiida/schedulers/plugins/pbspro.py
@@ -13,6 +13,7 @@ This has been tested on PBSPro v. 12.
 """
 
 import logging
+
 from .pbsbaseclasses import PbsBaseClass
 
 _LOGGER = logging.getLogger(__name__)

--- a/aiida/schedulers/plugins/sge.py
+++ b/aiida/schedulers/plugins/sge.py
@@ -14,13 +14,13 @@ This has been tested on GE 6.2u3.
 Plugin originally written by Marco Dorigo.
 Email: marco(DOT)dorigo(AT)rub(DOT)de
 """
-import xml.parsers.expat
 import xml.dom.minidom
+import xml.parsers.expat
 
 from aiida.common.escaping import escape_for_bash
 import aiida.schedulers
 from aiida.schedulers import SchedulerError, SchedulerParsingError
-from aiida.schedulers.datastructures import (JobInfo, JobState, ParEnvJobResource)
+from aiida.schedulers.datastructures import JobInfo, JobState, ParEnvJobResource
 
 # 'http://www.loni.ucla.edu/twiki/bin/view/Infrastructure/GridComputing?skin=plain':
 # Jobs Status:
@@ -469,8 +469,8 @@ class SgeScheduler(aiida.schedulers.Scheduler):
         returns a datetime object.
         Example format: 2013-06-13T11:53:11
         """
-        import time
         import datetime
+        import time
 
         try:
             time_struct = time.strptime(string, fmt)

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -16,7 +16,7 @@ import re
 from aiida.common.escaping import escape_for_bash
 from aiida.common.lang import type_check
 from aiida.schedulers import Scheduler, SchedulerError
-from aiida.schedulers.datastructures import (JobInfo, JobState, NodeNumberJobResource)
+from aiida.schedulers.datastructures import JobInfo, JobState, NodeNumberJobResource
 
 # This maps SLURM state codes to our own status list
 
@@ -680,8 +680,8 @@ stderr='{stderr.strip()}'"""
         Parse a time string in the format returned from qstat -f and
         returns a datetime object.
         """
-        import time
         import datetime
+        import time
 
         try:
             time_struct = time.strptime(string, fmt)

--- a/aiida/sphinxext/__init__.py
+++ b/aiida/sphinxext/__init__.py
@@ -14,7 +14,7 @@ def setup(app):
     """Setup function to add the extension classes / nodes to Sphinx."""
     import aiida
 
-    from . import process, workchain, calcjob
+    from . import calcjob, process, workchain
 
     app.setup_extension('sphinxcontrib.details.directive')
     process.setup_extension(app)

--- a/aiida/sphinxext/calcjob.py
+++ b/aiida/sphinxext/calcjob.py
@@ -13,7 +13,8 @@ Defines an rst directive to auto-document AiiDA calculation job.
 import inspect
 
 from aiida.engine import CalcJob
-from .process import AiidaProcessDocumenter, AiidaProcessDirective
+
+from .process import AiidaProcessDirective, AiidaProcessDocumenter
 
 
 def setup_extension(app):

--- a/aiida/sphinxext/process.py
+++ b/aiida/sphinxext/process.py
@@ -10,18 +10,17 @@
 """
 Defines an rst directive to auto-document AiiDA processes.
 """
-from collections.abc import Mapping, Iterable
+from collections.abc import Iterable, Mapping
 import inspect
 
 from docutils import nodes
 from docutils.core import publish_doctree
 from docutils.parsers.rst import directives
+from plumpy.ports import OutputPort
 from sphinx import addnodes
 from sphinx.ext.autodoc import ClassDocumenter
 from sphinx.util.docutils import SphinxDirective
 from sphinxcontrib.details.directive import details, summary
-
-from plumpy.ports import OutputPort
 
 from aiida.common.utils import get_object_from_string
 from aiida.engine import Process

--- a/aiida/sphinxext/workchain.py
+++ b/aiida/sphinxext/workchain.py
@@ -13,7 +13,8 @@ Defines an rst directive to auto-document AiiDA workchains.
 import inspect
 
 from aiida.engine import WorkChain
-from .process import AiidaProcessDocumenter, AiidaProcessDirective
+
+from .process import AiidaProcessDirective, AiidaProcessDocumenter
 
 
 def setup_extension(app):

--- a/aiida/tools/data/array/kpoints/main.py
+++ b/aiida/tools/data/array/kpoints/main.py
@@ -11,7 +11,7 @@
 Various utilities to deal with KpointsData instances or create new ones
 (e.g. band paths, kpoints from a parsed input text file, ...)
 """
-from aiida.orm import KpointsData, Dict
+from aiida.orm import Dict, KpointsData
 
 __all__ = ('get_kpoints_path', 'get_explicit_kpoints_path')
 

--- a/aiida/tools/data/array/kpoints/seekpath.py
+++ b/aiida/tools/data/array/kpoints/seekpath.py
@@ -10,7 +10,7 @@
 """Tool to automatically determine k-points for a given structure using SeeK-path."""
 import seekpath
 
-from aiida.orm import KpointsData, Dict
+from aiida.orm import Dict, KpointsData
 
 
 def get_explicit_kpoints_path(structure, parameters):

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -109,6 +109,7 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
     .. note:: requires pymatgen module.
     """
     from pymatgen.io.cif import CifParser
+
     from aiida.orm import Dict, StructureData
 
     parameters = kwargs.get('parameters', {})

--- a/aiida/tools/data/orbital/realhydrogen.py
+++ b/aiida/tools/data/orbital/realhydrogen.py
@@ -13,7 +13,7 @@ complex-valued).
 """
 from aiida.common.exceptions import ValidationError
 
-from .orbital import Orbital, validate_len3_list_or_none, validate_float_or_none
+from .orbital import Orbital, validate_float_or_none, validate_len3_list_or_none
 
 __all__ = ('RealhydrogenOrbital',)
 

--- a/aiida/tools/data/structure.py
+++ b/aiida/tools/data/structure.py
@@ -20,8 +20,8 @@ import re
 import numpy as np
 
 from aiida.common.constants import elements
-from aiida.orm.nodes.data.structure import Kind, Site, StructureData
 from aiida.engine import calcfunction
+from aiida.orm.nodes.data.structure import Kind, Site, StructureData
 
 __all__ = ('structure_to_spglib_tuple', 'spglib_tuple_to_structure')
 

--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -220,8 +220,8 @@ class DbEntry:
         Returns raw contents of a file as string.
         """
         if self._contents is None:
-            from urllib.request import urlopen
             from hashlib import md5
+            from urllib.request import urlopen
 
             with urlopen(self.source['uri']) as handle:
                 self._contents = handle.read().decode('utf-8')
@@ -282,8 +282,9 @@ class CifEntry(DbEntry):
 
         :return: :py:class:`aiida.orm.nodes.data.cif.CifData` object
         """
-        from aiida.orm.nodes.data.cif import CifData
         import tempfile
+
+        from aiida.orm.nodes.data.cif import CifData
 
         cifnode = None
 
@@ -327,8 +328,9 @@ class UpfEntry(DbEntry):
 
         :return: :py:class:`aiida.orm.nodes.data.upf.UpfData` object
         """
-        from aiida.orm import UpfData
         import tempfile
+
+        from aiida.orm import UpfData
 
         upfnode = None
 

--- a/aiida/tools/dbimporters/plugins/cod.py
+++ b/aiida/tools/dbimporters/plugins/cod.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=no-self-use
 """"Implementation of `DbImporter` for the COD database."""
-from aiida.tools.dbimporters.baseclasses import (DbImporter, DbSearchResults, CifEntry)
+from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 
 
 class CodDbImporter(DbImporter):

--- a/aiida/tools/dbimporters/plugins/icsd.py
+++ b/aiida/tools/dbimporters/plugins/icsd.py
@@ -11,7 +11,7 @@
 """"Implementation of `DbImporter` for the CISD database."""
 import io
 
-from aiida.tools.dbimporters.baseclasses import DbImporter, DbSearchResults, CifEntry
+from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 
 
 class IcsdImporterExp(Exception):
@@ -582,9 +582,10 @@ class IcsdSearchResults(DbSearchResults):  # pylint: disable=abstract-method,too
             self._disconnect_db()
 
         else:
-            from bs4 import BeautifulSoup  # pylint: disable=import-error
-            from urllib.request import urlopen
             import re
+            from urllib.request import urlopen
+
+            from bs4 import BeautifulSoup  # pylint: disable=import-error
 
             with urlopen(
                 self.db_parameters['server'] + self.db_parameters['db'] + '/' + self.query.format(str(self.page))

--- a/aiida/tools/dbimporters/plugins/materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/materialsproject.py
@@ -10,9 +10,9 @@
 """"Implementation of `DbImporter` for the Materials Project database."""
 import datetime
 import os
-import requests
 
 from pymatgen.ext.matproj import MPRester
+import requests
 
 from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 

--- a/aiida/tools/dbimporters/plugins/mpds.py
+++ b/aiida/tools/dbimporters/plugins/mpds.py
@@ -14,8 +14,8 @@ import os
 
 import requests
 
-from aiida.tools.dbimporters.baseclasses import CifEntry, DbEntry, DbImporter, DbSearchResults
 from aiida.common import json
+from aiida.tools.dbimporters.baseclasses import CifEntry, DbEntry, DbImporter, DbSearchResults
 
 
 class ApiFormat(enum.Enum):

--- a/aiida/tools/dbimporters/plugins/mpod.py
+++ b/aiida/tools/dbimporters/plugins/mpod.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=no-self-use
 """"Implementation of `DbImporter` for the MPOD database."""
-from aiida.tools.dbimporters.baseclasses import (DbImporter, DbSearchResults, CifEntry)
+from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 
 
 class MpodDbImporter(DbImporter):
@@ -79,8 +79,8 @@ class MpodDbImporter(DbImporter):
         :return: an instance of
             :py:class:`aiida.tools.dbimporters.plugins.mpod.MpodSearchResults`.
         """
-        from urllib.request import urlopen
         import re
+        from urllib.request import urlopen
 
         query_statements = self.query_get(**kwargs)
         results = None

--- a/aiida/tools/dbimporters/plugins/nninc.py
+++ b/aiida/tools/dbimporters/plugins/nninc.py
@@ -63,8 +63,8 @@ class NnincDbImporter(DbImporter):
         :return: an instance of
             :py:class:`aiida.tools.dbimporters.plugins.nninc.NnincSearchResults`.
         """
-        from urllib.request import urlopen
         import re
+        from urllib.request import urlopen
 
         query = self.query_get(**kwargs)
         with urlopen(query) as handle:

--- a/aiida/tools/dbimporters/plugins/oqmd.py
+++ b/aiida/tools/dbimporters/plugins/oqmd.py
@@ -9,7 +9,7 @@
 ###########################################################################
 # pylint: disable=no-self-use
 """"Implementation of `DbImporter` for the OQMD database."""
-from aiida.tools.dbimporters.baseclasses import DbImporter, DbSearchResults, CifEntry
+from aiida.tools.dbimporters.baseclasses import CifEntry, DbImporter, DbSearchResults
 
 
 class OqmdDbImporter(DbImporter):
@@ -53,8 +53,8 @@ class OqmdDbImporter(DbImporter):
         :return: an instance of
             :py:class:`aiida.tools.dbimporters.plugins.oqmd.OqmdSearchResults`.
         """
-        from urllib.request import urlopen
         import re
+        from urllib.request import urlopen
 
         query_statement = self.query_get(**kwargs)
         with urlopen(query_statement) as handle:

--- a/aiida/tools/dbimporters/plugins/pcod.py
+++ b/aiida/tools/dbimporters/plugins/pcod.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """"Implementation of `DbImporter` for the PCOD database."""
-from aiida.tools.dbimporters.plugins.cod import CodDbImporter, CodSearchResults, CodEntry
+from aiida.tools.dbimporters.plugins.cod import CodDbImporter, CodEntry, CodSearchResults
 
 
 class PcodDbImporter(CodDbImporter):

--- a/aiida/tools/dbimporters/plugins/tcod.py
+++ b/aiida/tools/dbimporters/plugins/tcod.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """"Implementation of `DbImporter` for the TCOD database."""
-from aiida.tools.dbimporters.plugins.cod import (CodDbImporter, CodSearchResults, CodEntry)
+from aiida.tools.dbimporters.plugins.cod import CodDbImporter, CodEntry, CodSearchResults
 
 
 class TcodDbImporter(CodDbImporter):

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -11,11 +11,12 @@
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+
 import numpy as np
 
 from aiida import orm
-from aiida.tools.graph.age_entities import Basket
 from aiida.common.lang import type_check
+from aiida.tools.graph.age_entities import Basket
 
 
 class Operation(metaclass=ABCMeta):

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -9,7 +9,7 @@
 ###########################################################################
 """Module for functions to traverse AiiDA graphs."""
 import sys
-from typing import Any, Callable, cast, Dict, Iterable, List, Mapping, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, cast
 
 from numpy import inf
 
@@ -18,7 +18,7 @@ from aiida.common import exceptions
 from aiida.common.links import GraphTraversalRules, LinkType
 from aiida.orm.utils.links import LinkQuadruple
 from aiida.tools.graph.age_entities import Basket
-from aiida.tools.graph.age_rules import UpdateRule, RuleSequence, RuleSaveWalkers, RuleSetWalkers
+from aiida.tools.graph.age_rules import RuleSaveWalkers, RuleSequence, RuleSetWalkers, UpdateRule
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict

--- a/aiida/tools/importexport/archive/migrations/v01_to_v02.py
+++ b/aiida/tools/importexport/archive/migrations/v01_to_v02.py
@@ -10,7 +10,7 @@
 """Migration from v0.1 to v0.2, used by `verdi export migrate` command."""
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata
+from .utils import update_metadata, verify_metadata_version
 
 
 def migrate_v1_to_v2(folder: CacheFolder):

--- a/aiida/tools/importexport/archive/migrations/v02_to_v03.py
+++ b/aiida/tools/importexport/archive/migrations/v02_to_v03.py
@@ -13,7 +13,8 @@ import enum
 
 from aiida.tools.importexport.archive.common import CacheFolder
 from aiida.tools.importexport.common.exceptions import DanglingLinkError
-from .utils import verify_metadata_version, update_metadata
+
+from .utils import update_metadata, verify_metadata_version
 
 
 def migrate_v2_to_v3(folder: CacheFolder):

--- a/aiida/tools/importexport/archive/migrations/v03_to_v04.py
+++ b/aiida/tools/importexport/archive/migrations/v03_to_v04.py
@@ -32,7 +32,8 @@ import numpy as np
 from aiida.common import json
 from aiida.tools.importexport.archive.common import CacheFolder
 from aiida.tools.importexport.common.exceptions import ArchiveMigrationError
-from .utils import verify_metadata_version, update_metadata, remove_fields
+
+from .utils import remove_fields, update_metadata, verify_metadata_version
 
 
 def migration_base_data_plugin_type_string(data):
@@ -119,8 +120,8 @@ def migration_provenance_redesign(data):  # pylint: disable=too-many-locals,too-
     """Apply migration: 0020 - REV. 1.0.20
     Provenance redesign
     """
-    from aiida.manage.database.integrity.plugins import infer_calculation_entry_point
     from aiida.manage.database.integrity import write_database_integrity_violation
+    from aiida.manage.database.integrity.plugins import infer_calculation_entry_point
     from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR
 
     fallback_cases = []

--- a/aiida/tools/importexport/archive/migrations/v04_to_v05.py
+++ b/aiida/tools/importexport/archive/migrations/v04_to_v05.py
@@ -26,7 +26,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 # pylint: disable=invalid-name
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata, remove_fields
+from .utils import remove_fields, update_metadata, verify_metadata_version
 
 
 def migration_drop_node_columns_nodeversion_public(metadata, data):

--- a/aiida/tools/importexport/archive/migrations/v05_to_v06.py
+++ b/aiida/tools/importexport/archive/migrations/v05_to_v06.py
@@ -28,7 +28,7 @@ from typing import Union
 
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata
+from .utils import update_metadata, verify_metadata_version
 
 
 def migrate_deserialized_datetime(data, conversion):

--- a/aiida/tools/importexport/archive/migrations/v06_to_v07.py
+++ b/aiida/tools/importexport/archive/migrations/v06_to_v07.py
@@ -26,7 +26,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 # pylint: disable=invalid-name
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata
+from .utils import update_metadata, verify_metadata_version
 
 
 def data_migration_legacy_process_attributes(data):
@@ -54,8 +54,8 @@ def data_migration_legacy_process_attributes(data):
         the ProcessNode is in an active state, i.e. `process_state` is one of ('created', 'running', 'waiting').
         A log-file, listing all illegal ProcessNodes, will be produced in the current directory.
     """
-    from aiida.tools.importexport.common.exceptions import CorruptArchive
     from aiida.manage.database.integrity import write_database_integrity_violation
+    from aiida.tools.importexport.common.exceptions import CorruptArchive
 
     attrs_to_remove = ['_sealed', '_finished', '_failed', '_aborted', '_do_abort']
     active_states = {'created', 'running', 'waiting'}

--- a/aiida/tools/importexport/archive/migrations/v07_to_v08.py
+++ b/aiida/tools/importexport/archive/migrations/v07_to_v08.py
@@ -26,7 +26,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 # pylint: disable=invalid-name
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata
+from .utils import update_metadata, verify_metadata_version
 
 
 def migration_default_link_label(data: dict):

--- a/aiida/tools/importexport/archive/migrations/v08_to_v09.py
+++ b/aiida/tools/importexport/archive/migrations/v08_to_v09.py
@@ -26,7 +26,7 @@ Where id is a SQLA id and migration-name is the name of the particular migration
 # pylint: disable=invalid-name
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata
+from .utils import update_metadata, verify_metadata_version
 
 
 def migration_dbgroup_type_string(data):

--- a/aiida/tools/importexport/archive/migrations/v09_to_v10.py
+++ b/aiida/tools/importexport/archive/migrations/v09_to_v10.py
@@ -11,7 +11,7 @@
 # pylint: disable=invalid-name
 from aiida.tools.importexport.archive.common import CacheFolder
 
-from .utils import verify_metadata_version, update_metadata
+from .utils import update_metadata, verify_metadata_version
 
 
 def migrate_v9_to_v10(folder: CacheFolder):

--- a/aiida/tools/importexport/archive/migrations/v10_to_v11.py
+++ b/aiida/tools/importexport/archive/migrations/v10_to_v11.py
@@ -15,13 +15,15 @@ import os
 import shutil
 
 from aiida.tools.importexport.archive.common import CacheFolder
-from .utils import verify_metadata_version, update_metadata
+
+from .utils import update_metadata, verify_metadata_version
 
 
 def migrate_repository(metadata, data, folder):
     """Migrate the file repository to a disk object store container."""
     from disk_objectstore import Container
-    from aiida.repository import Repository, File
+
+    from aiida.repository import File, Repository
     from aiida.repository.backend import DiskObjectStoreRepositoryBackend
 
     container = Container(os.path.join(folder.get_path(), 'container'))

--- a/aiida/tools/importexport/archive/migrations/v11_to_v12.py
+++ b/aiida/tools/importexport/archive/migrations/v11_to_v12.py
@@ -12,7 +12,8 @@
 This migration applies the name change of the ``Computer`` attribute ``name`` to ``label``.
 """
 from aiida.tools.importexport.archive.common import CacheFolder
-from .utils import verify_metadata_version, update_metadata
+
+from .utils import update_metadata, verify_metadata_version
 
 
 def migrate_v11_to_v12(folder: CacheFolder):

--- a/aiida/tools/importexport/archive/migrations/v12_to_v13.py
+++ b/aiida/tools/importexport/archive/migrations/v12_to_v13.py
@@ -12,7 +12,8 @@
 This migration is necessary after the `core.` prefix was added to entry points shipped with `aiida-core`.
 """
 from aiida.tools.importexport.archive.common import CacheFolder
-from .utils import verify_metadata_version, update_metadata
+
+from .utils import update_metadata, verify_metadata_version
 
 MAPPING_DATA = {
     'data.array.ArrayData.': 'data.core.array.ArrayData.',

--- a/aiida/tools/importexport/archive/migrators.py
+++ b/aiida/tools/importexport/archive/migrators.py
@@ -15,17 +15,17 @@ from pathlib import Path
 import shutil
 import tarfile
 import tempfile
-from typing import Any, Callable, cast, List, Optional, Type, Union
+from typing import Any, Callable, List, Optional, Type, Union, cast
 import zipfile
 
 from archive_path import TarPath, ZipPath, read_file_in_tar, read_file_in_zip
 
 from aiida.common.log import AIIDA_LOGGER
-from aiida.common.progress_reporter import get_progress_reporter, create_callback
-from aiida.tools.importexport.common.exceptions import (ArchiveMigrationError, CorruptArchive, DanglingLinkError)
-from aiida.tools.importexport.common.config import ExportFileFormat
+from aiida.common.progress_reporter import create_callback, get_progress_reporter
 from aiida.tools.importexport.archive.common import CacheFolder
 from aiida.tools.importexport.archive.migrations import MIGRATE_FUNCTIONS
+from aiida.tools.importexport.common.config import ExportFileFormat
+from aiida.tools.importexport.common.exceptions import ArchiveMigrationError, CorruptArchive, DanglingLinkError
 
 __all__ = (
     'ArchiveMigratorAbstract', 'ArchiveMigratorJsonBase', 'ArchiveMigratorJsonZip', 'ArchiveMigratorJsonTar',

--- a/aiida/tools/importexport/archive/readers.py
+++ b/aiida/tools/importexport/archive/readers.py
@@ -9,24 +9,23 @@
 ###########################################################################
 """Archive reader classes."""
 from abc import ABC, abstractmethod
+from distutils.version import StrictVersion
 import json
 from pathlib import Path
 import tarfile
 from types import TracebackType
-from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Set, Tuple, Type
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, cast
 import zipfile
 
-from distutils.version import StrictVersion
 from archive_path import TarPath, ZipPath, read_file_in_tar, read_file_in_zip
 from disk_objectstore import Container
 
-from aiida.common.log import AIIDA_LOGGER
 from aiida.common.exceptions import InvalidOperation
 from aiida.common.folders import SandboxFolder
-from aiida.tools.importexport.common.config import EXPORT_VERSION, ExportFileFormat
-from aiida.tools.importexport.common.exceptions import (CorruptArchive, IncompatibleArchiveVersionError)
-from aiida.tools.importexport.archive.common import (ArchiveMetadata, null_callback)
-from aiida.tools.importexport.common.config import NODE_ENTITY_NAME, GROUP_ENTITY_NAME
+from aiida.common.log import AIIDA_LOGGER
+from aiida.tools.importexport.archive.common import ArchiveMetadata, null_callback
+from aiida.tools.importexport.common.config import EXPORT_VERSION, GROUP_ENTITY_NAME, NODE_ENTITY_NAME, ExportFileFormat
+from aiida.tools.importexport.common.exceptions import CorruptArchive, IncompatibleArchiveVersionError
 
 __all__ = (
     'ArchiveReaderAbstract',

--- a/aiida/tools/importexport/archive/writers.py
+++ b/aiida/tools/importexport/archive/writers.py
@@ -13,10 +13,10 @@ from copy import deepcopy
 from pathlib import Path
 import shelve
 import shutil
-import time
 import tempfile
+import time
 from types import TracebackType
-from typing import Any, cast, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union, cast
 import zipfile
 
 from archive_path import TarPath, ZipPath

--- a/aiida/tools/importexport/common/config.py
+++ b/aiida/tools/importexport/common/config.py
@@ -10,7 +10,8 @@
 # pylint: disable=invalid-name
 """ Configuration file for AiiDA Import/Export module """
 from enum import Enum
-from aiida.orm import Computer, Group, Node, User, Log, Comment
+
+from aiida.orm import Comment, Computer, Group, Log, Node, User
 
 __all__ = ('EXPORT_VERSION',)
 

--- a/aiida/tools/importexport/common/utils.py
+++ b/aiida/tools/importexport/common/utils.py
@@ -10,11 +10,16 @@
 """ Utility functions for import/export of AiiDA entities """
 # pylint: disable=too-many-branches,too-many-return-statements,too-many-nested-blocks,too-many-locals
 from html.parser import HTMLParser
-import urllib.request
 import urllib.parse
+import urllib.request
 
 from aiida.tools.importexport.common.config import (
-    NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME, USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME
+    COMMENT_ENTITY_NAME,
+    COMPUTER_ENTITY_NAME,
+    GROUP_ENTITY_NAME,
+    LOG_ENTITY_NAME,
+    NODE_ENTITY_NAME,
+    USER_ENTITY_NAME,
 )
 
 

--- a/aiida/tools/importexport/dbexport/main.py
+++ b/aiida/tools/importexport/dbexport/main.py
@@ -12,25 +12,14 @@
 from collections import defaultdict
 import os
 import tempfile
-from typing import (
-    Any,
-    Callable,
-    DefaultDict,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Callable, DefaultDict, Dict, Iterable, List, Optional, Set, Tuple, Type, Union, cast
 
 from aiida import get_version, orm
-from aiida.common.links import GraphTraversalRules
 from aiida.common.lang import type_check
-from aiida.common.progress_reporter import get_progress_reporter, create_callback
+from aiida.common.links import GraphTraversalRules
+from aiida.common.progress_reporter import create_callback, get_progress_reporter
+from aiida.tools.graph.graph_traversers import get_nodes_export, validate_traversal_rules
+from aiida.tools.importexport.archive.writers import ArchiveMetadata, ArchiveWriterAbstract, get_writer
 from aiida.tools.importexport.common import exceptions
 from aiida.tools.importexport.common.config import (
     COMMENT_ENTITY_NAME,
@@ -45,8 +34,6 @@ from aiida.tools.importexport.common.config import (
     get_all_fields_info,
     model_fields_to_file_fields,
 )
-from aiida.tools.graph.graph_traversers import get_nodes_export, validate_traversal_rules
-from aiida.tools.importexport.archive.writers import ArchiveMetadata, ArchiveWriterAbstract, get_writer
 from aiida.tools.importexport.dbexport.utils import (
     EXPORT_LOGGER,
     check_licenses,
@@ -578,6 +565,7 @@ def _write_node_repositories(
 
         with tempfile.TemporaryDirectory() as temp:
             from disk_objectstore import Container
+
             from aiida.manage.manager import get_manager
 
             dirpath = os.path.join(temp, 'container')

--- a/aiida/tools/importexport/dbexport/utils.py
+++ b/aiida/tools/importexport/dbexport/utils.py
@@ -8,13 +8,14 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """ Utility functions for export of AiiDA entities """
-# pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks
-from aiida.orm import QueryBuilder, ProcessNode
 from aiida.common.log import AIIDA_LOGGER, LOG_LEVEL_REPORT
-
+# pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks
+from aiida.orm import ProcessNode, QueryBuilder
 from aiida.tools.importexport.common import exceptions
 from aiida.tools.importexport.common.config import (
-    file_fields_to_model_fields, entity_names_to_entities, get_all_fields_info
+    entity_names_to_entities,
+    file_fields_to_model_fields,
+    get_all_fields_info,
 )
 
 EXPORT_LOGGER = AIIDA_LOGGER.getChild('export')
@@ -104,8 +105,9 @@ def fill_in_query(partial_query, originating_entity_str, current_entity_str, tag
 
 def check_licenses(node_licenses, allowed_licenses, forbidden_licenses):
     """Check licenses"""
-    from aiida.common.exceptions import LicensingException
     from inspect import isfunction
+
+    from aiida.common.exceptions import LicensingException
 
     for pk, license_ in node_licenses:
         if allowed_licenses is not None:
@@ -148,8 +150,9 @@ def serialize_field(data, track_conversion=False):
         import
     """
     import datetime
-    import pytz
     from uuid import UUID
+
+    import pytz
 
     if isinstance(data, dict):
         ret_data = {}

--- a/aiida/tools/importexport/dbimport/backends/common.py
+++ b/aiida/tools/importexport/dbimport/backends/common.py
@@ -12,8 +12,8 @@ import copy
 from typing import Dict, List, Optional
 
 from aiida.common import timezone
-from aiida.common.progress_reporter import get_progress_reporter, create_callback
-from aiida.orm import Group, ImportGroup, Node, QueryBuilder, ProcessNode
+from aiida.common.progress_reporter import create_callback, get_progress_reporter
+from aiida.orm import Group, ImportGroup, Node, ProcessNode, QueryBuilder
 from aiida.tools.importexport.archive.readers import ArchiveReaderAbstract
 from aiida.tools.importexport.common import exceptions
 from aiida.tools.importexport.dbimport.utils import IMPORT_LOGGER

--- a/aiida/tools/importexport/dbimport/backends/django.py
+++ b/aiida/tools/importexport/dbimport/backends/django.py
@@ -17,22 +17,34 @@ from aiida.common.progress_reporter import get_progress_reporter
 from aiida.common.utils import get_object_from_string, validate_uuid
 from aiida.manage.configuration import get_config_option
 from aiida.orm import Group
-
-from aiida.tools.importexport.common import exceptions
-from aiida.tools.importexport.common.config import DUPL_SUFFIX
-from aiida.tools.importexport.common.config import (
-    NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME, USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME
-)
-from aiida.tools.importexport.common.config import entity_names_to_signatures
-from aiida.tools.importexport.dbimport.utils import (
-    deserialize_field, merge_comment, merge_extras, start_summary, result_summary, IMPORT_LOGGER
-)
-
 from aiida.tools.importexport.archive.common import detect_archive_type
 from aiida.tools.importexport.archive.readers import ArchiveReaderAbstract, get_reader
-
+from aiida.tools.importexport.common import exceptions
+from aiida.tools.importexport.common.config import (
+    COMMENT_ENTITY_NAME,
+    COMPUTER_ENTITY_NAME,
+    DUPL_SUFFIX,
+    GROUP_ENTITY_NAME,
+    LOG_ENTITY_NAME,
+    NODE_ENTITY_NAME,
+    USER_ENTITY_NAME,
+    entity_names_to_signatures,
+)
 from aiida.tools.importexport.dbimport.backends.common import (
-    _copy_node_repositories, _make_import_group, _sanitize_extras, _strip_checkpoints, MAX_COMPUTERS, MAX_GROUPS
+    MAX_COMPUTERS,
+    MAX_GROUPS,
+    _copy_node_repositories,
+    _make_import_group,
+    _sanitize_extras,
+    _strip_checkpoints,
+)
+from aiida.tools.importexport.dbimport.utils import (
+    IMPORT_LOGGER,
+    deserialize_field,
+    merge_comment,
+    merge_extras,
+    result_summary,
+    start_summary,
 )
 
 

--- a/aiida/tools/importexport/dbimport/backends/sqla.py
+++ b/aiida/tools/importexport/dbimport/backends/sqla.py
@@ -19,26 +19,38 @@ from aiida.common import json
 from aiida.common.links import LinkType
 from aiida.common.progress_reporter import get_progress_reporter
 from aiida.common.utils import get_object_from_string, validate_uuid
-from aiida.orm import QueryBuilder, Node, Group
+from aiida.orm import Group, Node, QueryBuilder
 from aiida.orm.utils.links import link_triple_exists, validate_link
-
-from aiida.tools.importexport.common import exceptions
-from aiida.tools.importexport.common.config import DUPL_SUFFIX
-from aiida.tools.importexport.common.config import (
-    NODE_ENTITY_NAME, GROUP_ENTITY_NAME, COMPUTER_ENTITY_NAME, USER_ENTITY_NAME, LOG_ENTITY_NAME, COMMENT_ENTITY_NAME
-)
-from aiida.tools.importexport.common.config import (
-    entity_names_to_sqla_schema, file_fields_to_model_fields, entity_names_to_entities
-)
-from aiida.tools.importexport.dbimport.utils import (
-    deserialize_field, merge_comment, merge_extras, start_summary, result_summary, IMPORT_LOGGER
-)
-
 from aiida.tools.importexport.archive.common import detect_archive_type
 from aiida.tools.importexport.archive.readers import ArchiveReaderAbstract, get_reader
-
+from aiida.tools.importexport.common import exceptions
+from aiida.tools.importexport.common.config import (
+    COMMENT_ENTITY_NAME,
+    COMPUTER_ENTITY_NAME,
+    DUPL_SUFFIX,
+    GROUP_ENTITY_NAME,
+    LOG_ENTITY_NAME,
+    NODE_ENTITY_NAME,
+    USER_ENTITY_NAME,
+    entity_names_to_entities,
+    entity_names_to_sqla_schema,
+    file_fields_to_model_fields,
+)
 from aiida.tools.importexport.dbimport.backends.common import (
-    _copy_node_repositories, _make_import_group, _sanitize_extras, _strip_checkpoints, MAX_COMPUTERS, MAX_GROUPS
+    MAX_COMPUTERS,
+    MAX_GROUPS,
+    _copy_node_repositories,
+    _make_import_group,
+    _sanitize_extras,
+    _strip_checkpoints,
+)
+from aiida.tools.importexport.dbimport.utils import (
+    IMPORT_LOGGER,
+    deserialize_field,
+    merge_comment,
+    merge_extras,
+    result_summary,
+    start_summary,
 )
 
 
@@ -406,8 +418,8 @@ def _store_entity_data(
     ret_dict: dict, session: Session
 ):
     """Store the entity data on the AiiDA profile."""
-    from aiida.backends.sqlalchemy.utils import flag_modified
     from aiida.backends.sqlalchemy.models.node import DbNode
+    from aiida.backends.sqlalchemy.utils import flag_modified
 
     entity = entity_names_to_entities[entity_name]
 

--- a/aiida/tools/importexport/dbimport/main.py
+++ b/aiida/tools/importexport/dbimport/main.py
@@ -66,8 +66,8 @@ def import_data(in_path, group=None, **kwargs):
     :raises `~aiida.tools.importexport.common.exceptions.ArchiveImportError`: if there are any internal errors when
         importing.
     """
-    from aiida.manage import configuration
     from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
+    from aiida.manage import configuration
     from aiida.tools.importexport.common.exceptions import ArchiveImportError
 
     backend = configuration.PROFILE.database_backend

--- a/aiida/tools/importexport/dbimport/utils.py
+++ b/aiida/tools/importexport/dbimport/utils.py
@@ -16,8 +16,7 @@ from tabulate import tabulate
 
 from aiida.common.log import AIIDA_LOGGER, LOG_LEVEL_REPORT
 from aiida.common.utils import get_new_uuid
-from aiida.orm import QueryBuilder, Comment
-
+from aiida.orm import Comment, QueryBuilder
 from aiida.tools.importexport.common import exceptions
 
 IMPORT_LOGGER = AIIDA_LOGGER.getChild('import')
@@ -186,6 +185,7 @@ def merge_extras(old_extras, new_extras, mode):
 def deserialize_attributes(attributes_data, conversion_data):
     """Deserialize attributes"""
     import datetime
+
     import pytz
 
     if conversion_data == 'jsonb':

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -34,7 +34,7 @@ Usage
    In [2]: %aiida
 """
 
-from IPython import version_info, get_ipython
+from IPython import get_ipython, version_info
 from IPython.core import magic
 
 
@@ -75,8 +75,8 @@ class AiiDALoaderMagics(magic.Magics):
         .. todo:: implement parameters, e.g. for the profile to load.
         """
         # pylint: disable=unused-argument,attribute-defined-outside-init
-        from aiida.manage.configuration import load_profile
         from aiida.cmdline.utils.shell import get_start_namespace
+        from aiida.manage.configuration import load_profile
 
         self.is_warning = False
         lcontent = line.strip()

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -8,15 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Common cli utilities for transport plugins."""
-import inspect
 from functools import partial
+import inspect
 
 import click
 
-from aiida.cmdline.params import options, arguments
+from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.interactive import InteractiveOption
-from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.cmdline.utils import echo
+from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common.exceptions import NotExistent
 from aiida.manage.manager import get_manager
 

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -20,11 +20,11 @@ Local transport
 ### in the exact same way as paramiko does already.
 
 import errno
+import glob
 import io
 import os
 import shutil
 import subprocess
-import glob
 
 from aiida.transports import cli as transport_cli
 from aiida.transports.transport import Transport, TransportInternalError

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -21,6 +21,7 @@ import paramiko
 from aiida.cmdline.params import options
 from aiida.cmdline.params.types.path import AbsolutePathOrEmptyParamType
 from aiida.common.escaping import escape_for_bash
+
 from ..transport import Transport, TransportInternalError
 
 __all__ = ('parse_sshconfig', 'convert_to_bool', 'SshTransport')
@@ -446,6 +447,7 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         :raise aiida.common.InvalidOperation: if the channel is already open
         """
         from paramiko.ssh_exception import SSHException
+
         from aiida.common.exceptions import InvalidOperation
         from aiida.transports.util import _DetachedProxyCommand
 

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -9,11 +9,11 @@
 ###########################################################################
 """Transport interface."""
 import abc
+from collections import OrderedDict
+import fnmatch
 import os
 import re
-import fnmatch
 import sys
-from collections import OrderedDict
 
 from aiida.common.exceptions import InternalError
 from aiida.common.lang import classproperty

--- a/aiida/transports/util.py
+++ b/aiida/transports/util.py
@@ -37,8 +37,8 @@ class _DetachedProxyCommand(ProxyCommand):
 
     def __init__(self, command_line):  # pylint: disable=super-init-not-called
         # Note that the super().__init__ MUST NOT be called here, otherwise two subprocesses will be created.
-        from subprocess import Popen, PIPE
         from shlex import split as shlsplit
+        from subprocess import PIPE, Popen
 
         self.cmd = shlsplit(command_line)
         self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, start_new_session=True)  # pylint: disable=consider-using-with

--- a/aiida/workflows/arithmetic/multiply_add.py
+++ b/aiida/workflows/arithmetic/multiply_add.py
@@ -10,8 +10,8 @@
 # pylint: disable=no-member
 # start-marker for docs
 """Implementation of the MultiplyAddWorkChain for testing and demonstration purposes."""
+from aiida.engine import ToContext, WorkChain, calcfunction
 from aiida.orm import Code, Int
-from aiida.engine import calcfunction, WorkChain, ToContext
 from aiida.plugins.factories import CalculationFactory
 
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')

--- a/docs/source/howto/include/snippets/extend_workflows.py
+++ b/docs/source/howto/include/snippets/extend_workflows.py
@@ -10,8 +10,8 @@
 # pylint: disable=no-member
 # start-marker for docs
 """Code snippets for the "How to extend workflows" section."""
-from aiida.orm import Code, Int, Bool
-from aiida.engine import calcfunction, WorkChain, ToContext
+from aiida.engine import ToContext, WorkChain, calcfunction
+from aiida.orm import Bool, Code, Int
 from aiida.plugins.factories import CalculationFactory
 
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')

--- a/docs/source/howto/include/snippets/myprofile-rest.wsgi
+++ b/docs/source/howto/include/snippets/myprofile-rest.wsgi
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # wsgi script for AiiDA profile 'myprofile'
-from aiida.restapi.run_api import configure_api
 from aiida.manage.configuration import load_profile
+from aiida.restapi.run_api import configure_api
 
 load_profile('myprofile')
 

--- a/docs/source/howto/include/snippets/plugins/launch.py
+++ b/docs/source/howto/include/snippets/plugins/launch.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Launch a calculation using the 'diff-tutorial' plugin"""
 from pathlib import Path
-from aiida import orm, engine
+
+from aiida import engine, orm
 from aiida.common.exceptions import NotExistent
 
 INPUT_DIR = Path(__file__).resolve().parent / 'input_files'

--- a/docs/source/internals/includes/snippets/api.py
+++ b/docs/source/internals/includes/snippets/api.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from flask_restful import Resource
+
 from aiida.restapi.api import AiidaApi, App
 from aiida.restapi.run_api import run_api
-from flask_restful import Resource
+
 
 class NewResource(Resource):
     """
@@ -17,7 +19,7 @@ class NewResource(Resource):
     """
 
     def get(self):
-        from aiida.orm import QueryBuilder, Dict
+        from aiida.orm import Dict, QueryBuilder
 
         qb = QueryBuilder()
         qb.append(Dict,
@@ -53,12 +55,14 @@ class NewApi(AiidaApi):
 
 # processing the options and running the app
 
-import aiida.restapi.common as common
 from aiida import load_profile
+import aiida.restapi.common as common
 
 CONFIG_DIR = common.__path__[0]
 
 import click
+
+
 @click.command()
 @click.option('-P', '--port', type=click.INT, default=5000,
     help='Port number')

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_load_node.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_load_node.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     result = load_node(100)

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_store.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_store.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     result = Int(x + y).store()

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_data_types.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_data_types.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_decorator.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_decorator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_metadata.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_metadata.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction, run
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_no_provenance.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_no_provenance.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction, run
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction, run, run_get_node, run_get_pk
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run_attribute.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run_attribute.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_run.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from aiida.engine import run
-from aiida.orm import load_code, Int
+from aiida.orm import Int, load_code
 from aiida.plugins import CalculationFactory
 
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_inputs.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_inputs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from aiida.engine import CalcJob
 
+
 class ArithmeticAddCalculation(CalcJob):
     """Implementation of CalcJob to add two numbers for testing and demonstration purposes."""
 

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_outputs.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_outputs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from aiida.engine import CalcJob
 
+
 class ArithmeticAddCalculation(CalcJob):
     """Implementation of CalcJob to add two numbers for testing and demonstration purposes."""
 

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_prepare_for_submission.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_prepare_for_submission.py
@@ -2,6 +2,7 @@
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 
+
 class ArithmeticAddCalculation(CalcJob):
     """Implementation of CalcJob to add two numbers for testing and demonstration purposes."""
 

--- a/docs/source/topics/include/scheduler_template.py
+++ b/docs/source/topics/include/scheduler_template.py
@@ -5,7 +5,7 @@ import logging
 
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import Scheduler, SchedulerError, SchedulerParsingError
-from aiida.schedulers.datastructures import JobInfo, JobState, JobResource
+from aiida.schedulers.datastructures import JobInfo, JobResource, JobState
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_exception.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_exception.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def divide(x, y):
     return x / y

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_exit_code.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_exit_code.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from aiida.engine import calcfunction, ExitCode
+from aiida.engine import ExitCode, calcfunction
 from aiida.orm import Int
+
 
 @calcfunction
 def divide(x, y):

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_multiple_outputs.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_multiple_outputs.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def sum_and_difference(alpha, beta):
     return {'sum': alpha + beta, 'difference': alpha - beta}

--- a/docs/source/topics/processes/include/snippets/functions/process_function_attributes.py
+++ b/docs/source/topics/processes/include/snippets/functions/process_function_attributes.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_default.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_default.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add_multiply(x, y, z=None):
     if z is None:

--- a/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_kwargs.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_kwargs.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(**kwargs):
     return sum(kwargs.values())

--- a/docs/source/topics/processes/include/snippets/launch/launch_process_function.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_process_function.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return x + y

--- a/docs/source/topics/processes/include/snippets/serialize/run_workchain_serialize.py
+++ b/docs/source/topics/processes/include/snippets/serialize/run_workchain_serialize.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env runaiida
 # -*- coding: utf-8 -*-
-from aiida.engine import run
-
 from serialize_workchain import SerializeWorkChain
+
+from aiida.engine import run
 
 if __name__ == '__main__':
     print(run(

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/child.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/child.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from aiida.orm import Bool, Float, Int
 from aiida.engine import WorkChain
+from aiida.orm import Bool, Float, Int
 
 
 class ChildWorkChain(WorkChain):

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/complex_parent.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/complex_parent.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from child import ChildWorkChain
+
 from aiida.engine import ToContext, WorkChain, run
 
-from child import ChildWorkChain
 
 class ComplexParentWorkChain(WorkChain):
     @classmethod

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/run_complex.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/run_complex.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env runaiida
 # -*- coding: utf-8 -*-
 
-from aiida.orm import Bool, Float, Int
-from aiida.engine import run
 from complex_parent import ComplexParentWorkChain
+
+from aiida.engine import run
+from aiida.orm import Bool, Float, Int
 
 if __name__ == '__main__':
     result = run(

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/run_simple.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/run_simple.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env runaiida
 # -*- coding: utf-8 -*-
 
-from aiida.orm import Bool, Float, Int
-from aiida.engine import run
 from simple_parent import SimpleParentWorkChain
+
+from aiida.engine import run
+from aiida.orm import Bool, Float, Int
 
 if __name__ == '__main__':
     result = run(SimpleParentWorkChain, a=Int(1), b=Float(1.2), c=Bool(True))

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/simple_parent.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/simple_parent.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from aiida.engine import ToContext, WorkChain, run
 from child import ChildWorkChain
+
+from aiida.engine import ToContext, WorkChain, run
 
 
 class SimpleParentWorkChain(WorkChain):

--- a/docs/source/topics/workflows/include/snippets/workchains/add_multiply_workchain_external_computation.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/add_multiply_workchain_external_computation.py
@@ -2,6 +2,7 @@
 from aiida.engine import WorkChain, calcfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return Int(x + y)

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_complete.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_complete.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from aiida.engine import WorkChain, ToContext
+from aiida.engine import ToContext, WorkChain
 
 
 class SomeWorkChain(WorkChain):

--- a/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_orchestrate.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_orchestrate.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction, workfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return Int(x + y)

--- a/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_select.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_select.py
@@ -2,6 +2,7 @@
 from aiida.engine import workfunction
 from aiida.orm import Int
 
+
 @workfunction
 def maximum(x, y, z):
     return sorted([x, y, z])[-1]

--- a/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_halfway.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_halfway.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction, workfunction
 from aiida.orm import Int
 
+
 @calcfunction
 def add(x, y):
     return Int(x + y)

--- a/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_internal.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_internal.py
@@ -2,6 +2,7 @@
 from aiida.engine import calcfunction, workfunction
 from aiida.orm import Int
 
+
 @workfunction
 def add_and_multiply(x, y, z):
     sum = Int(x + y)

--- a/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_store.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_store.py
@@ -2,6 +2,7 @@
 from aiida.engine import workfunction
 from aiida.orm import Int
 
+
 @workfunction
 def illegal_workfunction(x, y):
     return Int(x + y)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ markers = [
 ]
 
 [tool.isort]
-line_length = 100
+line_length = 120
 force_sort_within_sections = true
 # this configuration is compatible with yapf
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ markers = [
     "sphinx: set parameters for the sphinx `app` fixture"
 ]
 
+[tool.isort]
+# this configuration is compatible with yapf
+multi_line_output = 3
+include_trailing_comma = true
+
 [tool.yapf]
 based_on_style = "google"
 column_limit = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ markers = [
 ]
 
 [tool.isort]
+line_length = 100
+force_sort_within_sections = true
 # this configuration is compatible with yapf
 multi_line_output = 3
 include_trailing_comma = true

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except ImportError:
     # This should only occur when building the package, i.e. when
     # executing 'python setup.py sdist' or 'python setup.py bdist_wheel'
     pass
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 if __name__ == '__main__':
     THIS_FOLDER = os.path.split(os.path.abspath(__file__))[0]

--- a/tests/backends/aiida_django/migrations/test_migrations_0037_attributes_extras_settings_json.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_0037_attributes_extras_settings_json.py
@@ -363,6 +363,7 @@ class DbMultipleValueAttributeBaseClass:
                 transaction.savepoint_commit(sid)
         except BaseException as exc:  # All exceptions including CTRL+C, ...
             from django.db.utils import IntegrityError
+
             from aiida.common.exceptions import UniquenessError
 
             if with_transaction:
@@ -406,7 +407,7 @@ class DbMultipleValueAttributeBaseClass:
         import datetime
 
         from aiida.common import json
-        from aiida.common.timezone import is_naive, make_aware, get_current_timezone
+        from aiida.common.timezone import get_current_timezone, is_naive, make_aware
 
         if cls._subspecifier_field_name is None:
             if subspecifier_value is not None:

--- a/tests/backends/aiida_django/migrations/test_migrations_0038_data_migration_legacy_job_calculations.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_0038_data_migration_legacy_job_calculations.py
@@ -13,6 +13,7 @@ Tests for the migrations of the attributes, extras and settings from EAV to JSON
 Migration 0037_attributes_extras_settings_json
 """
 from aiida.backends.general.migrations.calc_state import STATE_MAPPING
+
 from .test_migrations_common import TestMigrations
 
 

--- a/tests/backends/aiida_django/migrations/test_migrations_0047_migrate_repository.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_0047_migrate_repository.py
@@ -13,6 +13,7 @@ import hashlib
 import os
 
 from aiida.backends.general.migrations import utils
+
 from .test_migrations_common import TestMigrations
 
 REPOSITORY_UUID_KEY = 'repository|uuid'

--- a/tests/backends/aiida_django/migrations/test_migrations_common.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_common.py
@@ -10,8 +10,8 @@
 # pylint: disable=import-error,no-name-in-module,invalid-name
 """ The basic functionality for the migration tests"""
 from django.apps import apps
-from django.db.migrations.executor import MigrationExecutor
 from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.utils import Capturing

--- a/tests/backends/aiida_django/migrations/test_migrations_many.py
+++ b/tests/backends/aiida_django/migrations/test_migrations_many.py
@@ -14,10 +14,11 @@ go to a separate file.
 """
 import numpy
 
-from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.djsite.db.migrations import ModelModifierV0025
 from aiida.backends.general.migrations import utils
+from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import IntegrityError
+
 from .test_migrations_common import TestMigrations
 
 
@@ -75,8 +76,8 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
     migrate_to = '0014_add_node_uuid_unique_constraint'
 
     def setUpBeforeMigration(self):
-        from aiida.common.utils import get_new_uuid
         from aiida.backends.general.migrations.duplicate_uuids import deduplicate_uuids, verify_uuid_uniqueness
+        from aiida.common.utils import get_new_uuid
         self.file_name = 'test.temp'
         self.file_content = '#!/bin/bash\n\necho test run\n'
 
@@ -302,8 +303,9 @@ class TestDbLogMigrationRecordCleaning(TestMigrations):
     migrate_to = '0024_dblog_update'
 
     def setUpBeforeMigration(self):  # pylint: disable=too-many-locals
-        import json
         import importlib
+        import json
+
         from aiida.backends.general.migrations.utils import dumps_json
 
         update_024 = importlib.import_module('aiida.backends.djsite.db.migrations.0024_dblog_update')

--- a/tests/backends/aiida_sqlalchemy/test_migrations.py
+++ b/tests/backends/aiida_sqlalchemy/test_migrations.py
@@ -23,6 +23,7 @@ from aiida.backends.sqlalchemy import manager
 from aiida.backends.sqlalchemy.models.base import Base
 from aiida.backends.sqlalchemy.utils import flag_modified
 from aiida.backends.testbase import AiidaTestCase
+
 from .test_utils import new_database
 
 
@@ -267,6 +268,7 @@ class TestMigrationSchemaVsModelsSchema(AiidaTestCase):
 
     def setUp(self):
         from sqlalchemydiff.util import get_temporary_uri
+
         from aiida.backends.sqlalchemy.migrations import versions
 
         self.migr_method_dir_path = os.path.dirname(os.path.realpath(manager.__file__))
@@ -646,7 +648,9 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
     def setUpBeforeMigration(self):
         # pylint: disable=too-many-locals,too-many-statements
         import importlib
+
         from sqlalchemy.orm import Session  # pylint: disable=import-error,no-name-in-module
+
         from aiida.backends.general.migrations.utils import dumps_json
 
         log_migration = importlib.import_module(
@@ -1288,6 +1292,7 @@ class TestLegacyJobCalcStateDataMigration(TestMigrationsSQLA):
 
     def setUpBeforeMigration(self):
         from sqlalchemy.orm import Session  # pylint: disable=import-error,no-name-in-module
+
         from aiida.backends.general.migrations.calc_state import STATE_MAPPING
 
         self.state_mapping = STATE_MAPPING
@@ -1353,6 +1358,7 @@ class TestResetHash(TestMigrationsSQLA):
 
     def setUpBeforeMigration(self):
         from sqlalchemy.orm import Session  # pylint: disable=import-error,no-name-in-module
+
         from aiida.backends.general.migrations.calc_state import STATE_MAPPING
 
         self.state_mapping = STATE_MAPPING

--- a/tests/backends/aiida_sqlalchemy/test_nodes.py
+++ b/tests/backends/aiida_sqlalchemy/test_nodes.py
@@ -10,9 +10,9 @@
 # pylint: disable=import-error,no-name-in-module
 """Tests for nodes, attributes and links."""
 
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm import Data
-from aiida import orm
 
 
 class TestNodeBasicSQLA(AiidaTestCase):
@@ -20,13 +20,14 @@ class TestNodeBasicSQLA(AiidaTestCase):
 
     def test_settings(self):
         """Test the settings table (similar to Attributes, but without the key."""
-        from aiida.backends.sqlalchemy.models.settings import DbSetting
         from aiida.backends.sqlalchemy import get_scoped_session
+        from aiida.backends.sqlalchemy.models.settings import DbSetting
         session = get_scoped_session()
 
         from pytz import UTC
-        from aiida.common import timezone
         from sqlalchemy.exc import IntegrityError
+
+        from aiida.common import timezone
 
         DbSetting.set_value(key='pippo', value=[1, 2, 3])
 
@@ -50,8 +51,8 @@ class TestNodeBasicSQLA(AiidaTestCase):
 
     def test_load_nodes(self):
         """Test for load_node() function."""
-        from aiida.orm import load_node
         from aiida.backends.sqlalchemy import get_scoped_session
+        from aiida.orm import load_node
 
         a_obj = Data()
         a_obj.store()
@@ -104,9 +105,9 @@ class TestNodeBasicSQLA(AiidaTestCase):
         (and subsequently committed) when a user is in the session.
         It tests the fix for the issue #234
         """
+        import aiida.backends.sqlalchemy
         from aiida.backends.sqlalchemy.models.node import DbNode
         from aiida.common.utils import get_new_uuid
-        import aiida.backends.sqlalchemy
 
         backend = self.backend
 

--- a/tests/backends/aiida_sqlalchemy/test_query.py
+++ b/tests/backends/aiida_sqlalchemy/test_query.py
@@ -10,7 +10,7 @@
 """Tests for generic queries."""
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm import Group, User, Computer, Node, Data, ProcessNode, QueryBuilder
+from aiida.orm import Computer, Data, Group, Node, ProcessNode, QueryBuilder, User
 
 
 class TestQueryBuilderSQLA(AiidaTestCase):

--- a/tests/backends/aiida_sqlalchemy/test_schema.py
+++ b/tests/backends/aiida_sqlalchemy/test_schema.py
@@ -13,15 +13,13 @@ import warnings
 
 from sqlalchemy import exc as sa_exc
 
-from aiida.backends.testbase import AiidaTestCase
-from aiida.backends.sqlalchemy.models.user import DbUser
-from aiida.backends.sqlalchemy.models.node import DbNode
-from aiida.common.links import LinkType
-from aiida.orm import Data
-from aiida.orm import CalculationNode
 import aiida
-
+from aiida.backends.sqlalchemy.models.node import DbNode
+from aiida.backends.sqlalchemy.models.user import DbUser
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.links import LinkType
 from aiida.common.utils import get_new_uuid
+from aiida.orm import CalculationNode, Data
 
 
 class TestRelationshipsSQLA(AiidaTestCase):

--- a/tests/backends/aiida_sqlalchemy/test_session.py
+++ b/tests/backends/aiida_sqlalchemy/test_session.py
@@ -152,8 +152,8 @@ class TestSessionSqla(AiidaTestCase):
         to node.description will immediately be seen.
 
         Tests for bug #1372"""
-        from aiida.common import timezone
         import aiida.backends.sqlalchemy as sa
+        from aiida.common import timezone
 
         session = sessionmaker(bind=sa.ENGINE)
         custom_session = session()

--- a/tests/backends/aiida_sqlalchemy/test_utils.py
+++ b/tests/backends/aiida_sqlalchemy/test_utils.py
@@ -43,9 +43,10 @@ def database_exists(url):
     Performs backend-specific testing to quickly determine if a database
     exists on the server."""
 
-    from sqlalchemy.engine.url import make_url
     from copy import copy
+
     import sqlalchemy as sa
+    from sqlalchemy.engine.url import make_url
 
     url = copy(make_url(url))
     database = url.database
@@ -79,10 +80,11 @@ def create_database(url, encoding='utf8'):
     It currently supports only PostgreSQL and the psycopg2 driver.
     """
 
+    from copy import copy
+
+    import sqlalchemy as sa
     from sqlalchemy.engine.url import make_url
     from sqlalchemy_utils.functions.orm import quote
-    from copy import copy
-    import sqlalchemy as sa
 
     url = copy(make_url(url))
 

--- a/tests/benchmark/test_engine.py
+++ b/tests/benchmark/test_engine.py
@@ -17,7 +17,7 @@ import asyncio
 
 import pytest
 
-from aiida.engine import run_get_node, submit, while_, WorkChain
+from aiida.engine import WorkChain, run_get_node, submit, while_
 from aiida.manage.manager import get_manager
 from aiida.orm import Code, Int
 from aiida.plugins.factories import CalculationFactory

--- a/tests/benchmark/test_importexport.py
+++ b/tests/benchmark/test_importexport.py
@@ -20,7 +20,7 @@ import pytest
 from aiida.common.links import LinkType
 from aiida.engine import ProcessState
 from aiida.orm import CalcFunctionNode, Dict, load_node
-from aiida.tools.importexport import import_data, export
+from aiida.tools.importexport import export, import_data
 
 
 def recursive_provenance(in_node, depth, breadth, num_objects=0):

--- a/tests/calculations/arithmetic/test_add.py
+++ b/tests/calculations/arithmetic/test_add.py
@@ -11,8 +11,8 @@
 import pytest
 
 from aiida import orm
-from aiida.common import datastructures
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+from aiida.common import datastructures
 
 
 @pytest.mark.requires_rmq

--- a/tests/calculations/test_templatereplacer.py
+++ b/tests/calculations/test_templatereplacer.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Tests for the `TemplatereplacerCalculation` plugin."""
 import io
+
 import pytest
 
 from aiida import orm

--- a/tests/calculations/test_transfer.py
+++ b/tests/calculations/test_transfer.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Tests for the `TransferCalculation` plugin."""
 import os
+
 import pytest
 
 from aiida import orm
@@ -143,8 +144,8 @@ def test_validate_instructions():
 
 def test_validate_transfer_inputs(aiida_localhost, tmp_path, temp_dir):
     """Test the `TransferCalculation` validators."""
-    from aiida.orm import Computer
     from aiida.calculations.transfer import check_node_type, validate_transfer_inputs
+    from aiida.orm import Computer
 
     fake_localhost = Computer(
         label='localhost-fake',

--- a/tests/cmdline/commands/test_archive_export.py
+++ b/tests/cmdline/commands/test_archive_export.py
@@ -15,9 +15,8 @@ import zipfile
 import pytest
 
 from aiida.cmdline.commands import cmd_archive
-from aiida.orm import Computer, Code, Group, Data
+from aiida.orm import Code, Computer, Data, Group
 from aiida.tools.importexport import EXPORT_VERSION, ReaderJsonZip
-
 from tests.utils.archives import get_archive_file
 
 pytest.mark.usefixtures('chdir_tmp_path')

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -8,16 +8,14 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for `verdi import`."""
-from click.testing import CliRunner
 from click.exceptions import BadParameter
-
+from click.testing import CliRunner
 import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_archive
 from aiida.orm import Group
 from aiida.tools.importexport import EXPORT_VERSION
-
 from tests.utils.archives import get_archive_file
 
 

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -19,7 +19,6 @@ from aiida.cmdline.commands import cmd_calcjob as command
 from aiida.common.datastructures import CalcJobState
 from aiida.plugins import CalculationFactory
 from aiida.plugins.entry_point import get_entry_point_string_from_class
-
 from tests.utils.archives import import_archive
 
 

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -12,15 +12,15 @@
 import os
 import subprocess as sp
 from textwrap import dedent
-
 from unittest import mock
+
 from click.testing import CliRunner
 import pytest
 
-from aiida.backends.testbase import AiidaTestCase
-from aiida.cmdline.commands.cmd_code import (setup_code, delete, hide, reveal, relabel, code_list, show, code_duplicate)
-from aiida.common.exceptions import NotExistent
 from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
+from aiida.cmdline.commands.cmd_code import code_duplicate, code_list, delete, hide, relabel, reveal, setup_code, show
+from aiida.common.exceptions import NotExistent
 
 
 class TestVerdiCodeSetup(AiidaTestCase):

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -18,9 +18,16 @@ import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.cmdline.commands.cmd_computer import computer_setup
-from aiida.cmdline.commands.cmd_computer import computer_show, computer_list, computer_relabel, computer_delete
-from aiida.cmdline.commands.cmd_computer import computer_test, computer_configure, computer_duplicate
+from aiida.cmdline.commands.cmd_computer import (
+    computer_configure,
+    computer_delete,
+    computer_duplicate,
+    computer_list,
+    computer_relabel,
+    computer_setup,
+    computer_show,
+    computer_test,
+)
 
 
 def generate_setup_options_dict(replace_args=None, non_interactive=True):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -14,9 +14,9 @@ import asyncio
 import io
 import os
 import shutil
-import unittest
-import tempfile
 import subprocess as sp
+import tempfile
+import unittest
 
 from click.testing import CliRunner
 import numpy as np
@@ -24,12 +24,21 @@ import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.cmdline.commands.cmd_data import cmd_array, cmd_bands, cmd_cif, cmd_dict, cmd_remote
-from aiida.cmdline.commands.cmd_data import cmd_structure, cmd_trajectory, cmd_upf, cmd_singlefile
 from aiida.cmdline.commands import cmd_group
+from aiida.cmdline.commands.cmd_data import (
+    cmd_array,
+    cmd_bands,
+    cmd_cif,
+    cmd_dict,
+    cmd_remote,
+    cmd_singlefile,
+    cmd_structure,
+    cmd_trajectory,
+    cmd_upf,
+)
 from aiida.engine import calcfunction
+from aiida.orm import ArrayData, BandsData, CifData, Dict, Group, KpointsData, RemoteData, StructureData, TrajectoryData
 from aiida.orm.nodes.data.cif import has_pycifrw
-from aiida.orm import Group, ArrayData, BandsData, KpointsData, CifData, Dict, RemoteData, StructureData, TrajectoryData
 from tests.static import STATIC_DIR
 
 

--- a/tests/cmdline/commands/test_database.py
+++ b/tests/cmdline/commands/test_database.py
@@ -17,7 +17,7 @@ import pytest
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_database
 from aiida.common.links import LinkType
-from aiida.orm import Data, CalculationNode, WorkflowNode
+from aiida.orm import CalculationNode, Data, WorkflowNode
 
 
 class TestVerdiDatabasaIntegrity(AiidaTestCase):

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -10,9 +10,9 @@
 """Tests for the `verdi group` command."""
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import exceptions
 from aiida.cmdline.commands import cmd_group
 from aiida.cmdline.utils.echo import ExitCode
+from aiida.common import exceptions
 
 
 class TestVerdiGroup(AiidaTestCase):

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -8,12 +8,12 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for verdi node"""
-import os
-import io
 import errno
+import gzip
+import io
+import os
 import pathlib
 import tempfile
-import gzip
 
 from click.testing import CliRunner
 import pytest
@@ -317,8 +317,8 @@ class TestVerdiGraph(AiidaTestCase):
         Test that an invalid root_node pk (non-numeric, negative, or decimal),
         or non-existent pk will produce an error
         """
-        from aiida.orm import load_node
         from aiida.common.exceptions import NotExistent
+        from aiida.orm import load_node
 
         # Forbidden pk
         for root_node in ['xyz', '-5', '3.14']:
@@ -499,7 +499,7 @@ class TestVerdiRehash(AiidaTestCase):
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super().setUpClass(*args, **kwargs)
-        from aiida.orm import Data, Bool, Float, Int
+        from aiida.orm import Bool, Data, Float, Int
 
         cls.node_base = Data().store()
         cls.node_bool_true = Bool(True).store()

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for `verdi process`."""
-import time
 import asyncio
 from concurrent.futures import Future
+import time
 
 from click.testing import CliRunner
 import kiwipy
@@ -21,8 +21,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_process
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
-from aiida.orm import CalcJobNode, WorkflowNode, WorkFunctionNode, WorkChainNode
-
+from aiida.orm import CalcJobNode, WorkChainNode, WorkflowNode, WorkFunctionNode
 from tests.utils import processes as test_processes
 
 
@@ -303,7 +302,7 @@ def test_list_worker_slot_warning(run_cli_command, monkeypatch):
     that the warning message is displayed to the user when running `verdi process list`
     """
     from aiida.cmdline.utils import common
-    from aiida.engine import ProcessState, DaemonClient
+    from aiida.engine import DaemonClient, ProcessState
     from aiida.manage.configuration import get_config
 
     monkeypatch.setattr(common, 'get_num_workers', lambda: 1)
@@ -396,9 +395,9 @@ def test_pause_play_kill(cmd_try_all, run_cli_command):
     Test the pause/play/kill commands
     """
     # pylint: disable=no-member, too-many-locals
-    from aiida.cmdline.commands.cmd_process import process_pause, process_play, process_kill
-    from aiida.manage.manager import get_manager
+    from aiida.cmdline.commands.cmd_process import process_kill, process_pause, process_play
     from aiida.engine import ProcessState
+    from aiida.manage.manager import get_manager
     from aiida.orm import load_node
 
     runner = get_manager().create_runner(rmq_submit=True)

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -15,7 +15,6 @@ import pytest
 from aiida.backends.testbase import AiidaPostgresTestCase
 from aiida.cmdline.commands import cmd_profile, cmd_verdi
 from aiida.manage import configuration
-
 from tests.utils.configuration import create_mock_profile
 
 

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -34,7 +34,7 @@ class TestVerdiRun(AiidaTestCase):
         that are defined within the script will fail, as the inspect module will not correctly be able to determin
         the full path of the source file.
         """
-        from aiida.orm import load_node, WorkFunctionNode
+        from aiida.orm import WorkFunctionNode, load_node
 
         script_content = textwrap.dedent(
             """\
@@ -95,7 +95,7 @@ class TestAutoGroups(AiidaTestCase):
 
     def test_autogroup(self):
         """Check if the autogroup is properly generated."""
-        from aiida.orm import QueryBuilder, Node, AutoGroup, load_node
+        from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
         script_content = textwrap.dedent(
             """\
@@ -125,7 +125,7 @@ class TestAutoGroups(AiidaTestCase):
 
     def test_autogroup_custom_label(self):
         """Check if the autogroup is properly generated with the label specified."""
-        from aiida.orm import QueryBuilder, Node, AutoGroup, load_node
+        from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
         script_content = textwrap.dedent(
             """\
@@ -157,7 +157,7 @@ class TestAutoGroups(AiidaTestCase):
 
     def test_no_autogroup(self):
         """Check if the autogroup is not generated if ``verdi run`` is asked not to."""
-        from aiida.orm import QueryBuilder, Node, AutoGroup, load_node
+        from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
         script_content = textwrap.dedent(
             """\
@@ -186,7 +186,7 @@ class TestAutoGroups(AiidaTestCase):
     @pytest.mark.requires_rmq
     def test_autogroup_filter_class(self):  # pylint: disable=too-many-locals
         """Check if the autogroup is properly generated but filtered classes are skipped."""
-        from aiida.orm import Code, QueryBuilder, Node, AutoGroup, load_node
+        from aiida.orm import AutoGroup, Code, Node, QueryBuilder, load_node
 
         script_content = textwrap.dedent(
             """\
@@ -357,7 +357,7 @@ class TestAutoGroups(AiidaTestCase):
 
     def test_autogroup_clashing_label(self):
         """Check if the autogroup label is properly (re)generated when it clashes with an existing group name."""
-        from aiida.orm import QueryBuilder, Node, AutoGroup, load_node
+        from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
         script_content = textwrap.dedent(
             """\

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Tests for `verdi profile`."""
 import traceback
+
 from click.testing import CliRunner
 import pytest
 
@@ -17,8 +18,8 @@ from aiida.backends import BACKEND_DJANGO
 from aiida.backends.testbase import AiidaPostgresTestCase
 from aiida.cmdline.commands import cmd_setup
 from aiida.manage import configuration
-from aiida.manage.manager import get_manager
 from aiida.manage.external.postgres import Postgres
+from aiida.manage.manager import get_manager
 
 
 @pytest.mark.usefixtures('config_with_profile')
@@ -83,8 +84,8 @@ class TestVerdiSetup(AiidaPostgresTestCase):
 
     def test_quicksetup_from_config_file(self):
         """Test `verdi quicksetup` from configuration file."""
-        import tempfile
         import os
+        import tempfile
 
         with tempfile.NamedTemporaryFile('w') as handle:
             handle.write(

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -11,9 +11,9 @@
 
 from click.testing import CliRunner
 
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_user
-from aiida import orm
 
 USER_1 = {  # pylint: disable=invalid-name
     'email': 'testuser1@localhost',

--- a/tests/cmdline/params/options/test_verbosity.py
+++ b/tests/cmdline/params/options/test_verbosity.py
@@ -13,8 +13,8 @@ import logging
 import click
 import pytest
 
-from aiida.cmdline.utils import echo
 from aiida.cmdline.params import options
+from aiida.cmdline.utils import echo
 from aiida.common.log import AIIDA_LOGGER, LOG_LEVELS
 
 

--- a/tests/cmdline/params/types/test_calculation.py
+++ b/tests/cmdline/params/types/test_calculation.py
@@ -11,7 +11,7 @@
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params.types import CalculationParamType
-from aiida.orm import CalculationNode, CalcFunctionNode, CalcJobNode, WorkChainNode, WorkFunctionNode
+from aiida.orm import CalcFunctionNode, CalcJobNode, CalculationNode, WorkChainNode, WorkFunctionNode
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 

--- a/tests/cmdline/params/types/test_computer.py
+++ b/tests/cmdline/params/types/test_computer.py
@@ -10,10 +10,9 @@
 """Tests for the `ComputerParamType`."""
 import pytest
 
+from aiida import orm
 from aiida.cmdline.params.types import ComputerParamType
 from aiida.orm.utils.loaders import OrmEntityLoader
-
-from aiida import orm
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/cmdline/params/types/test_group.py
+++ b/tests/cmdline/params/types/test_group.py
@@ -13,7 +13,7 @@ import click
 import pytest
 
 from aiida.cmdline.params.types import GroupParamType
-from aiida.orm import Group, AutoGroup, ImportGroup
+from aiida.orm import AutoGroup, Group, ImportGroup
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 

--- a/tests/common/test_extendeddicts.py
+++ b/tests/common/test_extendeddicts.py
@@ -14,9 +14,7 @@ import copy
 import pickle
 import unittest
 
-from aiida.common import json
-from aiida.common import exceptions
-from aiida.common import extendeddicts
+from aiida.common import exceptions, extendeddicts, json
 
 
 class FFADExample(extendeddicts.FixedFieldsAttributeDict):

--- a/tests/common/test_folders.py
+++ b/tests/common/test_folders.py
@@ -10,8 +10,8 @@
 """Tests for the folder class."""
 import io
 import os
-import sys
 import shutil
+import sys
 import tempfile
 import unittest
 

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -12,11 +12,11 @@ Unittests for aiida.common.hashing:make_hash with hardcoded hash values
 """
 
 import collections
-import itertools
 from datetime import datetime
-import hashlib
-import uuid
 from decimal import Decimal
+import hashlib
+import itertools
+import uuid
 
 import numpy as np
 import pytz
@@ -26,11 +26,11 @@ try:
 except ImportError:
     import unittest
 
-from aiida.common.utils import DatetimePrecision
-from aiida.common.exceptions import HashingError
-from aiida.common.hashing import make_hash, float_to_text, chunked_file_hash
-from aiida.common.folders import SandboxFolder
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common.exceptions import HashingError
+from aiida.common.folders import SandboxFolder
+from aiida.common.hashing import chunked_file_hash, float_to_text, make_hash
+from aiida.common.utils import DatetimePrecision
 from aiida.orm import Dict
 
 

--- a/tests/common/test_serialize.py
+++ b/tests/common/test_serialize.py
@@ -14,8 +14,8 @@ import types
 import numpy as np
 
 from aiida import orm
-from aiida.orm.utils import serialize
 from aiida.backends.testbase import AiidaTestCase
+from aiida.orm.utils import serialize
 
 
 class TestSerialize(AiidaTestCase):

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -10,8 +10,7 @@
 """Tests for the aiida.common.utils functionality."""
 import unittest
 
-from aiida.common import escaping
-from aiida.common import utils
+from aiida.common import escaping, utils
 
 
 class UniqueTest(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def non_interactive_editor(request):
     :param request: the command to set for the editor that is to be called
     """
     from unittest.mock import patch
+
     from click._termui_impl import Editor
 
     os.environ['EDITOR'] = request.param
@@ -163,6 +164,7 @@ def isolated_config(monkeypatch):
     Python process and so doesn't have access to the loaded config in memory in the process that is running the test.
     """
     import copy
+
     from aiida.manage import configuration
 
     monkeypatch.setattr(configuration.Config, '_backup', lambda *args, **kwargs: None)
@@ -189,7 +191,7 @@ def empty_config(tmp_path) -> Config:
     """
     from aiida.common.utils import Capturing
     from aiida.manage import configuration
-    from aiida.manage.configuration import settings, reset_profile
+    from aiida.manage.configuration import reset_profile, settings
 
     # Store the current configuration instance and config directory path
     current_config = configuration.CONFIG
@@ -369,12 +371,12 @@ def override_logging(isolated_config):
 @pytest.fixture
 def with_daemon():
     """Starts the daemon process and then makes sure to kill it once the test is done."""
-    import sys
     import signal
     import subprocess
+    import sys
 
-    from aiida.engine.daemon.client import DaemonClient
     from aiida.cmdline.utils.common import get_env_with_venv_bin
+    from aiida.engine.daemon.client import DaemonClient
 
     # Add the current python path to the environment that will be used for the daemon sub process.
     # This is necessary to guarantee the daemon can also import all the classes that are defined

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -137,7 +137,7 @@ def test_upload_local_copy_list(fixture_sandbox, aiida_localhost, aiida_local_co
     Specifically, verify that files in the ``local_copy_list`` do not end up in the repository of the node.
     """
     from aiida.common.datastructures import CalcInfo, CodeInfo
-    from aiida.orm import CalcJobNode, SinglefileData, FolderData
+    from aiida.orm import CalcJobNode, FolderData, SinglefileData
 
     create_file_hierarchy(file_hierarchy, tmp_path)
     folder = FolderData()

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -9,10 +9,10 @@
 ###########################################################################
 # pylint: disable=too-many-public-methods,redefined-outer-name,no-self-use
 """Test for the `CalcJob` process sub class."""
-import json
 from copy import deepcopy
 from functools import partial
 import io
+import json
 import os
 import tempfile
 from unittest.mock import patch
@@ -21,10 +21,10 @@ import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import exceptions, LinkType, CalcJobState, StashMode
-from aiida.engine import launch, CalcJob, Process, ExitCode, CalcJobImporter
-from aiida.engine.processes.ports import PortNamespace
+from aiida.common import CalcJobState, LinkType, StashMode, exceptions
+from aiida.engine import CalcJob, CalcJobImporter, ExitCode, Process, launch
 from aiida.engine.processes.calcjobs.calcjob import validate_stash_options
+from aiida.engine.processes.ports import PortNamespace
 from aiida.plugins import CalculationFactory
 
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')  # pylint: disable=invalid-name

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -10,9 +10,9 @@
 """Tests for `aiida.engine.processes.builder.ProcessBuilder`."""
 import pytest
 
+from aiida import orm
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from aiida.engine.processes.builder import ProcessBuilder
-from aiida import orm
 
 
 def test_access_methods():

--- a/tests/engine/processes/workchains/test_utils.py
+++ b/tests/engine/processes/workchains/test_utils.py
@@ -14,7 +14,7 @@ import pytest
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import ExitCode, ProcessState
 from aiida.engine.processes.workchains.restart import BaseRestartWorkChain
-from aiida.engine.processes.workchains.utils import process_handler, ProcessHandlerReport
+from aiida.engine.processes.workchains.utils import ProcessHandlerReport, process_handler
 from aiida.orm import ProcessNode
 from aiida.plugins import CalculationFactory
 

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -13,9 +13,9 @@ import pytest
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 from aiida.common.links import LinkType
-from aiida.engine import calcfunction, Process
+from aiida.engine import Process, calcfunction
 from aiida.manage.caching import enable_caching
-from aiida.orm import Int, CalcFunctionNode
+from aiida.orm import CalcFunctionNode, Int
 
 # Global required for one of the caching tests to keep track of the number of times the calculation function is executed
 EXECUTION_COUNTER = 0

--- a/tests/engine/test_class_loader.py
+++ b/tests/engine/test_class_loader.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """A module to test class loader factories."""
 import aiida
-
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import Process
 from aiida.plugins import CalculationFactory

--- a/tests/engine/test_futures.py
+++ b/tests/engine/test_futures.py
@@ -15,7 +15,6 @@ import pytest
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import processes, run
 from aiida.manage.manager import get_manager
-
 from tests.utils import processes as test_processes
 
 

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -13,7 +13,7 @@ import pytest
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
-from aiida.engine import launch, Process, CalcJob, WorkChain, calcfunction
+from aiida.engine import CalcJob, Process, WorkChain, calcfunction, launch
 
 
 @calcfunction
@@ -156,6 +156,7 @@ class TestLaunchersDryRun(AiidaTestCase):
     def tearDown(self):
         import os
         import shutil
+
         from aiida.common.folders import CALC_JOB_DRY_RUN_BASE_PATH
 
         super().tearDown()

--- a/tests/engine/test_manager.py
+++ b/tests/engine/test_manager.py
@@ -9,13 +9,13 @@
 ###########################################################################
 """Tests for the classes in `aiida.engine.processes.calcjobs.manager`."""
 
-import time
 import asyncio
+import time
 
-from aiida.orm import AuthInfo, User
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine.processes.calcjobs.manager import JobManager, JobsList
 from aiida.engine.transports import TransportQueue
+from aiida.orm import AuthInfo, User
 
 
 class TestJobManager(AiidaTestCase):

--- a/tests/engine/test_persistence.py
+++ b/tests/engine/test_persistence.py
@@ -12,9 +12,8 @@ import plumpy
 import pytest
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.engine.persistence import AiiDAPersister
 from aiida.engine import Process, run
-
+from aiida.engine.persistence import AiiDAPersister
 from tests.utils.processes import DummyProcess
 
 

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -18,11 +18,10 @@ import pytest
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.lang import override
-from aiida.engine import ExitCode, ExitCodesNamespace, Process, run, run_get_pk, run_get_node
+from aiida.engine import ExitCode, ExitCodesNamespace, Process, run, run_get_node, run_get_pk
 from aiida.engine.processes.ports import PortNamespace
 from aiida.manage.caching import enable_caching
 from aiida.plugins import CalculationFactory
-
 from tests.utils import processes as test_processes
 
 

--- a/tests/engine/test_process_builder.py
+++ b/tests/engine/test_process_builder.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping, MutableMapping
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import LinkType
-from aiida.engine import WorkChain, Process, ProcessBuilderNamespace
+from aiida.engine import Process, ProcessBuilderNamespace, WorkChain
 from aiida.plugins import CalculationFactory
 
 DEFAULT_INT = 256

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -12,7 +12,7 @@ import pytest
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.engine import run, run_get_node, submit, calcfunction, workfunction, Process, ExitCode
+from aiida.engine import ExitCode, Process, calcfunction, run, run_get_node, submit, workfunction
 from aiida.orm.nodes.data.bool import get_true_node
 from aiida.workflows.arithmetic.add_multiply import add_multiply
 

--- a/tests/engine/test_process_spec.py
+++ b/tests/engine/test_process_spec.py
@@ -11,7 +11,7 @@
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import Process
-from aiida.orm import Node, Data
+from aiida.orm import Data, Node
 
 
 class TestProcessSpec(AiidaTestCase):

--- a/tests/engine/test_rmq.py
+++ b/tests/engine/test_rmq.py
@@ -17,7 +17,6 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import ProcessState
 from aiida.manage.manager import get_manager
 from aiida.orm import Int
-
 from tests.utils import processes as test_processes
 
 

--- a/tests/engine/test_run.py
+++ b/tests/engine/test_run.py
@@ -12,8 +12,7 @@ import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import run, run_get_node
-from aiida.orm import Int, Str, ProcessNode
-
+from aiida.orm import Int, ProcessNode, Str
 from tests.utils.processes import DummyProcess
 
 

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -9,8 +9,8 @@
 ###########################################################################
 # pylint: disable=redefined-outer-name
 """Module to test process runners."""
-import threading
 import asyncio
+import threading
 
 import plumpy
 import pytest

--- a/tests/engine/test_transport.py
+++ b/tests/engine/test_transport.py
@@ -10,9 +10,9 @@
 """Module to test transport."""
 import asyncio
 
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine.transports import TransportQueue
-from aiida import orm
 
 
 class TestTransportQueue(AiidaTestCase):

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -16,8 +16,7 @@ import pytest
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import calcfunction, workfunction
-from aiida.engine.utils import exponential_backoff_retry, is_process_function, \
-        InterruptableFuture, interruptable_task
+from aiida.engine.utils import InterruptableFuture, exponential_backoff_retry, interruptable_task, is_process_function
 
 ITERATION = 0
 MAX_ITERATIONS = 3

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -20,10 +20,10 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.common.utils import Capturing
-from aiida.engine import ExitCode, Process, ToContext, WorkChain, if_, while_, return_, launch, calcfunction, append_
+from aiida.engine import ExitCode, Process, ToContext, WorkChain, append_, calcfunction, if_, launch, return_, while_
 from aiida.engine.persistence import ObjectLoader
 from aiida.manage.manager import get_manager
-from aiida.orm import load_node, Bool, Float, Int, Str
+from aiida.orm import Bool, Float, Int, Str, load_node
 
 
 def run_until_paused(proc):

--- a/tests/engine/test_workfunctions.py
+++ b/tests/engine/test_workfunctions.py
@@ -12,9 +12,9 @@ import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.engine import calcfunction, workfunction, Process
+from aiida.engine import Process, calcfunction, workfunction
 from aiida.manage.caching import enable_caching
-from aiida.orm import Int, WorkFunctionNode, CalcFunctionNode
+from aiida.orm import CalcFunctionNode, Int, WorkFunctionNode
 
 
 @pytest.mark.requires_rmq

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -9,14 +9,13 @@
 ###########################################################################
 """Tests for the configuration migration functionality."""
 import os
-import uuid
 from unittest import TestCase
 from unittest.mock import patch
+import uuid
 
 from aiida.common import json
-
-from aiida.manage.configuration.migrations.utils import check_and_migrate_config
 from aiida.manage.configuration.migrations.migrations import _MIGRATION_LOOKUP
+from aiida.manage.configuration.migrations.utils import check_and_migrate_config
 
 
 class TestConfigMigration(TestCase):

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -12,8 +12,8 @@ import pytest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ConfigurationError
-from aiida.manage.configuration.options import get_option, get_option_names, parse_option, Option
-from aiida.manage.configuration import get_config, get_config_option, ConfigValidationError
+from aiida.manage.configuration import ConfigValidationError, get_config, get_config_option
+from aiida.manage.configuration.options import Option, get_option, get_option_names, parse_option
 
 
 class TestConfigurationOptions(AiidaTestCase):

--- a/tests/manage/configuration/test_profile.py
+++ b/tests/manage/configuration/test_profile.py
@@ -14,7 +14,6 @@ import uuid
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.manage.configuration import Profile
-
 from tests.utils.configuration import create_mock_profile
 
 

--- a/tests/manage/test_caching_config.py
+++ b/tests/manage/test_caching_config.py
@@ -15,11 +15,11 @@ import contextlib
 import json
 from pathlib import Path
 
-import yaml
 import pytest
+import yaml
 
 from aiida.common import exceptions
-from aiida.manage.caching import get_use_cache, enable_caching, disable_caching
+from aiida.manage.caching import disable_caching, enable_caching, get_use_cache
 
 
 @pytest.fixture
@@ -50,7 +50,7 @@ def test_merge_deprecated_yaml(tmp_path):
     """
     from aiida.common.warnings import AiidaDeprecationWarning
     from aiida.manage import configuration
-    from aiida.manage.configuration import settings, load_profile, reset_profile, get_config_option
+    from aiida.manage.configuration import get_config_option, load_profile, reset_profile, settings
 
     # Store the current configuration instance and config directory path
     current_config = configuration.CONFIG

--- a/tests/orm/data/test_array.py
+++ b/tests/orm/data/test_array.py
@@ -12,7 +12,7 @@ import numpy
 import pytest
 
 from aiida.manage.manager import get_manager
-from aiida.orm import load_node, ArrayData
+from aiida.orm import ArrayData, load_node
 
 
 @pytest.mark.usefixtures('clear_database_before_test')

--- a/tests/orm/data/test_data.py
+++ b/tests/orm/data/test_data.py
@@ -10,6 +10,7 @@
 """Tests for the `Data` base class."""
 
 import os
+
 import numpy
 import pytest
 

--- a/tests/orm/data/test_kpoints.py
+++ b/tests/orm/data/test_kpoints.py
@@ -12,7 +12,7 @@
 import numpy as np
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm import KpointsData, load_node, StructureData
+from aiida.orm import KpointsData, StructureData, load_node
 
 
 class TestKpoints(AiidaTestCase):

--- a/tests/orm/data/test_orbital.py
+++ b/tests/orm/data/test_orbital.py
@@ -10,6 +10,7 @@
 """Tests for the `OrbitalData` class."""
 
 import copy
+
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import ValidationError
 from aiida.orm import OrbitalData

--- a/tests/orm/data/test_remote.py
+++ b/tests/orm/data/test_remote.py
@@ -14,7 +14,7 @@ import shutil
 import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm import RemoteData, User, AuthInfo
+from aiida.orm import AuthInfo, RemoteData, User
 
 
 class TestRemoteData(AiidaTestCase):

--- a/tests/orm/data/test_singlefile.py
+++ b/tests/orm/data/test_singlefile.py
@@ -9,10 +9,10 @@
 ###########################################################################
 """Tests for the `SinglefileData` class."""
 
-import os
 import io
-import tempfile
+import os
 import pathlib
+import tempfile
 
 import pytest
 

--- a/tests/orm/data/test_upf.py
+++ b/tests/orm/data/test_upf.py
@@ -11,10 +11,11 @@
 This module contains tests for UpfData and UpfData related functions.
 """
 import errno
-import tempfile
-import shutil
 import json
 import os
+import shutil
+import tempfile
+
 import numpy
 from numpy import array, isclose
 

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -8,8 +8,8 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Unit tests for the ORM Backend class."""
-from aiida.backends.testbase import AiidaTestCase
 from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 
 

--- a/tests/orm/implementation/test_comments.py
+++ b/tests/orm/implementation/test_comments.py
@@ -14,8 +14,7 @@ from uuid import UUID
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import timezone
-from aiida.common import exceptions
+from aiida.common import exceptions, timezone
 
 
 class TestBackendComment(AiidaTestCase):

--- a/tests/orm/implementation/test_groups.py
+++ b/tests/orm/implementation/test_groups.py
@@ -16,7 +16,7 @@ from aiida import orm
 @pytest.mark.usefixtures('clear_database_before_test')
 def test_query(backend):
     """Test if queries are working."""
-    from aiida.common.exceptions import NotExistent, MultipleObjectsError
+    from aiida.common.exceptions import MultipleObjectsError, NotExistent
 
     default_user = backend.users.create('simple@ton.com')
 

--- a/tests/orm/implementation/test_logs.py
+++ b/tests/orm/implementation/test_logs.py
@@ -9,14 +9,13 @@
 ###########################################################################
 """Unit tests for the BackendLog and BackendLogCollection classes."""
 
-import logging
 from datetime import datetime
+import logging
 from uuid import UUID
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import exceptions
-from aiida.common import timezone
+from aiida.common import exceptions, timezone
 from aiida.common.log import LOG_LEVEL_REPORT
 
 

--- a/tests/orm/implementation/test_nodes.py
+++ b/tests/orm/implementation/test_nodes.py
@@ -15,8 +15,7 @@ from datetime import datetime
 from uuid import UUID
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import timezone
-from aiida.common import exceptions
+from aiida.common import exceptions, timezone
 
 
 class TestBackendNode(AiidaTestCase):

--- a/tests/orm/implementation/test_utils.py
+++ b/tests/orm/implementation/test_utils.py
@@ -12,7 +12,7 @@ import math
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
-from aiida.orm.implementation.utils import validate_attribute_extra_key, clean_value, FIELD_SEPARATOR
+from aiida.orm.implementation.utils import FIELD_SEPARATOR, clean_value, validate_attribute_extra_key
 
 
 class TestOrmImplementationUtils(AiidaTestCase):

--- a/tests/orm/node/test_calcjob.py
+++ b/tests/orm/node/test_calcjob.py
@@ -11,7 +11,7 @@
 import io
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import LinkType, CalcJobState
+from aiida.common import CalcJobState, LinkType
 from aiida.orm import CalcJobNode, FolderData
 
 

--- a/tests/orm/node/test_node.py
+++ b/tests/orm/node/test_node.py
@@ -9,15 +9,15 @@
 ###########################################################################
 # pylint: disable=attribute-defined-outside-init,no-member,no-self-use,too-many-public-methods
 """Tests for the Node ORM class."""
+from decimal import Decimal
 import logging
 import os
 import tempfile
-from decimal import Decimal
 
 import pytest
 
-from aiida.common import exceptions, LinkType
-from aiida.orm import Computer, Data, Log, Node, User, CalculationNode, WorkflowNode, load_node
+from aiida.common import LinkType, exceptions
+from aiida.orm import CalculationNode, Computer, Data, Log, Node, User, WorkflowNode, load_node
 from aiida.orm.utils.links import LinkTriple
 
 
@@ -802,8 +802,8 @@ class TestNodeDelete:
     @pytest.mark.usefixtures('clear_database_before_test')
     def test_delete_through_utility_method(self):
         """Test deletion works correctly through the `aiida.backends.utils.delete_nodes_and_connections`."""
-        from aiida.common import timezone
         from aiida.backends.utils import delete_nodes_and_connections
+        from aiida.common import timezone
 
         data_one = Data().store()
         data_two = Data().store()

--- a/tests/orm/node/test_repository.py
+++ b/tests/orm/node/test_repository.py
@@ -9,7 +9,7 @@ import pytest
 from aiida.common import exceptions
 from aiida.engine import ProcessState
 from aiida.manage.caching import enable_caching
-from aiida.orm import load_node, CalcJobNode, Data
+from aiida.orm import CalcJobNode, Data, load_node
 from aiida.repository.backend import DiskObjectStoreRepositoryBackend, SandboxRepositoryBackend
 from aiida.repository.common import File, FileType
 

--- a/tests/orm/test_comments.py
+++ b/tests/orm/test_comments.py
@@ -10,9 +10,9 @@
 """Unit tests for the Comment ORM class."""
 
 from aiida import orm
-from aiida.orm.comments import Comment
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
+from aiida.orm.comments import Comment
 
 
 class TestComment(AiidaTestCase):

--- a/tests/orm/test_entities.py
+++ b/tests/orm/test_entities.py
@@ -9,8 +9,8 @@
 ###########################################################################
 """Test for general backend entities"""
 
-from aiida.backends.testbase import AiidaTestCase
 from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
 
 
 class TestBackendEntitiesAndCollections(AiidaTestCase):

--- a/tests/orm/test_logs.py
+++ b/tests/orm/test_logs.py
@@ -167,7 +167,7 @@ class TestBackendLog(AiidaTestCase):
         """
         Test the order_by option of log.find
         """
-        from aiida.orm.logs import OrderSpecifier, ASCENDING, DESCENDING
+        from aiida.orm.logs import ASCENDING, DESCENDING, OrderSpecifier
 
         node_ids = []
         for _ in range(10):
@@ -218,7 +218,7 @@ class TestBackendLog(AiidaTestCase):
         by firing a log message through the regular logging module
         attached to a calculation node
         """
-        from aiida.orm.logs import OrderSpecifier, ASCENDING
+        from aiida.orm.logs import ASCENDING, OrderSpecifier
 
         message = 'Testing logging of critical failure'
         node = orm.CalculationNode()

--- a/tests/orm/test_mixins.py
+++ b/tests/orm/test_mixins.py
@@ -12,7 +12,7 @@
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 from aiida.common.links import LinkType
-from aiida.orm import Int, CalculationNode
+from aiida.orm import CalculationNode, Int
 from aiida.orm.utils.mixins import Sealable
 
 

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -18,9 +18,9 @@ import warnings
 import pytest
 
 from aiida import orm, plugins
-from aiida.orm.querybuilder import _get_ormclass
 from aiida.common.links import LinkType
 from aiida.manage import configuration
+from aiida.orm.querybuilder import _get_ormclass
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
@@ -112,7 +112,7 @@ class TestBasic:
 
     def test_get_group_type_filter(self):
         """Test the `aiida.orm.querybuilder.get_group_type_filter` function."""
-        from aiida.orm.querybuilder import _get_group_type_filter, Classifier
+        from aiida.orm.querybuilder import Classifier, _get_group_type_filter
 
         classifiers = Classifier('group.core')
         assert _get_group_type_filter(classifiers, False) == {'==': 'core'}
@@ -133,8 +133,8 @@ class TestBasic:
         """
         Test querying for a process class.
         """
-        from aiida.engine import run, WorkChain, if_, return_, ExitCode
         from aiida.common.warnings import AiidaEntryPointWarning
+        from aiida.engine import ExitCode, WorkChain, if_, return_, run
 
         class PotentialFailureWorkChain(WorkChain):
             EXIT_STATUS = 1

--- a/tests/orm/utils/test_loaders.py
+++ b/tests/orm/utils/test_loaders.py
@@ -10,8 +10,8 @@
 """Module to test orm utilities to load nodes, codes etc."""
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import NotExistent
-from aiida.orm import Node, Group, Data
-from aiida.orm.utils import load_entity, load_code, load_computer, load_group, load_node
+from aiida.orm import Data, Group, Node
+from aiida.orm.utils import load_code, load_computer, load_entity, load_group, load_node
 from aiida.orm.utils.loaders import NodeEntityLoader
 
 

--- a/tests/orm/utils/test_managers.py
+++ b/tests/orm/utils/test_managers.py
@@ -12,8 +12,8 @@
 import pytest
 
 from aiida import orm
+from aiida.common import AttributeDict, LinkType
 from aiida.common.exceptions import NotExistent, NotExistentAttributeError, NotExistentKeyError
-from aiida.common import LinkType, AttributeDict
 
 
 def test_dot_dict_manager(clear_database_before_test):

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -18,8 +18,8 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.common import LinkType
 from aiida.engine import CalcJob
 from aiida.parsers import Parser
-from aiida.plugins import CalculationFactory, ParserFactory
 from aiida.parsers.plugins.arithmetic.add import SimpleArithmeticAddParser  # for demonstration purposes only
+from aiida.plugins import CalculationFactory, ParserFactory
 
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')  # pylint: disable=invalid-name
 ArithmeticAddParser = ParserFactory('core.arithmetic.add')  # pylint: disable=invalid-name

--- a/tests/plugins/test_factories.py
+++ b/tests/plugins/test_factories.py
@@ -12,14 +12,14 @@
 import pytest
 
 from aiida.common.exceptions import InvalidEntryPointTypeError
-from aiida.engine import calcfunction, workfunction, CalcJob, WorkChain, CalcJobImporter
-from aiida.orm import Data, Node, CalcFunctionNode, WorkFunctionNode
+from aiida.engine import CalcJob, CalcJobImporter, WorkChain, calcfunction, workfunction
+from aiida.orm import CalcFunctionNode, Data, Node, WorkFunctionNode
 from aiida.parsers import Parser
 from aiida.plugins import entry_point, factories
 from aiida.schedulers import Scheduler
-from aiida.transports import Transport
 from aiida.tools.data.orbital import Orbital
 from aiida.tools.dbimporters import DbImporter
+from aiida.transports import Transport
 
 
 def custom_load_entry_point(group, name):

--- a/tests/plugins/test_utils.py
+++ b/tests/plugins/test_utils.py
@@ -10,7 +10,7 @@
 """Tests for utilities dealing with plugins and entry points."""
 from aiida import __version__ as version_core
 from aiida.backends.testbase import AiidaTestCase
-from aiida.engine import calcfunction, WorkChain
+from aiida.engine import WorkChain, calcfunction
 from aiida.plugins import CalculationFactory
 from aiida.plugins.utils import PluginVersionProvider
 

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -8,8 +8,8 @@ import typing as t
 
 import pytest
 
-from aiida.repository import Repository, File, FileType
-from aiida.repository.backend import SandboxRepositoryBackend, DiskObjectStoreRepositoryBackend
+from aiida.repository import File, FileType, Repository
+from aiida.repository.backend import DiskObjectStoreRepositoryBackend, SandboxRepositoryBackend
 
 
 @contextlib.contextmanager

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -42,7 +42,7 @@ def restapi_server():
 
 @pytest.fixture
 def server_url():
-    from aiida.restapi.common.config import CLI_DEFAULTS, API_CONFIG
+    from aiida.restapi.common.config import API_CONFIG, CLI_DEFAULTS
 
     return f"http://{CLI_DEFAULTS['HOST_NAME']}:{CLI_DEFAULTS['PORT']}{API_CONFIG['PREFIX']}"
 

--- a/tests/restapi/test_identifiers.py
+++ b/tests/restapi/test_identifiers.py
@@ -10,11 +10,11 @@
 """Tests for the `aiida.restapi.common.identifiers` module."""
 from threading import Thread
 
-import requests
 import pytest
+import requests
 
 from aiida import orm
-from aiida.restapi.common.identifiers import get_full_type_filters, FULL_TYPE_CONCATENATOR, LIKE_OPERATOR_CHARACTER
+from aiida.restapi.common.identifiers import FULL_TYPE_CONCATENATOR, LIKE_OPERATOR_CHARACTER, get_full_type_filters
 
 
 def test_get_full_type_filters():

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -9,8 +9,8 @@
 ###########################################################################
 # pylint: disable=too-many-lines
 """Unittests for REST API."""
-import io
 from datetime import date
+import io
 
 from flask_cors.core import ACL_ORIGIN
 
@@ -81,6 +81,7 @@ class RESTApiTestCase(AiidaTestCase):
 
         # create log message for calcjob
         import logging
+
         from aiida.common.log import LOG_LEVEL_REPORT
         from aiida.common.timezone import now
         from aiida.orm import Log

--- a/tests/restapi/test_statistics.py
+++ b/tests/restapi/test_statistics.py
@@ -10,8 +10,8 @@
 """Unit tests for REST API statistics."""
 from threading import Thread
 
-import requests
 import pytest
+import requests
 
 
 def linearize_namespace(tree_namespace, linear_namespace=None):

--- a/tests/restapi/test_threaded_restapi.py
+++ b/tests/restapi/test_threaded_restapi.py
@@ -12,11 +12,11 @@
 Threaded mode is the default (and only) way to run the AiiDA REST API (see `aiida.restapi.run_api:run_api()`).
 This test file's layout is inspired by https://gist.github.com/prschmid/4643738
 """
-import time
 from threading import Thread
+import time
 
-import requests
 import pytest
+import requests
 
 NO_OF_REQUESTS = 100
 

--- a/tests/restapi/test_translator.py
+++ b/tests/restapi/test_translator.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the `aiida.restapi.translator` module."""
+from aiida.orm import Data
 # pylint: disable=invalid-name
 from aiida.restapi.translator.nodes.node import NodeTranslator
-from aiida.orm import Data
 
 
 def test_get_all_download_formats():

--- a/tests/schedulers/test_datastructures.py
+++ b/tests/schedulers/test_datastructures.py
@@ -120,8 +120,9 @@ class TestParEnvJobResource:
 
 def test_serialization():
     """Test the serialization/deserialization of JobInfo classes."""
-    from aiida.schedulers.datastructures import JobInfo, JobState
     from datetime import datetime
+
+    from aiida.schedulers.datastructures import JobInfo, JobState
 
     dict_serialized_content = {
         'job_id': '12723',

--- a/tests/schedulers/test_lsf.py
+++ b/tests/schedulers/test_lsf.py
@@ -11,11 +11,12 @@
 """Tests for the `LsfScheduler` plugin."""
 import logging
 import uuid
+
 import pytest
 
 from aiida.schedulers.datastructures import JobState
-from aiida.schedulers.scheduler import SchedulerError
 from aiida.schedulers.plugins.lsf import LsfScheduler
+from aiida.schedulers.scheduler import SchedulerError
 
 BJOBS_STDOUT_TO_TEST = '764213236|EXIT|TERM_RUNLIMIT: job killed after reaching LSF run time limit' \
                        '|b681e480bd|inewton|1|-|b681e480bd|test|Feb  2 00:46|Feb  2 00:45|-|Feb  2 00:44' \
@@ -111,8 +112,8 @@ def test_parse_common_joblist_output():
 
 def test_submit_script():
     """Test the creation of a simple submission script"""
-    from aiida.schedulers.datastructures import JobTemplate
     from aiida.common.datastructures import CodeInfo, CodeRunMode
+    from aiida.schedulers.datastructures import JobTemplate
 
     scheduler = LsfScheduler()
 
@@ -141,8 +142,8 @@ def test_submit_script():
 
 def test_submit_script_rerunnable():
     """Test the `rerunnable` option of the submit script."""
-    from aiida.schedulers.datastructures import JobTemplate
     from aiida.common.datastructures import CodeInfo, CodeRunMode
+    from aiida.schedulers.datastructures import JobTemplate
 
     scheduler = LsfScheduler()
 
@@ -214,8 +215,8 @@ def test_kill_output():
 
 def test_job_tmpl_errors():
     """Test the raising of the appropriate errors"""
-    from aiida.schedulers.datastructures import JobTemplate
     from aiida.common.datastructures import CodeRunMode
+    from aiida.schedulers.datastructures import JobTemplate
 
     scheduler = LsfScheduler()
     job_tmpl = JobTemplate()

--- a/tests/schedulers/test_pbspro.py
+++ b/tests/schedulers/test_pbspro.py
@@ -12,8 +12,8 @@
 import unittest
 import uuid
 
-from aiida.schedulers.plugins.pbspro import PbsproScheduler
 from aiida.schedulers.datastructures import JobState
+from aiida.schedulers.plugins.pbspro import PbsproScheduler
 
 text_qstat_f_to_test = """Job Id: 68350.mycluster
     Job_Name = cell-Qnormal
@@ -896,8 +896,8 @@ class TestSubmitScript(unittest.TestCase):
         """
         Test to verify if scripts works fine with default options
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = PbsproScheduler()
 
@@ -924,8 +924,8 @@ class TestSubmitScript(unittest.TestCase):
         """
         Test to verify if scripts works fine with default options
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = PbsproScheduler()
         code_info = CodeInfo()
@@ -952,8 +952,8 @@ class TestSubmitScript(unittest.TestCase):
         Test to verify if script works fine if we specify only
         num_cores_per_machine value.
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = PbsproScheduler()
 
@@ -985,8 +985,8 @@ class TestSubmitScript(unittest.TestCase):
         Test to verify if scripts works fine if we pass only
         num_cores_per_mpiproc value
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = PbsproScheduler()
 
@@ -1020,8 +1020,8 @@ class TestSubmitScript(unittest.TestCase):
         It should pass in check:
         res.num_cores_per_mpiproc * res.num_mpiprocs_per_machine = res.num_cores_per_machine
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = PbsproScheduler()
 
@@ -1066,8 +1066,8 @@ class TestSubmitScript(unittest.TestCase):
 
     def test_submit_script_rerunnable(self):  # pylint: disable=no-self-use
         """Test the `rerunnable` option of the submit script."""
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = PbsproScheduler()
 

--- a/tests/schedulers/test_sge.py
+++ b/tests/schedulers/test_sge.py
@@ -9,8 +9,8 @@
 ###########################################################################
 # pylint: disable=invalid-name,protected-access
 """Tests for the `SgeScheduler` plugin."""
-import unittest
 import logging
+import unittest
 
 from aiida.schedulers.datastructures import JobState
 from aiida.schedulers.plugins.sge import SgeScheduler
@@ -364,8 +364,8 @@ class TestCommand(unittest.TestCase):
         returns a datetime object.
         Example format: 2013-06-13T11:53:11
         """
-        import time
         import datetime
+        import time
 
         try:
             time_struct = time.strptime(string, fmt)

--- a/tests/schedulers/test_slurm.py
+++ b/tests/schedulers/test_slurm.py
@@ -8,16 +8,16 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the SLURM scheduler plugin."""
+import datetime
+import logging
 #pylint: disable=no-self-use,line-too-long
 import unittest
-import logging
 import uuid
-import datetime
 
 import pytest
 
-from aiida.schedulers.plugins.slurm import SlurmJobResource, SlurmScheduler, JobState
 from aiida.schedulers import SchedulerError
+from aiida.schedulers.plugins.slurm import JobState, SlurmJobResource, SlurmScheduler
 
 # job_id, state_raw, annotation, executing_host, username, number_nodes, number_cpus, allocated_machines, partition, time_limit, time_used, dispatch_time, job_name, submission_time
 # See SlurmScheduler.fields
@@ -195,8 +195,8 @@ class TestSubmitScript:
         """
         Test the creation of a simple submission script.
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = SlurmScheduler()
 
@@ -223,8 +223,8 @@ class TestSubmitScript:
 
     def test_submit_script_bad_shebang(self):
         """Test that first line of submit script is as expected."""
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = SlurmScheduler()
         code_info = CodeInfo()
@@ -251,8 +251,8 @@ class TestSubmitScript:
         Test to verify if script works fine if we specify only
         num_cores_per_machine value.
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = SlurmScheduler()
 
@@ -283,8 +283,8 @@ class TestSubmitScript:
         """
         Test to verify if scripts works fine if we pass only num_cores_per_mpiproc value
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = SlurmScheduler()
 
@@ -318,8 +318,8 @@ class TestSubmitScript:
         It should pass in check:
         res.num_cores_per_mpiproc * res.num_mpiprocs_per_machine = res.num_cores_per_machine
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = SlurmScheduler()
 
@@ -368,8 +368,8 @@ class TestSubmitScript:
         """
         Test the creation of a submission script with the `rerunnable` option.
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = SlurmScheduler()
 

--- a/tests/schedulers/test_torque.py
+++ b/tests/schedulers/test_torque.py
@@ -872,8 +872,8 @@ class TestSubmitScript(unittest.TestCase):
         """
         Test to verify if scripts works fine with default options
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         s = TorqueScheduler()
 
@@ -900,8 +900,8 @@ class TestSubmitScript(unittest.TestCase):
         Test to verify if script works fine if we specify only
         num_cores_per_machine value.
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = TorqueScheduler()
 
@@ -930,8 +930,8 @@ class TestSubmitScript(unittest.TestCase):
         Test to verify if scripts works fine if we pass only
         num_cores_per_mpiproc value
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = TorqueScheduler()
 
@@ -962,8 +962,8 @@ class TestSubmitScript(unittest.TestCase):
         It should pass in check:
         res.num_cores_per_mpiproc * res.num_mpiprocs_per_machine = res.num_cores_per_machine
         """
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = TorqueScheduler()
 
@@ -1006,8 +1006,8 @@ class TestSubmitScript(unittest.TestCase):
 
     def test_submit_script_rerunnable(self):  # pylint: disable=no-self-use
         """Test the `rerunnable` option of the submit script."""
-        from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.datastructures import CodeInfo, CodeRunMode
+        from aiida.schedulers.datastructures import JobTemplate
 
         scheduler = TorqueScheduler()
 

--- a/tests/sphinxext/conftest.py
+++ b/tests/sphinxext/conftest.py
@@ -10,13 +10,13 @@
 """Pytest fixtures for AiiDA sphinx extension tests."""
 import os
 from pathlib import Path
-import sys
 import shutil
+import sys
 import xml.etree.ElementTree as ET
 
+import pytest
 from sphinx.testing.path import path as sphinx_path
 from sphinx.testing.util import SphinxTestApp
-import pytest
 
 SRC_DIR = Path(__file__).parent / 'sources'
 WORKCHAIN_DIR = Path(__file__).parent / 'workchains'

--- a/tests/test_base_dataclasses.py
+++ b/tests/test_base_dataclasses.py
@@ -12,8 +12,8 @@ import operator
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ModificationNotAllowed
-from aiida.orm import load_node, List, Bool, Float, Int, Str, NumericType
-from aiida.orm.nodes.data.bool import get_true_node, get_false_node
+from aiida.orm import Bool, Float, Int, List, NumericType, Str, load_node
+from aiida.orm.nodes.data.bool import get_false_node, get_true_node
 
 
 class TestList(AiidaTestCase):

--- a/tests/test_calculation_node.py
+++ b/tests/test_calculation_node.py
@@ -10,9 +10,9 @@
 """Tests for the CalculationNode and CalcJobNode class."""
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida.common.datastructures import CalcJobState
-from aiida.orm import CalculationNode, CalcJobNode
+from aiida.common.exceptions import ModificationNotAllowed
+from aiida.orm import CalcJobNode, CalculationNode
 
 
 class TestProcessNode(AiidaTestCase):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -18,12 +18,17 @@ import pytest
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ModificationNotAllowed
 from aiida.common.utils import Capturing
-from aiida.orm import load_node
-from aiida.orm import CifData, StructureData, KpointsData, BandsData, ArrayData, TrajectoryData, Dict
+from aiida.orm import ArrayData, BandsData, CifData, Dict, KpointsData, StructureData, TrajectoryData, load_node
 from aiida.orm.nodes.data.structure import (
-    ase_refine_cell, get_formula, get_pymatgen_version, has_ase, has_pymatgen, has_spglib
+    Kind,
+    Site,
+    ase_refine_cell,
+    get_formula,
+    get_pymatgen_version,
+    has_ase,
+    has_pymatgen,
+    has_spglib,
 )
-from aiida.orm.nodes.data.structure import Kind, Site
 
 
 def has_seekpath():
@@ -62,6 +67,7 @@ def test_get_pymatgen_version():
 class TestCifData(AiidaTestCase):
     """Tests for CifData class."""
     from distutils.version import StrictVersion
+
     from aiida.orm.nodes.data.cif import has_pycifrw
 
     valid_sample_cif_str = '''
@@ -339,8 +345,9 @@ Te2 0.00000 0.00000 0.79030 0.01912
         """
         Tests CifData.pycifrw_from_cif()
         """
-        from aiida.orm.nodes.data.cif import pycifrw_from_cif
         import re
+
+        from aiida.orm.nodes.data.cif import pycifrw_from_cif
 
         datablocks = [{
             '_atom_site_label': ['A', 'B', 'C'],
@@ -402,8 +409,9 @@ _publ_section_title                     'Test CIF'
     @unittest.skipIf(not has_pycifrw(), 'Unable to import PyCifRW')
     def test_pycifrw_syntax(self):
         """Tests CifData.pycifrw_from_cif() - check syntax pb in PyCifRW 3.6."""
-        from aiida.orm.nodes.data.cif import pycifrw_from_cif
         import re
+
+        from aiida.orm.nodes.data.cif import pycifrw_from_cif
 
         datablocks = [{
             '_tag': '[value]',
@@ -1518,8 +1526,9 @@ class TestStructureData(AiidaTestCase):
         Test the ase_refine_cell() function
         """
         # pylint: disable=too-many-statements
-        import ase
         import math
+
+        import ase
         import numpy
 
         a = ase.Atoms(cell=[10, 10, 10])
@@ -2171,6 +2180,7 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
 
         def recursively_compare_values(left, right):
             from collections.abc import Mapping
+
             from numpy import testing
 
             if isinstance(left, Mapping):
@@ -2223,8 +2233,8 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests pymatgen -> StructureData, with partial occupancies and spins.
         This should raise a ValueError.
         """
-        from pymatgen.core.periodic_table import Specie
         from pymatgen.core.composition import Composition
+        from pymatgen.core.periodic_table import Specie
         from pymatgen.core.structure import Structure
 
         Fe_spin_up = Specie('Fe', 0, properties={'spin': 1})
@@ -2989,6 +2999,7 @@ class TestTrajectoryData(AiidaTestCase):
     def test_export_to_file():
         """Export the band structure on a file, check if it is working."""
         import numpy
+
         from aiida.orm.nodes.data.cif import has_pycifrw
 
         n = TrajectoryData()
@@ -3189,6 +3200,7 @@ class TestKpointsData(AiidaTestCase):
         the same behavior of the old implementation
         """
         import numpy
+
         from aiida.tools.data.array.kpoints import get_explicit_kpoints_path
 
         # Shouldn't get anything without having set the cell
@@ -3240,6 +3252,7 @@ class TestKpointsData(AiidaTestCase):
         the same behavior of the old implementation
         """
         import numpy
+
         from aiida.tools.data.array.kpoints import get_kpoints_path
 
         alat = 1.5
@@ -3263,6 +3276,7 @@ class TestSpglibTupleConversion(AiidaTestCase):
         Test conversion of a simple tuple to an AiiDA structure
         """
         import numpy as np
+
         from aiida.tools import spglib_tuple_to_structure
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
@@ -3285,6 +3299,7 @@ class TestSpglibTupleConversion(AiidaTestCase):
     def test_complex1_to_aiida(self):
         """Test conversion of a  tuple to an AiiDA structure when passing also information on the kinds."""
         import numpy as np
+
         from aiida.tools import spglib_tuple_to_structure
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
@@ -3346,6 +3361,7 @@ class TestSpglibTupleConversion(AiidaTestCase):
     def test_from_aiida(self):
         """Test conversion of an AiiDA structure to a spglib tuple."""
         import numpy as np
+
         from aiida.tools import structure_to_spglib_tuple
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
@@ -3375,7 +3391,8 @@ class TestSpglibTupleConversion(AiidaTestCase):
         Convert an AiiDA structure to a tuple and go back to see if we get the same results
         """
         import numpy as np
-        from aiida.tools import structure_to_spglib_tuple, spglib_tuple_to_structure
+
+        from aiida.tools import spglib_tuple_to_structure, structure_to_spglib_tuple
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
 
@@ -3410,8 +3427,8 @@ class TestSeekpathExplicitPath(AiidaTestCase):
     def test_simple(self):
         """Test a simple case."""
         import numpy as np
-        from aiida.plugins import DataFactory
 
+        from aiida.plugins import DataFactory
         from aiida.tools import get_explicit_kpoints_path
 
         structure = DataFactory('core.structure')(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 6]])
@@ -3493,6 +3510,7 @@ class TestSeekpathPath(AiidaTestCase):
     def test_simple(self):
         """Test SeekPath for BaTiO3 structure."""
         import numpy as np
+
         from aiida.plugins import DataFactory
         from aiida.tools import get_kpoints_path
 

--- a/tests/test_dbimporters.py
+++ b/tests/test_dbimporters.py
@@ -20,8 +20,9 @@ class TestCodDbImporter(AiidaTestCase):
 
     def test_query_construction_1(self):
         """Test query construction."""
-        from aiida.tools.dbimporters.plugins.cod import CodDbImporter
         import re
+
+        from aiida.tools.dbimporters.plugins.cod import CodDbImporter
 
         codi = CodDbImporter()
         q_sql = codi.query_sql(
@@ -103,8 +104,7 @@ class TestCodDbImporter(AiidaTestCase):
 
     def test_dbentry_creation(self):
         """Tests the creation of CodEntry from CodSearchResults."""
-        from aiida.tools.dbimporters.plugins.cod \
-            import CodSearchResults
+        from aiida.tools.dbimporters.plugins.cod import CodSearchResults
 
         results = CodSearchResults([{
             'id': '1000000',
@@ -249,8 +249,8 @@ class TestNnincDbImporter(AiidaTestCase):
         """Tests the creation of NnincEntry from NnincSearchResults."""
         import os
 
-        from aiida.tools.dbimporters.plugins.nninc import NnincSearchResults
         from aiida.common.exceptions import ParsingError
+        from aiida.tools.dbimporters.plugins.nninc import NnincSearchResults
 
         upf = 'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030'
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -9,8 +9,8 @@
 ###########################################################################
 """Generic tests that need the use of the DB."""
 
-from aiida.backends.testbase import AiidaTestCase
 from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
 
 
 class TestCode(AiidaTestCase):
@@ -20,8 +20,8 @@ class TestCode(AiidaTestCase):
         """Test local code."""
         import tempfile
 
-        from aiida.orm import Code
         from aiida.common.exceptions import ValidationError
+        from aiida.orm import Code
 
         code = Code(local_executable='test.sh')
         with self.assertRaises(ValidationError):
@@ -42,8 +42,8 @@ class TestCode(AiidaTestCase):
         """Test remote code."""
         import tempfile
 
-        from aiida.orm import Code
         from aiida.common.exceptions import ValidationError
+        from aiida.orm import Code
 
         with self.assertRaises(ValueError):
             # remote_computer_exec has length 2 but is not a list or tuple

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -20,7 +20,7 @@ from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import InvalidOperation, ModificationNotAllowed, StoringNotAllowed, ValidationError
 from aiida.common.links import LinkType
-from aiida.tools import delete_nodes, delete_group_nodes
+from aiida.tools import delete_group_nodes, delete_nodes
 
 
 class TestNodeIsStorable(AiidaTestCase):
@@ -551,8 +551,8 @@ class TestNodeBasic(AiidaTestCase):
         Similar as test_files, but I manipulate a tree of folders
         """
         import os
-        import shutil
         import random
+        import shutil
         import string
 
         a = orm.Data()
@@ -972,8 +972,9 @@ class TestNodeBasic(AiidaTestCase):
         # of directly loading datetime.datetime.now(), or you can get a
         # "can't compare offset-naive and offset-aware datetimes" error
         from datetime import timedelta
-        from aiida.common import timezone
         from time import sleep
+
+        from aiida.common import timezone
 
         user = orm.User.objects.get_default()
 
@@ -1009,7 +1010,7 @@ class TestNodeBasic(AiidaTestCase):
         """
         Checks that the method Code.get_from_string works correctly.
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError
+        from aiida.common.exceptions import MultipleObjectsError, NotExistent
 
         # Create some code nodes
         code1 = orm.Code()
@@ -1056,7 +1057,7 @@ class TestNodeBasic(AiidaTestCase):
         """
         Checks that the method Code.get(pk) works correctly.
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError
+        from aiida.common.exceptions import MultipleObjectsError, NotExistent
 
         # Create some code nodes
         code1 = orm.Code()

--- a/tests/tools/data/orbital/test_orbitals.py
+++ b/tests/tools/data/orbital/test_orbitals.py
@@ -12,9 +12,8 @@
 #from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ValidationError
-from aiida.tools.data.orbital import Orbital
-
 from aiida.plugins import OrbitalFactory
+from aiida.tools.data.orbital import Orbital
 
 
 class TestOrbital(AiidaTestCase):

--- a/tests/tools/dbimporters/test_icsd.py
+++ b/tests/tools/dbimporters/test_icsd.py
@@ -11,6 +11,7 @@
 Tests for IcsdDbImporter
 """
 import urllib.request
+
 import pytest
 
 from aiida.backends.testbase import AiidaTestCase

--- a/tests/tools/graph/test_age.py
+++ b/tests/tools/graph/test_age.py
@@ -12,13 +12,11 @@
 
 import numpy as np
 
-from aiida.tools.graph.age_entities import AiidaEntitySet, DirectedEdgeSet
-from aiida.tools.graph.age_entities import Basket, GroupNodeEdge
-from aiida.tools.graph.age_rules import UpdateRule, ReplaceRule, RuleSequence, RuleSaveWalkers, RuleSetWalkers
-
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida import orm
+from aiida.tools.graph.age_entities import AiidaEntitySet, Basket, DirectedEdgeSet, GroupNodeEdge
+from aiida.tools.graph.age_rules import ReplaceRule, RuleSaveWalkers, RuleSequence, RuleSetWalkers, UpdateRule
 
 
 def create_tree(max_depth=3, branching=3, starting_cls=orm.Data):

--- a/tests/tools/graph/test_graph_traversers.py
+++ b/tests/tools/graph/test_graph_traversers.py
@@ -9,9 +9,9 @@
 ###########################################################################
 """Tests for aiida.tools.graph.graph_traversers"""
 
-from aiida.common.links import LinkType
 from aiida.backends.testbase import AiidaTestCase
-from aiida.tools.graph.graph_traversers import traverse_graph, get_nodes_delete
+from aiida.common.links import LinkType
+from aiida.tools.graph.graph_traversers import get_nodes_delete, traverse_graph
 
 
 def create_minimal_graph():
@@ -346,8 +346,8 @@ class TestTraverseGraph(AiidaTestCase):
 
     def test_traversal_errors(self):
         """This will test the errors of the traversers."""
-        from aiida.common.exceptions import NotExistent
         from aiida import orm
+        from aiida.common.exceptions import NotExistent
 
         test_node = orm.Data().store()
         false_node = -1

--- a/tests/tools/groups/test_paths.py
+++ b/tests/tools/groups/test_paths.py
@@ -12,7 +12,7 @@
 import pytest
 
 from aiida import orm
-from aiida.tools.groups.paths import GroupAttr, GroupPath, InvalidPath, GroupNotFoundError, NoGroupsInPathError
+from aiida.tools.groups.paths import GroupAttr, GroupNotFoundError, GroupPath, InvalidPath, NoGroupsInPathError
 
 
 @pytest.fixture

--- a/tests/tools/importexport/migration/test_migration.py
+++ b/tests/tools/importexport/migration/test_migration.py
@@ -12,10 +12,9 @@
 import pytest
 
 from aiida import orm
-from aiida.tools.importexport import detect_archive_type, get_migrator
-from aiida.tools.importexport import import_data, ArchiveMigrationError, EXPORT_VERSION as newest_version
+from aiida.tools.importexport import ArchiveMigrationError, detect_archive_type, get_migrator, import_data
+from aiida.tools.importexport import EXPORT_VERSION as newest_version
 from aiida.tools.importexport.archive.migrations.utils import verify_metadata_version
-
 from tests.utils.archives import get_archive_file, read_json_files
 
 # archives to test migration against

--- a/tests/tools/importexport/migration/test_migration_funcs.py
+++ b/tests/tools/importexport/migration/test_migration_funcs.py
@@ -14,9 +14,9 @@ import zipfile
 import pytest
 
 from aiida import get_version
+from aiida.tools.importexport.archive.common import CacheFolder
 from aiida.tools.importexport.archive.migrations import MIGRATE_FUNCTIONS
 from aiida.tools.importexport.archive.migrations.utils import verify_metadata_version
-from aiida.tools.importexport.archive.common import CacheFolder
 from tests.utils.archives import get_archive_file, read_json_files
 
 

--- a/tests/tools/importexport/migration/test_v02_to_v03.py
+++ b/tests/tools/importexport/migration/test_v02_to_v03.py
@@ -10,8 +10,7 @@
 # pylint: disable=too-many-branches
 """Test archive file migration from export version 0.2 to 0.3"""
 from aiida.tools.importexport.archive.migrations.v02_to_v03 import migrate_v2_to_v3
-
-from tests.utils.archives import read_json_files, get_archive_file
+from tests.utils.archives import get_archive_file, read_json_files
 
 
 def test_migrate_external(migrate_from_func):

--- a/tests/tools/importexport/migration/test_v03_to_v04.py
+++ b/tests/tools/importexport/migration/test_v03_to_v04.py
@@ -14,12 +14,11 @@ import zipfile
 
 from archive_path import TarPath, ZipPath
 
-from aiida.common.exceptions import NotExistent
 from aiida.common import json
+from aiida.common.exceptions import NotExistent
 from aiida.tools.importexport.archive import CacheFolder
 from aiida.tools.importexport.archive.migrations.utils import verify_metadata_version
 from aiida.tools.importexport.archive.migrations.v03_to_v04 import migrate_v3_to_v4
-
 from tests.utils.archives import get_archive_file, read_json_files
 
 

--- a/tests/tools/importexport/migration/test_v05_to_v06.py
+++ b/tests/tools/importexport/migration/test_v05_to_v06.py
@@ -11,8 +11,7 @@
 from aiida.backends.general.migrations.calc_state import STATE_MAPPING
 from aiida.tools.importexport.archive.migrations.utils import verify_metadata_version
 from aiida.tools.importexport.archive.migrations.v05_to_v06 import migrate_v5_to_v6
-
-from tests.utils.archives import read_json_files, get_archive_file
+from tests.utils.archives import get_archive_file, read_json_files
 
 
 def test_migrate_external(migrate_from_func):

--- a/tests/tools/importexport/migration/test_v06_to_v07.py
+++ b/tests/tools/importexport/migration/test_v06_to_v07.py
@@ -46,8 +46,8 @@ def test_migrate_external(migrate_from_func):
 
 def test_migration_0040_corrupt_archive():
     """Check CorruptArchive is raised for different cases during migration 0040"""
-    from aiida.tools.importexport.common.exceptions import CorruptArchive
     from aiida.tools.importexport.archive.migrations.v06_to_v07 import data_migration_legacy_process_attributes
+    from aiida.tools.importexport.common.exceptions import CorruptArchive
 
     # data has one "valid" entry, in the form of Node <PK=42>.
     # At least it has the needed key `node_type`.
@@ -107,6 +107,7 @@ def test_migration_0040_corrupt_archive():
 def test_migration_0040_no_process_state():
     """Check old ProcessNodes without a `process_state` can be migrated"""
     from aiida.tools.importexport.archive.migrations.v06_to_v07 import data_migration_legacy_process_attributes
+
     # data has one "new" entry, in the form of Node <PK=52>.
     # data also has one "old" entry, in form of Node <PK=42>.
     # It doesn't have a `process_state` attribute (nor a `sealed` or `_sealed`)

--- a/tests/tools/importexport/orm/test_attributes.py
+++ b/tests/tools/importexport/orm/test_attributes.py
@@ -13,9 +13,9 @@
 import os
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_calculations.py
+++ b/tests/tools/importexport/orm/test_calculations.py
@@ -15,9 +15,9 @@ import os
 import pytest
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 
@@ -28,8 +28,8 @@ class TestCalculations(AiidaArchiveTestCase):
     @with_temp_dir
     def test_calcfunction(self, temp_dir):
         """Test @calcfunction"""
-        from aiida.engine import calcfunction
         from aiida.common.exceptions import NotExistent
+        from aiida.engine import calcfunction
 
         @calcfunction
         def add(a, b):

--- a/tests/tools/importexport/orm/test_codes.py
+++ b/tests/tools/importexport/orm/test_codes.py
@@ -13,10 +13,10 @@ import os
 
 from aiida import orm
 from aiida.common.links import LinkType
-from aiida.tools.importexport import import_data, export
-
-from tests.utils.configuration import with_temp_dir
+from aiida.tools.importexport import export, import_data
 from tests.tools.importexport.utils import get_all_node_links
+from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_comments.py
+++ b/tests/tools/importexport/orm/test_comments.py
@@ -13,9 +13,9 @@
 import os
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_computers.py
+++ b/tests/tools/importexport/orm/test_computers.py
@@ -13,9 +13,9 @@
 import os
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_extras.py
+++ b/tests/tools/importexport/orm/test_extras.py
@@ -15,7 +15,8 @@ import shutil
 import tempfile
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
+from aiida.tools.importexport import export, import_data
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_groups.py
+++ b/tests/tools/importexport/orm/test_groups.py
@@ -12,10 +12,9 @@
 import os
 
 from aiida import orm
-
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_links.py
+++ b/tests/tools/importexport/orm/test_links.py
@@ -13,16 +13,15 @@ import os
 import tarfile
 
 from aiida import orm
-
 from aiida.common import json
 from aiida.common.folders import SandboxFolder
 from aiida.common.links import LinkType
 from aiida.common.utils import get_new_uuid
-from aiida.tools.importexport import import_data, export
+from aiida.tools.importexport import export, import_data
 from aiida.tools.importexport.common.exceptions import DanglingLinkError
-
-from tests.utils.configuration import with_temp_dir
 from tests.tools.importexport.utils import get_all_node_links
+from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_logs.py
+++ b/tests/tools/importexport/orm/test_logs.py
@@ -13,10 +13,9 @@
 import os
 
 from aiida import orm
-
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/orm/test_users.py
+++ b/tests/tools/importexport/orm/test_users.py
@@ -12,9 +12,9 @@
 import os
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from .. import AiidaArchiveTestCase
 
 

--- a/tests/tools/importexport/test_complex.py
+++ b/tests/tools/importexport/test_complex.py
@@ -14,9 +14,9 @@ import os
 
 from aiida import orm
 from aiida.common.links import LinkType
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from . import AiidaArchiveTestCase
 
 
@@ -107,10 +107,11 @@ class TestComplex(AiidaArchiveTestCase):
            |___|     |___|        |___|
 
         """
-        import numpy as np
-        import string
-        import random
         from datetime import datetime
+        import random
+        import string
+
+        import numpy as np
 
         from aiida.common.hashing import make_hash
 

--- a/tests/tools/importexport/test_prov_redesign.py
+++ b/tests/tools/importexport/test_prov_redesign.py
@@ -15,9 +15,9 @@ import os
 import pytest
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
-
+from aiida.tools.importexport import export, import_data
 from tests.utils.configuration import with_temp_dir
+
 from . import AiidaArchiveTestCase
 
 
@@ -94,6 +94,7 @@ class TestProvenanceRedesign(AiidaArchiveTestCase):
         """ Column `process_type` added to `Node` entity DB table """
         from aiida.engine import run_get_node
         from tests.utils.processes import AddProcess
+
         # Node types
         node_type = 'process.workflow.WorkflowNode.'
         node_process_type = 'tests.utils.processes.AddProcess'
@@ -199,6 +200,7 @@ class TestProvenanceRedesign(AiidaArchiveTestCase):
         as the type_string content for the relevant Groups.
         """
         from aiida.orm.nodes.data.upf import upload_upf_family
+
         # To be saved
         groups_label = ['Users', 'UpfData']
         upf_filename = 'Al.test_file.UPF'

--- a/tests/tools/importexport/test_simple.py
+++ b/tests/tools/importexport/test_simple.py
@@ -17,7 +17,7 @@ from aiida.common import json
 from aiida.common.exceptions import LicensingException
 from aiida.common.folders import SandboxFolder
 from aiida.common.links import LinkType
-from aiida.tools.importexport import import_data, export
+from aiida.tools.importexport import export, import_data
 from aiida.tools.importexport.common import exceptions
 
 

--- a/tests/tools/importexport/test_specific_import.py
+++ b/tests/tools/importexport/test_specific_import.py
@@ -13,7 +13,7 @@ import tempfile
 import numpy as np
 
 from aiida import orm
-from aiida.tools.importexport import import_data, export
+from aiida.tools.importexport import export, import_data
 
 from . import AiidaArchiveTestCase
 

--- a/tests/tools/importexport/utils.py
+++ b/tests/tools/importexport/utils.py
@@ -9,7 +9,7 @@
 ###########################################################################
 """Utility functions for tests for the export and import routines"""
 
-from aiida.orm import QueryBuilder, Node
+from aiida.orm import Node, QueryBuilder
 
 
 def get_all_node_links():

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -11,8 +11,8 @@
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common.links import LinkType
 from aiida.common import AttributeDict
+from aiida.common.links import LinkType
 from aiida.engine import ProcessState
 from aiida.orm.utils.links import LinkPair
 from aiida.tools.visualization import graph as graph_mod

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -17,10 +17,10 @@ Plugin specific tests will be written in the plugin itself.
 import io
 import os
 import random
-import tempfile
-import signal
 import shutil
+import signal
 import string
+import tempfile
 import time
 import unittest
 import uuid

--- a/tests/utils/archives.py
+++ b/tests/utils/archives.py
@@ -10,8 +10,8 @@
 """Test utility to import, inspect, or migrate AiiDA export archives."""
 import os
 import tarfile
-import zipfile
 from typing import List
+import zipfile
 
 from archive_path import read_file_in_tar, read_file_in_zip
 

--- a/tests/utils/configuration.py
+++ b/tests/utils/configuration.py
@@ -21,7 +21,7 @@ def create_mock_profile(name, repository_dirpath=None, **kwargs):
     :param name: name of the profile
     :param repository_dirpath: optional absolute path to use as the base for the repository path
     """
-    from aiida.manage.configuration import get_config, Profile
+    from aiida.manage.configuration import Profile, get_config
     from aiida.manage.external.postgres import DEFAULT_DBINFO
 
     if repository_dirpath is None:

--- a/tests/utils/memory.py
+++ b/tests/utils/memory.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Utilities for testing memory leakage."""
 import asyncio
+
 from pympler import muppy
 
 

--- a/tests/utils/processes.py
+++ b/tests/utils/processes.py
@@ -11,8 +11,8 @@
 
 import plumpy
 
-from aiida.orm import Data, WorkflowNode, CalcJobNode, Bool
 from aiida.engine import Process
+from aiida.orm import Bool, CalcJobNode, Data, WorkflowNode
 
 
 class DummyProcess(Process):

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -9,18 +9,18 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utility CLI to manage dependencies for aiida-core."""
-import os
-import sys
-import re
-import json
-import subprocess
-from pathlib import Path
 from collections import OrderedDict, defaultdict
-from pkg_resources import Requirement, parse_requirements
-from packaging.utils import canonicalize_name
-from packaging.version import parse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
 
 import click
+from packaging.utils import canonicalize_name
+from packaging.version import parse
+from pkg_resources import Requirement, parse_requirements
 import requests
 import yaml
 

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -140,6 +140,7 @@ def cli():
 def validate_verdi_documentation():
     """Auto-generate the documentation for `verdi` through `click`."""
     from click import Context
+
     from aiida.cmdline.commands.cmd_verdi import verdi
 
     width = 90  # The maximum width of the formatted help strings in characters


### PR DESCRIPTION
To nicely sort imports: https://pycqa.github.io/isort/

~~I've set it as "opt-in" (via file regex) for now, so we can introduce it gradually, without introducing too many merge conflicts in existing PRs~~

Annoyingly, there is no specific integration with yapf (as there is for black), but from googling the configuration I added should be fine.
I added `force_sort_within_sections=true` to not split `import a` and `from a import` types, which I feel is nicer