### PR TITLE
Fix issue with time in lsf and gaussian plugins

### DIFF
--- a/aiida/orm/implementation/utils.py
+++ b/aiida/orm/implementation/utils.py
@@ -9,10 +9,10 @@
 ###########################################################################
 """Utility methods for backend non-specific implementations."""
 from collections.abc import Iterable, Mapping
+import datetime
 from decimal import Decimal
 import math
 import numbers
-import datetime
 
 from aiida.common import exceptions
 from aiida.common.constants import AIIDA_FLOAT_PRECISION
@@ -76,7 +76,7 @@ def clean_value(value):
             # see https://www.postgresql.org/docs/current/static/datatype-json.html#JSON-TYPE-MAPPING-TABLE
             raise exceptions.ValidationError('nan and inf/-inf can not be serialized to the database')
 
-        # This fixes an error that occurs when aiida.gaussian passes the output from '_parse_log_cclib' 
+        # This fixes an error that occurs when aiida.gaussian passes the output from '_parse_log_cclib'
         # It contains a datetime.timedelta instance which is not json-serializable
         if isinstance(val, (datetime.timedelta)):
             return int(val.total_seconds())

--- a/aiida/orm/implementation/utils.py
+++ b/aiida/orm/implementation/utils.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable, Mapping
 from decimal import Decimal
 import math
 import numbers
+import datetime
 
 from aiida.common import exceptions
 from aiida.common.constants import AIIDA_FLOAT_PRECISION
@@ -74,6 +75,11 @@ def clean_value(value):
         if isinstance(val, numbers.Real) and (math.isnan(val) or math.isinf(val)):
             # see https://www.postgresql.org/docs/current/static/datatype-json.html#JSON-TYPE-MAPPING-TABLE
             raise exceptions.ValidationError('nan and inf/-inf can not be serialized to the database')
+
+        # This fixes an error that occurs when aiida.gaussian passes the output from '_parse_log_cclib' 
+        # It contains a datetime.timedelta instance which is not json-serializable
+        if isinstance(val, (datetime.timedelta)):
+            return int(val.total_seconds())
 
         # This is for float-like types, like ``numpy.float128`` that are not json-serializable
         # Note that `numbers.Real` also match booleans but they are already returned above

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -264,9 +264,8 @@ class LsfScheduler(aiida.schedulers.Scheduler):
         """
         from aiida.common.exceptions import FeatureNotAvailable
 
-        # I add the environment variable SLURM_TIME_FORMAT in front to be
-        # sure to get the times in 'standard' format
-        command = ['bjobs', '-noheader', f"-o '{' '.join(self._joblist_fields)} delimiter=\"{_FIELD_SEPARATOR}\"'"]
+        # Force to display year
+        command = ["LSB_DISPLAY_YEAR='Y'", 'bjobs', '-noheader', f"-o '{' '.join(self._joblist_fields)} delimiter=\"{_FIELD_SEPARATOR}\"'"]
 
         if user and jobs:
             raise FeatureNotAvailable('Cannot query by user and job(s) in LSF')
@@ -599,9 +598,9 @@ fi
 
             this_job.queue_name = partition
 
-            psd_finish_time = self._parse_time_string(finish_time, fmt='%b %d %H:%M')
-            psd_start_time = self._parse_time_string(start_time, fmt='%b %d %H:%M')
-            psd_submission_time = self._parse_time_string(submission_time, fmt='%b %d %H:%M')
+            psd_finish_time = self._parse_time_string(finish_time, fmt='%b %d %H:%M:%S %Y')
+            psd_start_time = self._parse_time_string(start_time, fmt='%b %d %H:%M:%S %Y')
+            psd_submission_time = self._parse_time_string(submission_time, fmt='%b %d %H:%M:%S %Y')
 
             # Now get the time in seconds which has been used
             # Only if it is RUNNING; otherwise it is not meaningful,
@@ -699,17 +698,11 @@ fi
         if string == '-':
             return None
 
-        # The year is not specified. I have to add it, and I set it to the
-        # current year. This is actually not correct, if we are close
-        # new year... we should ask the scheduler also the year.
-        actual_string = f'{datetime.datetime.now().year} {string}'
-        actual_fmt = f'%Y {fmt}'
-
         try:
             try:
-                thetime = datetime.datetime.strptime(actual_string, actual_fmt)
+                thetime = datetime.datetime.strptime(string, fmt)
             except ValueError:
-                thetime = datetime.datetime.strptime(actual_string, f'{actual_fmt} L')
+                thetime = datetime.datetime.strptime(string, f'{fmt} L')
         except Exception as exc:
             self.logger.debug(f'Unable to parse time string {string}, the message was {exc}')
             raise ValueError(f'Problem parsing the time string: `{string}`') from exc

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -265,7 +265,10 @@ class LsfScheduler(aiida.schedulers.Scheduler):
         from aiida.common.exceptions import FeatureNotAvailable
 
         # Force to display year
-        command = ["LSB_DISPLAY_YEAR='Y'", 'bjobs', '-noheader', f"-o '{' '.join(self._joblist_fields)} delimiter=\"{_FIELD_SEPARATOR}\"'"]
+        command = [
+            "LSB_DISPLAY_YEAR='Y'", 'bjobs', '-noheader',
+            f"-o '{' '.join(self._joblist_fields)} delimiter=\"{_FIELD_SEPARATOR}\"'"
+        ]
 
         if user and jobs:
             raise FeatureNotAvailable('Cannot query by user and job(s) in LSF')


### PR DESCRIPTION
This fixes an error that occurs when aiida.gaussian passes the output from '_parse_log_cclib' 
It contains a datetime.timedelta instance which is not json-serializable

Set `LSB_DISPLAY_YEAR=Y` before `bjobs` to display years. 
No workaround (`actual_fmt` and `actual_string`) required. 
