### PR TITLE
Docker: Default to number of physical cores for localhost code.

### DIFF
--- a/.docker/opt/configure-aiida.sh
+++ b/.docker/opt/configure-aiida.sh
@@ -33,7 +33,23 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
 
     # Setup and configure local computer.
     computer_name=localhost
-    cpu_count=`python -c 'import psutil; print(psutil.cpu_count(logical=False))'`
+
+    # Determine the number of physical cores as a default for the number of
+    # available MPI ranks on the localhost. We do not count "logical" cores,
+    # since MPI parallelization over hyper-threaded cores is typically
+    # associated with a significant performance penalty. We use the
+    # `psutil.cpu_count(logical=False)` function as opposed to simply
+    # `os.cpu_count()` since the latter would include hyperthreaded (logical
+    # cores).
+    NUM_PHYSICAL_CORES=$(python -c 'import psutil; print(int(psutil.cpu_count(logical=False)))' 2>/dev/null)
+    LOCALHOST_MPI_PROCS_PER_MACHINE=${MPI_PROCS_PER_MACHINE:-${NUM_PHYSICAL_CORES}}
+
+    if [ -z $LOCALHOST_MPI_PROCS_PER_MACHINE ]; then
+      echo "Unable to automatically determine the number of logical CPUs on this "
+      echo "machine. Please set the LOCALHOST_MPI_PROCS_PER_MACHINE variable to "
+      echo "explicitly set the number of available MPI ranks."
+      exit 1
+    fi
 
     verdi computer show ${computer_name} || verdi computer setup   \
         --non-interactive                                          \
@@ -44,7 +60,7 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
         --scheduler core.direct                                    \
         --work-dir /home/aiida/aiida_run/                          \
         --mpirun-command "mpirun -np {tot_num_mpiprocs}"           \
-        --mpiprocs-per-machine ${MPI_PROCS_PER_MACHINE:-${cpu_count}} && \
+        --mpiprocs-per-machine ${LOCALHOST_MPI_PROCS_PER_MACHINE} && \
     verdi computer configure core.local "${computer_name}"              \
         --non-interactive                                          \
         --safe-interval 0.0

--- a/.docker/opt/configure-aiida.sh
+++ b/.docker/opt/configure-aiida.sh
@@ -42,7 +42,7 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
     # `os.cpu_count()` since the latter would include hyperthreaded (logical
     # cores).
     NUM_PHYSICAL_CORES=$(python -c 'import psutil; print(int(psutil.cpu_count(logical=False)))' 2>/dev/null)
-    LOCALHOST_MPI_PROCS_PER_MACHINE=${MPI_PROCS_PER_MACHINE:-${NUM_PHYSICAL_CORES}}
+    LOCALHOST_MPI_PROCS_PER_MACHINE=${LOCALHOST_MPI_PROCS_PER_MACHINE:-${NUM_PHYSICAL_CORES}}
 
     if [ -z $LOCALHOST_MPI_PROCS_PER_MACHINE ]; then
       echo "Unable to automatically determine the number of logical CPUs on this "

--- a/.docker/opt/configure-aiida.sh
+++ b/.docker/opt/configure-aiida.sh
@@ -33,6 +33,8 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
 
     # Setup and configure local computer.
     computer_name=localhost
+    cpu_count=`python -c 'import psutil; print(psutil.cpu_count(logical=False))'`
+
     verdi computer show ${computer_name} || verdi computer setup   \
         --non-interactive                                          \
         --label "${computer_name}"                                 \
@@ -42,7 +44,7 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
         --scheduler core.direct                                    \
         --work-dir /home/aiida/aiida_run/                          \
         --mpirun-command "mpirun -np {tot_num_mpiprocs}"           \
-        --mpiprocs-per-machine 1 &&                                \
+        --mpiprocs-per-machine ${MPI_PROCS_PER_MACHINE:-${cpu_count}} && \
     verdi computer configure core.local "${computer_name}"              \
         --non-interactive                                          \
         --safe-interval 0.0


### PR DESCRIPTION
Adjust how the "localhost" code is configured on the aiida-core Docker
image. The default value is based on the actual number of physical cores
and is further configurable via an environment variable.

Closes #5117.