### PR TITLE
Add capability to download orm.ArrayData from REST-API

### DIFF
--- a/aiida/orm/nodes/data/array/array.py
+++ b/aiida/orm/nodes/data/array/array.py
@@ -222,4 +222,4 @@ class ArrayData(Data):
         if comments:
             json_dict['comments'] = get_file_header(comment_char='')
 
-        return json.dumps(json_dict).encode('utf-8'), {}
+        return json.dumps(json_dict, ignore_nan=True).encode('utf-8'), {}

--- a/aiida/orm/nodes/data/array/array.py
+++ b/aiida/orm/nodes/data/array/array.py
@@ -193,3 +193,28 @@ class ArrayData(Data):
                 f'Mismatch of files and properties for ArrayData node (pk= {self.pk}): {files} vs. {properties}'
             )
         super()._validate()
+
+    def _get_array_entries(self):
+
+        array_dict = {}
+        for key, val in self.get_iterarrays():
+            array_dict[key] = val.tolist()
+        return array_dict
+
+    def _prepare_json(self, main_file_name='', comments=True):  # pylint: disable=unused-argument
+        """
+        Prepare a json file in a format compatible with the AiiDA band visualizer
+
+        :param comments: if True, print comments (if it makes sense for the given
+            format)
+        """
+        from aiida import get_file_header
+        from aiida.common import json
+
+        json_dict = self._get_array_entries()
+        json_dict['original_uuid'] = self.uuid
+
+        if comments:
+            json_dict['comments'] = get_file_header(comment_char='')
+
+        return json.dumps(json_dict).encode('utf-8'), {}

--- a/aiida/orm/nodes/data/array/array.py
+++ b/aiida/orm/nodes/data/array/array.py
@@ -195,7 +195,12 @@ class ArrayData(Data):
         super()._validate()
 
     def _get_array_entries(self):
+        """Return a dictionary with the different array entries.
 
+        The idea is that this dictionary contains the array name as a key and
+        the value is the numpy array transformed into a list. This is so that
+        it can be transformed into a json object.
+        """
         array_dict = {}
         for key, val in self.get_iterarrays():
             array_dict[key] = val.tolist()
@@ -203,7 +208,7 @@ class ArrayData(Data):
 
     def _prepare_json(self, main_file_name='', comments=True):  # pylint: disable=unused-argument
         """
-        Prepare a json file in a format compatible with the AiiDA band visualizer
+        Prepare a json file to extract the arrays stored in this node
 
         :param comments: if True, print comments (if it makes sense for the given
             format)

--- a/tests/orm/data/test_data.py
+++ b/tests/orm/data/test_data.py
@@ -12,7 +12,6 @@
 import os
 
 import numpy
-from aiida.orm.nodes.data import orbital
 import pytest
 
 from aiida import orm, plugins
@@ -22,6 +21,7 @@ from tests.static import STATIC_DIR
 @pytest.fixture
 @pytest.mark.usefixtures('clear_database_before_test')
 def generate_class_instance():
+    # pylint: disable=too-many-return-statements, too-many-statements
     """Generate a dummy `Data` instance for the given sub class."""
 
     def _generate_class_instance(data_class):
@@ -77,8 +77,8 @@ def generate_class_instance():
 
         if data_class is orm.XyData:
             instance = data_class()
-            instance.set_x(numpy.arange(5),'xdata','m')
-            instance.set_y(numpy.arange(5),'ydata','m')
+            instance.set_x(numpy.arange(5), 'xdata', 'm')
+            instance.set_y(numpy.arange(5), 'ydata', 'm')
             return instance
 
         if data_class is orm.ProjectionData:
@@ -108,10 +108,8 @@ def generate_class_instance():
             instance = data_class()
             instance.set_reference_bandsdata(bands)
             instance.set_projectiondata(
-                orbital,
-                list_of_pdos=numpy.asarray([1.0]),
-                list_of_energy=numpy.asarray([1.0]),
-                bands_check=False)
+                orbital, list_of_pdos=numpy.asarray([1.0]), list_of_energy=numpy.asarray([1.0]), bands_check=False
+            )
             return instance
 
         raise RuntimeError(

--- a/tests/orm/data/test_data.py
+++ b/tests/orm/data/test_data.py
@@ -12,6 +12,7 @@
 import os
 
 import numpy
+from aiida.orm.nodes.data import orbital
 import pytest
 
 from aiida import orm, plugins
@@ -59,6 +60,58 @@ def generate_class_instance():
             filepath_base = os.path.abspath(os.path.join(STATIC_DIR, 'pseudos'))
             filepath_carbon = os.path.join(filepath_base, 'C_pbe_v1.2.uspp.F.UPF')
             instance = data_class(file=filepath_carbon)
+            return instance
+
+        if data_class is orm.ArrayData:
+            instance = data_class()
+            array_data = numpy.identity(3)
+            instance.set_array('data', array_data)
+            return instance
+
+        if data_class is orm.KpointsData:
+            instance = data_class()
+            cell = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+            instance.set_cell(cell)
+            instance.set_kpoints_mesh_from_density(0.5)
+            return instance
+
+        if data_class is orm.XyData:
+            instance = data_class()
+            instance.set_x(numpy.arange(5),'xdata','m')
+            instance.set_y(numpy.arange(5),'ydata','m')
+            return instance
+
+        if data_class is orm.ProjectionData:
+
+            my_real_hydrogen_dict = {
+                'angular_momentum': -3,
+                'diffusivity': None,
+                'kind_name': 'As',
+                'magnetic_number': 0,
+                'position': [-1.420047044832945, 1.420047044832945, 1.420047044832945],
+                'radial_nodes': 0,
+                'spin': 0,
+                'spin_orientation': None,
+                'x_orientation': None,
+                'z_orientation': None
+            }
+            kpoints = orm.KpointsData()
+            kpoints.set_cell([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+            kpoints.set_kpoints([[0., 0., 0.]])
+            bands = orm.BandsData()
+            bands.set_kpointsdata(kpoints)
+            bands.set_bands([[1.0]])
+
+            RealHydrogen = plugins.OrbitalFactory('core.realhydrogen')  # pylint: disable=invalid-name
+            orbital = RealHydrogen(**my_real_hydrogen_dict)
+
+            instance = data_class()
+            instance.set_reference_bandsdata(bands)
+            instance.set_projectiondata(
+                orbital,
+                list_of_pdos=numpy.asarray([1.0]),
+                list_of_energy=numpy.asarray([1.0]),
+                bands_check=False)
             return instance
 
         raise RuntimeError(


### PR DESCRIPTION
Right now it is not possible to access the arrays stored in the db via the REST-API.

To try to solve this a simple option to download the data in a JSON format has been added.
The function creates a dictionary where the keys are the `arraynames` and the values are lists obtained from the numpy arrays via the `.tolist()` method.

This dictionary is then converted into JSON format so that the user can obtain the contents of the arrays via a REST request in the form
`http://127.0.0.1:5000/api/v4//nodes/UUID_OF_ARRAY/download?download_format=json`.

closes #2809