### PR TITLE
conftest: add input arg for run_cli_command, fix typings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 """Configuration file for pytest tests."""
 import os
 import pathlib
+from typing import IO, List, Optional, Union
 
 import click
 import pytest
@@ -428,7 +429,12 @@ def run_cli_command(reset_log_level):  # pylint: disable=unused-argument
     """
     from click.testing import Result
 
-    def _run_cli_command(command: click.Command, options: list = None, raises: bool = False) -> Result:
+    def _run_cli_command(
+        command: click.Command,
+        options: Optional[List] = None,
+        input: Optional[Union[str, bytes, IO]] = None,  # pylint: disable=redefined-builtin
+        raises: bool = False
+    ) -> Result:
         """Run the command and check the result.
 
         .. note:: the `output_lines` attribute is added to return value containing list of stripped output lines.
@@ -457,7 +463,7 @@ def run_cli_command(reset_log_level):  # pylint: disable=unused-argument
         command = VerdiCommandGroup.add_verbosity_option(command)
 
         runner = click.testing.CliRunner()
-        result = runner.invoke(command, options, obj=obj)
+        result = runner.invoke(command, args=options, obj=obj, input=input)
 
         if raises:
             assert result.exception is not None, result.output


### PR DESCRIPTION
Additional arg "input" may be needed when testing interactive commands. For the typings: PEP484 mandates explicit Optional for optional args.
