### PR TITLE
`Code`: add `validate_remote_exec_path` method to check executable

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -18,6 +18,7 @@ from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.commands import code as options_code
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.common import exceptions
 
 
 @verdi.group('code')
@@ -102,6 +103,26 @@ def setup_code(ctx, non_interactive, **kwargs):
 
     code.reveal()
     echo.echo_success(f'Code<{code.pk}> {code.full_label} created')
+
+
+@verdi_code.command('test')
+@arguments.CODE(callback=set_code_builder)
+@with_dbenv()
+def code_test(code):
+    """Run tests for the given code to check whether it is usable.
+
+    For remote codes the following checks are performed:
+
+     * Whether the remote executable exists.
+
+    """
+    if not code.is_local():
+        try:
+            code.validate_remote_exec_path()
+        except exceptions.ValidationError as exception:
+            echo.echo_critical(f'validation failed: {exception}')
+
+    echo.echo_success('all tests succeeded.')
 
 
 # Defining the ``COMPUTER`` option first guarantees that the user is prompted for the computer first. This is necessary

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -265,6 +265,13 @@ Use this, for instance, to load modules or set variables that are needed by the 
 
 At the end, you receive a confirmation, with the *PK* and the *UUID* of your new code.
 
+.. tip::
+
+    The ``verdi code setup`` command performs minimal checks in order to keep it performant and not rely on an internet connection.
+    If you want additional checks to verify the code is properly configured and usable, run the `verdi code test` command.
+    For remote codes for example, this will check whether the associated computer can be connected to and whether the specified executable exists.
+    Look at the command help to see what other checks may be run.
+
 .. admonition:: Using configuration files
     :class: tip title-icon-lightbulb
 

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -78,6 +78,7 @@ Below is a list with all available subcommands.
       reveal     Reveal one or more hidden codes in `verdi code list`.
       setup      Setup a new code.
       show       Display detailed information for a code.
+      test       Run tests for the given code to check whether it is usable.
 
 
 .. _reference:command-line:verdi-computer:

--- a/tests/orm/data/test_code.py
+++ b/tests/orm/data/test_code.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=redefined-outer-name
+"""Tests for :class:`aiida.orm.nodes.data.code.Code` class."""
+import pytest
+
+from aiida.common.exceptions import ValidationError
+from aiida.orm import Code, Computer
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_validate_remote_exec_path():
+    """Test ``Code.validate_remote_exec_path``."""
+    computer = Computer(
+        label='test-code-computer', transport_type='core.local', hostname='localhost', scheduler_type='core.slurm'
+    ).store()
+    code = Code(remote_computer_exec=[computer, '/bin/invalid'])
+
+    with pytest.raises(ValidationError, match=r'Could not connect to the configured computer.*'):
+        code.validate_remote_exec_path()
+
+    computer.configure()
+
+    with pytest.raises(ValidationError, match=r'the provided remote absolute path `.*` does not exist.*'):
+        code.validate_remote_exec_path()
+
+    code = Code(remote_computer_exec=[computer, '/bin/bash'])
+    code.validate_remote_exec_path()


### PR DESCRIPTION
Fixes #5179 
Fixes #868 

A common problem is that the filepath of the executable for remote codes
is mistyped by accident. The user often doesn't realize until they
launch a calculation and it mysteriously fails with a non-descript
error. They have to look into the output files to find that the
executable could not be found.

At that point, it is not trivial to correct the mistake because the
`Code` cannot be edited nor can it be deleted, without first deleting
the calculation that was just run first. Therefore, it would be nice to
warn the user at the time of the code creation or storing.

However, the check requires opening a connection to the associated
computer which carries both significant overhead, and it may not always
be available at time of the code creation. Setup scripts for automated
environments may want to configure the computers and codes at a time
when they cannot be necessarily reached. Therefore, preventing codes
from being created in this case is not acceptable.

The compromise is to implement the check in `validate_remote_exec_path`
which can then freely be called by a user to check if the executable of
the remote code is usable. The method is added to the CLI through the
addition of the command `verdi code test`. Also here, we decide to not
add the check by default to `verdi code setup` as that should be able to
function without internet connection and with minimal overhead. The docs
are updated to encourage the user to run `verdi code test` before using
it in any calculations if they want to make sure it is functioning. In
the future, additional checks can be added to this command.

~~A common problem is that the filepath of the executable for remote codes
is mistyped by accident. The user often doesn't realize until they
launch a calculation and it mysteriously fails with a non-descript
error. They have to look into the output files to find that the
executable could not be found.~~

~~At that point, it is not trivial to correct the mistake because the
`Code` cannot be edited nor can it be deleted, without first deleting
the calculation that was just run first.~~

~~It would be nice to warn the user at the time of the code creation.
Therefore a check is added to `Code._validate`, which is called
automatically when the code is stored, which checks whether the
specified executable exists on the remote computer. However, we need to
account for the fact that for a code on a remote computer, the computer
may not actually be reachable at the time of the code setup. When this
is the case and opening the transport fails, instead of failing the
command, a warning is logged instead, stating that the presence of the
code could not be verified. This is preferred to making the command fail
entirely as this would make it impossible to setup codes for computers
that are not currently reachable, which is undesirable.~~

This is a first quick implementation and would need tests before merging but there are first some open questions to be answered:
* ~~Should this be done in `verdi code setup` or in `Code` constructor?
  I would definitely say in `verdi code setup` because it goes beyond the scope of the constructor. Downside is that it puts the burden of adding the check in other interfaces, but this is to be expected and the correct way IMO.~~ This is now added in the `Code.validate_remote_exec_path` method which is automatically called by `store()`.
* ~~Should the implementation catch just `Exception` instead of `TransportOpenException` to account for custom transport plugins that don't raise the "right" exception? It's not nice to catch a bare `Exception` but maybe in this case it is necessary.~~ Reverted this change and just catch broad-except
* ~~Should we check the permissions of the file to make sure it is executable? This is something we could potentially check, but maybe not all transport types properly implement it. Maybe this is going to far, because there are plenty of other things to still check that would prevent the binary from running.~~ Won't implement this for now

Another note: this fix still doesn't address a calculation failing if it is run with a binary that doesn't exist and having a uniform exit code. We could try this, but it would depend on parsing the `_scheduler_stderr.txt` for the error message of the missing binary and I am not sure how deterministic we can make this. At the very least this should depend on the used shell, which I believe we require to be bash, so at least that would be something. But does this also depend on anything else of the environment, for example with what MPI library it is called, e.g. `mpirun` vs `srun` etc.?