### PR TITLE
👌 IMPROVE: Get session from backend in `SqlaModelEntity`

### DIFF
--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -8,8 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Module for the SqlAlchemy backend implementation of the `AuthInfo` ORM class."""
-
-from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
 from aiida.common import exceptions
 from aiida.common.lang import type_check
@@ -123,7 +121,7 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
         # pylint: disable=import-error,no-name-in-module
         from sqlalchemy.orm.exc import NoResultFound
 
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             session.query(DbAuthInfo).filter_by(id=pk).one().delete()
@@ -143,7 +141,7 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
         # pylint: disable=import-error,no-name-in-module
         from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             authinfo = session.query(DbAuthInfo).filter_by(dbcomputer_id=computer.id, aiidauser_id=user.id).one()

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -14,7 +14,6 @@ from datetime import datetime
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import comment as models
 from aiida.common import exceptions, lang
 
@@ -125,7 +124,7 @@ class SqlaCommentCollection(BackendCommentCollection):
         if not isinstance(comment_id, int):
             raise TypeError('comment_id must be an int')
 
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             session.query(models.DbComment).filter_by(id=comment_id).one().delete()
@@ -140,7 +139,7 @@ class SqlaCommentCollection(BackendCommentCollection):
 
         :raises `~aiida.common.exceptions.IntegrityError`: if all Comments could not be deleted
         """
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             session.query(models.DbComment).delete()

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -15,7 +15,6 @@ from copy import copy
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import make_transient
 
-from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models.computer import DbComputer
 from aiida.common import exceptions
 from aiida.orm.implementation.computers import BackendComputer, BackendComputerCollection
@@ -52,7 +51,7 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
 
     def copy(self):
         """Create an unstored clone of an already stored `Computer`."""
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         if not self.is_stored:
             raise exceptions.InvalidOperation('You can copy a computer only after having stored it')
@@ -128,14 +127,13 @@ class SqlaComputerCollection(BackendComputerCollection):
 
     ENTITY_CLASS = SqlaComputer
 
-    @staticmethod
-    def list_names():
-        session = get_scoped_session()
+    def list_names(self):
+        session = self.backend.get_session()
         return session.query(DbComputer.label).all()
 
     def delete(self, pk):
         try:
-            session = get_scoped_session()
+            session = self.backend.get_session()
             session.get(DbComputer, pk).delete()
             session.commit()
         except SQLAlchemyError as exc:

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -12,7 +12,6 @@
 from collections.abc import Iterable
 import logging
 
-from aiida.backends import sqlalchemy as sa
 from aiida.backends.sqlalchemy.models.group import DbGroup, table_groups_nodes
 from aiida.backends.sqlalchemy.models.node import DbNode
 from aiida.common.exceptions import UniquenessError
@@ -124,14 +123,12 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
 
         :return: integer number of entities contained within the group
         """
-        from aiida.backends.sqlalchemy import get_scoped_session
-        session = get_scoped_session()
+        session = self.backend.get_session()
         return session.query(self.MODEL_CLASS).join(self.MODEL_CLASS.dbnodes).filter(DbGroup.id == self.pk).count()
 
     def clear(self):
         """Remove all the nodes from this group."""
-        from aiida.backends.sqlalchemy import get_scoped_session
-        session = get_scoped_session()
+        session = self.backend.get_session()
         # Note we have to call `dbmodel` and `_dbmodel` to circumvent the `ModelWrapper`
         self.dbmodel.dbnodes = []
         session.commit()
@@ -184,7 +181,6 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
         from sqlalchemy.dialects.postgresql import insert  # pylint: disable=import-error, no-name-in-module
         from sqlalchemy.exc import IntegrityError  # pylint: disable=import-error, no-name-in-module
 
-        from aiida.backends.sqlalchemy import get_scoped_session
         from aiida.backends.sqlalchemy.models.base import Base
         from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode
 
@@ -199,7 +195,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
             if not given_node.is_stored:
                 raise ValueError('At least one of the provided nodes is unstored, stopping...')
 
-        with utils.disable_expire_on_commit(get_scoped_session()) as session:
+        with utils.disable_expire_on_commit(self.backend.get_session()) as session:
             if not skip_orm:
                 # Get dbnodes here ONCE, otherwise each call to dbnodes will re-read the current value in the database
                 dbnodes = self._dbmodel.dbnodes
@@ -241,7 +237,6 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
         """
         from sqlalchemy import and_
 
-        from aiida.backends.sqlalchemy import get_scoped_session
         from aiida.backends.sqlalchemy.models.base import Base
         from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode
 
@@ -260,7 +255,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
 
         list_nodes = []
 
-        with utils.disable_expire_on_commit(get_scoped_session()) as session:
+        with utils.disable_expire_on_commit(self.backend.get_session()) as session:
             if not skip_orm:
                 for node in nodes:
                     check_node(node)
@@ -303,7 +298,7 @@ class SqlaGroupCollection(BackendGroupCollection):
         # pylint: disable=too-many-branches
         from aiida.orm.implementation.sqlalchemy.nodes import SqlaNode
 
-        session = sa.get_scoped_session()
+        session = self.backend.get_session()
 
         filters = []
 
@@ -366,7 +361,7 @@ class SqlaGroupCollection(BackendGroupCollection):
         return [SqlaGroup.from_dbmodel(group, self._backend) for group in groups]  # pylint: disable=no-member
 
     def delete(self, id):  # pylint: disable=redefined-builtin
-        session = sa.get_scoped_session()
+        session = self.backend.get_session()
 
         session.get(DbGroup, id).delete()
         session.commit()

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -12,7 +12,6 @@
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import log as models
 from aiida.common import exceptions
 
@@ -107,7 +106,7 @@ class SqlaLogCollection(BackendLogCollection):
         if not isinstance(log_id, int):
             raise TypeError('log_id must be an int')
 
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             session.query(models.DbLog).filter_by(id=log_id).one().delete()
@@ -122,7 +121,7 @@ class SqlaLogCollection(BackendLogCollection):
 
         :raises `~aiida.common.exceptions.IntegrityError`: if all Logs could not be deleted
         """
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             session.query(models.DbLog).delete()

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.exc import NoResultFound
 
-from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import node as models
 from aiida.common import exceptions
 from aiida.common.lang import type_check
@@ -158,7 +157,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         :return: True if the proposed link is allowed, False otherwise
         :raise aiida.common.ModificationNotAllowed: if either source or target node is not stored
         """
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         type_check(source, SqlaNode)
 
@@ -180,7 +179,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         """
         from aiida.backends.sqlalchemy.models.node import DbLink
 
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             with session.begin_nested():
@@ -200,7 +199,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         :param with_transaction: if False, do not use a transaction because the caller will already have opened one.
         :param clean: boolean, if True, will clean the attributes and extras before attempting to store
         """
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         if clean:
             self.clean_values()
@@ -231,7 +230,7 @@ class SqlaNodeCollection(BackendNodeCollection):
 
         :param pk: id of the node
         """
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             return self.ENTITY_CLASS.from_dbmodel(session.query(models.DbNode).filter_by(id=pk).one(), self.backend)
@@ -243,7 +242,7 @@ class SqlaNodeCollection(BackendNodeCollection):
 
         :param pk: id of the node to delete
         """
-        session = get_scoped_session()
+        session = self.backend.get_session()
 
         try:
             session.query(models.DbNode).filter_by(id=pk).one().delete()


### PR DESCRIPTION
Replace `get_scoped_session()` with `self.backend.get_session()`.
Note currently `SqlaBackend.get_session` simply calls
`get_scoped_session()`, so this does not change any logic.
But eventually `SqlaBackend` instances will manage their own session,
and `get_scoped_session()` will be removed.