### PR TITLE
👌 IMPROVE: Allow `Graph` to be used by any backend

### DIFF
--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -428,8 +428,7 @@ class Graph:
         """return a copy of the edges"""
         return self._edges.copy()
 
-    @staticmethod
-    def _load_node(node):
+    def _load_node(self, node):
         """ load a node (if not already loaded)
 
         :param node: node or node pk/uuid


### PR DESCRIPTION
This is a follow-up to #5186,
to ensure `Graph` always uses the initialised `Backend`.