### PR TITLE
Fix `verdi calcjob cleanworkdir` command

### DIFF
--- a/aiida/orm/utils/remote.py
+++ b/aiida/orm/utils/remote.py
@@ -10,6 +10,8 @@
 """Utilities for operations on files on remote computers."""
 import os
 
+from aiida.orm.nodes.data.remote.base import RemoteData
+
 
 def clean_remote(transport, path):
     """
@@ -37,7 +39,16 @@ def clean_remote(transport, path):
         pass
 
 
-def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computers=None, user=None, backend=None):
+def get_calcjob_remote_paths(  # pylint: disable=too-many-locals
+    pks=None,
+    past_days=None,
+    older_than=None,
+    computers=None,
+    user=None,
+    backend=None,
+    exit_status=None,
+    only_not_cleaned=False,
+):
     """
     Return a mapping of computer uuids to a list of remote paths, for a given set of calcjobs. The set of
     calcjobs will be determined by a query with filters based on the pks, past_days, older_than,
@@ -48,7 +59,9 @@ def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computer
     :param older_than: only include calcjobs older than
     :param computers: only include calcjobs that were ran on these computers
     :param user: only include calcjobs of this user
-    :return: mapping of computer uuid and list of remote paths, or None
+    :param exit_status: only select calcjob with this exit_status
+    :param only_not_cleaned: only include calcjobs whose workdir have not been cleaned
+    :return: mapping of computer uuid and list of remote folder
     """
     from datetime import timedelta
 
@@ -58,6 +71,7 @@ def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computer
 
     filters_calc = {}
     filters_computer = {}
+    filters_remote = {}
 
     if user is None:
         user = orm.User.objects.get_default()
@@ -69,14 +83,37 @@ def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computer
         filters_calc['mtime'] = {'>': timezone.now() - timedelta(days=past_days)}
 
     if older_than is not None:
-        filters_calc['mtime'] = {'<': timezone.now() - timedelta(days=older_than)}
+        older_filter = {'<': timezone.now() - timedelta(days=older_than)}
+        # Check if we need to apply the AND condition
+        if 'mtime' not in filters_calc:
+            filters_calc['mtime'] = older_filter
+        else:
+            past_filter = filters_calc['mtime']
+            filters_calc['mtime'] = {'and': [past_filter, older_filter]}
+
+    if exit_status is not None:
+        filters_calc['attributes.exit_status'] = exit_status
 
     if pks:
         filters_calc['id'] = {'in': pks}
 
+    if only_not_cleaned is True:
+        filters_remote['or'] = [{
+            f'extras.{RemoteData.KEY_EXTRA_CLEANED}': {
+                '!==': True
+            }
+        }, {
+            'extras': {
+                '!has_key': RemoteData.KEY_EXTRA_CLEANED
+            }
+        }]
+
     query = orm.QueryBuilder(backend=backend)
-    query.append(CalcJobNode, tag='calc', project=['attributes.remote_workdir'], filters=filters_calc)
-    query.append(orm.Computer, with_node='calc', tag='computer', project=['*'], filters=filters_computer)
+    query.append(CalcJobNode, tag='calc', filters=filters_calc)
+    query.append(
+        RemoteData, tag='remote', project=['*'], edge_filters={'label': 'remote_folder'}, filters=filters_remote
+    )
+    query.append(orm.Computer, with_node='calc', tag='computer', project=['uuid'], filters=filters_computer)
     query.append(orm.User, with_node='calc', filters={'email': user.email})
 
     if query.count() == 0:
@@ -84,8 +121,7 @@ def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computer
 
     path_mapping = {}
 
-    for path, computer in query.all():
-        if path is not None:
-            path_mapping.setdefault(computer.uuid, []).append(path)
+    for remote_data, computer_uuid in query.all():
+        path_mapping.setdefault(computer_uuid, []).append(remote_data)
 
     return path_mapping

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -98,6 +98,9 @@ class Transport(abc.ABC):
         self._is_open = False
         self._enters = 0
 
+        # for accessing the identity of the underlying machine
+        self.hostname = kwargs.get('machine')
+
     def __enter__(self):
         """
         For transports that require opening a connection, opens

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -7,52 +7,28 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Module to test remote data."""
-import errno
-import os
-import shutil
-import tempfile
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`aiida.orm.nodes.data.remote.base.RemoteData` module."""
+import pytest
 
-from aiida.backends.testbase import AiidaTestCase
-from aiida.orm import AuthInfo, RemoteData, User
+from aiida.orm import RemoteData
 
 
-class TestRemoteData(AiidaTestCase):
-    """Test for the RemoteData class."""
+@pytest.fixture
+def remote_data(tmp_path, aiida_localhost):
+    """Return a non-empty ``RemoteData`` instance."""
+    node = RemoteData(computer=aiida_localhost)
+    node.set_remote_path(str(tmp_path))
+    node.store()
+    (tmp_path / 'file.txt').write_bytes(b'some content')
+    return node
 
-    @classmethod
-    def setUpClass(cls):  # pylint: disable=arguments-differ
-        super().setUpClass()
-        user = User.objects.get_default()
-        authinfo = AuthInfo(cls.computer, user)
-        authinfo.store()
 
-    def setUp(self):
-        """Create a dummy RemoteData on the default computer."""
-        self.tmp_path = tempfile.mkdtemp()
-        self.remote = RemoteData(computer=self.computer)
-        self.remote.set_remote_path(self.tmp_path)
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_clean(remote_data):
+    """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
+    assert not remote_data.is_empty
 
-        with open(os.path.join(self.tmp_path, 'file.txt'), 'w', encoding='utf8') as fhandle:
-            fhandle.write('test string')
-
-        self.remote.computer = self.computer
-        self.remote.store()
-
-    def tearDown(self):
-        """Delete the temporary path for the dummy RemoteData node."""
-        try:
-            shutil.rmtree(self.tmp_path)
-        except OSError as exception:
-            if exception.errno == errno.ENOENT:
-                pass
-            elif exception.errno == errno.ENOTDIR:
-                os.remove(self.tmp_path)
-            else:
-                raise IOError(exception)
-
-    def test_clean(self):
-        """Try cleaning a RemoteData node."""
-        self.assertFalse(self.remote.is_empty)
-        self.remote._clean()  # pylint: disable=protected-access
-        self.assertTrue(self.remote.is_empty)
+    remote_data._clean()  #  pylint: disable=protected-access
+    assert remote_data.is_empty
+    assert remote_data.get_attribute(RemoteData.KEY_EXTRA_CLEANED, True)


### PR DESCRIPTION
Previously the AND condition is not apply when -o and -p are both supplied, only the former is applied....
Also adds the ability to filter by `exit_status` of the calcjob. 