### PR TITLE
`verdi code setup`: validate the uniqueness of label for local codes

### DIFF
--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -24,18 +24,34 @@ def is_not_on_computer(ctx):
 
 
 def validate_label_uniqueness(ctx, _, value):
-    """Validate the uniqueness of the full label of the code, i.e., `label@computer.label`.
+    """Validate the uniqueness of the label of the code.
 
-    .. note:: For this to work, the computer parameter already needs to have been parsed. In interactive mode, this
-        means that the computer parameter needs to be defined after the label parameter in the command definition. For
-        non-interactive mode, the parsing order will always be determined by the order the parameters are specified by
-        the caller and so this validator may get called before the computer is parsed. For that reason, this validator
-        should also be called in the command itself, to ensure it has both the label and computer parameter available.
+    The exact uniqueness criterion depends on the type of the code, whether it is "local" or "remote". For the former,
+    the `label` itself should be unique, whereas for the latter it is the full label, i.e., `label@computer.label`.
+
+    .. note:: For this to work in the case of the remote code, the computer parameter already needs to have been parsed
+        In interactive mode, this means that the computer parameter needs to be defined after the label parameter in the
+        command definition. For non-interactive mode, the parsing order will always be determined by the order the
+        parameters are specified by the caller and so this validator may get called before the computer is parsed. For
+        that reason, this validator should also be called in the command itself, to ensure it has both the label and
+        computer parameter available.
+
     """
     from aiida.common import exceptions
     from aiida.orm import load_code
 
     computer = ctx.params.get('computer', None)
+    on_computer = ctx.params.get('on_computer', None)
+
+    if on_computer is False:
+        try:
+            load_code(value)
+        except exceptions.NotExistent:
+            pass
+        except exceptions.MultipleObjectsError:
+            raise click.BadParameter(f'multiple copies of the remote code `{value}` already exist.')
+        else:
+            raise click.BadParameter(f'the code `{value}` already exists.')
 
     if computer is not None:
         full_label = f'{value}@{computer.label}'
@@ -44,6 +60,8 @@ def validate_label_uniqueness(ctx, _, value):
             load_code(full_label)
         except exceptions.NotExistent:
             pass
+        except exceptions.MultipleObjectsError:
+            raise click.BadParameter(f'multiple copies of the local code `{full_label}` already exist.')
         else:
             raise click.BadParameter(f'the code `{full_label}` already exists.')
 


### PR DESCRIPTION
In commit d25339dd7e8f8bed40145392dd5166817f3afef5 `verdi code setup`
was improved to have a callback for the `label` option to check for its
uniqueness. However, it only implemented this for "remote" computers,
which have an associated `Computer` and so the uniqueness criterion is
on the "full label", which is the `label@computer.label`.

However, there are also "local" codes, which don't have an associated
computer and so only have the label as the identifier that should be
unique. The callback `validate_label_uniqueness` is now updated to
distinguish between these two cases.