### PR TITLE
`ProcessNode.is_valid_cache`: catch `AttributeError` for unloadable identifier

### DIFF
--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -110,15 +110,13 @@ class ProcessNode(Sealable, Node):
         from aiida.plugins.entry_point import load_entry_point_from_string
 
         if not self.process_type:
-            raise ValueError(f'no process type for CalcJobNode<{self.pk}>: cannot recreate process class')
+            raise ValueError(f'no process type for Node<{self.pk}>: cannot recreate process class')
 
         try:
             process_class = load_entry_point_from_string(self.process_type)
         except exceptions.EntryPointError as exception:
             raise ValueError(
-                'could not load process class for entry point {} for CalcJobNode<{}>: {}'.format(
-                    self.pk, self.process_type, exception
-                )
+                f'could not load process class for entry point `{self.process_type}` for Node<{self.pk}>: {exception}'
             )
         except ValueError:
             try:
@@ -126,9 +124,9 @@ class ProcessNode(Sealable, Node):
                 module_name, class_name = self.process_type.rsplit('.', 1)
                 module = importlib.import_module(module_name)
                 process_class = getattr(module, class_name)
-            except (ValueError, ImportError):
+            except (AttributeError, ValueError, ImportError) as exception:
                 raise ValueError(
-                    f'could not load process class CalcJobNode<{self.pk}> given its `process_type`: {self.process_type}'
+                    f'could not load process class from `{self.process_type}` for Node<{self.pk}>: {exception}'
                 )
 
         return process_class


### PR DESCRIPTION
Fixes #5220 

The `is_valid_cache` property is supposed to only raise a `ValueError`
when the function or class represented by the `process_type` identifier
cannot be loaded. However, for a normal Python identifier of an existing
module but with a function or class that does not exist in that module
an `AttributeError` will be thrown which was not caught and converted.