### PR TITLE
Add the `EnumData` data plugin to easily store `Enum` instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,7 @@ repos:
                 aiida/orm/groups.py|
                 aiida/orm/logs.py|
                 aiida/orm/users.py|
+                aiida/orm/nodes/data/enum.py|
                 aiida/orm/nodes/data/jsonable.py|
                 aiida/orm/nodes/node.py|
                 aiida/orm/nodes/process/.*py|

--- a/aiida/orm/__init__.py
+++ b/aiida/orm/__init__.py
@@ -53,6 +53,7 @@ __all__ = (
     'Entity',
     'EntityAttributesMixin',
     'EntityExtrasMixin',
+    'EnumData',
     'Float',
     'FolderData',
     'Group',

--- a/aiida/orm/nodes/__init__.py
+++ b/aiida/orm/nodes/__init__.py
@@ -31,6 +31,7 @@ __all__ = (
     'Code',
     'Data',
     'Dict',
+    'EnumData',
     'Float',
     'FolderData',
     'Int',

--- a/aiida/orm/nodes/data/__init__.py
+++ b/aiida/orm/nodes/data/__init__.py
@@ -21,6 +21,7 @@ from .cif import *
 from .code import *
 from .data import *
 from .dict import *
+from .enum import *
 from .float import *
 from .folder import *
 from .int import *
@@ -42,6 +43,7 @@ __all__ = (
     'Code',
     'Data',
     'Dict',
+    'EnumData',
     'Float',
     'FolderData',
     'Int',

--- a/aiida/orm/nodes/data/enum.py
+++ b/aiida/orm/nodes/data/enum.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Data plugin that allows to easily wrap an :class:`enum.Enum` member.
+
+Nomenclature is taken from Python documentation: https://docs.python.org/3/library/enum.html
+Given the following example implementation:
+
+.. code:: python
+
+    from enum import Enum
+    class Color(Enum):
+        RED = 1
+        GREEN = 2
+
+The class ``Color`` is an enumeration (or enum). The attributes ``Color.RED`` and ``Color.GREEN`` are enumeration
+members (or enum members) and are functionally constants. The enum members have names and values: the name of
+``Color.RED`` is ``RED`` and the value of ``Color.RED`` is ``1``.
+"""
+from enum import Enum
+import typing as t
+
+from plumpy.loaders import get_object_loader
+
+from aiida.common.lang import type_check
+
+from .data import Data
+
+__all__ = ('EnumData',)
+
+EnumType = t.TypeVar('EnumType', bound=Enum)
+
+
+class EnumData(Data):
+    """Data plugin that allows to easily wrap an :class:`enum.Enum` member.
+
+    The enum member is stored in the database by storing the value, name and the identifier (string that represents the
+    class of the enumeration) in the ``KEY_NAME``, ``KEY_VALUE`` and ``KEY_IDENTIFIER`` attribute, respectively. The
+    original enum member can be reconstructured from the (loaded) node through the ``get_member`` method. The enum
+    itself can be retrieved from the ``get_enum`` method. Like a normal enum member, the ``EnumData`` plugin provides
+    the ``name`` and ``value`` properties which return the name and value of the enum member, respectively.
+    """
+
+    KEY_NAME = 'name'
+    KEY_VALUE = 'value'
+    KEY_IDENTIFIER = 'identifier'
+
+    def __init__(self, member: Enum, *args, **kwargs):
+        """Construct the node for the to enum member that is to be wrapped."""
+        type_check(member, Enum)
+        super().__init__(*args, **kwargs)
+
+        data = {
+            self.KEY_NAME: member.name,
+            self.KEY_VALUE: member.value,
+            self.KEY_IDENTIFIER: get_object_loader().identify_object(member.__class__)
+        }
+
+        self.set_attribute_many(data)
+
+    @property
+    def name(self) -> str:
+        """Return the name of the enum member."""
+        return self.get_attribute(self.KEY_NAME)
+
+    @property
+    def value(self) -> t.Any:
+        """Return the value of the enum member."""
+        return self.get_attribute(self.KEY_VALUE)
+
+    def get_enum(self) -> t.Type[EnumType]:
+        """Return the enum class reconstructed from the serialized identifier stored in the database.
+
+        :raises `ImportError`: if the enum class represented by the stored identifier cannot be imported.
+        """
+        identifier = self.get_attribute(self.KEY_IDENTIFIER)
+        try:
+            return get_object_loader().load_object(identifier)
+        except ValueError as exc:
+            raise ImportError(f'Could not reconstruct enum class because `{identifier}` could not be loaded.') from exc
+
+    def get_member(self) -> EnumType:
+        """Return the enum member reconstructed from the serialized data stored in the database.
+
+        For the enum member to be successfully reconstructed, the class of course has to still be importable and its
+        implementation should not have changed since the node was stored. That is to say, the value of the member when
+        it was stored, should still be a valid value for the enum class now.
+
+        :raises `ImportError`: if the enum class represented by the stored identifier cannot be imported.
+        :raises `ValueError`: if the stored enum member value is no longer valid for the imported enum class.
+        """
+        value = self.get_attribute(self.KEY_VALUE)
+        enum: t.Type[EnumType] = self.get_enum()
+
+        try:
+            return enum(value)
+        except ValueError as exc:
+            raise ValueError(
+                f'The stored value `{value}` is no longer a valid value for the enum `{enum}`. The definition must '
+                'have changed since storing the node.'
+            ) from exc
+
+    def __eq__(self, other: t.Any) -> bool:
+        """Return whether the other object is equivalent to ourselves."""
+        if isinstance(other, Enum):
+            try:
+                return self.get_member() == other
+            except (ImportError, ValueError):
+                return False
+        elif isinstance(other, EnumData):
+            return self.attributes == other.attributes
+
+        return False

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -64,6 +64,7 @@ py:class DbImporter
 py:class DiskObjectStoreRepositoryBackend
 py:class EntityType
 py:class EntityTypes
+py:class EnumType
 py:class ExitCode
 py:class File
 py:class FilterType

--- a/setup.json
+++ b/setup.json
@@ -165,6 +165,7 @@
             "core.cif = aiida.orm.nodes.data.cif:CifData",
             "core.code = aiida.orm.nodes.data.code:Code",
             "core.dict = aiida.orm.nodes.data.dict:Dict",
+            "core.enum = aiida.orm.nodes.data.enum:EnumData",
             "core.float = aiida.orm.nodes.data.float:Float",
             "core.folder = aiida.orm.nodes.data.folder:FolderData",
             "core.int = aiida.orm.nodes.data.int:Int",

--- a/tests/orm/data/test_enum.py
+++ b/tests/orm/data/test_enum.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :class:`aiida.orm.nodes.data.enum.Enum` data plugin."""
+import enum
+
+import pytest
+
+from aiida.common import links
+from aiida.orm import load_node
+from aiida.orm.nodes.data.enum import EnumData
+
+
+class DummyEnum(enum.Enum):
+    """Dummy enum for testing."""
+
+    OPTION_A = 'a'
+    OPTION_B = 'b'
+
+
+def test_construct():
+    """Test the ``EnumData`` constructor."""
+    instance = DummyEnum.OPTION_A
+    node = EnumData(instance)
+
+    assert isinstance(node, EnumData)
+    assert not node.is_stored
+
+
+@pytest.mark.parametrize('value', (None, 'string'))
+def test_construct_invalid_type(value):
+    """Test the ``EnumData`` constructor raises if object is ``None``."""
+    with pytest.raises(TypeError, match=r'Got object of type .*, expecting .*.'):
+        EnumData(value)
+
+
+def test_load_node():
+    """Test loading a stored ``EnumData`` node."""
+    member = DummyEnum.OPTION_A
+    node = EnumData(member)
+    node.store()
+
+    loaded = load_node(node.pk)
+    assert isinstance(loaded, EnumData)
+    assert loaded.is_stored
+
+
+def test_name():
+    """Test the ``name`` property."""
+    member = DummyEnum.OPTION_A
+    node = EnumData(member)
+    assert node.name == member.name
+
+    node.store()
+    assert node.name == member.name
+
+    loaded = load_node(node.pk)
+    assert loaded.name == member.name
+
+
+def test_value():
+    """Test the ``value`` property."""
+    member = DummyEnum.OPTION_A
+    node = EnumData(member)
+    assert node.value == member.value
+
+    node.store()
+    assert node.value == member.value
+
+    loaded = load_node(node.pk)
+    assert loaded.value == member.value
+
+
+def test_get_enum():
+    """Test the ``get_enum`` method."""
+    member = DummyEnum.OPTION_A
+    node = EnumData(member)
+    assert node.get_enum() == DummyEnum
+
+    node.store()
+    assert node.get_enum() == DummyEnum
+
+    loaded = load_node(node.pk)
+    assert loaded.get_enum() == DummyEnum
+
+
+def test_get_member():
+    """Test the ``get_member`` method."""
+    member = DummyEnum.OPTION_A
+    node = EnumData(member)
+    assert node.get_member() == member
+
+    node.store()
+    assert node.get_member() == member
+
+    loaded = load_node(node.pk)
+    assert loaded.get_member() == member
+
+
+def test_get_member_module_not_importable():
+    """Test the ``get_member`` property when the enum cannot be imported from the identifier."""
+    member = DummyEnum.OPTION_A
+    node = EnumData(member)
+    node.set_attribute(EnumData.KEY_IDENTIFIER, 'aiida.common.links:NonExistingEnum')
+    node.store()
+
+    loaded = load_node(node.pk)
+
+    with pytest.raises(ImportError):
+        loaded.get_member()  # pylint: disable=pointless-statement
+
+
+def test_get_member_invalid_value(monkeypatch):
+    """Test the ``get_member`` method when stored value is no longer valid for the class loaded from the identifier."""
+    member = links.LinkType.RETURN
+    node = EnumData(member).store()
+
+    class ChangedLinkType(enum.Enum):
+        """Change the definition of the :class:`aiida.common.links.LinkType`"""
+
+        RETURN = 'different_return'
+
+    # And then monkeypatch the :mod:`aiida.common.links` module with the mock enum.
+    monkeypatch.setattr(links, 'LinkType', ChangedLinkType)
+
+    loaded = load_node(node.pk)
+
+    with pytest.raises(ValueError, match=r'The stored value `return` is no longer a valid value for the enum `.*`'):
+        loaded.get_member()  # pylint: disable=pointless-statement
+
+
+def test_eq():
+    """Test the ``__eq__`` implementation."""
+    node_a = EnumData(DummyEnum.OPTION_A)
+    node_b = EnumData(DummyEnum.OPTION_B)
+
+    assert node_a == DummyEnum.OPTION_A
+    assert node_a != DummyEnum.OPTION_B
+    assert node_a == node_a  # pylint: disable=comparison-with-itself
+    assert node_a != node_b
+    assert node_a != DummyEnum.OPTION_A.value
+
+    # If the identifier cannot be resolved, the equality should not raise but simply return ``False``.
+    node_a.set_attribute(EnumData.KEY_IDENTIFIER, 'aiida.common.links:NonExistingEnum')
+    assert node_a != DummyEnum.OPTION_A
+
+    # If the value is incorrect for the resolved identifier, the equality should not raise but simply return ``False``.
+    node_b.set_attribute(EnumData.KEY_VALUE, 'c')
+    assert node_b != DummyEnum.OPTION_B


### PR DESCRIPTION
Fixes #5224 

The `Enum` instance is represented by two attributes in the database:

 * `value`: the enum value
 * `identifier`: the string representation of the enum's class

The original enum instance can be obtained from the node through the
`value` property. This will except if the enum class can no longer be
imported or the stored value is no longer a valid enum value. This can
be the case if the implementation of the class changed since the
original node was stored.

The plugin is named `EnumData`, and not `Enum`, because the latter would
overlap with the Python built-in class `Enum` from the `enum` module.
The downside is that this differs from the naming of other Python base
type analogs, such as `Str` and `Float`, which simply use a capitalized
version of the type for the data plugin class.