### PR TITLE
♻️ REFACTOR: rename schema names

### DIFF
--- a/aiida/backends/djsite/manager.py
+++ b/aiida/backends/djsite/manager.py
@@ -63,10 +63,9 @@ class DjangoBackendManager(BackendManager):
         """
         # For Django the versions numbers are numerical so we can compare them
         from distutils.version import StrictVersion
-        return StrictVersion(self.get_schema_version_database()) > StrictVersion(self.get_schema_version_code())
+        return StrictVersion(self.get_schema_version_backend()) > StrictVersion(self.get_schema_version_head())
 
-    def get_schema_version_code(self):
-        """Return the code schema version."""
+    def get_schema_version_head(self):
         from .db.models import SCHEMA_VERSION
         return SCHEMA_VERSION
 
@@ -101,11 +100,7 @@ class DjangoBackendManager(BackendManager):
             except (IndexError, ValueError, TypeError):
                 return '1'
 
-    def get_schema_version_database(self):
-        """Return the database schema version.
-
-        :return: `distutils.version.StrictVersion` with schema version of the database
-        """
+    def get_schema_version_backend(self):
         from django.db.utils import ProgrammingError
 
         from aiida.manage.manager import get_manager
@@ -118,11 +113,7 @@ class DjangoBackendManager(BackendManager):
             result = backend.execute_raw(r"""SELECT tval FROM db_dbsetting WHERE key = 'db|schemaversion';""")
         return result[0][0]
 
-    def set_schema_version_database(self, version):
-        """Set the database schema version.
-
-        :param version: string with schema version to set
-        """
+    def set_schema_version_backend(self, version: str) -> None:
         return self.get_settings_manager().set(SCHEMA_VERSION_KEY, version, description=SCHEMA_VERSION_DESCRIPTION)
 
     def _migrate_database_generation(self):

--- a/aiida/backends/sqlalchemy/manager.py
+++ b/aiida/backends/sqlalchemy/manager.py
@@ -11,13 +11,14 @@
 import contextlib
 import os
 
+from alembic.command import downgrade, upgrade
 import sqlalchemy
 from sqlalchemy.orm.exc import NoResultFound
 
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.common import NotExistent
 
-from ..manager import BackendManager, Setting, SettingsManager
+from ..manager import SCHEMA_GENERATION_VALUE, BackendManager, Setting, SettingsManager
 
 ALEMBIC_REL_PATH = 'migrations'
 
@@ -94,6 +95,14 @@ class SqlaBackendManager(BackendManager):
         from . import reset_session
         reset_session()
 
+    def list_schema_versions(self):
+        """List all available schema versions (oldest to latest).
+
+        :return: list of strings with schema versions
+        """
+        with self.alembic_script() as script:
+            return list(reversed([entry.revision for entry in script.walk_revisions()]))
+
     def is_database_schema_ahead(self):
         """Determine whether the database schema version is ahead of the code schema version.
 
@@ -102,10 +111,9 @@ class SqlaBackendManager(BackendManager):
         :return: boolean, True if the database schema version is ahead of the code schema version.
         """
         with self.alembic_script() as script:
-            return self.get_schema_version_database() not in [entry.revision for entry in script.walk_revisions()]
+            return self.get_schema_version_backend() not in [entry.revision for entry in script.walk_revisions()]
 
-    def get_schema_version_code(self):
-        """Return the code schema version."""
+    def get_schema_version_head(self):
         with self.alembic_script() as script:
             return script.get_current_head()
 
@@ -117,29 +125,38 @@ class SqlaBackendManager(BackendManager):
         """
         return SCHEMA_VERSION_RESET[schema_generation_code]
 
-    def get_schema_version_database(self):
-        """Return the database schema version.
-
-        :return: `distutils.version.StrictVersion` with schema version of the database
-        """
+    def get_schema_version_backend(self):
         with self.migration_context() as context:
             return context.get_current_revision()
 
-    def set_schema_version_database(self, version):
-        """Set the database schema version.
-
-        :param version: string with schema version to set
-        """
+    def set_schema_version_backend(self, version: str) -> None:
         with self.migration_context() as context:
-            return context.stamp(context.script, 'head')
+            return context.stamp(context.script, version)
+
+    def _migrate_database_generation(self):
+        self.set_schema_generation_database(SCHEMA_GENERATION_VALUE)
+        self.set_schema_version_backend('head')
+
+    def migrate_up(self, version: str):
+        """Migrate the database up to a specific version.
+
+        :param version: string with schema version to migrate to
+        """
+        with self.alembic_config() as config:
+            upgrade(config, version)
+
+    def migrate_down(self, version: str):
+        """Migrate the database down to a specific version.
+
+        :param version: string with schema version to migrate to
+        """
+        with self.alembic_config() as config:
+            downgrade(config, version)
 
     def _migrate_database_version(self):
-        """Migrate the database to the current schema version."""
+        """Migrate the database to the latest schema version."""
         super()._migrate_database_version()
-        from alembic.command import upgrade
-
-        with self.alembic_config() as config:
-            upgrade(config, 'head')
+        self.migrate_up('head')
 
 
 class SqlaSettingsManager(SettingsManager):

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -38,7 +38,7 @@ def database_version():
     echo.echo('Generation: ', bold=True, nl=False)
     echo.echo(backend_manager.get_schema_generation_database())
     echo.echo('Revision:   ', bold=True, nl=False)
-    echo.echo(backend_manager.get_schema_version_database())
+    echo.echo(backend_manager.get_schema_version_backend())
 
 
 @verdi_database.command('migrate')

--- a/tests/cmdline/commands/test_database.py
+++ b/tests/cmdline/commands/test_database.py
@@ -177,7 +177,7 @@ def tests_database_version(run_cli_command, manager):
     backend_manager = manager.get_backend_manager()
     result = run_cli_command(cmd_database.database_version)
     assert result.output_lines[0].endswith(backend_manager.get_schema_generation_database())
-    assert result.output_lines[1].endswith(backend_manager.get_schema_version_database())
+    assert result.output_lines[1].endswith(backend_manager.get_schema_version_backend())
 
 
 @pytest.mark.usefixtures('clear_database_before_test')


### PR DESCRIPTION
This change is extracted from #5192, and has already been accepted there:

Migration methods have been renamed (and their docstrings updated):

-  `get_schema_version_database()` -> `get_schema_version_backend()`
-  `get_schema_version_code()` -> `get_schema_version_head()`