### PR TITLE
Do not use the deprecated matplotlib config option 'text.latex.preview'.

### DIFF
--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -1612,9 +1612,6 @@ AGR_SINGLESET_TEMPLATE = Template("""
     $xydata
     """)
 
-# text.latex.preview=True is needed to have a proper alignment of
-# tick marks with and without subscripts
-# see e.g. http://matplotlib.org/1.3.0/examples/pylab_examples/usetex_baseline_test.html
 MATPLOTLIB_HEADER_AGG_TEMPLATE = Template(
     """# -*- coding: utf-8 -*-
 
@@ -1629,8 +1626,6 @@ rc('font', **{'family': 'serif', 'serif': ['Computer Modern', 'CMU Serif', 'Time
 rc('mathtext', fontset='cm')
 
 rc('text', usetex=True)
-import matplotlib.pyplot as plt
-plt.rcParams.update({'text.latex.preview': True})
 
 import pylab as pl
 
@@ -1641,9 +1636,6 @@ print_comment = False
 """
 )
 
-# text.latex.preview=True is needed to have a proper alignment of
-# tick marks with and without subscripts
-# see e.g. http://matplotlib.org/1.3.0/examples/pylab_examples/usetex_baseline_test.html
 MATPLOTLIB_HEADER_TEMPLATE = Template(
     """# -*- coding: utf-8 -*-
 
@@ -1655,8 +1647,6 @@ rc('font', **{'family': 'serif', 'serif': ['Computer Modern', 'CMU Serif', 'Time
 rc('mathtext', fontset='cm')
 
 rc('text', usetex=True)
-import matplotlib.pyplot as plt
-plt.rcParams.update({'text.latex.preview': True})
 
 import pylab as pl
 

--- a/setup.json
+++ b/setup.json
@@ -82,6 +82,7 @@
         "atomic_tools": [
             "PyCifRW~=4.4",
             "ase~=3.18",
+            "matplotlib~=3.3,>=3.3.4",
             "pymatgen>=2019.7.2,<=2022.02.03,!=2019.9.7",
             "pymysql~=0.9.3",
             "seekpath~=1.9,>=1.9.3",


### PR DESCRIPTION
Deprecated as of version 3.3.4, see:
https://matplotlib.org/3.3.4/api/api_changes.html#text-latex-preview-rcparam

Requires matplotlib~=3.3.

Fixes #5231.