### PR TITLE
🐛 FIX: listdir method with pattern for SSH

### DIFF
--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -1274,7 +1274,7 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         else:
             base_dir = os.path.join(self.getcwd(), path)
 
-        filtered_list = glob.glob(os.path.join(base_dir, pattern))
+        filtered_list = self.glob(os.path.join(base_dir, pattern))
         if not base_dir.endswith('/'):
             base_dir += '/'
         return [re.sub(base_dir, '', i) for i in filtered_list]


### PR DESCRIPTION
The `listdir` method of the SSH transport plugin was using
`glob.glob` instead of `self.glob` when a pattern was specified.
This is wrong because it's listing files locally and not on the
remote.
The tests passed because they are running on localhost.
Also, this method is probably never called by AiiDA so it went unnoticed.

This commit fixes the issue. I'm not sure if there is a simple
way to fix the tests - probably we should run them against a
docker container or at least a chroot'ed folder? This might be
another issue to be opened though.

Fixes #5244