### PR TITLE
📚 DOCS: add trove classifier for development status

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -9,6 +9,7 @@
     "include_package_data": true,
     "python_requires": ">=3.7",
     "classifiers": [
+        "Development Status :: 5 - Production/Stable",
         "Framework :: AiiDA",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
aiida-core was missing the trove classifier for the development status.