### PR TITLE
The computer configure command include profile if not in the current profile

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -237,7 +237,9 @@ def computer_setup(ctx, non_interactive, **kwargs):
         echo.echo_success(f'Computer<{computer.pk}> {computer.label} created')
 
     echo.echo_report('Note: before the computer can be used, it has to be configured with the command:')
-    echo.echo_report(f'  verdi computer configure {computer.transport_type} {computer.label}')
+
+    profile = ctx.obj['profile']
+    echo.echo_report(f'  verdi -p {profile.name} computer configure {computer.transport_type} {computer.label}')
 
 
 @verdi_computer.command('duplicate')
@@ -290,7 +292,9 @@ def computer_duplicate(ctx, computer, non_interactive, **kwargs):
 
     if not is_configured:
         echo.echo_report('Note: before the computer can be used, it has to be configured with the command:')
-        echo.echo_report(f'  verdi computer configure {computer.transport_type} {computer.label}')
+
+        profile = ctx.obj['profile']
+        echo.echo_report(f'  verdi -p {profile.name} computer configure {computer.transport_type} {computer.label}')
 
 
 @verdi_computer.command('enable')

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -141,6 +141,7 @@ def aiida_localhost(temp_dir):
         )
         computer.store()
         computer.set_minimum_job_poll_interval(0.)
+        computer.set_default_mpiprocs_per_machine(1)
         computer.configure()
 
     return computer


### PR DESCRIPTION
Fixes #4679 

If setup computer for another profile with `-p <profile_name>` when it is not the current default profile, the prompt hint for setting the computer configure will now include the `-p <profile_name>`. 