### PR TITLE
`DirectScheduler`: remove the `-e` option for bash invocation

### DIFF
--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -210,7 +210,7 @@ class DirectScheduler(aiida.schedulers.Scheduler):
             directory.
             IMPORTANT: submit_script should be already escaped.
         """
-        submit_command = f'bash -e {submit_script} > /dev/null 2>&1 & echo $!'
+        submit_command = f'bash {submit_script} > /dev/null 2>&1 & echo $!'
 
         self.logger.info(f'submitting with: {submit_command}')
 


### PR DESCRIPTION
Fixes #5229 

The scheduler implementation was submitting the submit script using bash
with the `-e` option. This flags toggles the behavior that bash will
exit the script as soon as any of the commands in the script return a
non-zero exit code.

This is in contrast with most (if not all) other implementations that
will continue running the script. This is for a good reason, because
often there are critical lines in the rest of the script that need to be
executed for cleanup. For example, with the current state, if the main
executable returns with a non-zero exit code, the script would exit, and
any lines that were added through the `append_text` of either the
`Computer` or the `Code` will be skipped.

Therefore, we remove the `-e` flag, which technically changes the
behavior, but it is very unlikely that any clients were relying on
particular parts of the submit script to not be executed in case of an
error.