### PR TITLE
CI: move `pytest` configuration to `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-source = aiida
-
-[html]
-directory = .coverage_html

--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -14,14 +14,14 @@ bash ${SYSTEM_TESTS}/test_polish_workchains.sh
 verdi daemon stop
 
 # tests for the testing infrastructure
-pytest --noconftest ${SYSTEM_TESTS}/test_test_manager.py
-pytest --noconftest ${SYSTEM_TESTS}/test_ipython_magics.py
-pytest --noconftest ${SYSTEM_TESTS}/test_profile_manager.py
+pytest --cov aiida --verbose --noconftest ${SYSTEM_TESTS}/test_test_manager.py
+pytest --cov aiida --verbose --noconftest ${SYSTEM_TESTS}/test_ipython_magics.py
+pytest --cov aiida --verbose --noconftest ${SYSTEM_TESTS}/test_profile_manager.py
 python ${SYSTEM_TESTS}/test_plugin_testcase.py  # uses custom unittest test runner
 
 # Until the `${SYSTEM_TESTS}/pytest` tests are moved within `tests` we have to run them separately and pass in the path to the
 # `conftest.py` explicitly, because otherwise it won't be able to find the fixtures it provides
-AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest tests/conftest.py ${SYSTEM_TESTS}/pytest
+AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest --cov aiida --verbose tests/conftest.py ${SYSTEM_TESTS}/pytest
 
 # main aiida-core tests
-AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest tests
+AIIDA_TEST_PROFILE=test_$AIIDA_TEST_BACKEND pytest --cov aiida --verbose tests

--- a/.github/workflows/tests.sh
+++ b/.github/workflows/tests.sh
@@ -7,20 +7,6 @@ MODULE_POLISH="${GITHUB_WORKSPACE}/.molecule/default/files/polish"
 
 export PYTHONPATH="${PYTHONPATH}:${SYSTEM_TESTS}:${MODULE_POLISH}"
 
-# pytest options:
-# - report timings of tests
-# - pytest-cov configuration taken from top-level .coveragerc
-# - coverage is reported as XML and in terminal,
-#   including the numbers/ranges of lines which are not covered
-# - coverage results of multiple tests (within a single GH Actions CI job) are collected
-# - coverage is reported on files in aiida/
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --durations=50"
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-config=${GITHUB_WORKSPACE}/.coveragerc"
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-report xml"
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov-append"
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov=aiida"
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --verbose"
-
 # daemon tests
 verdi daemon start 4
 verdi -p test_${AIIDA_TEST_BACKEND} run ${SYSTEM_TESTS}/test_daemon.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ max-locals = 20
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--benchmark-skip"
+addopts = "--benchmark-skip --durations=50 --cov aiida --cov-report xml --cov-append --verbose"
 testpaths = [
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ max-locals = 20
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--benchmark-skip --durations=50 --cov aiida --cov-report xml --cov-append --verbose"
+addopts = "--benchmark-skip --durations=50 --cov-report xml --cov-append "
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
Part of the `pytest` configuration was done through environment
variables in the `.github/workflows/tests.sh`. This is moved to the
`pyproject.toml` where the rest of the configuration is and as such
everything is one place.

The `.coveragerc` configuration file no longer seems necessary since the
configuration is specified directly.