### PR TITLE
`Scheduler`: abstract generation of submit script env variables

### DIFF
--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -311,8 +311,6 @@ class LsfScheduler(aiida.schedulers.Scheduler):
         import re
         import string
 
-        empty_line = ''
-
         lines = []
         if job_tmpl.submit_as_hold:
             lines.append('#BSUB -H')
@@ -433,23 +431,6 @@ class LsfScheduler(aiida.schedulers.Scheduler):
 
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
-
-        # Job environment variables are to be set on one single line.
-        # This is a tough job due to the escaping of commas, etc.
-        # moreover, I am having issues making it work.
-        # Therefore, I assume that this is bash and export variables by
-        # hand.
-        if job_tmpl.job_environment:
-            lines.append(empty_line)
-            lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
-            if not isinstance(job_tmpl.job_environment, dict):
-                raise ValueError('If you provide job_environment, it must be a dictionary')
-            for key, value in job_tmpl.job_environment.items():
-                lines.append(f'export {key.strip()}={escape_for_bash(value)}')
-            lines.append('# ENVIRONMENT VARIABLES END  ###')
-            lines.append(empty_line)
-
-        lines.append(empty_line)
 
         # The following seems to be the only way to copy the input files
         # to the node where the computation are actually launched (the

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -432,6 +432,9 @@ class LsfScheduler(aiida.schedulers.Scheduler):
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
 
+        if job_tmpl.job_environment:
+            lines.append(self._get_submit_script_environment_variables(job_tmpl))
+
         # The following seems to be the only way to copy the input files
         # to the node where the computation are actually launched (the
         # -f option of bsub that does not always work...)

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -297,6 +297,9 @@ class PbsBaseClass(Scheduler):
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
 
+        if job_tmpl.job_environment:
+            lines.append(self._get_submit_script_environment_variables(job_tmpl))
+
         # Required to change directory to the working directory, that is
         # the one from which the job was submitted
         lines.append('cd "$PBS_O_WORKDIR"')

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -297,22 +297,6 @@ class PbsBaseClass(Scheduler):
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
 
-        # Job environment variables are to be set on one single line.
-        # This is a tough job due to the escaping of commas, etc.
-        # moreover, I am having issues making it work.
-        # Therefore, I assume that this is bash and export variables by
-        # and.
-
-        if job_tmpl.job_environment:
-            lines.append(empty_line)
-            lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
-            if not isinstance(job_tmpl.job_environment, dict):
-                raise ValueError('If you provide job_environment, it must be a dictionary')
-            for key, value in job_tmpl.job_environment.items():
-                lines.append(f'export {key.strip()}={escape_for_bash(value)}')
-            lines.append('# ENVIRONMENT VARIABLES  END  ###')
-            lines.append(empty_line)
-
         # Required to change directory to the working directory, that is
         # the one from which the job was submitted
         lines.append('cd "$PBS_O_WORKDIR"')

--- a/aiida/schedulers/plugins/sge.py
+++ b/aiida/schedulers/plugins/sge.py
@@ -150,8 +150,6 @@ class SgeScheduler(aiida.schedulers.Scheduler):
         import re
         import string
 
-        empty_line = ''
-
         lines = []
 
         # SGE provides flags for wd and cwd
@@ -266,22 +264,6 @@ class SgeScheduler(aiida.schedulers.Scheduler):
 
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
-
-        # TAKEN FROM PBSPRO:
-        # Job environment variables are to be set on one single line.
-        # This is a tough job due to the escaping of commas, etc.
-        # moreover, I am having issues making it work.
-        # Therefore, I assume that this is bash and export variables by
-        # and.
-        if job_tmpl.job_environment:
-            lines.append(empty_line)
-            lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
-            if not isinstance(job_tmpl.job_environment, dict):
-                raise ValueError('If you provide job_environment, it must be a dictionary')
-            for key, value in job_tmpl.job_environment.items():
-                lines.append(f'export {key.strip()}={escape_for_bash(value)}')
-            lines.append('# ENVIRONMENT VARIABLES  END  ###')
-            lines.append(empty_line)
 
         return '\n'.join(lines)
 

--- a/aiida/schedulers/plugins/sge.py
+++ b/aiida/schedulers/plugins/sge.py
@@ -265,6 +265,9 @@ class SgeScheduler(aiida.schedulers.Scheduler):
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
 
+        if job_tmpl.job_environment:
+            lines.append(self._get_submit_script_environment_variables(job_tmpl))
+
         return '\n'.join(lines)
 
     def _get_submit_command(self, submit_script):

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -13,7 +13,6 @@ This has been tested on SLURM 14.03.7 on the CSCS.ch machines.
 """
 import re
 
-from aiida.common.escaping import escape_for_bash
 from aiida.common.lang import type_check
 from aiida.schedulers import Scheduler, SchedulerError
 from aiida.schedulers.datastructures import JobInfo, JobState, NodeNumberJobResource
@@ -263,8 +262,6 @@ class SlurmScheduler(Scheduler):
         # pylint: disable=too-many-statements,too-many-branches
         import string
 
-        empty_line = ''
-
         lines = []
         if job_tmpl.submit_as_hold:
             lines.append('#SBATCH -H')
@@ -397,24 +394,6 @@ class SlurmScheduler(Scheduler):
 
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
-
-        # Job environment variables are to be set on one single line.
-        # This is a tough job due to the escaping of commas, etc.
-        # moreover, I am having issues making it work.
-        # Therefore, I assume that this is bash and export variables by
-        # and.
-
-        if job_tmpl.job_environment:
-            lines.append(empty_line)
-            lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
-            if not isinstance(job_tmpl.job_environment, dict):
-                raise ValueError('If you provide job_environment, it must be a dictionary')
-            for key, value in job_tmpl.job_environment.items():
-                lines.append(f'export {key.strip()}={escape_for_bash(value)}')
-            lines.append('# ENVIRONMENT VARIABLES  END  ###')
-            lines.append(empty_line)
-
-        lines.append(empty_line)
 
         return '\n'.join(lines)
 

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -395,6 +395,9 @@ class SlurmScheduler(Scheduler):
         if job_tmpl.custom_scheduler_commands:
             lines.append(job_tmpl.custom_scheduler_commands)
 
+        if job_tmpl.job_environment:
+            lines.append(self._get_submit_script_environment_variables(job_tmpl))
+
         return '\n'.join(lines)
 
     def _get_submit_command(self, submit_script):

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -152,6 +152,13 @@ class Scheduler(metaclass=abc.ABCMeta):
         script_lines.append(self._get_submit_script_header(job_tmpl))
         script_lines.append(empty_line)
 
+        environment_variables = self._get_submit_script_environment_variables(job_tmpl)
+        if environment_variables:
+            script_lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
+            script_lines.append(environment_variables)
+            script_lines.append('# ENVIRONMENT VARIABLES END ###')
+            script_lines.append(empty_line)
+
         if job_tmpl.prepend_text:
             script_lines.append(job_tmpl.prepend_text)
             script_lines.append(empty_line)
@@ -169,6 +176,21 @@ class Scheduler(metaclass=abc.ABCMeta):
             script_lines.append(empty_line)
 
         return '\n'.join(script_lines)
+
+    def _get_submit_script_environment_variables(self, template):  # pylint: disable=no-self-use
+        """Return the part of the submit script header that defines environment variables.
+
+        :parameter template: a `aiida.schedulers.datastrutures.JobTemplate` instance.
+        :return: string containing environment variable declarations.
+        """
+        if template.job_environment is None:
+            return ''
+
+        if not isinstance(template.job_environment, dict):
+            raise ValueError('If you provide job_environment, it must be a dictionary')
+
+        lines = [f'export {key.strip()}={escape_for_bash(value)}' for key, value in template.job_environment.items()]
+        return '\n'.join(lines)
 
     @abc.abstractmethod
     def _get_submit_script_header(self, job_tmpl):

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -152,13 +152,6 @@ class Scheduler(metaclass=abc.ABCMeta):
         script_lines.append(self._get_submit_script_header(job_tmpl))
         script_lines.append(empty_line)
 
-        environment_variables = self._get_submit_script_environment_variables(job_tmpl)
-        if environment_variables:
-            script_lines.append('# ENVIRONMENT VARIABLES BEGIN ###')
-            script_lines.append(environment_variables)
-            script_lines.append('# ENVIRONMENT VARIABLES END ###')
-            script_lines.append(empty_line)
-
         if job_tmpl.prepend_text:
             script_lines.append(job_tmpl.prepend_text)
             script_lines.append(empty_line)
@@ -183,13 +176,16 @@ class Scheduler(metaclass=abc.ABCMeta):
         :parameter template: a `aiida.schedulers.datastrutures.JobTemplate` instance.
         :return: string containing environment variable declarations.
         """
-        if template.job_environment is None:
-            return ''
-
         if not isinstance(template.job_environment, dict):
             raise ValueError('If you provide job_environment, it must be a dictionary')
 
-        lines = [f'export {key.strip()}={escape_for_bash(value)}' for key, value in template.job_environment.items()]
+        lines = ['# ENVIRONMENT VARIABLES BEGIN ###']
+
+        for key, value in template.job_environment.items():
+            lines.append(f'export {key.strip()}={escape_for_bash(value)}')
+
+        lines.append('# ENVIRONMENT VARIABLES END ###')
+
         return '\n'.join(lines)
 
     @abc.abstractmethod


### PR DESCRIPTION
The environment variables defined in the `JobTemplate` need to be
written to the submit script header. The `Scheduler.get_submit_script`
relied on the `__get_submit_script_header` abstract method to do this.
This forces each plugin to write this code, even though this is very
likely to be scheduler independent.

Therefore it is best to abstract this functionality to the base class
such that each scheduler plugin automatically has this implemented. If
really needed, the plugin can still override the behavior by explicitly
reimplementing the `_get_submit_script_environment_variables` method.

Note that it looks that `_get_submit_script_environment_variables` could
be a `staticmethod`, but unfortunately it is not possible to call the
super when overriding the staticmethod in a subclass.