### PR TITLE
Update pymatgen dependencies to fix CI

### DIFF
--- a/aiida/backends/managers/__init__.py
+++ b/aiida/backends/managers/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -104,7 +104,7 @@ PyCifRW==4.4.3
 pycparser==2.21
 pydata-sphinx-theme==0.6.3
 Pygments==2.10.0
-pymatgen==2022.0.16
+pymatgen==2022.1.9
 Pympler==0.9
 PyMySQL==0.9.3
 PyNaCl==1.4.0

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -106,7 +106,7 @@ PyCifRW==4.4.3
 pycparser==2.21
 pydata-sphinx-theme==0.6.3
 Pygments==2.10.0
-pymatgen==2022.0.16
+pymatgen==2022.1.9
 Pympler==0.9
 PyMySQL==0.9.3
 PyNaCl==1.4.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -105,7 +105,7 @@ PyCifRW==4.4.3
 pycparser==2.21
 pydata-sphinx-theme==0.6.3
 Pygments==2.10.0
-pymatgen==2022.0.16
+pymatgen==2022.1.9
 Pympler==0.9
 PyMySQL==0.9.3
 PyNaCl==1.4.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -104,7 +104,7 @@ PyCifRW==4.4.3
 pycparser==2.21
 pydata-sphinx-theme==0.6.3
 Pygments==2.10.0
-pymatgen==2022.0.16
+pymatgen==2022.1.9
 Pympler==0.9
 PyMySQL==0.9.3
 PyNaCl==1.4.0


### PR DESCRIPTION
Fixes #5293.

Updated the version of `pymatgen` to `2022.1.9` which should include the fixes to our problems with the CI (see the links in the original issue, [here](https://github.com/materialsproject/pymatgen/issues/2332) and [here](https://github.com/materialsproject/pymatgen/issues/2333)).