### PR TITLE
`List`/`Dict`: Add `value` property

### DIFF
--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -75,6 +75,14 @@ class Dict(Data):
             return self.get_dict() == other.get_dict()
         return self.get_dict() == other
 
+    @property
+    def value(self):
+        return self.attributes
+
+    @value.setter
+    def value(self, value):
+        self.set_dict(value)
+
     def set_dict(self, dictionary):
         """ Replace the current dictionary with another one.
 

--- a/aiida/orm/nodes/data/list.py
+++ b/aiida/orm/nodes/data/list.py
@@ -56,6 +56,14 @@ class List(Data, MutableSequence):
             return self.get_list() == other.get_list()
         return self.get_list() == other
 
+    @property
+    def value(self):
+        return self.get_list()
+
+    @value.setter
+    def value(self, value):
+        self.set_list(value)  # pylint: disable=no-member
+
     def append(self, value):
         data = self.get_list()
         data.append(value)


### PR DESCRIPTION
~~Fixes #4495~~

Fixes #5313 

Add the `value` property to the `List` and `Dict` classes, to make them
more consistent with other base type classes.