### PR TITLE
Dependencies: add upper limit for `pytest-asyncio`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -110,7 +110,7 @@
             "pg8000~=1.13",
             "pgtest~=1.3,>=1.3.1",
             "pytest~=6.2",
-            "pytest-asyncio~=0.12",
+            "pytest-asyncio~=0.12,<0.17",
             "pytest-timeout~=1.3",
             "pytest-cov~=2.7,<2.11",
             "pytest-rerunfailures~=9.1,>=9.1.1",


### PR DESCRIPTION
The just released version v0.17 of `pytest-asyncio` causes the async
tests in `tests/engine/test_utils.py` to fail. For now we are putting an
upper limit on the requirement until a proper solution is found.