### PR TITLE
Print warning to stdout on `load_profile` for development versions

### DIFF
--- a/aiida/manage/configuration/schema/config-v5.schema.json
+++ b/aiida/manage/configuration/schema/config-v5.schema.json
@@ -164,6 +164,12 @@
                     "default": true,
                     "description": "Whether to print AiiDA deprecation warnings"
                 },
+                "warnings.development_version": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to print a warning when a profile is loaded while a development version is installed",
+                    "global_only": true
+                },
                 "transport.task_retry_initial_interval": {
                     "type": "integer",
                     "default": 20,

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida.manage.configuration` module."""
+import pytest
+
+import aiida
+from aiida.manage.configuration import check_version
+
+
+def test_check_version_release(monkeypatch, capsys, isolated_config):
+    """Test that ``check_version`` prints nothing for a release version.
+
+    If a warning is emitted, it should be printed to stdout. So even though it will go through the logging system, the
+    logging configuration of AiiDA will interfere with that of pytest and the ultimately the output will simply be
+    written to stdout, so we use the ``capsys`` fixture and not the ``caplog`` one.
+    """
+    version = '1.0.0'
+    monkeypatch.setattr(aiida, '__version__', version)
+
+    # Explicitly setting the default in case the test profile has it changed.
+    isolated_config.set_option('warnings.development_version', True)
+
+    check_version()
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert not captured.out
+
+
+@pytest.mark.parametrize('suppress_warning', (True, False))
+def test_check_version_development(monkeypatch, capsys, isolated_config, suppress_warning):
+    """Test that ``check_version`` prints a warning for a post release development version.
+
+    The warning can be suppressed by setting the option ``warnings.development_version`` to ``False``.
+
+    If a warning is emitted, it should be printed to stdout. So even though it will go through the logging system, the
+    logging configuration of AiiDA will interfere with that of pytest and the ultimately the output will simply be
+    written to stdout, so we use the ``capsys`` fixture and not the ``caplog`` one.
+    """
+    version = '1.0.0.post0'
+    monkeypatch.setattr(aiida, '__version__', version)
+
+    isolated_config.set_option('warnings.development_version', not suppress_warning)
+
+    check_version()
+    captured = capsys.readouterr()
+    assert not captured.err
+
+    if suppress_warning:
+        assert not captured.out
+    else:
+        assert f'You are currently using a post release development version of AiiDA: {version}' in captured.out

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -22,7 +22,7 @@ class TestConfigurationOptions(AiidaTestCase):
     def test_get_option_names(self):
         """Test `get_option_names` function."""
         self.assertIsInstance(get_option_names(), list)
-        self.assertEqual(len(get_option_names()), 26)
+        self.assertEqual(len(get_option_names()), 27)
 
     def test_get_option(self):
         """Test `get_option` function."""


### PR DESCRIPTION
Fixes #5290 

The `load_profile` method now calls a `check_version` function. This
checks what version of `aiida-core` is currently installed and if it is
a post release development version, a warning is printed that it should
not be run with production databases. The reason is that we cannot
support automatic data migrations for anything other than released
versions (alpha, beta, and pre-releases are supported).

This function relies on the protocol that development branches will
always use a proper post release development version defined in the
`__version__` attribute of the init file of the `aiida` module. This
means it should be of the form `2.0.0.post0`.

The choice to place the check of the version in `load_profile` is based
on two requirements:

 * It should be guaranteed to run however the database can be loaded
 * It should ideally only run once and not spam stdout multiple times

The `load_profile` function is the only way to load a profile which is
a necessary step to load any database, therefore this should guarantee
that the version check is always called when it is needed. Another
location could have been `Manager._load_backend` which is also
guaranteed to be called before a database is loaded, however, the
downside here is that this can be called multiple times. this would lead
to the warning being spammed multiple times.