### PR TITLE
`Dict`: implement the `__contains__` method

### DIFF
--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -75,8 +75,12 @@ class Dict(Data):
             return self.get_dict() == other.get_dict()
         return self.get_dict() == other
 
+    def __contains__(self, key: str) -> bool:
+        """Return whether the node contains a key."""
+        return key in self.attributes
+
     def set_dict(self, dictionary):
-        """ Replace the current dictionary with another one.
+        """Replace the current dictionary with another one.
 
         :param dictionary: dictionary to set
         """

--- a/tests/orm/nodes/data/test_dict.py
+++ b/tests/orm/nodes/data/test_dict.py
@@ -66,6 +66,18 @@ def test_set_item(dictionary):
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
+@pytest.mark.parametrize('key, expected', (('value', True), ('non-existing', False)))
+def test_contains(dictionary, key, expected):
+    """Test the ``__contains__`` implementation."""
+    node = Dict(dictionary)
+    assert (key in dictionary) is expected
+    assert (key in node) is expected
+
+    node.store()
+    assert (key in node) is expected
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
 def test_correct_raises(dictionary):
     """Test that the methods for accessing the item raise the correct error.
 


### PR DESCRIPTION
Fixes #5326 

This now allows to do the following:

    'some_key' in Dict({'value'})

and is guaranteed to return a boolean, instead of raising a `KeyError`
if the key doesn't exist, which was the previous behavior.