### PR TITLE
`Dict`: implement `items()` method

### DIFF
--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -124,6 +124,11 @@ class Dict(Data):
         for key in self.attributes.keys():
             yield key
 
+    def items(self):
+        """Iterator of all items stored in the Dict node."""
+        for key, value in self.attributes_items():
+            yield key, value
+
     @property
     def dict(self):
         """Return an instance of `AttributeManager` that transforms the dictionary into an attribute dict.

--- a/tests/orm/nodes/data/test_dict.py
+++ b/tests/orm/nodes/data/test_dict.py
@@ -27,6 +27,13 @@ def test_keys(dictionary):
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
+def test_items(dictionary):
+    """Test the ``items`` method."""
+    node = Dict(dictionary)
+    assert sorted(node.items()) == sorted(dictionary.items())
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
 def test_get_dict(dictionary):
     """Test the ``get_dict`` method."""
     node = Dict(dictionary)


### PR DESCRIPTION
Fixes #5332 

This allows the user to directly iterate over the `Dict` items instead
of first retrieving the `dict` with `get_dict()` method:

```python
In [1]: d = Dict({'a': 1, 'b': {'c': 2}})

In [2]: for k, v in d.items():
   ...:     print(k, v)
   ...:
a 1
b {'c': 2}
```