### PR TITLE
`verdi daemon start`: fix debug suggestion in error message

### DIFF
--- a/aiida/cmdline/utils/daemon.py
+++ b/aiida/cmdline/utils/daemon.py
@@ -35,7 +35,7 @@ def print_client_response_status(response):
         return 0
     if response['status'] == DaemonClient.DAEMON_ERROR_NOT_RUNNING:
         echo.echo('FAILED', fg='red', bold=True)
-        echo.echo('Try to run `verdi daemon start --foreground` to potentially see the exception')
+        echo.echo('Try to run `verdi daemon start-circus --foreground` to potentially see the exception')
         return 2
     if response['status'] == DaemonClient.DAEMON_ERROR_TIMEOUT:
         echo.echo('TIMEOUT', fg='red', bold=True)


### PR DESCRIPTION
Fixes #5234 

If the Circus daemon fails to start, typically the exception is hidden
because by default the daemonizer is launched in the background. The
error message already suggested to run with the `--foreground` flag to
be able to see the exception, however, it did so suggesting to run the
same command. In certain cases this is not enough and one actually has
to run the hidden command `verdi daemon start-circus` with the
`--foreground` flag enabled.