### PR TITLE
Docs: Add instructions on how to install Conda.

### DIFF
--- a/docs/source/intro/install_conda.rst
+++ b/docs/source/intro/install_conda.rst
@@ -19,6 +19,12 @@ If you want to install AiiDA onto you own personal workstation/laptop, it is rec
 
    **Install prerequisite services + AiiDA (core)**
 
+   *Install all required services and the aiida-core package in a Conda environment.*
+
+   #. Make sure that conda is installed, e.g., by following `the instructions on installing Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__.
+
+   #. Open a terminal and execute:
+
    .. code-block:: console
 
        $ conda create -n aiida -c conda-forge aiida-core aiida-core.services


### PR DESCRIPTION
Similar to already existing documentation on installing conda as part of
the system-wide installation path.

Resolves #5308.