### PR TITLE
Factories: do not explicitly check type of entry point if `load=False`

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Upgrade pip and setuptools
       run: |
-        pip install --upgrade pip
+        pip install --upgrade pip setuptools
         pip --version
 
     - name: Build pymatgen with compatible numpy

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -89,6 +89,9 @@ def setup_code(ctx, non_interactive, **kwargs):
     else:
         kwargs['code_type'] = CodeBuilder.CodeType.STORE_AND_UPLOAD
 
+    # Convert entry point to its name
+    kwargs['input_plugin'] = kwargs['input_plugin'].name
+
     code_builder = CodeBuilder(**kwargs)
 
     try:
@@ -159,6 +162,9 @@ def code_duplicate(ctx, code, non_interactive, **kwargs):
 
     if kwargs.pop('hide_original'):
         code.hide()
+
+    # Convert entry point to its name
+    kwargs['input_plugin'] = kwargs['input_plugin'].name
 
     code_builder = ctx.code_builder
     for key, value in kwargs.items():

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -11,8 +11,6 @@
 import enum
 import os
 
-import importlib_metadata
-
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common.utils import ErrorAccumulator
 
@@ -155,9 +153,6 @@ class CodeBuilder:
 
         Checks compatibility with other code attributes.
         """
-        if key == 'input_plugin' and isinstance(value, importlib_metadata.EntryPoint):
-            value = value.name
-
         if key == 'description' and value is None:
             value = ''
 

--- a/aiida/plugins/factories.py
+++ b/aiida/plugins/factories.py
@@ -78,10 +78,11 @@ def CalculationFactory(entry_point_name: str, load: bool = True) -> Optional[Uni
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (CalcJob, calcfunction)
 
-    if (
-        isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, CalcJob)) or
-        (is_process_function(entry_point) and entry_point.node_class is CalcFunctionNode)
-    ):
+    if not load:
+        return entry_point
+
+    if ((isclass(entry_point) and issubclass(entry_point, CalcJob)) or
+        (is_process_function(entry_point) and entry_point.node_class is CalcFunctionNode)):  # type: ignore[union-attr]
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -99,6 +100,9 @@ def CalcJobImporterFactory(entry_point_name: str, load: bool = True) -> Optional
     entry_point_group = 'aiida.calculations.importers'
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (CalcJobImporter,)
+
+    if not load:
+        return entry_point
 
     if isclass(entry_point) and issubclass(entry_point, CalcJobImporter):
         return entry_point  # type: ignore[return-value]
@@ -120,7 +124,10 @@ def DataFactory(entry_point_name: str, load: bool = True) -> Optional[Union[Entr
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (Data,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, Data)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, Data):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -140,7 +147,10 @@ def DbImporterFactory(entry_point_name: str, load: bool = True) -> Optional[Unio
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (DbImporter,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, DbImporter)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, DbImporter):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -160,7 +170,10 @@ def GroupFactory(entry_point_name: str, load: bool = True) -> Optional[Union[Ent
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (Group,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, Group)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, Group):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -180,7 +193,10 @@ def OrbitalFactory(entry_point_name: str, load: bool = True) -> Optional[Union[E
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (Orbital,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, Orbital)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, Orbital):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -200,7 +216,10 @@ def ParserFactory(entry_point_name: str, load: bool = True) -> Optional[Union[En
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (Parser,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, Parser)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, Parser):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -220,7 +239,10 @@ def SchedulerFactory(entry_point_name: str, load: bool = True) -> Optional[Union
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (Scheduler,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, Scheduler)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, Scheduler):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -239,7 +261,10 @@ def TransportFactory(entry_point_name: str, load: bool = True) -> Optional[Union
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (Transport,)
 
-    if isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, Transport)):
+    if not load:
+        return entry_point
+
+    if isclass(entry_point) and issubclass(entry_point, Transport):
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)
@@ -260,10 +285,11 @@ def WorkflowFactory(entry_point_name: str, load: bool = True) -> Optional[Union[
     entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
     valid_classes = (WorkChain, workfunction)
 
-    if (
-        isinstance(entry_point, EntryPoint) or (isclass(entry_point) and issubclass(entry_point, WorkChain)) or
-        (is_process_function(entry_point) and entry_point.node_class is WorkFunctionNode)
-    ):
+    if not load:
+        return entry_point
+
+    if ((isclass(entry_point) and issubclass(entry_point, WorkChain)) or
+        (is_process_function(entry_point) and entry_point.node_class is WorkFunctionNode)):  # type: ignore[union-attr]
         return entry_point
 
     raise_invalid_type_error(entry_point_name, entry_point_group, valid_classes)

--- a/tests/plugins/test_entry_point.py
+++ b/tests/plugins/test_entry_point.py
@@ -11,7 +11,7 @@
 import pytest
 
 from aiida.common.warnings import AiidaDeprecationWarning
-from aiida.plugins.entry_point import EntryPoint, get_entry_point, validate_registered_entry_points
+from aiida.plugins.entry_point import get_entry_point, validate_registered_entry_points
 
 
 def test_validate_registered_entry_points():
@@ -42,6 +42,4 @@ def test_get_entry_point_deprecated(group, name):
     warning = f'The entry point `{name}` is deprecated. Please replace it with `core.{name}`.'
 
     with pytest.warns(AiidaDeprecationWarning, match=warning):
-        entry_point = get_entry_point(group, name)
-
-    assert isinstance(entry_point, EntryPoint)
+        get_entry_point(group, name)


### PR DESCRIPTION
The recent release of `setuptools==60.9.0` caused the CI to start
failing. The `CalculationFactory` started raising, when invoked through
the `PluginParamType`, when `load=False` because the loaded entry points
were no longer an instance of `importlib_metadata.EntryPoint`. The
reason for this change is that as of that `setuptools` release, it
started vendoring the `importlib_metadata` package and so it overrides
the type to `setuptools._vendor.importlib_metadata.EntryPoint` for the
loaded entry points.

For reasons unknown, this behavior of the changing of the type of loaded
entry points, only manifested when invoking the CLI through `pytest`.
When calling the failing CLI command directly, it would work just fine.

One solution to this problem would have been to extend the check to also
allow the vendored entry point type of `setuptools` but this seems
fragile. Really, it seems that the original design of checking the type
of the entry point in the case of `load=False` is unnecessary. There is
no reason to suspect that `get_entry_point` should return anything that
does not behave as an entry point if it didn't except. It is better to
be Pythonic here and rely on duck typing. If what is returned by the
factory behaves like an `EntryPoint` instance, regardless of its exact
module and class, then that is all that matters.