### PR TITLE
🔧 MAINTAIN: Rename `_dbmodel -> aiida_model` and `dbmodel -> sqla_model`

### DIFF
--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -32,28 +32,29 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
         super().__init__(backend)
         type_check(user, users.SqlaUser)
         type_check(computer, computers.SqlaComputer)
-        self._dbmodel = utils.ModelWrapper(DbAuthInfo(dbcomputer=computer.dbmodel, aiidauser=user.dbmodel), backend)
+        self._aiida_model = utils.ModelWrapper(
+            DbAuthInfo(dbcomputer=computer.sqla_model, aiidauser=user.sqla_model), backend
+        )
 
     @property
     def id(self):  # pylint: disable=invalid-name
-        return self._dbmodel.id
+        return self.aiida_model.id
 
     @property
-    def is_stored(self):
+    def is_stored(self) -> bool:
         """Return whether the entity is stored.
 
         :return: True if stored, False otherwise
-        :rtype: bool
         """
-        return self._dbmodel.is_saved()
+        return self.aiida_model.is_saved()
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Return whether this instance is enabled.
 
         :return: boolean, True if enabled, False otherwise
         """
-        return self._dbmodel.enabled
+        return self.aiida_model.enabled
 
     @enabled.setter
     def enabled(self, enabled):
@@ -61,7 +62,7 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
 
         :param enabled: boolean, True to enable the instance, False to disable it
         """
-        self._dbmodel.enabled = enabled
+        self.aiida_model.enabled = enabled
 
     @property
     def computer(self):
@@ -69,7 +70,7 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
 
         :return: :class:`aiida.orm.implementation.computers.BackendComputer`
         """
-        return self.backend.computers.from_dbmodel(self._dbmodel.dbcomputer)
+        return self.backend.computers.from_dbmodel(self.aiida_model.dbcomputer)
 
     @property
     def user(self):
@@ -77,35 +78,35 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
 
         :return: :class:`aiida.orm.implementation.users.BackendUser`
         """
-        return self._backend.users.from_dbmodel(self._dbmodel.aiidauser)
+        return self._backend.users.from_dbmodel(self.aiida_model.aiidauser)
 
     def get_auth_params(self):
         """Return the dictionary of authentication parameters
 
         :return: a dictionary with authentication parameters
         """
-        return self._dbmodel.auth_params
+        return self.aiida_model.auth_params
 
     def set_auth_params(self, auth_params):
         """Set the dictionary of authentication parameters
 
         :param auth_params: a dictionary with authentication parameters
         """
-        self._dbmodel.auth_params = auth_params
+        self.aiida_model.auth_params = auth_params
 
     def get_metadata(self):
         """Return the dictionary of metadata
 
         :return: a dictionary with metadata
         """
-        return self._dbmodel._metadata  # pylint: disable=protected-access
+        return self.aiida_model._metadata  # pylint: disable=protected-access
 
     def set_metadata(self, metadata):
         """Set the dictionary of metadata
 
         :param metadata: a dictionary with metadata
         """
-        self._dbmodel._metadata = metadata  # pylint: disable=protected-access
+        self.aiida_model._metadata = metadata  # pylint: disable=protected-access
 
 
 class SqlaAuthInfoCollection(BackendAuthInfoCollection):

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -42,8 +42,8 @@ class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):
         lang.type_check(user, users.SqlaUser)  # pylint: disable=no-member
 
         arguments = {
-            'dbnode': node.dbmodel,
-            'user': user.dbmodel,
+            'dbnode': node.sqla_model,
+            'user': user.sqla_model,
             'content': content,
         }
 
@@ -55,48 +55,48 @@ class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):
             lang.type_check(mtime, datetime, f'the given mtime is of type {type(mtime)}')
             arguments['mtime'] = mtime
 
-        self._dbmodel = utils.ModelWrapper(models.DbComment(**arguments), backend)
+        self._aiida_model = utils.ModelWrapper(models.DbComment(**arguments), backend)
 
     def store(self):
         """Can only store if both the node and user are stored as well."""
-        if self._dbmodel.dbnode.id is None or self._dbmodel.user.id is None:
-            self._dbmodel.dbnode = None
+        if self.aiida_model.dbnode.id is None or self.aiida_model.user.id is None:
+            self.aiida_model.dbnode = None
             raise exceptions.ModificationNotAllowed('The corresponding node and/or user are not stored')
 
         super().store()
 
     @property
     def uuid(self) -> str:
-        return str(self._dbmodel.uuid)
+        return str(self.aiida_model.uuid)
 
     @property
     def ctime(self):
-        return self._dbmodel.ctime
+        return self.aiida_model.ctime
 
     @property
     def mtime(self):
-        return self._dbmodel.mtime
+        return self.aiida_model.mtime
 
     def set_mtime(self, value):
-        self._dbmodel.mtime = value
+        self.aiida_model.mtime = value
 
     @property
     def node(self):
-        return self.backend.nodes.from_dbmodel(self.dbmodel.dbnode)
+        return self.backend.nodes.from_dbmodel(self.sqla_model.dbnode)
 
     @property
     def user(self):
-        return self.backend.users.from_dbmodel(self.dbmodel.user)
+        return self.backend.users.from_dbmodel(self.sqla_model.user)
 
     def set_user(self, value):
-        self._dbmodel.user = value
+        self.aiida_model.user = value
 
     @property
     def content(self):
-        return self._dbmodel.content
+        return self.aiida_model.content
 
     def set_content(self, value):
-        self._dbmodel.content = value
+        self.aiida_model.content = value
 
 
 class SqlaCommentCollection(BackendCommentCollection):

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -31,23 +31,23 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
 
     def __init__(self, backend, **kwargs):
         super().__init__(backend)
-        self._dbmodel = utils.ModelWrapper(DbComputer(**kwargs), backend)
+        self._aiida_model = utils.ModelWrapper(DbComputer(**kwargs), backend)
 
     @property
     def uuid(self):
-        return str(self._dbmodel.uuid)
+        return str(self.aiida_model.uuid)
 
     @property
     def pk(self):
-        return self._dbmodel.id
+        return self.aiida_model.id
 
     @property
     def id(self):  # pylint: disable=invalid-name
-        return self._dbmodel.id
+        return self.aiida_model.id
 
     @property
     def is_stored(self):
-        return self._dbmodel.id is not None
+        return self.aiida_model.id is not None
 
     def copy(self):
         """Create an unstored clone of an already stored `Computer`."""
@@ -56,7 +56,7 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
         if not self.is_stored:
             raise exceptions.InvalidOperation('You can copy a computer only after having stored it')
 
-        dbcomputer = copy(self._dbmodel)
+        dbcomputer = copy(self.aiida_model)
         make_transient(dbcomputer)
         session.add(dbcomputer)
 
@@ -67,7 +67,7 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
     def store(self):
         """Store the `Computer` instance."""
         try:
-            self._dbmodel.save()
+            self.aiida_model.save()
         except SQLAlchemyError:
             raise ValueError('Integrity error, probably the hostname already exists in the DB')
 
@@ -75,42 +75,42 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
 
     @property
     def label(self):
-        return self._dbmodel.label
+        return self.aiida_model.label
 
     @property
     def description(self):
-        return self._dbmodel.description
+        return self.aiida_model.description
 
     @property
     def hostname(self):
-        return self._dbmodel.hostname
+        return self.aiida_model.hostname
 
     def get_metadata(self):
-        return self._dbmodel._metadata  # pylint: disable=protected-access
+        return self.aiida_model._metadata  # pylint: disable=protected-access
 
     def set_metadata(self, metadata):
-        self._dbmodel._metadata = metadata  # pylint: disable=protected-access
+        self.aiida_model._metadata = metadata  # pylint: disable=protected-access
 
     def set_label(self, val):
-        self._dbmodel.label = val
+        self.aiida_model.label = val
 
     def set_hostname(self, val):
-        self._dbmodel.hostname = val
+        self.aiida_model.hostname = val
 
     def set_description(self, val):
-        self._dbmodel.description = val
+        self.aiida_model.description = val
 
     def get_scheduler_type(self):
-        return self._dbmodel.scheduler_type
+        return self.aiida_model.scheduler_type
 
     def set_scheduler_type(self, scheduler_type):
-        self._dbmodel.scheduler_type = scheduler_type
+        self.aiida_model.scheduler_type = scheduler_type
 
     def get_transport_type(self):
-        return self._dbmodel.transport_type
+        return self.aiida_model.transport_type
 
     def set_transport_type(self, transport_type):
-        self._dbmodel.transport_type = transport_type
+        self.aiida_model.transport_type = transport_type
 
 
 class SqlaComputerCollection(BackendComputerCollection):

--- a/aiida/orm/implementation/sqlalchemy/entities.py
+++ b/aiida/orm/implementation/sqlalchemy/entities.py
@@ -16,13 +16,14 @@ from aiida.common.lang import type_check
 from . import utils
 
 ModelType = TypeVar('ModelType')  # pylint: disable=invalid-name
+SelfType = TypeVar('SelfType', bound='SqlaModelEntity')
 
 
 class SqlaModelEntity(Generic[ModelType]):
     """A mixin that adds some common SQLA backend entity methods"""
 
     MODEL_CLASS = None
-    _dbmodel = None
+    _aiida_model: utils.ModelWrapper
 
     @classmethod
     def _class_check(cls):
@@ -32,11 +33,11 @@ class SqlaModelEntity(Generic[ModelType]):
     @classmethod
     def from_dbmodel(cls, dbmodel, backend):
         """
-        Create a DjangoEntity from the corresponding db model class
+        Create an AiiDA Entity from the corresponding ORM model and storage backend
 
-        :param dbmodel: the model to create the entity from
-        :param backend: the corresponding backend
-        :return: the Django entity
+        :param dbmodel: the SQLAlchemy model to create the entity from
+        :param backend: the corresponding storage backend
+        :return: the AiiDA entity
         """
         from .backend import PsqlDosBackend  # pylint: disable=cyclic-import
         cls._class_check()
@@ -44,59 +45,53 @@ class SqlaModelEntity(Generic[ModelType]):
         type_check(backend, PsqlDosBackend)
         entity = cls.__new__(cls)
         super(SqlaModelEntity, entity).__init__(backend)
-        entity._dbmodel = utils.ModelWrapper(dbmodel, backend)  # pylint: disable=protected-access
+        entity._aiida_model = utils.ModelWrapper(dbmodel, backend)  # pylint: disable=protected-access
         return entity
-
-    @classmethod
-    def get_dbmodel_attribute_name(cls, attr_name):
-        """
-        Given the name of an attribute of the entity class give the corresponding name of the attribute
-        in the db model.  It if doesn't exit this raises a ValueError
-
-        :param attr_name:
-        :return: the dbmodel attribute name
-        :rtype: str
-        """
-        if hasattr(cls.MODEL_CLASS, attr_name):
-            return attr_name
-
-        raise ValueError(f"Unknown attribute '{attr_name}'")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._class_check()
 
     @property
-    def dbmodel(self):
-        return self._dbmodel._model  # pylint: disable=protected-access
+    def aiida_model(self) -> utils.ModelWrapper:
+        """Return an ORM model that correctly updates and flushes the data when getting or setting a field."""
+        return self._aiida_model
 
     @property
-    def id(self):  # pylint: disable=redefined-builtin, invalid-name
+    def sqla_model(self):
+        """Return the underlying SQLA ORM model for this entity.
+
+        .. warning:: Getting/setting attributes on this model bypasses AiiDA's internal update/flush mechanisms.
+        """
+        return self.aiida_model._model  # pylint: disable=protected-access
+
+    @property
+    def id(self) -> int:  # pylint: disable=redefined-builtin, invalid-name
         """
         Get the id of this entity
 
         :return: the entity id
         """
-        return self._dbmodel.id
+        return self.aiida_model.id
 
     @property
-    def is_stored(self):
+    def is_stored(self) -> bool:
         """
         Is this entity stored?
 
         :return: True if stored, False otherwise
         """
-        return self._dbmodel.id is not None
+        return self.aiida_model.id is not None
 
-    def store(self):
+    def store(self: SelfType) -> SelfType:
         """
         Store this entity
 
         :return: the entity itself
         """
-        self._dbmodel.save()
+        self.aiida_model.save()
         return self
 
     def _flush_if_stored(self, fields: Set[str]) -> None:
-        if self._dbmodel.is_saved():
-            self._dbmodel._flush(fields)  # pylint: disable=protected-access
+        if self.aiida_model.is_saved():
+            self.aiida_model._flush(fields)  # pylint: disable=protected-access

--- a/aiida/orm/implementation/sqlalchemy/extras_mixin.py
+++ b/aiida/orm/implementation/sqlalchemy/extras_mixin.py
@@ -17,17 +17,17 @@ from aiida.orm.implementation.utils import clean_value, validate_attribute_extra
 class ExtrasMixin:
     """Mixin class for SQL implementations of ``extras``."""
 
-    _dbmodel: Any
-    dbmodel: Any
+    aiida_model: Any
+    sqla_model: Any
     is_stored: bool
 
     @property
     def extras(self) -> Dict[str, Any]:
-        return self._dbmodel.extras
+        return self.aiida_model.extras
 
     def get_extra(self, key: str) -> Any:
         try:
-            return self._dbmodel.extras[key]
+            return self.aiida_model.extras[key]
         except KeyError as exception:
             raise AttributeError(f'extra `{exception}` does not exist') from exception
 
@@ -37,7 +37,7 @@ class ExtrasMixin:
         if self.is_stored:
             value = clean_value(value)
 
-        self._dbmodel.extras[key] = value
+        self.aiida_model.extras[key] = value
         self._flush_if_stored({'extras'})
 
     def set_extra_many(self, extras: Dict[str, Any]) -> None:
@@ -48,7 +48,7 @@ class ExtrasMixin:
             extras = {key: clean_value(value) for key, value in extras.items()}
 
         for key, value in extras.items():
-            self.dbmodel.extras[key] = value
+            self.sqla_model.extras[key] = value
 
         self._flush_if_stored({'extras'})
 
@@ -59,36 +59,36 @@ class ExtrasMixin:
         if self.is_stored:
             extras = clean_value(extras)
 
-        self.dbmodel.extras = extras
+        self.sqla_model.extras = extras
         self._flush_if_stored({'extras'})
 
     def delete_extra(self, key: str) -> None:
         try:
-            self._dbmodel.extras.pop(key)
+            self.aiida_model.extras.pop(key)
         except KeyError as exception:
             raise AttributeError(f'extra `{exception}` does not exist') from exception
         else:
             self._flush_if_stored({'extras'})
 
     def delete_extra_many(self, keys: Iterable[str]) -> None:
-        non_existing_keys = [key for key in keys if key not in self._dbmodel.extras]
+        non_existing_keys = [key for key in keys if key not in self.aiida_model.extras]
 
         if non_existing_keys:
             raise AttributeError(f"extras `{', '.join(non_existing_keys)}` do not exist")
 
         for key in keys:
-            self.dbmodel.extras.pop(key)
+            self.sqla_model.extras.pop(key)
 
         self._flush_if_stored({'extras'})
 
     def clear_extras(self) -> None:
-        self._dbmodel.extras = {}
+        self.aiida_model.extras = {}
         self._flush_if_stored({'extras'})
 
     def extras_items(self) -> Iterable[Tuple[str, Any]]:
-        for key, value in self._dbmodel.extras.items():
+        for key, value in self.aiida_model.extras.items():
             yield key, value
 
     def extras_keys(self) -> Iterable[str]:
-        for key in self._dbmodel.extras.keys():
+        for key in self.aiida_model.extras.keys():
             yield key

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -27,7 +27,7 @@ class SqlaLog(entities.SqlaModelEntity[models.DbLog], BackendLog):
     def __init__(self, backend, time, loggername, levelname, dbnode_id, message='', metadata=None):
         # pylint: disable=too-many-arguments
         super().__init__(backend)
-        self._dbmodel = utils.ModelWrapper(
+        self._aiida_model = utils.ModelWrapper(
             models.DbLog(
                 time=time,
                 loggername=loggername,
@@ -43,49 +43,49 @@ class SqlaLog(entities.SqlaModelEntity[models.DbLog], BackendLog):
         """
         Get the string representation of the UUID of the log entry
         """
-        return str(self._dbmodel.uuid)
+        return str(self.aiida_model.uuid)
 
     @property
     def time(self):
         """
         Get the time corresponding to the entry
         """
-        return self._dbmodel.time
+        return self.aiida_model.time
 
     @property
     def loggername(self):
         """
         The name of the logger that created this entry
         """
-        return self._dbmodel.loggername
+        return self.aiida_model.loggername
 
     @property
     def levelname(self):
         """
         The name of the log level
         """
-        return self._dbmodel.levelname
+        return self.aiida_model.levelname
 
     @property
     def dbnode_id(self):
         """
         Get the id of the object that created the log entry
         """
-        return self._dbmodel.dbnode_id
+        return self.aiida_model.dbnode_id
 
     @property
     def message(self):
         """
         Get the message corresponding to the entry
         """
-        return self._dbmodel.message
+        return self.aiida_model.message
 
     @property
     def metadata(self):
         """
         Get the metadata corresponding to the entry
         """
-        return self._dbmodel._metadata  # pylint: disable=protected-access
+        return self.aiida_model._metadata  # pylint: disable=protected-access
 
 
 class SqlaLogCollection(BackendLogCollection):

--- a/aiida/orm/implementation/sqlalchemy/users.py
+++ b/aiida/orm/implementation/sqlalchemy/users.py
@@ -24,41 +24,41 @@ class SqlaUser(entities.SqlaModelEntity[DbUser], BackendUser):
     def __init__(self, backend, email, first_name, last_name, institution):
         # pylint: disable=too-many-arguments
         super().__init__(backend)
-        self._dbmodel = utils.ModelWrapper(
+        self._aiida_model = utils.ModelWrapper(
             DbUser(email=email, first_name=first_name, last_name=last_name, institution=institution), backend
         )
 
     @property
     def email(self):
-        return self._dbmodel.email
+        return self.aiida_model.email
 
     @email.setter
     def email(self, email):
-        self._dbmodel.email = email
+        self.aiida_model.email = email
 
     @property
     def first_name(self):
-        return self._dbmodel.first_name
+        return self.aiida_model.first_name
 
     @first_name.setter
     def first_name(self, first_name):
-        self._dbmodel.first_name = first_name
+        self.aiida_model.first_name = first_name
 
     @property
     def last_name(self):
-        return self._dbmodel.last_name
+        return self.aiida_model.last_name
 
     @last_name.setter
     def last_name(self, last_name):
-        self._dbmodel.last_name = last_name
+        self.aiida_model.last_name = last_name
 
     @property
     def institution(self):
-        return self._dbmodel.institution
+        return self.aiida_model.institution
 
     @institution.setter
     def institution(self, institution):
-        self._dbmodel.institution = institution
+        self.aiida_model.institution = institution
 
 
 class SqlaUserCollection(BackendUserCollection):

--- a/aiida/tools/archive/implementations/sqlite/backend.py
+++ b/aiida/tools/archive/implementations/sqlite/backend.py
@@ -32,6 +32,7 @@ from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation.backends import Backend as BackendAbstract
 from aiida.orm.implementation.sqlalchemy import authinfos, comments, computers, entities, groups, logs, nodes, users
 from aiida.orm.implementation.sqlalchemy.querybuilder import SqlaQueryBuilder
+from aiida.orm.implementation.sqlalchemy.utils import ModelWrapper
 from aiida.repository.backend.abstract import AbstractRepositoryBackend
 from aiida.tools.archive.exceptions import ArchiveClosedError, CorruptArchive, ReadOnlyError
 
@@ -386,13 +387,18 @@ def create_backend_cls(base_class, model_cls):
 
         def __init__(self, _backend, model):
             """Initialise the backend entity."""
-            from aiida.orm.implementation.sqlalchemy.utils import ModelWrapper
             self._backend = _backend
-            self._dbmodel = ModelWrapper(model, _backend)
+            self._aiida_model = ModelWrapper(model, _backend)
 
         @property
-        def dbmodel(self):
-            return self._dbmodel._model  # pylint: disable=protected-access
+        def aiida_model(self) -> ModelWrapper:
+            """Return an ORM model that correctly updates and flushes the data model when getting or setting a field."""
+            return self.aiida_model
+
+        @property
+        def sqla_model(self):
+            """Return the underlying SQLAlchemy ORM model for this entity."""
+            return self.aiida_model._model  # pylint: disable=protected-access
 
         @classmethod
         def from_dbmodel(cls, model, _backend):

--- a/tests/backends/aiida_sqlalchemy/test_nodes.py
+++ b/tests/backends/aiida_sqlalchemy/test_nodes.py
@@ -77,7 +77,7 @@ class TestNodeBasicSQLA(AiidaTestCase):
         from aiida.common.utils import get_new_uuid
 
         # Get the automatic user
-        dbuser = self.backend.users.create(f'{self.id()}@aiida.net').store().dbmodel
+        dbuser = self.backend.users.create(f'{self.id()}@aiida.net').store().sqla_model
         # Create a new node but don't add it to the session
         node_uuid = get_new_uuid()
         DbNode(user=dbuser, uuid=node_uuid, node_type=None)
@@ -96,7 +96,7 @@ class TestNodeBasicSQLA(AiidaTestCase):
         self.assertEqual(len(res), 0, 'There should not be any nodes with this UUID in the session/DB.')
 
         # Get the automatic user
-        dbuser = orm.User.objects.get_default().backend_entity.dbmodel
+        dbuser = orm.User.objects.get_default().backend_entity.sqla_model
         # Create a new node but now add it to the session
         node_uuid = get_new_uuid()
         node = DbNode(user=dbuser, uuid=node_uuid, node_type=None)

--- a/tests/backends/aiida_sqlalchemy/test_schema.py
+++ b/tests/backends/aiida_sqlalchemy/test_schema.py
@@ -44,16 +44,16 @@ class TestRelationshipsSQLA(AiidaTestCase):
         n_3.add_incoming(n_2, link_type=LinkType.CREATE, link_label='N2')
 
         # Check that the result of outputs is a list
-        self.assertIsInstance(n_1.backend_entity.dbmodel.outputs, list, 'This is expected to be a list')
+        self.assertIsInstance(n_1.backend_entity.sqla_model.outputs, list, 'This is expected to be a list')
 
         # Check that the result of outputs_q is a query
         from sqlalchemy.orm.dynamic import AppenderQuery
         self.assertIsInstance(
-            n_1.backend_entity.dbmodel.outputs_q, AppenderQuery, 'This is expected to be an AppenderQuery'
+            n_1.backend_entity.sqla_model.outputs_q, AppenderQuery, 'This is expected to be an AppenderQuery'
         )
 
         # Check that the result of outputs is correct
-        out = {_.pk for _ in n_1.backend_entity.dbmodel.outputs}
+        out = {_.pk for _ in n_1.backend_entity.sqla_model.outputs}
         self.assertEqual(out, set([n_2.pk]))
 
     def test_inputs_parents_relationship(self):
@@ -69,16 +69,16 @@ class TestRelationshipsSQLA(AiidaTestCase):
         n_3.add_incoming(n_2, link_type=LinkType.CREATE, link_label='N2')
 
         # Check that the result of outputs is a list
-        self.assertIsInstance(n_1.backend_entity.dbmodel.inputs, list, 'This is expected to be a list')
+        self.assertIsInstance(n_1.backend_entity.sqla_model.inputs, list, 'This is expected to be a list')
 
         # Check that the result of outputs_q is a query
         from sqlalchemy.orm.dynamic import AppenderQuery
         self.assertIsInstance(
-            n_1.backend_entity.dbmodel.inputs_q, AppenderQuery, 'This is expected to be an AppenderQuery'
+            n_1.backend_entity.sqla_model.inputs_q, AppenderQuery, 'This is expected to be an AppenderQuery'
         )
 
         # Check that the result of inputs is correct
-        out = {_.pk for _ in n_3.backend_entity.dbmodel.inputs}
+        out = {_.pk for _ in n_3.backend_entity.sqla_model.inputs}
         self.assertEqual(out, set([n_2.pk]))
 
     def test_user_node_1(self):

--- a/tests/backends/aiida_sqlalchemy/test_session.py
+++ b/tests/backends/aiida_sqlalchemy/test_session.py
@@ -53,18 +53,18 @@ class TestSessionSqla:
         session = self.backend.get_session()
 
         user = self.backend.users.create(email='other@example.com')
-        session.add(user.dbmodel)
+        session.add(user.sqla_model)
         session.commit()
 
         defaults = dict(
             label='localhost', hostname='localhost', transport_type='core.local', scheduler_type='core.pbspro'
         )
         computer = self.backend.computers.create(**defaults)
-        session.add(computer.dbmodel)
+        session.add(computer.sqla_model)
         session.commit()
 
         node = self.backend.nodes.create(node_type='', user=user).store()
-        session.add(node.dbmodel)
+        session.add(node.sqla_model)
         session.commit()
 
         self.drop_connection()
@@ -77,7 +77,7 @@ class TestSessionSqla:
         session = self.backend.get_session()
 
         user = self.backend.users.create(email='other@example.com')
-        session.add(user.dbmodel)
+        session.add(user.sqla_model)
         session.commit()
 
         computer = self.backend.computers.create(
@@ -98,18 +98,18 @@ class TestSessionSqla:
         session = self.backend.get_session()
 
         user = self.backend.users.create(email='other@example.com')
-        session.add(user.dbmodel)
+        session.add(user.sqla_model)
         session.commit()
 
         defaults = dict(
             label='localhost', hostname='localhost', transport_type='core.local', scheduler_type='core.pbspro'
         )
         computer = self.backend.computers.create(**defaults)
-        session.add(computer.dbmodel)
+        session.add(computer.sqla_model)
         session.commit()
 
         node = self.backend.nodes.create(node_type='', user=user).store()
-        session.add(node.dbmodel)
+        session.add(node.sqla_model)
         session.commit()
 
         self.drop_connection()
@@ -123,7 +123,7 @@ class TestSessionSqla:
         session = self.backend.get_session()
 
         user = self.backend.users.create(email='other@example.com')
-        session.add(user.dbmodel)
+        session.add(user.sqla_model)
         session.commit()
 
         defaults = dict(
@@ -151,7 +151,7 @@ class TestSessionSqla:
         try:
             user = self.backend.users.create(email='test@localhost').store()
             node = self.backend.nodes.create(node_type='', user=user).store()
-            master_session = node._dbmodel.session  # pylint: disable=protected-access
+            master_session = node.aiida_model.session  # pylint: disable=protected-access
             assert master_session is not custom_session
 
             # Manually load the DbNode in a different session

--- a/tests/orm/implementation/test_groups.py
+++ b/tests/orm/implementation/test_groups.py
@@ -24,7 +24,7 @@ def test_creation_from_dbgroup(backend):
     group.store()
     group.add_nodes([node.backend_entity])
 
-    dbgroup = group.dbmodel
+    dbgroup = group.sqla_model
     gcopy = backend.groups.from_dbmodel(dbgroup)
 
     assert group.pk == gcopy.pk

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -334,7 +334,7 @@ class TestGroupsSubclasses(AiidaTestCase):
         a normal group and manipulating the type string directly on the database model.
         """
         group = orm.Group(label='group')
-        group.backend_entity.dbmodel.type_string = 'unregistered.subclass'
+        group.backend_entity.sqla_model.type_string = 'unregistered.subclass'
         group.store()
 
         with pytest.warns(UserWarning):
@@ -355,7 +355,7 @@ class TestGroupsSubclasses(AiidaTestCase):
 
         # Fake a subclass by manually setting the type string
         group = orm.Group(label='custom-group')
-        group.backend_entity.dbmodel.type_string = 'custom.group'
+        group.backend_entity.sqla_model.type_string = 'custom.group'
         group.store()
 
         assert orm.QueryBuilder().append(orm.AutoGroup).count() == 1

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -268,7 +268,7 @@ class TestNodeBasic(AiidaTestCase):
 
         a = orm.Data()
         b = orm.Data()
-        b.backend_entity.dbmodel.uuid = a.uuid
+        b.backend_entity.sqla_model.uuid = a.uuid
         a.store()
 
         with self.assertRaises(SqlaIntegrityError):


### PR DESCRIPTION
This fixes a confusing naming, since `_dbmodel` pointed to the `ModelWrapper`,
which wraps together the SQLA ORM model and storage backend,
and `dbmodel` which pointed to the "raw" SQLA ORM model.

When getting/setting fields, the behaviour of both is very different, and so there should be a clear distinction.

closes #3064