### PR TITLE
🔧 MAINTAIN: Remove `BackendEntity.from_dbmodel`  and `BackendCollection.from_dbmodel`

### DIFF
--- a/aiida/orm/implementation/entities.py
+++ b/aiida/orm/implementation/entities.py
@@ -68,11 +68,6 @@ class BackendEntity(abc.ABC):
         :return: True if stored, False otherwise
         """
 
-    @classmethod
-    @abc.abstractmethod
-    def from_dbmodel(cls, dbmodel: Any, backend: 'Backend') -> EntityType:
-        """Create this entity from a dbmodel."""
-
 
 class BackendCollection(Generic[EntityType]):
     """Container class that represents a collection of entries of a particular backend entity."""
@@ -85,15 +80,6 @@ class BackendCollection(Generic[EntityType]):
         """
         assert issubclass(self.ENTITY_CLASS, BackendEntity), 'Must set the ENTRY_CLASS class variable to an entity type'
         self._backend = backend
-
-    def from_dbmodel(self, dbmodel):
-        """
-        Create an entity from the backend dbmodel
-
-        :param dbmodel: the dbmodel to create the entity from
-        :return: the entity instance
-        """
-        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
 
     @property
     def backend(self) -> 'Backend':

--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -113,6 +113,10 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
 
     ENTITY_CLASS = SqlaAuthInfo
 
+    def from_dbmodel(self, dbmodel) -> SqlaAuthInfo:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def delete(self, pk):
         """Delete an entry from the collection.
 

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -104,6 +104,10 @@ class SqlaCommentCollection(BackendCommentCollection):
 
     ENTITY_CLASS = SqlaComment
 
+    def from_dbmodel(self, dbmodel) -> SqlaComment:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def create(self, node, user, content=None, **kwargs):
         """
         Create a Comment for a given node and user

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -118,6 +118,10 @@ class SqlaComputerCollection(BackendComputerCollection):
 
     ENTITY_CLASS = SqlaComputer
 
+    def from_dbmodel(self, dbmodel) -> SqlaComputer:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def list_names(self):
         session = self.backend.get_session()
         return session.query(DbComputer.label).all()

--- a/aiida/orm/implementation/sqlalchemy/convert.py
+++ b/aiida/orm/implementation/sqlalchemy/convert.py
@@ -10,11 +10,7 @@
 """
 Module to get the backend instance from the Models instance
 """
-
-try:  # Python3
-    from functools import singledispatch
-except ImportError:  # Python2
-    from singledispatch import singledispatch
+from functools import singledispatch
 
 from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
 from aiida.backends.sqlalchemy.models.comment import DbComment

--- a/aiida/orm/implementation/sqlalchemy/entities.py
+++ b/aiida/orm/implementation/sqlalchemy/entities.py
@@ -31,8 +31,7 @@ class SqlaModelEntity(Generic[ModelType]):
 
     @classmethod
     def from_dbmodel(cls, dbmodel, backend):
-        """
-        Create a DjangoEntity from the corresponding db model class
+        """Create an AiiDA Entity from the corresponding SQLA ORM model and storage backend
 
         :param dbmodel: the model to create the entity from
         :param backend: the corresponding backend

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -280,6 +280,10 @@ class SqlaGroupCollection(BackendGroupCollection):
 
     ENTITY_CLASS = SqlaGroup
 
+    def from_dbmodel(self, dbmodel) -> SqlaGroup:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def delete(self, id):  # pylint: disable=redefined-builtin
         session = self.backend.get_session()
 

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -93,6 +93,10 @@ class SqlaLogCollection(BackendLogCollection):
 
     ENTITY_CLASS = SqlaLog
 
+    def from_dbmodel(self, dbmodel) -> SqlaLog:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def delete(self, log_id):
         """
         Remove a Log entry from the collection with the given id

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -310,6 +310,10 @@ class SqlaNodeCollection(BackendNodeCollection):
 
     ENTITY_CLASS = SqlaNode
 
+    def from_dbmodel(self, dbmodel) -> SqlaNode:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def get(self, pk):
         session = self.backend.get_session()
 

--- a/aiida/orm/implementation/sqlalchemy/users.py
+++ b/aiida/orm/implementation/sqlalchemy/users.py
@@ -66,6 +66,10 @@ class SqlaUserCollection(BackendUserCollection):
 
     ENTITY_CLASS = SqlaUser
 
+    def from_dbmodel(self, dbmodel) -> SqlaUser:
+        """Create an entity from the SQLA ORM model"""
+        return self.ENTITY_CLASS.from_dbmodel(dbmodel, self.backend)
+
     def create(self, email, first_name='', last_name='', institution=''):  # pylint: disable=arguments-differ
         """
         Create a user with the provided email address


### PR DESCRIPTION
These methods are implementation details of the `PsqlDosBackend`,
and not accessed by the "front-end" ORM,
thus should not be required by other backend implementations.