### PR TITLE
Docs: minor fixes in migration docstrings

### DIFF
--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -45,7 +45,7 @@ echo "Invoking verdi via `python -m aiida`"
 OUTPUT=$(python -m aiida 2>&1)
 RETVAL=$?
 echo $OUTPUT
-if [ $RETVAT -ne 0 ]; then
+if [ $RETVAL -ne 0 ]; then
     echo "'python -m aiida' exitted with code $RETVAL"
     exit 2
 fi

--- a/aiida/backends/sqlalchemy/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,no-member
 """Move trajectory symbols from repository array to attribute
 
-Note, this is similar to the django migration django_0025
+Note, this is similar to the django migration django_0026
 
 Revision ID: 12536798d4d3
 Revises: 37f3d4882837

--- a/aiida/backends/sqlalchemy/migrations/versions/1830c8430131_drop_node_columns_nodeversion_public.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/1830c8430131_drop_node_columns_nodeversion_public.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,no-member
 """Drop `db_dbnode.nodeversion` and `db_dbnode.public`
 
-This is similar to migration django_0033
+This is similar to migration django_0034
 
 Revision ID: 1830c8430131
 Revises: 1b8ed3425af9

--- a/aiida/backends/sqlalchemy/migrations/versions/5ddd24e52864_dbnode_type_to_dbnode_node_type.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/5ddd24e52864_dbnode_type_to_dbnode_node_type.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,no-member
 """Rename `db_dbnode.type` to `db_dbnode.node_type`
 
-This is identical to migration django_0029
+This is identical to migration django_0030
 
 Revision ID: 5ddd24e52864
 Revises: d254fdfed416

--- a/aiida/backends/sqlalchemy/migrations/versions/61fc0913fae9_remove_node_prefix.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/61fc0913fae9_remove_node_prefix.py
@@ -12,7 +12,7 @@
 
 Final data migration for `Nodes` after `aiida.orm.nodes` reorganization was finalized to remove the `node.` prefix
 
-Note, this is identical to the django_0027 migration.
+Note, this is identical to the django_0028 migration.
 
 Revision ID: 61fc0913fae9
 Revises: ce56d84bcc35

--- a/aiida/backends/sqlalchemy/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,no-member
 """Delete trajectory symbols array from the repository and the reference in the attributes
 
-Note, this is similar to the django migration django_0026
+Note, this is similar to the django migration django_0027
 
 Revision ID: ce56d84bcc35
 Revises: 12536798d4d3

--- a/aiida/backends/sqlalchemy/migrations/versions/d254fdfed416_rename_parameter_data_to_dict.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/d254fdfed416_rename_parameter_data_to_dict.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,no-member
 """Rename `db_dbnode.type` values `data.parameter.ParameterData.` to `data.dict.Dict.`
 
-Note this is identical to migration django_0028
+Note this is identical to migration django_0029
 
 Revision ID: d254fdfed416
 Revises: 61fc0913fae9


### PR DESCRIPTION
Some of the SqlAlchemy migrations referenced the incorrect analog Django
revisions, which could cause confusion.

Also corrects a small typo in the recently added changes to the bash
script `.github/workflows/verdi.sh` used in the test workflows.