### PR TITLE
🔧 MAINTAIN: Pin itsdangerous

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ rest = [
     "flask-cors~=3.0",
     "flask-restful~=0.3.7",
     "flask~=1.1",
+    "itsdangerous<2.1",
     "pyparsing~=2.4",
     "python-memcached~=1.59",
     "seekpath~=1.9,>=1.9.3"


### PR DESCRIPTION
`itsdangerous` just released 2.1.0, which drops `itsdangerous.json`: https://itsdangerous.palletsprojects.com/en/2.1.x/changes/#version-2-1-0
This is incompatible with flask 1.x (in the `rest` extra)

Incidentally, whilst looking at this, I noted that aiida-core actually only installs `flask<=1.1.2`, because that has no upper pins on dependencies, whereas aiida-core is incompatible with `flask>=1.1.3` because of the click/jinja upper versions it pins:
https://github.com/pallets/flask/blob/c04b0de558fe8e1ccb8edb4525d40e725ae9a24d/setup.py#L55-L59
(flask v2 is also out)

Given the `rest` code is eventually intended to be deprecated for aiida-restapi, I wouldn't be too worried though