### PR TITLE
Dependencies: put upper limit `markupsafe<2.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
     "docutils==0.15.2",
     "pygments~=2.5",
     "pydata-sphinx-theme~=0.6.3",
+    "markupsafe<2.1",
     "sphinx~=3.2.1",
     "sphinxcontrib-details-directive~=0.1.0",
     "sphinx-panels~=0.5.0",


### PR DESCRIPTION
Fixes #5367 

The latest release `markupsafe==2.1` breaks `jinja<3.0` and that in
turn breaks `sphinx<4.0`. Upgrading to `sphinx~=4.0` brings its own
problems with a whole host of new warnings that cannot be easily fixed
and so instead we are putting an upper limit on `markupsafe`.