### PR TITLE
Move `aiida.cmdline.utils.common.get_database_summary` to storage backend

### DIFF
--- a/aiida/cmdline/commands/cmd_archive.py
+++ b/aiida/cmdline/commands/cmd_archive.py
@@ -23,7 +23,6 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.types import GroupParamType, PathOrUrl
 from aiida.cmdline.utils import decorators, echo
-from aiida.cmdline.utils.common import get_database_summary
 from aiida.common.links import GraphTraversalRules
 from aiida.common.log import AIIDA_LOGGER
 
@@ -95,9 +94,7 @@ def inspect(archive, version, meta_data, database):
         echo.echo('-------------------')
         with spinner():
             with archive_format.open(archive, 'r') as archive_reader:
-                data = get_database_summary(archive_reader.querybuilder, True)
-                repo = archive_reader.get_backend().get_repository()
-                data['Repo Files'] = {'count': sum(1 for _ in repo.list_objects())}
+                data = archive_reader.get_backend().get_info(statistics=True)
         echo.echo_dictionary(data, sort_keys=False, fmt='yaml')
 
 

--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -92,17 +92,13 @@ def storage_integrity():
 @click.option('--statistics', is_flag=True, help='Provides more in-detail statistically relevant data.')
 def storage_info(statistics):
     """Summarise the contents of the storage."""
-    from aiida.cmdline.utils.common import get_database_summary
     from aiida.manage.manager import get_manager
-    from aiida.orm import QueryBuilder
 
     manager = get_manager()
     storage = manager.get_profile_storage()
 
     with spinner():
         data = storage.get_info(statistics=statistics)
-        data.setdefault('database', {})
-        data['database']['summary'] = get_database_summary(QueryBuilder, statistics)
 
     echo.echo_dictionary(data, sort_keys=False, fmt='yaml')
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -11,7 +11,7 @@
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from tabulate import tabulate
 
@@ -528,55 +528,3 @@ def check_worker_load(active_slots):
             echo.echo_report(f'Using {percent_load * 100:.0f}%% of the available daemon worker slots.')
     else:
         echo.echo_report('No active daemon workers.')
-
-
-def get_database_summary(querybuilder: Callable, verbose: bool) -> dict:
-    """Generate a summary of the database."""
-    from aiida.orm import Comment, Computer, Group, Log, Node, User
-
-    data = {}
-
-    # User
-    query_user = querybuilder().append(User, project=['email'])
-    data['Users'] = {'count': query_user.count()}
-    if verbose:
-        data['Users']['emails'] = sorted({email for email, in query_user.iterall() if email is not None})
-
-    # Computer
-    query_comp = querybuilder().append(Computer, project=['label'])
-    data['Computers'] = {'count': query_comp.count()}
-    if verbose:
-        data['Computers']['labels'] = sorted({comp for comp, in query_comp.iterall() if comp is not None})
-
-    # Node
-    count = querybuilder().append(Node).count()
-    data['Nodes'] = {'count': count}
-    if verbose:
-        node_types = sorted({
-            typ for typ, in querybuilder().append(Node, project=['node_type']).iterall() if typ is not None
-        })
-        data['Nodes']['node_types'] = node_types
-        process_types = sorted({
-            typ for typ, in querybuilder().append(Node, project=['process_type']).iterall() if typ is not None
-        })
-        data['Nodes']['process_types'] = [p for p in process_types if p]
-
-    # Group
-    query_group = querybuilder().append(Group, project=['type_string'])
-    data['Groups'] = {'count': query_group.count()}
-    if verbose:
-        data['Groups']['type_strings'] = sorted({typ for typ, in query_group.iterall() if typ is not None})
-
-    # Comment
-    count = querybuilder().append(Comment).count()
-    data['Comments'] = {'count': count}
-
-    # Log
-    count = querybuilder().append(Log).count()
-    data['Logs'] = {'count': count}
-
-    # Links
-    count = querybuilder().append(entity_type='link').count()
-    data['Links'] = {'count': count}
-
-    return data

--- a/aiida/storage/psql_dos/backend.py
+++ b/aiida/storage/psql_dos/backend.py
@@ -398,9 +398,6 @@ class PsqlDosBackend(StorageBackend):  # pylint: disable=too-many-public-methods
         return keyset_repository - keyset_database
 
     def get_info(self, statistics: bool = False) -> dict:
-        repository = self.get_repository()
-        output_dict = {
-            'database': {},
-            'repository': repository.get_info(statistics),
-        }
-        return output_dict
+        results = super().get_info(statistics=statistics)
+        results['repository'] = self.get_repository().get_info(statistics)
+        return results

--- a/aiida/tools/archive/implementations/sqlite/backend.py
+++ b/aiida/tools/archive/implementations/sqlite/backend.py
@@ -202,7 +202,7 @@ class ZipfileBackendRepository(AbstractRepositoryBackend):
         raise NotImplementedError
 
     def get_info(self, statistics: bool = False, **kwargs) -> dict:
-        raise NotImplementedError
+        return {'objects': {'count': len(list(self.list_objects()))}}
 
 
 class ArchiveBackendQueryBuilder(SqlaQueryBuilder):
@@ -380,7 +380,9 @@ class ArchiveReadOnlyBackend(StorageBackend):  # pylint: disable=too-many-public
         raise NotImplementedError
 
     def get_info(self, statistics: bool = False) -> dict:
-        raise NotImplementedError
+        results = super().get_info(statistics=statistics)
+        results['repository'] = self.get_repository().get_info(statistics)
+        return results
 
 
 def create_backend_cls(base_class, model_cls):

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -124,7 +124,7 @@ def test_get_info(monkeypatch):
     monkeypatch.setattr(RepoBackendClass, 'get_info', mock_get_info)
 
     storage_info_out = storage_backend.get_info()
-    assert 'database' in storage_info_out
+    assert 'entities' in storage_info_out
     assert 'repository' in storage_info_out
 
     repository_info_out = storage_info_out['repository']


### PR DESCRIPTION
Fixes #5384 

This utility was used in `verdi archive inspect` and `verdi storage info`
to give information about the contents of an archive or normal storage
backend. Historically, a distinction used to be made between the contents
of the database and the repository, but in v2.0 these are unified by the
storage backend. The information about the repository is already
retrieved through `StorageBackend.get_info` but the contents of the
database were still built through the `get_database_summary` function.

The implementation is moved to the `get_orm_entity_overview` method of
the `StorageBackend` base class. This is done because the implementation
is currently still independent of the storage backend implementation. So
for now the implementations can simply call to this method in their
`get_info` implementation, but it leaves the option to override it with
a more performant implementation that doesn't go through the shared ORM
of AiiDA.