### PR TITLE
fix: verdi data trajectory show

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -90,7 +90,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
-      run: sudo apt update && sudo apt install postgresql graphviz jmol xcrysden
+      run: sudo apt update && sudo apt install postgresql graphviz
 
     - name: Upgrade pip and setuptools
       # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -90,7 +90,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
-      run: sudo apt update && sudo apt install postgresql graphviz
+      run: sudo apt update && sudo apt install postgresql graphviz jmol xcrysden
 
     - name: Upgrade pip and setuptools
       # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -21,9 +21,7 @@ def has_executable(exec_name):
     :return: True if executable can be found in PATH, False otherwise.
     """
     import shutil
-    if shutil.which(exec_name) is None:
-        return False
-    return True
+    return shutil.which(exec_name) is not None
 
 
 def _show_jmol(exec_name, trajectory_list, **_kwargs):

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -12,56 +12,34 @@ This allows to manage showfunctionality to all data types.
 """
 import pathlib
 
-import click
-
-from aiida.cmdline.params import options
-from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.utils import echo
 from aiida.common.exceptions import MultipleObjectsError
 
-SHOW_OPTIONS = [
-    options.TRAJECTORY_INDEX(),
-    options.WITH_ELEMENTS(),
-    click.option('-c', '--contour', type=click.FLOAT, cls=MultipleValueOption, default=None, help='Isovalues to plot'),
-    click.option(
-        '--sampling-stepsize',
-        type=click.INT,
-        default=None,
-        help='Sample positions in plot every sampling_stepsize timestep'
-    ),
-    click.option(
-        '--stepsize',
-        type=click.INT,
-        default=None,
-        help='The stepsize for the trajectory, set it higher to reduce number of points'
-    ),
-    click.option('--mintime', type=click.INT, default=None, help='The time to plot from'),
-    click.option('--maxtime', type=click.INT, default=None, help='The time to plot to'),
-    click.option('--indices', type=click.INT, cls=MultipleValueOption, default=None, help='Show only these indices'),
-    click.option(
-        '--dont-block', 'block', is_flag=True, default=True, help="Don't block interpreter when showing plot."
-    ),
-]
+
+def has_executable(exec_name):
+    """
+    :return: True if executable can be found in PATH, False otherwise.
+    """
+    import shutil
+    if shutil.which(exec_name) is None:
+        return False
+    return True
 
 
-def show_options(func):
-    for option in reversed(SHOW_OPTIONS):
-        func = option(func)
-
-    return func
-
-
-def _show_jmol(exec_name, trajectory_list, **kwargs):
+def _show_jmol(exec_name, trajectory_list, **_kwargs):
     """
     Plugin for jmol
     """
     import subprocess
     import tempfile
 
+    if not has_executable(exec_name):
+        echo.echo_critical(f"No executable '{exec_name}' found. Add to the path, or try with an absolute path.")
+
     # pylint: disable=protected-access
     with tempfile.NamedTemporaryFile(mode='w+b') as handle:
         for trajectory in trajectory_list:
-            handle.write(trajectory._exportcontent('cif', **kwargs)[0])
+            handle.write(trajectory._exportcontent('cif')[0])
         handle.flush()
 
         try:
@@ -69,27 +47,26 @@ def _show_jmol(exec_name, trajectory_list, **kwargs):
         except subprocess.CalledProcessError:
             # The program died: just print a message
             echo.echo_error(f'the call to {exec_name} ended with an error.')
-        except OSError as err:
-            if err.errno == 2:
-                echo.echo_critical(f"No executable '{exec_name}' found. Add to the path, or try with an absolute path.")
-            else:
-                raise
 
 
-def _show_xcrysden(exec_name, object_list, **kwargs):
+def _show_xcrysden(exec_name, trajectory_list, **_kwargs):
     """
     Plugin for xcrysden
     """
     import subprocess
     import tempfile
 
-    if len(object_list) > 1:
+    if len(trajectory_list) > 1:
         raise MultipleObjectsError('Visualization of multiple trajectories is not implemented')
-    obj = object_list[0]
+    obj = trajectory_list[0]
+
+    if not has_executable(exec_name):
+        echo.echo_critical(f"No executable '{exec_name}' found.")
 
     # pylint: disable=protected-access
     with tempfile.NamedTemporaryFile(mode='w+b', suffix='.xsf') as tmpf:
-        tmpf.write(obj._exportcontent('xsf', **kwargs)[0])
+
+        tmpf.write(obj._exportcontent('xsf')[0])
         tmpf.flush()
 
         try:
@@ -97,11 +74,6 @@ def _show_xcrysden(exec_name, object_list, **kwargs):
         except subprocess.CalledProcessError:
             # The program died: just print a message
             echo.echo_error(f'the call to {exec_name} ended with an error.')
-        except OSError as err:
-            if err.errno == 2:
-                echo.echo_critical(f"No executable '{exec_name}' found. Add to the path, or try with an absolute path.")
-            else:
-                raise
 
 
 # pylint: disable=unused-argument

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -14,7 +14,6 @@ import click
 from aiida.cmdline.commands.cmd_data import cmd_show, verdi_data
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_options
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
-from aiida.cmdline.commands.cmd_data.cmd_show import show_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
 
@@ -66,16 +65,38 @@ def trajectory_list(raw, past_days, groups, all_users):
 @trajectory.command('show')
 @arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:core.array.trajectory',)))
 @options.VISUALIZATION_FORMAT(type=click.Choice(VISUALIZATION_FORMATS), default='jmol')
-@show_options
+@options.TRAJECTORY_INDEX()
+@options.WITH_ELEMENTS()
+@click.option(
+    '-c', '--contour', type=click.FLOAT, cls=options.MultipleValueOption, default=None, help='Isovalues to plot'
+)
+@click.option(
+    '--sampling-stepsize',
+    type=click.INT,
+    default=None,
+    help='Sample positions in plot every sampling_stepsize timestep'
+)
+@click.option(
+    '--stepsize',
+    type=click.INT,
+    default=None,
+    help='The stepsize for the trajectory, set it higher to reduce number of points'
+)
+@click.option('--mintime', type=click.INT, default=None, help='The time to plot from')
+@click.option('--maxtime', type=click.INT, default=None, help='The time to plot to')
+@click.option(
+    '--indices', type=click.INT, cls=options.MultipleValueOption, default=None, help='Show only these indices'
+)
+@click.option('--dont-block', 'block', is_flag=True, default=True, help="Don't block interpreter when showing plot.")
 @decorators.with_dbenv()
-def trajectory_show(data, fmt):
+def trajectory_show(data, fmt, **kwargs):
     """Visualize a trajectory."""
     try:
         show_function = getattr(cmd_show, f'_show_{fmt}')
     except AttributeError:
         echo.echo_critical(f'visualization format {fmt} is not supported')
 
-    show_function(fmt, data)
+    show_function(exec_name=fmt, trajectory_list=data, **kwargs)
 
 
 @trajectory.command('export')

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -652,8 +652,6 @@ class TrajectoryData(ArrayData):
             from ase.data.colors import cpk_colors as colors
         else:
             raise ValueError(f'Unknown color spec {colors}')
-        if kwargs:
-            raise ValueError(f'Unrecognized keyword {kwargs.keys()}')
 
         if element_list is None:
             # If not all elements are allowed
@@ -703,12 +701,8 @@ class TrajectoryData(ArrayData):
             from mayavi import mlab
         except ImportError:
             raise ImportError(
-                'Unable to import the mayavi package, that is required to'
-                'use the plotting feature you requested. '
-                'Please install it first and then call this command again '
-                '(note that the installation of mayavi is quite complicated '
-                'and requires that you already installed the python numpy '
-                'package, as well as the vtk package'
+                'The plotting feature you requested requires the mayavi package.'
+                'Try `pip install mayavi` or consult the documentation.'
             )
         from ase.data import atomic_numbers
         from ase.data.colors import jmol_colors
@@ -847,7 +841,7 @@ def plot_positions_XYZ(  # pylint: disable=too-many-arguments,too-many-locals,in
         dont_block=False,
         mintime=None,
         maxtime=None,
-        label_sparsity=10):
+        n_labels=10):
     """
     Plot with matplotlib the positions of the coordinates of the atoms
     over time for a trajectory
@@ -862,14 +856,14 @@ def plot_positions_XYZ(  # pylint: disable=too-many-arguments,too-many-locals,in
     :param dont_block: passed to plt.show() as ``block=not dont_block``
     :param mintime: if specified, cut the time axis at the specified min value
     :param maxtime: if specified, cut the time axis at the specified max value
-    :param label_sparsity: how often to put a label with the pair (t, coord)
+    :param n_labels: how many labels (t, coord) to put
     """
     from matplotlib import pyplot as plt
     from matplotlib.gridspec import GridSpec
     import numpy as np
 
     tlim = [times[0], times[-1]]
-    index_range = [0, len(times)]
+    index_range = [0, len(times) - 1]
     if mintime is not None:
         tlim[0] = mintime
         index_range[0] = np.argmax(times > mintime)
@@ -896,7 +890,8 @@ def plot_positions_XYZ(  # pylint: disable=too-many-arguments,too-many-locals,in
     plt.ylabel(r'Z Position $\left[{}\right]$'.format(positions_unit))
     plt.xlabel(f'Time [{times_unit}]')
     plt.xlim(*tlim)
-    sparse_indices = np.linspace(*index_range, num=label_sparsity, dtype=int)
+    n_labels = np.minimum(n_labels, len(times))  # don't need more labels than times
+    sparse_indices = np.linspace(*index_range, num=n_labels, dtype=int)
 
     for index, traj in enumerate(trajectories):
         if index not in indices_to_show:

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -528,7 +528,8 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.data_export_test(TrajectoryData, pks, new_supported_formats, output_flag, tmp_path)
 
     @pytest.mark.parametrize(
-        'fmt', (
+        'fmt',
+        (
             pytest.param(
                 'jmol', marks=pytest.mark.skipif(not cmd_show.has_executable('jmol'), reason='No jmol executable.')
             ),
@@ -545,7 +546,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_trajectoryshow(self, fmt, monkeypatch):
         """Test showing the trajectory data in different formats"""
-        # from matplotlib import pyplot
+        from matplotlib import pyplot
 
 
 # @pytest.mark.usefixtures('aiida_profile_clean')

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -542,20 +542,19 @@ def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
     def mock_pyplot_show(*_args, **_kwargs):
         pass
 
-    trajectory_pk = TestVerdiDataTrajectory.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
-    options = ['--format', fmt, str(trajectory_pk), '--dont-block']
+    # trajectory_pk = TestVerdiDataTrajectory.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
+    # options = ['--format', fmt, str(trajectory_pk), '--dont-block']
 
-    with monkeypatch.context() as ctx:
-        # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-        ctx.setattr(pyplot, 'show', mock_pyplot_show)
+    # with monkeypatch.context() as ctx:
+    #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
+    #     ctx.setattr(pyplot, 'show', mock_pyplot_show)
 
-        # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
-        # but not the actual commands through a sub process. Since it concerns a stdlib module, the patching is doing
-        # inside a context to prevent other parts of the test.
-        ctx.setattr(sp, 'check_output', mock_check_output)
+    #     # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
+    #     # but not the actual commands through a sub process. Since it concerns a stdlib module, the patching is doing
+    #     # inside a context to prevent other parts of the test.
+    #     ctx.setattr(sp, 'check_output', mock_check_output)
 
-        # run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
-
+    #     # run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -521,7 +521,17 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
     def test_trajectoryshow(self, fmt, monkeypatch):
         """Test showing the trajectory data in different formats"""
-        print(fmt)
+        from matplotlib import pyplot
+
+        if fmt == 'mpl_heatmap':
+            try:
+                import mayavi  # pylint: disable=unused-import
+            except ImportError:
+                pytest.skip('`mayavi` not importable')
+
+        if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
+            pytest.skip(f'Executable `{fmt}` not found on the system.')
+
 
 # @pytest.mark.usefixtures('aiida_profile_clean')
 # # @pytest.mark.parametrize('fmt', ['mpl_pos'])

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -536,12 +536,15 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             assert isinstance(options, list)
             assert options[0] == fmt
 
+        def mock_pyplot_show(*_args, **_kwargs):
+            pass
+
         # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
         # but not the actual commands through a sub process.
         monkeypatch.setattr(sp, 'check_output', mock_check_output)
 
         # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-        monkeypatch.setattr(pyplot, 'show', lambda *args, **kwargs: None)
+        monkeypatch.setattr(pyplot, 'show', mock_pyplot_show)
 
         options = ['--format', fmt, str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
         run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -443,9 +443,13 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     """Test verdi data core.trajectory."""
 
     @pytest.fixture(autouse=True)
-    def init_profile(self, run_cli_command):  # pylint: disable=unused-argument
+    def init_profile(self, aiida_profile_clean, aiida_localhost, run_cli_command):  # pylint: disable=unused-argument
         """Initialize the profile."""
         # pylint: disable=attribute-defined-outside-init
+        self.comp = aiida_localhost
+        self.this_folder = os.path.dirname(__file__)
+        self.this_file = os.path.basename(__file__)
+        self.pks = self.create_trajectory_data()
         self.cli_runner = run_cli_command
 
     @staticmethod
@@ -509,25 +513,19 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.pk
         }
 
-    @pytest.mark.usefixtures('aiida_profile')
-    def test_showhelp(self, run_cli_command):
-        res = run_cli_command(cmd_trajectory.trajectory_show, ['--help'])
+    def test_showhelp(self):
+        res = self.cli_runner(cmd_trajectory.trajectory_show, ['--help'])
         assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output' \
-            ' of verdi data trajectory show --help'
+            ' of verdi data trajecotry show --help'
 
-    @pytest.mark.usefixtures('aiida_profile_clean')
     def test_list(self):
-        pks = self.create_trajectory_data()
-        self.data_listing_test(TrajectoryData, str(pks[DummyVerdiDataListable.NODE_ID_STR]), pks)
+        self.data_listing_test(TrajectoryData, str(self.pks[DummyVerdiDataListable.NODE_ID_STR]), self.pks)
 
     @pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
     @pytest.mark.parametrize('output_flag', ['-o', '--output'])
-    @pytest.mark.usefixtures('aiida_profile_clean')
     def test_export(self, output_flag, tmp_path):
-        """Test the export functionality."""
-        pks = self.create_trajectory_data()
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
-        self.data_export_test(TrajectoryData, pks, new_supported_formats, output_flag, tmp_path)
+        self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
 
     @pytest.mark.parametrize(
         'fmt', (
@@ -543,10 +541,9 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             ), pytest.param('mpl_pos')
         )
     )
-    @pytest.mark.usefixtures('aiida_profile_clean')
     def test_trajectoryshow(self, fmt, monkeypatch, run_cli_command):
         """Test showing the trajectory data in different formats"""
-        trajectory_pk = self.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
+        trajectory_pk = self.pks[DummyVerdiDataListable.NODE_ID_STR]
         options = ['--format', fmt, str(trajectory_pk), '--dont-block']
 
         def mock_check_output(options):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -559,10 +559,9 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             # these specific formats, because ``matplotlib`` used in the others _also_ calls ``subprocess.check_output``
             monkeypatch.setattr(sp, 'check_output', mock_check_output)
 
-        # if fmt in ['mpl_pos', 'mpl_heatmap']:
-        #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-        #     import matplotlib.pyplot
-        #     monkeypatch.setattr(matplotlib.pyplot, 'show', lambda *args, **kwargs: None)
+        if fmt in ['mpl_pos']:
+            from aiida.orm.nodes.data.array import trajectory
+            monkeypatch.setattr(trajectory, 'plot_positions_XYZ', lambda *args, **kwargs: None)
 
         run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -518,36 +518,36 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
         self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
 
-    @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
-    def test_trajectoryshow(self, fmt, monkeypatch, run_cli_command):
-        """Test showing the trajectory data in different formats"""
-        from matplotlib import pyplot
+    # @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+    # def test_trajectoryshow(self, fmt, monkeypatch, run_cli_command):
+    #     """Test showing the trajectory data in different formats"""
+    #     from matplotlib import pyplot
 
-        if fmt == 'mpl_heatmap':
-            try:
-                import mayavi  # pylint: disable=unused-import
-            except ImportError:
-                pytest.skip('`mayavi` not importable')
+    #     if fmt == 'mpl_heatmap':
+    #         try:
+    #             import mayavi  # pylint: disable=unused-import
+    #         except ImportError:
+    #             pytest.skip('`mayavi` not importable')
 
-        if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
-            pytest.skip(f'Executable `{fmt}` not found on the system.')
+    #     if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
+    #         pytest.skip(f'Executable `{fmt}` not found on the system.')
 
-        def mock_check_output(options):
-            assert isinstance(options, list)
-            assert options[0] == fmt
+    #     def mock_check_output(options):
+    #         assert isinstance(options, list)
+    #         assert options[0] == fmt
 
-        def mock_pyplot_show(*_args, **_kwargs):
-            pass
+    #     def mock_pyplot_show(*_args, **_kwargs):
+    #         pass
 
-        # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
-        # but not the actual commands through a sub process.
-        monkeypatch.setattr(sp, 'check_output', mock_check_output)
+    #     # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
+    #     # but not the actual commands through a sub process.
+    #     monkeypatch.setattr(sp, 'check_output', mock_check_output)
 
-        # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-        monkeypatch.setattr(pyplot, 'show', mock_pyplot_show)
+    #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
+    #     monkeypatch.setattr(pyplot, 'show', mock_pyplot_show)
 
-        options = ['--format', fmt, str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
-        run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
+    #     options = ['--format', fmt, str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
+    #     run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -518,36 +518,38 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
         self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
 
-    # @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
-    # def test_trajectoryshow(self, fmt, monkeypatch, run_cli_command):
-    #     """Test showing the trajectory data in different formats"""
-    #     from matplotlib import pyplot
 
-    #     if fmt == 'mpl_heatmap':
-    #         try:
-    #             import mayavi  # pylint: disable=unused-import
-    #         except ImportError:
-    #             pytest.skip('`mayavi` not importable')
+@pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
+    """Test showing the trajectory data in different formats"""
+    from matplotlib import pyplot
 
-    #     if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
-    #         pytest.skip(f'Executable `{fmt}` not found on the system.')
+    if fmt == 'mpl_heatmap':
+        try:
+            import mayavi  # pylint: disable=unused-import
+        except ImportError:
+            pytest.skip('`mayavi` not importable')
 
-    #     def mock_check_output(options):
-    #         assert isinstance(options, list)
-    #         assert options[0] == fmt
+    if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
+        pytest.skip(f'Executable `{fmt}` not found on the system.')
 
-    #     def mock_pyplot_show(*_args, **_kwargs):
-    #         pass
+    def mock_check_output(options):
+        assert isinstance(options, list)
+        assert options[0] == fmt
 
-    #     # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
-    #     # but not the actual commands through a sub process.
-    #     monkeypatch.setattr(sp, 'check_output', mock_check_output)
+    def mock_pyplot_show(*_args, **_kwargs):
+        pass
 
-    #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-    #     monkeypatch.setattr(pyplot, 'show', mock_pyplot_show)
+    # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
+    # but not the actual commands through a sub process.
+    monkeypatch.setattr(sp, 'check_output', mock_check_output)
 
-    #     options = ['--format', fmt, str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
-    #     run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
+    # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
+    monkeypatch.setattr(pyplot, 'show', mock_pyplot_show)
+
+    trajectory_pk = TestVerdiDataTrajectory.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
+    options = ['--format', fmt, str(trajectory_pk)]
+    run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -520,12 +520,10 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-@pytest.mark.parametrize('fmt', ['mpl_pos'])
-# @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+# @pytest.mark.parametrize('fmt', ['mpl_pos'])
+@pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
 def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
     """Test showing the trajectory data in different formats"""
-    import gc
-
     from matplotlib import pyplot
 
     if fmt == 'mpl_heatmap':
@@ -556,9 +554,8 @@ def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
         # inside a context to prevent other parts of the test.
         ctx.setattr(sp, 'check_output', mock_check_output)
 
-        run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
+        # run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 
-    gc.collect()
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -520,7 +520,8 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-@pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+@pytest.mark.parametrize('fmt', ['jmol'])
+# @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
 def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
     """Test showing the trajectory data in different formats"""
     import gc

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -520,7 +520,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-@pytest.mark.parametrize('fmt', ['jmol'])
+@pytest.mark.parametrize('fmt', ['mpl_pos'])
 # @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
 def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
     """Test showing the trajectory data in different formats"""

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -518,6 +518,10 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
         self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
 
+    @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+    def test_trajectoryshow(self, fmt, monkeypatch):
+        """Test showing the trajectory data in different formats"""
+        print(fmt)
 
 # @pytest.mark.usefixtures('aiida_profile_clean')
 # # @pytest.mark.parametrize('fmt', ['mpl_pos'])

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -536,15 +536,16 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
                 'xcrysden',
                 marks=pytest.mark.skipif(not cmd_show.has_executable('xcrysden'), reason='No xcrysden executable.')
             ),
-            pytest.param(
-                'mpl_heatmap', marks=pytest.mark.skipif(not has_mayavi(), reason='Package `mayavi` not installed.')
-            ), pytest.param('mpl_pos')
+            # pytest.param(
+            #     'mpl_heatmap', marks=pytest.mark.skipif(not has_mayavi(), reason='Package `mayavi` not installed.')
+            # ),
+            pytest.param('mpl_pos')
         )
     )
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_trajectoryshow(self, fmt, monkeypatch):
         """Test showing the trajectory data in different formats"""
-        from matplotlib import pyplot
+        # from matplotlib import pyplot
 
 
 # @pytest.mark.usefixtures('aiida_profile_clean')

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -519,42 +519,42 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
 
 
-@pytest.mark.usefixtures('aiida_profile_clean')
-# @pytest.mark.parametrize('fmt', ['mpl_pos'])
-@pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
-def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
-    """Test showing the trajectory data in different formats"""
-    from matplotlib import pyplot
+# @pytest.mark.usefixtures('aiida_profile_clean')
+# # @pytest.mark.parametrize('fmt', ['mpl_pos'])
+# @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+# def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
+#     """Test showing the trajectory data in different formats"""
+#     from matplotlib import pyplot
 
-    if fmt == 'mpl_heatmap':
-        try:
-            import mayavi  # pylint: disable=unused-import
-        except ImportError:
-            pytest.skip('`mayavi` not importable')
+#     if fmt == 'mpl_heatmap':
+#         try:
+#             import mayavi  # pylint: disable=unused-import
+#         except ImportError:
+#             pytest.skip('`mayavi` not importable')
 
-    if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
-        pytest.skip(f'Executable `{fmt}` not found on the system.')
+#     if fmt in ['jmol', 'xcrysden'] and not cmd_show.has_executable(fmt):
+#         pytest.skip(f'Executable `{fmt}` not found on the system.')
 
-    def mock_check_output(options):
-        assert isinstance(options, list)
-        assert options[0] == fmt
+#     def mock_check_output(options):
+#         assert isinstance(options, list)
+#         assert options[0] == fmt
 
-    def mock_pyplot_show(*_args, **_kwargs):
-        pass
+#     def mock_pyplot_show(*_args, **_kwargs):
+#         pass
 
-    # trajectory_pk = TestVerdiDataTrajectory.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
-    # options = ['--format', fmt, str(trajectory_pk), '--dont-block']
+#     # trajectory_pk = TestVerdiDataTrajectory.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
+#     # options = ['--format', fmt, str(trajectory_pk), '--dont-block']
 
-    # with monkeypatch.context() as ctx:
-    #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-    #     ctx.setattr(pyplot, 'show', mock_pyplot_show)
+#     # with monkeypatch.context() as ctx:
+#     #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
+#     #     ctx.setattr(pyplot, 'show', mock_pyplot_show)
 
-    #     # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
-    #     # but not the actual commands through a sub process. Since it concerns a stdlib module, the patching is doing
-    #     # inside a context to prevent other parts of the test.
-    #     ctx.setattr(sp, 'check_output', mock_check_output)
+#     #     # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function
+#     #     # but not the actual commands through a sub process. Since it concerns a stdlib module, the patching is doing
+#     #     # inside a context to prevent other parts of the test.
+#     #     ctx.setattr(sp, 'check_output', mock_check_output)
 
-    #     # run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
+#     #     # run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -542,7 +542,7 @@ def test_trajectoryshow(fmt, monkeypatch, run_cli_command):
         pass
 
     trajectory_pk = TestVerdiDataTrajectory.create_trajectory_data()[DummyVerdiDataListable.NODE_ID_STR]
-    options = ['--format', fmt, str(trajectory_pk)]
+    options = ['--format', fmt, str(trajectory_pk), '--dont-block']
 
     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
     # This is called by the ``_show_jmol`` and ``_show_xcrysden`` implementations. We want to test just the function

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -543,6 +543,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     )
     def test_trajectoryshow(self, fmt, monkeypatch, run_cli_command):
         """Test showing the trajectory data in different formats"""
+        from matplotlib import pyplot
         trajectory_pk = self.pks[DummyVerdiDataListable.NODE_ID_STR]
         options = ['--format', fmt, str(trajectory_pk), '--dont-block']
 

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -540,7 +540,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             pytest.param(
                 'mpl_heatmap', marks=pytest.mark.skipif(not has_mayavi(), reason='Package `mayavi` not installed.')
             ),
-            # pytest.param('mpl_pos')
+            pytest.param('mpl_pos')
         )
     )
     @pytest.mark.usefixtures('aiida_profile_clean')

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -26,6 +26,7 @@ from aiida.cmdline.commands.cmd_data import (
     cmd_cif,
     cmd_dict,
     cmd_remote,
+    cmd_show,
     cmd_singlefile,
     cmd_structure,
     cmd_trajectory,
@@ -506,7 +507,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_showhelp(self):
         res = self.cli_runner(cmd_trajectory.trajectory_show, ['--help'])
         assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output' \
-            ' of verdi data trajecotry show --help'
+            ' of verdi data trajectory show --help'
 
     def test_list(self):
         self.data_listing_test(TrajectoryData, str(self.pks[DummyVerdiDataListable.NODE_ID_STR]), self.pks)
@@ -516,6 +517,15 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_export(self, output_flag, tmp_path):
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
         self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
+
+    @pytest.mark.parametrize('fmt', cmd_trajectory.VISUALIZATION_FORMATS)
+    def test_trajectoryshow(self, fmt):
+        """Test showing the trajectory data in different formats"""
+        if fmt in ['xcrysden', 'jmol'] and not cmd_show.has_executable(fmt):
+            pytest.skip()
+        options = ['--format', fmt, str(self.ids[DummyVerdiDataListable.NODE_ID_STR])]
+        res = self.cli_runner(cmd_trajectory.trajectory_show, options, catch_exceptions=False)
+        assert res.exit_code == 0
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -559,10 +559,10 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             # these specific formats, because ``matplotlib`` used in the others _also_ calls ``subprocess.check_output``
             monkeypatch.setattr(sp, 'check_output', mock_check_output)
 
-        if fmt in ['mpl_pos', 'mpl_heatmap']:
-            # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
-            import matplotlib.pyplot
-            monkeypatch.setattr(matplotlib.pyplot, 'show', lambda *args, **kwargs: None)
+        # if fmt in ['mpl_pos', 'mpl_heatmap']:
+        #     # This will be called by ``_show_mpl_pos`` which will actually open a window, causing the tests to hang.
+        #     import matplotlib.pyplot
+        #     monkeypatch.setattr(matplotlib.pyplot, 'show', lambda *args, **kwargs: None)
 
         run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 


### PR DESCRIPTION
fix #2435

The `verdi data trajectory show` command was broken at least since
dc7cdd0443ba18b13775fa84cd3391caa4d7af71 (Jul 2018).

The fact that most of its formats rely on external programs makes
it somewhat tedious to test.