### PR TITLE
fix: better error message when flask not installed

### DIFF
--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -56,11 +56,17 @@ def restapi(hostname, port, config_dir, debug, wsgi_profile, posting):
     from aiida.restapi.run_api import run_api
 
     # Invoke the runner
-    run_api(
-        hostname=hostname,
-        port=port,
-        config=config_dir,
-        debug=debug,
-        wsgi_profile=wsgi_profile,
-        posting=posting,
-    )
+    try:
+        run_api(
+            hostname=hostname,
+            port=port,
+            config=config_dir,
+            debug=debug,
+            wsgi_profile=wsgi_profile,
+            posting=posting,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            'Failed to import modules required for the REST API. '
+            'You may need to install the `rest` extra, e.g. via `pip install aiida-core[rest]`.'
+        ) from exc


### PR DESCRIPTION
fix #1393

The dependencies for the AiiDA REST API are currently not installed by
default - only when users request the `rest` extra.

When users were starting the REST API without installing the extra, they
were greeted by an unhelpful/unexpected error message

	ModuleNotFoundError: No module named 'flask_restful'

Here we catch ImportErrors upon starting the REST API and provide an
error message that includes instructions on how to remedy the situation.
For cases where the ImportError has another cause, the original
exception is carried along as well.