### PR TITLE
👌 IMPROVE: Hide `verdi database`

### DIFF
--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -17,7 +17,7 @@ from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators
 
 
-@verdi.group('database')
+@verdi.group('database', hidden=True)
 def verdi_database():
     """Inspect and manage the database.
 


### PR DESCRIPTION
This commit hides the (deprecated) `database` command group,
when using `verdi --help`.