### PR TITLE
🐛 FIX: Ensure removal of "dangling" entity rows

### DIFF
--- a/tests/orm/test_comments.py
+++ b/tests/orm/test_comments.py
@@ -14,6 +14,7 @@ import pytest
 from aiida import orm
 from aiida.common import exceptions
 from aiida.orm.comments import Comment
+from aiida.tools.graph.deletions import delete_nodes
 
 
 class TestComment:
@@ -194,3 +195,11 @@ class TestComment:
         comment = node.add_comment('Check out the comment on _this_ one')
         gotten_comment = Comment.objects.get(id=comment.id)
         assert isinstance(gotten_comment, Comment)
+
+    def test_delete_node_with_comments(self):
+        """Test deleting a node with comments."""
+        node = orm.Data().store()
+        node.add_comment('Check out the comment on _this_ one')
+        assert len(Comment.objects.all()) == 2
+        delete_nodes([node.pk], dry_run=False)
+        assert len(Comment.objects.all()) == 1

--- a/tests/orm/test_comments.py
+++ b/tests/orm/test_comments.py
@@ -198,8 +198,6 @@ class TestComment:
 
     def test_delete_node_with_comments(self):
         """Test deleting a node with comments."""
-        node = orm.Data().store()
-        node.add_comment('Check out the comment on _this_ one')
-        assert len(Comment.objects.all()) == 2
-        delete_nodes([node.pk], dry_run=False)
         assert len(Comment.objects.all()) == 1
+        delete_nodes([self.node.pk], dry_run=False)
+        assert len(Comment.objects.all()) == 0

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -13,6 +13,7 @@ import pytest
 
 from aiida import orm
 from aiida.common import exceptions
+from aiida.tools.graph.deletions import delete_nodes
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
@@ -206,6 +207,15 @@ class TestGroups:
         with pytest.raises(exceptions.NotExistent):
             # The group does not exist anymore
             orm.Group.get(label='testgroup3')
+
+    def test_delete_node(self):
+        """Test deletion of a node that has been assigned to a group."""
+        node = orm.Data().store()
+        group = orm.Group(label='testgroup', description='some desc').store()
+        group.add_nodes(node)
+        assert len(group.nodes) == 1
+        delete_nodes([node.pk], dry_run=False)
+        assert len(group.nodes) == 0
 
     def test_rename(self):
         """Test the renaming of a Group."""


### PR DESCRIPTION
In #5396 (now fixed) it was found that, for sqlalchemy, the deletion of a computer was not removing the related `AuthInfo`, but instead converting the `dbcomputer_id` foreign key to `null`.
Subsequently, in #5379, @mbercx noted that a migration failed, due to a `db_dbgroup_dbnodes` with a `null` `dbnode_id` foreign key.

For such child entities (`db_dbauthinfo`, `db_dbgroup_dbnodes` and also `db_dbcomment`) the deletion of a parent entity, should also remove their rows, rather than leaving them dangling.
The latest PostgreSQL schema, enforces non-null values for these foreign keys.

This PR
- add two additional tests, to ensure both `db_dbgroup_dbnodes` and `db_dbcomment` entries are indeed removed, when removing a node
- Removes any dangling entities, when  migrating from a legacy sqlalchemy database.