### PR TITLE
🧪 CI: Also run nightly on PRs with relevant changes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,10 @@ name: nightly
 on:
     schedule:
     -   cron: '0 0 * * *'  # Run every day at midnight
+    pull_request:
+        paths:
+        - 'aiida/storage/psql_dos/migrations/**'
+        - 'tests/storage/psql_dos/migrations/**'
 
 jobs:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,7 @@ on:
     -   cron: '0 0 * * *'  # Run every day at midnight
     pull_request:
         paths:
+        - '.github/workflows/nightly.yml'
         - 'aiida/storage/psql_dos/migrations/**'
         - 'tests/storage/psql_dos/migrations/**'
 


### PR DESCRIPTION
I think it may also be a good idea to trigger the nightly run on PRs that have changes relevant to these tests, e.g. the legacy migration tests