### PR TITLE
`ProfileManager`: always clear storage in `clear_profile`

### DIFF
--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -163,8 +163,7 @@ class ProfileManager:
     def clear_profile():
         """Reset the global profile, clearing all its data and closing any open resources."""
         manager = get_manager()
-        if manager.profile_storage_loaded:
-            manager.get_profile_storage()._clear(recreate_user=True)  # pylint: disable=protected-access
+        manager.get_profile_storage()._clear(recreate_user=True)  # pylint: disable=protected-access
         manager.reset_profile()
         manager.get_profile_storage()  # reload the storage connection
 


### PR DESCRIPTION
The call to `_clear` on the storage in `ProfileManager.clear_profile`
was conditional on it already having been loaded. However, sometimes the
method may be called before the storage had already been loaded. This is
the case, for example, for the `aiida_profile_clean` fixture, which is
used by tests to start with an empty storage. Due to the conditional, in
some cases the storage would not be emptied and the test would fail if
the storage still contained data from a previous session.