### PR TITLE
`Config`: add the hidden `warnings.rabbitmq_version` option

### DIFF
--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -60,7 +60,7 @@ def verdi_status(print_traceback, no_rmq):
     from aiida.cmdline.utils.daemon import delete_stale_pid_file, get_daemon_status
     from aiida.common.utils import Capturing
     from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
-    from aiida.manage.manager import check_rabbitmq_version, get_manager
+    from aiida.manage.manager import get_manager
 
     exit_code = ExitCode.SUCCESS
 
@@ -125,7 +125,7 @@ def verdi_status(print_traceback, no_rmq):
             print_status(ServiceStatus.ERROR, 'rabbitmq', message, exception=exc, print_traceback=print_traceback)
             exit_code = ExitCode.CRITICAL
         else:
-            version, supported = check_rabbitmq_version(comm)
+            version, supported = manager.check_rabbitmq_version(comm)
             connection = f'Connected to RabbitMQ v{version} as {profile.get_rmq_url()}'
             if supported:
                 print_status(ServiceStatus.UP, 'rabbitmq', connection)

--- a/aiida/manage/configuration/schema/config-v8.schema.json
+++ b/aiida/manage/configuration/schema/config-v8.schema.json
@@ -107,6 +107,11 @@
           "description": "Whether to print a warning when a profile is loaded while a development version is installed",
           "global_only": true
         },
+        "warnings.rabbitmq_version": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to print a warning when an incompatible version of RabbitMQ is configured"
+        },
         "transport.task_retry_initial_interval": {
           "type": "integer",
           "default": 20,

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -3,11 +3,11 @@
 import pytest
 
 import aiida
-from aiida.manage.manager import check_version
+from aiida.manage.manager import get_manager
 
 
 def test_check_version_release(monkeypatch, capsys, isolated_config):
-    """Test that ``check_version`` prints nothing for a release version.
+    """Test that ``Manager.check_version`` prints nothing for a release version.
 
     If a warning is emitted, it should be printed to stdout. So even though it will go through the logging system, the
     logging configuration of AiiDA will interfere with that of pytest and the ultimately the output will simply be
@@ -19,7 +19,7 @@ def test_check_version_release(monkeypatch, capsys, isolated_config):
     # Explicitly setting the default in case the test profile has it changed.
     isolated_config.set_option('warnings.development_version', True)
 
-    check_version()
+    get_manager().check_version()
     captured = capsys.readouterr()
     assert not captured.err
     assert not captured.out
@@ -27,7 +27,7 @@ def test_check_version_release(monkeypatch, capsys, isolated_config):
 
 @pytest.mark.parametrize('suppress_warning', (True, False))
 def test_check_version_development(monkeypatch, capsys, isolated_config, suppress_warning):
-    """Test that ``check_version`` prints a warning for a post release development version.
+    """Test that ``Manager.check_version`` prints a warning for a post release development version.
 
     The warning can be suppressed by setting the option ``warnings.development_version`` to ``False``.
 
@@ -40,7 +40,7 @@ def test_check_version_development(monkeypatch, capsys, isolated_config, suppres
 
     isolated_config.set_option('warnings.development_version', not suppress_warning)
 
-    check_version()
+    get_manager().check_version()
     captured = capsys.readouterr()
     assert not captured.err
 

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -24,7 +24,7 @@ class TestConfigurationOptions:
     def test_get_option_names(self):
         """Test `get_option_names` function."""
         assert isinstance(get_option_names(), list)
-        assert len(get_option_names()) == 27
+        assert len(get_option_names()) == 28
 
     def test_get_option(self):
         """Test `get_option` function."""


### PR DESCRIPTION
Fixes #5414 

This option can be used to suppress the warning that is emitted when a
profile storage is loaded that is configured with a version of RabbitMQ
that is known to be able to cause problems. The option is hidden because
the warning is very important and should not easily be ignorable by
normal users, but it is mostly intended for developers.

The `check_rabbitmq_version` and `check_version` free functions are
moved to `Manager` as methods which allows to use `get_option` instead
of the `get_config_option` free function which is just an indirect way
of calling `Manager.get_option`.

The `is_rabbitmq_version_supported` function is also corrected. It was
still using `< parse('3.8')` as a condition whereas it should be
`< parse('3.8.15')` which was recently already changed for the
`check_rabbitmq_version` function.