### PR TITLE
♻️ REFACTOR: Storage info flag `statistics` -> `detailed`

### DIFF
--- a/aiida/cmdline/commands/cmd_archive.py
+++ b/aiida/cmdline/commands/cmd_archive.py
@@ -57,8 +57,8 @@ def archive_version(path):
 
 @verdi_archive.command('info')
 @click.argument('path', nargs=1, type=click.Path(exists=True, readable=True))
-@click.option('--statistics', is_flag=True, help='Provides more in-detail statistically relevant data.')
-def archive_info(path, statistics):
+@click.option('--detailed', is_flag=True, help='Provides more detailed information.')
+def archive_info(path, detailed):
     """Summarise the contents of an archive."""
     # note: this mirrors `cmd_storage:storage_info`
     # it is currently hardcoded to the `SqliteZipBackend`, but could be generalized in the future
@@ -71,7 +71,7 @@ def archive_info(path, statistics):
         echo.echo_critical(f'archive version incompatible: {exc}')
     with spinner():
         try:
-            data = storage.get_info(statistics=statistics)
+            data = storage.get_info(detailed=detailed)
         finally:
             storage.close()
 
@@ -96,9 +96,9 @@ def inspect(ctx, archive, version, meta_data, database):  # pylint: disable=unus
     if version:
         ctx.invoke(archive_version, path=archive)
     elif database:
-        ctx.invoke(archive_info, path=archive, statistics=True)
+        ctx.invoke(archive_info, path=archive, detailed=True)
     else:
-        ctx.invoke(archive_info, path=archive, statistics=False)
+        ctx.invoke(archive_info, path=archive, detailed=False)
 
 
 @verdi_archive.command('create')

--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -89,8 +89,8 @@ def storage_integrity():
 
 
 @verdi_storage.command('info')
-@click.option('--statistics', is_flag=True, help='Provides more in-detail statistically relevant data.')
-def storage_info(statistics):
+@click.option('--detailed', is_flag=True, help='Provides more detailed information.')
+def storage_info(detailed):
     """Summarise the contents of the storage."""
     from aiida.manage.manager import get_manager
 
@@ -98,7 +98,7 @@ def storage_info(statistics):
     storage = manager.get_profile_storage()
 
     with spinner():
-        data = storage.get_info(statistics=statistics)
+        data = storage.get_info(detailed=detailed)
 
     echo.echo_dictionary(data, sort_keys=False, fmt='yaml')
 

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -259,18 +259,18 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         :param dry_run: flag to only print the actions that would be taken without actually executing them.
         """
 
-    def get_info(self, statistics: bool = False) -> dict:
+    def get_info(self, detailed: bool = False) -> dict:
         """Return general information on the storage.
 
-        :param statistics: flag to request more detailed information about the content of the storage.
+        :param detailed: flag to request more detailed information about the content of the storage.
         :returns: a nested dict with the relevant information.
         """
-        return {'entities': self.get_orm_entities(statistics=statistics)}
+        return {'entities': self.get_orm_entities(detailed=detailed)}
 
-    def get_orm_entities(self, statistics: bool = False) -> dict:
+    def get_orm_entities(self, detailed: bool = False) -> dict:
         """Return a mapping with an overview of the storage contents regarding ORM entities.
 
-        :param statistics: flag to request more detailed information about the content of the storage.
+        :param detailed: flag to request more detailed information about the content of the storage.
         :returns: a nested dict with the relevant information.
         """
         from aiida.orm import Comment, Computer, Group, Log, Node, QueryBuilder, User
@@ -279,17 +279,17 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
 
         query_user = QueryBuilder(self).append(User, project=['email'])
         data['Users'] = {'count': query_user.count()}
-        if statistics:
+        if detailed:
             data['Users']['emails'] = sorted({email for email, in query_user.iterall() if email is not None})
 
         query_comp = QueryBuilder(self).append(Computer, project=['label'])
         data['Computers'] = {'count': query_comp.count()}
-        if statistics:
+        if detailed:
             data['Computers']['labels'] = sorted({comp for comp, in query_comp.iterall() if comp is not None})
 
         count = QueryBuilder(self).append(Node).count()
         data['Nodes'] = {'count': count}
-        if statistics:
+        if detailed:
             node_types = sorted({
                 typ for typ, in QueryBuilder(self).append(Node, project=['node_type']).iterall() if typ is not None
             })
@@ -301,7 +301,7 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
 
         query_group = QueryBuilder(self).append(Group, project=['type_string'])
         data['Groups'] = {'count': query_group.count()}
-        if statistics:
+        if detailed:
             data['Groups']['type_strings'] = sorted({typ for typ, in query_group.iterall() if typ is not None})
 
         count = QueryBuilder(self).append(Comment).count()

--- a/aiida/repository/backend/abstract.py
+++ b/aiida/repository/backend/abstract.py
@@ -120,11 +120,11 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def get_info(self, statistics: bool = False, **kwargs) -> dict:
+    def get_info(self, detailed: bool = False, **kwargs) -> dict:
         """Returns relevant information about the content of the repository.
 
-        :param statistics:
-            flag to enable extra information (statistics=False by default, only returns basic information).
+        :param detailed:
+            flag to enable extra information (detailed=False by default, only returns basic information).
 
         :return: a dictionary with the information.
         """

--- a/aiida/repository/backend/disk_object_store.py
+++ b/aiida/repository/backend/disk_object_store.py
@@ -198,7 +198,7 @@ class DiskObjectStoreRepositoryBackend(AbstractRepositoryBackend):
 
     def get_info( # type: ignore[override] # pylint: disable=arguments-differ
         self,
-        statistics=False,
+        detailed=False,
     ) -> t.Dict[str, t.Union[int, str, t.Dict[str, int], t.Dict[str, float]]]:
         """Return information on configuration and content of the repository."""
         output_info: t.Dict[str, t.Union[int, str, t.Dict[str, int], t.Dict[str, float]]] = {}
@@ -207,7 +207,7 @@ class DiskObjectStoreRepositoryBackend(AbstractRepositoryBackend):
             output_info['SHA-hash algorithm'] = container.hash_type
             output_info['Compression algorithm'] = container.compression_algorithm
 
-            if not statistics:
+            if not detailed:
                 return output_info
 
             files_data = container.count_objects()

--- a/aiida/repository/backend/sandbox.py
+++ b/aiida/repository/backend/sandbox.py
@@ -117,5 +117,5 @@ class SandboxRepositoryBackend(AbstractRepositoryBackend):
     def maintain(self, dry_run: bool = False, live: bool = True, **kwargs) -> None:
         raise NotImplementedError
 
-    def get_info(self, statistics: bool = False, **kwargs) -> dict:
+    def get_info(self, detailed: bool = False, **kwargs) -> dict:
         raise NotImplementedError

--- a/aiida/storage/psql_dos/backend.py
+++ b/aiida/storage/psql_dos/backend.py
@@ -397,7 +397,7 @@ class PsqlDosBackend(StorageBackend):  # pylint: disable=too-many-public-methods
 
         return keyset_repository - keyset_database
 
-    def get_info(self, statistics: bool = False) -> dict:
-        results = super().get_info(statistics=statistics)
-        results['repository'] = self.get_repository().get_info(statistics)
+    def get_info(self, detailed: bool = False) -> dict:
+        results = super().get_info(detailed=detailed)
+        results['repository'] = self.get_repository().get_info(detailed)
         return results

--- a/aiida/storage/psql_dos/migrations/utils/utils.py
+++ b/aiida/storage/psql_dos/migrations/utils/utils.py
@@ -125,7 +125,7 @@ class NoopRepositoryBackend(AbstractRepositoryBackend):
     def maintain(self, dry_run: bool = False, live: bool = True, **kwargs) -> None:
         raise NotImplementedError
 
-    def get_info(self, statistics: bool = False, **kwargs) -> dict:
+    def get_info(self, detailed: bool = False, **kwargs) -> dict:
         raise NotImplementedError
 
 

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -212,12 +212,12 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
     def maintain(self, dry_run: bool = False, live: bool = True, **kwargs) -> None:
         raise NotImplementedError
 
-    def get_info(self, statistics: bool = False) -> dict:
-        # since extracting the database file is expensive, we only do it if statistics is True
+    def get_info(self, detailed: bool = False) -> dict:
+        # since extracting the database file is expensive, we only do it if detailed is True
         results = {'metadata': extract_metadata(self._path)}
-        if statistics:
-            results.update(super().get_info(statistics=statistics))
-            results['repository'] = self.get_repository().get_info(statistics)
+        if detailed:
+            results.update(super().get_info(detailed=detailed))
+            results['repository'] = self.get_repository().get_info(detailed)
         return results
 
 
@@ -281,7 +281,7 @@ class _RoBackendRepository(AbstractRepositoryBackend):  # pylint: disable=abstra
     def maintain(self, dry_run: bool = False, live: bool = True, **kwargs) -> None:
         pass
 
-    def get_info(self, statistics: bool = False, **kwargs) -> dict:
+    def get_info(self, detailed: bool = False, **kwargs) -> dict:
         return {'objects': {'count': len(list(self.list_objects()))}}
 
 

--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -198,10 +198,10 @@ def test_info(run_cli_command):
 
 
 def test_info_detailed(run_cli_command):
-    """Test the functionality of `verdi archive info --statistics`."""
+    """Test the functionality of `verdi archive info --detailed`."""
     archive = f'export_{ArchiveFormatSqlZip().latest_version}_simple.aiida'
     filename_input = get_archive_file(archive, filepath='export/migrate')
-    options = ['--statistics', filename_input]
+    options = ['--detailed', filename_input]
     result = run_cli_command(cmd_archive.archive_info, options)
     assert 'Nodes:' in result.output
 

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -25,11 +25,11 @@ def tests_storage_version(run_cli_command):
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 def tests_storage_info(aiida_localhost, run_cli_command):
-    """Test the ``verdi storage info`` command with the ``-statistics`` option."""
+    """Test the ``verdi storage info`` command with the ``--detailed`` option."""
     from aiida import orm
     node = orm.Dict().store()
 
-    result = run_cli_command(cmd_storage.storage_info, options=['--statistics'])
+    result = run_cli_command(cmd_storage.storage_info, options=['--detailed'])
 
     assert aiida_localhost.label in result.output
     assert node.node_type in result.output

--- a/tests/repository/backend/test_abstract.py
+++ b/tests/repository/backend/test_abstract.py
@@ -52,7 +52,7 @@ class RepositoryBackend(AbstractRepositoryBackend):
     def maintain(self, dry_run: bool = False, live: bool = True, **kwargs) -> None:
         raise NotImplementedError
 
-    def get_info(self, statistics: bool = False, **kwargs) -> dict:
+    def get_info(self, detailed: bool = False, **kwargs) -> dict:
         raise NotImplementedError
 
 

--- a/tests/repository/backend/test_disk_object_store.py
+++ b/tests/repository/backend/test_disk_object_store.py
@@ -218,7 +218,7 @@ def test_get_info(populated_repository):
     assert repository_info['SHA-hash algorithm'] == 'sha256'
     assert repository_info['Compression algorithm'] == 'zlib+1'
 
-    repository_info = populated_repository.get_info(statistics=True)
+    repository_info = populated_repository.get_info(detailed=True)
     assert 'SHA-hash algorithm' in repository_info
     assert 'Compression algorithm' in repository_info
     assert repository_info['SHA-hash algorithm'] == 'sha256'

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -114,9 +114,9 @@ def test_get_info(monkeypatch):
 
     storage_backend = get_manager().get_profile_storage()
 
-    def mock_get_info(self, statistics=False, **kwargs):  # pylint: disable=unused-argument
+    def mock_get_info(self, detailed=False, **kwargs):  # pylint: disable=unused-argument
         output = {'value': 42}
-        if statistics:
+        if detailed:
             output['extra_value'] = 0
         return output
 
@@ -132,7 +132,7 @@ def test_get_info(monkeypatch):
     assert 'extra_value' not in repository_info_out
     assert repository_info_out['value'] == 42
 
-    storage_info_out = storage_backend.get_info(statistics=True)
+    storage_info_out = storage_backend.get_info(detailed=True)
     repository_info_out = storage_info_out['repository']
     assert 'value' in repository_info_out
     assert 'extra_value' in repository_info_out


### PR DESCRIPTION
The `statistics` keyword and CLI flag is not really descriptive of its purpose (particularly after recent changes).
`verdi storage info` already gives statistics, then the flag simply generates more detailed information.

As an example:

```console
$ verdi storage info
entities:
  Users:
    count: 4
  Computers:
    count: 14
  Nodes:
    count: 109521
  Groups:
    count: 5
  Comments:
    count: 0
  Logs:
    count: 0
  Links:
    count: 159848
repository:
  SHA-hash algorithm: sha256
  Compression algorithm: zlib+1

$ verdi storage info --detailed
entities:
  Users:
    count: 4
    emails:
    - a@b.com
    - aiida@theossrv2.epfl.ch
    - aiida@theossrv5.epfl.ch
    - xxx@epfl.ch
  Computers:
    count: 14
    labels:
    - bellatrix
    - brisi
    - 'daint (Imported #1)'
    - daint-gpu
    - daint-mc
    - daint_aprun
    - daint_mc
    - 'daint_mc (Imported #0)'
    - daint_old
    - dora
    - dora_aprun
    - localhost
    - theospc14-direct_
    - theospc27slurm
  Nodes:
    count: 109521
    node_types:
    - data.Data.
    - data.array.kpoints.KpointsData.
    - data.core.array.ArrayData.
    - data.core.array.bands.BandsData.
    - data.core.array.trajectory.TrajectoryData.
    - data.core.cif.CifData.
    - data.core.code.Code.
    - data.core.dict.Dict.
    - data.core.folder.FolderData.
    - data.core.remote.RemoteData.
    - data.core.singlefile.SinglefileData.
    - data.core.structure.StructureData.
    - data.core.upf.UpfData.
    - data.forceconstants.ForceconstantsData.
    - process.calculation.calcfunction.CalcFunctionNode.
    - process.calculation.calcjob.CalcJobNode.
    process_types:
    - aiida.calculations:codtools.ciffilter
    - aiida.calculations:quantumespresso.matdyn
    - aiida.calculations:quantumespresso.ph
    - aiida.calculations:quantumespresso.pw
    - aiida.calculations:quantumespresso.q2r
  Groups:
    count: 5
    type_strings:
    - core
    - core.import
  Comments:
    count: 0
  Logs:
    count: 0
  Links:
    count: 159848
repository:
  SHA-hash algorithm: sha256
  Compression algorithm: zlib+1
  Packs: 0
  Objects:
    unpacked: 199565
    packed: 0
  Size (MB):
    unpacked: 3734.387812614441
    packed: 0.0
    other: 0.01171875
```