### PR TITLE
feat: make aiida ipython magics available

### DIFF
--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -84,3 +84,8 @@ def get_file_header(comment_char: str = '# ') -> str:
     """
     lines = _get_raw_file_header().splitlines()
     return '\n'.join(f'{comment_char}{line}' for line in lines)
+
+
+def load_ipython_extension(ipython):
+    from .tools.ipython.ipython_magics import AiiDALoaderMagics
+    ipython.register_magics(AiiDALoaderMagics)


### PR DESCRIPTION
AiiDA comes with an `%aiida` IPython magic that loads the default
profile (and imports some modules).
However, in order to take advantage of this, so far, users had to
manually copy a python module into their IPython startup folder.

This change makes it possible to load the ipython magics as follows:

%load_ext aiida
%aiida