### PR TITLE
CLI: fix choices of `InteractiveOption` not being displayed

### DIFF
--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -128,18 +128,19 @@ class InteractiveOption(ConditionalOption):
     def get_help_message(self):
         """Return a message to be displayed for in-prompt help."""
         message = self.help or f'Expecting {self.type.name}'
-        choices = getattr(self.type, 'complete', lambda x, y: [])(None, '')
 
-        if choices:
-            choice_table = []
+        choices = getattr(self.type, 'shell_complete', lambda x, y, z: [])(self.type, None, '')
+        choices_string = []
+
+        for choice in choices:
+            if choice.value and choice.help:
+                choices_string.append(f' * {choice.value:<12} {choice.help}')
+            elif choice.value:
+                choices_string.append(f' * {choice.value}')
+
+        if any(choices_string):
             message += '\nSelect one of:\n'
-
-            for choice in choices:
-                if isinstance(choice, tuple):
-                    choice_table.append('\t{:<12} {}'.format(*choice))
-                else:
-                    choice_table.append(f'\t{choice:<12}')
-            message += '\n'.join(choice_table)
+            message += '\n'.join([choice for choice in choices_string if choice.strip()])
 
         return message
 

--- a/tests/cmdline/params/options/test_interactive.py
+++ b/tests/cmdline/params/options/test_interactive.py
@@ -13,6 +13,7 @@ import pytest
 
 from aiida.cmdline.params.options import NON_INTERACTIVE
 from aiida.cmdline.params.options.interactive import InteractiveOption
+from aiida.cmdline.params.types.plugin import PluginParamType
 
 
 class Only42IntParamType(click.types.IntParamType):
@@ -473,3 +474,17 @@ def test_not_required_interactive_default(run_cli_command):
     result = run_cli_command(cmd, user_input='\nnot needed\n')
     expected = 'Opt []: \n\n'
     assert expected in result.output
+
+
+def test_get_help_message():
+    """Test the :meth:`aiida.cmdline.params.options.interactive.InteractiveOption.get_help_message`."""
+    option = InteractiveOption('-s', type=click.STRING)
+    message = option.get_help_message()
+    assert message == 'Expecting text'
+
+    option = InteractiveOption('-P', type=PluginParamType(group='aiida.groups'))
+    message = option.get_help_message()
+    assert 'Expecting plugin' in message
+    assert 'Select one of:' in message
+    assert 'core' in message
+    assert 'core.auto' in message


### PR DESCRIPTION
Fixes #5406 

The choices of interactive options were not being displayed in
interactive mode when the special character `?` was passed. This bug was
introduced when `click_completion` was dropped for the tab-completion
feature that ships with `click` itself as of `v8.0`. The complete method
changed from `complete` to `shell_complete` and the `get_help_message`
of the `InteractiveOption` was not properly updated.