### PR TITLE
CLI: fix prompt info being shown in `verdi code setup --config`

### DIFF
--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -84,13 +84,13 @@ class InteractiveOption(ConditionalOption):
         if not self.is_interactive(ctx):
             return self.get_default(ctx)
 
+        if self._prompt_fn is not None and self._prompt_fn(ctx) is False:
+            return None
+
         if not hasattr(ctx, 'prompt_loop_info_printed'):
             echo.echo_report(f'enter {self.CHARACTER_PROMPT_HELP} for help.')
             echo.echo_report(f'enter {self.CHARACTER_IGNORE_DEFAULT} to ignore the default and set no value.')
             ctx.prompt_loop_info_printed = True
-
-        if self._prompt_fn is not None and self._prompt_fn(ctx) is False:
-            return None
 
         return super().prompt_for_value(ctx)
 


### PR DESCRIPTION
Fixes #5433 

When calling `verdi code setup` with the `--config` option providing a
config file that specifies all required options, the generic prompting
info would still be displayed. Technically this is not a bug since the
command is being invoked in interactive mode and so it is not wholly
surprising that the generic prompt info is displayed.

The prompt actually comes from the `--code-rel-path` and `--code-folder`
options (at least when configuring a remote code) which are in that case
not required. The `click` parser still calls `consume_value` though
which calls our `prompt_for_value` and so hits the code that prints the
prompt info.

By moving that code after the check of whether the prompt function
should even be called, prevents the info to be displayed for these
options that don't actually need to be prompted for.