### PR TITLE
`verdi code setup`: make `--input-plugin` optional

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -90,7 +90,8 @@ def setup_code(ctx, non_interactive, **kwargs):
         kwargs['code_type'] = CodeBuilder.CodeType.STORE_AND_UPLOAD
 
     # Convert entry point to its name
-    kwargs['input_plugin'] = kwargs['input_plugin'].name
+    if kwargs['input_plugin']:
+        kwargs['input_plugin'] = kwargs['input_plugin'].name
 
     code_builder = CodeBuilder(**kwargs)
 

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -124,6 +124,7 @@ DESCRIPTION = options.DESCRIPTION.clone(
 )
 
 INPUT_PLUGIN = options.INPUT_PLUGIN.clone(
+    required=False,
     prompt='Default calculation input plugin',
     cls=InteractiveOption,
     help="Entry point name of the default calculation plugin (as listed in 'verdi plugin list aiida.calculations')."


### PR DESCRIPTION
Fixes #4991 

The `Code` data plugin does not require a value for `input_plugin`,
which can be used to specify the entry point of the calcjob plugin to be
used by default, however, `verdi code setup` required it nonetheless.
The `--input-plugin` is now made optional.