### PR TITLE
ORM: add `entry_point` property to `Node` and `Group`

### DIFF
--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -23,6 +23,7 @@ from . import convert, entities, extras, users
 if TYPE_CHECKING:
     from aiida.orm import Node, User
     from aiida.orm.implementation import BackendGroup, StorageBackend
+    from aiida.plugins.entry_point import EntryPoint
 
 __all__ = ('Group', 'AutoGroup', 'ImportGroup', 'UpfFamily')
 
@@ -184,6 +185,16 @@ class Group(entities.Entity['BackendGroup'], metaclass=GroupMeta):
             raise exceptions.StoringNotAllowed('`type_string` is `None` so the group cannot be stored.')
 
         return super().store()
+
+    @classproperty
+    def entry_point(cls) -> Optional['EntryPoint']:
+        """Return the entry point associated this group type.
+
+        :return: the associated entry point or ``None`` if it isn't known.
+        """
+        # pylint: disable=no-self-use
+        from aiida.plugins.entry_point import get_entry_point_from_class
+        return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
 
     @property
     def uuid(self) -> str:

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -35,6 +35,8 @@ from .links import NodeLinks
 from .repository import NodeRepository
 
 if TYPE_CHECKING:
+    from aiida.plugins.entry_point import EntryPoint
+
     from ..implementation import BackendNode, StorageBackend
 
 __all__ = ('Node',)
@@ -270,6 +272,16 @@ class Node(Entity['BackendNode'], metaclass=AbstractNodeMeta):
         # pylint: disable=no-self-argument,no-member
         return cls._plugin_type_string
 
+    @classproperty
+    def entry_point(cls) -> Optional['EntryPoint']:
+        """Return the entry point associated this node class.
+
+        :return: the associated entry point or ``None`` if it isn't known.
+        """
+        # pylint: disable=no-self-argument
+        from aiida.plugins.entry_point import get_entry_point_from_class
+        return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
+
     @property
     def logger(self) -> Optional[Logger]:
         """Return the logger configured for this Node.
@@ -283,7 +295,6 @@ class Node(Entity['BackendNode'], metaclass=AbstractNodeMeta):
         """Return the node UUID.
 
         :return: the string representation of the UUID
-
         """
         return self.backend_entity.uuid
 

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -19,7 +19,7 @@ import pytest
 
 from aiida.common import LinkType, exceptions, timezone
 from aiida.manage import get_manager
-from aiida.orm import CalculationNode, Computer, Data, Log, Node, User, WorkflowNode, load_node
+from aiida.orm import CalculationNode, Computer, Data, Int, Log, Node, User, WorkflowNode, load_node
 from aiida.orm.utils.links import LinkTriple
 
 
@@ -114,6 +114,21 @@ class TestNode:
 
         with pytest.raises(ValueError, match=match):
             node.process_class  # pylint: disable=pointless-statement
+
+    def test_entry_point(self):
+        """Test the :meth:`aiida.orm.nodes.node.Node.entry_point` property."""
+        from aiida.plugins.entry_point import get_entry_point_from_string
+
+        node = Int()
+        assert node.entry_point == get_entry_point_from_string('aiida.data:core.int')
+        assert Int.entry_point == get_entry_point_from_string('aiida.data:core.int')
+
+        class Custom(Data):
+            pass
+
+        node = Custom()
+        assert node.entry_point is None
+        assert Custom.entry_point is None
 
 
 @pytest.mark.usefixtures('aiida_profile_clean_class')

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -81,6 +81,21 @@ class TestGroups:
         assert all(isinstance(node, orm.Data) for node in nodes_sliced)
         assert all(node.uuid in set(node.uuid for node in nodes) for node in nodes_sliced)
 
+    def test_entry_point(self):
+        """Test the :meth:`aiida.orm.groups.Group.entry_point` property."""
+        from aiida.plugins.entry_point import get_entry_point_from_string
+
+        group = orm.Group('label')
+        assert group.entry_point == get_entry_point_from_string('aiida.groups:core')
+        assert orm.Group.entry_point == get_entry_point_from_string('aiida.groups:core')
+
+        class Custom(orm.Group):
+            pass
+
+        group = Custom('label')
+        assert group.entry_point is None
+        assert Custom.entry_point is None
+
     def test_description(self):
         """Test the update of the description both for stored and unstored groups."""
         node = orm.Data().store()


### PR DESCRIPTION
Fixes #4939 

This property will return the entry point of a `Node` or `Group` instance
if one is associated with the class, otherwise `None` is returned.