### PR TITLE
🔧 MAINTAIN: Limit the use of `pylint:disable consider-using-with`

### DIFF
--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -161,12 +161,9 @@ def logshow():
 
     client = get_daemon_client()
 
-    try:
-        currenv = get_env_with_venv_bin()
-        process = subprocess.Popen(['tail', '-f', client.daemon_log_file], env=currenv)  # pylint: disable=consider-using-with
+    currenv = get_env_with_venv_bin()
+    with subprocess.Popen(['tail', '-f', client.daemon_log_file], env=currenv) as process:
         process.wait()
-    except KeyboardInterrupt:
-        process.kill()
 
 
 @verdi_daemon.command()

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utility functions to operate on filesystem folders."""
+import contextlib
 import errno
 import fnmatch
 import os
@@ -272,6 +273,7 @@ class Folder:
 
         return dest_abs_path
 
+    @contextlib.contextmanager
     def open(self, name, mode='r', encoding='utf8', check_existence=False):
         """
         Open a file in the current folder and return the corresponding file object.
@@ -283,9 +285,8 @@ class Folder:
         if 'b' in mode:
             encoding = None
 
-        return open(  # pylint: disable=consider-using-with
-            self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding
-        )
+        with open(self.get_abs_path(name, check_existence=check_existence), mode, encoding=encoding) as handle:
+            yield handle
 
     @property
     def abspath(self):

--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -109,9 +109,9 @@ def test_migrate_version_specific(run_cli_command, tmp_path):
     options = [filename_input, filename_output, '--version', target_version]
     run_cli_command(cmd_archive.migrate, options)
     assert filename_output.is_file()
-    assert zipfile.ZipFile(filename_output).testzip() is None  # pylint: disable=consider-using-with
-
     assert ArchiveFormatSqlZip().read_version(filename_output) == target_version
+    with zipfile.ZipFile(filename_output) as handle:
+        assert handle.testzip() is None
 
 
 def test_migrate_file_already_exists(run_cli_command, tmp_path):
@@ -155,9 +155,9 @@ def test_migrate_in_place(run_cli_command, tmp_path):
     options = [filename_clone, '--in-place', '--version', target_version]
     run_cli_command(cmd_archive.migrate, options)
     assert filename_clone.is_file()
-    assert zipfile.ZipFile(filename_clone).testzip() is None  # pylint: disable=consider-using-with
-
     assert ArchiveFormatSqlZip().read_version(filename_clone) == target_version
+    with zipfile.ZipFile(filename_clone) as handle:
+        assert handle.testzip() is None
 
 
 @pytest.mark.usefixtures('config_with_profile')
@@ -174,8 +174,9 @@ def test_migrate_low_verbosity(run_cli_command, tmp_path):
     result = run_cli_command(cmd_archive.migrate, options)
     assert result.output == ''
     assert filename_output.is_file()
-    assert zipfile.ZipFile(filename_output).testzip() is None  # pylint: disable=consider-using-with
     assert ArchiveFormatSqlZip().read_version(filename_output) == ArchiveFormatSqlZip().latest_version
+    with zipfile.ZipFile(filename_output) as handle:
+        assert handle.testzip() is None
 
 
 @pytest.mark.parametrize('version', [v for v in list_versions() if v not in ('main_0000a', 'main_0000b')])

--- a/tests/common/test_folders.py
+++ b/tests/common/test_folders.py
@@ -7,78 +7,77 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for the folder class."""
+"""Tests for the :class:`aiida.common.folders.Folder` class."""
 import io
-import os
-import shutil
+import pathlib
 import sys
 import tempfile
-import unittest
+
+import pytest
 
 from aiida.common.folders import Folder
 
 
 def fs_encoding_is_utf8():
-    """
+    """Return whether the current filesystem encoding is set to UTF-8.
+
     :return: True if the current filesystem encoding is set to UTF-8
     """
     return sys.getfilesystemencoding() == 'utf-8'
 
 
-class FoldersTest(unittest.TestCase):
-    """Tests for the Folder class."""
+@pytest.mark.skipif(
+    not fs_encoding_is_utf8(), reason='Testing for unicode folders requires UTF-8 to be set for filesystem encoding'
+)
+def test_unicode(tmpdir):
+    """Check that there are no exceptions raised when using unicode folders."""
+    with tempfile.TemporaryDirectory() as dirpath_target:
 
-    @unittest.skipUnless(
-        fs_encoding_is_utf8(), ('Testing for unicode folders requires UTF-8 to be set for filesystem encoding')
-    )
-    def test_unicode(self):
-        """Check that there are no exceptions raised when using unicode folders."""
-        tmpsource = tempfile.mkdtemp()
-        tmpdest = tempfile.mkdtemp()
+        (pathlib.Path(tmpdir) / 'sąžininga').write_text('test')
+        (pathlib.Path(tmpdir) / 'žąsis').write_text('test')
 
-        with open(os.path.join(tmpsource, 'sąžininga'), 'w', encoding='utf8') as fhandle:
-            fhandle.write('test')
-        with open(os.path.join(tmpsource, 'žąsis'), 'w', encoding='utf8') as fhandle:
-            fhandle.write('test')
+        folder = Folder(dirpath_target)
+        folder.insert_path(tmpdir, 'destination')
+        folder.insert_path(tmpdir, 'šaltinis')
 
-        folder = Folder(tmpdest)
-        folder.insert_path(tmpsource, 'destination')
-        folder.insert_path(tmpsource, 'šaltinis')
+        assert sorted(folder.get_content_list()) == sorted(['destination', 'šaltinis'])
+        assert sorted(folder.get_subfolder('destination').get_content_list()) == sorted(['sąžininga', 'žąsis'])
+        assert sorted(folder.get_subfolder('šaltinis').get_content_list()) == sorted(['sąžininga', 'žąsis'])
 
-        self.assertEqual(sorted(folder.get_content_list()), sorted(['destination', 'šaltinis']))
-        self.assertEqual(sorted(folder.get_subfolder('destination').get_content_list()), sorted(['sąžininga', 'žąsis']))
-        self.assertEqual(sorted(folder.get_subfolder('šaltinis').get_content_list()), sorted(['sąžininga', 'žąsis']))
+        folder = Folder(pathlib.Path(tmpdir) / 'šaltinis')
+        folder.insert_path(dirpath_target, 'destination')
+        folder.insert_path(dirpath_target, 'kitas-šaltinis')
+        assert sorted(folder.get_content_list()) == sorted(['destination', 'kitas-šaltinis'])
 
-        folder = Folder(os.path.join(tmpsource, 'šaltinis'))
-        folder.insert_path(tmpdest, 'destination')
-        folder.insert_path(tmpdest, 'kitas-šaltinis')
-        self.assertEqual(sorted(folder.get_content_list()), sorted(['destination', 'kitas-šaltinis']))
 
-    def test_get_abs_path_without_limit(self):
-        """
-        Check that the absolute path function can get an absolute path
-        """
-        folder = Folder('/tmp')
-        # Should not raise any exception
-        self.assertEqual(folder.get_abs_path('test_file.txt'), '/tmp/test_file.txt')
+def test_get_abs_path_without_limit():
+    """Check that the absolute path function can get an absolute path."""
+    folder = Folder('/tmp')
+    assert folder.get_abs_path('test_file.txt') == '/tmp/test_file.txt'
 
-    def test_create_file_from_filelike(self):
-        """Test `aiida.common.folders.Folder.create_file_from_filelike`."""
-        unicode_string = 'unicode_string'
-        byte_string = b'byte_string'
 
-        try:
-            tempdir = tempfile.mkdtemp()
-            folder = Folder(tempdir)
+def test_create_file_from_filelike(tmpdir):
+    """Test the :meth:`aiida.common.folders.Folder.create_file_from_filelike` method."""
+    unicode_string = 'unicode_string'
+    byte_string = b'byte_string'
 
-            folder.create_file_from_filelike(io.StringIO(unicode_string), 'random.dat', mode='w', encoding='utf-8')
-            folder.create_file_from_filelike(io.BytesIO(byte_string), 'random.dat', mode='wb', encoding=None)
+    folder = Folder(tmpdir)
 
-            with self.assertRaises(TypeError):
-                folder.create_file_from_filelike(io.StringIO(unicode_string), 'random.dat', mode='wb')
+    folder.create_file_from_filelike(io.StringIO(unicode_string), 'random.dat', mode='w', encoding='utf-8')
+    folder.create_file_from_filelike(io.BytesIO(byte_string), 'random.dat', mode='wb', encoding=None)
 
-            with self.assertRaises(TypeError):
-                folder.create_file_from_filelike(io.BytesIO(byte_string), 'random.dat', mode='w')
+    with pytest.raises(TypeError):
+        folder.create_file_from_filelike(io.StringIO(unicode_string), 'random.dat', mode='wb')
 
-        finally:
-            shutil.rmtree(tempdir)
+    with pytest.raises(TypeError):
+        folder.create_file_from_filelike(io.BytesIO(byte_string), 'random.dat', mode='w')
+
+
+def test_open(tmpdir):
+    """Test the :meth:`aiida.common.folders.Folder.open` method."""
+    filename = 'random.dat'
+    folder = Folder(tmpdir)
+    folder.create_file_from_filelike(io.StringIO('test'), filename, mode='w', encoding='utf-8')
+
+    with folder.open(filename) as handle:
+        assert handle.read() == 'test'

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -175,10 +175,10 @@ class TestMakeHashTest:
     def test_folder(self):
         # create directories for the Folder test
         with SandboxFolder(sandbox_in_repo=False) as folder:
-            folder.open('file1', 'a').close()
-            fhandle = folder.open('file2', 'w')
-            fhandle.write('hello there!\n')
-            fhandle.close()
+            with folder.open('file1', 'a') as handle:
+                pass
+            with folder.open('file2', 'w') as handle:
+                handle.write('hello there!\n')
 
             folder_hash = make_hash(folder)
             assert folder_hash == '47d9cdb2247e75eca492035f60f09fdd0daf87bbba40bb658d2d7e84f21f26c5'

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,fixme,consider-using-with
+# pylint: disable=too-many-lines,fixme
 """
 This module contains a set of unittest test classes that can be loaded from
 the plugin.
@@ -16,6 +16,7 @@ Plugin specific tests will be written in the plugin itself.
 """
 import io
 import os
+import pathlib
 import random
 import shutil
 import signal
@@ -583,8 +584,7 @@ class TestPutGetFile(unittest.TestCase):
             remote_file_name = 'file_remote.txt'
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
-            fhandle = open(local_file_name, 'w', encoding='utf8')
-            fhandle.close()
+            pathlib.Path(local_file_name).touch()
 
             # partial_file_name is not an abs path
             with self.assertRaises(ValueError):
@@ -1067,9 +1067,7 @@ class TestPutGetTree(unittest.TestCase):
 
             transport.chdir(directory)
             local_file_name = os.path.join(local_subfolder, 'file.txt')
-
-            fhandle = open(local_file_name, 'w', encoding='utf8')
-            fhandle.close()
+            pathlib.Path(local_file_name).touch()
 
             # 'tmp1' is not an abs path
             with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes #5090 

Many of the occurrences of this disable statement were actually better
off with refactoring the relevant code to use a context manager. Not all
disable statements have been removed as certain cases actually
justifiably do not use a context manager.