### PR TITLE
♻️ REFACTOR: Remove `Entity.from_backend_entity` from the public API

### DIFF
--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -84,12 +84,12 @@ class AuthInfo(entities.Entity['BackendAuthInfo', AuthInfoCollection]):
     def computer(self) -> 'Computer':
         """Return the computer associated with this instance."""
         from . import computers  # pylint: disable=cyclic-import
-        return computers.Computer.from_backend_entity(self._backend_entity.computer)
+        return entities.from_backend_entity(computers.Computer, self._backend_entity.computer)
 
     @property
     def user(self) -> 'User':
         """Return the user associated with this instance."""
-        return users.User.from_backend_entity(self._backend_entity.user)
+        return entities.from_backend_entity(users.User, self._backend_entity.user)
 
     def get_auth_params(self) -> Dict[str, Any]:
         """Return the dictionary of authentication parameters

--- a/aiida/orm/comments.py
+++ b/aiida/orm/comments.py
@@ -115,7 +115,7 @@ class Comment(entities.Entity['BackendComment', CommentCollection]):
 
     @property
     def user(self) -> 'User':
-        return users.User.from_backend_entity(self._backend_entity.user)
+        return entities.from_backend_entity(users.User, self._backend_entity.user)
 
     def set_user(self, value: 'User') -> None:
         self._backend_entity.user = value.backend_entity

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -276,7 +276,7 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
         """
         Return a copy of the current object to work with, not stored yet.
         """
-        return Computer.from_backend_entity(self._backend_entity.copy())
+        return entities.from_backend_entity(Computer, self._backend_entity.copy())
 
     def store(self) -> 'Computer':
         """

--- a/aiida/orm/convert.py
+++ b/aiida/orm/convert.py
@@ -12,6 +12,7 @@
 from collections.abc import Iterator, Mapping, Sized
 from functools import singledispatch
 
+from aiida.orm.entities import from_backend_entity
 from aiida.orm.implementation import (
     BackendAuthInfo,
     BackendComment,
@@ -72,44 +73,44 @@ def _(backend_entity):
 def _(backend_entity):
     from .groups import load_group_class
     group_class = load_group_class(backend_entity.type_string)
-    return group_class.from_backend_entity(backend_entity)
+    return from_backend_entity(group_class, backend_entity)
 
 
 @get_orm_entity.register(BackendComputer)
 def _(backend_entity):
     from . import computers
-    return computers.Computer.from_backend_entity(backend_entity)
+    return from_backend_entity(computers.Computer, backend_entity)
 
 
 @get_orm_entity.register(BackendUser)
 def _(backend_entity):
     from . import users
-    return users.User.from_backend_entity(backend_entity)
+    return from_backend_entity(users.User, backend_entity)
 
 
 @get_orm_entity.register(BackendAuthInfo)
 def _(backend_entity):
     from . import authinfos
-    return authinfos.AuthInfo.from_backend_entity(backend_entity)
+    return from_backend_entity(authinfos.AuthInfo, backend_entity)
 
 
 @get_orm_entity.register(BackendLog)
 def _(backend_entity):
     from . import logs
-    return logs.Log.from_backend_entity(backend_entity)
+    return from_backend_entity(logs.Log, backend_entity)
 
 
 @get_orm_entity.register(BackendComment)
 def _(backend_entity):
     from . import comments
-    return comments.Comment.from_backend_entity(backend_entity)
+    return from_backend_entity(comments.Comment, backend_entity)
 
 
 @get_orm_entity.register(BackendNode)
 def _(backend_entity):
     from .utils.node import load_node_class  # pylint: disable=import-error,no-name-in-module
     node_class = load_node_class(backend_entity.node_type)
-    return node_class.from_backend_entity(backend_entity)
+    return from_backend_entity(node_class, backend_entity)
 
 
 class ConvertIterator(Iterator, Sized):

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -195,22 +195,6 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
         )
         return cls.collection.get(**kwargs)  # pylint: disable=no-member
 
-    @classmethod
-    def from_backend_entity(cls: Type[EntityType], backend_entity: BackendEntityType) -> EntityType:
-        """Construct an entity from a backend entity instance
-
-        :param backend_entity: the backend entity
-
-        :return: an AiiDA entity instance
-        """
-        from .implementation.entities import BackendEntity
-
-        type_check(backend_entity, BackendEntity)
-        entity = cls.__new__(cls)
-        entity._backend_entity = backend_entity
-        call_with_super_check(entity.initialize)
-        return entity
-
     def __init__(self, backend_entity: BackendEntityType) -> None:
         """
         :param backend_entity: the backend model supporting this entity
@@ -271,3 +255,19 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
     def backend_entity(self) -> BackendEntityType:
         """Get the implementing class for this object"""
         return self._backend_entity
+
+
+def from_backend_entity(cls: Type[EntityType], backend_entity: BackendEntityType) -> EntityType:
+    """Construct an entity from a backend entity instance
+
+    :param backend_entity: the backend entity
+
+    :return: an AiiDA entity instance
+    """
+    from .implementation.entities import BackendEntity
+
+    type_check(backend_entity, BackendEntity)
+    entity = cls.__new__(cls)
+    entity._backend_entity = backend_entity  # pylint: disable=protected-access
+    call_with_super_check(entity.initialize)
+    return entity

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -253,7 +253,7 @@ class Group(entities.Entity['BackendGroup', GroupCollection], metaclass=GroupMet
         """
         :return: the user associated with this group
         """
-        return users.User.from_backend_entity(self._backend_entity.user)
+        return entities.from_backend_entity(users.User, self._backend_entity.user)
 
     @user.setter
     def user(self, user: 'User') -> None:

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -25,6 +25,7 @@ from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
 from aiida.orm import Computer
+from aiida.orm.entities import from_backend_entity
 
 from .legacy import Code
 
@@ -105,7 +106,7 @@ class InstalledCode(Code):
     def computer(self) -> Computer:
         """Return the computer of this code."""
         assert self.backend_entity.computer is not None
-        return Computer.from_backend_entity(self.backend_entity.computer)
+        return from_backend_entity(Computer, self.backend_entity.computer)
 
     @computer.setter
     def computer(self, computer: Computer) -> None:

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -13,6 +13,7 @@ from typing import Dict
 from aiida.common import exceptions
 from aiida.common.lang import override
 from aiida.common.links import LinkType
+from aiida.orm.entities import from_backend_entity
 
 from ..node import Node
 
@@ -70,7 +71,7 @@ class Data(Node):
         import copy
 
         backend_clone = self.backend_entity.clone()
-        clone = self.__class__.from_backend_entity(backend_clone)
+        clone = from_backend_entity(self.__class__, backend_clone)
         clone.base.attributes.reset(copy.deepcopy(self.base.attributes.all))
         clone.base.repository._clone(self.base.repository)  # pylint: disable=protected-access
 

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -24,7 +24,7 @@ from aiida.orm.utils.node import AbstractNodeMeta
 
 from ..computers import Computer
 from ..entities import Collection as EntityCollection
-from ..entities import Entity
+from ..entities import Entity, from_backend_entity
 from ..extras import EntityExtras
 from ..querybuilder import QueryBuilder
 from ..users import User
@@ -358,7 +358,7 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
     def computer(self) -> Optional[Computer]:
         """Return the computer of this node."""
         if self.backend_entity.computer:
-            return Computer.from_backend_entity(self.backend_entity.computer)
+            return from_backend_entity(Computer, self.backend_entity.computer)
 
         return None
 
@@ -378,7 +378,7 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
     @property
     def user(self) -> User:
         """Return the user of this node."""
-        return User.from_backend_entity(self.backend_entity.user)
+        return from_backend_entity(User, self._backend_entity.user)
 
     @user.setter
     def user(self, user: User) -> None:


### PR DESCRIPTION
This should not be exposed on the public API, for e.g. `Node` (see #4976).
Instead, we move it to a pure function.

Note, you could rename to `Entity._from_backend_entity`, but this generates numerous pylint `protected-access` warnings 