### PR TITLE
SingleFile empty initialization

### DIFF
--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -24,7 +24,7 @@ class SinglefileData(Data):
 
     DEFAULT_FILENAME = 'file.txt'
 
-    def __init__(self, file, filename=None, **kwargs):
+    def __init__(self, file=None, filename=None, **kwargs):
         """Construct a new instance and set the contents to that of the file.
 
         :param file: an absolute filepath or filelike object whose contents to copy.


### PR DESCRIPTION
SingleFileData can not be initialized empty, even though the check for whether `file` is `None` is done on the initialization. This PR makes it consistent with the other `DataNodes` which I think are all initializable as empty. 