### PR TITLE
`Computer`: fallback on transport for `get_minimum_job_poll_interval` default

### DIFF
--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -491,15 +491,21 @@ class Computer(entities.Entity['BackendComputer']):
         self.set_property('default_memory_per_machine', def_memory_per_machine)
 
     def get_minimum_job_poll_interval(self) -> float:
-        """
-        Get the minimum interval between subsequent requests to update the list
-        of jobs currently running on this computer.
+        """Get the minimum interval between subsequent requests to poll the scheduler for job status.
 
-        :return: The minimum interval (in seconds)
+        .. note:: If no value was ever set for this computer it will fall back on the default provided by the associated
+            transport class in the ``DEFAULT_MINIMUM_JOB_POLL_INTERVAL`` attribute. If the computer doesn't have a
+            transport class, or it cannot be loaded, or it doesn't provide a job poll interval default, then this will
+            fall back on the ``PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT`` attribute of this class.
+
+        :return: The minimum interval (in seconds).
         """
-        return self.get_property(
-            self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT
-        )
+        try:
+            default = self.get_transport_class().DEFAULT_MINIMUM_JOB_POLL_INTERVAL
+        except (exceptions.ConfigurationError, AttributeError):
+            default = self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT
+
+        return self.get_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, default)
 
     def set_minimum_job_poll_interval(self, interval: float) -> None:
         """

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -49,6 +49,12 @@ class LocalTransport(Transport):
     # where the remote computer will rate limit the number of connections.
     _DEFAULT_SAFE_OPEN_INTERVAL = 0.0
 
+    # Like the connection open interval, for local transport, which should be used for localhost, one probably doesn't
+    # want to have a long polling time in most cases. Since localhost is typically used for short running jobs and tests
+    # one doesn't want to be waiting tens of seconds for a job that should last less than one second. We don't set 0 but
+    # a small finite number that should prevent the CPUs from spinning while still guaranteeing fast throughput.
+    DEFAULT_MINIMUM_JOB_POLL_INTERVAL = 0.1
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # The `_internal_dir` will emulate the concept of working directory, as the real current working directory is

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -40,6 +40,9 @@ class Transport(abc.ABC):
     """Abstract class for a generic transport (ssh, local, ...) contains the set of minimal methods."""
     # pylint: disable=too-many-public-methods
 
+    # This will be used for ``Computer.get_minimum_job_poll_interval``
+    DEFAULT_MINIMUM_JOB_POLL_INTERVAL = 10
+
     # This is used as a global default in case subclasses don't redefine this,
     # but this should  be redefined in plugins where appropriate
     _DEFAULT_SAFE_OPEN_INTERVAL = 30.


### PR DESCRIPTION
Fixes #5455 

The `get_minimum_job_poll_interval` returns a default when no value was
ever explicitly defined for the `Computer` instance. This is currently
provided by the `PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT`
attribute which is set to 10 seconds. This is a reasonable default for
most cases, but for the localhost it is probably excessive and can lead
to users waiting for a long time when running singular jobs on the
localhost.

The minimum job poll interval is not strictly a property of the
transport but in this case it is the transport that defines what happens
to be a sensible default. Therefore we still choose to add a new
attribute `DEFAULT_MINIMUM_JOB_POLL_INTERVAL` to `Transport` which the
`Computer` can use as a default if none is specified on the instance.
The `Transport` base class sets it to 10, which is backwards compatible
with the current behavior, and the `LocalTransport` then overrides it to
`0.1`. We choose a small finite number such that the waiting time in
most cases should not really be noticeable without running the risk that
the CPUs will really spin like crazy for jobs that run slightly longer.