### PR TITLE
`CalcJob`: always call `Scheduler.parse_output`

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -515,21 +515,23 @@ class CalcJob(Process):
             self.logger.info('could not parse scheduler output: return value of `detailed_job_info` is non-zero')
             detailed_job_info = None
 
-        try:
-            scheduler_stderr = retrieved.get_object_content(filename_stderr)
-        except FileNotFoundError:
-            scheduler_stderr = None
-            self.logger.warning(f'could not parse scheduler output: the `{filename_stderr}` file is missing')
+        if filename_stderr is None:
+            self.logger.warning('could not determine `stderr` filename because `scheduler_stderr` option was not set.')
+        else:
+            try:
+                scheduler_stderr = retrieved.get_object_content(filename_stderr)
+            except FileNotFoundError:
+                scheduler_stderr = None
+                self.logger.warning(f'could not parse scheduler output: the `{filename_stderr}` file is missing')
 
-        try:
-            scheduler_stdout = retrieved.get_object_content(filename_stdout)
-        except FileNotFoundError:
-            scheduler_stdout = None
-            self.logger.warning(f'could not parse scheduler output: the `{filename_stdout}` file is missing')
-
-        # Only attempt to call the scheduler parser if all three resources of information are available
-        if any(entry is None for entry in [detailed_job_info, scheduler_stderr, scheduler_stdout]):
-            return None
+        if filename_stdout is None:
+            self.logger.warning('could not determine `stdout` filename because `scheduler_stdout` option was not set.')
+        else:
+            try:
+                scheduler_stdout = retrieved.get_object_content(filename_stdout)
+            except FileNotFoundError:
+                scheduler_stdout = None
+                self.logger.warning(f'could not parse scheduler output: the `{filename_stdout}` file is missing')
 
         try:
             exit_code = scheduler.parse_output(detailed_job_info, scheduler_stdout, scheduler_stderr)

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -707,53 +707,71 @@ stderr='{stderr.strip()}'"""
 
         return True
 
-    def parse_output(self, detailed_job_info, stdout, stderr):  # pylint: disable=inconsistent-return-statements
+    def parse_output(self, detailed_job_info=None, stdout=None, stderr=None):
         """Parse the output of the scheduler.
 
         :param detailed_job_info: dictionary with the output returned by the `Scheduler.get_detailed_job_info` command.
             This should contain the keys `retval`, `stdout` and `stderr` corresponding to the return value, stdout and
             stderr returned by the accounting command executed for a specific job id.
-        :param stdout: string with the output written by the scheduler to stdout
-        :param stderr: string with the output written by the scheduler to stderr
-        :return: None or an instance of `aiida.engine.processes.exit_code.ExitCode`
-        :raises TypeError or ValueError: if the passed arguments have incorrect type or value
+        :param stdout: string with the output written by the scheduler to stdout.
+        :param stderr: string with the output written by the scheduler to stderr.
+        :return: None or an instance of :class:`aiida.engine.processes.exit_code.ExitCode`.
+        :raises TypeError or ValueError: if the passed arguments have incorrect type or value.
         """
         from aiida.engine import CalcJob
 
-        type_check(detailed_job_info, dict)
+        if detailed_job_info is not None:
 
-        try:
-            detailed_stdout = detailed_job_info['stdout']
-        except KeyError:
-            raise ValueError('the `detailed_job_info` does not contain the required key `stdout`.')
+            type_check(detailed_job_info, dict)
 
-        type_check(detailed_stdout, str)
+            try:
+                detailed_stdout = detailed_job_info['stdout']
+            except KeyError:
+                raise ValueError('the `detailed_job_info` does not contain the required key `stdout`.')
 
-        # The format of the detailed job info should be a multiline string, where the first line is the header, with
-        # the labels of the projected attributes. The following line should be the values of those attributes for the
-        # entire job. Any additional lines correspond to those values for any additional tasks that were run.
-        lines = detailed_stdout.splitlines()
+            type_check(detailed_stdout, str)
 
-        try:
-            master = lines[1]
-        except IndexError:
-            raise ValueError('the `detailed_job_info.stdout` contained less than two lines.')
+            # The format of the detailed job info should be a multiline string, where the first line is the header, with
+            # the labels of the projected attributes. The following line should be the values of those attributes for
+            # the entire job. Any additional lines correspond to those values for any additional tasks that were run.
+            lines = detailed_stdout.splitlines()
 
-        attributes = master.split('|')
+            try:
+                master = lines[1]
+            except IndexError:
+                raise ValueError('the `detailed_job_info.stdout` contained less than two lines.')
 
-        # Pop the last element if it is empty. This happens if the `master` string just finishes with a pipe
-        if not attributes[-1]:
-            attributes.pop()
+            attributes = master.split('|')
 
-        if len(self._detailed_job_info_fields) != len(attributes):
-            raise ValueError(
-                'second line in `detailed_job_info.stdout` differs in length with schedulers `_detailed_job_info_fields'
-            )
+            # Pop the last element if it is empty. This happens if the `master` string just finishes with a pipe
+            if not attributes[-1]:
+                attributes.pop()
 
-        data = dict(zip(self._detailed_job_info_fields, attributes))
+            if len(self._detailed_job_info_fields) != len(attributes):
+                raise ValueError(
+                    'second line in `detailed_job_info.stdout` differs in length with the `_detailed_job_info_fields '
+                    'attribute of the scheduler.'
+                )
 
-        if data['State'] == 'OUT_OF_MEMORY':
-            return CalcJob.exit_codes.ERROR_SCHEDULER_OUT_OF_MEMORY  # pylint: disable=no-member
+            data = dict(zip(self._detailed_job_info_fields, attributes))
 
-        if data['State'] == 'TIMEOUT':
-            return CalcJob.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME  # pylint: disable=no-member
+            if data['State'] == 'OUT_OF_MEMORY':
+                return CalcJob.exit_codes.ERROR_SCHEDULER_OUT_OF_MEMORY
+
+            if data['State'] == 'TIMEOUT':
+                return CalcJob.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME
+
+        # Alternatively, if the ``detailed_job_info`` is not defined or hasn't already determined an error, try to match
+        # known error messages from the output written to the ``stderr`` descriptor.
+        if stderr is not None:
+
+            type_check(stderr, str)
+            stderr_lower = stderr.lower()
+
+            if re.match(r'.*exceeded.*memory limit.*', stderr_lower):
+                return CalcJob.exit_codes.ERROR_SCHEDULER_OUT_OF_MEMORY
+
+            if re.match(r'.*cancelled at.*due to time limit.*', stderr_lower):
+                return CalcJob.exit_codes.ERROR_SCHEDULER_OUT_OF_MEMORY
+
+        return None

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -390,14 +390,14 @@ class Scheduler(metaclass=abc.ABCMeta):
         :return: True if everything seems ok, False otherwise.
         """
 
-    def parse_output(self, detailed_job_info, stdout, stderr):
+    def parse_output(self, detailed_job_info=None, stdout=None, stderr=None):
         """Parse the output of the scheduler.
 
         :param detailed_job_info: dictionary with the output returned by the `Scheduler.get_detailed_job_info` command.
             This should contain the keys `retval`, `stdout` and `stderr` corresponding to the return value, stdout and
             stderr returned by the accounting command executed for a specific job id.
-        :param stdout: string with the output written by the scheduler to stdout
-        :param stderr: string with the output written by the scheduler to stderr
-        :return: None or an instance of `aiida.engine.processes.exit_code.ExitCode`
+        :param stdout: string with the output written by the scheduler to stdout.
+        :param stderr: string with the output written by the scheduler to stderr.
+        :return: None or an instance of :class:`aiida.engine.processes.exit_code.ExitCode`.
         """
         raise exceptions.FeatureNotAvailable(f'output parsing is not available for `{self.__class__.__name__}`')


### PR DESCRIPTION
Fixes #4840

When the functionality was added for a `Scheduler` plugin to parse the
output that was written to `stdout` and `stderr` or retrieved from a
specialized status command, it was decided to only call `parse_output`
if all three information streams were successfully retrieved. The
reasoning was especially that the `detailed_info` should be required as
that would return well-structured data and would allow to reliably
determine what had happened, whereas parsing free text from stdout and
stderr would be error prone.

Although probably a safe choice, the direct result was that setups where
the scheduler didn't have the necessary implementation to return the
`detailed_info`, no scheduler output parsing would be available. This
would lead to many OOM and OOW problems to go unnoticed and the engine
retrying to submit without any error handling.

Here we remove the requirement that all three information streams from
the parser, `detailed_info`, `stderr` and `stdout` should be known, but
that `parse_output` will always be called, with a default of `None` for
each. The advantage is that this will allow scheduler plugins to
implement parsing from `stderr`, on top of `detailed_info` wherever
applicable, to increase the chances of catching basic problems.

The major downside is that this is a backwards incompatible change for
scheduler plugins that rely on the assumption that the arguments always
have values that are not `None`.