### PR TITLE
👌 IMPROVE: Move default user caching to `StorageBackend`

### DIFF
--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -155,7 +155,7 @@ class Group(entities.Entity['BackendGroup'], metaclass=GroupMeta):
             raise ValueError('Group label must be provided')
 
         backend = backend or get_manager().get_profile_storage()
-        user = user if user else backend.default_user
+        user = user or backend.default_user
         type_check(user, users.User)
         type_string = self._type_string
 

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -155,7 +155,7 @@ class Group(entities.Entity['BackendGroup'], metaclass=GroupMeta):
             raise ValueError('Group label must be provided')
 
         backend = backend or get_manager().get_profile_storage()
-        user = user or users.User.collection(backend).get_default()
+        user = user if user else backend.default_user
         type_check(user, users.User)
         type_string = self._type_string
 

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         BackendQueryBuilder,
         BackendUserCollection,
     )
+    from aiida.orm.users import User
     from aiida.repository.backend.abstract import AbstractRepositoryBackend
 
 __all__ = ('StorageBackend',)
@@ -84,6 +85,7 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         """
         from aiida.orm.autogroup import AutogroupManager
         self._profile = profile
+        self._default_user: Optional['User'] = None
         self._autogroup = AutogroupManager(self)
 
     @abc.abstractmethod
@@ -160,6 +162,21 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
     @abc.abstractmethod
     def users(self) -> 'BackendUserCollection':
         """Return the collection of users"""
+
+    @property
+    def default_user(self) -> Optional['User']:
+        """Return the default user for the profile, if it has been created.
+
+        This is cached, since it is a frequently used operation, for creating other entities.
+        """
+        from aiida.orm import QueryBuilder, User
+
+        if self._default_user is None and self.profile.default_user_email:
+            query = QueryBuilder().append(User, filters={'email': self.profile.default_user_email})
+            results = query.all(flat=True)
+            if results:
+                self._default_user = results[0]
+        return self._default_user
 
     @abc.abstractmethod
     def query(self) -> 'BackendQueryBuilder':

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -172,7 +172,7 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         from aiida.orm import QueryBuilder, User
 
         if self._default_user is None and self.profile.default_user_email:
-            query = QueryBuilder().append(User, filters={'email': self.profile.default_user_email})
+            query = QueryBuilder(self).append(User, filters={'email': self.profile.default_user_email})
             results = query.all(flat=True)
             if results:
                 self._default_user = results[0]

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -173,9 +173,7 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
 
         if self._default_user is None and self.profile.default_user_email:
             query = QueryBuilder(self).append(User, filters={'email': self.profile.default_user_email})
-            results = query.all(flat=True)
-            if results:
-                self._default_user = results[0]
+            self._default_user = query.first(flat=True)
         return self._default_user
 
     @abc.abstractmethod

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -181,7 +181,7 @@ class Node(Entity['BackendNode'], metaclass=AbstractNodeMeta):
             raise ValueError('the computer is not stored')
 
         computer = computer.backend_entity if computer else None
-        user = user if user else User.collection(backend).get_default()
+        user = user if user else backend.default_user
 
         if user is None:
             raise ValueError('the user cannot be None')

--- a/aiida/orm/users.py
+++ b/aiida/orm/users.py
@@ -29,9 +29,6 @@ class UserCollection(entities.Collection['User']):
     def _entity_base_cls() -> Type['User']:
         return User
 
-    def __init__(self, entity_class: Type['User'], backend: Optional['StorageBackend'] = None) -> None:
-        super().__init__(entity_class=entity_class, backend=backend)
-
     def get_or_create(self, email: str, **kwargs) -> Tuple[bool, 'User']:
         """Get the existing user with a given email address or create an unstored one
 

--- a/aiida/orm/users.py
+++ b/aiida/orm/users.py
@@ -31,7 +31,6 @@ class UserCollection(entities.Collection['User']):
 
     def __init__(self, entity_class: Type['User'], backend: Optional['StorageBackend'] = None) -> None:
         super().__init__(entity_class=entity_class, backend=backend)
-        self._default_user: Optional[User] = None
 
     def get_or_create(self, email: str, **kwargs) -> Tuple[bool, 'User']:
         """Get the existing user with a given email address or create an unstored one
@@ -48,23 +47,7 @@ class UserCollection(entities.Collection['User']):
 
     def get_default(self) -> Optional['User']:
         """Get the current default user"""
-        if self._default_user is None:
-            email = self.backend.profile.default_user_email
-            if not email:
-                self._default_user = None
-
-            try:
-                self._default_user = self.get(email=email)
-            except (exceptions.MultipleObjectsError, exceptions.NotExistent):
-                self._default_user = None
-
-        return self._default_user
-
-    def reset(self) -> None:
-        """
-        Reset internal caches (default user).
-        """
-        self._default_user = None
+        return self.backend.default_user
 
 
 class User(entities.Entity['BackendUser']):

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -12,6 +12,7 @@
 import pytest
 
 from aiida.manage import get_manager
+from aiida.orm import User
 
 
 @pytest.fixture(scope='function')
@@ -21,6 +22,11 @@ def clear_storage_before_test(aiida_profile_clean):  # pylint: disable=unused-ar
     object_keys = list(repository.list_objects())
     repository.delete_objects(object_keys)
     repository.maintain(live=False)
+
+
+@pytest.mark.usefixtures('clear_storage_before_test')
+def test_default_user():
+    assert isinstance(get_manager().get_profile_storage().default_user, User)
 
 
 @pytest.mark.usefixtures('clear_storage_before_test')


### PR DESCRIPTION
Currently it is cached on the `UserCollection`,
but this means that, on profile switching,
it would return a user associated with the wrong backend instance.