### PR TITLE
👌 IMPROVE: Reinstate old profile after `profile_context`

### DIFF
--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -172,9 +172,14 @@ def profile_context(profile: Optional[str] = None, allow_switch=False) -> 'Profi
     :return: a context manager for temporarily loading a profile
     """
     from aiida.manage import get_manager
-    get_manager().load_profile(profile, allow_switch)
+    manager = get_manager()
+    current_profile = manager.get_profile()
+    manager.load_profile(profile, allow_switch)
     yield profile
-    get_manager().unload_profile()
+    if current_profile is None:
+        manager.unload_profile()
+    else:
+        manager.load_profile(current_profile, allow_switch=True)
 
 
 def reset_config():

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -3,6 +3,7 @@
 import pytest
 
 import aiida
+from aiida.manage.configuration import get_profile, profile_context
 from aiida.manage.manager import get_manager
 
 
@@ -48,3 +49,21 @@ def test_check_version_development(monkeypatch, capsys, isolated_config, suppres
         assert not captured.out
     else:
         assert f'You are currently using a post release development version of AiiDA: {version}' in captured.out
+
+
+def test_profile_context(config_with_profile, profile_factory):
+    """Test that the original profile is restored when ``profile_context`` returns from the context."""
+    config = config_with_profile
+
+    # Get current profile
+    profile_original = get_profile()
+    assert profile_original is not None
+
+    # Create a new profile and add it to the config
+    profile_alternate = profile_factory()
+    config.add_profile(profile_alternate)
+
+    with profile_context(profile_alternate.name):
+        assert get_profile() == profile_alternate
+
+    assert get_profile() == profile_original


### PR DESCRIPTION
Note, currently this would still reload a new storage backend instance (and hence new sqlalchemy session), and so any existing ORM entities would be invalidated, e.g.

```python
load_profile('x')
node = load_node(1)

with profile_context('y', allow_switch=True):
    pass

node.uuid  # this would fail, with a `ClosedStorage` exception 
```

Not sure if this is ideal, but otherwise you would need to allow multiple profiles to be open at the same time.