### PR TITLE
👌 IMPROVE: Check nodes are from same backend in `validate_link`

### DIFF
--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -155,8 +155,9 @@ def validate_link(
     type_check(target, Node, f'target should be a `Node` but got: {type(target)}')
 
     if source.backend != target.backend:
-        raise ValueError(f'source and target nodes must be stored in the same backend, but got {source.backend} and '
-                         f'{target.backend}')
+        raise ValueError(
+            f'source and target nodes must be stored in the same backend, but got {source.backend} and {target.backend}'
+        )
 
     if source.uuid is None or target.uuid is None:
         raise ValueError('source or target node does not have a UUID')


### PR DESCRIPTION
Since here: https://github.com/aiidateam/aiida-core/blob/bab1ad6cfc8e4ff041bce268f9270c613663cb35/aiida/storage/psql_dos/orm/nodes.py#L204

Only the node ID's are used to create the `DbLink` row,  it would be possible currently to accidentally pass it two nodes associated with different backends, and so create an incorrect link.

We could possibly use the actual `DbNode`s, to instantiate the `DbLink`, and have sqlalchemy check that they are associated with the same `Session`,
but adding the check in `validate_link` should catch any issue earlier on, and make it backend agnostic.