### PR TITLE
Backport addition of warning on RabbitMQ version

### DIFF
--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -28,6 +28,38 @@ __all__ = (
 )
 
 
+def is_rabbitmq_version_supported():
+    """Return whether the version of RabbitMQ configured for the current profile is supported.
+
+    Versions 3.8 and above are not compatible with AiiDA with default configuration.
+
+    :return: boolean whether the current RabbitMQ version is supported.
+    """
+    from packaging.version import parse
+    return get_rabbitmq_version() < parse('3.8.15')
+
+
+def get_rabbitmq_version():
+    """Return the version of the RabbitMQ server that the current profile connects to.
+
+    :return: :class:`packaging.version.Version`
+    """
+    from packaging.version import parse
+
+    from aiida.manage.manager import get_manager
+    communicator = get_manager().get_communicator()
+    return parse(communicator.server_properties['version'].decode('utf-8'))
+
+
+def check_rabbitmq_version():
+    """Check the version of RabbitMQ that is being connected to and emit warning if the version is not compatible."""
+    from aiida.cmdline.utils import echo
+    if not is_rabbitmq_version_supported():
+        echo.echo_warning(f'RabbitMQ v{get_rabbitmq_version()} is not supported and will cause unexpected problems!')
+        echo.echo_warning('It can cause long-running workflows to crash and jobs to be submitted multiple times.')
+        echo.echo_warning('See https://github.com/aiidateam/aiida-core/wiki/RabbitMQ-version-to-use for details.')
+
+
 def load_profile(profile=None):
     """Load a profile.
 
@@ -64,6 +96,9 @@ def load_profile(profile=None):
     # Note that we do not configure with `with_orm=True` because that will force the backend to be loaded. This should
     # instead be done lazily in `Manager._load_backend`.
     configure_logging()
+
+    # Check whether a compatible version of RabbitMQ is being used.
+    check_rabbitmq_version()
 
     return PROFILE
 

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -28,38 +28,6 @@ __all__ = (
 )
 
 
-def is_rabbitmq_version_supported():
-    """Return whether the version of RabbitMQ configured for the current profile is supported.
-
-    Versions 3.8 and above are not compatible with AiiDA with default configuration.
-
-    :return: boolean whether the current RabbitMQ version is supported.
-    """
-    from packaging.version import parse
-    return get_rabbitmq_version() < parse('3.8.15')
-
-
-def get_rabbitmq_version():
-    """Return the version of the RabbitMQ server that the current profile connects to.
-
-    :return: :class:`packaging.version.Version`
-    """
-    from packaging.version import parse
-
-    from aiida.manage.manager import get_manager
-    communicator = get_manager().get_communicator()
-    return parse(communicator.server_properties['version'].decode('utf-8'))
-
-
-def check_rabbitmq_version():
-    """Check the version of RabbitMQ that is being connected to and emit warning if the version is not compatible."""
-    from aiida.cmdline.utils import echo
-    if not is_rabbitmq_version_supported():
-        echo.echo_warning(f'RabbitMQ v{get_rabbitmq_version()} is not supported and will cause unexpected problems!')
-        echo.echo_warning('It can cause long-running workflows to crash and jobs to be submitted multiple times.')
-        echo.echo_warning('See https://github.com/aiidateam/aiida-core/wiki/RabbitMQ-version-to-use for details.')
-
-
 def load_profile(profile=None):
     """Load a profile.
 
@@ -96,9 +64,6 @@ def load_profile(profile=None):
     # Note that we do not configure with `with_orm=True` because that will force the backend to be loaded. This should
     # instead be done lazily in `Manager._load_backend`.
     configure_logging()
-
-    # Check whether a compatible version of RabbitMQ is being used.
-    check_rabbitmq_version()
 
     return PROFILE
 

--- a/aiida/manage/configuration/schema/config-v5.schema.json
+++ b/aiida/manage/configuration/schema/config-v5.schema.json
@@ -164,6 +164,11 @@
                     "default": true,
                     "description": "Whether to print AiiDA deprecation warnings"
                 },
+                "warnings.rabbitmq_version": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Whether to print a warning when an incompatible version of RabbitMQ is configured"
+                },
                 "transport.task_retry_initial_interval": {
                     "type": "integer",
                     "default": 20,

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
 - ipython~=7.20
 - jinja2~=2.10
 - jsonschema~=3.0
-- kiwipy[rmq]~=0.7.4
+- kiwipy[rmq]~=0.7.5
 - markupsafe<2.1
 - numpy~=1.17
 - pamqp~=2.3

--- a/requirements/requirements-py-3.7.txt
+++ b/requirements/requirements-py-3.7.txt
@@ -57,7 +57,7 @@ jupyter-console==6.2.0
 jupyter-core==4.7.1
 jupyterlab-pygments==0.1.2
 jupyterlab-widgets==1.0.0
-kiwipy==0.7.4
+kiwipy==0.7.5
 kiwisolver==1.3.1
 Mako==1.1.4
 MarkupSafe==1.1.1

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -56,7 +56,7 @@ jupyter-console==6.2.0
 jupyter-core==4.7.1
 jupyterlab-pygments==0.1.2
 jupyterlab-widgets==1.0.0
-kiwipy==0.7.4
+kiwipy==0.7.5
 kiwisolver==1.3.1
 Mako==1.1.4
 MarkupSafe==1.1.1

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -56,7 +56,7 @@ jupyter-console==6.2.0
 jupyter-core==4.7.1
 jupyterlab-pygments==0.1.2
 jupyterlab-widgets==1.0.0
-kiwipy==0.7.4
+kiwipy==0.7.5
 kiwisolver==1.3.1
 Mako==1.1.4
 MarkupSafe==1.1.1

--- a/setup.json
+++ b/setup.json
@@ -35,7 +35,7 @@
         "ipython~=7.20",
         "jinja2~=2.10",
         "jsonschema~=3.0",
-        "kiwipy[rmq]~=0.7.4",
+        "kiwipy[rmq]~=0.7.5",
         "markupsafe<2.1",
         "numpy~=1.17",
         "pamqp~=2.3",

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -63,7 +63,7 @@ class TestVerdiRun(AiidaTestCase):
             self.assertClickResultNoException(result)
 
             # Try to load the function calculation node from the printed pk in the output
-            pk = int(result.output)
+            pk = int(result.output.strip().split('\n')[-1])
             node = load_node(pk)
 
             # Verify that the node has the correct function name and content
@@ -285,7 +285,7 @@ class TestAutoGroups(AiidaTestCase):
                 result = self.cli_runner.invoke(cmd_run.run, options)
                 self.assertClickResultNoException(result)
 
-                pk1_str, pk2_str, pk3_str, pk4_str, pk5_str, pk6_str = result.output.split()
+                pk1_str, pk2_str, pk3_str, pk4_str, pk5_str, pk6_str = result.output.strip().split('\n')[-6:]
                 pk1 = int(pk1_str)
                 pk2 = int(pk2_str)
                 pk3 = int(pk3_str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,13 @@ def profile_factory() -> Profile:
             'database_name': kwargs.pop('database_name', name),
             'database_username': kwargs.pop('database_username', 'user'),
             'database_password': kwargs.pop('database_password', 'pass'),
+            'broker_protocol': kwargs.pop('broker_protocol', 'amqp'),
+            'broker_username': kwargs.pop('broker_username', 'guest'),
+            'broker_password': kwargs.pop('broker_password', 'guest'),
+            'broker_host': kwargs.pop('broker_host', 'localhost'),
+            'broker_port': kwargs.pop('broker_port', 5672),
+            'broker_virtual_host': kwargs.pop('broker_virtual_host', ''),
+            'broker_parameters': kwargs.pop('broker_parameters', {}),
             'repository_uri': f"file:///{os.path.join(repository_dirpath, f'repository_{name}')}",
         }
 

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -22,7 +22,7 @@ class TestConfigurationOptions(AiidaTestCase):
     def test_get_option_names(self):
         """Test `get_option_names` function."""
         self.assertIsInstance(get_option_names(), list)
-        self.assertEqual(len(get_option_names()), 26)
+        self.assertEqual(len(get_option_names()), 27)
 
     def test_get_option(self):
         """Test `get_option` function."""


### PR DESCRIPTION
These fixes were added in `v2.0.0b1` but they are also important to have on `v1.6.x`. As that version will still be used for a while and AiiDA will fail horribly with modern RabbitMQ versions, it is important to have this warning there.