### PR TITLE
Containerized code: double quotes setting of computer and code setup

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -72,6 +72,7 @@ def set_code_builder(ctx, param, value):
 @options_code.REMOTE_ABS_PATH()
 @options_code.FOLDER()
 @options_code.REL_PATH()
+@options_code.USE_DOUBLE_QUOTES()
 @options_code.PREPEND_TEXT()
 @options_code.APPEND_TEXT()
 @options.NON_INTERACTIVE()

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -204,6 +204,7 @@ def set_computer_builder(ctx, param, value):
 @options_computer.MPI_RUN_COMMAND()
 @options_computer.MPI_PROCS_PER_MACHINE()
 @options_computer.DEFAULT_MEMORY_PER_MACHINE()
+@options_computer.USE_DOUBLE_QUOTES()
 @options_computer.PREPEND_TEXT()
 @options_computer.APPEND_TEXT()
 @options.NON_INTERACTIVE()

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -109,6 +109,15 @@ REL_PATH = OverridableOption(
     help='[if --store-in-db]: Relative path of the executable inside the code-folder.'
 )
 
+USE_DOUBLE_QUOTES = OverridableOption(
+    '--use-double-quotes/--not-use-double-quotes',
+    default=False,
+    cls=InteractiveOption,
+    prompt='Escape CLI arguments in double quotes',
+    help='Whether the executable and arguments of the code in the submission script should be escaped with single '
+    'or double quotes.'
+)
+
 LABEL = options.LABEL.clone(
     prompt='Label',
     callback=validate_label_uniqueness,

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -117,6 +117,15 @@ DEFAULT_MEMORY_PER_MACHINE = OverridableOption(
     help='The default amount of RAM (kB) that should be allocated per machine (node), if not otherwise specified.'
 )
 
+USE_DOUBLE_QUOTES = OverridableOption(
+    '--use-double-quotes/--not-use-double-quotes',
+    default=False,
+    cls=InteractiveOption,
+    prompt='Escape CLI arguments in double quotes',
+    help='Whether the command line arguments before and after the executable in the submission script should be '
+    'escaped with single or double quotes.'
+)
+
 PREPEND_TEXT = OverridableOption(
     '--prepend-text',
     cls=TemplateInteractiveOption,

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -708,16 +708,16 @@ class CalcJob(Process):
                 this_withmpi = code_info.withmpi
 
             if this_withmpi:
-                this_argv = (
-                    mpi_args + extra_mpirun_params + [this_code.get_execname()] +
-                    (code_info.cmdline_params if code_info.cmdline_params is not None else [])
-                )
+                prepend_cmdline_params = mpi_args + extra_mpirun_params
             else:
-                this_argv = [this_code.get_execname()
-                             ] + (code_info.cmdline_params if code_info.cmdline_params is not None else [])
+                prepend_cmdline_params = []
+
+            cmdline_params = [this_code.get_execname()] + (code_info.cmdline_params or [])
 
             tmpl_code_info = JobTemplateCodeInfo()
-            tmpl_code_info.cmdline_params = this_argv
+            tmpl_code_info.prepend_cmdline_params = prepend_cmdline_params
+            tmpl_code_info.cmdline_params = cmdline_params
+            tmpl_code_info.use_double_quotes = [computer.get_use_double_quotes(), this_code.get_use_double_quotes()]
             tmpl_code_info.stdin_name = code_info.stdin_name
             tmpl_code_info.stdout_name = code_info.stdout_name
             tmpl_code_info.stderr_name = code_info.stderr_name

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -439,6 +439,22 @@ class Computer(entities.Entity['BackendComputer']):
     def set_append_text(self, val: str) -> None:
         self.set_property('append_text', str(val))
 
+    def get_use_double_quotes(self) -> bool:
+        """Return whether the command line parameters of this computer should be escaped with double quotes.
+
+        :returns: True if to escape with double quotes, False otherwise which is also the default.
+        """
+        return self.get_property('use_double_quotes', False)
+
+    def set_use_double_quotes(self, val: bool) -> None:
+        """Set whether the command line parameters of this computer should be escaped with double quotes.
+
+        :param use_double_quotes: True if to escape with double quotes, False otherwise.
+        """
+        from aiida.common.lang import type_check
+        type_check(val, bool)
+        self.set_property('use_double_quotes', val)
+
     def get_mpirun_command(self) -> List[str]:
         """
         Return the mpirun command. Must be a list of strings, that will be

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -351,6 +351,22 @@ class Code(Data):
         """
         return self.base.attributes.get('input_plugin', None)
 
+    def set_use_double_quotes(self, use_double_quotes: bool):
+        """Set whether the command line invocation of this code should be escaped with double quotes.
+
+        :param use_double_quotes: True if to escape with double quotes, False otherwise.
+        """
+        from aiida.common.lang import type_check
+        type_check(use_double_quotes, bool)
+        self.base.attributes.set('use_double_quotes', use_double_quotes)
+
+    def get_use_double_quotes(self) -> bool:
+        """Return whether the command line invocation of this code should be escaped with double quotes.
+
+        :returns: True if to escape with double quotes, False otherwise which is also the default.
+        """
+        return self.base.attributes.get('use_double_quotes', False)
+
     def set_append_text(self, code):
         """
         Pass a string of code that will be put in the scheduler script after the

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -63,6 +63,7 @@ class CodeBuilder:
         code.label = self._get_and_count('label', used)
         code.description = self._get_and_count('description', used)
         code.set_input_plugin_name(self._get_and_count('input_plugin', used))
+        code.set_use_double_quotes(self._get_and_count('use_double_quotes', used))
         code.set_prepend_text(self._get_and_count('prepend_text', used))
         code.set_append_text(self._get_and_count('append_text', used))
 
@@ -98,6 +99,7 @@ class CodeBuilder:
         spec['label'] = code.label
         spec['description'] = code.description
         spec['input_plugin'] = code.get_input_plugin_name()
+        spec['use_double_quotes'] = code.get_use_double_quotes()
         spec['prepend_text'] = code.get_prepend_text()
         spec['append_text'] = code.get_append_text()
 

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -39,6 +39,7 @@ class ComputerBuilder:  # pylint: disable=too-many-instance-attributes
         spec['hostname'] = computer.hostname
         spec['scheduler'] = computer.scheduler_type
         spec['transport'] = computer.transport_type
+        spec['use_double_quotes'] = computer.get_use_double_quotes()
         spec['prepend_text'] = computer.get_prepend_text()
         spec['append_text'] = computer.get_append_text()
         spec['work_dir'] = computer.get_workdir()
@@ -76,6 +77,7 @@ class ComputerBuilder:  # pylint: disable=too-many-instance-attributes
         computer.description = self._get_and_count('description', used)
         computer.scheduler_type = self._get_and_count('scheduler', used)
         computer.transport_type = self._get_and_count('transport', used)
+        computer.set_use_double_quotes(self._get_and_count('use_double_quotes', used))
         computer.set_prepend_text(self._get_and_count('prepend_text', used))
         computer.set_append_text(self._get_and_count('append_text', used))
         computer.set_workdir(self._get_and_count('work_dir', used))

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -370,13 +370,18 @@ class JobTemplateCodeInfo:
     `Scheduler.get_submit_script` will pass a list of these objects to `Scheduler._get_run_line` which
     should build up the code execution line based on the parameters specified in this dataclass.
 
+    :param preprend_cmdline_params: list of unescaped command line arguments that are to be prepended to the executable.
     :param cmdline_params: list of unescaped command line parameters.
+    :param use_double_quotes: list of two booleans. If true, use double quotes to escape command line arguments. The
+        first value applies to `prepend_cmdline_params` and the second to `cmdline_params`.
     :param stdin_name: filename of the the stdin file descriptor.
     :param stdout_name: filename of the the `stdout` file descriptor.
     :param stderr_name: filename of the the `stderr` file descriptor.
     :param join_files: boolean, if true, `stderr` should be redirected to `stdout`.
     """
+    prepend_cmdline_params: list[str] = field(default_factory=list)
     cmdline_params: list[str] = field(default_factory=list)
+    use_double_quotes: list[bool] = field(default_factory=lambda: [False, False])
     stdin_name: None | str = None
     stdout_name: None | str = None
     stderr_name: None | str = None

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -219,19 +219,28 @@ class Scheduler(metaclass=abc.ABCMeta):
         list_of_runlines = []
 
         for code_info in codes_info:
+            computer_use_double_quotes = code_info.use_double_quotes[0]
+            code_use_double_quotes = code_info.use_double_quotes[1]
+
             command_to_exec_list = []
+            for arg in code_info.prepend_cmdline_params:
+                command_to_exec_list.append(escape_for_bash(arg, use_double_quotes=computer_use_double_quotes))
             for arg in code_info.cmdline_params:
-                command_to_exec_list.append(escape_for_bash(arg))
+                command_to_exec_list.append(escape_for_bash(arg, use_double_quotes=code_use_double_quotes))
             command_to_exec = ' '.join(command_to_exec_list)
 
-            stdin_str = f'< {escape_for_bash(code_info.stdin_name)}' if code_info.stdin_name else ''
-            stdout_str = f'> {escape_for_bash(code_info.stdout_name)}' if code_info.stdout_name else ''
+            escape_stdin_name = escape_for_bash(code_info.stdin_name, use_double_quotes=computer_use_double_quotes)
+            escape_stdout_name = escape_for_bash(code_info.stdout_name, use_double_quotes=computer_use_double_quotes)
+            escape_sterr_name = escape_for_bash(code_info.stderr_name, use_double_quotes=computer_use_double_quotes)
+
+            stdin_str = f'< {escape_stdin_name}' if code_info.stdin_name else ''
+            stdout_str = f'> {escape_stdout_name}' if code_info.stdout_name else ''
 
             join_files = code_info.join_files
             if join_files:
                 stderr_str = '2>&1'
             else:
-                stderr_str = f'2> {escape_for_bash(code_info.stderr_name)}' if code_info.stderr_name else ''
+                stderr_str = f'2> {escape_sterr_name}' if code_info.stderr_name else ''
 
             output_string = f'{command_to_exec} {stdin_str} {stdout_str} {stderr_str}'
 

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -150,8 +150,13 @@ def test_noninteractive_remote(run_cli_command, aiida_localhost, non_interactive
     """Test non-interactive remote code setup."""
     label = 'noninteractive_remote'
     options = [
-        '--non-interactive', f'--label={label}', '--description=description', '--input-plugin=core.arithmetic.add',
-        '--on-computer', f'--computer={aiida_localhost.label}', '--remote-abs-path=/remote/abs/path'
+        '--non-interactive',
+        f'--label={label}',
+        '--description=description',
+        '--input-plugin=core.arithmetic.add',
+        '--on-computer',
+        f'--computer={aiida_localhost.label}',
+        '--remote-abs-path=/remote/abs/path',
     ]
     run_cli_command(cmd_code.setup_code, options)
     assert isinstance(load_code(label), Code)

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -351,6 +351,7 @@ class TestVerdiComputerConfigure:
         self.comp_builder.description = 'Test Computer'
         self.comp_builder.scheduler = 'core.direct'
         self.comp_builder.work_dir = '/tmp/aiida'
+        self.comp_builder.use_double_quotes = False
         self.comp_builder.prepend_text = ''
         self.comp_builder.append_text = ''
         self.comp_builder.mpiprocs_per_machine = 8

--- a/tests/engine/processes/calcjobs/test_calc_job/test_code_double_quotes_False_.sh
+++ b/tests/engine/processes/calcjobs/test_calc_job/test_code_double_quotes_False_.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'mpirun' '-np' '1' '/bin/bash' '--version' '-c' < 'aiida.in' > 'aiida.out' 2> 'aiida.err'

--- a/tests/engine/processes/calcjobs/test_calc_job/test_code_double_quotes_True_.sh
+++ b/tests/engine/processes/calcjobs/test_calc_job/test_code_double_quotes_True_.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'mpirun' '-np' '1' "/bin/bash" "--version" "-c" < 'aiida.in' > 'aiida.out' 2> 'aiida.err'

--- a/tests/engine/processes/calcjobs/test_calc_job/test_computer_double_quotes_False_.sh
+++ b/tests/engine/processes/calcjobs/test_calc_job/test_computer_double_quotes_False_.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'mpirun' '-np' '1' '/bin/bash' '--version' '-c' < 'aiida.in' > 'aiida.out' 2> 'aiida.err'

--- a/tests/engine/processes/calcjobs/test_calc_job/test_computer_double_quotes_True_.sh
+++ b/tests/engine/processes/calcjobs/test_calc_job/test_computer_double_quotes_True_.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+"mpirun" "-np" "1" '/bin/bash' '--version' '-c' < "aiida.in" > "aiida.out" 2> "aiida.err"

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -99,6 +99,7 @@ class TestComputerConfigure:
         self.comp_builder.work_dir = '/tmp/aiida'
         self.comp_builder.prepend_text = ''
         self.comp_builder.append_text = ''
+        self.comp_builder.use_double_quotes = False
         self.comp_builder.mpiprocs_per_machine = 8
         self.comp_builder.default_memory_per_machine = 1000000
         self.comp_builder.mpirun_command = 'mpirun'


### PR DESCRIPTION
The PR is a part required for containerized code implementation (also for hyperqueue without hacky workaround to evaluate command-line variable by `$` properly) and is separated from https://github.com/aiidateam/aiida-core/pull/5250. It allows users to set up computer and code with an extra option `--use-double-quotes` to using double quotes for the command run line of job script.