### PR TITLE
Tests: reinstate `test_daemon.py` in CI workflow

### DIFF
--- a/.github/workflows/tests_nightly.sh
+++ b/.github/workflows/tests_nightly.sh
@@ -8,6 +8,7 @@ MODULE_POLISH="${GITHUB_WORKSPACE}/.molecule/default/files/polish"
 export PYTHONPATH="${PYTHONPATH}:${SYSTEM_TESTS}:${MODULE_POLISH}"
 
 verdi daemon start 4
+verdi -p test_aiida run ${SYSTEM_TESTS}/test_daemon.py
 bash ${SYSTEM_TESTS}/test_polish_workchains.sh
 verdi daemon stop
 

--- a/aiida/parsers/plugins/templatereplacer/doubler.py
+++ b/aiida/parsers/plugins/templatereplacer/doubler.py
@@ -28,7 +28,7 @@ class TemplatereplacerDoublerParser(Parser):
             return self.exit_codes.ERROR_NO_OUTPUT_FILE_NAME_DEFINED
 
         try:
-            with output_folder.open(output_file, 'r') as handle:
+            with output_folder.base.repository.open(output_file, 'r') as handle:
                 result = self.parse_stdout(handle)
         except (OSError, IOError):
             self.logger.exception(f'unable to parse the output for CalcJobNode<{self.node.pk}>')


### PR DESCRIPTION
This got removed in 5d2f15380417ce963544e209346b31eb37b0490d by accident
when moving the RPN workchains to the nightly build. The tests are
integration tests and take roughly 4 minutes so they are added to the
nightly build instead of the normal CI build as it would slow down PR
builds too much.