### PR TITLE
♻️  REFACTOR: Move link related methods to `Node.base.links`

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -214,7 +214,7 @@ def show(code):
     table.append(['Append text', code.get_append_text()])
 
     if is_verbose():
-        table.append(['Calculations', len(code.get_outgoing().all())])
+        table.append(['Calculations', len(code.base.links.get_outgoing().all())])
 
     echo.echo(tabulate.tabulate(table))
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -154,10 +154,10 @@ def get_node_info(node, include_summary=True):
     else:
         result = ''
 
-    nodes_caller = node.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
-    nodes_called = node.get_outgoing(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
-    nodes_input = node.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
-    nodes_output = node.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN))
+    nodes_caller = node.base.links.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
+    nodes_called = node.base.links.get_outgoing(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
+    nodes_input = node.base.links.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
+    nodes_output = node.base.links.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN))
 
     if nodes_input:
         result += f"\n{format_nested_links(nodes_input.nested(), headers=['Inputs', 'PK', 'Type'])}"

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -487,7 +487,7 @@ class CalcJob(Process):
             exit_code = exit_code_scheduler
 
         # Finally link up the outputs and we're done
-        for entry in self.node.get_outgoing():
+        for entry in self.node.base.links.get_outgoing():
             self.out(entry.link_label, entry.node)
 
         return exit_code or ExitCode(0)
@@ -592,10 +592,10 @@ class CalcJob(Process):
         from aiida.orm import Code, Computer, load_node
         from aiida.schedulers.datastructures import JobTemplate, JobTemplateCodeInfo
 
-        inputs = self.node.get_incoming(link_type=LinkType.INPUT_CALC)
+        inputs = self.node.base.links.get_incoming(link_type=LinkType.INPUT_CALC)
 
-        if not self.inputs.metadata.dry_run and self.node.has_cached_links():  # type: ignore[union-attr]
-            raise InvalidOperation('calculation node has unstored links in cache')
+        if not self.inputs.metadata.dry_run and not self.node.is_stored:  # type: ignore[union-attr]
+            raise InvalidOperation('calculation node is not stored.')
 
         computer = self.node.computer
         codes = [_ for _ in inputs.all_nodes() if isinstance(_, Code)]

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -45,10 +45,10 @@ def calcfunction(function: Callable[..., Any]) -> Callable[..., Any]:
     >>> r = sum(Int(4), Int(5))
     >>> print(r)
     9
-    >>> r.get_incoming().all() # doctest: +SKIP
+    >>> r.base.links.get_incoming().all() # doctest: +SKIP
     [Neighbor(link_type='', link_label='result',
     node=<CalcFunctionNode: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>)]
-    >>> r.get_incoming().get_node_by_label('result').get_incoming().all_nodes()
+    >>> r.base.links.get_incoming().get_node_by_label('result').base.links.get_incoming().all_nodes()
     [4, 5]
 
     :param function: The function to decorate.
@@ -75,10 +75,10 @@ def workfunction(function: Callable[..., Any]) -> Callable[..., Any]:
     >>> r = select(Int(4), Int(5))
     >>> print(r)
     4
-    >>> r.get_incoming().all() # doctest: +SKIP
+    >>> r.base.links.get_incoming().all() # doctest: +SKIP
     [Neighbor(link_type='', link_label='result',
     node=<WorkFunctionNode: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>)]
-    >>> r.get_incoming().get_node_by_label('result').get_incoming().all_nodes()
+    >>> r.base.links.get_incoming().get_node_by_label('result').base.links.get_incoming().all_nodes()
     [4, 5]
 
     :param function: The function to decorate.

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -339,7 +339,7 @@ class WorkChain(Process):
             raise ValueError(f'provided pk<{awaitable.pk}> could not be resolved to a valid Node instance')
 
         if awaitable.outputs:
-            value = {entry.link_label: entry.node for entry in node.get_outgoing()}
+            value = {entry.link_label: entry.node for entry in node.base.links.get_outgoing()}
         else:
             value = node
 

--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -196,7 +196,9 @@ class ProcessLauncher(plumpy.ProcessLauncher):
             future = Future()
 
             if node.is_finished:
-                future.set_result({entry.link_label: entry.node for entry in node.get_outgoing(node_class=Data)})
+                future.set_result({
+                    entry.link_label: entry.node for entry in node.base.links.get_outgoing(node_class=Data)
+                })
             elif node.is_excepted:
                 future.set_exception(PastException(node.exception))
             elif node.is_killed:

--- a/aiida/orm/nodes/comments.py
+++ b/aiida/orm/nodes/comments.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Interface for comments of a node instance."""
+from __future__ import annotations
+
+import typing as t
+
+from ..comments import Comment
+from ..users import User
+
+
+class NodeComments:
+    """Interface for comments of a node instance."""
+
+    def __init__(self, node: 'Node') -> None:
+        """Initialize the comments interface."""
+        self._node = node
+
+    def add(self, content: str, user: t.Optional[User] = None) -> Comment:
+        """Add a new comment.
+
+        :param content: string with comment
+        :param user: the user to associate with the comment, will use default if not supplied
+        :return: the newly created comment
+        """
+        user = user or User.objects(self._node.backend).get_default()
+        return Comment(node=self._node, user=user, content=content).store()
+
+    def get(self, identifier: int) -> Comment:
+        """Return a comment corresponding to the given identifier.
+
+        :param identifier: the comment pk
+        :raise aiida.common.NotExistent: if the comment with the given id does not exist
+        :raise aiida.common.MultipleObjectsError: if the id cannot be uniquely resolved to a comment
+        :return: the comment
+        """
+        return Comment.objects(self._node.backend).get(dbnode_id=self._node.pk, id=identifier)
+
+    def all(self) -> list[Comment]:
+        """Return a sorted list of comments for this node.
+
+        :return: the list of comments, sorted by pk
+        """
+        return Comment.objects(self._node.backend).find(filters={'dbnode_id': self._node.pk}, order_by=[{'id': 'asc'}])
+
+    def update(self, identifier: int, content: str) -> None:
+        """Update the content of an existing comment.
+
+        :param identifier: the comment pk
+        :param content: the new comment content
+        :raise aiida.common.NotExistent: if the comment with the given id does not exist
+        :raise aiida.common.MultipleObjectsError: if the id cannot be uniquely resolved to a comment
+        """
+        comment = Comment.objects(self._node.backend).get(dbnode_id=self._node.pk, id=identifier)
+        comment.set_content(content)
+
+    def remove(self, identifier: int) -> None:  # pylint: disable=no-self-use
+        """Delete an existing comment.
+
+        :param identifier: the comment pk
+        """
+        Comment.objects(self._node.backend).delete(identifier)

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -123,7 +123,7 @@ class Data(Node):
 
         :return: the creating node or None
         """
-        inputs = self.get_incoming(link_type=LinkType.CREATE)
+        inputs = self.base.links.get_incoming(link_type=LinkType.CREATE)
         if inputs:
             return inputs.first().node
 

--- a/aiida/orm/nodes/links.py
+++ b/aiida/orm/nodes/links.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Interface for links of a node instance."""
+from __future__ import annotations
+
+import typing as t
+
+from aiida.common import exceptions
+from aiida.common.escaping import sql_string_match
+from aiida.common.lang import type_check
+from aiida.common.links import LinkType
+
+from ..querybuilder import QueryBuilder
+from ..utils.links import LinkManager, LinkTriple
+
+
+class NodeLinks:
+    """Interface for links of a node instance."""
+
+    def __init__(self, node: 'Node') -> None:
+        """Initialize the links interface."""
+        self._node = node
+        self.incoming_cache: list[LinkTriple] = []
+
+    def _add_incoming_cache(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
+        """Add an incoming link to the cache.
+
+        .. note: the proposed link is not validated in this function, so this should not be called directly
+            but it should only be called by `Node.add_incoming`.
+
+        :param source: the node from which the link is coming
+        :param link_type: the link type
+        :param link_label: the link label
+        :raise aiida.common.UniquenessError: if the given link triple already exists in the cache
+        """
+        assert self.incoming_cache is not None, 'incoming_cache not initialised'
+
+        link_triple = LinkTriple(source, link_type, link_label)
+
+        if link_triple in self.incoming_cache:
+            raise exceptions.UniquenessError(f'the link triple {link_triple} is already present in the cache')
+
+        self.incoming_cache.append(link_triple)
+
+    def add_incoming(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
+        """Add a link of the given type from a given node to ourself.
+
+        :param source: the node from which the link is coming
+        :param link_type: the link type
+        :param link_label: the link label
+        :raise TypeError: if `source` is not a Node instance or `link_type` is not a `LinkType` enum
+        :raise ValueError: if the proposed link is invalid
+        """
+        self.validate_incoming(source, link_type, link_label)
+        source.base.links.validate_outgoing(self._node, link_type, link_label)
+
+        if self._node.is_stored and source.is_stored:
+            self._node.backend_entity.add_incoming(source.backend_entity, link_type, link_label)
+        else:
+            self._add_incoming_cache(source, link_type, link_label)
+
+    def validate_incoming(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
+        """Validate adding a link of the given type from a given node to ourself.
+
+        This function will first validate the types of the inputs, followed by the node and link types and validate
+        whether in principle a link of that type between the nodes of these types is allowed.
+
+        Subsequently, the validity of the "degree" of the proposed link is validated, which means validating the
+        number of links of the given type from the given node type is allowed.
+
+        :param source: the node from which the link is coming
+        :param link_type: the link type
+        :param link_label: the link label
+        :raise TypeError: if `source` is not a Node instance or `link_type` is not a `LinkType` enum
+        :raise ValueError: if the proposed link is invalid
+        """
+        from aiida.orm.utils.links import validate_link
+
+        from .node import Node
+
+        validate_link(source, self._node, link_type, link_label, backend=self._node.backend)
+
+        # Check if the proposed link would introduce a cycle in the graph following ancestor/descendant rules
+        if link_type in [LinkType.CREATE, LinkType.INPUT_CALC, LinkType.INPUT_WORK]:
+            builder = QueryBuilder(backend=self._node.backend).append(
+                Node, filters={'id': self._node.pk}, tag='parent').append(
+                Node, filters={'id': source.pk}, tag='child', with_ancestors='parent')  # yapf:disable
+            if builder.count() > 0:
+                raise ValueError('the link you are attempting to create would generate a cycle in the graph')
+
+    def validate_outgoing(self, target: 'Node', link_type: LinkType, link_label: str) -> None:  # pylint: disable=unused-argument,no-self-use
+        """Validate adding a link of the given type from ourself to a given node.
+
+        The validity of the triple (source, link, target) should be validated in the `validate_incoming` call.
+        This method will be called afterwards and can be overriden by subclasses to add additional checks that are
+        specific to that subclass.
+
+        :param target: the node to which the link is going
+        :param link_type: the link type
+        :param link_label: the link label
+        :raise TypeError: if `target` is not a Node instance or `link_type` is not a `LinkType` enum
+        :raise ValueError: if the proposed link is invalid
+        """
+        from .node import Node
+        type_check(link_type, LinkType, f'link_type should be a LinkType enum but got: {type(link_type)}')
+        type_check(target, Node, f'target should be a `Node` instance but got: {type(target)}')
+
+    def get_stored_link_triples(
+        self,
+        node_class: t.Type['Node'] = None,
+        link_type: t.Union[LinkType, t.Sequence[LinkType]] = (),
+        link_label_filter: t.Optional[str] = None,
+        link_direction: str = 'incoming',
+        only_uuid: bool = False
+    ) -> list[LinkTriple]:
+        """Return the list of stored link triples directly incoming to or outgoing of this node.
+
+        Note this will only return link triples that are stored in the database. Anything in the cache is ignored.
+
+        :param node_class: If specified, should be a class, and it filters only elements of that (subclass of) type
+        :param link_type: Only get inputs of this link type, if empty tuple then returns all inputs of all link types.
+        :param link_label_filter: filters the incoming nodes by its link label. This should be a regex statement as
+            one would pass directly to a QueryBuilder filter statement with the 'like' operation.
+        :param link_direction: `incoming` or `outgoing` to get the incoming or outgoing links, respectively.
+        :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
+        """
+        from .node import Node
+
+        if not isinstance(link_type, tuple):
+            link_type = (link_type,)
+
+        if link_type and not all(isinstance(t, LinkType) for t in link_type):
+            raise TypeError(f'link_type should be a LinkType or tuple of LinkType: got {link_type}')
+
+        node_class = node_class or Node
+        node_filters: dict[str, t.Any] = {'id': {'==': self._node.id}}
+        edge_filters: dict[str, t.Any] = {}
+
+        if link_type:
+            edge_filters['type'] = {'in': [t.value for t in link_type]}
+
+        if link_label_filter:
+            edge_filters['label'] = {'like': link_label_filter}
+
+        builder = QueryBuilder(backend=self._node.backend)
+        builder.append(Node, filters=node_filters, tag='main')
+
+        node_project = ['uuid'] if only_uuid else ['*']
+        if link_direction == 'outgoing':
+            builder.append(
+                node_class,
+                with_incoming='main',
+                project=node_project,
+                edge_project=['type', 'label'],
+                edge_filters=edge_filters
+            )
+        else:
+            builder.append(
+                node_class,
+                with_outgoing='main',
+                project=node_project,
+                edge_project=['type', 'label'],
+                edge_filters=edge_filters
+            )
+
+        return [LinkTriple(entry[0], LinkType(entry[1]), entry[2]) for entry in builder.all()]
+
+    def get_incoming(
+        self,
+        node_class: t.Type['Node'] = None,
+        link_type: t.Union[LinkType, t.Sequence[LinkType]] = (),
+        link_label_filter: t.Optional[str] = None,
+        only_uuid: bool = False
+    ) -> LinkManager:
+        """Return a list of link triples that are (directly) incoming into this node.
+
+        :param node_class: If specified, should be a class or tuple of classes, and it filters only
+            elements of that specific type (or a subclass of 'type')
+        :param link_type: If specified should be a string or tuple to get the inputs of this
+            link type, if None then returns all inputs of all link types.
+        :param link_label_filter: filters the incoming nodes by its link label.
+            Here wildcards (% and _) can be passed in link label filter as we are using "like" in QB.
+        :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
+        """
+        if not isinstance(link_type, tuple):
+            link_type = (link_type,)
+
+        if self._node.is_stored:
+            link_triples = self.get_stored_link_triples(
+                node_class, link_type, link_label_filter, 'incoming', only_uuid=only_uuid
+            )
+        else:
+            link_triples = []
+
+        # Get all cached link triples
+        for link_triple in self.incoming_cache:
+
+            if only_uuid:
+                link_triple = LinkTriple(link_triple.node.uuid, link_triple.link_type, link_triple.link_label)
+
+            if link_triple in link_triples:
+                raise exceptions.InternalError(
+                    f'Node<{self._node.pk}> has both a stored and cached link triple {link_triple}'
+                )
+
+            if not link_type or link_triple.link_type in link_type:
+                if link_label_filter is not None:
+                    if sql_string_match(string=link_triple.link_label, pattern=link_label_filter):
+                        link_triples.append(link_triple)
+                else:
+                    link_triples.append(link_triple)
+
+        return LinkManager(link_triples)
+
+    def get_outgoing(
+        self,
+        node_class: t.Type['Node'] = None,
+        link_type: t.Union[LinkType, t.Sequence[LinkType]] = (),
+        link_label_filter: t.Optional[str] = None,
+        only_uuid: bool = False
+    ) -> LinkManager:
+        """Return a list of link triples that are (directly) outgoing of this node.
+
+        :param node_class: If specified, should be a class or tuple of classes, and it filters only
+            elements of that specific type (or a subclass of 'type')
+        :param link_type: If specified should be a string or tuple to get the inputs of this
+            link type, if None then returns all outputs of all link types.
+        :param link_label_filter: filters the outgoing nodes by its link label.
+            Here wildcards (% and _) can be passed in link label filter as we are using "like" in QB.
+        :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
+        """
+        link_triples = self.get_stored_link_triples(node_class, link_type, link_label_filter, 'outgoing', only_uuid)
+        return LinkManager(link_triples)

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=too-many-lines,too-many-arguments
+# pylint: disable=too-many-arguments
 """Package for node ORM classes."""
 import datetime
 from functools import cached_property
@@ -24,7 +24,6 @@ from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
 from aiida.orm.utils.node import AbstractNodeMeta
 
-from ..comments import Comment
 from ..computers import Computer
 from ..entities import Collection as EntityCollection
 from ..entities import Entity
@@ -32,6 +31,7 @@ from ..extras import EntityExtras
 from ..querybuilder import QueryBuilder
 from ..users import User
 from .attributes import NodeAttributes
+from .comments import NodeComments
 from .links import NodeLinks
 from .repository import NodeRepository
 
@@ -787,56 +787,3 @@ class Node(Entity['BackendNode'], metaclass=AbstractNodeMeta):
             return getattr(self.base.links, new_name)
 
         raise AttributeError(name)
-
-
-class NodeComments:
-    """Interface for comments of a node instance."""
-
-    def __init__(self, node: Node) -> None:
-        """Initialize the comments interface."""
-        self._node = node
-
-    def add(self, content: str, user: Optional[User] = None) -> Comment:
-        """Add a new comment.
-
-        :param content: string with comment
-        :param user: the user to associate with the comment, will use default if not supplied
-        :return: the newly created comment
-        """
-        user = user or User.objects(self._node.backend).get_default()
-        return Comment(node=self._node, user=user, content=content).store()
-
-    def get(self, identifier: int) -> Comment:
-        """Return a comment corresponding to the given identifier.
-
-        :param identifier: the comment pk
-        :raise aiida.common.NotExistent: if the comment with the given id does not exist
-        :raise aiida.common.MultipleObjectsError: if the id cannot be uniquely resolved to a comment
-        :return: the comment
-        """
-        return Comment.objects(self._node.backend).get(dbnode_id=self._node.pk, id=identifier)
-
-    def all(self) -> List[Comment]:
-        """Return a sorted list of comments for this node.
-
-        :return: the list of comments, sorted by pk
-        """
-        return Comment.objects(self._node.backend).find(filters={'dbnode_id': self._node.pk}, order_by=[{'id': 'asc'}])
-
-    def update(self, identifier: int, content: str) -> None:
-        """Update the content of an existing comment.
-
-        :param identifier: the comment pk
-        :param content: the new comment content
-        :raise aiida.common.NotExistent: if the comment with the given id does not exist
-        :raise aiida.common.MultipleObjectsError: if the id cannot be uniquely resolved to a comment
-        """
-        comment = Comment.objects(self._node.backend).get(dbnode_id=self._node.pk, id=identifier)
-        comment.set_content(content)
-
-    def remove(self, identifier: int) -> None:  # pylint: disable=no-self-use
-        """Delete an existing comment.
-
-        :param identifier: the comment pk
-        """
-        Comment.objects(self._node.backend).delete(identifier)

--- a/aiida/orm/nodes/process/calculation/calcfunction.py
+++ b/aiida/orm/nodes/process/calculation/calcfunction.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from aiida.common.links import LinkType
 from aiida.orm.utils.mixins import FunctionCalculationMixin
 
+from ..process import ProcessNodeLinks
 from .calculation import CalculationNode
 
 if TYPE_CHECKING:
@@ -21,12 +22,11 @@ if TYPE_CHECKING:
 __all__ = ('CalcFunctionNode',)
 
 
-class CalcFunctionNode(FunctionCalculationMixin, CalculationNode):
-    """ORM class for all nodes representing the execution of a calcfunction."""
+class CalcFunctionNodeLinks(ProcessNodeLinks):
+    """Interface for links of a node instance."""
 
     def validate_outgoing(self, target: 'Node', link_type: LinkType, link_label: str) -> None:
-        """
-        Validate adding a link of the given type from ourself to a given node.
+        """Validate adding a link of the given type from ourself to a given node.
 
         A calcfunction cannot return Data, so if we receive an outgoing link to a stored Data node, that means
         the user created a Data node within our function body and stored it themselves or they are returning an input
@@ -45,3 +45,9 @@ class CalcFunctionNode(FunctionCalculationMixin, CalculationNode):
                 'return data. If you stored the node yourself, simply do not call `store()` yourself. If you want to '
                 'return an input node, use a @workfunction instead.'
             )
+
+
+class CalcFunctionNode(FunctionCalculationMixin, CalculationNode):
+    """ORM class for all nodes representing the execution of a calcfunction."""
+
+    _CLS_NODE_LINKS = CalcFunctionNodeLinks

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -131,7 +131,7 @@ class CalcJobNode(CalculationNode):
             self.computer.uuid if self.computer is not None else None,  # pylint: disable=no-member
             {
                 entry.link_label: entry.node.get_hash()
-                for entry in self.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
+                for entry in self.base.links.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
                 if entry.link_label not in self._hash_ignored_inputs
             }
         ]
@@ -464,7 +464,8 @@ class CalcJobNode(CalculationNode):
         """
         from aiida.orm import FolderData
         try:
-            return self.get_outgoing(node_class=FolderData, link_label_filter=self.link_label_retrieved).one().node
+            return self.base.links.get_outgoing(node_class=FolderData,
+                                                link_label_filter=self.link_label_retrieved).one().node
         except ValueError:
             return None
 

--- a/aiida/orm/nodes/process/workflow/workfunction.py
+++ b/aiida/orm/nodes/process/workflow/workfunction.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from aiida.common.links import LinkType
 from aiida.orm.utils.mixins import FunctionCalculationMixin
 
-from .workflow import WorkflowNode
+from .workflow import WorkflowNode, WorkflowNodeLinks
 
 if TYPE_CHECKING:
     from aiida.orm import Node
@@ -21,12 +21,11 @@ if TYPE_CHECKING:
 __all__ = ('WorkFunctionNode',)
 
 
-class WorkFunctionNode(FunctionCalculationMixin, WorkflowNode):
-    """ORM class for all nodes representing the execution of a workfunction."""
+class WorkFunctionNodeLinks(WorkflowNodeLinks):
+    """Interface for links of a node instance."""
 
     def validate_outgoing(self, target: 'Node', link_type: LinkType, link_label: str) -> None:
-        """
-        Validate adding a link of the given type from ourself to a given node.
+        """Validate adding a link of the given type from ourself to a given node.
 
         A workfunction cannot create Data, so if we receive an outgoing RETURN link to an unstored Data node, that means
         the user created a Data node within our function body and is trying to return it. This use case should be
@@ -44,3 +43,9 @@ class WorkFunctionNode(FunctionCalculationMixin, WorkflowNode):
                 'trying to return an unstored Data node from a @workfunction, however, @workfunctions cannot create '
                 'data. You probably want to use a @calcfunction instead.'
             )
+
+
+class WorkFunctionNode(FunctionCalculationMixin, WorkflowNode):
+    """ORM class for all nodes representing the execution of a workfunction."""
+
+    _CLS_NODE_LINKS = WorkFunctionNodeLinks

--- a/aiida/orm/utils/calcjob.py
+++ b/aiida/orm/utils/calcjob.py
@@ -61,7 +61,7 @@ class CalcJobResultManager:
             raise ValueError(f'cannot load results as {process_class} does not specify a default output node')
 
         try:
-            default_output_node = self.node.get_outgoing().get_node_by_label(default_output_node_label)
+            default_output_node = self.node.base.links.get_outgoing().get_node_by_label(default_output_node_label)
         except exceptions.NotExistent as exception:
             raise ValueError(f'cannot load results as the default node could not be retrieved: {exception}')
 

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -58,8 +58,10 @@ def link_triple_exists(
     """
     from aiida.orm import Node, QueryBuilder
 
+    target_links_cache = target.base.links.incoming_cache
+
     # First check if the triple exist in the cache, in the case of an unstored target node
-    if target._incoming_cache and LinkTriple(source, link_type, link_label) in target._incoming_cache:  # pylint: disable=protected-access
+    if target_links_cache and LinkTriple(source, link_type, link_label) in target_links_cache:
         return True
 
     # If either node is unstored (i.e. does not have a pk), the link cannot exist in the database, so no need to check
@@ -188,11 +190,11 @@ def validate_link(
         duplicate_link_triple = link_triple_exists(source, target, link_type, link_label, backend)
 
     # If the outdegree is `unique` there cannot already be any other outgoing link of that type
-    if outdegree == 'unique' and source.get_outgoing(link_type=link_type, only_uuid=True).all():
+    if outdegree == 'unique' and source.base.links.get_outgoing(link_type=link_type, only_uuid=True).all():
         raise ValueError(f'node<{source.uuid}> already has an outgoing {link_type} link')
 
     # If the outdegree is `unique_pair`, then the link labels for outgoing links of this type should be unique
-    elif outdegree == 'unique_pair' and source.get_outgoing(
+    elif outdegree == 'unique_pair' and source.base.links.get_outgoing(
             link_type=link_type, only_uuid=True, link_label_filter=link_label).all():
         raise ValueError(f'node<{source.uuid}> already has an outgoing {link_type} link with label "{link_label}"')
 
@@ -202,11 +204,11 @@ def validate_link(
             source.uuid, link_type, link_label, target.uuid))
 
     # If the indegree is `unique` there cannot already be any other incoming links of that type
-    if indegree == 'unique' and target.get_incoming(link_type=link_type, only_uuid=True).all():
+    if indegree == 'unique' and target.base.links.get_incoming(link_type=link_type, only_uuid=True).all():
         raise ValueError(f'node<{target.uuid}> already has an incoming {link_type} link')
 
     # If the indegree is `unique_pair`, then the link labels for incoming links of this type should be unique
-    elif indegree == 'unique_pair' and target.get_incoming(
+    elif indegree == 'unique_pair' and target.base.links.get_incoming(
             link_type=link_type, link_label_filter=link_label, only_uuid=True).all():
         raise ValueError(f'node<{target.uuid}> already has an incoming {link_type} link with label "{link_label}"')
 

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -54,9 +54,9 @@ class NodeLinksManager:
         :param incoming: if True, inspect incoming links, otherwise inspect outgoing links.
         """
         if incoming:
-            links = self._node.get_incoming(link_type=self._link_type)
+            links = self._node.base.links.get_incoming(link_type=self._link_type)
         else:
-            links = self._node.get_outgoing(link_type=self._link_type)
+            links = self._node.base.links.get_outgoing(link_type=self._link_type)
 
         return AttributeDict(links.nested())
 

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -151,33 +151,3 @@ class Sealable:
                 raise exceptions.ModificationNotAllowed(
                     f'Cannot modify non-updatable attributes of a stored+unsealed node: {keys}'
                 )
-
-    def validate_incoming(self, source, link_type, link_label):
-        """Validate adding a link of the given type from a given node to ourself.
-
-        Adding an incoming link to a sealed node is forbidden.
-
-        :param source: the node from which the link is coming
-        :param link_type: the link type
-        :param link_label: the link label
-        :raise aiida.common.ModificationNotAllowed: if the target node (self) is sealed
-        """
-        if self.is_sealed:
-            raise exceptions.ModificationNotAllowed('Cannot add a link to a sealed node')
-
-        super().validate_incoming(source, link_type=link_type, link_label=link_label)
-
-    def validate_outgoing(self, target, link_type, link_label):
-        """Validate adding a link of the given type from ourself to a given node.
-
-        Adding an outgoing link from a sealed node is forbidden.
-
-        :param target: the node to which the link is going
-        :param link_type: the link type
-        :param link_label: the link label
-        :raise aiida.common.ModificationNotAllowed: if the source node (self) is sealed
-        """
-        if self.is_sealed:
-            raise exceptions.ModificationNotAllowed('Cannot add a link from a sealed node')
-
-        super().validate_outgoing(target, link_type=link_type, link_label=link_label)

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -61,7 +61,7 @@ class Parser(ABC):
 
     @property
     def retrieved(self):
-        return self.node.get_outgoing().get_node_by_label(self.node.process_class.link_label_retrieved)
+        return self.node.base.links.get_outgoing().get_node_by_label(self.node.process_class.link_label_retrieved)
 
     @property
     def outputs(self):
@@ -90,7 +90,7 @@ class Parser(ABC):
 
         :return: dictionary of nodes that are required by the `parse` method
         """
-        link_triples = self.node.get_outgoing()
+        link_triples = self.node.base.links.get_outgoing()
         result = {}
 
         for label, port in self.node.process_class.spec().outputs.items():

--- a/docs/source/howto/data.rst
+++ b/docs/source/howto/data.rst
@@ -575,7 +575,7 @@ This data can be safely deleted at any time.
 This includes, notably:
 
 * *Node extras*: These can be deleted using :py:attr:`Node.base.extras <aiida.orm.extras.EntityExtras>`.
-* *Node comments*: These can be removed using :py:attr:`Node.base.comments <aiida.orm.nodes.node.NodeComments>`.
+* *Node comments*: These can be removed using :py:attr:`Node.base.comments <aiida.orm.nodes.comments.NodeComments>`.
 * *Groups*: These can be deleted using :py:meth:`Group.objects.delete() <aiida.orm.groups.GroupCollection.delete>`.
   This command will only delete the group, not the nodes contained in the group.
 

--- a/docs/source/howto/query.rst
+++ b/docs/source/howto/query.rst
@@ -280,7 +280,7 @@ The provenance graph in AiiDA is a :ref:`directed graph <topics:provenance:conce
 The vertices of the graph are the *nodes*, and the edges that connect them are called *links*.
 Since the graph is directed, any node can have *incoming* and *outgoing* links that connect it to neighboring nodes.
 
-To discover the neighbors of a given node, you can use the methods :meth:`~aiida.orm.nodes.node.Node.get_incoming` and :meth:`~aiida.orm.nodes.node.Node.get_outgoing`.
+To discover the neighbors of a given node, you can use the methods :meth:`~aiida.orm.nodes.links.NodeLinks.get_incoming` and :meth:`~aiida.orm.nodes.links.NodeLinks.get_outgoing`.
 They have the exact same interface but will return the neighbors connected to the current node with a link coming into it or with links going out of it, respectively.
 For example, for a given ``node``, to inspect all the neighboring nodes from which a link is incoming to the ``node``:
 
@@ -308,7 +308,7 @@ For example, to list all the neighbors of a node from which a link is incoming:
 
 Note that the :class:`~aiida.orm.utils.links.LinkManager` provides many convenience methods to get information from the neigboring nodes, such as :meth:`~aiida.orm.utils.links.LinkManager.all_link_labels` if you only need the list of link labels.
 
-The :meth:`~aiida.orm.nodes.node.Node.get_incoming` and :meth:`~aiida.orm.nodes.node.Node.get_outgoing` methods accept various arguments that allow one to filter what neighboring nodes should be matched:
+The :meth:`~aiida.orm.nodes.links.NodeLinks.get_incoming` and :meth:`~aiida.orm.nodes.links.NodeLinks.get_outgoing` methods accept various arguments that allow one to filter what neighboring nodes should be matched:
 
  * ``node_class``: accepts a subclass of :class:`~aiida.orm.nodes.node.Node`, only neighboring nodes with a class that matches this will be returned
  * ``link_type``: accepts a value of :class:`~aiida.common.links.LinkType`, only neighboring nodes that are linked with this link type will be returned
@@ -330,10 +330,10 @@ These two special characters can be escaped by prepending them with a backslash 
 Inputs and outputs of processes
 -------------------------------
 
-The :meth:`~aiida.orm.nodes.node.Node.get_incoming` and :meth:`~aiida.orm.nodes.node.Node.get_outgoing` methods, described in the :ref:`previous section <how-to:query:shortcuts:incoming-outgoing>`, can be used to access all neighbors from a certain node and provide advanced filtering options.
+The :meth:`~aiida.orm.nodes.links.NodeLinks.get_incoming` and :meth:`~aiida.orm.nodes.links.NodeLinks.get_outgoing` methods, described in the :ref:`previous section <how-to:query:shortcuts:incoming-outgoing>`, can be used to access all neighbors from a certain node and provide advanced filtering options.
 However, often one doesn't need this expressivity and simply wants to retrieve all neighboring nodes with a syntax that is as succint as possible.
 A prime example is to retrieve the *inputs* or *outputs* of :ref:`a process <topics:processes:concepts>`.
-Instead of using :meth:`~aiida.orm.nodes.node.Node.get_incoming` and :meth:`~aiida.orm.nodes.node.Node.get_outgoing`, to get the inputs and outputs of a ``process_node`` one can do:
+Instead of using :meth:`~aiida.orm.nodes.links.NodeLinks.get_incoming` and :meth:`~aiida.orm.nodes.links.NodeLinks.get_outgoing`, to get the inputs and outputs of a ``process_node`` one can do:
 
 .. code-block:: python
 

--- a/tests/benchmark/test_archive.py
+++ b/tests/benchmark/test_archive.py
@@ -34,13 +34,13 @@ def recursive_provenance(in_node, depth, breadth, num_objects=0):
         calcfunc = CalcFunctionNode()
         calcfunc.set_process_state(ProcessState.FINISHED)
         calcfunc.set_exit_status(0)
-        calcfunc.add_incoming(in_node, link_type=LinkType.INPUT_CALC, link_label='input')
+        calcfunc.base.links.add_incoming(in_node, link_type=LinkType.INPUT_CALC, link_label='input')
         calcfunc.store()
 
         out_node = Dict(dict={str(i): i for i in range(10)})
         for idx in range(num_objects):
             out_node.base.repository.put_object_from_filelike(StringIO('a' * 10000), f'key{str(idx)}')
-        out_node.add_incoming(calcfunc, link_type=LinkType.CREATE, link_label='output')
+        out_node.base.links.add_incoming(calcfunc, link_type=LinkType.CREATE, link_label='output')
         out_node.store()
 
         calcfunc.seal()

--- a/tests/benchmark/test_engine.py
+++ b/tests/benchmark/test_engine.py
@@ -127,7 +127,7 @@ def test_workchain_local(benchmark, aiida_localhost, workchain, iterations, outg
     result = benchmark.pedantic(_run, iterations=1, rounds=10, warmup_rounds=1)
 
     assert result.node.is_finished_ok, (result.node.exit_status, result.node.exit_message)
-    assert len(result.node.get_outgoing().all()) == outgoing
+    assert len(result.node.base.links.get_outgoing().all()) == outgoing
 
 
 async def with_timeout(what, timeout=60):
@@ -183,4 +183,4 @@ def test_workchain_daemon(benchmark, submit_get_node, aiida_localhost, workchain
     result = benchmark.pedantic(_run, iterations=1, rounds=10, warmup_rounds=1)
 
     assert result.is_finished_ok, (result.exit_status, result.exit_message)
-    assert len(result.get_outgoing().all()) == outgoing
+    assert len(result.base.links.get_outgoing().all()) == outgoing

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -54,7 +54,7 @@ class TestVerdiCalculation:
             calc.set_remote_workdir('/tmp/aiida/work')
             remote = RemoteData(remote_path='/tmp/aiida/work')
             remote.computer = calc.computer
-            remote.add_incoming(calc, LinkType.CREATE, link_label='remote_folder')
+            remote.base.links.add_incoming(calc, LinkType.CREATE, link_label='remote_folder')
             calc.store()
             remote.store()
 
@@ -72,7 +72,7 @@ class TestVerdiCalculation:
                     self.KEY_TWO: self.VAL_TWO,
                 }).store()
 
-                output_parameters.add_incoming(calc, LinkType.CREATE, 'output_parameters')
+                output_parameters.base.links.add_incoming(calc, LinkType.CREATE, 'output_parameters')
 
                 # Create shortcut for easy dereferencing
                 self.result_job = calc
@@ -90,7 +90,7 @@ class TestVerdiCalculation:
         calc.set_remote_workdir('/tmp/aiida/work')
         remote = RemoteData(remote_path='/tmp/aiida/work')
         remote.computer = calc.computer
-        remote.add_incoming(calc, LinkType.CREATE, link_label='remote_folder')
+        remote.base.links.add_incoming(calc, LinkType.CREATE, link_label='remote_folder')
         remote.store()
         self.calcs.append(calc)
 

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -186,7 +186,7 @@ class TestVerdiProcess:
 
         workchain_two.base.attributes.set('process_label', 'workchain_one_caller')
         workchain_two.store()
-        workchain_one.add_incoming(workchain_two, link_type=LinkType.CALL_WORK, link_label='called')
+        workchain_one.base.links.add_incoming(workchain_two, link_type=LinkType.CALL_WORK, link_label='called')
         workchain_one.store()
 
         calcjob_one = CalcJobNode()
@@ -195,8 +195,8 @@ class TestVerdiProcess:
         calcjob_one.base.attributes.set('process_label', 'process_label_one')
         calcjob_two.base.attributes.set('process_label', 'process_label_two')
 
-        calcjob_one.add_incoming(workchain_one, link_type=LinkType.CALL_CALC, link_label='one')
-        calcjob_two.add_incoming(workchain_one, link_type=LinkType.CALL_CALC, link_label='two')
+        calcjob_one.base.links.add_incoming(workchain_one, link_type=LinkType.CALL_CALC, link_label='one')
+        calcjob_two.base.links.add_incoming(workchain_one, link_type=LinkType.CALL_CALC, link_label='two')
 
         calcjob_one.store()
         calcjob_two.store()
@@ -251,9 +251,9 @@ class TestVerdiProcess:
         parent = WorkChainNode()
         child = WorkChainNode()
 
-        parent.add_incoming(grandparent, link_type=LinkType.CALL_WORK, link_label='link')
+        parent.base.links.add_incoming(grandparent, link_type=LinkType.CALL_WORK, link_label='link')
         parent.store()
-        child.add_incoming(parent, link_type=LinkType.CALL_WORK, link_label='link')
+        child.base.links.add_incoming(parent, link_type=LinkType.CALL_WORK, link_label='link')
         child.store()
 
         grandparent.logger.log(LOG_LEVEL_REPORT, 'grandparent_message')
@@ -340,10 +340,12 @@ class TestVerdiProcessCallRoot:
 
         self.node_root.store()
 
-        self.node_middle.add_incoming(self.node_root, link_type=LinkType.CALL_WORK, link_label='call_middle')
+        self.node_middle.base.links.add_incoming(self.node_root, link_type=LinkType.CALL_WORK, link_label='call_middle')
         self.node_middle.store()
 
-        self.node_terminal.add_incoming(self.node_middle, link_type=LinkType.CALL_WORK, link_label='call_terminal')
+        self.node_terminal.base.links.add_incoming(
+            self.node_middle, link_type=LinkType.CALL_WORK, link_label='call_terminal'
+        )
         self.node_terminal.store()
 
         self.cli_runner = run_cli_command

--- a/tests/cmdline/utils/test_common.py
+++ b/tests/cmdline/utils/test_common.py
@@ -22,7 +22,7 @@ def test_get_node_summary(aiida_local_code_factory):
     code = aiida_local_code_factory(entry_point='core.arithmetic.add', executable='/bin/bash')
     node = CalculationNode()
     node.computer = code.computer
-    node.add_incoming(code, link_type=LinkType.INPUT_CALC, link_label='code')
+    node.base.links.add_incoming(code, link_type=LinkType.INPUT_CALC, link_label='code')
     node.store()
 
     summary = common.get_node_summary(node)
@@ -41,8 +41,8 @@ def test_get_node_info_multiple_call_links():
     node_one = CalculationNode()
     node_two = CalculationNode()
 
-    node_one.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL_IDENTICAL')
-    node_two.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL_IDENTICAL')
+    node_one.base.links.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL_IDENTICAL')
+    node_two.base.links.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL_IDENTICAL')
     node_one.store()
     node_two.store()
 

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -457,7 +457,7 @@ class TestCalcJob:
         """Test the `CalcJob.parse` method when there is a retrieved folder."""
         process = self.instantiate_process()
         retrieved = orm.FolderData().store()
-        retrieved.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
+        retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
         exit_code = process.parse()
 
         # The following exit code is specific to the `ArithmeticAddCalculation` we are testing here and is returned
@@ -517,7 +517,7 @@ def test_parse_insufficient_data(generate_process):
     process = generate_process()
 
     retrieved = orm.FolderData().store()
-    retrieved.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
+    retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
     process.parse()
 
     filename_stderr = process.node.get_option('scheduler_stderr')
@@ -549,7 +549,7 @@ def test_parse_non_zero_retval(generate_process):
     process = generate_process()
 
     retrieved = orm.FolderData().store()
-    retrieved.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
+    retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
 
     process.node.base.attributes.set('detailed_job_info', {'retval': 1, 'stderr': 'accounting disabled', 'stdout': ''})
     process.parse()
@@ -568,7 +568,7 @@ def test_parse_not_implemented(generate_process):
     process = generate_process()
 
     retrieved = orm.FolderData()
-    retrieved.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
+    retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
 
     process.node.base.attributes.set('detailed_job_info', {})
 
@@ -602,7 +602,7 @@ def test_parse_scheduler_excepted(generate_process, monkeypatch):
     process = generate_process()
 
     retrieved = orm.FolderData()
-    retrieved.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
+    retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
 
     process.node.base.attributes.set('detailed_job_info', {})
 
@@ -689,7 +689,7 @@ def test_parse_exit_code_priority(
     }
     process = generate_calc_job(fixture_sandbox, 'core.arithmetic.add', inputs, return_process=True)
     retrieved = orm.FolderData().store()
-    retrieved.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
+    retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
 
     result = process.parse()
     assert isinstance(result, ExitCode)

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -226,12 +226,14 @@ def test_builder_restart_work_chain(example_inputs):
     caller = orm.WorkChainNode().store()
 
     node = orm.WorkChainNode(process_type=ExampleWorkChain.build_process_type())
-    node.add_incoming(example_inputs['dynamic']['namespace']['alp'], LinkType.INPUT_WORK, 'dynamic__namespace__alp')
-    node.add_incoming(example_inputs['name']['spaced'], LinkType.INPUT_WORK, 'name__spaced')
-    node.add_incoming(example_inputs['name_spaced'], LinkType.INPUT_WORK, 'name_spaced')
-    node.add_incoming(example_inputs['boolean'], LinkType.INPUT_WORK, 'boolean')
-    node.add_incoming(orm.Int(DEFAULT_INT).store(), LinkType.INPUT_WORK, 'default')
-    node.add_incoming(caller, link_type=LinkType.CALL_WORK, link_label='CALL_WORK')
+    node.base.links.add_incoming(
+        example_inputs['dynamic']['namespace']['alp'], LinkType.INPUT_WORK, 'dynamic__namespace__alp'
+    )
+    node.base.links.add_incoming(example_inputs['name']['spaced'], LinkType.INPUT_WORK, 'name__spaced')
+    node.base.links.add_incoming(example_inputs['name_spaced'], LinkType.INPUT_WORK, 'name_spaced')
+    node.base.links.add_incoming(example_inputs['boolean'], LinkType.INPUT_WORK, 'boolean')
+    node.base.links.add_incoming(orm.Int(DEFAULT_INT).store(), LinkType.INPUT_WORK, 'default')
+    node.base.links.add_incoming(caller, link_type=LinkType.CALL_WORK, link_label='CALL_WORK')
     node.store()
 
     builder = node.get_builder_restart()
@@ -294,8 +296,8 @@ def test_calc_job_node_get_builder_restart(aiida_localhost):
     original.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     original.set_option('max_wallclock_seconds', 1800)
 
-    original.add_incoming(orm.Int(1).store(), link_type=LinkType.INPUT_CALC, link_label='x')
-    original.add_incoming(orm.Int(2).store(), link_type=LinkType.INPUT_CALC, link_label='y')
+    original.base.links.add_incoming(orm.Int(1).store(), link_type=LinkType.INPUT_CALC, link_label='x')
+    original.base.links.add_incoming(orm.Int(2).store(), link_type=LinkType.INPUT_CALC, link_label='y')
     original.store()
 
     builder = original.get_builder_restart()

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -64,8 +64,8 @@ class TestCalcFunction:
         """Verify that a calcfunction can only get CREATE links and no RETURN links."""
         _, node = self.test_calcfunction.run_get_node(self.default_int)
 
-        assert len(node.get_outgoing(link_type=LinkType.CREATE).all()) == 1
-        assert len(node.get_outgoing(link_type=LinkType.RETURN).all()) == 0
+        assert len(node.base.links.get_outgoing(link_type=LinkType.CREATE).all()) == 1
+        assert len(node.base.links.get_outgoing(link_type=LinkType.RETURN).all()) == 0
 
     def test_calcfunction_return_stored(self):
         """Verify that a calcfunction will raise when a stored node is returned."""
@@ -97,7 +97,7 @@ class TestCalcFunction:
             assert result.is_stored
             assert cached.is_created_from_cache
             assert cached.get_cache_source() in original.uuid
-            assert cached.get_incoming().one().node.uuid == input_node.uuid
+            assert cached.base.links.get_incoming().one().node.uuid == input_node.uuid
 
     def test_calcfunction_caching_change_code(self):
         """Verify that changing the source codde of a calcfunction invalidates any existing cached nodes."""
@@ -151,5 +151,5 @@ class TestCalcFunction:
         assert isinstance(node, CalcFunctionNode)
 
         # The node of the outermost `calcfunction` should have a single `CREATE` link and no `CALL_CALC` links
-        assert len(node.get_outgoing(link_type=LinkType.CREATE).all()) == 1
-        assert len(node.get_outgoing(link_type=LinkType.CALL_CALC).all()) == 0
+        assert len(node.base.links.get_outgoing(link_type=LinkType.CREATE).all()) == 1
+        assert len(node.base.links.get_outgoing(link_type=LinkType.CALL_CALC).all()) == 0

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -64,8 +64,8 @@ class TestProcessNamespace:
         assert input_node.value == 5
 
         # Check that the link of the process node has the correct link name
-        assert 'some__name__space__a' in proc.node.get_incoming().all_link_labels()
-        assert proc.node.get_incoming().get_node_by_label('some__name__space__a') == 5
+        assert 'some__name__space__a' in proc.node.base.links.get_incoming().all_link_labels()
+        assert proc.node.base.links.get_incoming().get_node_by_label('some__name__space__a') == 5
         assert proc.node.inputs.some.name.space.a == 5
         assert proc.node.inputs['some']['name']['space']['a'] == 5
 
@@ -127,7 +127,7 @@ class TestProcess:
         inputs['metadata'] = {'store_provenance': True}
         process = test_processes.DummyProcess(inputs)
 
-        for entry in process.node.get_incoming().all():
+        for entry in process.node.base.links.get_incoming().all():
             assert entry.link_label in inputs
             assert entry.link_label == entry.node.value
             dummy_inputs.remove(entry.link_label)
@@ -146,7 +146,7 @@ class TestProcess:
         process = test_processes.DummyProcess()
 
         with pytest.raises(ValueError):
-            process.node.add_incoming(orm.Int(1), link_type=LinkType.INPUT_WORK, link_label='illegal_link')
+            process.node.base.links.add_incoming(orm.Int(1), link_type=LinkType.INPUT_WORK, link_label='illegal_link')
 
     def test_seal(self):
         _, p_k = run_get_pk(test_processes.DummyProcess)
@@ -379,9 +379,9 @@ class TestProcess:
 
         node_child = orm.WorkflowNode().store()
         node_output = orm.Int(1).store()
-        node_output.add_incoming(node_child, link_label='output', link_type=LinkType.RETURN)
+        node_output.base.links.add_incoming(node_child, link_label='output', link_type=LinkType.RETURN)
         node_name_space = orm.Int(1).store()
-        node_name_space.add_incoming(node_child, link_label='name__space', link_type=LinkType.RETURN)
+        node_name_space.base.links.add_incoming(node_child, link_label='name__space', link_type=LinkType.RETURN)
 
         process = instantiate_process(runner, ParentProcess, input=orm.Int(1))
         exposed_outputs = process.exposed_outputs(node_child, ChildProcess)
@@ -427,9 +427,9 @@ class TestProcess:
 
         node_child = orm.WorkflowNode().store()
         node_output = orm.Int(1).store()
-        node_output.add_incoming(node_child, link_label='output', link_type=LinkType.RETURN)
+        node_output.base.links.add_incoming(node_child, link_label='output', link_type=LinkType.RETURN)
         node_name_space = orm.Int(1).store()
-        node_name_space.add_incoming(node_child, link_label='name__space', link_type=LinkType.RETURN)
+        node_name_space.base.links.add_incoming(node_child, link_label='name__space', link_type=LinkType.RETURN)
 
         process = instantiate_process(runner, ParentProcess, input=orm.Int(1))
 

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -239,12 +239,12 @@ class TestProcessFunction:
 
         result, node = self.function_kwargs.run_get_node()
         assert isinstance(result, dict)
-        assert len(node.get_incoming().all()) == 0
+        assert len(node.base.links.get_incoming().all()) == 0
         assert result == {}
 
         result, node = self.function_kwargs.run_get_node(**kwargs)
         assert isinstance(result, dict)
-        assert len(node.get_incoming().all()) == 1
+        assert len(node.base.links.get_incoming().all()) == 1
         assert result == kwargs
 
         # Calling with any number of positional arguments should raise

--- a/tests/engine/test_workfunctions.py
+++ b/tests/engine/test_workfunctions.py
@@ -49,8 +49,8 @@ class TestWorkFunction:
         """Verify that a workfunction can only get RETURN links and no CREATE links."""
         _, node = self.test_workfunction.run_get_node(self.default_int)
 
-        assert len(node.get_outgoing(link_type=LinkType.RETURN).all()) == 1
-        assert len(node.get_outgoing(link_type=LinkType.CREATE).all()) == 0
+        assert len(node.base.links.get_outgoing(link_type=LinkType.RETURN).all()) == 1
+        assert len(node.base.links.get_outgoing(link_type=LinkType.CREATE).all()) == 0
 
     def test_workfunction_return_unstored(self):
         """Verify that a workfunction will raise when an unstored node is returned."""
@@ -95,5 +95,5 @@ class TestWorkFunction:
         _, node = caller.run_get_node()
 
         # Verify that the `CALL` link of the calculation function is there with the correct label
-        link_triple = node.get_outgoing(link_type=LinkType.CALL_CALC, link_label_filter=link_label).one()
+        link_triple = node.base.links.get_outgoing(link_type=LinkType.CALL_CALC, link_label_filter=link_label).one()
         assert isinstance(link_triple.node, CalcFunctionNode)

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -147,7 +147,7 @@ class TestBackend:
         # create node, link and add to group
         node = orm.Data()
         calc_node = orm.CalcFunctionNode().store()
-        node.add_incoming(calc_node, link_type=LinkType.CREATE, link_label='link')
+        node.base.links.add_incoming(calc_node, link_type=LinkType.CREATE, link_label='link')
         node.store()
         node_pk = node.pk
         group = orm.Group('name').store()
@@ -155,7 +155,7 @@ class TestBackend:
 
         # checks before deletion
         orm.Node.objects.get(id=node_pk)
-        assert len(calc_node.get_outgoing().all()) == 1
+        assert len(calc_node.base.links.get_outgoing().all()) == 1
         assert len(group.nodes) == 1
 
         # cannot call outside a transaction
@@ -168,5 +168,5 @@ class TestBackend:
         # checks after deletion
         with pytest.raises(exceptions.NotExistent):
             orm.Node.objects.get(id=node_pk)
-        assert len(calc_node.get_outgoing().all()) == 0
+        assert len(calc_node.base.links.get_outgoing().all()) == 0
         assert len(group.nodes) == 0

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -63,7 +63,7 @@ class TestCalcJobNode:
                     node.set_option(option_key, option_value)
                 node.store()
                 retrieved.store()
-                retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+                retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
                 # It should return `None` if no scheduler output is there (file not there, or option not set),
                 # while it should return the content if both are set
@@ -91,7 +91,7 @@ class TestCalcJobNode:
                     node.set_option(option_key, option_value)
                 node.store()
                 retrieved.store()
-                retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+                retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
                 # It should return `None` if no scheduler output is there (file not there, or option not set),
                 # while it should return the content if both are set

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -469,9 +469,9 @@ class TestNodeLinks:
         data = Data().store()
         calculation = CalculationNode()
 
-        calculation.add_incoming(data, LinkType.INPUT_CALC, 'input')
+        calculation.base.links.add_incoming(data, LinkType.INPUT_CALC, 'input')
         calculation.store()
-        stored_triples = calculation.get_stored_link_triples()
+        stored_triples = calculation.base.links.get_stored_link_triples()
 
         assert len(stored_triples) == 1
 
@@ -488,7 +488,7 @@ class TestNodeLinks:
     def test_validate_incoming_ipsum(self):
         """Test the `validate_incoming` method with respect to linking ourselves."""
         with pytest.raises(ValueError):
-            self.node_target.validate_incoming(self.node_target, LinkType.CREATE, 'link_label')
+            self.node_target.base.links.validate_incoming(self.node_target, LinkType.CREATE, 'link_label')
 
     def test_validate_incoming(self):
         """Test the `validate_incoming` method
@@ -497,13 +497,13 @@ class TestNodeLinks:
         type is a valid LinkType enum value.
         """
         with pytest.raises(TypeError):
-            self.node_target.validate_incoming(self.node_source, None, 'link_label')
+            self.node_target.base.links.validate_incoming(self.node_source, None, 'link_label')
 
         with pytest.raises(TypeError):
-            self.node_target.validate_incoming(None, LinkType.CREATE, 'link_label')
+            self.node_target.base.links.validate_incoming(None, LinkType.CREATE, 'link_label')
 
         with pytest.raises(TypeError):
-            self.node_target.validate_incoming(self.node_source, LinkType.CREATE.value, 'link_label')
+            self.node_target.base.links.validate_incoming(self.node_source, LinkType.CREATE.value, 'link_label')
 
     def test_add_incoming_create(self):
         """Nodes can only have a single incoming CREATE link, independent of the source node."""
@@ -511,19 +511,19 @@ class TestNodeLinks:
         source_two = CalculationNode()
         target = Data()
 
-        target.add_incoming(source_one, LinkType.CREATE, 'link_label')
+        target.base.links.add_incoming(source_one, LinkType.CREATE, 'link_label')
 
         # Can only have a single incoming CREATE link
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.CREATE, 'link_label')
+            target.base.links.validate_incoming(source_one, LinkType.CREATE, 'link_label')
 
         # Even when the source node is different
         with pytest.raises(ValueError):
-            target.validate_incoming(source_two, LinkType.CREATE, 'link_label')
+            target.base.links.validate_incoming(source_two, LinkType.CREATE, 'link_label')
 
         # Or when the link label is different
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.CREATE, 'other_label')
+            target.base.links.validate_incoming(source_one, LinkType.CREATE, 'other_label')
 
     def test_add_incoming_call_calc(self):
         """Nodes can only have a single incoming CALL_CALC link, independent of the source node."""
@@ -531,19 +531,19 @@ class TestNodeLinks:
         source_two = WorkflowNode()
         target = CalculationNode()
 
-        target.add_incoming(source_one, LinkType.CALL_CALC, 'link_label')
+        target.base.links.add_incoming(source_one, LinkType.CALL_CALC, 'link_label')
 
         # Can only have a single incoming CALL_CALC link
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.CALL_CALC, 'link_label')
+            target.base.links.validate_incoming(source_one, LinkType.CALL_CALC, 'link_label')
 
         # Even when the source node is different
         with pytest.raises(ValueError):
-            target.validate_incoming(source_two, LinkType.CALL_CALC, 'link_label')
+            target.base.links.validate_incoming(source_two, LinkType.CALL_CALC, 'link_label')
 
         # Or when the link label is different
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.CALL_CALC, 'other_label')
+            target.base.links.validate_incoming(source_one, LinkType.CALL_CALC, 'other_label')
 
     def test_add_incoming_call_work(self):
         """Nodes can only have a single incoming CALL_WORK link, independent of the source node."""
@@ -551,19 +551,19 @@ class TestNodeLinks:
         source_two = WorkflowNode()
         target = WorkflowNode()
 
-        target.add_incoming(source_one, LinkType.CALL_WORK, 'link_label')
+        target.base.links.add_incoming(source_one, LinkType.CALL_WORK, 'link_label')
 
         # Can only have a single incoming CALL_WORK link
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.CALL_WORK, 'link_label')
+            target.base.links.validate_incoming(source_one, LinkType.CALL_WORK, 'link_label')
 
         # Even when the source node is different
         with pytest.raises(ValueError):
-            target.validate_incoming(source_two, LinkType.CALL_WORK, 'link_label')
+            target.base.links.validate_incoming(source_two, LinkType.CALL_WORK, 'link_label')
 
         # Or when the link label is different
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.CALL_WORK, 'other_label')
+            target.base.links.validate_incoming(source_one, LinkType.CALL_WORK, 'other_label')
 
     def test_add_incoming_input_calc(self):
         """Nodes can have an infinite amount of incoming INPUT_CALC links, as long as the link pair is unique."""
@@ -571,18 +571,18 @@ class TestNodeLinks:
         source_two = Data()
         target = CalculationNode()
 
-        target.add_incoming(source_one, LinkType.INPUT_CALC, 'link_label')
+        target.base.links.add_incoming(source_one, LinkType.INPUT_CALC, 'link_label')
 
         # Can only have a single incoming INPUT_CALC link from each source node if the label is not unique
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.INPUT_CALC, 'link_label')
+            target.base.links.validate_incoming(source_one, LinkType.INPUT_CALC, 'link_label')
 
         # Using another link label is fine
-        target.validate_incoming(source_one, LinkType.INPUT_CALC, 'other_label')
+        target.base.links.validate_incoming(source_one, LinkType.INPUT_CALC, 'other_label')
 
         # However, using the same link, even from another node is illegal
         with pytest.raises(ValueError):
-            target.validate_incoming(source_two, LinkType.INPUT_CALC, 'link_label')
+            target.base.links.validate_incoming(source_two, LinkType.INPUT_CALC, 'link_label')
 
     def test_add_incoming_input_work(self):
         """Nodes can have an infinite amount of incoming INPUT_WORK links, as long as the link pair is unique."""
@@ -590,18 +590,18 @@ class TestNodeLinks:
         source_two = Data()
         target = WorkflowNode()
 
-        target.add_incoming(source_one, LinkType.INPUT_WORK, 'link_label')
+        target.base.links.add_incoming(source_one, LinkType.INPUT_WORK, 'link_label')
 
         # Can only have a single incoming INPUT_WORK link from each source node if the label is not unique
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.INPUT_WORK, 'link_label')
+            target.base.links.validate_incoming(source_one, LinkType.INPUT_WORK, 'link_label')
 
         # Using another link label is fine
-        target.validate_incoming(source_one, LinkType.INPUT_WORK, 'other_label')
+        target.base.links.validate_incoming(source_one, LinkType.INPUT_WORK, 'other_label')
 
         # However, using the same link, even from another node is illegal
         with pytest.raises(ValueError):
-            target.validate_incoming(source_two, LinkType.INPUT_WORK, 'link_label')
+            target.base.links.validate_incoming(source_two, LinkType.INPUT_WORK, 'link_label')
 
     def test_add_incoming_return(self):
         """Nodes can have an infinite amount of incoming RETURN links, as long as the link triple is unique."""
@@ -609,15 +609,15 @@ class TestNodeLinks:
         source_two = WorkflowNode()
         target = Data().store()  # Needs to be stored: see `test_validate_outgoing_workflow`
 
-        target.add_incoming(source_one, LinkType.RETURN, 'link_label')
+        target.base.links.add_incoming(source_one, LinkType.RETURN, 'link_label')
 
         # Can only have a single incoming RETURN link from each source node if the label is not unique
         with pytest.raises(ValueError):
-            target.validate_incoming(source_one, LinkType.RETURN, 'link_label')
+            target.base.links.validate_incoming(source_one, LinkType.RETURN, 'link_label')
 
         # From another source node or using another label is fine
-        target.validate_incoming(source_one, LinkType.RETURN, 'other_label')
-        target.validate_incoming(source_two, LinkType.RETURN, 'link_label')
+        target.base.links.validate_incoming(source_one, LinkType.RETURN, 'other_label')
+        target.base.links.validate_incoming(source_two, LinkType.RETURN, 'link_label')
 
     def test_validate_outgoing_workflow(self):
         """Verify that attaching an unstored `Data` node with `RETURN` link from a `WorkflowNode` raises.
@@ -630,7 +630,7 @@ class TestNodeLinks:
         target = Data()
 
         with pytest.raises(ValueError):
-            target.add_incoming(source, LinkType.RETURN, 'link_label')
+            target.base.links.add_incoming(source, LinkType.RETURN, 'link_label')
 
     def test_get_incoming(self):
         """Test that `Node.get_incoming` will return stored and cached input links."""
@@ -638,21 +638,21 @@ class TestNodeLinks:
         source_two = Data().store()
         target = CalculationNode()
 
-        target.add_incoming(source_one, LinkType.INPUT_CALC, 'link_one')
-        target.add_incoming(source_two, LinkType.INPUT_CALC, 'link_two')
+        target.base.links.add_incoming(source_one, LinkType.INPUT_CALC, 'link_one')
+        target.base.links.add_incoming(source_two, LinkType.INPUT_CALC, 'link_two')
 
         # Without link type
-        incoming_nodes = target.get_incoming().all()
+        incoming_nodes = target.base.links.get_incoming().all()
         incoming_uuids = sorted([neighbor.node.uuid for neighbor in incoming_nodes])
         assert incoming_uuids == sorted([source_one.uuid, source_two.uuid])
 
         # Using a single link type
-        incoming_nodes = target.get_incoming(link_type=LinkType.INPUT_CALC).all()
+        incoming_nodes = target.base.links.get_incoming(link_type=LinkType.INPUT_CALC).all()
         incoming_uuids = sorted([neighbor.node.uuid for neighbor in incoming_nodes])
         assert incoming_uuids == sorted([source_one.uuid, source_two.uuid])
 
         # Using a link type tuple
-        incoming_nodes = target.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)).all()
+        incoming_nodes = target.base.links.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)).all()
         incoming_uuids = sorted([neighbor.node.uuid for neighbor in incoming_nodes])
         assert incoming_uuids == sorted([source_one.uuid, source_two.uuid])
 
@@ -667,11 +667,11 @@ class TestNodeLinks:
         called = CalculationNode()
 
         # Verify that adding two incoming links with the same link label but different type is allowed
-        called.add_incoming(caller, link_type=LinkType.CALL_CALC, link_label='call')
-        called.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='call')
+        called.base.links.add_incoming(caller, link_type=LinkType.CALL_CALC, link_label='call')
+        called.base.links.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='call')
         called.store()
 
-        uuids_incoming = set(node.uuid for node in called.get_incoming().all_nodes())
+        uuids_incoming = set(node.uuid for node in called.base.links.get_incoming().all_nodes())
         uuids_expected = set([caller.uuid, data.uuid])
         assert uuids_incoming == uuids_expected
 
@@ -686,10 +686,10 @@ class TestNodeLinks:
         data = Data().store()  # Needs to be stored: see `test_validate_outgoing_workflow`
 
         # Verify that adding two return links with the same link label but from different source is allowed
-        data.add_incoming(return_one, link_type=LinkType.RETURN, link_label='returned')
-        data.add_incoming(return_two, link_type=LinkType.RETURN, link_label='returned')
+        data.base.links.add_incoming(return_one, link_type=LinkType.RETURN, link_label='returned')
+        data.base.links.add_incoming(return_two, link_type=LinkType.RETURN, link_label='returned')
 
-        uuids_incoming = set(node.uuid for node in data.get_incoming().all_nodes())
+        uuids_incoming = set(node.uuid for node in data.base.links.get_incoming().all_nodes())
         uuids_expected = set([return_one.uuid, return_two.uuid])
         assert uuids_incoming == uuids_expected
 
@@ -705,12 +705,12 @@ class TestNodeLinks:
 
         # Verify that adding two create links with the same link label but to different target is allowed from the
         # perspective of the source node (the CalculationNode in this case)
-        data_one.add_incoming(creator, link_type=LinkType.CREATE, link_label='create')
-        data_two.add_incoming(creator, link_type=LinkType.CREATE, link_label='create')
+        data_one.base.links.add_incoming(creator, link_type=LinkType.CREATE, link_label='create')
+        data_two.base.links.add_incoming(creator, link_type=LinkType.CREATE, link_label='create')
         data_one.store()
         data_two.store()
 
-        uuids_outgoing = set(node.uuid for node in creator.get_outgoing().all_nodes())
+        uuids_outgoing = set(node.uuid for node in creator.base.links.get_outgoing().all_nodes())
         uuids_expected = set([data_one.uuid, data_two.uuid])
         assert uuids_outgoing == uuids_expected
 
@@ -726,24 +726,24 @@ class TestNodeLinks:
         calc_two = CalculationNode()
 
         # Two calcs using the data with the same label
-        calc_one_a.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='input')
-        calc_one_b.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='input')
+        calc_one_a.base.links.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='input')
+        calc_one_b.base.links.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='input')
         # A different label
-        calc_two.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='the_input')
+        calc_two.base.links.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='the_input')
 
         calc_one_a.store()
         calc_one_b.store()
         calc_two.store()
 
         # Retrieve a link when the label is unique
-        output_the_input = data.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('the_input')
+        output_the_input = data.base.links.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('the_input')
         assert output_the_input.pk == calc_two.pk
 
         with pytest.raises(exceptions.MultipleObjectsError):
-            data.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('input')
+            data.base.links.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('input')
 
         with pytest.raises(exceptions.NotExistent):
-            data.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('some_weird_label')
+            data.base.links.get_outgoing(link_type=LinkType.INPUT_CALC).get_node_by_label('some_weird_label')
 
     def test_tab_completable_properties(self):
         """Test properties to go from one node to a neighboring one"""
@@ -761,29 +761,29 @@ class TestNodeLinks:
 
         # The `top_workflow` has two inputs, proxies them to `workflow`, that in turn calls two calculations, passing
         # one data node to each as input, and return the two data nodes returned one by each called calculation
-        top_workflow.add_incoming(input1, link_type=LinkType.INPUT_WORK, link_label='a')
-        top_workflow.add_incoming(input2, link_type=LinkType.INPUT_WORK, link_label='b')
+        top_workflow.base.links.add_incoming(input1, link_type=LinkType.INPUT_WORK, link_label='a')
+        top_workflow.base.links.add_incoming(input2, link_type=LinkType.INPUT_WORK, link_label='b')
         top_workflow.store()
 
-        workflow.add_incoming(input1, link_type=LinkType.INPUT_WORK, link_label='a')
-        workflow.add_incoming(input2, link_type=LinkType.INPUT_WORK, link_label='b')
-        workflow.add_incoming(top_workflow, link_type=LinkType.CALL_WORK, link_label='CALL')
+        workflow.base.links.add_incoming(input1, link_type=LinkType.INPUT_WORK, link_label='a')
+        workflow.base.links.add_incoming(input2, link_type=LinkType.INPUT_WORK, link_label='b')
+        workflow.base.links.add_incoming(top_workflow, link_type=LinkType.CALL_WORK, link_label='CALL')
         workflow.store()
 
-        calc1.add_incoming(input1, link_type=LinkType.INPUT_CALC, link_label='input_value')
-        calc1.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL')
+        calc1.base.links.add_incoming(input1, link_type=LinkType.INPUT_CALC, link_label='input_value')
+        calc1.base.links.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL')
         calc1.store()
-        output1.add_incoming(calc1, link_type=LinkType.CREATE, link_label='result')
+        output1.base.links.add_incoming(calc1, link_type=LinkType.CREATE, link_label='result')
 
-        calc2.add_incoming(input2, link_type=LinkType.INPUT_CALC, link_label='input_value')
-        calc2.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL')
+        calc2.base.links.add_incoming(input2, link_type=LinkType.INPUT_CALC, link_label='input_value')
+        calc2.base.links.add_incoming(workflow, link_type=LinkType.CALL_CALC, link_label='CALL')
         calc2.store()
-        output2.add_incoming(calc2, link_type=LinkType.CREATE, link_label='result')
+        output2.base.links.add_incoming(calc2, link_type=LinkType.CREATE, link_label='result')
 
-        output1.add_incoming(workflow, link_type=LinkType.RETURN, link_label='result_a')
-        output2.add_incoming(workflow, link_type=LinkType.RETURN, link_label='result_b')
-        output1.add_incoming(top_workflow, link_type=LinkType.RETURN, link_label='result_a')
-        output2.add_incoming(top_workflow, link_type=LinkType.RETURN, link_label='result_b')
+        output1.base.links.add_incoming(workflow, link_type=LinkType.RETURN, link_label='result_a')
+        output2.base.links.add_incoming(workflow, link_type=LinkType.RETURN, link_label='result_b')
+        output1.base.links.add_incoming(top_workflow, link_type=LinkType.RETURN, link_label='result_a')
+        output2.base.links.add_incoming(top_workflow, link_type=LinkType.RETURN, link_label='result_b')
 
         # creator
         assert output1.creator.pk == calc1.pk
@@ -837,8 +837,8 @@ class TestNodeDelete:
         data_one = Data().store()
         data_two = Data().store()
         calculation = CalculationNode()
-        calculation.add_incoming(data_one, LinkType.INPUT_CALC, 'input_one')
-        calculation.add_incoming(data_two, LinkType.INPUT_CALC, 'input_two')
+        calculation.base.links.add_incoming(data_one, LinkType.INPUT_CALC, 'input_one')
+        calculation.base.links.add_incoming(data_two, LinkType.INPUT_CALC, 'input_two')
         calculation.store()
 
         log_one = Log(timezone.now(), 'test', 'INFO', data_one.pk).store()
@@ -881,7 +881,7 @@ class TestNodeDelete:
         """Test deletion through objects collection raises when there are incoming links."""
         data = Data().store()
         calculation = CalculationNode()
-        calculation.add_incoming(data, LinkType.INPUT_CALC, 'input')
+        calculation.base.links.add_incoming(data, LinkType.INPUT_CALC, 'input')
         calculation.store()
 
         with pytest.raises(exceptions.InvalidOperation):
@@ -892,7 +892,7 @@ class TestNodeDelete:
         """Test deletion through objects collection raises when there are outgoing links."""
         calculation = CalculationNode().store()
         data = Data()
-        data.add_incoming(calculation, LinkType.CREATE, 'output')
+        data.base.links.add_incoming(calculation, LinkType.CREATE, 'output')
         data.store()
 
         with pytest.raises(exceptions.InvalidOperation):

--- a/tests/orm/test_mixins.py
+++ b/tests/orm/test_mixins.py
@@ -39,7 +39,7 @@ class TestSealable:
         node.seal()
 
         with pytest.raises(exceptions.ModificationNotAllowed):
-            node.validate_incoming(data, link_type=LinkType.INPUT_CALC, link_label='input')
+            node.base.links.validate_incoming(data, link_type=LinkType.INPUT_CALC, link_label='input')
 
     def test_validate_outgoing_sealed(self):
         """Verify that trying to add a link from a sealed node will raise."""
@@ -48,4 +48,4 @@ class TestSealable:
         node.seal()
 
         with pytest.raises(exceptions.ModificationNotAllowed):
-            node.validate_outgoing(data, link_type=LinkType.CREATE, link_label='create')
+            node.base.links.validate_outgoing(data, link_type=LinkType.CREATE, link_label='create')

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -249,13 +249,13 @@ class TestBasic:
         n5.base.attributes.set('foo', None)
         n5.store()
 
-        n2.add_incoming(n1, link_type=LinkType.INPUT_CALC, link_label='link1')
+        n2.base.links.add_incoming(n1, link_type=LinkType.INPUT_CALC, link_label='link1')
         n2.store()
-        n3.add_incoming(n2, link_type=LinkType.CREATE, link_label='link2')
+        n3.base.links.add_incoming(n2, link_type=LinkType.CREATE, link_label='link2')
 
-        n4.add_incoming(n3, link_type=LinkType.INPUT_CALC, link_label='link3')
+        n4.base.links.add_incoming(n3, link_type=LinkType.INPUT_CALC, link_label='link3')
         n4.store()
-        n5.add_incoming(n4, link_type=LinkType.CREATE, link_label='link4')
+        n5.base.links.add_incoming(n4, link_type=LinkType.CREATE, link_label='link4')
 
         qb1 = orm.QueryBuilder()
         qb1.append(orm.Node, filters={'attributes.foo': 1.000})
@@ -305,8 +305,8 @@ class TestBasic:
         n2.label = 'bar'
         n2.description = 'I am BaR'
 
-        n2.add_incoming(n1, link_type=LinkType.CREATE, link_label='random_2')
-        n1.add_incoming(n0, link_type=LinkType.INPUT_CALC, link_label='random_1')
+        n2.base.links.add_incoming(n1, link_type=LinkType.CREATE, link_label='random_2')
+        n1.base.links.add_incoming(n0, link_type=LinkType.INPUT_CALC, link_label='random_1')
 
         for n in (n0, n1, n2):
             n.store()
@@ -598,13 +598,13 @@ class TestBasic:
         """
         d1, d2, d3, d4 = [orm.Data().store() for _ in range(4)]
         c1, c2 = [orm.CalculationNode() for _ in range(2)]
-        c1.add_incoming(d1, link_type=LinkType.INPUT_CALC, link_label='link_d1c1')
+        c1.base.links.add_incoming(d1, link_type=LinkType.INPUT_CALC, link_label='link_d1c1')
         c1.store()
-        d2.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d2')
-        d4.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d4')
-        c2.add_incoming(d2, link_type=LinkType.INPUT_CALC, link_label='link_d2c2')
+        d2.base.links.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d2')
+        d4.base.links.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d4')
+        c2.base.links.add_incoming(d2, link_type=LinkType.INPUT_CALC, link_label='link_d2c2')
         c2.store()
-        d3.add_incoming(c2, link_type=LinkType.CREATE, link_label='link_c2d3')
+        d3.base.links.add_incoming(c2, link_type=LinkType.CREATE, link_label='link_c2d3')
 
         # testing direction=1 for d1, which should return the outgoing
         qb = orm.QueryBuilder()
@@ -690,13 +690,13 @@ class TestBasic:
         """Test querying for links"""
         d1, d2, d3, d4 = [orm.Data().store() for _ in range(4)]
         c1, c2 = [orm.CalculationNode() for _ in range(2)]
-        c1.add_incoming(d1, link_type=LinkType.INPUT_CALC, link_label='link_d1c1')
+        c1.base.links.add_incoming(d1, link_type=LinkType.INPUT_CALC, link_label='link_d1c1')
         c1.store()
-        d2.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d2')
-        d4.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d4')
-        c2.add_incoming(d2, link_type=LinkType.INPUT_CALC, link_label='link_d2c2')
+        d2.base.links.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d2')
+        d4.base.links.add_incoming(c1, link_type=LinkType.CREATE, link_label='link_c1d4')
+        c2.base.links.add_incoming(d2, link_type=LinkType.INPUT_CALC, link_label='link_d2c2')
         c2.store()
-        d3.add_incoming(c2, link_type=LinkType.CREATE, link_label='link_c2d3')
+        d3.base.links.add_incoming(c2, link_type=LinkType.CREATE, link_label='link_c2d3')
 
         builder = orm.QueryBuilder().append(entity_type='link')
         assert builder.count() == 5
@@ -1036,8 +1036,8 @@ class TestQueryBuilderJoins:
         unrelated.label = 'unrelated'
         unrelated.store()
 
-        good_child.add_incoming(parent, link_type=LinkType.INPUT_CALC, link_label='parent')
-        bad_child.add_incoming(parent, link_type=LinkType.INPUT_CALC, link_label='parent')
+        good_child.base.links.add_incoming(parent, link_type=LinkType.INPUT_CALC, link_label='parent')
+        bad_child.base.links.add_incoming(parent, link_type=LinkType.INPUT_CALC, link_label='parent')
         good_child.store()
         bad_child.store()
 
@@ -1066,18 +1066,18 @@ class TestQueryBuilderJoins:
 
         # advisor 0 get student 0, 1
         for i in (0, 1):
-            students[i].add_incoming(advisors[0], link_type=LinkType.CREATE, link_label=f'is_advisor_{i}')
+            students[i].base.links.add_incoming(advisors[0], link_type=LinkType.CREATE, link_label=f'is_advisor_{i}')
 
         # advisor 1 get student 3, 4
         for i in (3, 4):
-            students[i].add_incoming(advisors[1], link_type=LinkType.CREATE, link_label=f'is_advisor_{i}')
+            students[i].base.links.add_incoming(advisors[1], link_type=LinkType.CREATE, link_label=f'is_advisor_{i}')
 
         # advisor 2 get student 5, 6, 7
         for i in (5, 6, 7):
-            students[i].add_incoming(advisors[2], link_type=LinkType.CREATE, link_label=f'is_advisor_{i}')
+            students[i].base.links.add_incoming(advisors[2], link_type=LinkType.CREATE, link_label=f'is_advisor_{i}')
 
         # let's add a differnt relationship than advisor:
-        students[9].add_incoming(advisors[2], link_type=LinkType.CREATE, link_label='lover')
+        students[9].base.links.add_incoming(advisors[2], link_type=LinkType.CREATE, link_label='lover')
 
         assert orm.QueryBuilder().append(
             orm.Node
@@ -1244,13 +1244,13 @@ class QueryBuilderPath:
         # I create a strange graph, inserting links in a order
         # such that I often have to create the transitive closure
         # between two graphs
-        n3.add_incoming(n2, link_type=LinkType.CREATE, link_label='link1')
-        n2.add_incoming(n1, link_type=LinkType.INPUT_CALC, link_label='link2')
-        n5.add_incoming(n3, link_type=LinkType.INPUT_CALC, link_label='link3')
-        n5.add_incoming(n4, link_type=LinkType.INPUT_CALC, link_label='link4')
-        n4.add_incoming(n2, link_type=LinkType.CREATE, link_label='link5')
-        n7.add_incoming(n6, link_type=LinkType.INPUT_CALC, link_label='link6')
-        n8.add_incoming(n7, link_type=LinkType.CREATE, link_label='link7')
+        n3.base.links.add_incoming(n2, link_type=LinkType.CREATE, link_label='link1')
+        n2.base.links.add_incoming(n1, link_type=LinkType.INPUT_CALC, link_label='link2')
+        n5.base.links.add_incoming(n3, link_type=LinkType.INPUT_CALC, link_label='link3')
+        n5.base.links.add_incoming(n4, link_type=LinkType.INPUT_CALC, link_label='link4')
+        n4.base.links.add_incoming(n2, link_type=LinkType.CREATE, link_label='link5')
+        n7.base.links.add_incoming(n6, link_type=LinkType.INPUT_CALC, link_label='link6')
+        n8.base.links.add_incoming(n7, link_type=LinkType.CREATE, link_label='link7')
 
         for node in [n1, n2, n3, n4, n5, n6, n7, n8, n9]:
             node.store()
@@ -1277,7 +1277,7 @@ class QueryBuilderPath:
             'id': n1.pk
         }).count() == 0
 
-        n6.add_incoming(n5, link_type=LinkType.CREATE, link_label='link1')
+        n6.base.links.add_incoming(n5, link_type=LinkType.CREATE, link_label='link1')
         # Yet, now 2 links from 1 to 8
         assert orm.QueryBuilder().append(orm.Node, filters={
             'id': n1.pk
@@ -1361,7 +1361,7 @@ class QueryBuilderPath:
         # This part of the test is no longer possible as the nodes have already been stored and the previous parts of
         # the test rely on this, which means however, that here, no more links can be added as that will raise.
 
-        # n7.add_incoming(n9, link_type=LinkType.INPUT_CALC, link_label='link0')
+        # n7.base.links.add_incoming(n9, link_type=LinkType.INPUT_CALC, link_label='link0')
         # # Still two links...
 
         # self.assertEqual(
@@ -1377,7 +1377,7 @@ class QueryBuilderPath:
         #     }, tag='desc').append(orm.Node, with_descendants='desc', filters={
         #         'id': n1.pk
         #     }).count(), 2)
-        # n9.add_incoming(n5, link_type=LinkType.CREATE, link_label='link6')
+        # n9.base.links.add_incoming(n5, link_type=LinkType.CREATE, link_label='link6')
         # # And now there should be 4 nodes
 
         # self.assertEqual(
@@ -1435,7 +1435,7 @@ class TestConsistency:
         # adding 5 links going out:
         for inode in range(5):
             output_node = orm.Data().store()
-            output_node.add_incoming(parent, link_type=LinkType.CREATE, link_label=f'link_{inode}')
+            output_node.base.links.add_incoming(parent, link_type=LinkType.CREATE, link_label=f'link_{inode}')
         for projection in ('id', '*'):
             qb = orm.QueryBuilder()
             qb.append(orm.CalculationNode, filters={'id': parent.id}, tag='parent', project=projection)

--- a/tests/orm/utils/test_calcjob.py
+++ b/tests/orm/utils/test_calcjob.py
@@ -26,7 +26,9 @@ def get_calcjob_node(aiida_profile_clean, generate_calculation_node):
     }
 
     results = Dict(dict=dictionary).store()
-    results.add_incoming(node, link_type=LinkType.CREATE, link_label=node.process_class.spec().default_output_node)
+    results.base.links.add_incoming(
+        node, link_type=LinkType.CREATE, link_label=node.process_class.spec().default_output_node
+    )
 
     return node, dictionary
 

--- a/tests/orm/utils/test_managers.py
+++ b/tests/orm/utils/test_managers.py
@@ -61,16 +61,16 @@ def test_link_manager(aiida_profile_clean):
 
     # Create calc with inputs
     calc = orm.CalculationNode()
-    calc.add_incoming(inp1, link_type=LinkType.INPUT_CALC, link_label='inp1label')
-    calc.add_incoming(inp2, link_type=LinkType.INPUT_CALC, link_label='inp2label')
+    calc.base.links.add_incoming(inp1, link_type=LinkType.INPUT_CALC, link_label='inp1label')
+    calc.base.links.add_incoming(inp2, link_type=LinkType.INPUT_CALC, link_label='inp2label')
     calc.store()
 
     # Attach outputs
     out1 = orm.Data()
     out2 = orm.Data()
-    out1.add_incoming(calc, link_type=LinkType.CREATE, link_label='out1label')
+    out1.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='out1label')
     out1.store()
-    out2.add_incoming(calc, link_type=LinkType.CREATE, link_label='out2label')
+    out2.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='out2label')
     out2.store()
 
     expected_inputs = {'inp1label': inp1.uuid, 'inp2label': inp2.uuid}
@@ -144,16 +144,16 @@ def test_link_manager_with_nested_namespaces(aiida_profile_clean):
     inp1.store()
 
     calc = orm.CalculationNode()
-    calc.add_incoming(inp1, link_type=LinkType.INPUT_CALC, link_label='nested__sub__namespace')
+    calc.base.links.add_incoming(inp1, link_type=LinkType.INPUT_CALC, link_label='nested__sub__namespace')
     calc.store()
 
     # Attach outputs
     out1 = orm.Data()
-    out1.add_incoming(calc, link_type=LinkType.CREATE, link_label='nested__sub__namespace')
+    out1.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='nested__sub__namespace')
     out1.store()
 
     out2 = orm.Data()
-    out2.add_incoming(calc, link_type=LinkType.CREATE, link_label='remote_folder')
+    out2.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='remote_folder')
     out2.store()
 
     # Check that the recommended way of dereferencing works
@@ -200,7 +200,7 @@ def test_link_manager_contains(aiida_profile_clean):
     data.store()
 
     calc = orm.CalculationNode()
-    calc.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='nested__sub__name')
+    calc.base.links.add_incoming(data, link_type=LinkType.INPUT_CALC, link_label='nested__sub__name')
     calc.store()
 
     assert 'nested' in calc.inputs

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -60,7 +60,7 @@ class TestParser:
         node.store()
 
         retrieved = orm.FolderData().store()
-        retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+        retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
         parser = ArithmeticAddParser(node)
         assert parser.node.uuid == node.uuid
@@ -81,10 +81,10 @@ class TestParser:
         node.store()
 
         retrieved = orm.FolderData().store()
-        retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+        retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
         output = orm.Data().store()
-        output.add_incoming(node, link_type=LinkType.CREATE, link_label='output')
+        output.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='output')
 
         parser = ArithmeticAddParser(node)
         outputs_for_parsing = parser.get_outputs_for_parsing()
@@ -113,7 +113,7 @@ class TestParser:
         retrieved = orm.FolderData()
         retrieved.base.repository.put_object_from_filelike(io.StringIO(f'{summed}'), output_filename)
         retrieved.store()
-        retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+        retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
         for cls in [ArithmeticAddParser, SimpleArithmeticAddParser]:
             result, calcfunction = cls.parse_from_node(node)

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -77,8 +77,8 @@ class TestRestApi:
         calc.base.attributes.set('attr1', 'OK')
         calc.base.attributes.set('attr2', 'OK')
 
-        calc.add_incoming(structure, link_type=LinkType.INPUT_CALC, link_label='link_structure')
-        calc.add_incoming(parameter1, link_type=LinkType.INPUT_CALC, link_label='link_parameter')
+        calc.base.links.add_incoming(structure, link_type=LinkType.INPUT_CALC, link_label='link_structure')
+        calc.base.links.add_incoming(parameter1, link_type=LinkType.INPUT_CALC, link_label='link_parameter')
         calc.base.repository.put_object_from_filelike(
             io.BytesIO(b'The input file\nof the CalcJob node'), 'calcjob_inputs/aiida.in'
         )
@@ -107,9 +107,9 @@ class TestRestApi:
         stream = io.BytesIO(b'The output file\nof the CalcJob node')
         retrieved_outputs.base.repository.put_object_from_filelike(stream, 'calcjob_outputs/aiida.out')
         retrieved_outputs.store()
-        retrieved_outputs.add_incoming(calc, link_type=LinkType.CREATE, link_label='retrieved')
+        retrieved_outputs.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='retrieved')
 
-        kpoint.add_incoming(calc, link_type=LinkType.CREATE, link_label='create')
+        kpoint.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='create')
 
         calc1 = orm.CalcJobNode(computer=self.computer)
         calc1.set_option('resources', resources)

--- a/tests/storage/psql_dos/test_schema.py
+++ b/tests/storage/psql_dos/test_schema.py
@@ -40,9 +40,9 @@ class TestRelationshipsSQLA:
         n_3 = Data().store()
 
         # Create a link between these 2 nodes
-        n_2.add_incoming(n_1, link_type=LinkType.INPUT_CALC, link_label='N1')
+        n_2.base.links.add_incoming(n_1, link_type=LinkType.INPUT_CALC, link_label='N1')
         n_2.store()
-        n_3.add_incoming(n_2, link_type=LinkType.CREATE, link_label='N2')
+        n_3.base.links.add_incoming(n_2, link_type=LinkType.CREATE, link_label='N2')
 
         # Check that the result of outputs is a list
         assert isinstance(n_1.backend_entity.bare_model.outputs, list), 'This is expected to be a list'
@@ -65,9 +65,9 @@ class TestRelationshipsSQLA:
         n_3 = Data().store()
 
         # Create a link between these 2 nodes
-        n_2.add_incoming(n_1, link_type=LinkType.INPUT_CALC, link_label='N1')
+        n_2.base.links.add_incoming(n_1, link_type=LinkType.INPUT_CALC, link_label='N1')
         n_2.store()
-        n_3.add_incoming(n_2, link_type=LinkType.CREATE, link_label='N2')
+        n_3.base.links.add_incoming(n_2, link_type=LinkType.CREATE, link_label='N2')
 
         # Check that the result of outputs is a list
         assert isinstance(n_1.backend_entity.bare_model.inputs, list), 'This is expected to be a list'

--- a/tests/tools/archive/orm/test_calculations.py
+++ b/tests/tools/archive/orm/test_calculations.py
@@ -64,14 +64,14 @@ def test_workcalculation(tmp_path, aiida_profile):
     input_2 = orm.Int(5).store()
     output_1 = orm.Int(2).store()
 
-    master.add_incoming(input_1, LinkType.INPUT_WORK, 'input_1')
-    slave.add_incoming(master, LinkType.CALL_WORK, 'CALL')
-    slave.add_incoming(input_2, LinkType.INPUT_WORK, 'input_2')
+    master.base.links.add_incoming(input_1, LinkType.INPUT_WORK, 'input_1')
+    slave.base.links.add_incoming(master, LinkType.CALL_WORK, 'CALL')
+    slave.base.links.add_incoming(input_2, LinkType.INPUT_WORK, 'input_2')
 
     master.store()
     slave.store()
 
-    output_1.add_incoming(master, LinkType.RETURN, 'RETURN')
+    output_1.base.links.add_incoming(master, LinkType.RETURN, 'RETURN')
 
     master.seal()
     slave.seal()

--- a/tests/tools/archive/orm/test_codes.py
+++ b/tests/tools/archive/orm/test_codes.py
@@ -57,7 +57,7 @@ def test_input_code(tmp_path, aiida_profile_clean, aiida_localhost):
     calc.computer = aiida_localhost
     calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
 
-    calc.add_incoming(code, LinkType.INPUT_CALC, 'code')
+    calc.base.links.add_incoming(code, LinkType.INPUT_CALC, 'code')
     calc.store()
     calc.seal()
     links_count = 1

--- a/tests/tools/archive/orm/test_groups.py
+++ b/tests/tools/archive/orm/test_groups.py
@@ -37,7 +37,7 @@ def test_nodes_in_group(tmp_path, aiida_profile_clean, aiida_localhost):
     jc1.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     jc1.user = user
     jc1.label = 'jc1'
-    jc1.add_incoming(sd1, link_type=LinkType.INPUT_CALC, link_label='link')
+    jc1.base.links.add_incoming(sd1, link_type=LinkType.INPUT_CALC, link_label='link')
     jc1.store()
     jc1.seal()
 

--- a/tests/tools/archive/orm/test_links.py
+++ b/tests/tools/archive/orm/test_links.py
@@ -62,9 +62,9 @@ def test_input_and_create_links(tmp_path, aiida_profile_clean):
     node_input = orm.Int(1).store()
     node_output = orm.Int(2).store()
 
-    node_work.add_incoming(node_input, LinkType.INPUT_CALC, 'input')
+    node_work.base.links.add_incoming(node_input, LinkType.INPUT_CALC, 'input')
     node_work.store()
-    node_output.add_incoming(node_work, LinkType.CREATE, 'output')
+    node_output.base.links.add_incoming(node_work, LinkType.CREATE, 'output')
 
     node_work.seal()
 
@@ -157,36 +157,36 @@ def construct_complex_graph(aiida_localhost_factory, export_combination=0, work_
     data6 = orm.Int(1)
 
     # Link creation
-    work1.add_incoming(data1, LinkType.INPUT_WORK, 'input1')
-    work1.add_incoming(data2, LinkType.INPUT_WORK, 'input2')
+    work1.base.links.add_incoming(data1, LinkType.INPUT_WORK, 'input1')
+    work1.base.links.add_incoming(data2, LinkType.INPUT_WORK, 'input2')
 
-    work2.add_incoming(data1, LinkType.INPUT_WORK, 'input1')
-    work2.add_incoming(work1, LinkType.CALL_WORK, 'call2')
+    work2.base.links.add_incoming(data1, LinkType.INPUT_WORK, 'input1')
+    work2.base.links.add_incoming(work1, LinkType.CALL_WORK, 'call2')
 
     work1.store()
     work2.store()
 
-    calc1.add_incoming(data1, LinkType.INPUT_CALC, 'input1')
-    calc1.add_incoming(work2, LinkType.CALL_CALC, 'call1')
+    calc1.base.links.add_incoming(data1, LinkType.INPUT_CALC, 'input1')
+    calc1.base.links.add_incoming(work2, LinkType.CALL_CALC, 'call1')
     calc1.store()
 
-    data3.add_incoming(calc1, LinkType.CREATE, 'create3')
+    data3.base.links.add_incoming(calc1, LinkType.CREATE, 'create3')
     # data3 is stored now, because a @workfunction cannot return unstored Data,
     # i.e. create data.
     data3.store()
-    data3.add_incoming(work2, LinkType.RETURN, 'return3')
+    data3.base.links.add_incoming(work2, LinkType.RETURN, 'return3')
 
-    data4.add_incoming(calc1, LinkType.CREATE, 'create4')
+    data4.base.links.add_incoming(calc1, LinkType.CREATE, 'create4')
     # data3 is stored now, because a @workfunction cannot return unstored Data,
     # i.e. create data.
     data4.store()
-    data4.add_incoming(work2, LinkType.RETURN, 'return4')
+    data4.base.links.add_incoming(work2, LinkType.RETURN, 'return4')
 
-    calc2.add_incoming(data4, LinkType.INPUT_CALC, 'input4')
+    calc2.base.links.add_incoming(data4, LinkType.INPUT_CALC, 'input4')
     calc2.store()
 
-    data5.add_incoming(calc2, LinkType.CREATE, 'create5')
-    data6.add_incoming(calc2, LinkType.CREATE, 'create6')
+    data5.base.links.add_incoming(calc2, LinkType.CREATE, 'create5')
+    data6.base.links.add_incoming(calc2, LinkType.CREATE, 'create6')
 
     data5.store()
     data6.store()
@@ -548,11 +548,11 @@ def test_double_return_links_for_workflows(tmp_path, aiida_profile_clean):
     data_in = orm.Int(1).store()
     data_out = orm.Int(2).store()
 
-    work1.add_incoming(data_in, LinkType.INPUT_WORK, 'input_i1')
-    work1.add_incoming(work2, LinkType.CALL_WORK, 'call')
+    work1.base.links.add_incoming(data_in, LinkType.INPUT_WORK, 'input_i1')
+    work1.base.links.add_incoming(work2, LinkType.CALL_WORK, 'call')
     work1.store()
-    data_out.add_incoming(work1, LinkType.RETURN, 'return1')
-    data_out.add_incoming(work2, LinkType.RETURN, 'return2')
+    data_out.base.links.add_incoming(work1, LinkType.RETURN, 'return1')
+    data_out.base.links.add_incoming(work2, LinkType.RETURN, 'return2')
     links_count = 4
 
     work1.seal()
@@ -586,8 +586,8 @@ def test_multiple_post_return_links(tmp_path, aiida_profile_clean):  # pylint: d
     work = orm.WorkflowNode().store()
     link_label = 'output_data'
 
-    data.add_incoming(calc, LinkType.CREATE, link_label)
-    data.add_incoming(work, LinkType.RETURN, link_label)
+    data.base.links.add_incoming(calc, LinkType.CREATE, link_label)
+    data.base.links.add_incoming(work, LinkType.RETURN, link_label)
 
     calc.seal()
     work.seal()

--- a/tests/tools/archive/orm/test_users.py
+++ b/tests/tools/archive/orm/test_users.py
@@ -37,7 +37,7 @@ def test_nodes_belonging_to_different_users(tmp_path, aiida_profile_clean, aiida
     jc1.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     jc1.user = user
     jc1.label = 'jc1'
-    jc1.add_incoming(sd1, link_type=LinkType.INPUT_CALC, link_label='link')
+    jc1.base.links.add_incoming(sd1, link_type=LinkType.INPUT_CALC, link_label='link')
     jc1.store()
 
     # Create some nodes from a different user
@@ -45,20 +45,20 @@ def test_nodes_belonging_to_different_users(tmp_path, aiida_profile_clean, aiida
     sd2.user = user
     sd2.label = 'sd2'
     sd2.store()
-    sd2.add_incoming(jc1, link_type=LinkType.CREATE, link_label='l1')  # I assume jc1 CREATED sd2
+    sd2.base.links.add_incoming(jc1, link_type=LinkType.CREATE, link_label='l1')  # I assume jc1 CREATED sd2
     jc1.seal()
 
     jc2 = orm.CalcJobNode()
     jc2.computer = aiida_localhost
     jc2.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     jc2.label = 'jc2'
-    jc2.add_incoming(sd2, link_type=LinkType.INPUT_CALC, link_label='l2')
+    jc2.base.links.add_incoming(sd2, link_type=LinkType.INPUT_CALC, link_label='l2')
     jc2.store()
 
     sd3 = orm.StructureData(pbc=False)
     sd3.label = 'sd3'
     sd3.store()
-    sd3.add_incoming(jc2, link_type=LinkType.CREATE, link_label='l3')
+    sd3.base.links.add_incoming(jc2, link_type=LinkType.CREATE, link_label='l3')
     jc2.seal()
 
     uuids_u1 = [sd1.uuid, jc1.uuid, sd2.uuid]
@@ -107,14 +107,14 @@ def test_non_default_user_nodes(tmp_path, aiida_profile_clean, aiida_localhost_f
     jc1.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     jc1.user = user
     jc1.label = 'jc1'
-    jc1.add_incoming(sd1, link_type=LinkType.INPUT_CALC, link_label='link')
+    jc1.base.links.add_incoming(sd1, link_type=LinkType.INPUT_CALC, link_label='link')
     jc1.store()
 
     # Create some nodes from a different user
     sd2 = orm.StructureData(pbc=False)
     sd2.user = user
     sd2.label = 'sd2'
-    sd2.add_incoming(jc1, link_type=LinkType.CREATE, link_label='l1')
+    sd2.base.links.add_incoming(jc1, link_type=LinkType.CREATE, link_label='l1')
     sd2.store()
     jc1.seal()
     sd2_uuid = sd2.uuid
@@ -139,12 +139,12 @@ def test_non_default_user_nodes(tmp_path, aiida_profile_clean, aiida_localhost_f
     jc2.computer = aiida_localhost_factory()
     jc2.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     jc2.label = 'jc2'
-    jc2.add_incoming(sd2_imp, link_type=LinkType.INPUT_CALC, link_label='l2')
+    jc2.base.links.add_incoming(sd2_imp, link_type=LinkType.INPUT_CALC, link_label='l2')
     jc2.store()
 
     sd3 = orm.StructureData(pbc=False)
     sd3.label = 'sd3'
-    sd3.add_incoming(jc2, link_type=LinkType.CREATE, link_label='l3')
+    sd3.base.links.add_incoming(jc2, link_type=LinkType.CREATE, link_label='l3')
     sd3.store()
     jc2.seal()
 

--- a/tests/tools/archive/test_complex.py
+++ b/tests/tools/archive/test_complex.py
@@ -50,21 +50,21 @@ def test_complex_graph_import_export(aiida_profile_clean, tmp_path, aiida_localh
     rd1.set_remote_path('/x/y.py')
     rd1.computer = aiida_localhost
     rd1.store()
-    rd1.add_incoming(calc1, link_type=LinkType.CREATE, link_label='link')
+    rd1.base.links.add_incoming(calc1, link_type=LinkType.CREATE, link_label='link')
 
     calc2 = orm.CalcJobNode()
     calc2.computer = aiida_localhost
     calc2.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
     calc2.label = 'calc2'
-    calc2.add_incoming(pd1, link_type=LinkType.INPUT_CALC, link_label='link1')
-    calc2.add_incoming(pd2, link_type=LinkType.INPUT_CALC, link_label='link2')
-    calc2.add_incoming(rd1, link_type=LinkType.INPUT_CALC, link_label='link3')
+    calc2.base.links.add_incoming(pd1, link_type=LinkType.INPUT_CALC, link_label='link1')
+    calc2.base.links.add_incoming(pd2, link_type=LinkType.INPUT_CALC, link_label='link2')
+    calc2.base.links.add_incoming(rd1, link_type=LinkType.INPUT_CALC, link_label='link3')
     calc2.store()
 
     fd1 = orm.FolderData()
     fd1.label = 'fd1'
     fd1.store()
-    fd1.add_incoming(calc2, link_type=LinkType.CREATE, link_label='link')
+    fd1.base.links.add_incoming(calc2, link_type=LinkType.CREATE, link_label='link')
 
     calc1.seal()
     calc2.seal()
@@ -134,10 +134,10 @@ def test_reexport(aiida_profile, tmp_path):
     array.store()
     # LINKS
     # the calculation has input the parameters-instance
-    calc.add_incoming(param, link_type=LinkType.INPUT_CALC, link_label='input_parameters')
+    calc.base.links.add_incoming(param, link_type=LinkType.INPUT_CALC, link_label='input_parameters')
     calc.store()
     # I want the array to be an output of the calculation
-    array.add_incoming(calc, link_type=LinkType.CREATE, link_label='output_array')
+    array.base.links.add_incoming(calc, link_type=LinkType.CREATE, link_label='output_array')
     group = orm.Group(label='test-group')
     group.store()
     group.add_nodes(array)

--- a/tests/tools/archive/test_simple.py
+++ b/tests/tools/archive/test_simple.py
@@ -53,7 +53,7 @@ def test_calc_of_structuredata(aiida_profile_clean, tmp_path, aiida_localhost):
     calc.computer = aiida_localhost
     calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
 
-    calc.add_incoming(struct, link_type=LinkType.INPUT_CALC, link_label='link')
+    calc.base.links.add_incoming(struct, link_type=LinkType.INPUT_CALC, link_label='link')
     calc.store()
     calc.seal()
 

--- a/tests/tools/archive/test_specific_import.py
+++ b/tests/tools/archive/test_specific_import.py
@@ -94,10 +94,10 @@ def test_cycle_structure_data(aiida_profile_clean, aiida_localhost, tmp_path):
     child_calculation.base.attributes.set('key', 'value')
     remote_folder = orm.RemoteData(computer=aiida_localhost, remote_path='/').store()
 
-    remote_folder.add_incoming(parent_process, link_type=LinkType.CREATE, link_label='link')
-    child_calculation.add_incoming(remote_folder, link_type=LinkType.INPUT_CALC, link_label='link')
+    remote_folder.base.links.add_incoming(parent_process, link_type=LinkType.CREATE, link_label='link')
+    child_calculation.base.links.add_incoming(remote_folder, link_type=LinkType.INPUT_CALC, link_label='link')
     child_calculation.store()
-    structure.add_incoming(child_calculation, link_type=LinkType.CREATE, link_label='link')
+    structure.base.links.add_incoming(child_calculation, link_type=LinkType.CREATE, link_label='link')
 
     parent_process.seal()
     child_calculation.seal()

--- a/tests/tools/graph/test_age.py
+++ b/tests/tools/graph/test_age.py
@@ -55,7 +55,7 @@ def create_tree(max_depth=3, branching=3, starting_cls=orm.Data):
             for label_id in range(branching):
 
                 new_node = current_class()
-                new_node.add_incoming(previous_node, link_type=current_links, link_label=f'link{label_id}')
+                new_node.base.links.add_incoming(previous_node, link_type=current_links, link_label=f'link{label_id}')
                 new_node.store()
 
                 current_nodes.append(new_node)
@@ -120,24 +120,24 @@ class TestAiidaGraphExplorer:
         data_i = orm.Data().store()
 
         work_2 = orm.WorkflowNode()
-        work_2.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork2')
+        work_2.base.links.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork2')
         work_2.store()
 
         work_1 = orm.WorkflowNode()
-        work_1.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork1')
-        work_1.add_incoming(work_2, link_type=LinkType.CALL_WORK, link_label='callwork')
+        work_1.base.links.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork1')
+        work_1.base.links.add_incoming(work_2, link_type=LinkType.CALL_WORK, link_label='callwork')
         work_1.store()
 
         calc_0 = orm.CalculationNode()
-        calc_0.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc0')
-        calc_0.add_incoming(work_1, link_type=LinkType.CALL_CALC, link_label='callcalc')
+        calc_0.base.links.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc0')
+        calc_0.base.links.add_incoming(work_1, link_type=LinkType.CALL_CALC, link_label='callcalc')
         calc_0.store()
 
         data_o = orm.Data()
-        data_o.add_incoming(calc_0, link_type=LinkType.CREATE, link_label='create0')
+        data_o.base.links.add_incoming(calc_0, link_type=LinkType.CREATE, link_label='create0')
         data_o.store()
-        data_o.add_incoming(work_2, link_type=LinkType.RETURN, link_label='return2')
-        data_o.add_incoming(work_1, link_type=LinkType.RETURN, link_label='return1')
+        data_o.base.links.add_incoming(work_2, link_type=LinkType.RETURN, link_label='return2')
+        data_o.base.links.add_incoming(work_1, link_type=LinkType.RETURN, link_label='return1')
 
         output_dict = {
             'data_i': data_i,
@@ -252,9 +252,9 @@ class TestAiidaGraphExplorer:
         """
         data_node = orm.Data().store()
         work_node = orm.WorkflowNode()
-        work_node.add_incoming(data_node, link_type=LinkType.INPUT_WORK, link_label='input_link')
+        work_node.base.links.add_incoming(data_node, link_type=LinkType.INPUT_WORK, link_label='input_link')
         work_node.store()
-        data_node.add_incoming(work_node, link_type=LinkType.RETURN, link_label='return_link')
+        data_node.base.links.add_incoming(work_node, link_type=LinkType.RETURN, link_label='return_link')
 
         basket = Basket(nodes=[data_node.id])
         queryb = orm.QueryBuilder()
@@ -302,24 +302,24 @@ class TestAiidaGraphExplorer:
         """
         data_0 = orm.Data().store()
         calc_1 = orm.CalculationNode()
-        calc_1.add_incoming(data_0, link_type=LinkType.INPUT_CALC, link_label='inpcalc_data_0')
+        calc_1.base.links.add_incoming(data_0, link_type=LinkType.INPUT_CALC, link_label='inpcalc_data_0')
         calc_1.store()
 
         data_1 = orm.Data()
         data_o = orm.Data()
-        data_1.add_incoming(calc_1, link_type=LinkType.CREATE, link_label='create_data_1')
-        data_o.add_incoming(calc_1, link_type=LinkType.CREATE, link_label='create_data_o')
+        data_1.base.links.add_incoming(calc_1, link_type=LinkType.CREATE, link_label='create_data_1')
+        data_o.base.links.add_incoming(calc_1, link_type=LinkType.CREATE, link_label='create_data_o')
         data_1.store()
         data_o.store()
 
         data_i = orm.Data().store()
         calc_2 = orm.CalculationNode()
-        calc_2.add_incoming(data_1, link_type=LinkType.INPUT_CALC, link_label='inpcalc_data_1')
-        calc_2.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc_data_i')
+        calc_2.base.links.add_incoming(data_1, link_type=LinkType.INPUT_CALC, link_label='inpcalc_data_1')
+        calc_2.base.links.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc_data_i')
         calc_2.store()
 
         data_2 = orm.Data()
-        data_2.add_incoming(calc_2, link_type=LinkType.CREATE, link_label='create_data_2')
+        data_2.base.links.add_incoming(calc_2, link_type=LinkType.CREATE, link_label='create_data_2')
         data_2.store()
 
         output_dict = {

--- a/tests/tools/graph/test_graph_traversers.py
+++ b/tests/tools/graph/test_graph_traversers.py
@@ -57,20 +57,20 @@ def create_minimal_graph():
     work_1 = orm.WorkflowNode()
     work_2 = orm.WorkflowNode()
 
-    calc_0.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc')
-    work_1.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork')
-    work_2.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork')
+    calc_0.base.links.add_incoming(data_i, link_type=LinkType.INPUT_CALC, link_label='inpcalc')
+    work_1.base.links.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork')
+    work_2.base.links.add_incoming(data_i, link_type=LinkType.INPUT_WORK, link_label='inpwork')
 
-    calc_0.add_incoming(work_1, link_type=LinkType.CALL_CALC, link_label='callcalc')
-    work_1.add_incoming(work_2, link_type=LinkType.CALL_WORK, link_label='callwork')
+    calc_0.base.links.add_incoming(work_1, link_type=LinkType.CALL_CALC, link_label='callcalc')
+    work_1.base.links.add_incoming(work_2, link_type=LinkType.CALL_WORK, link_label='callwork')
 
     work_2.store()
     work_1.store()
     calc_0.store()
 
-    data_o.add_incoming(calc_0, link_type=LinkType.CREATE, link_label='create0')
-    data_o.add_incoming(work_1, link_type=LinkType.RETURN, link_label='return1')
-    data_o.add_incoming(work_2, link_type=LinkType.RETURN, link_label='return2')
+    data_o.base.links.add_incoming(calc_0, link_type=LinkType.CREATE, link_label='create0')
+    data_o.base.links.add_incoming(work_1, link_type=LinkType.RETURN, link_label='return1')
+    data_o.base.links.add_incoming(work_2, link_type=LinkType.RETURN, link_label='return2')
 
     output_dict = {
         'data_i': data_i,
@@ -289,11 +289,11 @@ class TestTraverseGraph:
         data_drop = orm.Data().store()
         work_select = orm.WorkflowNode()
 
-        work_select.add_incoming(data_take, link_type=LinkType.INPUT_WORK, link_label='input_take')
-        work_select.add_incoming(data_drop, link_type=LinkType.INPUT_WORK, link_label='input_drop')
+        work_select.base.links.add_incoming(data_take, link_type=LinkType.INPUT_WORK, link_label='input_take')
+        work_select.base.links.add_incoming(data_drop, link_type=LinkType.INPUT_WORK, link_label='input_drop')
         work_select.store()
 
-        data_take.add_incoming(work_select, link_type=LinkType.RETURN, link_label='return_link')
+        data_take.base.links.add_incoming(work_select, link_type=LinkType.RETURN, link_label='return_link')
 
         data_take = data_take.pk
         data_drop = data_drop.pk

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -40,8 +40,8 @@ class TestVisGraph:
 
         wc1 = orm.WorkChainNode()
         wc1.set_process_state(ProcessState.RUNNING)
-        wc1.add_incoming(pd0, link_type=LinkType.INPUT_WORK, link_label='input1')
-        wc1.add_incoming(pd1, link_type=LinkType.INPUT_WORK, link_label='input2')
+        wc1.base.links.add_incoming(pd0, link_type=LinkType.INPUT_WORK, link_label='input1')
+        wc1.base.links.add_incoming(pd1, link_type=LinkType.INPUT_WORK, link_label='input2')
         wc1.store()
 
         calc1 = orm.CalcJobNode()
@@ -50,9 +50,9 @@ class TestVisGraph:
         calc1.label = 'calc1'
         calc1.set_process_state(ProcessState.FINISHED)
         calc1.set_exit_status(0)
-        calc1.add_incoming(pd0, link_type=LinkType.INPUT_CALC, link_label='input1')
-        calc1.add_incoming(pd1, link_type=LinkType.INPUT_CALC, link_label='input2')
-        calc1.add_incoming(wc1, link_type=LinkType.CALL_CALC, link_label='call1')
+        calc1.base.links.add_incoming(pd0, link_type=LinkType.INPUT_CALC, link_label='input1')
+        calc1.base.links.add_incoming(pd1, link_type=LinkType.INPUT_CALC, link_label='input2')
+        calc1.base.links.add_incoming(wc1, link_type=LinkType.CALL_CALC, link_label='call1')
         calc1.store()
 
         rd1 = orm.RemoteData()
@@ -60,7 +60,7 @@ class TestVisGraph:
         rd1.set_remote_path('/x/y.py')
         rd1.computer = self.computer
         rd1.store()
-        rd1.add_incoming(calc1, link_type=LinkType.CREATE, link_label='output')
+        rd1.base.links.add_incoming(calc1, link_type=LinkType.CREATE, link_label='output')
 
         pd2 = orm.Dict()
         pd2.label = 'pd2'
@@ -70,9 +70,9 @@ class TestVisGraph:
         calcf1.label = 'calcf1'
         calcf1.set_process_state(ProcessState.FINISHED)
         calcf1.set_exit_status(200)
-        calcf1.add_incoming(rd1, link_type=LinkType.INPUT_CALC, link_label='input1')
-        calcf1.add_incoming(pd2, link_type=LinkType.INPUT_CALC, link_label='input2')
-        calcf1.add_incoming(wc1, link_type=LinkType.CALL_CALC, link_label='call2')
+        calcf1.base.links.add_incoming(rd1, link_type=LinkType.INPUT_CALC, link_label='input1')
+        calcf1.base.links.add_incoming(pd2, link_type=LinkType.INPUT_CALC, link_label='input2')
+        calcf1.base.links.add_incoming(wc1, link_type=LinkType.CALL_CALC, link_label='call2')
         calcf1.store()
 
         pd3 = orm.Dict()
@@ -81,13 +81,13 @@ class TestVisGraph:
         fd1 = orm.FolderData()
         fd1.label = 'fd1'
 
-        pd3.add_incoming(calcf1, link_type=LinkType.CREATE, link_label='output1')
+        pd3.base.links.add_incoming(calcf1, link_type=LinkType.CREATE, link_label='output1')
         pd3.store()
-        fd1.add_incoming(calcf1, link_type=LinkType.CREATE, link_label='output2')
+        fd1.base.links.add_incoming(calcf1, link_type=LinkType.CREATE, link_label='output2')
         fd1.store()
 
-        pd3.add_incoming(wc1, link_type=LinkType.RETURN, link_label='output1')
-        fd1.add_incoming(wc1, link_type=LinkType.RETURN, link_label='output2')
+        pd3.base.links.add_incoming(wc1, link_type=LinkType.RETURN, link_label='output1')
+        fd1.base.links.add_incoming(wc1, link_type=LinkType.RETURN, link_label='output2')
 
         return AttributeDict({
             'pd0': pd0,


### PR DESCRIPTION
This commit is part of the `Node` namespace restructure. It moves all
link related methods to a new `NodeLinks` class that is exposed through
the `Node.base.links` attribute.

A number of the `Node` subclasses for processes overrode the validation
methods `validate_incoming` and `validate_outgoing`. By changing the
design from straight-up inheritance to composition, and the link
validation functionality moving to the `NodeLinks` class, its is this
class that has to be overridden. To do so, the exact class to be used
for the `NodeLinks` class is made configurable on the `Node` class
through the `CLS_NODE_LINKS` class attribute. The subclasses can then
override the `NodeLinks` class and set this as the `CLS_NODE_LINKS`.

The `has_cached_links` property has been removed. It was only used
internally to check that when a process started running, all links had
been properly stored. This is a historic implementation detail, and
really what should be checked simply is that the node is stored. The
process should not start running before the node is stored and all links
are stored when the node is stored.