### PR TITLE
♻️  REFACTOR: Move caching related methods to `Node.base.caching

### DIFF
--- a/.github/system_tests/test_daemon.py
+++ b/.github/system_tests/test_daemon.py
@@ -200,7 +200,8 @@ def validate_cached(cached_calcs):
             print_report(calc.pk)
             valid = False
 
-        if '_aiida_cached_from' not in calc.base.extras or calc.get_hash() != calc.base.extras.get('_aiida_hash'):
+        if '_aiida_cached_from' not in calc.base.extras or calc.base.caching.get_hash(
+        ) != calc.base.extras.get('_aiida_hash'):
             print(f'Cached calculation<{calc.pk}> has invalid hash')
             print_report(calc.pk)
             valid = False

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -363,7 +363,7 @@ def rehash(nodes, entry_point, force):
 
     with click.progressbar(to_hash, label='Rehashing Nodes:') as iter_hash:
         for node, in iter_hash:
-            node.rehash()
+            node.base.caching.rehash()
 
     echo.echo_success(f'{num_nodes} nodes re-hashed.')
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -949,7 +949,7 @@ class Process(plumpy.processes.Process):
         corresponding process nodes are considered as a cache.
 
         .. warning :: When overriding this method, make sure to return ``False``
-            *at least* in all cases when ``super().is_valid_cache(node)``
+            *at least* in all cases when ``super()._node.base.caching.is_valid_cache(node)``
             returns ``False``. Otherwise, the ``invalidates_cache`` keyword on exit
             codes may have no effect.
 

--- a/aiida/orm/nodes/caching.py
+++ b/aiida/orm/nodes/caching.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Interface to control caching of a node instance."""
+from __future__ import annotations
+
+import importlib
+import typing as t
+
+from aiida.common import exceptions
+from aiida.common.hashing import make_hash
+from aiida.common.lang import type_check
+
+from ..querybuilder import QueryBuilder
+
+
+class NodeCaching:
+    """Interface to control caching of a node instance."""
+
+    # The keys in the extras that are used to store the hash of the node and whether it should be used in caching.
+    _HASH_EXTRA_KEY: str = '_aiida_hash'
+    _VALID_CACHE_KEY: str = '_aiida_valid_cache'
+
+    def __init__(self, node: 'Node') -> None:
+        """Initialize the caching interface."""
+        self._node = node
+
+    def get_hash(self, ignore_errors: bool = True, **kwargs: t.Any) -> str | None:
+        """Return the hash for this node based on its attributes.
+
+        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError`` (logging the exception)
+        """
+        if not self._node.is_stored:
+            raise exceptions.InvalidOperation('You can get the hash only after having stored the node')
+
+        return self._get_hash(ignore_errors=ignore_errors, **kwargs)
+
+    def _get_hash(self, ignore_errors: bool = True, **kwargs: t.Any) -> str | None:
+        """
+        Return the hash for this node based on its attributes.
+
+        This will always work, even before storing.
+
+        :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError`` (logging the exception)
+        """
+        try:
+            return make_hash(self._get_objects_to_hash(), **kwargs)
+        except exceptions.HashingError:
+            if not ignore_errors:
+                raise
+            if self._node.logger:
+                self._node.logger.exception('Node hashing failed')
+            return None
+
+    def _get_objects_to_hash(self) -> list[t.Any]:
+        """Return a list of objects which should be included in the hash."""
+        top_level_module = self._node.__module__.split('.', 1)[0]
+        try:
+            version = importlib.import_module(top_level_module).__version__
+        except (ImportError, AttributeError) as exc:
+            raise exceptions.HashingError("The node's package version could not be determined") from exc
+        objects = [
+            version,
+            {
+                key: val
+                for key, val in self._node.base.attributes.items()
+                if key not in self._node._hash_ignored_attributes and key not in self._node._updatable_attributes  # pylint: disable=unsupported-membership-test,protected-access
+            },
+            self._node.base.repository.hash(),
+            self._node.computer.uuid if self._node.computer is not None else None
+        ]
+        return objects
+
+    def rehash(self) -> None:
+        """Regenerate the stored hash of the Node."""
+        self._node.base.extras.set(self._HASH_EXTRA_KEY, self.get_hash())
+
+    def clear_hash(self) -> None:
+        """Sets the stored hash of the Node to None."""
+        self._node.base.extras.set(self._HASH_EXTRA_KEY, None)
+
+    def get_cache_source(self) -> str | None:
+        """Return the UUID of the node that was used in creating this node from the cache, or None if it was not cached.
+
+        :return: source node UUID or None
+        """
+        return self._node.base.extras.get('_aiida_cached_from', None)
+
+    @property
+    def is_created_from_cache(self) -> bool:
+        """Return whether this node was created from a cached node.
+
+        :return: boolean, True if the node was created by cloning a cached node, False otherwise
+        """
+        return self.get_cache_source() is not None
+
+    def _get_same_node(self) -> 'Node' | None:
+        """Returns a stored node from which the current Node can be cached or None if it does not exist
+
+        If a node is returned it is a valid cache, meaning its `_aiida_hash` extra matches `self.get_hash()`.
+        If there are multiple valid matches, the first one is returned.
+        If no matches are found, `None` is returned.
+
+        :return: a stored `Node` instance with the same hash as this code or None
+
+        Note: this should be only called on stored nodes, or internally from .store() since it first calls
+        clean_value() on the attributes to normalise them.
+        """
+        try:
+            return next(self._iter_all_same_nodes(allow_before_store=True))
+        except StopIteration:
+            return None
+
+    def get_all_same_nodes(self) -> list['Node']:
+        """Return a list of stored nodes which match the type and hash of the current node.
+
+        All returned nodes are valid caches, meaning their `_aiida_hash` extra matches `self.get_hash()`.
+
+        Note: this can be called only after storing a Node (since at store time attributes will be cleaned with
+        `clean_value` and the hash should become idempotent to the action of serialization/deserialization)
+        """
+        return list(self._iter_all_same_nodes())
+
+    def _iter_all_same_nodes(self, allow_before_store=False) -> t.Iterator['Node']:
+        """
+        Returns an iterator of all same nodes.
+
+        Note: this should be only called on stored nodes, or internally from .store() since it first calls
+        clean_value() on the attributes to normalise them.
+        """
+        if not allow_before_store and not self._node.is_stored:
+            raise exceptions.InvalidOperation('You can get the hash only after having stored the node')
+
+        node_hash = self._get_hash()
+
+        if not node_hash or not self._node._cachable:  # pylint: disable=protected-access
+            return iter(())
+
+        builder = QueryBuilder(backend=self._node.backend)
+        builder.append(self._node.__class__, filters={f'extras.{self._HASH_EXTRA_KEY}': node_hash}, subclassing=False)
+
+        return (
+            node for node in builder.all(flat=True) if node.base.caching.is_valid_cache
+        )  # type: ignore[misc,union-attr]
+
+    @property
+    def is_valid_cache(self) -> bool:
+        """Hook to exclude certain ``Node`` classes from being considered a valid cache.
+
+        The base class assumes that all node instances are valid to cache from, unless the ``_VALID_CACHE_KEY`` extra
+        has been set to ``False`` explicitly. Subclasses can override this property with more specific logic, but should
+        probably also consider the value returned by this base class.
+        """
+        return self._node.base.extras.get(self._VALID_CACHE_KEY, True)
+
+    @is_valid_cache.setter
+    def is_valid_cache(self, valid: bool) -> None:
+        """Set whether this node instance is considered valid for caching or not.
+
+        If a node instance has this property set to ``False``, it will never be used in the caching mechanism, unless
+        the subclass overrides the ``is_valid_cache`` property and ignores it implementation completely.
+
+        :param valid: whether the node is valid or invalid for use in caching.
+        """
+        type_check(valid, bool)
+        self._node.base.extras.set(self._VALID_CACHE_KEY, valid)

--- a/docs/source/internals/engine.rst
+++ b/docs/source/internals/engine.rst
@@ -27,10 +27,10 @@ On the level of the generic :class:`orm.Node <aiida.orm.Node>` class:
 
 On the level of the :class:`Process <aiida.engine.processes.process.Process>` and :class:`orm.ProcessNode <aiida.orm.ProcessNode>` classes:
 
-* The :meth:`ProcessNode.is_valid_cache <aiida.orm.ProcessNode.is_valid_cache>` calls :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>`, passing the node itself.
+* The :meth:`ProcessNodeCaching.is_valid_cache <aiida.orm.nodes.process.process.ProcessNodeCaching.is_valid_cache>` calls :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>`, passing the node itself.
   This can be used in :class:`~aiida.engine.processes.process.Process` subclasses (e.g. in calculation plugins) to implement custom ways of invalidating the cache.
-* The :meth:`ProcessNode._hash_ignored_inputs <aiida.orm.nodes.process.process.ProcessNode._hash_ignored_inputs>` attribute lists the inputs that should be ignored when creating the hash.
-  This is checked by the :meth:`ProcessNode._get_objects_to_hash <aiida.orm.nodes.process.process.ProcessNode._get_objects_to_hash>` method.
+* The :meth:`ProcessNodeCaching._hash_ignored_inputs <aiida.orm.nodes.process.process.ProcessNodeCaching._hash_ignored_inputs>` attribute lists the inputs that should be ignored when creating the hash.
+  This is checked by the :meth:`ProcessNodeCaching._get_objects_to_hash <aiida.orm.nodes.process.process.ProcessNodeCaching._get_objects_to_hash>` method.
 * The :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>` is where the :meth:`exit_codes <aiida.engine.processes.process_spec.ProcessSpec.exit_code>` that have been marked by ``invalidates_cache`` are checked.
 
 

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -28,17 +28,17 @@ The hash of a :class:`~aiida.orm.ProcessNode` includes, on top of this, the hash
 
 Once a node is stored in the database, its hash is stored in the ``_aiida_hash`` extra, and this extra is used to find matching nodes.
 If a node of the same class with the same hash already exists in the database, this is considered a cache match.
-You can use the :meth:`~aiida.orm.Node.get_hash` method to check the hash of any node.
-In order to figure out why a calculation is *not* being reused, the :meth:`~aiida.orm.Node._get_objects_to_hash` method may be useful:
+You can use the :meth:`~aiida.orm.nodes.caching.NodeCaching.get_hash` method to check the hash of any node.
+In order to figure out why a calculation is *not* being reused, the :meth:`~aiida.orm.nodes.caching.NodeCaching._get_objects_to_hash` method may be useful:
 
 .. code-block:: ipython
 
     In [5]: node = load_node(1234)
 
-    In [6]: node.get_hash()
+    In [6]: node.base.caching.get_hash()
     Out[6]: '62eca804967c9428bdbc11c692b7b27a59bde258d9971668e19ccf13a5685eb8'
 
-    In [7]: node._get_objects_to_hash()
+    In [7]: node.base.caching._get_objects_to_hash()
     Out[7]:
     [
         '1.0.0',
@@ -71,10 +71,10 @@ The hashing of *Data nodes* can be customized both when implementing a new data 
 In the :py:class:`~aiida.orm.Node` subclass:
 
 * Use the ``_hash_ignored_attributes`` to exclude a list of node attributes ``['attr1', 'attr2']`` from computing the hash.
-* Include extra information in computing the hash by overriding the :meth:`~aiida.orm.Node._get_objects_to_hash` method.
+* Include extra information in computing the hash by overriding the :meth:`~aiida.orm.nodes.caching.NodeCaching._get_objects_to_hash` method.
   Use the ``super()`` method, and then append to the list of objects to hash.
 
-You can also modify hashing behavior during runtime by passing a keyword argument to :meth:`~aiida.orm.Node.get_hash`, which are forwarded to :meth:`~aiida.common.hashing.make_hash`.
+You can also modify hashing behavior during runtime by passing a keyword argument to :meth:`~aiida.orm.nodes.caching.NodeCaching.get_hash`, which are forwarded to :meth:`~aiida.common.hashing.make_hash`.
 
 Process nodes
 .............
@@ -98,14 +98,14 @@ Section :ref:`how-to:run-codes:caching:configure` explains how this can be contr
 Sources
 .......
 
-When a node is being stored (the `target`) and caching is enabled for its node class (see section above), a valid cache `source` is obtained through the method :meth:`~aiida.orm.nodes.node.Node._get_same_node`.
-This method calls the iterator :meth:`~aiida.orm.nodes.node.Node._iter_all_same_nodes` and takes the first one it returns if there are any.
-To find the list of `source` nodes that are equivalent to the `target` that is being stored, :meth:`~aiida.orm.nodes.node.Node._iter_all_same_nodes` performs the following steps:
+When a node is being stored (the `target`) and caching is enabled for its node class (see section above), a valid cache `source` is obtained through the method :meth:`~aiida.orm.nodes.caching.NodeCaching._get_same_node`.
+This method calls the iterator :meth:`~aiida.orm.nodes.caching.NodeCaching._iter_all_same_nodes` and takes the first one it returns if there are any.
+To find the list of `source` nodes that are equivalent to the `target` that is being stored, :meth:`~aiida.orm.nodes.caching.NodeCaching._iter_all_same_nodes` performs the following steps:
 
  1. It queries the database for all nodes that have the same hash as the `target` node.
- 2. From the result, only those nodes are returned where the property :meth:`~aiida.orm.nodes.node.Node.is_valid_cache` returns ``True``.
+ 2. From the result, only those nodes are returned where the property :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` returns ``True``.
 
-The property :meth:`~aiida.orm.nodes.node.Node.is_valid_cache` therefore allows to control whether a stored node can be used as a `source` in the caching mechanism.
+The property :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` therefore allows to control whether a stored node can be used as a `source` in the caching mechanism.
 By default, for all nodes, the property returns ``True``.
 However, this can be changed on a per-node basis, by setting it to ``False``
 
@@ -123,8 +123,8 @@ Setting the property to ``False``, will cause an extra to be stored on the node 
 
 Through this method, it is possible to guarantee that individual nodes are never used as a `source` for caching.
 
-The :class:`~aiida.engine.processes.process.Process` class overrides the :meth:`~aiida.orm.nodes.node.Node.is_valid_cache` property to give more fine-grained control on process nodes as caching sources.
-If either :meth:`~aiida.orm.nodes.node.Node.is_valid_cache` of the base class or :meth:`~aiida.orm.nodes.process.process.ProcessNode.is_finished` returns ``False``, the process node is not a valid source.
+The :class:`~aiida.engine.processes.process.Process` class overrides the :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` property to give more fine-grained control on process nodes as caching sources.
+If either :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` of the base class or :meth:`~aiida.orm.nodes.process.process.ProcessNode.is_finished` returns ``False``, the process node is not a valid source.
 Likewise, if the process class cannot be loaded from the node, through the :meth:`~aiida.orm.nodes.process.process.ProcessNode.process_class`, the node is not a valid caching source.
 Finally, if the associated process class implements the :meth:`~aiida.engine.processes.process.Process.is_valid_cache` method, it is called, passing the node as an argument.
 If that returns ``True``, the node is considered to be a valid caching source.
@@ -136,7 +136,7 @@ Whether an exit code invalidates the cache, is controlled with the ``invalidates
 .. warning::
 
     Process plugins can override the :meth:`~aiida.engine.processes.process.Process.is_valid_cache` method, to further control how nodes are considered valid caching sources.
-    When doing so, make sure to call :meth:`super().is_valid_cache(node) <aiida.engine.processes.process.Process.is_valid_cache>` and respect its output: if it is `False`, your implementation should also return `False`.
+    When doing so, make sure to call :meth:`super().base.caching.is_valid_cache(node) <aiida.engine.processes.process.Process.is_valid_cache>` and respect its output: if it is `False`, your implementation should also return `False`.
     If you do not comply with this, the ``invalidates_cache`` keyword on exit codes will no longer work.
 
 

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -245,7 +245,7 @@ class TestCheckDBRoundTrip:
             node = Dict(dict={'data': val})
             node.store()
             first_hash = node.base.extras.get('_aiida_hash')
-            recomputed_hash = node.get_hash()
+            recomputed_hash = node.base.caching.get_hash()
 
             assert first_hash == recomputed_hash
 

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -96,7 +96,7 @@ class TestCalcFunction:
             assert EXECUTION_COUNTER == 1  # Calculation function body should not have been executed
             assert result.is_stored
             assert cached.is_created_from_cache
-            assert cached.get_cache_source() in original.uuid
+            assert cached.base.caching.get_cache_source() in original.uuid
             assert cached.base.links.get_incoming().one().node.uuid == input_node.uuid
 
     def test_calcfunction_caching_change_code(self):

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -412,14 +412,14 @@ class TestProcessFunction:
         """Test that the hashes generated for identical process functions with identical inputs are the same."""
         _, node1 = self.function_return_input.run_get_node(data=orm.Int(2))
         _, node2 = self.function_return_input.run_get_node(data=orm.Int(2))
-        assert node1.get_hash() == node1.base.extras.get('_aiida_hash')
-        assert node2.get_hash() == node2.base.extras.get('_aiida_hash')
-        assert node1.get_hash() == node2.get_hash()
+        assert node1.base.caching.get_hash() == node1.base.extras.get('_aiida_hash')
+        assert node2.base.caching.get_hash() == node2.base.extras.get('_aiida_hash')
+        assert node1.base.caching.get_hash() == node2.base.caching.get_hash()
 
     def test_hashes_different(self):
         """Test that the hashes generated for identical process functions with different inputs are the different."""
         _, node1 = self.function_return_input.run_get_node(data=orm.Int(2))
         _, node2 = self.function_return_input.run_get_node(data=orm.Int(3))
-        assert node1.get_hash() == node1.base.extras.get('_aiida_hash')
-        assert node2.get_hash() == node2.base.extras.get('_aiida_hash')
-        assert node1.get_hash() != node2.get_hash()
+        assert node1.base.caching.get_hash() == node1.base.extras.get('_aiida_hash')
+        assert node2.base.caching.get_hash() == node2.base.extras.get('_aiida_hash')
+        assert node1.base.caching.get_hash() != node2.base.caching.get_hash()

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -975,19 +975,19 @@ class TestNodeCaching:
         clone._store_from_cache(data, with_transaction=True)  # pylint: disable=protected-access
 
         assert clone.is_stored
-        assert clone.get_cache_source() == data.uuid
-        assert data.get_hash() == clone.get_hash()
+        assert clone.base.caching.get_cache_source() == data.uuid
+        assert data.base.caching.get_hash() == clone.base.caching.get_hash()
 
     def test_hashing_errors(self, aiida_caplog):
         """Tests that ``get_hash`` fails in an expected manner."""
         node = Data().store()
         node.__module__ = 'unknown'  # this will inhibit package version determination
-        result = node.get_hash(ignore_errors=True)
+        result = node.base.caching.get_hash(ignore_errors=True)
         assert result is None
         assert aiida_caplog.record_tuples == [(node.logger.name, logging.ERROR, 'Node hashing failed')]
 
         with pytest.raises(exceptions.HashingError, match='package version could not be determined'):
-            result = node.get_hash(ignore_errors=False)
+            result = node.base.caching.get_hash(ignore_errors=False)
         assert result is None
 
     def test_uuid_equality_fallback(self):

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -101,7 +101,7 @@ def test_caching(cacheable_node):
         cached.store()
 
     assert cached.is_created_from_cache
-    assert cached.get_cache_source() == cacheable_node.uuid
+    assert cached.base.caching.get_cache_source() == cacheable_node.uuid
     assert cacheable_node.base.repository.metadata == cached.base.repository.metadata
     assert cacheable_node.base.repository.hash() == cached.base.repository.hash()
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -120,16 +120,16 @@ class TestNodeHashing:
         f2 = self.create_folderdata_with_empty_folder().store()
 
         assert f1.base.repository.list_object_names('path') == f2.base.repository.list_object_names('path')
-        assert f1.get_hash() != f2.get_hash()
+        assert f1.base.caching.get_hash() != f2.base.caching.get_hash()
 
     def test_updatable_attributes(self):
         """
         Tests that updatable attributes are ignored.
         """
         node = orm.CalculationNode().store()
-        hash1 = node.get_hash()
+        hash1 = node.base.caching.get_hash()
         node.set_process_state('finished')
-        hash2 = node.get_hash()
+        hash2 = node.base.caching.get_hash()
         assert hash1 is not None
         assert hash1 == hash2
 


### PR DESCRIPTION
This commit is part of the `Node` namespace restructure. It moves all
caching related methods to a new `NodeLinks` class that is exposed through
the `Node.base.caching` attribute.`