### PR TITLE
♻️  REFACTOR: Deprecate methods fron `Node` namespace

### DIFF
--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -271,7 +271,7 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force, exit
 
         counter = 0
         computer = orm.load_computer(uuid=computer_uuid)
-        transport = orm.AuthInfo.objects.get(dbcomputer_id=computer.id, aiidauser_id=user.id).get_transport()
+        transport = orm.AuthInfo.objects.get(dbcomputer_id=computer.pk, aiidauser_id=user.pk).get_transport()
 
         with transport:
             for remote_folder in paths:

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -545,7 +545,7 @@ def computer_delete(computer):
     label = computer.label
 
     try:
-        orm.Computer.objects.delete(computer.id)
+        orm.Computer.objects.delete(computer.pk)
     except InvalidOperation as error:
         echo.echo_critical(str(error))
 

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -53,7 +53,7 @@ def bands_list(elements, elements_exclusive, raw, formula_mode, past_days, group
     args.past_days = past_days
     args.group_name = None
     if groups is not None:
-        args.group_pk = [group.id for group in groups]
+        args.group_pk = [group.pk for group in groups]
     else:
         args.group_pk = None
     args.all_users = all_users

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -368,7 +368,7 @@ def group_list(
 
     # Query groups that contain a particular node
     if node:
-        builder.append(orm.Node, filters={'id': {'==': node.id}}, with_group='group')
+        builder.append(orm.Node, filters={'id': {'==': node.pk}}, with_group='group')
 
     builder.order_by({orm.Group: {order_by: order_dir}})
     result = builder.all()

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -532,7 +532,7 @@ def comment_show(user, nodes):
 
         for comment in comments:
             comment_msg = [
-                f'Comment<{comment.id}> for Node<{node.pk}> by {comment.user.email}',
+                f'Comment<{comment.pk}> for Node<{node.pk}> by {comment.user.email}',
                 f"Created on {timezone.localtime(comment.ctime).strftime('%Y-%m-%d %H:%M')}",
                 f"Last modified on {timezone.localtime(comment.mtime).strftime('%Y-%m-%d %H:%M')}",
                 f'\n{comment.content}\n',

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -308,7 +308,7 @@ def get_process_function_report(node):
     report = []
 
     for log in orm.Log.objects.get_logs_for(node):
-        report.append(f'{log.time:%Y-%m-%d %H:%M:%S} [{log.id}]: {log.message}')
+        report.append(f'{log.time:%Y-%m-%d %H:%M:%S} [{log.pk}]: {log.message}')
 
     return '\n'.join(report)
 
@@ -328,7 +328,7 @@ def get_workchain_report(node: 'WorkChainNode', levelname, indent_size=4, max_de
 
     def get_report_messages(uuid, depth, levelname):
         """Return list of log messages with given levelname and their depth for a node with a given uuid."""
-        node_id = orm.load_node(uuid).id
+        node_id = orm.load_node(uuid).pk
         filters = {'dbnode_id': node_id}
 
         entries = orm.Log.objects.find(filters)
@@ -373,7 +373,7 @@ def get_workchain_report(node: 'WorkChainNode', levelname, indent_size=4, max_de
     if not reports:
         return 'No log messages recorded for this entry'
 
-    log_ids = [entry[0].id for entry in reports]
+    log_ids = [entry[0].pk for entry in reports]
     levelnames = [len(entry[0].levelname) for entry in reports]
     width_id = len(str(max(log_ids)))
     width_levelname = max(levelnames)
@@ -381,7 +381,7 @@ def get_workchain_report(node: 'WorkChainNode', levelname, indent_size=4, max_de
 
     for entry, depth in reports:
         line = '{time:%Y-%m-%d %H:%M:%S} [{id:<{width_id}} | {levelname:>{width_levelname}}]:{indent} {message}'.format(
-            id=entry.id,
+            id=entry.pk,
             levelname=entry.levelname,
             message=entry.message,
             time=entry.time,

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -138,7 +138,7 @@ class CalculationQueryBuilder:
 
         if relationships is not None:
             for tag, entity in relationships.items():
-                builder.append(cls=type(entity), filters={'id': entity.id}, **{tag: 'process'})
+                builder.append(cls=type(entity), filters={'id': entity.pk}, **{tag: 'process'})
 
         if order_by is not None:
             builder.order_by({'process': order_by})

--- a/aiida/engine/processes/calcjobs/manager.py
+++ b/aiida/engine/processes/calcjobs/manager.py
@@ -271,10 +271,10 @@ class JobManager:
         :param authinfo: the `AuthInfo`
         :return: a `JobsList` instance
         """
-        if authinfo.id not in self._job_lists:
-            self._job_lists[authinfo.id] = JobsList(authinfo, self._transport_queue)
+        if authinfo.pk not in self._job_lists:
+            self._job_lists[authinfo.pk] = JobsList(authinfo, self._transport_queue)
 
-        return self._job_lists[authinfo.id]
+        return self._job_lists[authinfo.pk]
 
     @contextlib.contextmanager
     def request_job_info_update(self, authinfo: AuthInfo, job_id: Hashable) -> Iterator['asyncio.Future[JobInfo]']:

--- a/aiida/engine/transports.py
+++ b/aiida/engine/transports.py
@@ -70,12 +70,12 @@ class TransportQueue:
         :return: A future that can be yielded to give the transport
         """
         open_callback_handle = None
-        transport_request = self._transport_requests.get(authinfo.id, None)
+        transport_request = self._transport_requests.get(authinfo.pk, None)
 
         if transport_request is None:
             # There is no existing request for this transport (i.e. on this authinfo)
             transport_request = TransportRequest()
-            self._transport_requests[authinfo.id] = transport_request
+            self._transport_requests[authinfo.pk] = transport_request
 
             transport = authinfo.get_transport()
             safe_open_interval = transport.get_safe_open_interval()
@@ -92,7 +92,7 @@ class TransportQueue:
                         transport_request.future.set_exception(exception)
 
                         # Cleanup of the stale TransportRequest with the excepted transport future
-                        self._transport_requests.pop(authinfo.id, None)
+                        self._transport_requests.pop(authinfo.pk, None)
                     else:
                         transport_request.future.set_result(transport)
 
@@ -127,4 +127,4 @@ class TransportQueue:
                 elif open_callback_handle is not None:
                     open_callback_handle.cancel()
 
-                self._transport_requests.pop(authinfo.id, None)
+                self._transport_requests.pop(authinfo.pk, None)

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -553,11 +553,11 @@ class Computer(entities.Entity['BackendComputer']):
         from . import authinfos
 
         try:
-            authinfo = authinfos.AuthInfo.objects(self.backend).get(dbcomputer_id=self.id, aiidauser_id=user.id)
+            authinfo = authinfos.AuthInfo.objects(self.backend).get(dbcomputer_id=self.pk, aiidauser_id=user.pk)
         except exceptions.NotExistent as exc:
             raise exceptions.NotExistent(
-                f'Computer `{self.label}` (ID={self.id}) not configured for user `{user.get_short_name()}` '
-                f'(ID={user.id}) - use `verdi computer configure` first'
+                f'Computer `{self.label}` (ID={self.pk}) not configured for user `{user.get_short_name()}` '
+                f'(ID={user.pk}) - use `verdi computer configure` first'
             ) from exc
 
         return authinfo

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Generic, List, Optional, Type, TypeVar, c
 from plumpy.base.utils import call_with_super_check, super_check
 
 from aiida.common.lang import classproperty, type_check
+from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
 
 if TYPE_CHECKING:
@@ -170,12 +171,19 @@ class Entity(abc.ABC, Generic[BackendEntityType]):
 
     @classmethod
     def get(cls, **kwargs):
+        """Get an entity of the collection matching the given filters.
+
+        .. deprecated: Will be removed in v3, use `Entity.objects.get` instead.
+
+        """
+        warn_deprecation(
+            f'This method is deprecated, use `{cls.__name__}.objects.get` instead.', version=3, stacklevel=2
+        )
         return cls.objects.get(**kwargs)  # pylint: disable=no-member
 
     @classmethod
     def from_backend_entity(cls: Type[EntityType], backend_entity: BackendEntityType) -> EntityType:
-        """
-        Construct an entity from a backend entity instance
+        """Construct an entity from a backend entity instance
 
         :param backend_entity: the backend entity
 
@@ -209,8 +217,11 @@ class Entity(abc.ABC, Generic[BackendEntityType]):
 
         This identifier is guaranteed to be unique amongst entities of the same type for a single backend instance.
 
+        .. deprecated: Will be removed in v3, use `pk` instead.
+
         :return: the entity's id
         """
+        warn_deprecation('This method is deprecated, use `pk` instead.', version=3, stacklevel=2)
         return self._backend_entity.id
 
     @property
@@ -221,7 +232,7 @@ class Entity(abc.ABC, Generic[BackendEntityType]):
 
         :return: the entity's principal key
         """
-        return self.id
+        return self._backend_entity.id
 
     def store(self: EntityType) -> EntityType:
         """Store the entity."""

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -465,7 +465,7 @@ class Code(Data):
             return True
 
         type_check(computer, orm.Computer)
-        return computer.id == self.get_remote_computer().id
+        return computer.pk == self.get_remote_computer().pk
 
     def get_execname(self):
         """

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -367,7 +367,7 @@ class UpfData(SinglefileData):
 
         query = QueryBuilder(backend=self.backend)
         query.append(UpfFamily, tag='group', project='label')
-        query.append(UpfData, filters={'id': {'==': self.id}}, with_group='group')
+        query.append(UpfData, filters={'id': {'==': self.pk}}, with_group='group')
         return query.all(flat=True)
 
     @property

--- a/aiida/orm/nodes/links.py
+++ b/aiida/orm/nodes/links.py
@@ -132,7 +132,7 @@ class NodeLinks:
             raise TypeError(f'link_type should be a LinkType or tuple of LinkType: got {link_type}')
 
         node_class = node_class or Node
-        node_filters: dict[str, t.Any] = {'id': {'==': self._node.id}}
+        node_filters: dict[str, t.Any] = {'id': {'==': self._node.pk}}
         edge_filters: dict[str, t.Any] = {}
 
         if link_type:

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -701,7 +701,7 @@ class QueryBuilder:
             if isinstance(value, entities.Entity):
                 # Convert to be the id of the joined entity because we can't query
                 # for the object instance directly
-                processed_filters[f'{key}_id'] = value.id
+                processed_filters[f'{key}_id'] = value.pk
             else:
                 processed_filters[key] = value
 

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -71,8 +71,8 @@ def link_triple_exists(
     # Here we have two stored nodes, so we need to check if the same link already exists in the database.
     # Finding just a single match is sufficient so we can use the `limit` clause for efficiency
     builder = QueryBuilder(backend=backend)
-    builder.append(Node, filters={'id': source.id}, project=['id'])
-    builder.append(Node, filters={'id': target.id}, edge_filters={'type': link_type.value, 'label': link_label})
+    builder.append(Node, filters={'id': source.pk}, project=['id'])
+    builder.append(Node, filters={'id': target.pk}, edge_filters={'type': link_type.value, 'label': link_label})
     builder.limit(1)
 
     return builder.count() != 0

--- a/aiida/orm/utils/log.py
+++ b/aiida/orm/utils/log.py
@@ -51,7 +51,7 @@ def get_dblogger_extra(node):
     if not isinstance(node, Node) or not node.is_stored:
         return {}
 
-    return {'dbnode_id': node.id, 'backend': node.backend}
+    return {'dbnode_id': node.pk, 'backend': node.backend}
 
 
 def create_logger_adapter(logger, node):

--- a/aiida/orm/utils/serialize.py
+++ b/aiida/orm/utils/serialize.py
@@ -132,7 +132,7 @@ def computer_constructor(loader, computer):
     :rtype: :class:`aiida.orm.Computer`
     """
     yaml_node = loader.construct_scalar(computer)
-    return orm.Computer.get(uuid=yaml_node)
+    return orm.Computer.objects.get(uuid=yaml_node)
 
 
 def represent_mapping(tag, dumper, mapping):

--- a/aiida/storage/psql_dos/orm/nodes.py
+++ b/aiida/storage/psql_dos/orm/nodes.py
@@ -201,7 +201,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], ExtrasMixin, BackendNode
 
         try:
             with session.begin_nested():
-                link = DbLink(input_id=source.id, output_id=self.id, label=link_label, type=link_type.value)
+                link = DbLink(input_id=source.pk, output_id=self.pk, label=link_label, type=link_type.value)
                 session.add(link)
         except SQLAlchemyError as exception:
             raise exceptions.UniquenessError(f'failed to create the link: {exception}') from exception

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -436,9 +436,9 @@ class Graph:
         :returns: aiida.orm.nodes.node.Node
         """
         if isinstance(node, int):
-            return orm.Node.Collection.get_cached(orm.Node, self._backend).get(pk=node)
+            return orm.Node.objects(self._backend).get(pk=node)
         if isinstance(node, str):
-            return orm.Node.Collection.get_cached(orm.Node, self._backend).get(uuid=node)
+            return orm.Node.objects(self._backend).get(uuid=node)
         return node
 
     @staticmethod

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -93,7 +93,7 @@ def interactive_default(key, also_non_interactive=False):
             return None
 
         try:
-            authinfo = orm.AuthInfo.objects.get(dbcomputer_id=computer.id, aiidauser_id=user.id)
+            authinfo = orm.AuthInfo.objects.get(dbcomputer_id=computer.pk, aiidauser_id=user.pk)
         except NotExistent:
             authinfo = orm.AuthInfo(computer=computer, user=user)
 

--- a/docs/source/internals/engine.rst
+++ b/docs/source/internals/engine.rst
@@ -20,7 +20,7 @@ There are several methods which the internal classes of AiiDA use to control the
 
 On the level of the generic :class:`orm.Node <aiida.orm.Node>` class:
 
-* The :meth:`~aiida.orm.Node.is_valid_cache` property determines whether a particular node can be used as a cache.
+* The :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` property determines whether a particular node can be used as a cache.
   This is used for example to disable caching from failed calculations.
 * Node classes have a ``_cachable`` attribute, which can be set to ``False`` to completely switch off caching for nodes of that class.
   This avoids performing queries for the hash altogether.

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -112,14 +112,14 @@ However, this can be changed on a per-node basis, by setting it to ``False``
 .. code-block:: python
 
     node = load_node(<IDENTIFIER>)
-    node.is_valid_cache = False
+    node.base.caching.is_valid_cache = False
 
 Setting the property to ``False``, will cause an extra to be stored on the node in the database, such that even when it is loaded at a later point in time, ``is_valid_cache`` returns ``False``.
 
 .. code-block:: python
 
     node = load_node(<IDENTIFIER>)
-    assert node.is_valid_cache is False
+    assert node.base.caching.is_valid_cache is False
 
 Through this method, it is possible to guarantee that individual nodes are never used as a `source` for caching.
 

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -519,7 +519,7 @@ safe_interval: {interval}
         username = 'TEST'
         options = ['core.ssh', comp.label, '--non-interactive', f'--username={username}', '--safe-interval', '1']
         result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        auth_info = orm.AuthInfo.objects.get(dbcomputer_id=comp.id, aiidauser_id=self.user.id)
+        auth_info = orm.AuthInfo.objects.get(dbcomputer_id=comp.pk, aiidauser_id=self.user.pk)
         assert comp.is_user_configured(self.user), result.output
         assert auth_info.get_auth_params()['username'] == username
 

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -223,7 +223,7 @@ class TestVerdiDataArray:
         assert b'Usage:' in output, 'Sub-command verdi data array show --help failed.'
 
     def test_arrayshow(self):
-        options = [str(self.arr.id)]
+        options = [str(self.arr.pk)]
         res = self.cli_runner(cmd_array.array_show, options, catch_exceptions=False)
         assert res.exit_code == 0, 'The command did not finish correctly'
 
@@ -238,7 +238,7 @@ class TestVerdiDataBands(DummyVerdiDataListable):
         # pylint: disable=attribute-defined-outside-init
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
-        self.ids = self.create_structure_bands()
+        self.pks = self.create_structure_bands()
         self.cli_runner = run_cli_command
         yield
         self.loop.close()
@@ -302,9 +302,9 @@ class TestVerdiDataBands(DummyVerdiDataListable):
         g_e.store()
 
         return {
-            DummyVerdiDataListable.NODE_ID_STR: bands.id,
-            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.id,
-            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.id
+            DummyVerdiDataListable.NODE_ID_STR: bands.pk,
+            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.pk,
+            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.pk
         }
 
     def test_bandsshowhelp(self):
@@ -316,8 +316,8 @@ class TestVerdiDataBands(DummyVerdiDataListable):
         assert b'Usage:' in output, 'Sub-command verdi data bands show --help failed.'
 
     def test_bandslist(self):
-        self.data_listing_test(BandsData, 'FeO', self.ids)
-        self.data_listing_test(BandsData, '<<NOT FOUND>>', self.ids)
+        self.data_listing_test(BandsData, 'FeO', self.pks)
+        self.data_listing_test(BandsData, '<<NOT FOUND>>', self.pks)
 
     def test_bandslist_with_elements(self):
         options = ['-e', 'Fe']
@@ -330,7 +330,7 @@ class TestVerdiDataBands(DummyVerdiDataListable):
         assert b'Usage:' in output, 'Sub-command verdi data bands export --help failed.'
 
     def test_bandsexport(self):
-        options = [str(self.ids[DummyVerdiDataListable.NODE_ID_STR])]
+        options = [str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
         res = self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
         assert res.exit_code == 0, 'The command did not finish correctly'
         assert b'[1.0, 3.0]' in res.stdout_bytes, 'The string [1.0, 3.0] was not found in the bands export'
@@ -348,14 +348,14 @@ class TestVerdiDataBands(DummyVerdiDataListable):
         bands.store()
 
         # matplotlib
-        options = [str(bands.id), '--format', 'mpl_singlefile']
+        options = [str(bands.pk), '--format', 'mpl_singlefile']
         res = self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
         assert b'p.scatter' in res.stdout_bytes, 'The string p.scatter was not found in the bands mpl export'
 
         # gnuplot
         from click.testing import CliRunner
         with CliRunner().isolated_filesystem():
-            options = [str(bands.id), '--format', 'gnuplot', '-o', 'bands.gnu']
+            options = [str(bands.pk), '--format', 'gnuplot', '-o', 'bands.gnu']
             self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
             with open('bands.gnu', 'r', encoding='utf8') as gnu_file:
                 res = gnu_file.read()
@@ -380,7 +380,7 @@ class TestVerdiDataDict:
 
     def test_dictshow(self):
         """Test verdi data dict show."""
-        options = [str(self.dct.id)]
+        options = [str(self.dct.pk)]
         res = self.cli_runner(cmd_dict.dictionary_show, options, catch_exceptions=False)
         assert res.exit_code == 0, 'The command verdi data dict show did not finish correctly'
         assert b'"a": 1' in res.stdout_bytes, 'The string "a": 1 was not found in the output' \
@@ -407,7 +407,7 @@ class TestVerdiDataRemote:
 
     def test_remoteshow(self):
         """Test verdi data remote show."""
-        options = [str(self.rmt.id)]
+        options = [str(self.rmt.pk)]
         res = self.cli_runner(cmd_remote.remote_show, options, catch_exceptions=False)
         assert res.exit_code == 0, 'The command verdi data remote show did not finish correctly'
         assert b'Remote computer name:' in res.stdout_bytes, (
@@ -422,7 +422,7 @@ class TestVerdiDataRemote:
         assert b'Usage:' in output, 'Sub-command verdi data remote ls --help failed.'
 
     def test_remotels(self):
-        options = ['--long', str(self.rmt.id)]
+        options = ['--long', str(self.rmt.pk)]
         res = self.cli_runner(cmd_remote.remote_ls, options, catch_exceptions=False)
         assert res.exit_code == 0, 'The command verdi data remote ls did not finish correctly'
         assert b'file.txt' in res.stdout_bytes, 'The file "file.txt" was not found in the output' \
@@ -433,7 +433,7 @@ class TestVerdiDataRemote:
         assert b'Usage:' in output, 'Sub-command verdi data remote cat --help failed.'
 
     def test_remotecat(self):
-        options = [str(self.rmt.id), 'file.txt']
+        options = [str(self.rmt.pk), 'file.txt']
         res = self.cli_runner(cmd_remote.remote_cat, options, catch_exceptions=False)
         assert res.exit_code == 0, 'The command verdi data remote cat did not finish correctly'
         assert b'test string' in res.stdout_bytes, 'The string "test string" was not found in the output' \
@@ -450,7 +450,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.comp = aiida_localhost
         self.this_folder = os.path.dirname(__file__)
         self.this_file = os.path.basename(__file__)
-        self.ids = self.create_trajectory_data()
+        self.pks = self.create_trajectory_data()
         self.cli_runner = run_cli_command
 
     @staticmethod
@@ -509,9 +509,9 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         g_e.store()
 
         return {
-            DummyVerdiDataListable.NODE_ID_STR: traj.id,
-            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.id,
-            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.id
+            DummyVerdiDataListable.NODE_ID_STR: traj.pk,
+            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.pk,
+            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.pk
         }
 
     def test_showhelp(self):
@@ -520,12 +520,12 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             ' of verdi data trajecotry show --help'
 
     def test_list(self):
-        self.data_listing_test(TrajectoryData, str(self.ids[DummyVerdiDataListable.NODE_ID_STR]), self.ids)
+        self.data_listing_test(TrajectoryData, str(self.pks[DummyVerdiDataListable.NODE_ID_STR]), self.pks)
 
     @pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
     def test_export(self):
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
-        self.data_export_test(TrajectoryData, self.ids, new_supported_formats)
+        self.data_export_test(TrajectoryData, self.pks, new_supported_formats)
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
@@ -539,7 +539,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.comp = aiida_localhost
         self.this_folder = os.path.dirname(__file__)
         self.this_file = os.path.basename(__file__)
-        self.ids = self.create_structure_data()
+        self.pks = self.create_structure_data()
         for group_label in ['xyz structure group', 'ase structure group']:
             Group(label=group_label).store()
         self.cli_runner = run_cli_command
@@ -584,9 +584,9 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
         g_e.store()
 
         return {
-            DummyVerdiDataListable.NODE_ID_STR: struc.id,
-            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.id,
-            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.id
+            DummyVerdiDataListable.NODE_ID_STR: struc.pk,
+            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.pk,
+            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.pk
         }
 
     def test_importhelp(self):
@@ -747,10 +747,10 @@ PRIMVEC
                 assert grpline in res.output
 
     def test_list(self):
-        self.data_listing_test(StructureData, 'BaO3Ti', self.ids)
+        self.data_listing_test(StructureData, 'BaO3Ti', self.pks)
 
     def test_export(self):
-        self.data_export_test(StructureData, self.ids, cmd_structure.EXPORT_FORMATS)
+        self.data_export_test(StructureData, self.pks, cmd_structure.EXPORT_FORMATS)
 
 
 @pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
@@ -783,7 +783,7 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.comp = aiida_localhost
         self.this_folder = os.path.dirname(__file__)
         self.this_file = os.path.basename(__file__)
-        self.ids = self.create_cif_data()
+        self.pks = self.create_cif_data()
         self.cli_runner = run_cli_command
 
     def create_cif_data(self):
@@ -805,9 +805,9 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.cif = a_cif  # pylint: disable=attribute-defined-outside-init
 
         return {
-            DummyVerdiDataListable.NODE_ID_STR: a_cif.id,
-            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.id,
-            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.id
+            DummyVerdiDataListable.NODE_ID_STR: a_cif.pk,
+            DummyVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.pk,
+            DummyVerdiDataListable.EMPTY_GROUP_ID_STR: g_e.pk
         }
 
     def test_list(self):
@@ -815,7 +815,7 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
         This method tests that the Cif listing works as expected with all
         possible flags and arguments.
         """
-        self.data_listing_test(CifData, 'C O2', self.ids)
+        self.data_listing_test(CifData, 'C O2', self.pks)
 
     def test_showhelp(self):
         options = ['--help']
@@ -850,7 +850,7 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_export(self):
         """This method checks if the Cif export works as expected with all
         possible flags and arguments."""
-        self.data_export_test(CifData, self.ids, cmd_cif.EXPORT_FORMATS)
+        self.data_export_test(CifData, self.pks, cmd_cif.EXPORT_FORMATS)
 
 
 class TestVerdiDataSinglefile(DummyVerdiDataListable, DummyVerdiDataExportable):

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -95,7 +95,7 @@ class TestCalcFunction:
 
             assert EXECUTION_COUNTER == 1  # Calculation function body should not have been executed
             assert result.is_stored
-            assert cached.is_created_from_cache
+            assert cached.base.caching.is_created_from_cache
             assert cached.base.caching.get_cache_source() in original.uuid
             assert cached.base.links.get_incoming().one().node.uuid == input_node.uuid
 
@@ -113,11 +113,11 @@ class TestCalcFunction:
         with enable_caching(identifier='*.add_calcfunction'):
             result_cached, cached = add_calcfunction.run_get_node(self.default_int)
             assert result_original != result_cached
-            assert not cached.is_created_from_cache
+            assert not cached.base.caching.is_created_from_cache
             # Test that the locally-created calcfunction can be cached in principle
             result2_cached, cached2 = add_calcfunction.run_get_node(self.default_int)
             assert result_original != result2_cached
-            assert cached2.is_created_from_cache
+            assert cached2.base.caching.is_created_from_cache
 
     def test_calcfunction_do_not_store_provenance(self):
         """Run the function without storing the provenance."""

--- a/tests/engine/test_workfunctions.py
+++ b/tests/engine/test_workfunctions.py
@@ -77,7 +77,7 @@ class TestWorkFunction:
         # Caching should always be disabled for a WorkFunctionNode
         with enable_caching():
             _, cached = self.test_workfunction.run_get_node(self.default_int)
-            assert not cached.is_created_from_cache
+            assert not cached.base.caching.is_created_from_cache
 
     def test_call_link_label(self):
         """Verify that setting a `call_link_label` on a `calcfunction` called from a `workfunction` works."""

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -951,13 +951,13 @@ class TestNodeCaching:
     def test_is_valid_cache(self):
         """Test the ``Node.is_valid_cache`` property."""
         node = Node()
-        assert node.is_valid_cache
+        assert node.base.caching.is_valid_cache
 
-        node.is_valid_cache = False
-        assert not node.is_valid_cache
+        node.base.caching.is_valid_cache = False
+        assert not node.base.caching.is_valid_cache
 
         with pytest.raises(TypeError):
-            node.is_valid_cache = 'false'
+            node.base.caching.is_valid_cache = 'false'
 
     def test_store_from_cache(self):
         """Regression test for storing a Node with (nested) repository content with caching."""

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -21,7 +21,7 @@ def cacheable_node():
     node.set_process_state(ProcessState.FINISHED)
     node.base.repository.put_object_from_bytes(b'content', 'relative/path')
     node.store()
-    assert node.is_valid_cache
+    assert node.base.caching.is_valid_cache
 
     return node
 
@@ -100,7 +100,7 @@ def test_caching(cacheable_node):
         cached.base.repository.put_object_from_bytes(b'content', 'relative/path')
         cached.store()
 
-    assert cached.is_created_from_cache
+    assert cached.base.caching.is_created_from_cache
     assert cached.base.caching.get_cache_source() == cacheable_node.uuid
     assert cacheable_node.base.repository.metadata == cached.base.repository.metadata
     assert cacheable_node.base.repository.hash() == cached.base.repository.hash()

--- a/tests/orm/test_comments.py
+++ b/tests/orm/test_comments.py
@@ -90,7 +90,7 @@ class TestComment:
         """Test deleting many Comments through the collection."""
         comment_one = Comment(self.node, self.user, 'I will perish').store()
         comment_two = Comment(self.node, self.user, 'Surely not?').store()
-        comment_ids = [_.id for _ in [comment_one, comment_two]]
+        comment_ids = [_.pk for _ in [comment_one, comment_two]]
 
         # Assert the Comments exist
         assert len(Comment.objects.all()) == 3
@@ -102,7 +102,7 @@ class TestComment:
         # Make sure only the setUp Comment is left
         builder = orm.QueryBuilder().append(Comment, project='id')
         assert builder.count() == 1
-        assert builder.all()[0][0] == self.comment.id
+        assert builder.all()[0][0] == self.comment.pk
 
         for comment_pk in comment_ids:
             with pytest.raises(exceptions.NotExistent):
@@ -133,7 +133,7 @@ class TestComment:
 
         # Retrieve a node by joining on a specific comment
         builder = orm.QueryBuilder()
-        builder.append(Comment, tag='comment', filters={'id': comment_one.id})
+        builder.append(Comment, tag='comment', filters={'id': comment_one.pk})
         builder.append(orm.Node, with_comment='comment', project=['uuid'])
         nodes = builder.all()
 
@@ -143,7 +143,7 @@ class TestComment:
 
         # Retrieve a comment by joining on a specific node
         builder = orm.QueryBuilder()
-        builder.append(orm.Node, tag='node', filters={'id': node_two.id})
+        builder.append(orm.Node, tag='node', filters={'id': node_two.pk})
         builder.append(Comment, with_node='node', project=['uuid'])
         comments = builder.all()
 
@@ -153,7 +153,7 @@ class TestComment:
 
         # Retrieve a user by joining on a specific comment
         builder = orm.QueryBuilder()
-        builder.append(Comment, tag='comment', filters={'id': comment_four.id})
+        builder.append(Comment, tag='comment', filters={'id': comment_four.pk})
         builder.append(orm.User, with_comment='comment', project=['email'])
         users = builder.all()
 
@@ -174,7 +174,7 @@ class TestComment:
 
         # Retrieve users from comments of a single node by joining specific node
         builder = orm.QueryBuilder()
-        builder.append(orm.Node, tag='node', filters={'id': node_four.id})
+        builder.append(orm.Node, tag='node', filters={'id': node_four.pk})
         builder.append(Comment, tag='comments', with_node='node', project=['uuid'])
         builder.append(orm.User, with_comment='comments', project=['email'])
         comments_and_users = builder.all()
@@ -193,7 +193,7 @@ class TestComment:
         """Test getting a comment from the collection"""
         node = orm.Data().store()
         comment = node.base.comments.add('Check out the comment on _this_ one')
-        gotten_comment = Comment.objects.get(id=comment.id)
+        gotten_comment = Comment.objects.get(id=comment.pk)
         assert isinstance(gotten_comment, Comment)
 
     def test_delete_node_with_comments(self):

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -127,8 +127,8 @@ class TestComputerConfigure:
         with pytest.raises(exceptions.NotExistent) as exc:
             comp.get_authinfo(self.user)
 
-        assert str(comp.id) in str(exc)
+        assert str(comp.pk) in str(exc)
         assert comp.label in str(exc)
         assert self.user.get_short_name() in str(exc)
-        assert str(self.user.id) in str(exc)
+        assert str(self.user.pk) in str(exc)
         assert 'verdi computer configure' in str(exc)

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -196,7 +196,7 @@ class TestGroups:
         node = orm.Data().store()
         group = orm.Group(label='testgroup3', description='some other desc').store()
 
-        group_copy = orm.Group.get(label='testgroup3')
+        group_copy = orm.Group.objects.get(label='testgroup3')
         assert group.uuid == group_copy.uuid
 
         group.add_nodes(node)
@@ -206,7 +206,7 @@ class TestGroups:
 
         with pytest.raises(exceptions.NotExistent):
             # The group does not exist anymore
-            orm.Group.get(label='testgroup3')
+            orm.Group.objects.get(label='testgroup3')
 
     def test_delete_node(self):
         """Test deletion of a node that has been assigned to a group."""
@@ -279,7 +279,7 @@ class TestGroups:
 
         # And that the results are correct
         assert builder.count() == 1
-        assert builder.first(flat=True) == group.id
+        assert builder.first(flat=True) == group.pk
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')

--- a/tests/orm/test_logs.py
+++ b/tests/orm/test_logs.py
@@ -42,7 +42,7 @@ class TestBackendLog:
     def create_log(self):
         node = orm.CalculationNode().store()
         record = self.log_record
-        record['dbnode_id'] = node.id
+        record['dbnode_id'] = node.pk
         return Log(**record), node
 
     def test_create_log_message(self):
@@ -57,7 +57,7 @@ class TestBackendLog:
         assert entry.message == self.log_record['message']
         assert entry.metadata == self.log_record['metadata']
         assert entry.dbnode_id == self.log_record['dbnode_id']
-        assert entry.dbnode_id == node.id
+        assert entry.dbnode_id == node.pk
 
     def test_create_log_unserializable_metadata(self):
         """Test that unserializable data will be removed before reaching the database causing an error."""
@@ -87,7 +87,7 @@ class TestBackendLog:
     def test_log_delete_single(self):
         """Test that a single log entry can be deleted through the collection."""
         entry, _ = self.create_log()
-        log_id = entry.id
+        log_id = entry.pk
 
         assert len(Log.objects.all()) == 1
 
@@ -104,7 +104,7 @@ class TestBackendLog:
         count = 10
         for _ in range(count):
             self.create_log()
-        log_id = Log.objects.find(limit=1)[0].id
+        log_id = Log.objects.find(limit=1)[0].pk
 
         assert len(Log.objects.all()) == count
 
@@ -126,7 +126,7 @@ class TestBackendLog:
         count = 5
         for _ in range(count):
             log_, _ = self.create_log()
-            log_ids.append(log_.id)
+            log_ids.append(log_.pk)
         special_log, _ = self.create_log()
 
         # Assert the Logs exist
@@ -139,7 +139,7 @@ class TestBackendLog:
         # Make sure only the special_log Log is left
         builder = orm.QueryBuilder().append(Log, project='id')
         assert builder.count() == 1
-        assert builder.all()[0][0] == special_log.id
+        assert builder.all()[0][0] == special_log.pk
 
         for log_id in log_ids:
             with pytest.raises(exceptions.NotExistent):
@@ -153,7 +153,7 @@ class TestBackendLog:
         node = orm.Data().store()
         for _ in range(10):
             record = self.log_record
-            record['dbnode_id'] = node.id
+            record['dbnode_id'] = node.pk
             Log(**record)
 
         entries = Log.objects.all()
@@ -169,7 +169,7 @@ class TestBackendLog:
         node_ids = []
         for _ in range(10):
             _, node = self.create_log()
-            node_ids.append(node.id)
+            node_ids.append(node.pk)
         node_ids.sort()
 
         order_by = [OrderSpecifier('dbnode_id', ASCENDING)]
@@ -187,7 +187,7 @@ class TestBackendLog:
         node = orm.Data().store()
         limit = 2
         for _ in range(limit * 2):
-            self.log_record['dbnode_id'] = node.id
+            self.log_record['dbnode_id'] = node.pk
             Log(**self.log_record)
         entries = Log.objects.find(limit=limit)
         assert len(entries) == limit
@@ -201,7 +201,7 @@ class TestBackendLog:
         node_ids = []
         for _ in range(10):
             _, node = self.create_log()
-            node_ids.append(node.id)
+            node_ids.append(node.pk)
 
         node_id_of_choice = node_ids.pop(randint(0, 9))
 
@@ -252,12 +252,12 @@ class TestBackendLog:
 
         # Setup nodes
         log_1, calc = self.create_log()
-        log_2 = Log(now(), 'loggername', logging.getLevelName(LOG_LEVEL_REPORT), calc.id, 'log message #2')
-        log_3 = Log(now(), 'loggername', logging.getLevelName(LOG_LEVEL_REPORT), calc.id, 'log message #3')
+        log_2 = Log(now(), 'loggername', logging.getLevelName(LOG_LEVEL_REPORT), calc.pk, 'log message #2')
+        log_3 = Log(now(), 'loggername', logging.getLevelName(LOG_LEVEL_REPORT), calc.pk, 'log message #3')
 
         # Retrieve a node by joining on a specific log ('log_1')
         builder = QueryBuilder()
-        builder.append(Log, tag='log', filters={'id': log_2.id})
+        builder.append(Log, tag='log', filters={'id': log_2.pk})
         builder.append(orm.CalculationNode, with_log='log', project=['uuid'])
         nodes = builder.all()
 
@@ -267,7 +267,7 @@ class TestBackendLog:
 
         # Retrieve all logs for a specific node by joining on a said node
         builder = QueryBuilder()
-        builder.append(orm.CalculationNode, tag='calc', filters={'id': calc.id})
+        builder.append(orm.CalculationNode, tag='calc', filters={'id': calc.pk})
         builder.append(Log, with_node='calc', project=['uuid'])
         logs = builder.all()
 
@@ -302,7 +302,7 @@ class TestBackendLog:
                 now(),
                 'loggername',
                 logging.getLevelName(LOG_LEVEL_REPORT),
-                calc.id,
+                calc.pk,
                 'To keep your balance, you must keep moving',
                 metadata=wrong_metadata_format
             )
@@ -312,7 +312,7 @@ class TestBackendLog:
             now(),
             'loggername',
             logging.getLevelName(LOG_LEVEL_REPORT),
-            calc.id,
+            calc.pk,
             'To keep your balance, you must keep moving',
             metadata=correct_metadata_format
         )
@@ -325,7 +325,7 @@ class TestBackendLog:
             now(),
             'loggername',
             logging.getLevelName(LOG_LEVEL_REPORT),
-            calc.id,
+            calc.pk,
             'To keep your balance, you must keep moving',
             metadata=json_metadata_format
         )
@@ -338,7 +338,7 @@ class TestBackendLog:
             now(),
             'loggername',
             logging.getLevelName(LOG_LEVEL_REPORT),
-            calc.id,
+            calc.pk,
             'To keep your balance, you must keep moving',
             metadata=None
         )

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -608,46 +608,46 @@ class TestBasic:
 
         # testing direction=1 for d1, which should return the outgoing
         qb = orm.QueryBuilder()
-        qb.append(orm.Data, filters={'id': d1.id})
+        qb.append(orm.Data, filters={'id': d1.pk})
         qb.append(orm.CalculationNode, direction=1, project='id')
         res1 = {_ for _, in qb.all()}
 
         qb = orm.QueryBuilder()
-        qb.append(orm.Data, filters={'id': d1.id}, tag='data')
+        qb.append(orm.Data, filters={'id': d1.pk}, tag='data')
         qb.append(orm.CalculationNode, with_incoming='data', project='id')
         res2 = {_ for _, in qb.all()}
 
         assert res1 == res2
-        assert res1 == {c1.id}
+        assert res1 == {c1.pk}
 
         # testing direction=-1, which should return the incoming
         qb = orm.QueryBuilder()
-        qb.append(orm.Data, filters={'id': d2.id})
+        qb.append(orm.Data, filters={'id': d2.pk})
         qb.append(orm.CalculationNode, direction=-1, project='id')
         res1 = {_ for _, in qb.all()}
 
         qb = orm.QueryBuilder()
-        qb.append(orm.Data, filters={'id': d2.id}, tag='data')
+        qb.append(orm.Data, filters={'id': d2.pk}, tag='data')
         qb.append(orm.CalculationNode, with_outgoing='data', project='id')
         res2 = {_ for _, in qb.all()}
         assert res1 == res2
-        assert res1 == {c1.id}
+        assert res1 == {c1.pk}
 
         # testing direction higher than 1
         qb = orm.QueryBuilder()
-        qb.append(orm.CalculationNode, tag='c1', filters={'id': c1.id})
+        qb.append(orm.CalculationNode, tag='c1', filters={'id': c1.pk})
         qb.append(orm.Data, with_incoming='c1', tag='d2or4')
         qb.append(orm.CalculationNode, tag='c2', with_incoming='d2or4')
         qb.append(orm.Data, tag='d3', with_incoming='c2', project='id')
         qh = qb.as_dict()  # saving query for later
         qb.append(orm.Data, direction=-4, project='id')
         res1 = {item[1] for item in qb.all()}
-        assert res1 == {d1.id}
+        assert res1 == {d1.pk}
 
         qb = orm.QueryBuilder(**qh)
         qb.append(orm.Data, direction=4, project='id')
         res2 = {item[1] for item in qb.all()}
-        assert res2 == {d2.id, d4.id}
+        assert res2 == {d2.pk, d4.pk}
 
     @staticmethod
     def test_all_flat():
@@ -705,7 +705,7 @@ class TestBasic:
         assert builder.count() == 3
 
         builder = orm.QueryBuilder().append(entity_type='link', filters={'label': 'link_d2c2'})
-        assert builder.one()[0] == LinkQuadruple(d2.id, c2.id, LinkType.INPUT_CALC.value, 'link_d2c2')
+        assert builder.one()[0] == LinkQuadruple(d2.pk, c2.pk, LinkType.INPUT_CALC.value, 'link_d2c2')
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
@@ -1108,14 +1108,14 @@ class TestQueryBuilderJoins:
 
         # Search for the group of the user
         qb = orm.QueryBuilder()
-        qb.append(orm.User, tag='user', filters={'id': {'==': user.id}})
-        qb.append(orm.Group, with_user='user', filters={'id': {'==': group.id}})
+        qb.append(orm.User, tag='user', filters={'id': {'==': user.pk}})
+        qb.append(orm.Group, with_user='user', filters={'id': {'==': group.pk}})
         assert qb.count() == 1, 'The expected group that belongs to the selected user was not found.'
 
         # Search for the user that owns a group
         qb = orm.QueryBuilder()
-        qb.append(orm.Group, tag='group', filters={'id': {'==': group.id}})
-        qb.append(orm.User, with_group='group', filters={'id': {'==': user.id}})
+        qb.append(orm.Group, tag='group', filters={'id': {'==': group.pk}})
+        qb.append(orm.User, with_group='group', filters={'id': {'==': user.pk}})
 
         assert qb.count() == 1, 'The expected user that owns the selected group was not found.'
 
@@ -1127,7 +1127,7 @@ class TestQueryBuilderJoins:
         ).store()
         authinfo = computer.configure(user)
         qb = orm.QueryBuilder()
-        qb.append(orm.AuthInfo, tag='auth', filters={'id': {'==': authinfo.id}})
+        qb.append(orm.AuthInfo, tag='auth', filters={'id': {'==': authinfo.pk}})
         qb.append(orm.User, with_authinfo='auth')
         assert qb.count() == 1, 'The expected user that owns the selected authinfo was not found.'
         assert qb.one()[0].pk == user.pk
@@ -1142,14 +1142,14 @@ class TestQueryBuilderJoins:
 
         # Search for the user of the authinfo
         qb = orm.QueryBuilder()
-        qb.append(orm.User, tag='user', filters={'id': {'==': user.id}})
-        qb.append(orm.AuthInfo, with_user='user', filters={'id': {'==': authinfo.id}})
+        qb.append(orm.User, tag='user', filters={'id': {'==': user.pk}})
+        qb.append(orm.AuthInfo, with_user='user', filters={'id': {'==': authinfo.pk}})
         assert qb.count() == 1, 'The expected user that owns the selected authinfo was not found.'
 
         # Search for the computer of the authinfo
         qb = orm.QueryBuilder()
-        qb.append(orm.Computer, tag='computer', filters={'id': {'==': computer.id}})
-        qb.append(orm.AuthInfo, with_computer='computer', filters={'id': {'==': authinfo.id}})
+        qb.append(orm.Computer, tag='computer', filters={'id': {'==': computer.pk}})
+        qb.append(orm.AuthInfo, with_computer='computer', filters={'id': {'==': authinfo.pk}})
         assert qb.count() == 1, 'The expected computer that owns the selected authinfo was not found.'
 
     def test_joins_group_node(self):
@@ -1193,10 +1193,10 @@ class TestQueryBuilderJoins:
         # Check that the nodes are in the group
         qb = orm.QueryBuilder()
         qb.append(orm.Node, tag='node', project=['id'])
-        qb.append(orm.Group, with_node='node', filters={'id': {'==': group.id}})
+        qb.append(orm.Group, with_node='node', filters={'id': {'==': group.pk}})
         assert qb.count() == 4, 'There should be 4 nodes in the group'
         id_res = [_ for [_] in qb.all()]
-        for curr_id in [n1.id, n2.id, n3.id, n4.id]:
+        for curr_id in [n1.pk, n2.pk, n3.pk, n4.pk]:
             assert curr_id in id_res
 
 
@@ -1438,7 +1438,7 @@ class TestConsistency:
             output_node.base.links.add_incoming(parent, link_type=LinkType.CREATE, link_label=f'link_{inode}')
         for projection in ('id', '*'):
             qb = orm.QueryBuilder()
-            qb.append(orm.CalculationNode, filters={'id': parent.id}, tag='parent', project=projection)
+            qb.append(orm.CalculationNode, filters={'id': parent.pk}, tag='parent', project=projection)
             qb.append(orm.Data, with_incoming='parent')
             assert len(qb.all()) == qb.count()
 
@@ -1544,13 +1544,13 @@ class TestDoubleStar:
         result = orm.QueryBuilder().append(
             orm.AuthInfo, tag='auth', filters={
                 'id': {
-                    '==': authinfo.id
+                    '==': authinfo.pk
                 }
             }, project=['**']
         ).dict()
         assert len(result) == 1
         print(result)
-        assert result[0]['auth']['id'] == authinfo.id
+        assert result[0]['auth']['id'] == authinfo.pk
 
     def test_statistics_default_class(self):
 
@@ -1563,7 +1563,7 @@ class TestDoubleStar:
             'uuid': self.computer.uuid,
             'label': self.computer.label,
             'transport_type': self.computer.transport_type,
-            'id': self.computer.id,
+            'id': self.computer.pk,
             'metadata': self.computer.metadata,
         }
 

--- a/tests/orm/utils/test_managers.py
+++ b/tests/orm/utils/test_managers.py
@@ -174,7 +174,7 @@ def test_link_manager_with_nested_namespaces(aiida_profile_clean):
             calc.inputs.__name__
         except AttributeError:
             pass
-        assert not record
+        assert not record, print(record.list[0].message)
 
     # Must raise a AttributeError, otherwise tab competion will not work
     for attribute in ['not_existent', 'not__existent__nested']:

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -95,7 +95,7 @@ class TestRestApi:
             'time': now(),
             'loggername': 'loggername',
             'levelname': logging.getLevelName(LOG_LEVEL_REPORT),
-            'dbnode_id': calc.id,
+            'dbnode_id': calc.pk,
             'message': 'This is a template record message',
             'metadata': {
                 'content': 'test'

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -88,7 +88,7 @@ class TestNodeHashing:
 
         # Search for the UUID of the stored node
         qb = orm.QueryBuilder()
-        qb.append(orm.Data, project=['uuid'], filters={'id': {'==': n.id}})
+        qb.append(orm.Data, project=['uuid'], filters={'id': {'==': n.pk}})
         uuid = qb.first(flat=True)
 
         # Look the node with the previously returned UUID
@@ -99,7 +99,7 @@ class TestNodeHashing:
         qb.all()
         # And that the results are correct
         assert qb.count() == 1
-        assert qb.first(flat=True) == n.id
+        assert qb.first(flat=True) == n.pk
 
     @staticmethod
     def create_folderdata_with_empty_file():
@@ -1042,19 +1042,19 @@ class TestNodeBasic:
 
         # Test that the code1 can be loaded correctly with its label
         q_code_1 = orm.Code.get_from_string(code1.label)
-        assert q_code_1.id == code1.id
+        assert q_code_1.pk == code1.pk
         assert q_code_1.label == code1.label
         assert q_code_1.get_remote_exec_path() == code1.get_remote_exec_path()
 
         # Test that the code2 can be loaded correctly with its label
         q_code_2 = orm.Code.get_from_string(f'{code2.label}@{self.computer.label}')  # pylint: disable=no-member
-        assert q_code_2.id == code2.id
+        assert q_code_2.pk == code2.pk
         assert q_code_2.label == code2.label
         assert q_code_2.get_remote_exec_path() == code2.get_remote_exec_path()
 
         # Calling get_from_string for a non string type raises exception
         with pytest.raises(TypeError):
-            orm.Code.get_from_string(code1.id)
+            orm.Code.get_from_string(code1.pk)
 
         # Test that the lookup of a nonexistent code works as expected
         with pytest.raises(NotExistent):
@@ -1089,25 +1089,25 @@ class TestNodeBasic:
 
         # Test that the code1 can be loaded correctly with its label only
         q_code_1 = orm.Code.get(label=code1.label)
-        assert q_code_1.id == code1.id
+        assert q_code_1.pk == code1.pk
         assert q_code_1.label == code1.label
         assert q_code_1.get_remote_exec_path() == code1.get_remote_exec_path()
 
         # Test that the code1 can be loaded correctly with its id/pk
-        q_code_1 = orm.Code.get(code1.id)
-        assert q_code_1.id == code1.id
+        q_code_1 = orm.Code.get(code1.pk)
+        assert q_code_1.pk == code1.pk
         assert q_code_1.label == code1.label
         assert q_code_1.get_remote_exec_path() == code1.get_remote_exec_path()
 
         # Test that the code2 can be loaded correctly with its label and computername
         q_code_2 = orm.Code.get(label=code2.label, machinename=self.computer.label)  # pylint: disable=no-member
-        assert q_code_2.id == code2.id
+        assert q_code_2.pk == code2.pk
         assert q_code_2.label == code2.label
         assert q_code_2.get_remote_exec_path() == code2.get_remote_exec_path()
 
         # Test that the code2 can be loaded correctly with its id/pk
-        q_code_2 = orm.Code.get(code2.id)
-        assert q_code_2.id == code2.id
+        q_code_2 = orm.Code.get(code2.pk)
+        assert q_code_2.pk == code2.pk
         assert q_code_2.label == code2.label
         assert q_code_2.get_remote_exec_path() == code2.get_remote_exec_path()
 
@@ -1136,7 +1136,7 @@ class TestNodeBasic:
         # Code.get(pk_label_duplicate) should return code1, as the pk takes
         # precedence
         q_code_4 = orm.Code.get(code4.label)
-        assert q_code_4.id == code1.id
+        assert q_code_4.pk == code1.pk
         assert q_code_4.label == code1.label
         assert q_code_4.get_remote_exec_path() == code1.get_remote_exec_path()
 
@@ -1155,7 +1155,7 @@ class TestNodeBasic:
         q_code1 = orm.Code.get(label=code.label)
         assert code.description == str(q_code1.description)
 
-        q_code2 = orm.Code.get(code.id)
+        q_code2 = orm.Code.get(code.pk)
         assert code.description == str(q_code2.description)
 
     def test_list_for_plugin(self):
@@ -1321,7 +1321,7 @@ class TestSubNodesAndLinks:
 
         with pytest.raises(Exception):
             # I should get an error if I ask for a computer id/pk that doesn't exist
-            CalcJobNode(computer=self.computer.id + 100000).store()
+            CalcJobNode(computer=self.computer.pk + 100000).store()
 
     def test_links_label_constraints(self):
         d1 = orm.Data().store()

--- a/tests/tools/archive/orm/test_links.py
+++ b/tests/tools/archive/orm/test_links.py
@@ -33,7 +33,7 @@ def test_links_to_unknown_nodes(tmp_path, aiida_profile_clean):
             EntityTypes.LINK, [{
                 'id': 1,
                 'input_id': 99999,
-                'output_id': node.id,
+                'output_id': node.pk,
                 'label': 'parent',
                 'type': LinkType.CREATE.value,
             }]

--- a/tests/tools/archive/orm/test_logs.py
+++ b/tests/tools/archive/orm/test_logs.py
@@ -29,7 +29,7 @@ def test_critical_log_msg_and_metadata(tmp_path, aiida_profile_clean):
     calc.logger.critical(message)
 
     # Store Log metadata
-    log_metadata = orm.Log.objects.get(dbnode_id=calc.id).metadata
+    log_metadata = orm.Log.objects.get(dbnode_id=calc.pk).metadata
 
     export_file = tmp_path.joinpath('export.aiida')
     create_archive([calc], filename=export_file)

--- a/tests/tools/archive/test_complex.py
+++ b/tests/tools/archive/test_complex.py
@@ -151,7 +151,7 @@ def test_reexport(aiida_profile, tmp_path):
         # Always new filename:
         filename = tmp_path / f'export-{i}.aiida'
         # Loading the group from the string
-        group = orm.Group.get(label=grouplabel)
+        group = orm.Group.objects.get(label=grouplabel)
         # exporting based on all members of the group
         # this also checks if group memberships are preserved!
         create_archive([group] + list(group.nodes), filename=filename)


### PR DESCRIPTION
The final step in the cleaning up of the `Node` namespace consists of
deprecating the following methods in favor of other existing ones:

 * `Node.id` -> `Node.pk`
 * `Node.Collection` -> `NodeCollection`
 * `Entity.get` -> `EntityCollection.get`