### PR TITLE
CLI: catch `LockedProfileError` in `with_dbenv` decorator

### DIFF
--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -8,13 +8,12 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi storage` commands."""
-
 import click
 from click_spinner import spinner
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
-from aiida.cmdline.utils import echo
+from aiida.cmdline.utils import decorators, echo
 from aiida.common import exceptions
 
 
@@ -90,6 +89,7 @@ def storage_integrity():
 
 @verdi_storage.command('info')
 @click.option('--detailed', is_flag=True, help='Provides more detailed information.')
+@decorators.with_dbenv()
 def storage_info(detailed):
     """Summarise the contents of the storage."""
     from aiida.manage.manager import get_manager
@@ -115,6 +115,7 @@ def storage_info(detailed):
     help=
     'Run the maintenance in dry-run mode which will print actions that would be taken without actually executing them.'
 )
+@decorators.with_dbenv()
 @click.pass_context
 def storage_maintain(ctx, full, dry_run):
     """Performs maintenance tasks on the repository."""
@@ -137,7 +138,7 @@ def storage_maintain(ctx, full, dry_run):
         )
 
     else:
-        echo.echo(
+        echo.echo_report(
             '\nThis command will perform all maintenance operations on the internal storage that can be safely '
             'executed while still running AiiDA. '
             'However, not all operations that are required to fully optimize disk usage and future performance '

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -63,11 +63,11 @@ def with_dbenv():
     @decorator
     def wrapper(wrapped, _, args, kwargs):
         """The wrapped function that should be called after having loaded the backend."""
-        from aiida.common.exceptions import ConfigurationError, IntegrityError
+        from aiida.common.exceptions import ConfigurationError, IntegrityError, LockedProfileError
 
         try:
             load_backend_if_not_loaded()
-        except (IntegrityError, ConfigurationError) as exception:
+        except (IntegrityError, ConfigurationError, LockedProfileError) as exception:
             echo.echo_critical(str(exception))
 
         return wrapped(*args, **kwargs)

--- a/aiida/manage/profile_access.py
+++ b/aiida/manage/profile_access.py
@@ -62,7 +62,7 @@ class ProfileAccessManager:
         :raises ~aiida.common.exceptions.LockedProfileError: if the profile is locked.
         """
         error_message = (
-            f'process {self.process.pid} cannot access profile `{self.profile.name}`'
+            f'process {self.process.pid} cannot access profile `{self.profile.name}` '
             f'because it is being locked.'
         )
         self._raise_if_locked(error_message)


### PR DESCRIPTION
Fixes #5486 

The `LockedProfileError` is thrown when a profile's storage is loaded
while it is locked by another process. When this is thrown during a CLI
command call, it is nice to convert it to a formatted message instead of
letting the exception bubble up and show the entire stacktrace.

The `aiida.cmdline.utils.decorators.with_dbenv` decorator is updated to
catch the `LockedProfileError` and call `echo.echo_critical`. This will
print the exception message and exit the command with a non-zero exit
status.

This fix does require that all CLI commands properly use `with_dbenv` if
they require the storage to be loaded. If they cannot use it for
whatever reason, the should ensure to catch the `LockedProfileError`
themselves and echo the exception message.