### PR TITLE
DOC: add list of valid keys in query builder of project and filter

### DIFF
--- a/docs/source/howto/query.rst
+++ b/docs/source/howto/query.rst
@@ -253,7 +253,7 @@ Examples of columns we have encountered so far are ``id``, ``uuid`` and ``attrib
 If the column is a dictionary, you can expand the dictionary values using a dot notation, as we have done in the previous example to obtain the ``attributes.value``.
 This can be used to project the values of nested dictionaries as well.
 
-The keys of columns can be one from following list: 
+The keys of columns can be one from following list:
 
 .. code-block:: python
 

--- a/docs/source/howto/query.rst
+++ b/docs/source/howto/query.rst
@@ -253,6 +253,23 @@ Examples of columns we have encountered so far are ``id``, ``uuid`` and ``attrib
 If the column is a dictionary, you can expand the dictionary values using a dot notation, as we have done in the previous example to obtain the ``attributes.value``.
 This can be used to project the values of nested dictionaries as well.
 
+The keys of columns can be one from following list: 
+
+.. code-block:: python
+
+    id
+    uuid
+    node_type
+    process_type
+    label
+    description
+    ctime
+    mtime
+    attributes
+    extras
+    user_id
+    dbcomputer_id
+
 .. note::
 
     Be aware that for consistency, ``QueryBuilder.all()`` / ``iterall()`` always returns a list of lists, even if you only project one property of a single entity.


### PR DESCRIPTION
Maybe it is somewhere in the documentation somewhere, but I struggle in finding it. 
Put it in section 'projections' is not the best choice I assume, let me know where it should move to.