### PR TITLE
UI: improve error message in storage_maintain

### DIFF
--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -119,6 +119,7 @@ def storage_info(detailed):
 @click.pass_context
 def storage_maintain(ctx, full, dry_run):
     """Performs maintenance tasks on the repository."""
+    from aiida.common.exceptions import LockingProfileError
     from aiida.manage.manager import get_manager
 
     manager = get_manager()
@@ -151,5 +152,8 @@ def storage_maintain(ctx, full, dry_run):
         if not click.confirm('Are you sure you want continue in this mode?'):
             return
 
-    storage.maintain(full=full, dry_run=dry_run)
+    try:
+        storage.maintain(full=full, dry_run=dry_run)
+    except LockingProfileError as exception:
+        echo.echo_critical(str(exception))
     echo.echo_success('Requested maintenance procedures finished.')


### PR DESCRIPTION
Thanks @giovannipizzi and @sphuber for catching and dealing with the bad display of `LockedProfileError` in the verdi commands (#5486). Looking at the implemented solution #5487, I thought that perhaps it would also be appropriate to catch and "clean up" the other error case `LockingProfileError`, which gets triggered in cases like calling `verdi storage maintain` with a verdi shell open, and returned a similarly raw-looking error:

``` bash
(aiida) root@aiida:~/workdir/aiida-core# verdi storage maintain --full 
Warning: You are currently using a post release development version of AiiDA: 2.0.0.post0
Warning: Be aware that this is not recommended for production and is not officially supported.
Warning: Databases used with this version may not be compatible with future releases of AiiDA
Warning: as you might not be able to automatically migrate your data.

Warning: 
In order to safely perform the full maintenance operations on the internal storage, the profile main_profile needs to be locked. This means that no other process will be able to access it and will fail instead. Moreover, if any process is already using the profile, the locking attempt will fail and you will have to either look for these processes and kill them or wait for them to stop by themselves. Note that this includes verdi shells, daemon workers, scripts that manually load it, etc.
For performing maintenance operations that are safe to run while actively using AiiDA, just run `verdi storage maintain` without the `--full` flag.

Are you sure you want continue in this mode? [y/N]: y
Traceback (most recent call last):
  File "/root/.virtualenvs/aiida/bin/verdi", line 8, in <module>
    sys.exit(verdi())
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/root/workdir/aiida-core/aiida/cmdline/utils/decorators.py", line 73, in wrapper
    return wrapped(*args, **kwargs)
  File "/root/.virtualenvs/aiida/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/root/workdir/aiida-core/aiida/cmdline/commands/cmd_storage.py", line 154, in storage_maintain
    storage.maintain(full=full, dry_run=dry_run)
  File "/root/workdir/aiida-core/aiida/storage/psql_dos/backend.py", line 361, in maintain
    with maintenance_context():
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/root/workdir/aiida-core/aiida/manage/profile_access.py", line 118, in lock
    self._raise_if_active(error_message)
  File "/root/workdir/aiida-core/aiida/manage/profile_access.py", line 222, in _raise_if_active
    raise LockingProfileError(error_msg)
aiida.common.exceptions.LockingProfileError: process 428 cannot lock profile `main_profile` because it is being accessed.
The following processes are accessing the profile:
 - pid 253 (`['/root/.virtualenvs/aiida/bin/python3', '/root/.virtualenvs/aiida/bin/verdi', 'shell']`)
```

With this PR it should look a bit cleaner:

``` bash
(aiida) root@aiida:~/workdir/aiida-core# verdi storage maintain --full 
Warning: You are currently using a post release development version of AiiDA: 2.0.0.post0
Warning: Be aware that this is not recommended for production and is not officially supported.
Warning: Databases used with this version may not be compatible with future releases of AiiDA
Warning: as you might not be able to automatically migrate your data.

Warning: 
In order to safely perform the full maintenance operations on the internal storage, the profile main_profile needs to be locked. This means that no other process will be able to access it and will fail instead. Moreover, if any process is already using the profile, the locking attempt will fail and you will have to either look for these processes and kill them or wait for them to stop by themselves. Note that this includes verdi shells, daemon workers, scripts that manually load it, etc.
For performing maintenance operations that are safe to run while actively using AiiDA, just run `verdi storage maintain` without the `--full` flag.

Are you sure you want continue in this mode? [y/N]: y
Critical: process 37736 cannot lock profile `main_profile` because it is being accessed.
The following processes are accessing the profile:
 - pid 253 (`['/root/.virtualenvs/aiida/bin/python3', '/root/.virtualenvs/aiida/bin/verdi', 'shell']`)
```