### PR TITLE
Fix `aiida.common.timezone.delta` having the wrong sign

### DIFF
--- a/aiida/common/timezone.py
+++ b/aiida/common/timezone.py
@@ -63,4 +63,4 @@ def delta(from_time: datetime, to_time: datetime = None) -> timedelta:
     :param to_time: The end datetime object. If not specified :func:`aiida.common.timezone.now` is used.
     :return: The delta datetime object.
     """
-    return make_aware(from_time) - make_aware(to_time or now())
+    return make_aware(to_time or now()) - make_aware(from_time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,7 @@ good-names = [
     "i",
     "j",
     "k",
+    "dt",
     "pk",
     "fg",
     "tz",


### PR DESCRIPTION
Fixes #5492 

In the refactoring of 25ac2131c0eaa61baa8f722427ed5a01a6f55688, the
operands of the subtraction in `delta` were accidentally inversed. This
would lead to a negative delta and would manifest, for example, in all
relative time differences reported in the output of `verdi process list`
to be listed as `0s ago`.