### PR TITLE
👌 IMPROVE: Compute file size, when writing to zip archive

### DIFF
--- a/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -122,10 +122,7 @@ def perform_v1_migration(  # pylint: disable=too-many-locals
                     with subpath.open('rb') as handle:
                         hashkey = chunked_file_hash(handle, sha256)
                     if f'{REPO_FOLDER}/{hashkey}' not in central_dir:
-                        with subpath.open('rb') as handle:
-                            # TODO compute subpath file size
-                            with (new_zip / f'{REPO_FOLDER}/{hashkey}').open(mode='wb') as handle2:
-                                shutil.copyfileobj(handle, handle2)
+                        (new_zip / f'{REPO_FOLDER}/{hashkey}').putfile(subpath)
                 node_repos.setdefault(uuid, []).append((posix_rel.as_posix(), hashkey))
         MIGRATE_LOGGER.report(f'Unique repository files written: {len(central_dir)}')
 

--- a/aiida/storage/sqlite_zip/migrator.py
+++ b/aiida/storage/sqlite_zip/migrator.py
@@ -261,9 +261,7 @@ def migrate(  # pylint: disable=too-many-branches,too-many-statements,too-many-l
             MIGRATE_LOGGER.report('Finalising the migration ...')
 
             # write the final database file to the new zip file
-            with db_path.open('rb') as handle:
-                with (new_zip / DB_FILENAME).open(mode='wb', file_size=db_path.stat().st_size) as handle2:
-                    shutil.copyfileobj(handle, handle2)
+            (new_zip / DB_FILENAME).putfile(db_path)
 
             # write the final metadata.json file to the new zip file
             (new_zip / META_FILENAME).write_text(json.dumps(metadata))

--- a/aiida/storage/sqlite_zip/migrator.py
+++ b/aiida/storage/sqlite_zip/migrator.py
@@ -262,7 +262,7 @@ def migrate(  # pylint: disable=too-many-branches,too-many-statements,too-many-l
 
             # write the final database file to the new zip file
             with db_path.open('rb') as handle:
-                with (new_zip / DB_FILENAME).open(mode='wb') as handle2:
+                with (new_zip / DB_FILENAME).open(mode='wb', file_size=db_path.stat().st_size) as handle2:
                     shutil.copyfileobj(handle, handle2)
 
             # write the final metadata.json file to the new zip file

--- a/aiida/tools/archive/implementations/sqlite_zip/writer.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/writer.py
@@ -286,8 +286,5 @@ class ArchiveAppenderSqlZip(ArchiveWriterSqlZip):
                     if subpath.is_dir():
                         new_path_sub.mkdir(exist_ok=True)
                     else:
-                        with subpath.open('rb') as handle:
-                            # TODO compute subpath size
-                            with new_path_sub.open(mode='wb') as new_handle:
-                                shutil.copyfileobj(handle, new_handle)
+                        new_path_sub.putfile(subpath)
                     progress.update()

--- a/aiida/tools/archive/implementations/sqlite_zip/writer.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/writer.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import hashlib
 from io import BytesIO
 import json
+import os
 from pathlib import Path
 import shutil
 import tempfile
@@ -97,10 +98,8 @@ class ArchiveWriterSqlZip(ArchiveWriterAbstract):
             self._conn.commit()
             self._conn.close()
         assert self._work_dir is not None
-        db_path = (self._work_dir / self.db_name)
-        db_path_size = db_path.stat().st_size
-        with db_path.open('rb') as handle:
-            self._stream_binary(self.db_name, handle, file_size=db_path_size)
+        with (self._work_dir / self.db_name).open('rb') as handle:
+            self._stream_binary(self.db_name, handle)
         self._stream_binary(
             self.meta_name,
             BytesIO(json.dumps(self._metadata).encode('utf8')),
@@ -150,7 +149,6 @@ class ArchiveWriterSqlZip(ArchiveWriterAbstract):
         name: str,
         handle: BinaryIO,
         *,
-        file_size: Optional[int] = None,
         buffer_size: Optional[int] = None,
         compression: Optional[int] = None,
         comment: Optional[bytes] = None,
@@ -167,9 +165,13 @@ class ArchiveWriterSqlZip(ArchiveWriterAbstract):
         if compression is not None:
             kwargs['compression'] = zipfile.ZIP_DEFLATED if compression else zipfile.ZIP_STORED
             kwargs['level'] = compression
-        if file_size is not None:
-            kwargs['file_size'] = file_size
-        with self._zip_path.joinpath(name).open(mode='wb', **kwargs) as zip_handle:
+
+        # compute the file size of the handle
+        handle.seek(0, os.SEEK_END)
+        file_size = handle.tell()
+        handle.seek(0)
+
+        with self._zip_path.joinpath(name).open(mode='wb', file_size=file_size, **kwargs) as zip_handle:
             if buffer_size is None:
                 shutil.copyfileobj(handle, zip_handle)
             else:
@@ -180,7 +182,6 @@ class ArchiveWriterSqlZip(ArchiveWriterAbstract):
             key = chunked_file_hash(stream, hashlib.sha256)
             stream.seek(0)
         if f'{utils.REPO_FOLDER}/{key}' not in self._central_dir:
-            # TODO how to compute stream size?
             self._stream_binary(f'{utils.REPO_FOLDER}/{key}', stream, buffer_size=buffer_size)
         return key
 
@@ -250,10 +251,8 @@ class ArchiveAppenderSqlZip(ArchiveWriterSqlZip):
             self._conn.close()
         assert self._work_dir is not None
         # write the database and metadata to the new archive
-        db_path = (self._work_dir / self.db_name)
-        db_path_size = db_path.stat().st_size
-        with db_path.open('rb') as handle:
-            self._stream_binary(self.db_name, handle, file_size=db_path_size)
+        with (self._work_dir / self.db_name).open('rb') as handle:
+            self._stream_binary(self.db_name, handle)
         self._stream_binary(
             self.meta_name,
             BytesIO(json.dumps(self._metadata).encode('utf8')),

--- a/aiida/tools/archive/implementations/sqlite_zip/writer.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/writer.py
@@ -167,9 +167,10 @@ class ArchiveWriterSqlZip(ArchiveWriterAbstract):
             kwargs['level'] = compression
 
         # compute the file size of the handle
+        position = handle.tell()
         handle.seek(0, os.SEEK_END)
         file_size = handle.tell()
-        handle.seek(0)
+        handle.seek(position)
 
         with self._zip_path.joinpath(name).open(mode='wb', file_size=file_size, **kwargs) as zip_handle:
             if buffer_size is None:

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - python~=3.8
 - alembic~=1.2
-- archive-path~=0.3.6
+- archive-path~=0.4.0
 - aio-pika~=6.6
 - circus~=0.17.1
 - click-config-file~=0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["aiida", "workflows"]
 requires-python = ">=3.8"
 dependencies = [
         "alembic~=1.2",
-        "archive-path~=0.3.6",
+        "archive-path~=0.4.0",
         "aio-pika~=6.6",
         "circus~=0.17.1",
         "click-config-file~=0.6.0",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -4,7 +4,7 @@ aiormq==3.3.1
 alabaster==0.7.12
 alembic==1.7.5
 aniso8601==9.0.1
-archive-path==0.3.6
+archive-path==0.4.0
 argon2-cffi==21.1.0
 ase==3.22.0
 asn1crypto==1.4.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -4,7 +4,7 @@ aiormq==3.3.1
 alabaster==0.7.12
 alembic==1.7.5
 aniso8601==9.0.1
-archive-path==0.3.6
+archive-path==0.4.0
 argon2-cffi==21.1.0
 ase==3.22.0
 asn1crypto==1.4.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -4,7 +4,7 @@ aiormq==3.3.1
 alabaster==0.7.12
 alembic==1.7.5
 aniso8601==9.0.1
-archive-path==0.3.6
+archive-path==0.4.0
 argon2-cffi==21.1.0
 ase==3.22.0
 asn1crypto==1.4.0


### PR DESCRIPTION
This allows for zipfile to decide if it should use the ZIP64 extension (when adding files >2Gb).

Note `ZipPath.putfile` does this internally

Should fix: https://github.com/aiidateam/aiida-core/discussions/5407#discussioncomment-2599275