### PR TITLE
Dependencies: update requirement `click~=8.1`

### DIFF
--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -11,7 +11,6 @@
 import difflib
 
 import click
-from click import shell_completion
 
 from aiida import __version__
 from aiida.cmdline.params import options, types
@@ -32,26 +31,6 @@ GIU = (
     'R9k7rh<eeM8~?e5)U+OloQYk-ebZsXE8KFmR5;uE)C;wlw}@dIbx-{${l+HbC|PrK*6{Q(q6jMpni4Be``)PJJRU>(GH9y|jm){jY9_xAI4N_EfU#4'
     'taTUXFY4a4l$v=N-+f+w&wuH;Z(6p6#=n8XwlZ;*L&-rcL~T_vEm@#-Xi8&g06!MO+R(<NRBkE$(0Y_~^2C_k<o~_a3*HAHukZKXCs8^y%UZZVvze'
 )
-
-
-def _start_of_option(value: str) -> bool:
-    """Check if the value looks like the start of an option.
-
-    This is an adaptation of :py:func:`click.shell_completion._start_of_option` that simply add ``.``, ``~``, ``$`` as
-    the characters that are interpreted as the start of a filepath, and so not the start of an option. This will ensure
-    that filepaths starting with these characters are autocompleted once again.
-
-    Here ``.`` indicates a relative path, ``~`` indicates the home directory, and ``$`` allows to expand environment
-    variables such as ``$HOME`` and ``$PWD``.
-    """
-    if not value:
-        return False
-
-    # Allow characters that typically designate the start of a path.
-    return not value[0].isalnum() and value[0] not in ['/', '.', '~', '$']
-
-
-shell_completion._start_of_option = _start_of_option  # pylint: disable=protected-access
 
 
 class VerdiCommandGroup(click.Group):

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - circus~=0.17.1
 - click-config-file~=0.6.0
 - click-spinner~=0.1.8
-- click>=8.0.3,~=8.0
+- click~=8.1
 - disk-objectstore~=0.6.0
 - python-graphviz~=0.13
 - ipython~=7.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
         "circus~=0.17.1",
         "click-config-file~=0.6.0",
         "click-spinner~=0.1.8",
-        "click~=8.0,>=8.0.3",
+        "click~=8.1",
         "disk-objectstore~=0.6.0",
         "graphviz~=0.13",
         "ipython~=7.20",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -19,7 +19,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.8
 circus==0.17.1
-click==8.0.3
+click==8.1.0
 click-config-file==0.6.0
 click-spinner==0.1.10
 configobj==5.0.6

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -19,7 +19,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.8
 circus==0.17.1
-click==8.0.3
+click==8.1.0
 click-config-file==0.6.0
 click-spinner==0.1.10
 configobj==5.0.6

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -19,7 +19,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.8
 circus==0.17.1
-click==8.0.3
+click==8.1.0
 click-config-file==0.6.0
 click-spinner==0.1.10
 configobj==5.0.6


### PR DESCRIPTION
Fixes #5502

A workaround was added in 186b16f419eca80022c084691c8a1cef407ab6ea
because the tab-completion in `click==8.0.x` would not autocomplete
option values starting with special characters. This behavior was fixed
in `click==8.1` so we can remove the workaround at the cost of upping
the lower version requirement.