### PR TITLE
Deprecate the method `aiida.get_strict_version`

### DIFF
--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -45,6 +45,11 @@ def get_strict_version():
     :rtype: :class:`!distutils.version.StrictVersion`
     """
     from distutils.version import StrictVersion
+
+    from aiida.common.warnings import warn_deprecation
+    warn_deprecation(
+        'This method is deprecated as the `distutils` package it uses will be removed in Python 3.12.', version=3
+    )
     return StrictVersion(__version__)
 
 


### PR DESCRIPTION
The method uses the `distutils` package of the standard library. With
the acceptance of PEP 632, this module was deprecated in Python 3.10 and
it will be removed in Python 3.12.

Since there is no exact replacement of the `StrictVersion` class in
another package, we deprecate the method and slate it for removal in the
next major version. We could have used `packaging.version.Version` as a
replacement, but the method is not used internally and doesn't seem to
be used by plugin packages either.