### PR TITLE
Deprecate `Profile.repository_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,6 @@ from aiida.storage.sqlite_temp import SqliteTempBackend
 profile = load_profile(
     SqliteTempBackend.create_profile(
         'myprofile',
-        sandbox_path='_sandbox',
         options={
             'runner.poll.interval': 1
         },

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -351,7 +351,12 @@ class Config:  # pylint: disable=too-many-public-methods
         profile = self.get_profile(name)
 
         if include_repository:
-            folder = profile.repository_path
+            # Note, this is currently being hardcoded, but really this `delete_profile` should get the storage backend
+            # for the given profile and call `StorageBackend.erase` method. Currently this is leaking details
+            # of the implementation of the PsqlDosBackend into a generic function which would fail for profiles that
+            # use a different storage backend implementation.
+            from aiida.storage.psql_dos.backend import get_filepath_container
+            folder = get_filepath_container(profile).parent
             if folder.exists():
                 shutil.rmtree(folder)
 

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -219,6 +219,10 @@ class Profile:  # pylint: disable=too-many-public-methods
         """
         from urllib.parse import urlparse
 
+        from aiida.common.warnings import warn_deprecation
+
+        warn_deprecation('This method has been deprecated', version=3)
+
         if 'repository_uri' not in self.storage_config:
             raise KeyError('repository_uri not defined in profile storage config')
 

--- a/aiida/storage/psql_dos/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
+++ b/aiida/storage/psql_dos/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
@@ -27,6 +27,7 @@ from sqlalchemy import Integer, String, cast
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.sql import column, func, select, table
 
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils.utils import load_numpy_array_from_repository
 
 # revision identifiers, used by Alembic.
@@ -42,8 +43,7 @@ depends_on = None
 def upgrade():
     """Migrations for the upgrade."""
     connection = op.get_bind()
-    profile = op.get_context().opts['aiida_profile']
-    repo_path = profile.repository_path
+    repo_path = get_filepath_container(op.get_context().opts['aiida_profile']).parent
 
     DbNode = table(
         'db_dbnode',

--- a/aiida/storage/psql_dos/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
+++ b/aiida/storage/psql_dos/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
@@ -22,6 +22,7 @@ from sqlalchemy import Integer, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.sql import column, select, table, text
 
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 
 # revision identifiers, used by Alembic.
@@ -34,8 +35,7 @@ depends_on = None
 def upgrade():
     """Migrations for the upgrade."""
     connection = op.get_bind()
-    profile = op.get_context().opts['aiida_profile']
-    repo_path = profile.repository_path
+    repo_path = get_filepath_container(op.get_context().opts['aiida_profile']).parent
 
     DbNode = table(
         'db_dbnode',

--- a/aiida/storage/psql_dos/migrations/versions/django_0026_trajectory_symbols_to_attribute.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0026_trajectory_symbols_to_attribute.py
@@ -20,6 +20,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils.create_dbattribute import create_rows
 from aiida.storage.psql_dos.migrations.utils.utils import load_numpy_array_from_repository
 
@@ -32,8 +33,7 @@ depends_on = None
 def upgrade():
     """Migrations for the upgrade."""
     connection = op.get_bind()
-    profile = op.get_context().opts['aiida_profile']
-    repo_path = profile.repository_path
+    repo_path = get_filepath_container(op.get_context().opts['aiida_profile']).parent
 
     node_model = sa.table(
         'db_dbnode',

--- a/aiida/storage/psql_dos/migrations/versions/django_0027_delete_trajectory_symbols_array.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0027_delete_trajectory_symbols_array.py
@@ -21,6 +21,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql.expression import delete
 
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 
 revision = 'django_0027'
@@ -33,8 +34,7 @@ def upgrade():
     """Migrations for the upgrade."""
     # pylint: disable=unused-variable
     connection = op.get_bind()
-    profile = op.get_context().opts['aiida_profile']
-    repo_path = profile.repository_path
+    repo_path = get_filepath_container(op.get_context().opts['aiida_profile']).parent
 
     node_tbl = sa.table(
         'db_dbnode',

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -12,15 +12,12 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from functools import cached_property
-import os
-from pathlib import Path
 from typing import Any, Iterator, Sequence
 
 from sqlalchemy.orm import Session
 
 from aiida.common.exceptions import ClosedStorage
 from aiida.manage import Profile, get_config_option
-from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import BackendEntity, StorageBackend
 from aiida.repository.backend.sandbox import SandboxRepositoryBackend
@@ -44,22 +41,17 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
     def create_profile(
         name: str = 'temp',
         default_user_email='user@email.com',
-        sandbox_path: str | Path | None = None,
         options: dict | None = None,
         debug: bool = False
     ) -> Profile:
         """Create a new profile instance for this backend, from the path to the zip file."""
-        sandbox_path = sandbox_path or os.path.join(AIIDA_CONFIG_FOLDER, 'repository', name)
         return Profile(
-            name,
-            {
+            name, {
                 'default_user_email': default_user_email,
                 'storage': {
                     'backend': 'core.sqlite_temp',
                     'config': {
                         'debug': debug,
-                        # Note this is currently required, see https://github.com/aiidateam/aiida-core/issues/5451
-                        'repository_uri': f'file://{os.path.abspath(sandbox_path)}',
                     }
                 },
                 'process_control': {
@@ -92,7 +84,7 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
 
     def __str__(self) -> str:
         state = 'closed' if self.is_closed else 'open'
-        return f'SqliteTemp storage [{state}], sandbox: {self.profile.repository_path}'
+        return f'SqliteTemp storage [{state}], sandbox: {self._repo}'
 
     @property
     def is_closed(self) -> bool:

--- a/docs/source/intro/tutorial.md
+++ b/docs/source/intro/tutorial.md
@@ -50,7 +50,6 @@ from aiida.storage.sqlite_temp import SqliteTempBackend
 profile = load_profile(
     SqliteTempBackend.create_profile(
         'myprofile',
-        sandbox_path='_sandbox',
         options={
             'warnings.development_version': False,
             'runner.poll.interval': 1
@@ -300,7 +299,7 @@ This command sets up a code with *label* `add` on the *computer* `tutor`, using 
 ```{code-cell} ipython3
 :tags: ["hide-cell"]
 
-%verdi computer setup -L tutor -H localhost -T core.local -S core.direct -w {profile.repository_path / 'work'} -n
+%verdi computer setup -L tutor -H localhost -T core.local -S core.direct -w /tmp -n
 %verdi computer configure core.local tutor --safe-interval 0 -n
 %verdi code setup -L add --on-computer --computer=tutor -P core.arithmetic.add --remote-abs-path=/bin/bash -n
 ```

--- a/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
@@ -13,6 +13,7 @@ import pytest
 
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 from aiida.storage.psql_dos.migrations.utils.create_dbattribute import create_rows
 from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
@@ -23,7 +24,7 @@ def test_traj_data(perform_migrations: PsqlDostoreMigrator):
     # starting revision
     perform_migrations.migrate_up('django@django_0025')
 
-    repo_path = perform_migrations.profile.repository_path
+    repo_path = get_filepath_container(perform_migrations.profile).parent
 
     # setup the database
     user_model = perform_migrations.get_current_table('db_dbuser')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0047_migrate_repository.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0047_migrate_repository.py
@@ -13,6 +13,7 @@ import os
 from uuid import uuid4
 
 from aiida.common import timezone
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
 
@@ -24,7 +25,7 @@ def test_node_repository(perform_migrations: PsqlDostoreMigrator):  # pylint: di
     # starting revision
     perform_migrations.migrate_up('django@django_0046')
 
-    repo_path = perform_migrations.profile.repository_path
+    repo_path = get_filepath_container(perform_migrations.profile).parent
 
     # setup the storage
     user_model = perform_migrations.get_current_table('db_dbuser')

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_11_v2_repository.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_11_v2_repository.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 
 from aiida.common.utils import get_new_uuid
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
 
@@ -148,7 +149,7 @@ def test_repository_migration(perform_migrations: PsqlDostoreMigrator):  # pylin
         node_03_pk = node_03.id
         node_05_pk = node_05.id
 
-        repo_path = perform_migrations.profile.repository_path
+        repo_path = get_filepath_container(perform_migrations.profile).parent
 
         utils.put_object_from_string(repo_path, node_01.uuid, 'sub/path/file_b.txt', 'b')
         utils.put_object_from_string(repo_path, node_01.uuid, 'sub/file_a.txt', 'a')

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
@@ -11,6 +11,7 @@
 import numpy as np
 import pytest
 
+from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
 from aiida.storage.psql_dos.utils import flag_modified
@@ -43,7 +44,7 @@ def test_trajectory_data(perform_migrations: PsqlDostoreMigrator):
 
     Verify that migration of symbols from repository array to attribute works properly.
     """
-    repo_path = perform_migrations.profile.repository_path
+    repo_path = get_filepath_container(perform_migrations.profile).parent
 
     # starting revision
     perform_migrations.migrate_up('sqlalchemy@37f3d4882837')  # 37f3d4882837_make_all_uuid_columns_unique

--- a/tests/storage/sqlite/test_orm.py
+++ b/tests/storage/sqlite/test_orm.py
@@ -86,11 +86,6 @@ from aiida.storage.sqlite_temp import SqliteTempBackend
                 '==': False
             }
         }, 1),
-        # ({
-        #     'attributes.null': {
-        #         '==': None
-        #     }
-        # }, 1),
         ({
             'attributes.list': {
                 '==': [1, 2]
@@ -135,16 +130,6 @@ from aiida.storage.sqlite_temp import SqliteTempBackend
                 '==': True
             }
         }, 0),
-        # ({
-        #     'attributes.null': {
-        #         '==': 0
-        #     }
-        # }, 0),
-        # ({
-        #     'attributes.other': {
-        #         '==': None
-        #     }
-        # }, 0),
         ({
             'attributes.list': {
                 '==': [1, 3]
@@ -334,17 +319,12 @@ from aiida.storage.sqlite_temp import SqliteTempBackend
                 'has_key': 'key1'
             }
         }, 1),
-        # ({
-        #     'attributes.dict': {
-        #         'has_key': 'key2'
-        #     }
-        # }, 1),
     ),
     ids=json.dumps,
 )
-def test_qb_json_filters(tmp_path, filters, matches):
+def test_qb_json_filters(filters, matches):
     """Test QueryBuilder filtering for JSON fields."""
-    profile = SqliteTempBackend.create_profile(sandbox_path=tmp_path, debug=False)
+    profile = SqliteTempBackend.create_profile(debug=False)
     backend = SqliteTempBackend(profile)
     Dict({
         'text': 'abcXYZ',
@@ -393,9 +373,9 @@ def test_qb_json_filters(tmp_path, filters, matches):
     ),
     ids=json.dumps
 )
-def test_qb_column_filters(tmp_path, filters, matches):
+def test_qb_column_filters(filters, matches):
     """Test querying directly those stored in the columns"""
-    profile = SqliteTempBackend.create_profile(sandbox_path=tmp_path, debug=False)
+    profile = SqliteTempBackend.create_profile(debug=False)
     backend = SqliteTempBackend(profile)
     dict1 = Dict({
         'text2': 'abc_XYZ',
@@ -413,9 +393,9 @@ def test_qb_column_filters(tmp_path, filters, matches):
     ('integer', 'i'),
     ('float', 'f'),
 ))
-def test_qb_json_order_by(tmp_path, key, cast_type):
+def test_qb_json_order_by(key, cast_type):
     """Test QueryBuilder ordering by JSON field keys."""
-    profile = SqliteTempBackend.create_profile(sandbox_path=tmp_path, debug=False)
+    profile = SqliteTempBackend.create_profile(debug=False)
     backend = SqliteTempBackend(profile)
     dict1 = Dict({
         'text': 'b',


### PR DESCRIPTION
Fixes #5513 

The `Profile.repository_path` was historically used to give the absolute
filepath to the file repository on the local file system. However, this
is a property of the storage backend and not all backends will have this.
So instead of being generic to all profiles, this should be a storage
specific setting.

The property is deprecated and the functionality is added to the new
`PsqlDosBackend.filepath_container`. This forwards to the same property
but on the `PsqlDostoreMigrator` that has the actual implementation. The
reason for this is because the migrator needs to get the repository
location in the `migrate` method, but that needs to remain a
classmethod. The alternative of having the migrator call the property on
the backend, would require the backend to be passed to the constructor
of the migrator, but this won't work as the migrator also needs to be
constructed in the constructor of the backend, leading to an infinite
regression.

There is a also  a slight difference in the implementation of the new
property. It returns the path of the disk object store container, which
is a subfolder of the original repository path. Old invocations of
`profile.repository_path` should therefore be replaced with
`backend.filepath_container.parent`.


~~Currently based on and blocked by #5496~~