### PR TITLE
Deps: pgtest move to dependencies from tests extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
         "psycopg2-binary~=2.8",
         "pytz~=2021.1",
         "pyyaml~=5.4",
+        "pgtest~=1.3,>=1.3.1",
         "sqlalchemy~=1.4.22",
         "tabulate~=0.8.5",
         "tqdm~=4.45",
@@ -110,7 +111,6 @@ pre-commit = [
 tests = [
     "aiida-export-migration-tests==0.9.0",
     "pg8000~=1.13",
-    "pgtest~=1.3,>=1.3.1",
     "pytest~=6.2",
     "pytest-asyncio~=0.12,<0.17",
     "pytest-timeout~=1.3",


### PR DESCRIPTION
The `pgtest` is required if from the plugin using fixtures defined in `aiida.manage.tests`. 