### PR TITLE
fix: pop `_v6_backend` key on `storage` level

### DIFF
--- a/aiida/manage/configuration/migrations/migrations.py
+++ b/aiida/manage/configuration/migrations/migrations.py
@@ -291,7 +291,7 @@ class MergeStorageBackendTypes(SingleMigration):
     def downgrade(self, config: ConfigType) -> None:
         for profile_name, profile in config.get('profiles', {}).items():
             if '_v6_backend' in profile.get('storage', {}):
-                profile.setdefault('storage', {})['backend'] = profile.pop('_v6_backend')
+                profile.setdefault('storage', {})['backend'] = profile['storage'].pop('_v6_backend')
             else:
                 CONFIG_LOGGER.warning(f'profile {profile_name!r} had no expected "storage._v6_backend" key')
 

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -108,7 +108,7 @@ def test_merge_storage_backends_downgrade_profile(empty_config, profile_factory,
     assert list(config_migrated['profiles'].keys()) == ['profile_a', 'profile_b']
     assert f'profile {profile_b.name!r} had no expected "storage._v6_backend" key' in caplog.records[0].message
 
-    
+
 def test_add_test_profile_key_downgrade_profile(empty_config, profile_factory, caplog):
     """Test the downgrade of schema version 8.
 


### PR DESCRIPTION
when migrating from new (aiida 2.0) configuration files to legacy ones using `verdi config downgrade 5` users encountered a  `KeyError`.
The reason is that the `_v6_backend` key was popped at the wrong level.

fixes #5527 