### PR TITLE
Tests: fix the RPN work chains for the nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,7 @@ on:
     pull_request:
         paths:
         - '.github/workflows/nightly.yml'
+        - '.molecule/default/files/**'
         - 'aiida/storage/psql_dos/migrations/**'
         - 'tests/storage/psql_dos/migrations/**'
 

--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -100,12 +100,12 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
     """
     # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-branches
     from aiida.engine import run_get_node
-    from aiida.orm import Code, Int, Str
+    from aiida.orm import AbstractCode, Int, Str
 
     lib_expression = importlib.import_module('lib.expression')
     lib_workchain = importlib.import_module('lib.workchain')
 
-    if use_calculations and not isinstance(code, Code):
+    if use_calculations and not isinstance(code, AbstractCode):
         raise click.BadParameter('if you specify the -C flag, you have to specify a code as well')
 
     if expression is None:

--- a/.molecule/default/files/polish/lib/template/base.tpl
+++ b/.molecule/default/files/polish/lib/template/base.tpl
@@ -2,7 +2,7 @@
 from numpy import prod
 from copy import deepcopy
 from aiida.engine import submit, WorkChain, if_, while_, append_, ToContext, calcfunction
-from aiida.orm import Code, Int, Str, Dict
+from aiida.orm import AbstractCode, Int, Str, Dict
 from aiida.plugins import CalculationFactory
 
 

--- a/.molecule/default/files/polish/lib/template/workchain.tpl
+++ b/.molecule/default/files/polish/lib/template/workchain.tpl
@@ -7,7 +7,7 @@ class ${class_name}(WorkChain):
     @classmethod
     def define(cls, spec):
         super().define(spec)
-        spec.input('code', valid_type=Code, required=False)
+        spec.input('code', valid_type=AbstractCode, required=False)
         spec.input('operands', valid_type=Str)
         spec.input('modulo', valid_type=Int)
         spec.outline(


### PR DESCRIPTION
The Reverse Polish Workchains were accidentally omitted in the recent
refactor of the `Code` class, causing the tests to fail which are run in
the nightly build. Updating `Code` to `AbstractCode` fixes this.