### PR TITLE
fix: raise when detecting multiple entry points

### DIFF
--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -283,7 +283,10 @@ def get_entry_point(group: str, name: str) -> EntryPoint:
     if name not in found.names:
         raise MissingEntryPointError(f"Entry point '{name}' not found in group '{group}'")
     if len(found) > 1:
-        raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}': {found}")
+        # if the entry points have the same *value*, it does not matter which one we load
+        # (needed e.g. to allow installing aiida-core in user space over an existing system-level installation)
+        if len(set(ep.value for ep in found)) != 1:
+            raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}': {found}")
     return found[name]
 
 

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -282,11 +282,10 @@ def get_entry_point(group: str, name: str) -> EntryPoint:
     found = eps().select(group=group, name=name)
     if name not in found.names:
         raise MissingEntryPointError(f"Entry point '{name}' not found in group '{group}'")
-    if len(found) > 1:
-        # if the entry points have the same *value*, it does not matter which one we load
-        # (needed e.g. to allow installing aiida-core in user space over an existing system-level installation)
-        if len(set(ep.value for ep in found)) != 1:
-            raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}': {found}")
+    # If multiple entry points are found and they have different values we raise, otherwise if they all
+    # correspond to the same value, we simply return one of them
+    if len(found) > 1 and len(set(ep.value for ep in found)) != 1:
+        raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}': {found}")
     return found[name]
 
 

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -282,7 +282,7 @@ def get_entry_point(group: str, name: str) -> EntryPoint:
     found = eps().select(group=group, name=name)
     if name not in found.names:
         raise MissingEntryPointError(f"Entry point '{name}' not found in group '{group}'")
-    if len(found.names) > 1:
+    if len(found) > 1:
         raise MultipleEntryPointError(f"Multiple entry points '{name}' found in group '{group}': {found}")
     return found[name]
 


### PR DESCRIPTION
Due to a slight misunderstanding of the new importlib.metadata API,
AiiDA did no longer raise when detecting multiple entries for a given
entry point (pair of group + name), and instead simply loaded the first
one.

Example illustrating the behavior:
```

In [8]: eps.select(group='aiida.workflows',name='mcscf.abcChain')
Out[8]:
[EntryPoint(name='mcscf.abcChain', value='aiida_mcscf.workflows:abcChain', group='aiida.workflows'),
 EntryPoint(name='mcscf.abcChain', value='aiida_mcscf.workflows:AbcDefChain', group='aiida.workflows')]

In [9]: result=eps.select(group='aiida.workflows',name='mcscf.abcChain')

In [10]: result.names
Out[10]: {'mcscf.abcChain'}

In [11]: len(result)
Out[11]: 2

In [12]: len(result.names)
Out[12]: 1

In [13]: result['mcscf.abcChain']
Out[13]: EntryPoint(name='mcscf.abcChain', value='aiida_mcscf.workflows:abcChain', group='aiida.workflows')
```

Fixes #5530