### PR TITLE
docs: remove note on disk space for caching

### DIFF
--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -159,6 +159,9 @@ Limitations and Guidelines
    While AiiDA's hashes include the version of the Python package containing the calculation/data classes, it cannot detect cases where the underlying Python code was changed without increasing the version number.
    Another scenario that can lead to an erroneous cache hit is if the parser and calculation are not implemented as part of the same Python package, because the calculation nodes store only the name, but not the version of the used parser.
 
+#. While caching saves unnecessary computations, it does not directly prevent duplication of data: the cached calculation and its output nodes are duplicated.
+   In practice, however, AiiDA's file repository implementation will detect that any files associated with these nodes are already present and simply point to those, reducing duplication to metadata stored at the database level.
+
 #. Finally, When modifying the hashing/caching behaviour of your classes, keep in mind that cache matches can go wrong in two ways:
 
    * False negatives, where two nodes *should* have the same hash but do not

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -159,8 +159,8 @@ Limitations and Guidelines
    While AiiDA's hashes include the version of the Python package containing the calculation/data classes, it cannot detect cases where the underlying Python code was changed without increasing the version number.
    Another scenario that can lead to an erroneous cache hit is if the parser and calculation are not implemented as part of the same Python package, because the calculation nodes store only the name, but not the version of the used parser.
 
-#. While caching saves unnecessary computations, it does lead result in duplication of the cached calculation and its output nodes in the provenance graph.
-   At the same time, AiiDA's default disk-objectstore storage backend comes with automatic de-duplication at the object level.
+#. While caching saves unnecessary computations, it does not necessarily save space as the cached calculation and its output nodes are duplicated in the provenance graph.
+   However, AiiDA's default disk-objectstore storage backend comes with automatic de-duplication at the object level.
    Disk usage therefore remains unaffected with this backend, except for node metadata stored at the database level.
 
 #. Finally, When modifying the hashing/caching behaviour of your classes, keep in mind that cache matches can go wrong in two ways:

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -159,8 +159,9 @@ Limitations and Guidelines
    While AiiDA's hashes include the version of the Python package containing the calculation/data classes, it cannot detect cases where the underlying Python code was changed without increasing the version number.
    Another scenario that can lead to an erroneous cache hit is if the parser and calculation are not implemented as part of the same Python package, because the calculation nodes store only the name, but not the version of the used parser.
 
-#. While caching saves unnecessary computations, it does not directly prevent duplication of data: the cached calculation and its output nodes are duplicated.
-   In practice, however, AiiDA's file repository implementation will detect that any files associated with these nodes are already present and simply point to those, reducing duplication to metadata stored at the database level.
+#. While caching saves unnecessary computations, it does lead result in duplication of the cached calculation and its output nodes in the provenance graph.
+   At the same time, AiiDA's default disk-objectstore storage backend comes with automatic de-duplication at the object level.
+   Disk usage therefore remains unaffected with this backend, except for node metadata stored at the database level.
 
 #. Finally, When modifying the hashing/caching behaviour of your classes, keep in mind that cache matches can go wrong in two ways:
 

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -159,8 +159,6 @@ Limitations and Guidelines
    While AiiDA's hashes include the version of the Python package containing the calculation/data classes, it cannot detect cases where the underlying Python code was changed without increasing the version number.
    Another scenario that can lead to an erroneous cache hit is if the parser and calculation are not implemented as part of the same Python package, because the calculation nodes store only the name, but not the version of the used parser.
 
-#. Note that while caching saves unnecessary computations, it does not save disk space: the output nodes of the cached calculation are full copies of the original outputs.
-
 #. Finally, When modifying the hashing/caching behaviour of your classes, keep in mind that cache matches can go wrong in two ways:
 
    * False negatives, where two nodes *should* have the same hash but do not


### PR DESCRIPTION
The new repository implementation includes automatic de-duplication of identical files.
Re-running a cached calculation should therefore not result in copies of the results stored
in the repository, and in no increase in disk space usage besides what is needed for storing
metadata for the new calculation nodes, data nodes & links in the database.