### PR TITLE
CLI: allow setting options for config without profiles

### DIFF
--- a/aiida/storage/psql_dos/alembic_cli.py
+++ b/aiida/storage/psql_dos/alembic_cli.py
@@ -14,6 +14,7 @@ import click
 from sqlalchemy.util.compat import nullcontext
 
 from aiida.cmdline import is_verbose
+from aiida.cmdline.groups.verdi import VerdiCommandGroup
 from aiida.cmdline.params import options
 from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
 
@@ -44,7 +45,7 @@ class AlembicRunner:
 pass_runner = click.make_pass_decorator(AlembicRunner, ensure=True)
 
 
-@click.group()
+@click.group(cls=VerdiCommandGroup)
 @options.PROFILE(required=True)
 @pass_runner
 def alembic_cli(runner, profile):

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -7,143 +7,162 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=no-self-use
-"""Tests for `verdi config`."""
-import pytest
-
+"""Tests for ``verdi config``."""
 from aiida import get_profile
 from aiida.cmdline.commands import cmd_verdi
-from aiida.manage.configuration import get_config
 
 
-class TestVerdiConfig:
-    """Tests for `verdi config`."""
+def test_config_set_option_no_profile(run_cli_command, empty_config):
+    """Test the `verdi config set` command when no profile is present in the config."""
+    config = empty_config
 
-    @pytest.fixture(autouse=True)
-    def setup_fixture(self, config_with_profile_factory):
-        config_with_profile_factory()
+    option_name = 'daemon.timeout'
+    option_value = str(10)
 
-    def test_config_set_option(self, run_cli_command):
-        """Test the `verdi config set` command when setting an option."""
-        config = get_config()
+    options = ['config', 'set', option_name, str(option_value)]
+    run_cli_command(cmd_verdi.verdi, options)
+    assert str(config.get_option(option_name, scope=None)) == option_value
 
-        option_name = 'daemon.timeout'
-        option_values = [str(10), str(20)]
 
-        for option_value in option_values:
-            options = ['config', 'set', option_name, str(option_value)]
-            run_cli_command(cmd_verdi.verdi, options)
-            assert str(config.get_option(option_name, scope=get_profile().name)) == option_value
+def test_config_set_option(run_cli_command, config_with_profile_factory):
+    """Test the `verdi config set` command when setting an option."""
+    config = config_with_profile_factory()
 
-    def test_config_append_option(self, run_cli_command):
-        """Test the `verdi config set --append` command when appending an option value."""
-        config = get_config()
-        option_name = 'caching.enabled_for'
-        for value in ['x', 'y']:
-            options = ['config', 'set', '--append', option_name, value]
-            run_cli_command(cmd_verdi.verdi, options)
-        assert config.get_option(option_name, scope=get_profile().name) == ['x', 'y']
+    option_name = 'daemon.timeout'
+    option_values = [str(10), str(20)]
 
-    def test_config_remove_option(self, run_cli_command):
-        """Test the `verdi config set --remove` command when removing an option value."""
-        config = get_config()
-
-        option_name = 'caching.disabled_for'
-        config.set_option(option_name, ['x', 'y'], scope=get_profile().name)
-
-        options = ['config', 'set', '--remove', option_name, 'x']
-        run_cli_command(cmd_verdi.verdi, options)
-        assert config.get_option(option_name, scope=get_profile().name) == ['y']
-
-    def test_config_get_option(self, run_cli_command):
-        """Test the `verdi config show` command when getting an option."""
-        option_name = 'daemon.timeout'
-        option_value = str(30)
-
+    for option_value in option_values:
         options = ['config', 'set', option_name, option_value]
-        result = run_cli_command(cmd_verdi.verdi, options)
+        run_cli_command(cmd_verdi.verdi, options)
+        assert str(config.get_option(option_name, scope=get_profile().name)) == option_value
 
-        options = ['config', 'get', option_name]
-        result = run_cli_command(cmd_verdi.verdi, options)
-        assert option_value in result.output.strip()
 
-    def test_config_unset_option(self, run_cli_command):
-        """Test the `verdi config` command when unsetting an option."""
-        option_name = 'daemon.timeout'
-        option_value = str(30)
+def test_config_append_option(run_cli_command, config_with_profile_factory):
+    """Test the `verdi config set --append` command when appending an option value."""
+    config = config_with_profile_factory()
+    option_name = 'caching.enabled_for'
+    for value in ['x', 'y']:
+        options = ['config', 'set', '--append', option_name, value]
+        run_cli_command(cmd_verdi.verdi, options)
+    assert config.get_option(option_name, scope=get_profile().name) == ['x', 'y']
 
-        options = ['config', 'set', option_name, str(option_value)]
-        result = run_cli_command(cmd_verdi.verdi, options)
 
-        options = ['config', 'get', option_name]
-        result = run_cli_command(cmd_verdi.verdi, options)
-        assert option_value in result.output.strip()
+def test_config_remove_option(run_cli_command, config_with_profile_factory):
+    """Test the `verdi config set --remove` command when removing an option value."""
+    config = config_with_profile_factory()
 
-        options = ['config', 'unset', option_name]
-        result = run_cli_command(cmd_verdi.verdi, options)
-        assert f"'{option_name}' unset" in result.output.strip()
+    option_name = 'caching.disabled_for'
+    config.set_option(option_name, ['x', 'y'], scope=get_profile().name)
 
-        options = ['config', 'get', option_name]
-        result = run_cli_command(cmd_verdi.verdi, options)
-        assert result.output.strip() == str(20)  # back to the default
+    options = ['config', 'set', '--remove', option_name, 'x']
+    run_cli_command(cmd_verdi.verdi, options)
+    assert config.get_option(option_name, scope=get_profile().name) == ['y']
 
-    def test_config_set_option_global_only(self, run_cli_command):
-        """Test that `global_only` options are only set globally even if the `--global` flag is not set."""
-        option_name = 'autofill.user.email'
-        option_value = 'some@email.com'
 
-        options = ['config', 'set', option_name, str(option_value)]
-        result = run_cli_command(cmd_verdi.verdi, options)
+def test_config_get_option(run_cli_command, config_with_profile_factory):
+    """Test the `verdi config show` command when getting an option."""
+    config_with_profile_factory()
+    option_name = 'daemon.timeout'
+    option_value = str(30)
 
-        options = ['config', 'get', option_name]
-        result = run_cli_command(cmd_verdi.verdi, options)
+    options = ['config', 'set', option_name, option_value]
+    result = run_cli_command(cmd_verdi.verdi, options)
 
-        # Check that the current profile name is not in the output
-        assert option_value in result.output.strip()
-        assert get_profile().name not in result.output.strip()
+    options = ['config', 'get', option_name]
+    result = run_cli_command(cmd_verdi.verdi, options)
+    assert option_value in result.output.strip()
 
-    def test_config_list(self, run_cli_command):
-        """Test `verdi config list`"""
-        options = ['config', 'list']
+
+def test_config_unset_option(run_cli_command, config_with_profile_factory):
+    """Test the `verdi config` command when unsetting an option."""
+    config_with_profile_factory()
+    option_name = 'daemon.timeout'
+    option_value = str(30)
+
+    options = ['config', 'set', option_name, str(option_value)]
+    result = run_cli_command(cmd_verdi.verdi, options)
+
+    options = ['config', 'get', option_name]
+    result = run_cli_command(cmd_verdi.verdi, options)
+    assert option_value in result.output.strip()
+
+    options = ['config', 'unset', option_name]
+    result = run_cli_command(cmd_verdi.verdi, options)
+    assert f"'{option_name}' unset" in result.output.strip()
+
+    options = ['config', 'get', option_name]
+    result = run_cli_command(cmd_verdi.verdi, options)
+    assert result.output.strip() == str(20)  # back to the default
+
+
+def test_config_set_option_global_only(run_cli_command, config_with_profile_factory):
+    """Test that `global_only` options are only set globally even if the `--global` flag is not set."""
+    config_with_profile_factory()
+    option_name = 'autofill.user.email'
+    option_value = 'some@email.com'
+
+    options = ['config', 'set', option_name, str(option_value)]
+    result = run_cli_command(cmd_verdi.verdi, options)
+
+    options = ['config', 'get', option_name]
+    result = run_cli_command(cmd_verdi.verdi, options)
+
+    # Check that the current profile name is not in the output
+    assert option_value in result.output.strip()
+    assert get_profile().name not in result.output.strip()
+
+
+def test_config_list(run_cli_command, config_with_profile_factory):
+    """Test `verdi config list`"""
+    config_with_profile_factory()
+    options = ['config', 'list']
+    result = run_cli_command(cmd_verdi.verdi, options)
+
+    assert 'daemon.timeout' in result.output
+    assert 'Timeout in seconds' not in result.output
+
+
+def test_config_list_description(run_cli_command, config_with_profile_factory):
+    """Test `verdi config list --description`"""
+    config_with_profile_factory()
+    for flag in ['-d', '--description']:
+        options = ['config', 'list', flag]
         result = run_cli_command(cmd_verdi.verdi, options)
 
         assert 'daemon.timeout' in result.output
-        assert 'Timeout in seconds' not in result.output
+        assert 'Timeout in seconds' in result.output
 
-    def test_config_list_description(self, run_cli_command):
-        """Test `verdi config list --description`"""
-        for flag in ['-d', '--description']:
-            options = ['config', 'list', flag]
-            result = run_cli_command(cmd_verdi.verdi, options)
 
-            assert 'daemon.timeout' in result.output
-            assert 'Timeout in seconds' in result.output
+def test_config_show(run_cli_command, config_with_profile_factory):
+    """Test `verdi config show`"""
+    config_with_profile_factory()
+    options = ['config', 'show', 'daemon.timeout']
+    result = run_cli_command(cmd_verdi.verdi, options)
+    assert 'schema' in result.output
 
-    def test_config_show(self, run_cli_command):
-        """Test `verdi config show`"""
-        options = ['config', 'show', 'daemon.timeout']
-        result = run_cli_command(cmd_verdi.verdi, options)
-        assert 'schema' in result.output
 
-    def test_config_caching(self, run_cli_command):
-        """Test `verdi config caching`"""
-        result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'])
-        assert result.output.strip() == ''
+def test_config_caching(run_cli_command, config_with_profile_factory):
+    """Test `verdi config caching`"""
+    config = config_with_profile_factory()
 
-        result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'])
-        assert 'core.arithmetic.add' in result.output.strip()
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'])
+    assert result.output.strip() == ''
 
-        config = get_config()
-        config.set_option('caching.default_enabled', True, scope=get_profile().name)
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'])
+    assert 'core.arithmetic.add' in result.output.strip()
 
-        result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'])
-        assert 'core.arithmetic.add' in result.output.strip()
+    config.set_option('caching.default_enabled', True, scope=get_profile().name)
 
-        result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'])
-        assert result.output.strip() == ''
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'])
+    assert 'core.arithmetic.add' in result.output.strip()
 
-    def test_config_downgrade(self, run_cli_command):
-        """Test `verdi config downgrade`"""
-        options = ['config', 'downgrade', '1']
-        result = run_cli_command(cmd_verdi.verdi, options)
-        assert 'Success: Downgraded' in result.output.strip()
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'])
+    assert result.output.strip() == ''
+
+
+def test_config_downgrade(run_cli_command, config_with_profile_factory):
+    """Test `verdi config downgrade`"""
+    config_with_profile_factory()
+    options = ['config', 'downgrade', '1']
+    result = run_cli_command(cmd_verdi.verdi, options)
+    assert 'Success: Downgraded' in result.output.strip()

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -376,6 +376,16 @@ def test_set_option_override(config_with_profile):
     assert config.get_option(option_name, scope=None, default=False) == option_value_two
 
 
+def test_option_empty_config(empty_config):
+    """Test setting an option on a config without any profiles."""
+    config = empty_config
+    option_name = 'autofill.user.email'
+    option_value = 'first@email.com'
+
+    config.set_option(option_name, option_value)
+    assert config.get_option(option_name, scope=None, default=False) == option_value
+
+
 def test_store(config_with_profile):
     """Test that the store method writes the configuration properly to disk."""
     config = config_with_profile


### PR DESCRIPTION
Fixes #5543 

The `verdi config set` command would except if the config had no
configured profiles. The reason is that the command would attempt to
retrieve the `Config` instance from the `ctx.obj` object. The problem is
however that this is created and set on the context in the `convert`
method of the `ProfileParamType`, which is used for the `--profile`
option.

The option specifies a default, which is the default profile, but if
that is not defined, it doesn't provide anything and so the `convert`
method is never called, resulting in the `ctx.obj` never being
initialized and the `config` not being set.

Since the config should always be present for all `verdi` comments, we
should ensure that it is always loaded and set on `ctx.obj`. Therefore
it is removed from `ProfileParamType.convert` and added to the
constructor of a custom implementation of the `click.Context` class,
called `VerdiContext`. The `VerdiCommandGroup` is updated to set the
`context_class` attribute to this `VerdiContext` which will ensure that
all commands will be invoked using a context that has the user defined
object constructure with the config loaded and added to it. Since all
commands in `verdi` will implement this class, this should guarantee
that the config will always be initialized.