### PR TITLE
CLI: normalize use of colors

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -478,7 +478,7 @@ def computer_test(user, print_traceback, computer):
         with transport:
             num_tests += 1
 
-            echo.echo('[OK]', fg='green')
+            echo.echo('[OK]', fg=echo.COLORS['success'])
 
             scheduler.set_transport(transport)
 
@@ -501,16 +501,16 @@ def computer_test(user, print_traceback, computer):
                 if not success:
                     num_failures += 1
                     if message:
-                        echo.echo('[Failed]: ', fg='red', nl=False)
+                        echo.echo('[Failed]: ', fg=echo.COLORS['error'], nl=False)
                         echo.echo(message)
                     else:
-                        echo.echo('[Failed]', fg='red')
+                        echo.echo('[Failed]', fg=echo.COLORS['error'])
                 else:
                     if message:
-                        echo.echo('[OK]: ', fg='green', nl=False)
+                        echo.echo('[OK]: ', fg=echo.COLORS['success'], nl=False)
                         echo.echo(message)
                     else:
-                        echo.echo('[OK]', fg='green')
+                        echo.echo('[OK]', fg=echo.COLORS['success'])
 
         if num_failures:
             echo.echo_warning(f'{num_failures} out of {num_tests} tests failed')
@@ -518,7 +518,7 @@ def computer_test(user, print_traceback, computer):
             echo.echo_success(f'all {num_tests} tests succeeded')
 
     except Exception:  # pylint:disable=broad-except
-        echo.echo('[FAILED]: ', fg='red', nl=False)
+        echo.echo('[FAILED]: ', fg=echo.COLORS['error'], nl=False)
         message = 'Error while trying to connect to the computer'
 
         if print_traceback:

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -76,7 +76,7 @@ def start(foreground, number):
         currenv = get_env_with_venv_bin()
         subprocess.check_output(command, env=currenv, stderr=subprocess.STDOUT)  # pylint: disable=unexpected-keyword-arg
     except subprocess.CalledProcessError as exception:
-        echo.echo('FAILED', fg='red', bold=True)
+        echo.echo('FAILED', fg=echo.COLORS['error'], bold=True)
         echo.echo_critical(str(exception))
 
     # We add a small timeout to give the pid-file a chance to be created
@@ -110,7 +110,7 @@ def status(all_profiles):
     for profile in profiles:
         client = get_daemon_client(profile.name)
         delete_stale_pid_file(client)
-        echo.echo('Profile: ', fg='red', bold=True, nl=False)
+        echo.echo('Profile: ', fg=echo.COLORS['report'], bold=True, nl=False)
         echo.echo(f'{profile.name}', bold=True)
         result = get_daemon_status(client)
         echo.echo(result)
@@ -188,7 +188,7 @@ def stop(no_wait, all_profiles):
 
         client = get_daemon_client(profile.name)
 
-        echo.echo('Profile: ', fg='red', bold=True, nl=False)
+        echo.echo('Profile: ', fg=echo.COLORS['report'], bold=True, nl=False)
         echo.echo(f'{profile.name}', bold=True)
 
         if not client.is_daemon_running:

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -50,7 +50,7 @@ def remote_ls(ls_long, path, datum):
             )
             echo.echo(pre_line, nl=False)
         if metadata['isdir']:
-            echo.echo(metadata['name'], fg='blue')
+            echo.echo(metadata['name'], fg=echo.COLORS['info'])
         else:
             echo.echo(metadata['name'])
 

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -48,7 +48,7 @@ class InteractiveOption(ConditionalOption):
             click.echo(f'Labeling with label: {label}')
     """
 
-    PROMPT_COLOR = 'yellow'
+    PROMPT_COLOR = echo.COLORS['warning']
     CHARACTER_PROMPT_HELP = '?'
     CHARACTER_IGNORE_DEFAULT = '!'
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -407,7 +407,7 @@ def print_process_info(process):
     if not docstring:
         docstring = ['No description available']
 
-    echo.echo('Description:\n', fg='red', bold=True)
+    echo.echo('Description:\n', fg=echo.COLORS['report'], bold=True)
     for line in docstring:
         echo.echo(f'    {line.lstrip()}')
     echo.echo('')
@@ -450,7 +450,7 @@ def print_process_spec(process_spec):
     max_width_type = max([len(entry[2]) for entry in inputs + outputs]) + 2
 
     if process_spec.inputs:
-        echo.echo('Inputs:', fg='red', bold=True)
+        echo.echo('Inputs:', fg=echo.COLORS['report'], bold=True)
     for entry in inputs:
         if entry[1] == 'required':
             echo.echo(template.format(*entry, width_name=max_width_name, width_type=max_width_type), bold=True)
@@ -458,7 +458,7 @@ def print_process_spec(process_spec):
             echo.echo(template.format(*entry, width_name=max_width_name, width_type=max_width_type))
 
     if process_spec.outputs:
-        echo.echo('Outputs:', fg='red', bold=True)
+        echo.echo('Outputs:', fg=echo.COLORS['report'], bold=True)
     for entry in outputs:
         if entry[1] == 'required':
             echo.echo(template.format(*entry, width_name=max_width_name, width_type=max_width_type), bold=True)
@@ -466,7 +466,7 @@ def print_process_spec(process_spec):
             echo.echo(template.format(*entry, width_name=max_width_name, width_type=max_width_type))
 
     if process_spec.exit_codes:
-        echo.echo('Exit codes:', fg='red', bold=True)
+        echo.echo('Exit codes:', fg=echo.COLORS['report'], bold=True)
     for exit_code in sorted(process_spec.exit_codes.values(), key=lambda exit_code: exit_code.status):
         message = exit_code.message
         echo.echo('{:>{width_name}d}:  {}'.format(exit_code.status, message, width_name=max_width_name))

--- a/aiida/cmdline/utils/daemon.py
+++ b/aiida/cmdline/utils/daemon.py
@@ -28,17 +28,17 @@ def print_client_response_status(response):
         return 1
 
     if response['status'] == 'active':
-        echo.echo('RUNNING', fg='green', bold=True)
+        echo.echo('RUNNING', fg=echo.COLORS['success'], bold=True)
         return 0
     if response['status'] == 'ok':
-        echo.echo('OK', fg='green', bold=True)
+        echo.echo('OK', fg=echo.COLORS['success'], bold=True)
         return 0
     if response['status'] == DaemonClient.DAEMON_ERROR_NOT_RUNNING:
-        echo.echo('FAILED', fg='red', bold=True)
+        echo.echo('FAILED', fg=echo.COLORS['error'], bold=True)
         echo.echo('Try to run `verdi daemon start-circus --foreground` to potentially see the exception')
         return 2
     if response['status'] == DaemonClient.DAEMON_ERROR_TIMEOUT:
-        echo.echo('TIMEOUT', fg='red', bold=True)
+        echo.echo('TIMEOUT', fg=echo.COLORS['error'], bold=True)
         return 3
     # Unknown status, I will consider it as failed
     echo.echo_critical(response['status'])

--- a/aiida/cmdline/utils/repository.py
+++ b/aiida/cmdline/utils/repository.py
@@ -22,4 +22,8 @@ def list_repository_contents(node, path, color):
 
     for entry in node.base.repository.list_objects(path):
         bold = bool(entry.file_type == FileType.DIRECTORY)
-        echo.echo(entry.name, bold=bold, fg='blue' if color and entry.file_type == FileType.DIRECTORY else None)
+        echo.echo(
+            entry.name,
+            bold=bold,
+            fg=echo.COLORS['report'] if color and entry.file_type == FileType.DIRECTORY else None
+        )


### PR DESCRIPTION
Fixes #5542 

Certain CLI commands used coloring in the output that was inconsistent
with what users might expect based on other parts of the CLI and basic
intuition. For example, red was sometimes used to highlight a purely
informative piece of data or a header, but red is typically associated
with errors.

To normalize the use of colors, all uses of it use the `COLORS` mapping
from the `aiida.cmdline.utils.echo` module and instead of naming the
literal color, it designates the intended meaning.