### PR TITLE
`DynamicEntryPointCommandGroup`: make actual command dynamic

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -27,7 +27,28 @@ def verdi_code():
     """Setup and manage codes."""
 
 
-@verdi_code.group('create', cls=DynamicEntryPointCommandGroup, entry_point_name_filter=r'core\.code\..*')
+def create_code(cls, non_interactive, **kwargs):  # pylint: disable=unused-argument
+    """Create a new `Code` instance."""
+    try:
+        instance = cls(**kwargs)
+    except (TypeError, ValueError) as exception:
+        echo.echo_critical(f'Failed to create instance `{cls}`: {exception}')
+
+    try:
+        instance.store()
+    except exceptions.ValidationError as exception:
+        echo.echo_critical(f'Failed to store instance of `{cls}`: {exception}')
+
+    echo.echo_success(f'Created {cls.__name__}<{instance.pk}>')
+
+
+@verdi_code.group(
+    'create',
+    cls=DynamicEntryPointCommandGroup,
+    command=create_code,
+    entry_point_group='aiida.data',
+    entry_point_name_filter=r'core\.code\..*'
+)
 def code_create():
     """Create a new code."""
 

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -22,7 +22,7 @@ import pytest
 from aiida.cmdline.commands import cmd_code
 from aiida.cmdline.params.options.commands.code import validate_label_uniqueness
 from aiida.common.exceptions import MultipleObjectsError, NotExistent
-from aiida.orm import Computer, InstalledCode, PortableCode, load_code
+from aiida.orm import Code, Computer, InstalledCode, PortableCode, QueryBuilder, load_code
 from aiida.plugins import DataFactory
 
 
@@ -414,7 +414,7 @@ def command_options(request, aiida_localhost, tmp_path):
     options = [request.param, '-n', '--label', str(uuid.uuid4())]
 
     if request.param == 'core.code.installed':
-        options.extend(['--computer', aiida_localhost.pk, '--filepath-executable', '/usr/bin/bash'])
+        options.extend(['--computer', str(aiida_localhost.pk), '--filepath-executable', '/usr/bin/bash'])
 
     if request.param == 'core.code.portable':
         filepath_executable = 'bash'
@@ -424,11 +424,14 @@ def command_options(request, aiida_localhost, tmp_path):
     return options, request.param
 
 
-@pytest.mark.usefixtures('aiida_profile')
+@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('command_options', ('core.code.installed', 'core.code.portable'), indirect=True)
-def test_code_create(run_cli_command, command_options):
+@pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
+def test_code_create(run_cli_command, command_options, non_interactive_editor):
     """Test the ``verdi code create`` command."""
     options, entry_point = command_options
     cls = DataFactory(entry_point)
     result = run_cli_command(cmd_code.code_create, options)
     assert f'Success: Created {cls.__name__}' in result.output
+    code = QueryBuilder().append(Code).one()[0]
+    assert code.entry_point.name == entry_point


### PR DESCRIPTION
The `DynamicEntryPointCommandGroup` was recently added to automatically
generate CLI commands for various entry groups in an entry point group.
The options of the generated commands would be dynamically created based
on the class registered with the entry points, however, the actual
command that would be executed was statically defined.

The command simply would create an instance of the class registered at
the entry point, but this might not always be the necessary action. To
make this configurable, the actual command can now be specified when
creating the command group. The only restriction is that it should
accept the loaded entry point as the first argument and kwargs in order
to accept the parsed command line parameters.