### PR TITLE
ORM: raise when trying to pickle instance of `Entity`

### DIFF
--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Generic, List, Optional, Type, TypeVar, c
 
 from plumpy.base.utils import call_with_super_check, super_check
 
+from aiida.common.exceptions import InvalidOperation
 from aiida.common.lang import classproperty, type_check
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
@@ -216,6 +217,10 @@ class Entity(abc.ABC, Generic[BackendEntityType]):
         """
         self._backend_entity = backend_entity
         call_with_super_check(self.initialize)
+
+    def __getstate__(self):
+        """Prevent an ORM entity instance from being pickled."""
+        raise InvalidOperation('pickling of AiiDA ORM instances is not supported.')
 
     @super_check
     def initialize(self) -> None:

--- a/tests/orm/test_entities.py
+++ b/tests/orm/test_entities.py
@@ -9,9 +9,12 @@
 ###########################################################################
 # pylint: disable=no-self-use
 """Test for general backend entities"""
+import pickle
+
 import pytest
 
 from aiida import orm
+from aiida.common.exceptions import InvalidOperation
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
@@ -37,3 +40,8 @@ class TestBackendEntitiesAndCollections:
             number_of_users, \
             '{} User(s) was/were found using Collections\' count() method, ' \
             'but {} User(s) was/were found using QueryBuilder directly'.format(user_collection_count, number_of_users)
+
+    def test_pickle(self):
+        """Pickling is not supported and should raise."""
+        with pytest.raises(InvalidOperation):
+            pickle.dumps(orm.Entity({}))


### PR DESCRIPTION
Fixes #5285 

The ORM entities should not be pickled since it is not clear whether the
connection to the storage backend should be included as well and if it
were, implementing that in a consistent way across implementations is
not feasible.

Therefore, we now raise an explicit an `InvalidOperation` when an
instance of `Entity` is being pickled. This is achieved by overriding
the `__getstate__` dunder method which will be called by the `pickle`
module when dumping a class instance.