### PR TITLE
📚 DOCS: correct snippet for workchain context nested keys

### DIFF
--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_parallel_nested.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_parallel_nested.py
@@ -15,9 +15,9 @@ class SomeWorkChain(WorkChain):
     def submit_workchains(self):
         for i in range(3):
             future = self.submit(SomeWorkChain)
-            key = f'workchain.sub{i}'
+            key = f'workchains.sub{i}'
             self.to_context(**{key: future})
 
     def inspect_workchains(self):
-        for i in range(3):
-            assert self.ctx.workchain[f'sub{i}'].is_finished_ok
+        for key, workchain in self.ctx.workchains.items():
+            assert workchain.is_finished_ok

--- a/docs/source/topics/workflows/usage.rst
+++ b/docs/source/topics/workflows/usage.rst
@@ -423,7 +423,7 @@ Nested context keys
 To simplify the organization of the context, the keys may contain dots ``.``, transparently creating namespaces in the process.
 As an example compare the following to the parallel submission example above:
 
-.. include:: include/snippets/workchains/run_workchain_submit_append.py
+.. include:: include/snippets/workchains/run_workchain_submit_parallel_nested.py
     :code: python
 
 This allows to create intuitively grouped and easily accessible structures of child calculations or workchains.


### PR DESCRIPTION
Fixes #5522 

The link to the snippet was incorrect and was pointing to the snippet of
the preceding section.