### PR TITLE
`QueryBuilder`: fix projection bug in `Group` joins on `Node`

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -68,10 +68,10 @@ def upf_listfamilies(elements, with_description):
 
     UpfData = DataFactory('core.upf')  # pylint: disable=invalid-name
     query = orm.QueryBuilder()
-    query.append(UpfData, tag='upfdata')
+    query.append(orm.UpfFamily, tag='group', project=['label', 'description'])
+    query.append(UpfData, with_group='group')
     if elements is not None:
         query.add_filter(UpfData, {'attributes.element': {'in': elements}})
-    query.append(orm.UpfFamily, with_node='upfdata', tag='group', project=['label', 'description'])
 
     query.distinct()
     if query.count() > 0:


### PR DESCRIPTION
Fixes #5535 

When appending the `Node` first and the `Group` second when joining the
two, the querybuilder will return a row for each node in the group as
opposed to a single row for each unique group. This incorrect behavior
disappears when appending the `Group` before the `Node`.