### PR TITLE
feat: `verdi process status --max-depth`

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -154,13 +154,16 @@ def process_report(processes, levelname, indent_size, max_depth):
 
 
 @verdi_process.command('status')
+@click.option(
+    '-m', '--max-depth', 'max_depth', type=int, default=None, help='Limit the number of levels to be printed.'
+)
 @arguments.PROCESSES()
-def process_status(processes):
+def process_status(max_depth, processes):
     """Print the status of one or multiple processes."""
     from aiida.cmdline.utils.ascii_vis import format_call_graph
 
     for process in processes:
-        graph = format_call_graph(process)
+        graph = format_call_graph(process, max_depth=max_depth)
         echo.echo(graph)
 
 

--- a/aiida/cmdline/utils/ascii_vis.py
+++ b/aiida/cmdline/utils/ascii_vis.py
@@ -296,20 +296,23 @@ def build_call_graph(calc_node, max_depth: int = None, info_fn=calc_info) -> str
     """Build the call graph of a given node.
 
     :param calc_node: The calculation node
-    :param max_depth: Maximum depth of the call graph to build. Use `None` or -1 for unlimited.
+    :param max_depth: Maximum depth of the call graph to build. Use `None` for unlimited.
     :param info_fn: An optional function that takes the node and returns a string
         of information to be displayed for each node.
     """
-    if max_depth is None:
-        max_depth = -1
-    if max_depth == 0:
-        return ''
+    if max_depth is not None:
+        if max_depth < 0:
+            raise ValueError('max_depth must be >= 0')
+        if max_depth == 0:
+            return ''
 
     info_string = info_fn(calc_node)
     called = calc_node.called
     called.sort(key=lambda x: x.ctime)
     if called and max_depth != 1:
-        return info_string, [build_call_graph(child, max_depth=max_depth - 1, info_fn=info_fn) for child in called]
+        if max_depth is not None:
+            max_depth -= 1
+        return info_string, [build_call_graph(child, max_depth=max_depth, info_fn=info_fn) for child in called]
 
     return info_string
 

--- a/aiida/cmdline/utils/ascii_vis.py
+++ b/aiida/cmdline/utils/ascii_vis.py
@@ -257,7 +257,7 @@ def _generate_node_label(node, node_attr, show_pk):
     return label
 
 
-def calc_info(node):
+def calc_info(node) -> str:
     """Return a string with the summary of the state of a CalculationNode."""
     from aiida.orm import ProcessNode, WorkChainNode
 
@@ -279,25 +279,37 @@ def calc_info(node):
     return string
 
 
-def format_call_graph(calc_node, info_fn=calc_info):
+def format_call_graph(calc_node, max_depth: int = None, info_fn=calc_info):
     """
     Print a tree like the POSIX tree command for the calculation call graph
 
     :param calc_node: The calculation node
+    :param max_depth: Maximum depth of the call graph to print
     :param info_fn: An optional function that takes the node and returns a string
         of information to be displayed for each node.
     """
-    call_tree = build_call_graph(calc_node, info_fn=info_fn)
+    call_tree = build_call_graph(calc_node, max_depth=max_depth, info_fn=info_fn)
     return format_tree_descending(call_tree)
 
 
-def build_call_graph(calc_node, info_fn=calc_info):
-    """Build the call graph of a given node."""
+def build_call_graph(calc_node, max_depth: int = None, info_fn=calc_info) -> str:
+    """Build the call graph of a given node.
+
+    :param calc_node: The calculation node
+    :param max_depth: Maximum depth of the call graph to build. Use `None` or -1 for unlimited.
+    :param info_fn: An optional function that takes the node and returns a string
+        of information to be displayed for each node.
+    """
+    if max_depth is None:
+        max_depth = -1
+    if max_depth == 0:
+        return ''
+
     info_string = info_fn(calc_node)
     called = calc_node.called
     called.sort(key=lambda x: x.ctime)
-    if called:
-        return info_string, [build_call_graph(child, info_fn) for child in called]
+    if called and max_depth != 1:
+        return info_string, [build_call_graph(child, max_depth=max_depth - 1, info_fn=info_fn) for child in called]
 
     return info_string
 

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -254,7 +254,7 @@ class TestVerdiProcess(AiidaTestCase):
         self.assertEqual(len(get_result_lines(result)), 0)
 
         # Giving a single identifier should print a non empty string message
-        options = ['--max-depth', 2, str(node.pk)]
+        options = [str(node.pk)]
         result = self.cli_runner.invoke(cmd_process.process_status, options)
         self.assertIsNone(result.exception, result.output)
         self.assertTrue(len(get_result_lines(result)) > 0)

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -259,6 +259,12 @@ class TestVerdiProcess(AiidaTestCase):
         self.assertIsNone(result.exception, result.output)
         self.assertTrue(len(get_result_lines(result)) > 0)
 
+        # With max depth 0, the output should be empty
+        options = ['--max-depth', 0, str(node.pk)]
+        result = self.cli_runner.invoke(cmd_process.process_status, options)
+        self.assertIsNone(result.exception, result.output)
+        self.assertTrue(len(get_result_lines(result)) == 0)
+
     def test_report(self):
         """Test the report command."""
         grandparent = WorkChainNode().store()


### PR DESCRIPTION
AiiDA workflows can get very complex with many layers, leading `verdi
process status` to print hundreds of lines of text.

The `--max-depth` allows the user to "zoom out" and look at the bigger
picture, while still being able to "zoom in" on subworkflows of interest
by calling `verdi process status` on those.

Example
```
$ verdi process status --max-depth 2 17460
VerificationWorkChain<17460> Waiting [4:if_(is_verify_convergence)(1:run_convergence)]
    ├── parse_pseudo_info<17461> Finished [0]
    ├── DeltaMeasureWorkChain<17464> Finished [0] [6:finalize]
    ├── _CachingConvergenceWorkChain<18301> Finished [0] [10:finalize]
    └── ConvergenceCohesiveEnergyWorkChain<18577> Waiting [6:run_reference]
```

Fixes #5557 