### PR TITLE
🐛 FIX: Archive creation after packing repository

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - python~=3.8
 - alembic~=1.2
-- archive-path~=0.4.0
+- archive-path~=0.4.1
 - aio-pika~=6.6
 - circus~=0.17.1
 - click-config-file~=0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["aiida", "workflows"]
 requires-python = ">=3.8"
 dependencies = [
         "alembic~=1.2",
-        "archive-path~=0.4.0",
+        "archive-path~=0.4.1",
         "aio-pika~=6.6",
         "circus~=0.17.1",
         "click-config-file~=0.6.0",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -4,7 +4,7 @@ aiormq==3.3.1
 alabaster==0.7.12
 alembic==1.7.5
 aniso8601==9.0.1
-archive-path==0.4.0
+archive-path==0.4.1
 argon2-cffi==21.1.0
 ase==3.22.0
 asn1crypto==1.4.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -4,7 +4,7 @@ aiormq==3.3.1
 alabaster==0.7.12
 alembic==1.7.5
 aniso8601==9.0.1
-archive-path==0.4.0
+archive-path==0.4.1
 argon2-cffi==21.1.0
 ase==3.22.0
 asn1crypto==1.4.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -4,7 +4,7 @@ aiormq==3.3.1
 alabaster==0.7.12
 alembic==1.7.5
 aniso8601==9.0.1
-archive-path==0.4.0
+archive-path==0.4.1
 argon2-cffi==21.1.0
 ase==3.22.0
 asn1crypto==1.4.0

--- a/tests/tools/archive/test_repository.py
+++ b/tests/tools/archive/test_repository.py
@@ -13,6 +13,7 @@ import os
 import pytest
 
 from aiida import orm
+from aiida.manage import get_manager
 from aiida.tools.archive import create_archive, import_archive
 
 
@@ -34,5 +35,31 @@ def test_export_repository(aiida_profile, tmp_path):
 
     loaded = orm.load_node(uuid=node_uuid)
     assert loaded.base.repository.metadata == repository_metadata
+    assert loaded.base.repository.get_object_content('file_a', mode='rb') == b'file_a'
+    assert loaded.base.repository.get_object_content('relative/file_b', mode='rb') == b'file_b'
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_export_repository_after_maintain(aiida_profile, tmp_path):
+    """Test exporting a node with files in the repository after maintenance.
+
+    Maintenance for the disk-objectstore repository will pack the files into binary files.
+    """
+    node = orm.Data()
+    node.base.repository.put_object_from_bytes(b'file_a', 'file_a')
+    node.base.repository.put_object_from_bytes(b'file_b', 'relative/file_b')
+    node.store()
+    node_uuid = node.uuid
+
+    repository = get_manager().get_profile_storage().get_repository()
+    repository.maintain(live=False)
+
+    filepath = os.path.join(tmp_path / 'export.aiida')
+    create_archive([node], filename=filepath)
+
+    aiida_profile.clear_profile()
+    import_archive(filepath)
+
+    loaded = orm.load_node(uuid=node_uuid)
     assert loaded.base.repository.get_object_content('file_a', mode='rb') == b'file_a'
     assert loaded.base.repository.get_object_content('relative/file_b', mode='rb') == b'file_b'


### PR DESCRIPTION
fixes #5564

`disk_objectstore.PackedObjectReader` does not implement the ability to `SEEK_END`,
required to determine the size of a stream.
The size of the stream is required to determine if the ZIP64 extension should be used,
so in this case, we now defer to `force_zip64=True`.
