### PR TITLE
docs: resubmit a `Process` from a `ProcessNode`

### DIFF
--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -400,6 +400,19 @@ After :ref:`setting up your computer <how-to:run-codes:computer>` and :ref:`sett
 
 After this, use ``verdi process list`` to monitor the status of the calculations.
 
+.. tip::
+
+    If you ever need to resubmit a previous calculation with modified inputs,
+    you can get a pre-populated copy of its process builder with
+
+    .. code-block:: python
+
+        builder = load_node(<IDENTIFIER>).get_builder_restart()
+        # now start modifying the builder
+
+    where ``<IDENTIFIER>`` is the ``PK`` or ``UUID`` (or label) of your *calculation*.
+
+
 See :ref:`topics:processes:usage:launching` and :ref:`topics:processes:usage:monitoring` for more details.
 
 


### PR DESCRIPTION
This is a common use case: you have run some processes, some of them
failed (perhaps for reasons outside AiiDA's control).  Now you want to
resubmit some of these processes - but you may no longer have the python
script you used to submit them, or that script may do many other things
that you don't want to happen.

This is also an important component of making it easier to reproduce
calculations by others, starting from an AiiDA archive file.

`ProcessNode`s have a `ProcessNode.get_builder_restart()` for exactly
this purpose but, except for the API docs, it seems this feature was
entirely undocumented.