### PR TITLE
fix: `is_valid_cache` setter for `ProcessNode`s

### DIFF
--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -65,7 +65,7 @@ class ProcessNodeCaching(NodeCaching):
 
         :param valid: whether the node is valid or invalid for use in caching.
         """
-        super().is_valid_cache = valid  # type: ignore[misc]
+        super(ProcessNodeCaching, self.__class__).is_valid_cache.fset(self, valid)
 
     def _get_objects_to_hash(self) -> List[Any]:
         """

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -974,6 +974,10 @@ class TestNodeCaching:
         with pytest.raises(TypeError):
             node.base.caching.is_valid_cache = 'false'
 
+        # prevent regression of issue #5582
+        calc = CalculationNode()
+        calc.base.caching.is_valid_cache = False
+
     def test_store_from_cache(self):
         """Regression test for storing a Node with (nested) repository content with caching."""
         data = Data()


### PR DESCRIPTION
7cea5bebd15737cb7ae0f4f38dc4f8ca61935ae8 introduced an `is_valid_cache`
setter that, in theory, can be used to invalidate specific process
node instances as far as the cache is concerned:

```
n=load_node(<PK>)
n.base.caching.is_valid_cache = False
```

Unfortunately, the setter did not actually work on any `ProcessNode`
because in Python `super()` cannot be used to access setters directly
(see e.g. https://stackoverflow.com/a/10810545/1069467).

fixes #5582