### PR TITLE
DevOps: Add a notification for nightly workflow on fail

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,7 @@ jobs:
             run: sudo apt update && sudo apt install postgresql
 
         -   name: Install aiida-core
+            id: install
             run: |
                 pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
                 pip install --no-deps -e .
@@ -71,4 +72,16 @@ jobs:
             run: .github/workflows/setup.sh
 
         -   name: Run tests
+            id: tests
             run: .github/workflows/tests_nightly.sh
+
+        -   name: Slack notification
+            if: always() && (steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure')
+            uses: rtCamp/action-slack-notify@v2
+            env:
+                SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+                SLACK_ICON: https://www.materialscloud.org/discover/images/0ba0a17d.aiida-logo-128.png
+                SLACK_CHANNEL: dev-aiida-core
+                SLACK_COLOR: b60205
+                SLACK_TITLE: "Nightly build of `aiida-core/main` failed"
+                SLACK_MESSAGE: "The tests of the `nightly.yml` GHA worklow failed."

--- a/.github/workflows/tests_nightly.sh
+++ b/.github/workflows/tests_nightly.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ev
 
+exit 2
+
 # Make sure the folder containing the workchains is in the python path before the daemon is started
 SYSTEM_TESTS="${GITHUB_WORKSPACE}/.github/system_tests"
 MODULE_POLISH="${GITHUB_WORKSPACE}/.molecule/default/files/polish"


### PR DESCRIPTION
When the `nightly.yml` workflow fails it will now send a notification to
the `dev-aiida-core` channel on the AiiDA Slack.