### PR TITLE
DevOps: Add a notification for nightly workflow on fail

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,7 @@ jobs:
             run: sudo apt update && sudo apt install postgresql
 
         -   name: Install aiida-core
+            id: install
             run: |
                 pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
                 pip install --no-deps -e .
@@ -71,4 +72,16 @@ jobs:
             run: .github/workflows/setup.sh
 
         -   name: Run tests
+            id: tests
             run: .github/workflows/tests_nightly.sh
+
+        -   name: Slack notification
+            if: always() && (steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure')
+            uses: rtCamp/action-slack-notify@v2
+            env:
+                SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+                SLACK_ICON: https://www.materialscloud.org/discover/images/0ba0a17d.aiida-logo-128.png
+                SLACK_CHANNEL: dev-aiida-core
+                SLACK_COLOR: b60205
+                SLACK_TITLE: "Nightly build of `aiida-core/main` failed"
+                SLACK_MESSAGE: "The tests of the `nightly.yml` GHA worklow failed."


### PR DESCRIPTION
When the `nightly.yml` workflow fails it will now send a notification to
the `dev-aiida-core` channel on the AiiDA Slack.

The specific logic in the conditional is on purpose:

    always() && (steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure')

The reason is that without the `always()`, the step will never run if
any of the previous steps fail, defeating the purpose. However, this
is not enough, because with just `always()` the final status of the
workflow will be that of the notification step and so will always be
successful. This is confusing since a failed build will be marked as
successful.

By adding the clause after `&&` the build will still be marked as failed
even if the final notification step runs fine.