### PR TITLE
Dependencies: set upper limit `werkzeug<2.2`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,4 +33,5 @@ dependencies:
 - tabulate~=0.8.5
 - tqdm~=4.45
 - upf_to_json~=0.9.2
+- werkzeug<2.2
 - wrapt~=1.11.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
         "tabulate~=0.8.5",
         "tqdm~=4.45",
         "upf_to_json~=0.9.2",
+        "werkzeug<2.2",
         "wrapt~=1.11.1"
 ]
 


### PR DESCRIPTION
The `werkzeug==2.2` release is breaking the REST API causing most of the
routes to return a 404 error.