### PR TITLE
Bump base docker image to 0.6.0

### DIFF
--- a/.github/workflows/push_image_to_dockerhub.yml
+++ b/.github/workflows/push_image_to_dockerhub.yml
@@ -51,4 +51,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.4.0
+FROM aiidateam/aiida-prerequisites:0.6.0
 
 USER root
 


### PR DESCRIPTION
The new image is based on Ubuntu 22.04. It comes with PostgreSQL 10 and
RabbitMQ 3.8.14 to facilitate the migration to AiiDA 2.0. The image
supports amd64 and arm64 architectures.