### PR TITLE
Release `v1.6.9`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.6.9 - 2022-08-02
+
+[full changelog](https://github.com/aiidateam/aiida-core/compare/v1.6.8...v1.6.9)
+
+### Improvements
+
+- `--max-depth` argument to `verdi process status`
+- Update the Docker image `aiidateam/aiida-prerequisites` base image to version `0.6.0`
+
+
 ## v1.6.8 - 2022-03-25
 
 [full changelog](https://github.com/aiidateam/aiida-core/compare/v1.6.7...v1.6.8)

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -31,7 +31,7 @@ __copyright__ = (
     'For further information please visit http://www.aiida.net/. All rights reserved.'
 )
 __license__ = 'MIT license, see LICENSE.txt file.'
-__version__ = '1.6.8'
+__version__ = '1.6.9'
 __authors__ = 'The AiiDA team.'
 __paper__ = (
     'S. P. Huber et al., "AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and '

--- a/setup.json
+++ b/setup.json
@@ -1,6 +1,6 @@
 {
     "name": "aiida-core",
-    "version": "1.6.8",
+    "version": "1.6.9",
     "url": "http://www.aiida.net/",
     "license": "MIT License",
     "author": "The AiiDA team",


### PR DESCRIPTION
Promised to make a new release, but I can't push directly to the `support/1.6.x` branch. Made this PR instead.