### PR TITLE
Bump base docker image to 0.6.0.

### DIFF
--- a/.github/workflows/push_image_to_dockerhub.yml
+++ b/.github/workflows/push_image_to_dockerhub.yml
@@ -50,4 +50,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.4.0
+FROM aiidateam/aiida-prerequisites:0.6.0
 
 USER root
 


### PR DESCRIPTION
This is a cherry-pick of (#5609)

The new image is built on top of Ubuntu 22.04. It comes with PostgreSQL 10 and
RabbitMQ 3.8.14 to facilitate the migration to AiiDA 2.0. It supports the `amd64`
and `arm64` architectures.