### PR TITLE
add file retrieval lists to job template

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -844,4 +844,9 @@ class CalcJob(Process):
                     'is absolute! ({})'.format(this_pk, dest_rel_path)
                 )
 
+        job_tmpl.retrieve_list = retrieve_list
+        job_tmpl.retrieve_temporary_list = retrieve_temporary_list
+        job_tmpl.local_copy_list = local_copy_list
+        job_tmpl.remote_copy_list = remote_copy_list
+
         return calc_info

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -359,6 +359,10 @@ class JobTemplate(DefaultFieldsAttributeDict):  # pylint: disable=too-many-insta
         'import_sys_environment',
         'codes_run_mode',
         'codes_info',
+        'retrieve_list',
+        'retrieve_temporary_list',
+        'local_copy_list',
+        'remote_copy_list',
     )
 
 


### PR DESCRIPTION
In some scenarios, retrieving files after job completion may need to be handled by pushing them back via the compute job rather than by AiiDA trying to fetch them.

By adding the various retrieval/copy lists to the JobTemplate, this is made possible.