### PR TITLE
Refactor: remove unnecessary use of `tempfile.mkdtemp`

### DIFF
--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -325,7 +325,7 @@ class TemporaryProfileManager(ProfileManager):
             self.create_aiida_db()
 
         if not self.root_dir:
-            self.root_dir = tempfile.mkdtemp()
+            self.root_dir = tempfile.TemporaryDirectory().name  # pylint: disable=consider-using-with
         configuration.CONFIG = None
 
         os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = self.config_dir

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -122,6 +122,7 @@ def temp_dir():
     :rtype: str
 
     """
+    warn_deprecation('This fixture is deprecated, use the `tmp_path` fixture of `pytest` instead.', version=3)
     try:
         dirpath = tempfile.mkdtemp()
         yield dirpath
@@ -131,7 +132,7 @@ def temp_dir():
 
 
 @pytest.fixture(scope='function')
-def aiida_localhost(temp_dir):
+def aiida_localhost(tmp_path):
     """Get an AiiDA computer for localhost.
 
     Usage::
@@ -156,7 +157,7 @@ def aiida_localhost(temp_dir):
             label=label,
             description='localhost computer set up by test manager',
             hostname=label,
-            workdir=temp_dir,
+            workdir=str(tmp_path),
             transport_type='core.local',
             scheduler_type='core.direct'
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,6 @@ max-line-length = 120
 [tool.pylint.messages_control]
 disable = [
     "bad-continuation",
-    "bad-option-value",
     "consider-using-f-string",
     "cyclic-import",
     "duplicate-code",

--- a/tests/calculations/test_transfer.py
+++ b/tests/calculations/test_transfer.py
@@ -142,7 +142,7 @@ def test_validate_instructions():
     assert result == expected
 
 
-def test_validate_transfer_inputs(aiida_localhost, tmp_path, temp_dir):
+def test_validate_transfer_inputs(aiida_localhost, tmp_path):
     """Test the `TransferCalculation` validators."""
     from aiida.calculations.transfer import check_node_type, validate_transfer_inputs
     from aiida.orm import Computer
@@ -151,7 +151,7 @@ def test_validate_transfer_inputs(aiida_localhost, tmp_path, temp_dir):
         label='localhost-fake',
         description='extra localhost computer set up by test',
         hostname='localhost-fake',
-        workdir=temp_dir,
+        workdir=str(tmp_path),
         transport_type='core.local',
         scheduler_type='core.direct'
     )

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -9,11 +9,9 @@
 ###########################################################################
 # pylint: disable=no-member,too-many-lines,no-self-use
 """Test data-related verdi commands."""
-
 import asyncio
 import io
 import os
-import shutil
 import subprocess as sp
 import tempfile
 
@@ -49,7 +47,7 @@ class DummyVerdiDataExportable:
     NON_EMPTY_GROUP_NAME_STR = 'non_empty_group'
 
     @pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
-    def data_export_test(self, datatype, ids, supported_formats):
+    def data_export_test(self, datatype, ids, supported_formats, output_flag, tmp_path):
         """This method tests that the data listing works as expected with all
         possible flags and arguments for different datatypes."""
         datatype_mapping = {
@@ -58,7 +56,7 @@ class DummyVerdiDataExportable:
             TrajectoryData: cmd_trajectory.trajectory_export,
         }
 
-        if datatype is None or datatype not in datatype_mapping.keys():
+        if datatype is None or datatype not in datatype_mapping:
             raise Exception(f'The listing of the objects {datatype} is not supported')
 
         export_cmd = datatype_mapping[datatype]
@@ -74,29 +72,21 @@ class DummyVerdiDataExportable:
                 res = self.cli_runner(export_cmd, options, catch_exceptions=False)
                 assert res.exit_code == 0, f'The command did not finish correctly. Output:\n{res.output}'
 
-        # Check that the output to file flags work correctly:
-        # -o, --output
-        output_flags = ['-o', '--output']
-        for flag in output_flags:
-            try:
-                tmpd = tempfile.mkdtemp()
-                filepath = os.path.join(tmpd, 'output_file.txt')
-                options = [flag, filepath, str(ids[self.NODE_ID_STR])]
-                res = self.cli_runner(export_cmd, options, catch_exceptions=False)
-                assert res.exit_code == 0, f'The command should finish correctly.Output:\n{res.output}'
+        filepath = tmp_path / 'output_file.txt'
+        options = [output_flag, str(filepath), str(ids[self.NODE_ID_STR])]
+        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        assert res.exit_code == 0, f'The command should finish correctly.Output:\n{res.output}'
 
-                # Try to export it again. It should fail because the
-                # file exists
-                res = self.cli_runner(export_cmd, options, catch_exceptions=False)
-                assert res.exit_code != 0, 'The command should fail because the file already exists'
+        # Try to export it again. It should fail because the
+        # file exists
+        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        assert res.exit_code != 0, 'The command should fail because the file already exists'
 
-                # Now we force the export of the file and it should overwrite
-                # existing files
-                options = [flag, filepath, '-f', str(ids[self.NODE_ID_STR])]
-                res = self.cli_runner(export_cmd, options, catch_exceptions=False)
-                assert res.exit_code == 0, f'The command should finish correctly.Output: {res.output}'
-            finally:
-                shutil.rmtree(tmpd)
+        # Now we force the export of the file and it should overwrite
+        # existing files
+        options = [output_flag, str(filepath), '-f', str(ids[self.NODE_ID_STR])]
+        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        assert res.exit_code == 0, f'The command should finish correctly.Output: {res.output}'
 
 
 class DummyVerdiDataListable:
@@ -126,7 +116,7 @@ class DummyVerdiDataListable:
             BandsData: cmd_bands.bands_list
         }
 
-        if datatype is None or datatype not in datatype_mapping.keys():
+        if datatype is None or datatype not in datatype_mapping:
             raise Exception(f'The listing of the objects {datatype} is not supported')
 
         listing_cmd = datatype_mapping[datatype]
@@ -523,9 +513,10 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
         self.data_listing_test(TrajectoryData, str(self.pks[DummyVerdiDataListable.NODE_ID_STR]), self.pks)
 
     @pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
-    def test_export(self):
+    @pytest.mark.parametrize('output_flag', ['-o', '--output'])
+    def test_export(self, output_flag, tmp_path):
         new_supported_formats = list(cmd_trajectory.EXPORT_FORMATS)
-        self.data_export_test(TrajectoryData, self.pks, new_supported_formats)
+        self.data_export_test(TrajectoryData, self.pks, new_supported_formats, output_flag, tmp_path)
 
 
 class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
@@ -749,8 +740,9 @@ PRIMVEC
     def test_list(self):
         self.data_listing_test(StructureData, 'BaO3Ti', self.pks)
 
-    def test_export(self):
-        self.data_export_test(StructureData, self.pks, cmd_structure.EXPORT_FORMATS)
+    @pytest.mark.parametrize('output_flag', ['-o', '--output'])
+    def test_export(self, output_flag, tmp_path):
+        self.data_export_test(StructureData, self.pks, cmd_structure.EXPORT_FORMATS, output_flag, tmp_path)
 
 
 @pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
@@ -847,10 +839,11 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
         for line in result.output.split('\n'):
             assert line in self.valid_sample_cif_str
 
-    def test_export(self):
+    @pytest.mark.parametrize('output_flag', ['-o', '--output'])
+    def test_export(self, output_flag, tmp_path):
         """This method checks if the Cif export works as expected with all
         possible flags and arguments."""
-        self.data_export_test(CifData, self.pks, cmd_cif.EXPORT_FORMATS)
+        self.data_export_test(CifData, self.pks, cmd_cif.EXPORT_FORMATS, output_flag, tmp_path)
 
 
 class TestVerdiDataSinglefile(DummyVerdiDataListable, DummyVerdiDataExportable):
@@ -909,14 +902,13 @@ class TestVerdiDataUpf:
         output = sp.check_output(['verdi', 'data', 'core.upf', 'exportfamily', '--help'])
         assert b'Usage:' in output, 'Sub-command verdi data upf exportfamily --help failed.'
 
-    def test_exportfamily(self):
+    def test_exportfamily(self, tmp_path):
         """Test verdi data upf exportfamily."""
         self.upload_family()
 
-        path = tempfile.mkdtemp()
-        options = [path, 'test_group']
+        options = [tmp_path, 'test_group']
         self.cli_runner(cmd_upf.upf_exportfamily, options, catch_exceptions=False)
-        output = sp.check_output(['ls', path])
+        output = sp.check_output(['ls', tmp_path])
         assert b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output, \
             f'Sub-command verdi data upf exportfamily --help failed: {output}'
         assert b'O.pbesol-n-rrkjus_psl.0.1-tested-pslib030.UPF' in output, \

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -12,8 +12,6 @@ import errno
 import gzip
 import io
 import os
-import pathlib
-import tempfile
 
 import pytest
 
@@ -180,62 +178,56 @@ class TestVerdiNode:
         result = self.cli_runner(cmd_node.repo_cat, options)
         assert gzip.decompress(result.stdout_bytes) == b'COMPRESS'
 
-    def test_node_repo_dump(self):
+    def test_node_repo_dump(self, tmp_path):
         """Test 'verdi node repo dump' command."""
         folder_node = self.get_unstored_folder_node().store()
+        out_path = tmp_path / 'out_dir'
+        options = [str(folder_node.uuid), str(out_path)]
+        res = self.cli_runner(cmd_node.repo_dump, options, catch_exceptions=False)
+        assert not res.stdout
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            out_path = pathlib.Path(tmp_dir) / 'out_dir'
-            options = [str(folder_node.uuid), str(out_path)]
-            res = self.cli_runner(cmd_node.repo_dump, options, catch_exceptions=False)
-            assert not res.stdout
+        for file_key, content in [(self.key_file1, self.content_file1), (self.key_file2, self.content_file2)]:
+            curr_path = out_path
+            for key_part in file_key.split('/'):
+                curr_path /= key_part
+                assert curr_path.exists()
+            with curr_path.open('r') as res_file:
+                assert res_file.read() == content
 
-            for file_key, content in [(self.key_file1, self.content_file1), (self.key_file2, self.content_file2)]:
-                curr_path = out_path
-                for key_part in file_key.split('/'):
-                    curr_path /= key_part
-                    assert curr_path.exists()
-                with curr_path.open('r') as res_file:
-                    assert res_file.read() == content
-
-    def test_node_repo_dump_to_nested_folder(self):
+    def test_node_repo_dump_to_nested_folder(self, tmp_path):
         """Test 'verdi node repo dump' command, with an output folder whose parent does not exist."""
         folder_node = self.get_unstored_folder_node().store()
+        out_path = tmp_path / 'out_dir' / 'nested' / 'path'
+        options = [str(folder_node.uuid), str(out_path)]
+        res = self.cli_runner(cmd_node.repo_dump, options, catch_exceptions=False)
+        assert not res.stdout
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            out_path = pathlib.Path(tmp_dir) / 'out_dir' / 'nested' / 'path'
-            options = [str(folder_node.uuid), str(out_path)]
-            res = self.cli_runner(cmd_node.repo_dump, options, catch_exceptions=False)
-            assert not res.stdout
+        for file_key, content in [(self.key_file1, self.content_file1), (self.key_file2, self.content_file2)]:
+            curr_path = out_path
+            for key_part in file_key.split('/'):
+                curr_path /= key_part
+                assert curr_path.exists()
+            with curr_path.open('r') as res_file:
+                assert res_file.read() == content
 
-            for file_key, content in [(self.key_file1, self.content_file1), (self.key_file2, self.content_file2)]:
-                curr_path = out_path
-                for key_part in file_key.split('/'):
-                    curr_path /= key_part
-                    assert curr_path.exists()
-                with curr_path.open('r') as res_file:
-                    assert res_file.read() == content
-
-    def test_node_repo_existing_out_dir(self):
+    def test_node_repo_existing_out_dir(self, tmp_path):
         """Test 'verdi node repo dump' command, check that an existing output directory is not overwritten."""
         folder_node = self.get_unstored_folder_node().store()
+        out_path = tmp_path / 'out_dir'
+        # Create the directory and put a file in it
+        out_path.mkdir()
+        some_file = out_path / 'file_name'
+        some_file_content = 'ni!'
+        with some_file.open('w') as file_handle:
+            file_handle.write(some_file_content)
+        options = [str(folder_node.uuid), str(out_path)]
+        res = self.cli_runner(cmd_node.repo_dump, options, catch_exceptions=False)
+        assert 'exists' in res.stdout
+        assert 'Critical:' in res.stdout
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            out_path = pathlib.Path(tmp_dir) / 'out_dir'
-            # Create the directory and put a file in it
-            out_path.mkdir()
-            some_file = out_path / 'file_name'
-            some_file_content = 'ni!'
-            with some_file.open('w') as file_handle:
-                file_handle.write(some_file_content)
-            options = [str(folder_node.uuid), str(out_path)]
-            res = self.cli_runner(cmd_node.repo_dump, options, catch_exceptions=False)
-            assert 'exists' in res.stdout
-            assert 'Critical:' in res.stdout
-
-            # Make sure the directory content is still there
-            with some_file.open('r') as file_handle:
-                assert file_handle.read() == some_file_content
+        # Make sure the directory content is still there
+        with some_file.open('r') as file_handle:
+            assert file_handle.read() == some_file_content
 
 
 def delete_temporary_file(filepath):

--- a/tests/common/test_folders.py
+++ b/tests/common/test_folders.py
@@ -29,25 +29,26 @@ def fs_encoding_is_utf8():
 @pytest.mark.skipif(
     not fs_encoding_is_utf8(), reason='Testing for unicode folders requires UTF-8 to be set for filesystem encoding'
 )
-def test_unicode(tmpdir):
+def test_unicode(tmp_path_factory):
     """Check that there are no exceptions raised when using unicode folders."""
-    with tempfile.TemporaryDirectory() as dirpath_target:
+    dirpath_source = tmp_path_factory.mktemp('source')
+    dirpath_target = tmp_path_factory.mktemp('target')
 
-        (pathlib.Path(tmpdir) / 'sąžininga').write_text('test')
-        (pathlib.Path(tmpdir) / 'žąsis').write_text('test')
+    (dirpath_source / 'sąžininga').write_text('test')
+    (dirpath_source / 'žąsis').write_text('test')
 
-        folder = Folder(dirpath_target)
-        folder.insert_path(tmpdir, 'destination')
-        folder.insert_path(tmpdir, 'šaltinis')
+    folder = Folder(dirpath_target)
+    folder.insert_path(dirpath_source, 'destination')
+    folder.insert_path(dirpath_source, 'šaltinis')
 
-        assert sorted(folder.get_content_list()) == sorted(['destination', 'šaltinis'])
-        assert sorted(folder.get_subfolder('destination').get_content_list()) == sorted(['sąžininga', 'žąsis'])
-        assert sorted(folder.get_subfolder('šaltinis').get_content_list()) == sorted(['sąžininga', 'žąsis'])
+    assert sorted(folder.get_content_list()) == sorted(['destination', 'šaltinis'])
+    assert sorted(folder.get_subfolder('destination').get_content_list()) == sorted(['sąžininga', 'žąsis'])
+    assert sorted(folder.get_subfolder('šaltinis').get_content_list()) == sorted(['sąžininga', 'žąsis'])
 
-        folder = Folder(pathlib.Path(tmpdir) / 'šaltinis')
-        folder.insert_path(dirpath_target, 'destination')
-        folder.insert_path(dirpath_target, 'kitas-šaltinis')
-        assert sorted(folder.get_content_list()) == sorted(['destination', 'kitas-šaltinis'])
+    folder = Folder(dirpath_source / 'šaltinis')
+    folder.insert_path(dirpath_target, 'destination')
+    folder.insert_path(dirpath_target, 'kitas-šaltinis')
+    assert sorted(folder.get_content_list()) == sorted(['destination', 'kitas-šaltinis'])
 
 
 def test_get_abs_path_without_limit():

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -939,63 +939,61 @@ class TestImport:
             }
         }
 
-    def test_import_from_valid(self):
+    def test_import_from_valid(self, tmp_path):
         """Test the import of a successfully completed `ArithmeticAddCalculation`."""
         expected_sum = (self.inputs['x'] + self.inputs['y']).value
 
-        with tempfile.TemporaryDirectory() as directory:
-            filepath = os.path.join(directory, ArithmeticAddCalculation.spec_options['output_filename'].default)
-            with open(filepath, 'w', encoding='utf8') as handle:
-                handle.write(f'{expected_sum}\n')
+        filepath = tmp_path / ArithmeticAddCalculation.spec_options['output_filename'].default
+        with open(filepath, 'w', encoding='utf8') as handle:
+            handle.write(f'{expected_sum}\n')
 
-            remote = orm.RemoteData(directory, computer=self.computer).store()
-            inputs = deepcopy(self.inputs)
-            inputs['remote_folder'] = remote
+        remote = orm.RemoteData(str(tmp_path), computer=self.computer).store()
+        inputs = deepcopy(self.inputs)
+        inputs['remote_folder'] = remote
 
-            results, node = launch.run.get_node(ArithmeticAddCalculation, **inputs)
+        results, node = launch.run.get_node(ArithmeticAddCalculation, **inputs)
 
-            # Check node attributes
-            assert isinstance(node, orm.CalcJobNode)
-            assert node.is_finished_ok
-            assert node.is_sealed
-            assert node.is_imported
+        # Check node attributes
+        assert isinstance(node, orm.CalcJobNode)
+        assert node.is_finished_ok
+        assert node.is_sealed
+        assert node.is_imported
 
-            # Verify the expected outputs are there
-            assert 'retrieved' in results
-            assert isinstance(results['retrieved'], orm.FolderData)
-            assert 'sum' in results
-            assert isinstance(results['sum'], orm.Int)
-            assert results['sum'].value == expected_sum
+        # Verify the expected outputs are there
+        assert 'retrieved' in results
+        assert isinstance(results['retrieved'], orm.FolderData)
+        assert 'sum' in results
+        assert isinstance(results['sum'], orm.Int)
+        assert results['sum'].value == expected_sum
 
-    def test_import_from_invalid(self):
+    def test_import_from_invalid(self, tmp_path):
         """Test the import of a completed `ArithmeticAddCalculation` where parsing will fail.
 
         The `ArithmeticParser` will return a non-zero exit code if the output file could not be parsed. Make sure that
         this is piped through correctly through the infrastructure and will cause the process to be marked as failed.
         """
-        with tempfile.TemporaryDirectory() as directory:
-            filepath = os.path.join(directory, ArithmeticAddCalculation.spec_options['output_filename'].default)
-            with open(filepath, 'w', encoding='utf8') as handle:
-                handle.write('a\n')  # On purpose write a non-integer to output so the parsing will fail
+        filepath = tmp_path / ArithmeticAddCalculation.spec_options['output_filename'].default
+        with open(filepath, 'w', encoding='utf8') as handle:
+            handle.write('a\n')  # On purpose write a non-integer to output so the parsing will fail
 
-            remote = orm.RemoteData(directory, computer=self.computer).store()
-            inputs = deepcopy(self.inputs)
-            inputs['remote_folder'] = remote
+        remote = orm.RemoteData(str(tmp_path), computer=self.computer).store()
+        inputs = deepcopy(self.inputs)
+        inputs['remote_folder'] = remote
 
-            results, node = launch.run.get_node(ArithmeticAddCalculation, **inputs)
+        results, node = launch.run.get_node(ArithmeticAddCalculation, **inputs)
 
-            # Check node attributes
-            assert isinstance(node, orm.CalcJobNode)
-            assert node.is_failed
-            assert node.is_sealed
-            assert node.is_imported
-            assert node.exit_status == ArithmeticAddCalculation.exit_codes.ERROR_INVALID_OUTPUT.status
+        # Check node attributes
+        assert isinstance(node, orm.CalcJobNode)
+        assert node.is_failed
+        assert node.is_sealed
+        assert node.is_imported
+        assert node.exit_status == ArithmeticAddCalculation.exit_codes.ERROR_INVALID_OUTPUT.status
 
-            # Verify the expected outputs are there
-            assert 'retrieved' in results
-            assert isinstance(results['retrieved'], orm.FolderData)
+        # Verify the expected outputs are there
+        assert 'retrieved' in results
+        assert isinstance(results['retrieved'], orm.FolderData)
 
-    def test_import_non_default_input_file(self):
+    def test_import_non_default_input_file(self, tmp_path):
         """Test the import of a successfully completed `ArithmeticAddCalculation`
 
         The only difference of this test with `test_import_from_valid` is that here the name of the output file
@@ -1004,27 +1002,26 @@ class TestImport:
 
         output_filename = 'non_standard.out'
 
-        with tempfile.TemporaryDirectory() as directory:
-            filepath = os.path.join(directory, output_filename)
-            with open(filepath, 'w', encoding='utf8') as handle:
-                handle.write(f'{expected_sum}\n')
+        filepath = tmp_path / output_filename
+        with open(filepath, 'w', encoding='utf8') as handle:
+            handle.write(f'{expected_sum}\n')
 
-            remote = orm.RemoteData(directory, computer=self.computer).store()
-            inputs = deepcopy(self.inputs)
-            inputs['remote_folder'] = remote
-            inputs['metadata']['options']['output_filename'] = output_filename
+        remote = orm.RemoteData(str(tmp_path), computer=self.computer).store()
+        inputs = deepcopy(self.inputs)
+        inputs['remote_folder'] = remote
+        inputs['metadata']['options']['output_filename'] = output_filename
 
-            results, node = launch.run.get_node(ArithmeticAddCalculation, **inputs)
+        results, node = launch.run.get_node(ArithmeticAddCalculation, **inputs)
 
-            # Check node attributes
-            assert isinstance(node, orm.CalcJobNode)
-            assert node.is_finished_ok
-            assert node.is_sealed
-            assert node.is_imported
+        # Check node attributes
+        assert isinstance(node, orm.CalcJobNode)
+        assert node.is_finished_ok
+        assert node.is_sealed
+        assert node.is_imported
 
-            # Verify the expected outputs are there
-            assert 'retrieved' in results
-            assert isinstance(results['retrieved'], orm.FolderData)
-            assert 'sum' in results
-            assert isinstance(results['sum'], orm.Int)
-            assert results['sum'].value == expected_sum
+        # Verify the expected outputs are there
+        assert 'retrieved' in results
+        assert isinstance(results['retrieved'], orm.FolderData)
+        assert 'sum' in results
+        assert isinstance(results['sum'], orm.Int)
+        assert results['sum'].value == expected_sum

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -13,7 +13,6 @@ from decimal import Decimal
 from io import BytesIO
 import logging
 import os
-import tempfile
 
 import pytest
 
@@ -978,15 +977,13 @@ class TestNodeCaching:
         calc = CalculationNode()
         calc.base.caching.is_valid_cache = False
 
-    def test_store_from_cache(self):
+    def test_store_from_cache(self, tmp_path):
         """Regression test for storing a Node with (nested) repository content with caching."""
         data = Data()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            dir_path = os.path.join(tmpdir, 'directory')
-            os.makedirs(dir_path)
-            with open(os.path.join(dir_path, 'file'), 'w', encoding='utf8') as file:
-                file.write('content')
-            data.base.repository.put_object_from_tree(tmpdir)
+        filepath = tmp_path / 'sub' / 'file'
+        filepath.parent.mkdir(parents=True)
+        filepath.write_text('content')
+        data.base.repository.put_object_from_tree(tmp_path)
 
         data.store()
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -108,16 +108,14 @@ class TestNodeHashing:
             node.base.repository.put_object_from_filelike(handle, 'path/name')
         return node
 
-    @staticmethod
-    def create_folderdata_with_empty_folder():
-        dirpath = tempfile.mkdtemp()
+    def create_folderdata_with_empty_folder(self, tmp_path):
         node = orm.FolderData()
-        node.base.repository.put_object_from_tree(dirpath, 'path/name')
+        node.base.repository.put_object_from_tree(tmp_path, 'path/name')
         return node
 
-    def test_folder_file_different(self):
+    def test_folder_file_different(self, tmp_path):
         f1 = self.create_folderdata_with_empty_file().store()
-        f2 = self.create_folderdata_with_empty_folder().store()
+        f2 = self.create_folderdata_with_empty_folder(tmp_path).store()
 
         assert f1.base.repository.list_object_names('path') == f2.base.repository.list_object_names('path')
         assert f1.base.caching.get_hash() != f2.base.caching.get_hash()


### PR DESCRIPTION
Fixes #4336 

When it is used for unit tests, it should be replaced by the `tmp_path` fixture provided by `pytest` since it will take care of cleanup automatically.

Then there are a few cases in the code where it was used where it was replaced with `tempfile.TemporaryDirectory`. The latter has the advantage that it will be automatically cleanup when the object goes out of scope.

A few places in the code still use `mkdtemp` since it needs to control the cleanup manually.

The `temp_dir` fixture is also deprecated. It works exactly as the `tmp_path` fixture which ships with `pytest` and should be used instead.