### PR TITLE
Not prompt memory set for core.direct

### DIFF
--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -14,6 +14,7 @@ from aiida.cmdline.params import options, types
 from aiida.cmdline.params.options.interactive import InteractiveOption, TemplateInteractiveOption
 from aiida.cmdline.params.options.overridable import OverridableOption
 
+
 def get_job_resource_cls(ctx):
     """
     Return job resource cls from ctx.
@@ -33,32 +34,34 @@ def get_job_resource_cls(ctx):
 
     return scheduler_cls.job_resource_class
 
+
 def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-name
     """
-    Return True if the scheduler can accept 'default_mpiprocs_per_machine',
-    False otherwise.
+    Return whether the selected scheduler type accepts `default_mpiprocs_per_machine`.
 
-    If there is a problem in determining the scheduler, return True to
-    avoid exceptions.
+
+    :return: `True` if the scheduler type accepts `default_mpiprocs_per_machine`, `False`
+    otherwise. If the scheduler class could not be loaded `False` is returned by default.
     """
     job_resource_cls = get_job_resource_cls(ctx)
-    
+
     if job_resource_cls is None:
         # Odd situation...
         return False
 
     return job_resource_cls.accepts_default_mpiprocs_per_machine()
 
+
 def should_call_default_memory_per_machine(ctx):  # pylint: disable=invalid-name
     """
-    Return True if the scheduler can accept 'default_memory_per_machine',
-    False otherwise.
+    Return whether the selected scheduler type accepts `default_memory_per_machine`.
 
-    If there is a problem in determining the scheduler, return True to
-    avoid exceptions.
+
+    :return: `True` if the scheduler type accepts `default_memory_per_machine`, `False`
+    otherwise. If the scheduler class could not be loaded `False` is returned by default.
     """
     job_resource_cls = get_job_resource_cls(ctx)
-    
+
     if job_resource_cls is None:
         # Odd situation...
         return False

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -14,14 +14,9 @@ from aiida.cmdline.params import options, types
 from aiida.cmdline.params.options.interactive import InteractiveOption, TemplateInteractiveOption
 from aiida.cmdline.params.options.overridable import OverridableOption
 
-
-def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-name
+def get_job_resource_cls(ctx):
     """
-    Return True if the scheduler can accept 'default_mpiprocs_per_machine',
-    False otherwise.
-
-    If there is a problem in determining the scheduler, return True to
-    avoid exceptions.
+    Return job resource cls from ctx.
     """
     from aiida.common.exceptions import ValidationError
 
@@ -36,7 +31,18 @@ def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-na
             'The should_call_... function should always be run (and prompted) AFTER asking for a scheduler'
         )
 
-    job_resource_cls = scheduler_cls.job_resource_class
+    return scheduler_cls.job_resource_class
+
+def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-name
+    """
+    Return True if the scheduler can accept 'default_mpiprocs_per_machine',
+    False otherwise.
+
+    If there is a problem in determining the scheduler, return True to
+    avoid exceptions.
+    """
+    job_resource_cls = get_job_resource_cls(ctx)
+    
     if job_resource_cls is None:
         # Odd situation...
         return False
@@ -51,20 +57,8 @@ def should_call_default_memory_per_machine(ctx):  # pylint: disable=invalid-name
     If there is a problem in determining the scheduler, return True to
     avoid exceptions.
     """
-    from aiida.common.exceptions import ValidationError
-
-    scheduler_ep = ctx.params['scheduler']
-    if scheduler_ep is not None:
-        try:
-            scheduler_cls = scheduler_ep.load()
-        except ImportError:
-            raise ImportError(f"Unable to load the '{scheduler_ep.name}' scheduler")
-    else:
-        raise ValidationError(
-            'The should_call_... function should always be run (and prompted) AFTER asking for a scheduler'
-        )
-
-    job_resource_cls = scheduler_cls.job_resource_class
+    job_resource_cls = get_job_resource_cls(ctx)
+    
     if job_resource_cls is None:
         # Odd situation...
         return False

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -39,9 +39,8 @@ def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-na
     """
     Return whether the selected scheduler type accepts `default_mpiprocs_per_machine`.
 
-
     :return: `True` if the scheduler type accepts `default_mpiprocs_per_machine`, `False`
-    otherwise. If the scheduler class could not be loaded `False` is returned by default.
+        otherwise. If the scheduler class could not be loaded `False` is returned by default.
     """
     job_resource_cls = get_job_resource_cls(ctx)
 
@@ -56,9 +55,8 @@ def should_call_default_memory_per_machine(ctx):  # pylint: disable=invalid-name
     """
     Return whether the selected scheduler type accepts `default_memory_per_machine`.
 
-
     :return: `True` if the scheduler type accepts `default_memory_per_machine`, `False`
-    otherwise. If the scheduler class could not be loaded `False` is returned by default.
+        otherwise. If the scheduler class could not be loaded `False` is returned by default.
     """
     job_resource_cls = get_job_resource_cls(ctx)
 

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -87,11 +87,11 @@ class JobResource(DefaultFieldsAttributeDict, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
-        
+
     @classmethod
-    @abc.abstractmethod
     def accepts_default_memory_per_machine(cls):
         """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
+        return True
 
     @abc.abstractmethod
     def get_tot_num_mpiprocs(self):
@@ -179,11 +179,6 @@ class NodeNumberJobResource(JobResource):
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
         return True
-      
-    @classmethod
-    def accepts_default_memory_per_machine(cls):
-        """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
-        return True
 
     def get_tot_num_mpiprocs(self):
         """Return the total number of cpus of this job resource."""
@@ -243,11 +238,6 @@ class ParEnvJobResource(JobResource):
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
         return False
-      
-    @classmethod
-    def accepts_default_memory_per_machine(cls):
-        """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
-        return True
 
     def get_tot_num_mpiprocs(self):
         """Return the total number of cpus of this job resource."""

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -87,6 +87,11 @@ class JobResource(DefaultFieldsAttributeDict, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
+        
+    @classmethod
+    @abc.abstractmethod
+    def accepts_default_memory_per_machine(cls):
+        """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
 
     @abc.abstractmethod
     def get_tot_num_mpiprocs(self):
@@ -174,6 +179,11 @@ class NodeNumberJobResource(JobResource):
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
         return True
+      
+    @classmethod
+    def accepts_default_memory_per_machine(cls):
+        """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
+        return True
 
     def get_tot_num_mpiprocs(self):
         """Return the total number of cpus of this job resource."""
@@ -233,6 +243,11 @@ class ParEnvJobResource(JobResource):
     def accepts_default_mpiprocs_per_machine(cls):
         """Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise."""
         return False
+      
+    @classmethod
+    def accepts_default_memory_per_machine(cls):
+        """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
+        return True
 
     def get_tot_num_mpiprocs(self):
         """Return the total number of cpus of this job resource."""

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -64,6 +64,9 @@ _MAP_STATUS_PS = {
 
 
 class DirectJobResource(NodeNumberJobResource):
+    """
+    An implementation of JobResource for the direct excution bypassing schedulers.
+    """
 
     @classmethod
     def accepts_default_memory_per_machine(cls):

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -64,7 +64,11 @@ _MAP_STATUS_PS = {
 
 
 class DirectJobResource(NodeNumberJobResource):
-    pass
+
+    @classmethod
+    def accepts_default_memory_per_machine(cls):
+        """Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise."""
+        return False
 
 
 class DirectScheduler(aiida.schedulers.Scheduler):

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -161,7 +161,9 @@ def test_mixed(run_cli_command):
     assert new_computer.get_shebang() == options_dict_full['shebang']
     assert new_computer.get_workdir() == options_dict_full['work-dir']
     assert new_computer.get_default_mpiprocs_per_machine() == int(options_dict_full['mpiprocs-per-machine'])
-    assert new_computer.get_default_memory_per_machine() == int(options_dict_full['default-memory-per-machine'])
+
+    # default_memory_per_machine should not prompt and set
+    assert new_computer.get_default_memory_per_machine() is None
 
     # For now I'm not writing anything in them
     assert new_computer.get_prepend_text() == options_dict_full['prepend-text']

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -736,11 +736,14 @@ def test_computer_duplicate_non_interactive(run_cli_command, aiida_localhost, no
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('non_interactive_editor', ('sleep 1; vim -cwq',), indirect=True)
-def test_interactive(run_cli_command, aiida_profile_clean, non_interactive_editor):
+def test_direct_interactive(run_cli_command, aiida_profile_clean, non_interactive_editor):
     """Test verdi computer setup in interactive mode."""
     label = 'interactive_computer'
 
     options_dict = generate_setup_options_dict(replace_args={'label': label}, non_interactive=False)
+    # default-memory-per-machine will not prompt for direct
+    options_dict.pop('default-memory-per-machine')
+
     # In any case, these would be managed by the visual editor
     options_dict.pop('prepend-text')
     options_dict.pop('append-text')


### PR DESCRIPTION
The warning `Warning: Physical memory limiting is not supported by the direct scheduler.` pop up if set the computer by interactive mode. 
The `default_memory_per_machine` should not pop up from computer setup with `core.direct` scheduler.

But I am not sure where to add the unit test for this. 