### PR TITLE
limit pytest-regressions version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ tests = [
     "pytest-cov~=2.7,<2.11",
     "pytest-rerunfailures~=9.1,>=9.1.1",
     "pytest-benchmark~=3.2",
-    "pytest-regressions~=2.2",
+    "pytest-regressions~=2.2,<2.4",
     "pympler~=0.9",
     "coverage<5.0",
     "sqlalchemy-utils~=0.37.2",


### PR DESCRIPTION
fix https://github.com/aiidateam/aiida-core/issues/5644

Version 2.4.0 of pytest-regressions seems to no longer be compatible with pytest 6.