### PR TITLE
`CalcJob`: Extend `retrieve_list` syntax with `depth=None`

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -576,6 +576,7 @@ def retrieve_files_from_list(
     :param folder: an absolute path to a folder that contains the files to copy.
     :param retrieve_list: the list of files to retrieve.
     """
+    # pylint: disable=too-many-branches
     for item in retrieve_list:
         if isinstance(item, (list, tuple)):
             tmp_rname, tmp_lname, depth = item
@@ -584,13 +585,16 @@ def retrieve_files_from_list(
                 remote_names = transport.glob(tmp_rname)
                 local_names = []
                 for rem in remote_names:
-                    to_append = rem.split(os.path.sep)[-depth:] if depth > 0 else []
-                    local_names.append(os.path.sep.join([tmp_lname] + to_append))
+                    if depth is None:
+                        local_names.append(os.path.join(tmp_lname, rem))
+                    else:
+                        to_append = rem.split(os.path.sep)[-depth:] if depth > 0 else []
+                        local_names.append(os.path.sep.join([tmp_lname] + to_append))
             else:
                 remote_names = [tmp_rname]
                 to_append = tmp_rname.split(os.path.sep)[-depth:] if depth > 0 else []
                 local_names = [os.path.sep.join([tmp_lname] + to_append)]
-            if depth > 1:  # create directories in the folder, if needed
+            if depth is None or depth > 1:  # create directories in the folder, if needed
                 for this_local_file in local_names:
                     new_folder = os.path.join(folder, os.path.split(this_local_file)[0])
                     if not os.path.exists(new_folder):

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -260,7 +260,7 @@ For example, imagine we have a `FolderData` node that is passed as the `folder` 
     │  └─ file_b.txt
     └─ file_a.txt
 
-If the entire content needs to be copied over, specify the `local_copy_list` as follows:
+If the entire content needs to be copied over, specify the ``local_copy_list`` as follows:
 
 .. code:: python
 
@@ -460,7 +460,19 @@ Pattern matching
 
 If the exact file or folder name is not known beforehand, glob patterns can be used.
 In the following examples, all files that match ``*c.txt`` in the directory ``path/sub`` will be retrieved.
-Since ``depth=0`` the files will be copied without the ``path/sub`` subdirectory.
+
+To maintain the folder structure set ``depth`` to ``None``:
+
+.. code:: bash
+
+    retrieve_list = [('path/sub/*c.txt', '.', None)]
+
+    └─ path
+        └─ sub
+           └─ file_c.txt
+
+Alternatively, the ``depth`` can be used to specify the number of levels of nesting that should be kept.
+For example, ``depth=0`` instructs to copy the matched files without any subfolders:
 
 .. code:: bash
 
@@ -468,7 +480,7 @@ Since ``depth=0`` the files will be copied without the ``path/sub`` subdirectory
 
     └─ file_c.txt
 
-To keep the subdirectory structure, one can set the depth parameter, just as in the previous examples.
+and ``depth=2`` will keep two levels in the final filepath:
 
 .. code:: bash
 

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -122,6 +122,8 @@ def test_hierarchy_utility(file_hierarchy, tmp_path):
     (['path/sub/file_c.txt'], {'file_c.txt': 'file_c'}),
     (['path'], {'path': {'file_b.txt': 'file_b', 'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),
     (['path/sub'], {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}),
+    (['*.txt'], {'file_a.txt': 'file_a'}),
+    (['*/*.txt'], {'file_b.txt': 'file_b'}),
     # Single nested file that is retrieved keeping a varying level of depth of original hierarchy
     ([('path/sub/file_c.txt', '.', 3)], {'path': {'sub': {'file_c.txt': 'file_c'}}}),
     ([('path/sub/file_c.txt', '.', 2)], {'sub': {'file_c.txt': 'file_c'}}),
@@ -135,6 +137,9 @@ def test_hierarchy_utility(file_hierarchy, tmp_path):
     ([('path/sub/*', '.', 0)], {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}),  # This is identical to ['path/sub']
     ([('path/sub/*c.txt', '.', 2)], {'sub': {'file_c.txt': 'file_c'}}),
     ([('path/sub/*c.txt', '.', 0)], {'file_c.txt': 'file_c'}),
+    # Using globbing with depth `None` should maintain exact folder hierarchy
+    ([('path/*.txt', '.', None)], {'path': {'file_b.txt': 'file_b'}}),
+    ([('path/sub/*.txt', '.', None)], {'path': {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),
     # Different target directory
     ([('path/sub/file_c.txt', 'target', 3)], {'target': {'path': {'sub': {'file_c.txt': 'file_c'}}}}),
     ([('path/sub', 'target', 1)], {'target': {'sub': {'file_c.txt': 'file_c', 'file_d.txt': 'file_d'}}}),


### PR DESCRIPTION
Fixes #5650 

There is currently no way to retrieve files using glob patterns while maintaining the exact file hierarchy of the remote working directory. The only supported syntaxes are:

 * Single string: `some/path/with/glob/*.txt`
 * Three-element tuple: `('glob/*.txt', '.', 1)`

For the former, the matched file will be retrieved without any subfolders. For the latter, the levels of nesting to be kept is indicated by the final `depth` integer, but it has to be specified and needs to be 0 or larger.

It would be far easier if one didn't have to specify the depth and the file hierarchy would be kept as is. This functionality is added, so it is now possible to specify

    retrieve_list = [('some/*.txt', '.', None)]

which will copy the files matched by the glob with the exact same file hierarchy, creating the nested directories where needed.