### PR TITLE
Tests: Add the `EntryPointManager` exposed as `entry_points` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,16 +9,22 @@
 ###########################################################################
 # pylint: disable=redefined-outer-name
 """Configuration file for pytest tests."""
+from __future__ import annotations
+
+import copy
 import os
 import pathlib
 import time
 from typing import IO, List, Optional, Union
+import warnings
 
 import click
 import plumpy
 import pytest
+import wrapt
 
-from aiida import get_profile
+from aiida import get_profile, plugins
+from aiida.common.lang import type_check
 from aiida.engine import Process, submit
 from aiida.manage.configuration import Config, Profile, get_config, load_profile
 
@@ -168,8 +174,6 @@ def isolated_config(monkeypatch):
     changing it in tests maybe necessary if a command is invoked that will be reading the config from disk in another
     Python process and so doesn't have access to the loaded config in memory in the process that is running the test.
     """
-    import copy
-
     from aiida.manage import configuration
 
     monkeypatch.setattr(configuration.Config, '_backup', lambda *args, **kwargs: None)
@@ -382,8 +386,6 @@ def suppress_internal_deprecations():
 
     Warnings emmitted of type :class:`aiida.common.warnings.AiidaDeprecationWarning` for the duration of the test.
     """
-    import warnings
-
     from aiida.common.warnings import AiidaDeprecationWarning
 
     with warnings.catch_warnings():
@@ -541,3 +543,120 @@ def submit_and_await():
         return node
 
     return _factory
+
+
+@wrapt.decorator
+def suppress_deprecations(wrapped, _, args, kwargs):
+    """Decorator that suppresses all ``DeprecationWarning``s."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        return wrapped(*args, **kwargs)
+
+
+class EntryPointManager:
+    """Manager to temporarily add or remove entry points."""
+
+    @staticmethod
+    def eps():
+        return plugins.entry_point.eps()
+
+    @staticmethod
+    def _validate_entry_point(entry_point_string: str | None, group: str | None, name: str | None) -> tuple[str, str]:
+        """Validate the definition of the entry point.
+
+        :param entry_point_string: Fully qualified entry point string.
+        :param name: Entry point name.
+        :param group: Entry point group.
+        :returns: The entry point group and name.
+        :raises TypeError: If `entry_point_string`, `group` or `name` are not a string, when defined.
+        :raises ValueError: If `entry_point_string` is not defined, nor a `group` and `name`.
+        :raises ValueError: If `entry_point_string` is not a complete entry point string with group and name.
+        """
+        if entry_point_string is not None:
+            try:
+                group, name = plugins.entry_point.parse_entry_point_string(entry_point_string)
+            except TypeError as exception:
+                raise TypeError('`entry_point_string` should be a string when defined.') from exception
+            except ValueError as exception:
+                raise ValueError('invalid `entry_point_string` format, should `group:name`.') from exception
+
+        if name is None or group is None:
+            raise ValueError('neither `entry_point_string` is defined, nor `name` and `group`.')
+
+        type_check(group, str)
+        type_check(name, str)
+
+        return group, name
+
+    @suppress_deprecations
+    def add(
+        self,
+        value: type | str,
+        entry_point_string: str | None = None,
+        *,
+        name: str | None = None,
+        group: str | None = None
+    ) -> None:
+        """Add an entry point.
+
+        :param value: The class or function to register as entry point. The resource needs to be importable, so it can't
+            be inlined. Alternatively, the fully qualified name can be passed as a string.
+        :param entry_point_string: Fully qualified entry point string.
+        :param name: Entry point name.
+        :param group: Entry point group.
+        :returns: The entry point group and name.
+        :raises TypeError: If `entry_point_string`, `group` or `name` are not a string, when defined.
+        :raises ValueError: If `entry_point_string` is not defined, nor a `group` and `name`.
+        :raises ValueError: If `entry_point_string` is not a complete entry point string with group and name.
+        """
+        if not isinstance(value, str):
+            value = f'{value.__module__}:{value.__name__}'
+
+        group, name = self._validate_entry_point(entry_point_string, group, name)
+        entry_point = plugins.entry_point.EntryPoint(name, value, group)
+        self.eps()[group].append(entry_point)
+
+    @suppress_deprecations
+    def remove(
+        self, entry_point_string: str | None = None, *, name: str | None = None, group: str | None = None
+    ) -> None:
+        """Remove an entry point.
+
+        :param value: Entry point value, fully qualified import path name.
+        :param entry_point_string: Fully qualified entry point string.
+        :param name: Entry point name.
+        :param group: Entry point group.
+        :returns: The entry point group and name.
+        :raises TypeError: If `entry_point_string`, `group` or `name` are not a string, when defined.
+        :raises ValueError: If `entry_point_string` is not defined, nor a `group` and `name`.
+        :raises ValueError: If `entry_point_string` is not a complete entry point string with group and name.
+        """
+        group, name = self._validate_entry_point(entry_point_string, group, name)
+
+        for entry_point in self.eps()[group]:
+            if entry_point.name == name:
+                self.eps()[group].remove(entry_point)
+                break
+        else:
+            raise KeyError(f'entry point `{name}` does not exist in group `{group}`.')
+
+
+@pytest.fixture
+def entry_points(monkeypatch) -> EntryPointManager:
+    """Return an instance of the ``EntryPointManager`` which allows to temporarily add or remove entry points.
+
+    This fixture creates a deep copy of the entry point cache returned by the :func:`aiida.plugins.entry_point.eps`
+    method and then monkey patches that function to return the deepcopy. This ensures that the changes on the entry
+    point cache performed during the test through the manager are undone at the end of the function scope.
+
+    .. note:: This fixture does not use the ``suppress_deprecations`` decorator on purpose, but instead adds it manually
+        inside the fixture's body. The reason is that otherwise all deprecations would be suppressed for the entire
+        scope of the fixture, including those raised by the code run in the test using the fixture, which is not
+        desirable.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        eps_copy = copy.deepcopy(plugins.entry_point.eps())
+    monkeypatch.setattr(plugins.entry_point, 'eps', lambda: eps_copy)
+    yield EntryPointManager()

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Tests for fixtures in the ``conftest.py``."""
+import pytest
+
+from aiida.common.exceptions import MissingEntryPointError
+from aiida.plugins.entry_point import EntryPoint, get_entry_point, load_entry_point
+
+ENTRY_POINT_GROUP = 'aiida.calculations.importers'
+
+
+def test_entry_points_add_invalid(entry_points):
+    """Test the :meth:`EntryPointManager.add` method."""
+    with pytest.raises(TypeError, match='`entry_point_string` should be a string when defined.'):
+        entry_points.add('some.module:SomeClass', [])
+
+    with pytest.raises(ValueError, match='invalid `entry_point_string` format, should `group:name`'):
+        entry_points.add('some.module:SomeClass', 'core.temporary.entry_point')
+
+    with pytest.raises(ValueError, match='neither `entry_point_string` is defined, nor `name` and `group`'):
+        entry_points.add('some.module:SomeClass')
+
+
+def test_entry_points_add_entry_point_string(entry_points):
+    """Test the :meth:`EntryPointManager.add` method using a full entry point string."""
+    entry_points.add('some.module:SomeClass', f'{ENTRY_POINT_GROUP}:core.test')
+    assert isinstance(get_entry_point(ENTRY_POINT_GROUP, 'core.test'), EntryPoint)
+
+
+def test_entry_points_add_group_and_name(entry_points):
+    """Test the :meth:`EntryPointManager.add` method using a separate entry point group and name."""
+    entry_points.add('some.module:SomeClass', group=ENTRY_POINT_GROUP, name='core.test')
+    assert isinstance(get_entry_point(ENTRY_POINT_GROUP, 'core.test'), EntryPoint)
+
+
+def test_entry_points_remove_invalid(entry_points):
+    """Test the :meth:`EntryPointManager.remove` method."""
+    with pytest.raises(TypeError, match='`entry_point_string` should be a string when defined.'):
+        entry_points.remove([])
+
+    with pytest.raises(ValueError, match='invalid `entry_point_string` format, should `group:name`'):
+        entry_points.remove('core.temporary.entry_point')
+
+    with pytest.raises(ValueError, match='neither `entry_point_string` is defined, nor `name` and `group`'):
+        entry_points.remove()
+
+
+def test_entry_points_remove_entry_point_string(entry_points):
+    """Test the :meth:`EntryPointManager.remove` method using a full entry point string."""
+    entry_points.add('some.module:SomeClass', f'{ENTRY_POINT_GROUP}:core.test')
+    entry_points.remove(f'{ENTRY_POINT_GROUP}:core.test')
+
+    with pytest.raises(MissingEntryPointError):
+        get_entry_point(ENTRY_POINT_GROUP, 'core.test')
+
+
+def test_entry_points_remove_group_and_name(entry_points):
+    """Test the :meth:`EntryPointManager.remove` method using a separate entry point group and name."""
+    entry_points.add('some.module:SomeClass', f'{ENTRY_POINT_GROUP}:core.test')
+    entry_points.remove(group=ENTRY_POINT_GROUP, name='core.test')
+
+    with pytest.raises(MissingEntryPointError):
+        get_entry_point(ENTRY_POINT_GROUP, 'core.test')
+
+
+def raise_runtime_error():
+    """Dummy function to be registered as an entry point."""
+    raise RuntimeError('inline function was called')
+
+
+def test_entry_points_add_and_load(entry_points):
+    """Test adding an entry point to an inline function loading it and calling it."""
+
+    entry_point_name = 'core.test'
+    entry_points.add(raise_runtime_error, group=ENTRY_POINT_GROUP, name=entry_point_name)
+
+    entry_point = load_entry_point(ENTRY_POINT_GROUP, entry_point_name)
+
+    with pytest.raises(RuntimeError, match='inline function was called'):
+        entry_point()


### PR DESCRIPTION
Fixes #5655 

This fixture allows to easily add or remove entry points for the scope
of the function. It temporarily manipulates the content of the entry
point cache as provided by `importlib.metadata.entry_points`. After the
test function ends, the additions and removals are undone.

The `SelectableEntryPoints` class fully implements the dictionary
interface which we use to update its state, however, this interface is
deprecated. The methods that replace it though, the `select` method,
are read-only and do not allow to modify the state, so we cannot use
them. To not flood the logs with deprecation warnings, they are
intentionally suppressed.