### PR TITLE
`PluginVersionProvider`: add support for entry point strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,7 @@ repos:
                 aiida/orm/utils/links.py|
                 aiida/plugins/entry_point.py|
                 aiida/plugins/factories.py|
+                aiida/plugins/utils.py|
                 aiida/repository/.*py|
                 aiida/storage/control.py|
                 aiida/storage/psql_dos/backend.py|

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -8,41 +8,61 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Utilities dealing with plugins and entry points."""
+from __future__ import annotations
 
 from importlib import import_module
+from inspect import isclass, isfunction
+from logging import Logger
 
 from aiida.common import AIIDA_LOGGER
+from aiida.common.exceptions import EntryPointError
+
+from .entry_point import load_entry_point_from_string
 
 __all__ = ('PluginVersionProvider',)
 
-KEY_VERSION_ROOT = 'version'
-KEY_VERSION_CORE = 'core'  # The version of `aiida-core`
-KEY_VERSION_PLUGIN = 'plugin'  # The version of the plugin top level module, e.g. `aiida-quantumespresso`
+KEY_VERSION_ROOT: str = 'version'
+KEY_VERSION_CORE: str = 'core'  # The version of `aiida-core`
+KEY_VERSION_PLUGIN: str = 'plugin'  # The version of the plugin top level module, e.g. `aiida-quantumespresso`
 
 
 class PluginVersionProvider:
     """Utility class that determines version information about a given plugin resource."""
 
     def __init__(self):
-        self._cache = {}
-        self._logger = AIIDA_LOGGER.getChild('plugin_version_provider')
+        self._cache: dict[type, dict[str, dict[str, str]]] = {}
+        self._logger: Logger = AIIDA_LOGGER.getChild('plugin_version_provider')
 
     @property
-    def logger(self):
+    def logger(self) -> Logger:
         return self._logger
 
-    def get_version_info(self, plugin):
+    def get_version_info(self, plugin: str | type) -> dict[str, dict[str, str]]:
         """Get the version information for a given plugin.
 
         .. note::
 
-            This container will keep a cache, so if this function was already called for the given ``plugin`` before
-            for this instance, the result computer at last invocation will be returned.
+            This container will keep a cache, so if this method was already called for the given ``plugin`` before for
+            this instance, the result computed at the last invocation will be returned.
 
-        :param plugin: a class or function
-        :return: dictionary with the `version.core` and optionally `version.plugin` if it could be determined.
+        :param plugin: A class, function, or an entry point string. If the type is string, it will be assumed to be an
+            entry point string and the class will attempt to load it first. It should be a full entry point string,
+            including the entry point group.
+        :return: Dictionary with the `version.core` and optionally `version.plugin` if it could be determined.
+        :raises EntryPointError: If ``plugin`` is a string but could not be loaded as a valid entry point.
+        :raises TypeError: If ``plugin`` (or the resource pointed to it in the case of an entry point) is not a class
+            or a function.
         """
         from aiida import __version__ as version_core
+
+        if isinstance(plugin, str):
+            try:
+                plugin = load_entry_point_from_string(plugin)
+            except EntryPointError as exc:
+                raise EntryPointError(f'got string `{plugin}` but could not load corresponding entry point') from exc
+
+        if not isclass(plugin) and not isfunction(plugin):
+            raise TypeError(f'`{plugin}` is not a class nor a function.')
 
         # If the `plugin` already exists in the cache, simply return it. On purpose we do not verify whether the version
         # information is completed. If it failed the first time, we don't retry. If the failure was temporarily, whoever

--- a/tests/plugins/test_utils.py
+++ b/tests/plugins/test_utils.py
@@ -7,23 +7,28 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name,no-self-use
 """Tests for utilities dealing with plugins and entry points."""
+import pytest
+
 from aiida import __version__ as version_core
+from aiida.common.exceptions import EntryPointError
 from aiida.engine import WorkChain, calcfunction
 from aiida.plugins import CalculationFactory
 from aiida.plugins.utils import PluginVersionProvider
 
 
-class TestPluginVersionProvider:
-    """Tests for the :py:class:`~aiida.plugins.utils.PluginVersionProvider` utility class."""
+@pytest.fixture
+def provider():
+    """Return an instance of the :class:`aiida.plugins.utils.PluginVersionProvider`."""
+    return PluginVersionProvider()
 
-    def setup_method(self):
-        # pylint: disable=attribute-defined-outside-init
-        self.provider = PluginVersionProvider()
 
-    @staticmethod
-    def create_dynamic_plugin_module(plugin, plugin_version, add_module_to_sys=True, add_version=True):
-        """Create a fake dynamic module with a certain `plugin` entity, a class or function and the given version."""
+@pytest.fixture
+def create_dynamic_plugin_module():
+    """Create a fake dynamic module with a certain `plugin` entity, a class or function and the given version."""
+
+    def _factory(plugin, plugin_version, add_module_to_sys=True, add_version=True):
         import sys
         import types
         import uuid
@@ -47,43 +52,49 @@ class TestPluginVersionProvider:
 
         return dynamic_plugin
 
-    def test_external_module_import_fail(self):
+    return _factory
+
+
+class TestPluginVersionProvider:
+    """Tests for the :py:class:`~aiida.plugins.utils.PluginVersionProvider` utility class."""
+
+    def test_external_module_import_fail(self, create_dynamic_plugin_module, provider):
         """Test that mapper does not except even if external module cannot be imported."""
 
         class DummyCalcJob():
             pass
 
         version_plugin = '0.1.01'
-        dynamic_plugin = self.create_dynamic_plugin_module(DummyCalcJob, version_plugin, add_module_to_sys=False)
+        dynamic_plugin = create_dynamic_plugin_module(DummyCalcJob, version_plugin, add_module_to_sys=False)
 
         expected_version = {'version': {'core': version_core}}
-        assert self.provider.get_version_info(dynamic_plugin) == expected_version
+        assert provider.get_version_info(dynamic_plugin) == expected_version
 
-    def test_external_module_no_version_attribute(self):
+    def test_external_module_no_version_attribute(self, create_dynamic_plugin_module, provider):
         """Test that mapper does not except even if external module does not define `__version__` attribute."""
 
         class DummyCalcJob():
             pass
 
         version_plugin = '0.1.02'
-        dynamic_plugin = self.create_dynamic_plugin_module(DummyCalcJob, version_plugin, add_version=False)
+        dynamic_plugin = create_dynamic_plugin_module(DummyCalcJob, version_plugin, add_version=False)
 
         expected_version = {'version': {'core': version_core}}
-        assert self.provider.get_version_info(dynamic_plugin) == expected_version
+        assert provider.get_version_info(dynamic_plugin) == expected_version
 
-    def test_external_module_class(self):
+    def test_external_module_class(self, create_dynamic_plugin_module, provider):
         """Test the mapper works for a class from an external module."""
 
         class DummyCalcJob():
             pass
 
         version_plugin = '0.1.17'
-        dynamic_plugin = self.create_dynamic_plugin_module(DummyCalcJob, version_plugin)
+        dynamic_plugin = create_dynamic_plugin_module(DummyCalcJob, version_plugin)
 
         expected_version = {'version': {'core': version_core, 'plugin': version_plugin}}
-        assert self.provider.get_version_info(dynamic_plugin) == expected_version
+        assert provider.get_version_info(dynamic_plugin) == expected_version
 
-    def test_external_module_function(self):
+    def test_external_module_function(self, create_dynamic_plugin_module, provider):
         """Test the mapper works for a function from an external module."""
 
         @calcfunction
@@ -91,12 +102,12 @@ class TestPluginVersionProvider:
             return
 
         version_plugin = '0.2.19'
-        dynamic_plugin = self.create_dynamic_plugin_module(test_calcfunction, version_plugin)
+        dynamic_plugin = create_dynamic_plugin_module(test_calcfunction, version_plugin)
 
         expected_version = {'version': {'core': version_core, 'plugin': version_plugin}}
-        assert self.provider.get_version_info(dynamic_plugin) == expected_version
+        assert provider.get_version_info(dynamic_plugin) == expected_version
 
-    def test_calcfunction(self):
+    def test_calcfunction(self, provider):
         """Test the mapper for a `calcfunction`."""
 
         @calcfunction
@@ -104,20 +115,30 @@ class TestPluginVersionProvider:
             return
 
         expected_version = {'version': {'core': version_core, 'plugin': version_core}}
-        assert self.provider.get_version_info(test_calcfunction) == expected_version
+        assert provider.get_version_info(test_calcfunction) == expected_version
 
-    def test_calc_job(self):
+    def test_calc_job(self, provider):
         """Test the mapper for a `CalcJob`."""
         AddArithmeticCalculation = CalculationFactory('core.arithmetic.add')  # pylint: disable=invalid-name
 
         expected_version = {'version': {'core': version_core, 'plugin': version_core}}
-        assert self.provider.get_version_info(AddArithmeticCalculation) == expected_version
+        assert provider.get_version_info(AddArithmeticCalculation) == expected_version
 
-    def test_work_chain(self):
+    def test_work_chain(self, provider):
         """Test the mapper for a `WorkChain`."""
 
         class SomeWorkChain(WorkChain):
             """Need to create a dummy class since there is no built-in work chain with entry point in `aiida-core`."""
 
         expected_version = {'version': {'core': version_core, 'plugin': version_core}}
-        assert self.provider.get_version_info(SomeWorkChain) == expected_version
+        assert provider.get_version_info(SomeWorkChain) == expected_version
+
+    def test_entry_point_string(self, provider):
+        """Test passing an entry point string."""
+        expected_version = {'version': {'core': version_core, 'plugin': version_core}}
+        assert provider.get_version_info('aiida.calculations:core.arithmetic.add') == expected_version
+
+    def test_entry_point_string_non_existant(self, provider):
+        """Test passing an entry point string that doesn't exist."""
+        with pytest.raises(EntryPointError, match=r'got string `.*` but could not load corresponding entry point'):
+            provider.get_version_info('aiida.calculations:core.non_existing')


### PR DESCRIPTION
Fixes #5661 

The `get_version_info` method now also supports `plugin` being an entry point string. It should be a full entry point string including the entry point group. The method will attempt to load the plugin before continuing as usual determining the version of the corresponding package.