### PR TITLE
Attmpt to decouple this_code setup

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -615,7 +615,7 @@ class CalcJob(Process):
         from aiida.common.datastructures import CodeInfo, CodeRunMode
         from aiida.common.exceptions import InputValidationError, InvalidOperation, PluginInternalError, ValidationError
         from aiida.common.utils import validate_list_of_string_tuples
-        from aiida.orm import AbstractCode, Computer, PortableCode, load_code
+        from aiida.orm import AbstractCode, Computer, load_code
         from aiida.schedulers.datastructures import JobTemplate, JobTemplateCodeInfo
 
         inputs = self.node.base.links.get_incoming(link_type=LinkType.INPUT_CALC)

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -738,7 +738,7 @@ class CalcJob(Process):
             else:
                 prepend_cmdline_params = this_code.get_prepend_cmdline_params()
 
-            cmdline_params = this_code.get_executable_cmdline_params(cmdline_params=code_info.cmdline_params)
+            cmdline_params = this_code.get_executable_cmdline_params(code_info.cmdline_params)
 
             tmpl_code_info = JobTemplateCodeInfo()
             tmpl_code_info.prepend_cmdline_params = prepend_cmdline_params

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -11,8 +11,8 @@
 from __future__ import annotations
 
 import abc
-import cmd
 import collections
+import pathlib
 
 import click
 
@@ -71,18 +71,26 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def get_executable(self) -> str:
+    def get_executable(self) -> pathlib.Path:
         """Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
         """
 
-    def get_executable_cmdline_params(self, cmdline_params: list = None) -> list:
-        """Return the list of executable with its cmdline_params"""
-        return [self.get_executable()] + (cmdline_params or [])
+    def get_executable_cmdline_params(self, cmdline_params: list[str] | None = None) -> list:
+        """Return the list of executable with its cmdline_params
 
-    def get_prepend_cmdline_params(self, mpi_args=None, extra_mpirun_params=None) -> list:
-        """Return the list of prepend cmdline params for mpi seeting"""
+        :return: list of executable with its cmdline parameters."""
+        return [str(self.get_executable())] + (cmdline_params or [])
+
+    def get_prepend_cmdline_params( # pylint: disable=no-self-use
+        self,
+        mpi_args: list[str] | None = None,
+        extra_mpirun_params: list[str] | None = None
+    ) -> list[str]:
+        """Return the list of prepend cmdline params for mpi seeting
+
+        :return: list of prepend cmdline parameters."""
         return (mpi_args or []) + (extra_mpirun_params or [])
 
     @property

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import abc
+import cmd
 import collections
 
 import click
@@ -75,6 +76,14 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
 
         :return: The executable to be called in the submission script.
         """
+        
+    def get_executable_cmdline_params(self, cmdline_params: list=None) -> list:
+        """Return the list of executable with its cmdline_params"""
+        return [self.get_executable()] + (cmdline_params or [])
+    
+    def get_prepend_cmdline_params(self, mpi_args=None, extra_mpirun_params=None) -> list:
+        """Return the list of prepend cmdline params for mpi seeting"""
+        return (mpi_args or []) + (extra_mpirun_params or [])
 
     @property
     @abc.abstractmethod

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -72,15 +72,19 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_executable(self) -> pathlib.Path:
-        """Return the executable that the submission script should execute to run the code.
+        """
+        Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
         """
 
     def get_executable_cmdline_params(self, cmdline_params: list[str] | None = None) -> list:
-        """Return the list of executable with its cmdline_params
+        """
+        Return the list of executable with its command line parameters.
 
-        :return: list of executable with its cmdline parameters."""
+        :param cmdline_params: List of command line parameters provided by the ``CalcJob`` plugin.
+        :return: List of the executable followed by its command line parameters.
+        """
         return [str(self.get_executable())] + (cmdline_params or [])
 
     def get_prepend_cmdline_params( # pylint: disable=no-self-use
@@ -88,9 +92,15 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         mpi_args: list[str] | None = None,
         extra_mpirun_params: list[str] | None = None
     ) -> list[str]:
-        """Return the list of prepend cmdline params for mpi seeting
-
-        :return: list of prepend cmdline parameters."""
+        """
+        Return List of command line parameters to be prepended to the executable in submission line.
+        These command line parameters are typically parameters related to MPI invocations.
+        
+        :param mpi_args: List of MPI parameters provided by the ``Computer.get_mpirun_command`` method.
+        :param extra_mpiruns_params: List of MPI parameters provided by the ``metadata.options.extra_mpirun_params`` 
+            input of the ``CalcJob``.
+        :return: List of command line parameters to be prepended to the executable in submission line.
+        """
         return (mpi_args or []) + (extra_mpirun_params or [])
 
     @property

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -72,15 +72,13 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_executable(self) -> pathlib.Path:
-        """
-        Return the executable that the submission script should execute to run the code.
+        """Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
         """
 
     def get_executable_cmdline_params(self, cmdline_params: list[str] | None = None) -> list:
-        """
-        Return the list of executable with its command line parameters.
+        """Return the list of executable with its command line parameters.
 
         :param cmdline_params: List of command line parameters provided by the ``CalcJob`` plugin.
         :return: List of the executable followed by its command line parameters.
@@ -92,8 +90,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         mpi_args: list[str] | None = None,
         extra_mpirun_params: list[str] | None = None
     ) -> list[str]:
-        """
-        Return List of command line parameters to be prepended to the executable in submission line.
+        """Return List of command line parameters to be prepended to the executable in submission line.
         These command line parameters are typically parameters related to MPI invocations.
 
         :param mpi_args: List of MPI parameters provided by the ``Computer.get_mpirun_command`` method.

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -76,11 +76,11 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
 
         :return: The executable to be called in the submission script.
         """
-        
-    def get_executable_cmdline_params(self, cmdline_params: list=None) -> list:
+
+    def get_executable_cmdline_params(self, cmdline_params: list = None) -> list:
         """Return the list of executable with its cmdline_params"""
         return [self.get_executable()] + (cmdline_params or [])
-    
+
     def get_prepend_cmdline_params(self, mpi_args=None, extra_mpirun_params=None) -> list:
         """Return the list of prepend cmdline params for mpi seeting"""
         return (mpi_args or []) + (extra_mpirun_params or [])

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -95,9 +95,9 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         """
         Return List of command line parameters to be prepended to the executable in submission line.
         These command line parameters are typically parameters related to MPI invocations.
-        
+
         :param mpi_args: List of MPI parameters provided by the ``Computer.get_mpirun_command`` method.
-        :param extra_mpiruns_params: List of MPI parameters provided by the ``metadata.options.extra_mpirun_params`` 
+        :param extra_mpiruns_params: List of MPI parameters provided by the ``metadata.options.extra_mpirun_params``
             input of the ``CalcJob``.
         :return: List of command line parameters to be prepended to the executable in submission line.
         """

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -77,7 +77,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
 
         :return: The executable to be called in the submission script.
         """
-        
+
     def get_executable_cmdline_params(self, cmdline_params: list[str] | None = None) -> list:
         """Return the list of executable with its command line parameters.
 

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -97,7 +97,7 @@ class InstalledCode(AbstractCode):
 
         :return: The executable to be called in the submission script.
         """
-        return self.filepath_executable
+        return str(self.filepath_executable)
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -92,12 +92,12 @@ class InstalledCode(AbstractCode):
         type_check(computer, Computer)
         return computer.pk == self.computer.pk
 
-    def get_executable(self) -> str:
+    def get_executable(self) -> pathlib.Path:
         """Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
         """
-        return str(self.filepath_executable)
+        return self.filepath_executable
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """Data plugin represeting an executable code to be wrapped and called through a `CalcJob` plugin."""
 import os
+import pathlib
 
 from aiida.common import exceptions
 from aiida.common.log import override_log_level
@@ -78,15 +79,17 @@ class Code(AbstractCode):
         type_check(computer, orm.Computer)
         return computer.pk == self.get_remote_computer().pk
 
-    def get_executable(self) -> str:
+    def get_executable(self) -> pathlib.Path:
         """Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
         """
         if self.is_local():
-            return f'./{self.get_local_executable()}'
+            exec_path = f'./{self.get_local_executable()}'
 
-        return self.get_remote_exec_path()
+        exec_path = self.get_remote_exec_path()
+
+        return pathlib.Path(exec_path)
 
     def hide(self):
         """

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -85,12 +85,12 @@ class PortableCode(AbstractCode):
         """
         return True
 
-    def get_executable(self) -> str:
+    def get_executable(self) -> pathlib.Path:
         """Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
         """
-        return str(self.filepath_executable)
+        return self.filepath_executable
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -90,7 +90,7 @@ class PortableCode(AbstractCode):
 
         :return: The executable to be called in the submission script.
         """
-        return self.filepath_executable
+        return str(self.filepath_executable)
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -111,7 +111,7 @@ class CodeBuilder:
         else:
             spec['code_type'] = CodeBuilder.CodeType.ON_COMPUTER
             spec['computer'] = code.computer
-            spec['remote_abs_path'] = code.get_executable()
+            spec['remote_abs_path'] = str(code.get_executable())
 
         return spec
 

--- a/tests/orm/data/code/test_abstract.py
+++ b/tests/orm/data/code/test_abstract.py
@@ -10,6 +10,7 @@
 # pylint: disable=redefined-outer-name
 """Tests for the :class:`aiida.orm.nodes.data.code.abstract.AbstractCode` class."""
 import pytest
+import pathlib
 
 from aiida.orm.nodes.data.code.abstract import AbstractCode
 
@@ -21,7 +22,7 @@ class MockCode(AbstractCode):
         """Return whether the code can run on a given computer."""
         return True
 
-    def get_executable(self) -> str:
+    def get_executable(self) -> pathlib.Path:
         """Return the executable that the submission script should execute to run the code."""
         return ''
 

--- a/tests/orm/data/code/test_abstract.py
+++ b/tests/orm/data/code/test_abstract.py
@@ -9,8 +9,9 @@
 ###########################################################################
 # pylint: disable=redefined-outer-name
 """Tests for the :class:`aiida.orm.nodes.data.code.abstract.AbstractCode` class."""
-import pytest
 import pathlib
+
+import pytest
 
 from aiida.orm.nodes.data.code.abstract import AbstractCode
 


### PR DESCRIPTION
Hi @sphuber, this is an attempt to move the code script generate for `prepend_cmdline_params` ad `cmdline_params` as the parameters into `AbstractCode` class which is required by the containerized code implementation if the code type check needs to be removed from `presubmmit` of `calcjob.py`.

I add two helper function into `AbstractCode` to generate `prepend_cmdline_params` and `cmdline_params` with parameters. This is the pre-requisites of the containerized code implementation.

Please have a look and let me know if it is in the right direction. Thanks!