### PR TITLE
Remove explicit PortableCode check in presubmit

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -634,10 +634,7 @@ class CalcJob(Process):
                     )
                 )
 
-            if isinstance(code, PortableCode) and str(code.filepath_executable) in folder.get_content_list():
-                raise PluginInternalError(
-                    f'The plugin created a file {code.filepath_executable} that is also the executable name!'
-                )
+            code.presubmit_check(folder)
 
         calc_info = self.prepare_for_submission(folder)
         calc_info.uuid = str(self.node.uuid)

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -634,7 +634,7 @@ class CalcJob(Process):
                     )
                 )
 
-            code.presubmit_check(folder)
+            code.validate_working_directory(folder)
 
         calc_info = self.prepare_for_submission(folder)
         calc_info.uuid = str(self.node.uuid)

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -80,8 +80,8 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
     def validate_working_directory(self, folder: Folder):
         """Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
 
-        This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new 
-        calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used 
+        This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new
+        calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used
         for the calculation to create the input files for the working directory. This method can be overridden by
         implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
 

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -17,6 +17,7 @@ import click
 
 from aiida.cmdline.params.options.interactive import TemplateInteractiveOption
 from aiida.common import exceptions
+from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.orm import Computer
 from aiida.plugins import CalculationFactory
@@ -74,6 +75,14 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         """Return the executable that the submission script should execute to run the code.
 
         :return: The executable to be called in the submission script.
+        """
+
+    @abc.abstractmethod
+    def presubmit_check(self, folder: Folder):
+        """check the validity when calling in presubmit.
+
+        :param folder: a SandboxFolder that can be used to write calculation input files and the scheduling script.
+        :raises PluginInternalError: The plugin created a file that is also the executable name!.
         """
 
     @property

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -77,12 +77,12 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         :return: The executable to be called in the submission script.
         """
 
-    def validate_working_directory(self, folder: SandboxFolder):
+    def validate_working_directory(self, folder: Folder):
         """Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
 
-        This method will be called by :meth:`~aiida.engine.processes.calcjobs.CalcJob.presubmit` when a new calculation
-        job is launched, passing the :class:`~aiida.common.folders.SandboxFolder` that was used by the plugin used for
-        the calculation to create the input files for the working directory. This method can be overridden by
+        This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new 
+        calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used 
+        for the calculation to create the input files for the working directory. This method can be overridden by
         implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
 
         :param folder: A sandbox folder that the ``CalcJob`` plugin wrote input files to that will be copied to the

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -77,12 +77,17 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         :return: The executable to be called in the submission script.
         """
 
-    @abc.abstractmethod
-    def presubmit_check(self, folder: Folder):
-        """check the validity when calling in presubmit.
+    def validate_working_directory(self, folder: SandboxFolder):
+        """Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
 
-        :param folder: a SandboxFolder that can be used to write calculation input files and the scheduling script.
-        :raises PluginInternalError: The plugin created a file that is also the executable name!.
+        This method will be called by :meth:`~aiida.engine.processes.calcjobs.CalcJob.presubmit` when a new calculation
+        job is launched, passing the :class:`~aiida.common.folders.SandboxFolder` that was used by the plugin used for
+        the calculation to create the input files for the working directory. This method can be overridden by
+        implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
+
+        :param folder: A sandbox folder that the ``CalcJob`` plugin wrote input files to that will be copied to the
+            working directory for the corresponding calculation job instance.
+        :raises PluginInternalError: If the content of the sandbox folder is not valid.
         """
 
     @property

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -20,7 +20,6 @@ import click
 
 from aiida.cmdline.params.types import ComputerParamType
 from aiida.common import exceptions
-from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
 from aiida.orm import Computer
@@ -99,13 +98,6 @@ class InstalledCode(AbstractCode):
         :return: The executable to be called in the submission script.
         """
         return self.filepath_executable
-
-    def presubmit_check(self, folder: Folder):
-        """check the validity when calling in presubmit.
-
-        :param folder: a SandboxFolder that can be used to write calculation input files and the scheduling script.
-        :raises PluginInternalError: The plugin created a file that is also the executable name!.
-        """
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -20,6 +20,7 @@ import click
 
 from aiida.cmdline.params.types import ComputerParamType
 from aiida.common import exceptions
+from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
 from aiida.orm import Computer
@@ -98,6 +99,13 @@ class InstalledCode(AbstractCode):
         :return: The executable to be called in the submission script.
         """
         return self.filepath_executable
+
+    def presubmit_check(self, folder: Folder):
+        """check the validity when calling in presubmit.
+
+        :param folder: a SandboxFolder that can be used to write calculation input files and the scheduling script.
+        :raises PluginInternalError: The plugin created a file that is also the executable name!.
+        """
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -93,7 +93,19 @@ class PortableCode(AbstractCode):
         """
         return self.filepath_executable
 
-    def presubmit_check(self, folder: Folder):
+    def validate_working_directory(self, folder: Folder):
+        """Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
+
+        This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new 
+        calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used 
+        for the calculation to create the input files for the working directory. This method can be overridden by
+        implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
+        
+        :param folder: A sandbox folder that the ``CalcJob`` plugin wrote input files to that will be copied to the
+            working directory for the corresponding calculation job instance.
+        :raises PluginInternalError: The ``CalcJob`` plugin created a file that has the same relative filepath as the
+            executable for this portable code.
+        """
         if str(self.filepath_executable) in folder.get_content_list():
             raise exceptions.PluginInternalError(
                 f'The plugin created a file {self.filepath_executable} that is also the executable name!'

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -22,6 +22,7 @@ import pathlib
 import click
 
 from aiida.common import exceptions
+from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.orm import Computer
 
@@ -91,6 +92,12 @@ class PortableCode(AbstractCode):
         :return: The executable to be called in the submission script.
         """
         return self.filepath_executable
+
+    def presubmit_check(self, folder: Folder):
+        if str(self.filepath_executable) in folder.get_content_list():
+            raise exceptions.PluginInternalError(
+                f'The plugin created a file {self.filepath_executable} that is also the executable name!'
+            )
 
     @property
     def full_label(self) -> str:

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -96,11 +96,11 @@ class PortableCode(AbstractCode):
     def validate_working_directory(self, folder: Folder):
         """Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
 
-        This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new 
-        calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used 
+        This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new
+        calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used
         for the calculation to create the input files for the working directory. This method can be overridden by
         implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
-        
+
         :param folder: A sandbox folder that the ``CalcJob`` plugin wrote input files to that will be copied to the
             working directory for the corresponding calculation job instance.
         :raises PluginInternalError: The ``CalcJob`` plugin created a file that has the same relative filepath as the


### PR DESCRIPTION
As mentioned at https://github.com/aiidateam/aiida-core/pull/5664#issuecomment-1258030838, in this PR I try to remove the explicit call of the `PortableCode` in `presubmit` by adding a `presubmit_check` helper function to code classes.