### PR TITLE
DOCS: pull tag "latest" from Docker Hub

### DIFF
--- a/docs/source/intro/run_docker.rst
+++ b/docs/source/intro/run_docker.rst
@@ -21,13 +21,13 @@ This image contains a fully pre-configured AiiDA environment which makes it part
 
       .. parsed-literal::
 
-         $ docker pull aiidateam/aiida-core:\ |release|\
+         $ docker pull aiidateam/aiida-core:latest
 
       Then start the container with:
 
       .. parsed-literal::
 
-         $ docker run -d --name aiida-container aiidateam/aiida-core:\ |release|\
+         $ docker run -d --name aiida-container aiidateam/aiida-core:latest
 
       You can use the following command to block until all services have started up:
 
@@ -88,7 +88,7 @@ This image contains a fully pre-configured AiiDA environment which makes it part
 
       .. parsed-literal::
 
-         $ docker run -d --name aiida-container --mount source=my-data,target=/tmp/my_data aiidateam/aiida-core:\ |release|\
+         $ docker run -d --name aiida-container --mount source=my-data,target=/tmp/my_data aiidateam/aiida-core:latest
 
       Starting the container with the above command, ensures that any data stored in the ``/tmp/my_data`` path within the container is stored in the ``my-data`` volume and therefore persists even if the container is removed.
 


### PR DESCRIPTION
Users running command `git pull aiidateam/aiida-core:2.0.3.post0` would face the following error:

```
Error response from daemon: manifest for aiidateam/aiida-core:2.0.4.post0 not found: manifest unknown: manifest unknown
```

That is because the images pushed to Docker Hub have tags that do not end in `.post0`.

This change reflects this fact, and instead recommends using tag `latest`.

As in: `docker pull aiidateam/aiida-core:latest`