### PR TITLE
`verdi setup`: Add the `--profile-uuid` option

### DIFF
--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """The `verdi setup` and `verdi quicksetup` commands."""
-
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -40,11 +39,12 @@ from aiida.manage.configuration import Profile, load_profile
 @options_setup.SETUP_BROKER_VIRTUAL_HOST()
 @options_setup.SETUP_REPOSITORY_URI()
 @options_setup.SETUP_TEST_PROFILE()
+@options_setup.SETUP_PROFILE_UUID()
 @options.CONFIG_FILE()
 def setup(
     non_interactive, profile: Profile, email, first_name, last_name, institution, db_engine, db_backend, db_host,
     db_port, db_name, db_username, db_password, broker_protocol, broker_username, broker_password, broker_host,
-    broker_port, broker_virtual_host, repository, test_profile
+    broker_port, broker_virtual_host, repository, test_profile, profile_uuid
 ):
     """Setup a new profile.
 
@@ -53,6 +53,9 @@ def setup(
     # pylint: disable=too-many-arguments,too-many-locals,unused-argument
     from aiida import orm
     from aiida.manage.configuration import get_config
+
+    if profile_uuid is not None:
+        profile.uuid = profile_uuid
 
     profile.set_storage(
         db_backend, {

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -152,6 +152,19 @@ def get_quicksetup_password(ctx, param, value):  # pylint: disable=unused-argume
     return value
 
 
+SETUP_PROFILE_UUID = options.OverridableOption(
+    '--profile-uuid',
+    prompt='Profile UUID',
+    prompt_fn=lambda x: False,  # This option should not be prompted for.
+    help='The UUID of the profile. This should only be defined if configuring a profile that should connect to the '
+    'same services of a profile that is already configured in another AiiDA instance, in which case the profile UUIDs '
+    'need to be identical.',
+    required=False,
+    hidden=True,
+    type=str,
+    cls=options.interactive.InteractiveOption
+)
+
 SETUP_PROFILE = options.OverridableOption(
     '--profile',
     prompt='Profile name',


### PR DESCRIPTION
Fixes #5670 

When setting up a profile in multiple AiiDA instances that should all use the same services (storage backend, message broker), for this to work, the profile UUID should be identical. Currently, there is no way to set the UUID of a profile through the CLI. The `verdi setup` and `verdi quicksetup` commands will always generate a new random UUID.

Here we add the `--profile-uuid` option to `verdi setup` which allows to specify the desired UUID instead of having one generated. It is not added to `verdi quicksetup` because in this use case of sharing resources between profiles, the resource is normally created before hand. Likewise, this use case is often deployed automatically which uses `verdi setup` in a non-interactive way. This is why the option will not be prompted for in interactive mode. That would only confuse normal users that are setting up a normal profile where the UUID should simply be generated automatically.