### PR TITLE
DevOps: Fix the nightly slack notification on PRs from forks 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,7 +76,10 @@ jobs:
             run: .github/workflows/tests_nightly.sh
 
         -   name: Slack notification
-            if: always() && (steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure')
+            # Always run this step (otherwise it would be skipped if any of the previous steps fail) but only if the
+            # `install` or `tests` steps failed, and the `SLACK_WEBHOOK` is available. The latter is not the case for
+            # pull requests that come from forks. This is a limitation of secrets on GHA
+            if: always() && (steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure') && env.SLACK_WEBHOOK != null
             uses: rtCamp/action-slack-notify@v2
             env:
                 SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Fixes #5668 

A limitation of secrets in Github Actions is that they are not available
in workflow runs that are triggered by pull requests that come from
forks. This would cause problems for the nightly workflow, which when
failed tried to send a notification to the Slack channel. However, this
requires the `SLACK_WEBHOOK` which is not available and so the step
would error out.

The solution is to only execute the step if the secret is available
which is now explicitly checked for in the conditional.