### PR TITLE
CLI: Add the `verdi devel revive` command

### DIFF
--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -14,12 +14,41 @@ import click
 
 from aiida import get_profile
 from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import decorators, echo
 
 
 @verdi.group('devel')
 def verdi_devel():
     """Commands for developers."""
+
+
+@verdi_devel.command('revive')
+@arguments.PROCESSES()
+@options.FORCE()
+@decorators.only_if_daemon_running(message='The daemon has to be running for this command to work.')
+def devel_revive(processes, force):
+    """Revive processes that seem stuck and are no longer reachable.
+
+    Warning: Use only as a last resort after you've gone through the checklist below.
+
+    \b
+        1. Does ``verdi status`` indicate that both daemon and RabbitMQ are running properly?
+           If not, restart the daemon with ``verdi daemon restart --reset`` and restart RabbitMQ.
+        2. Try ``verdi process play <PID>``.
+           If you receive a message that the process is no longer reachable, use ``verdi devel revive <PID>``.
+
+    Details: When RabbitMQ loses the process task before the process has completed, the process is never picked up by
+    the daemon and will remain "stuck". ``verdi devel revive`` recreates the task, which can lead to multiple instances
+    of the task being executed and should thus be used with caution.
+    """
+    from aiida.engine.processes.control import revive_processes
+
+    if not force:
+        echo.echo_warning('This command should only be used if you are absolutely sure the process task was lost.')
+        click.confirm(text='Do you want to continue?', abort=True)
+
+    revive_processes(processes)
 
 
 @verdi_devel.command('check-load-time')

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -197,7 +197,7 @@ def process_kill(processes, timeout, wait):
     try:
         control.kill_processes(processes, timeout=timeout, wait=wait)
     except control.ProcessTimeoutException as exception:
-        echo.echo_critical(str(exception))
+        echo.echo_critical(str(exception) + '\nFrom the CLI you can call `verdi devel revive <PID>`.')
 
 
 @verdi_process.command('pause')
@@ -217,7 +217,7 @@ def process_pause(processes, all_entries, timeout, wait):
     try:
         control.pause_processes(processes, all_entries=all_entries, timeout=timeout, wait=wait)
     except control.ProcessTimeoutException as exception:
-        echo.echo_critical(str(exception))
+        echo.echo_critical(str(exception) + '\nFrom the CLI you can call `verdi devel revive <PID>`.')
 
 
 @verdi_process.command('play')
@@ -237,7 +237,7 @@ def process_play(processes, all_entries, timeout, wait):
     try:
         control.play_processes(processes, all_entries=all_entries, timeout=timeout, wait=wait)
     except control.ProcessTimeoutException as exception:
-        echo.echo_critical(str(exception))
+        echo.echo_critical(str(exception) + '\nFrom the CLI you can call `verdi devel revive <PID>`.')
 
 
 @verdi_process.command('watch')

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -348,6 +348,7 @@ class TemporaryProfileManager(ProfileManager):
         if created:
             user.store()
         profile.default_user_email = user.email
+        config.store()
 
     def repo_ok(self):
         return bool(self.repo and os.path.isdir(os.path.dirname(self.repo)))

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -216,6 +216,7 @@ Below is a list with all available subcommands.
     Commands:
       check-load-time          Check for common indicators that slowdown `verdi`.
       check-undesired-imports  Check that verdi does not import python modules it shouldn't.
+      revive                   Revive processes that seem stuck and are no longer reachable.
       run-sql                  Run a raw SQL command on the profile database (only...
       validate-plugins         Validate all plugins by checking they can be loaded.
 

--- a/tests/cmdline/commands/test_devel.py
+++ b/tests/cmdline/commands/test_devel.py
@@ -8,8 +8,13 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for ``verdi devel``."""
+from plumpy.process_comms import RemoteProcessThreadController
+from plumpy.process_states import ProcessState
+import pytest
+
 from aiida.cmdline.commands import cmd_devel
-from aiida.orm import Node
+from aiida.engine import submit
+from aiida.orm import Int, Node
 
 
 def test_run_sql(run_cli_command):
@@ -17,3 +22,37 @@ def test_run_sql(run_cli_command):
     options = ['SELECT COUNT(*) FROM db_dbnode;']
     result = run_cli_command(cmd_devel.devel_run_sql, options)
     assert str(Node.collection.count()) in result.output, result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_revive_without_daemon(run_cli_command):
+    """Test that ``verdi devel revive`` fails if no daemon is running."""
+    assert run_cli_command(cmd_devel.devel_revive, raises=True)
+
+
+@pytest.mark.usefixtures('aiida_profile', 'started_daemon_client')
+def test_revive(run_cli_command, monkeypatch, aiida_local_code_factory, submit_and_await):
+    """Test ``verdi devel revive``."""
+    code = aiida_local_code_factory('core.arithmetic.add', '/bin/bash')
+    builder = code.get_builder()
+    builder.x = Int(1)
+    builder.y = Int(1)
+    builder.metadata.options.resources = {'num_machines': 1}
+
+    # Temporarily patch the ``RemoteProcessThreadController.continue_process`` method to do nothing and just return a
+    # completed future. This ensures that the submission creates a process node in the database but no task is sent to
+    # RabbitMQ and so the daemon will not start running it.
+    with monkeypatch.context() as context:
+        context.setattr(RemoteProcessThreadController, 'continue_process', lambda *args, **kwargs: None)
+        node = submit(builder)
+
+    # The node should now be created in the database but "stuck"
+    assert node.process_state == ProcessState.CREATED
+
+    # Time to revive it by recreating the task and send it to RabbitMQ
+    run_cli_command(cmd_devel.devel_revive, [str(node.pk), '--force'])
+
+    # Wait for the process to be picked up by the daemon and completed. If there is a problem with the code, this call
+    # should timeout and raise an exception
+    submit_and_await(node, ProcessState.FINISHED)
+    assert node.is_finished_ok


### PR DESCRIPTION
Fixes #5676 

This command is useful in debugging scenarios where a process is suspected to be stuck because the process task got lost with RabbitMQ. This is a known bug, the source of which is not yet known, but the remedy is very effective, which is to simply recreate the task.

There is a way to do this from the Python API, but it is not straight forward and so it is often not easy to tell users how to do this. Therefore this method is now exposed through a new CLI command called `verdi devel revive`. It is put under `verdi devel` since this command should be used prudently and as a last resort, when the cause of the problem is known with high certainty, because incorrect use of the command can create bigger problems.