### PR TITLE
`Code`: Use deprecated legacy code as base class for successors

### DIFF
--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -24,12 +24,12 @@ from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
 from aiida.orm import Computer
 
-from .abstract import AbstractCode
+from .legacy import Code
 
 __all__ = ('InstalledCode',)
 
 
-class InstalledCode(AbstractCode):
+class InstalledCode(Code):
     """Data plugin representing an executable code on a remote computer."""
 
     _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE: str = 'filepath_executable'
@@ -49,7 +49,7 @@ class InstalledCode(AbstractCode):
 
         :raises :class:`aiida.common.exceptions.ValidationError`: If the state of the node is invalid.
         """
-        super()._validate()
+        super(Code, self)._validate()  # Change to ``super()._validate()`` once deprecated ``Code`` class is removed.  # pylint: disable=bad-super-call
 
         if not self.computer:
             raise exceptions.ValidationError('The `computer` is undefined.')

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -20,6 +20,13 @@ from .abstract import AbstractCode
 
 __all__ = ('Code',)
 
+warn_deprecation(
+    'The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode`'
+    ' or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respetively. If you are '
+    'using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
+    version=3
+)
+
 
 class Code(AbstractCode):
     """

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -26,12 +26,12 @@ from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.orm import Computer
 
-from .abstract import AbstractCode
+from .legacy import Code
 
 __all__ = ('PortableCode',)
 
 
-class PortableCode(AbstractCode):
+class PortableCode(Code):
     """Data plugin representing an executable code stored in AiiDA's storage."""
 
     _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE: str = 'filepath_executable'
@@ -62,7 +62,7 @@ class PortableCode(AbstractCode):
 
         :raises :class:`aiida.common.exceptions.ValidationError`: If the state of the node is invalid.
         """
-        super()._validate()
+        super(Code, self)._validate()  # Change to ``super()._validate()`` once deprecated ``Code`` class is removed.  # pylint: disable=bad-super-call
 
         try:
             filepath_executable = self.filepath_executable


### PR DESCRIPTION
Fixes #5679 

The legacy `Code` class was deprecated in favor of a more generic and improved `AbstractCode` class. The "remote" and "local" variants that the single `Code` class provided, were recreated as separate implementations of `AbstractCode`: `InstalledCode` and `PortableCode`.

However, by having them subclass `AbstractCode`, any plugin code that would perform a type check on a code input based on the `Code` class, would now fail. A workaround is to have the two new concrete implementations actually subclass `Code`. Since `Code` was made to subclass `AbstractCode`, they still inherit all the functionality from that base class as they need it. The one change is that whenever they call `super` they have to explicitly call `super(Code, self)` to skip the implementation of `Code` and instead go straight to `AbstractCode`. Once `Code` is officially removed, these workarounds can also be removed and the normal `super` call can be reinstated.