### PR TITLE
Tests: Manually stop daemon after `verdi devel revive` test 

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -31,3 +31,5 @@ verdi computer test slurm-ssh --print-traceback
 
 verdi profile setdefault test_aiida
 verdi config set runner.poll.interval 0
+verdi config set warnings.development_version False
+verdi config set warnings.rabbitmq_version False

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -348,6 +348,11 @@ class TemporaryProfileManager(ProfileManager):
         if created:
             user.store()
         profile.default_user_email = user.email
+
+        # Set options to suppress certain warnings
+        config.set_option('warnings.development_version', False)
+        config.set_option('warnings.rabbitmq_version', False)
+
         config.store()
 
     def repo_ok(self):

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -164,7 +164,6 @@ def aiida_localhost(tmp_path):
         computer.store()
         computer.set_minimum_job_poll_interval(0.)
         computer.set_default_mpiprocs_per_machine(1)
-        computer.set_default_memory_per_machine(100000)
         computer.configure()
 
     return computer

--- a/tests/cmdline/commands/test_devel.py
+++ b/tests/cmdline/commands/test_devel.py
@@ -30,8 +30,8 @@ def test_revive_without_daemon(run_cli_command):
     assert run_cli_command(cmd_devel.devel_revive, raises=True)
 
 
-@pytest.mark.usefixtures('aiida_profile', 'started_daemon_client')
-def test_revive(run_cli_command, monkeypatch, aiida_local_code_factory, submit_and_await):
+@pytest.mark.usefixtures('aiida_profile')
+def test_revive(run_cli_command, monkeypatch, aiida_local_code_factory, submit_and_await, started_daemon_client):
     """Test ``verdi devel revive``."""
     code = aiida_local_code_factory('core.arithmetic.add', '/bin/bash')
     builder = code.get_builder()
@@ -56,3 +56,8 @@ def test_revive(run_cli_command, monkeypatch, aiida_local_code_factory, submit_a
     # should timeout and raise an exception
     submit_and_await(node, ProcessState.FINISHED)
     assert node.is_finished_ok
+
+    # Need to manually stop the daemon such that it cleans all state related to the submitted processes. It is not quite
+    # understood how, but leaving the daemon running, a following test that will submit to the daemon may hit an
+    # an exception because the node submitted here would no longer exist and the daemon would try to operate on it.
+    started_daemon_client.stop_daemon(wait=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -519,7 +519,7 @@ def reset_log_level():
 
 
 @pytest.fixture
-def submit_and_await():
+def submit_and_await(daemon_client):
     """Submit a process and wait for it to achieve the given state."""
 
     def _factory(
@@ -548,8 +548,11 @@ def submit_and_await():
                 raise RuntimeError(f'The process excepted: {node.exception}')
 
             if time.time() - start_time >= timeout:
+                daemon_log_file = pathlib.Path(daemon_client.daemon_log_file).read_text(encoding='utf-8')
+                daemon_status = 'running' if daemon_client.is_daemon_running else 'stopped'
                 raise RuntimeError(
-                    f'Timed out waiting for process with state `{node.process_state}` to enter state `{state}`.'
+                    f'Timed out waiting for process with state `{node.process_state}` to enter state `{state}`.\n'
+                    f'Daemon <{daemon_client.profile.name}|{daemon_status}> log file content: \n{daemon_log_file}'
                 )
 
         return node


### PR DESCRIPTION
Fixes #5687 

There was a problem where the `verdi process pause` test in the
`tests/cmdline/commands/test_process.py` would except because the
timeout would be hit. The direct result was because the daemon worker
could not load the node from the database, which in turns was because
the session was in a pending rollback state. This was because a previous
operation on the database excepted. This exception seemed to be due to
the daemon trying to call `CalcJob.delete_state` or
`Process.delete_checkpoint` in the `on_terminated` calls. For some
reason, the update statement that would be executed for this, to remove
the relevant attribute key, would match 0 rows. The suspicion is because
the relevant node had already been removed from the database, probably
because another test, ran between the two daemon tests, had cleaned the
database and so the node no longer existed, but the process task somehow
did.

It is not quite clear exactly where the problem lies, but for now the
temporary work-around is to manually stop the daemon in the first test,
which apparently cleans the state such that the original exception is no
longer hit and the daemon doesn't get stuck with an inconsistent session.