### PR TITLE
Engine: Do not call serializer for `None` values

### DIFF
--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -80,12 +80,12 @@ class WithSerialize:
         self._serializer: Callable[[Any], 'Data'] = serializer
 
     def serialize(self, value: Any) -> 'Data':
-        """Serialize the given value if it is not already a Data type and a serializer function is defined
+        """Serialize the given value, unless it is ``None``, already a Data type, or no serializer function is defined.
 
         :param value: the value to be serialized
         :returns: a serialized version of the value or the unchanged value
         """
-        if self._serializer is None or isinstance(value, Data):
+        if self._serializer is None or value is None or isinstance(value, Data):
             return value
 
         return self._serializer(value)

--- a/docs/source/topics/processes/usage.rst
+++ b/docs/source/topics/processes/usage.rst
@@ -194,9 +194,9 @@ This allows one to pass any normal value that one would also be able to pass to 
 Automatic input serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Quite often, inputs which are given as python data types need to be cast to the corresponding AiiDA type before passing them to a process.
+Quite often, inputs which are given as Python data types need to be cast to the corresponding AiiDA type before passing them to a process.
 Doing this manually can be cumbersome, so you can define a function when defining the process specification, which does the conversion automatically.
-This function, passed as ``serializer`` parameter to ``spec.input``, is invoked if the given input is *not* already an AiiDA type.
+This function, passed as ``serializer`` parameter to ``spec.input``, is invoked if the given input is not ``None`` *and* not already an AiiDA type.
 
 For inputs which are stored in the database (``non_db=False``), the serialization function should return an AiiDA data type.
 For ``non_db`` inputs, the function must be idempotent because it might be applied more than once.

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -496,3 +496,8 @@ def test_input_serialization(argument, node_cls):
         assert result.get_dict() == argument
     else:
         assert result.value == argument
+
+
+def test_input_serialization_none_default():
+    """Test that calling a function with explicit ``None`` for an argument that defines ``None`` as default works."""
+    assert function_with_none_default(int_a=1, int_b=2, int_c=None).value == 3


### PR DESCRIPTION
Fixes #5693 

Any port that defines a `serializer`, will have that serializer invoked
when a value is passed to this port. The invokation was correctly
skipped if no serializer was defined or if the value already was a
`Data` node (in which case serialization is no longer needed), but it
was also called when this value is `None`.

It arguably doesn't make sense to serialize a value that has not been
defined. This behavior would cause problems for processes that define a
port with a serializer but that also accept `None`. In this case the
serializer would nevertheless be called and, in the case of the
`to_aiida_type` serializer for example, would except.