### PR TITLE
Doc: switch image to base-with-services and adding aiidalab-launch

### DIFF
--- a/docs/source/intro/get_started.rst
+++ b/docs/source/intro/get_started.rst
@@ -60,10 +60,10 @@ If you are unsure, use the :ref:`system-wide installation <intro:get_started:sys
          :click-parent:
          :class: btn-link
 
-         Run AiiDA and prerequisite services as a single docker container.
+         Run AiiDA and prerequisite services as docker container.
 
       Does not require the separate installation of prerequisite services.
-      Especially well-suited to get directly started on the **tutorials**.
+      Especially well-suited to get clean environment for plugin development and to get directly started on the **tutorials**.
 
    .. grid-item-card:: :fa:`cloud;mr-1` Run via virtual machine
 

--- a/docs/source/intro/run_docker.rst
+++ b/docs/source/intro/run_docker.rst
@@ -5,8 +5,9 @@
 Run AiiDA via a Docker image
 ****************************
 
-The AiiDA team maintains a `Docker <https://www.docker.com/>`__ image on `Docker Hub <https://hub.docker.com/r/aiidateam/aiida-core>`__.
-This image contains a fully pre-configured AiiDA environment which makes it particularly useful for learning and testing purposes.
+AiiDA can deployed and run by using `Docker <https://www.docker.com/>`__.
+The AiiDA team maintains a `Docker image <https://hub.docker.com/r/aiidalab/base-with-services>`__ on `Docker Hub <https://hub.docker.com/r/aiidalab>`__.
+This image contains a fully pre-configured AiiDA environment which makes it particularly useful for developing, learning and testing purposes.
 
 .. caution::
 
@@ -21,35 +22,27 @@ This image contains a fully pre-configured AiiDA environment which makes it part
 
       .. parsed-literal::
 
-         $ docker pull aiidateam/aiida-core:latest
+         $ docker pull aiidalab/base-with-services:latest
 
       Then start the container with:
 
       .. parsed-literal::
 
-         $ docker run -d --name aiida-container aiidateam/aiida-core:latest
-
-      You can use the following command to block until all services have started up:
-
-      .. code-block:: console
-
-         $ docker exec -t aiida-container wait-for-services
+         $ docker run -d --name aiida-container aiidalab/base-with-services:latest
 
    .. grid-item-card:: Check setup
 
-      The default profile is created under the ``aiida`` user, so to execute commands you must add the ``--user aiida`` option.
-
-      For example, to check the verdi status, execute:
+      To check the verdi status, execute:
 
       .. code-block:: console
 
-         $ docker exec -t --user aiida aiida-container /bin/bash -l -c 'verdi status'
-         ✓ config dir:  /home/aiida/.aiida
-         ✓ profile:     On profile default
-         ✓ repository:  /home/aiida/.aiida/repository/default
-         ✓ postgres:    Connected as aiida_qs_aiida_477d3dfc78a2042156110cb00ae3618f@localhost:5432
-         ✓ rabbitmq:    Connected as amqp://127.0.0.1?heartbeat=600
-         ✓ daemon:      Daemon is running as PID 1795 since 2020-05-20 02:54:00
+         $ docker exec -t aiida-container /bin/bash -l -c 'verdi status'
+         ✔ version:     AiiDA v2.0.3
+         ✔ config:      /home/jovyan/.aiida
+         ✔ profile:     default
+         ✔ storage:     Storage for 'default' [open] @ postgresql://aiida:***@localhost:5432/aiida_db / file:///home/jovyan/.aiida/repository/default
+         ✔ rabbitmq:    Connected to RabbitMQ v3.8.14 as amqp://guest:guest@127.0.0.1:5672?heartbeat=600
+         ✔ daemon:      Daemon is running as PID 372 since 2022-10-12 19:58:32
 
    .. grid-item-card:: Use container interactively
 
@@ -57,9 +50,9 @@ This image contains a fully pre-configured AiiDA environment which makes it part
 
       .. code-block:: console
 
-         $ docker exec -it --user aiida aiida-container /bin/bash
+         $ docker exec -it aiida-container /bin/bash
 
-      This will drop you into the shell within the container as the user "aiida".
+      This will drop you into the shell within the container as the user "jovyan".
 
    .. grid-item-card:: Persist data across different containers
 
@@ -91,6 +84,11 @@ This image contains a fully pre-configured AiiDA environment which makes it part
          $ docker run -d --name aiida-container --mount source=my-data,target=/tmp/my_data aiidateam/aiida-core:latest
 
       Starting the container with the above command, ensures that any data stored in the ``/tmp/my_data`` path within the container is stored in the ``my-data`` volume and therefore persists even if the container is removed.
+
+.. note::
+
+   Besides using docker command to start container, we provide `AiiDAlab launch <https://github.com/aiidalab/aiidalab-launch>`__ to launch an AiiDA(lab) container with all services on a local workstation.
+   AiiDAlab launch also manage to create a docker volume to store data permanently.
 
       .. button-ref:: intro:get_started:next
          :ref-type: ref


### PR DESCRIPTION
The `aiidalab-launch` may be not proper to mention here which will somehow confuse users between aiida and aiidalab. But since from 2.x aiidalab is now all based on [jupyter/minimal-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-minimal-notebook) rather than `aiida-prerequisite`, there is no more effort to maintain `aiida-prerequisites`. 

As can be found from the change of the doc, it is more easy to use this `base-with-services` image. 
The main problem is the image is under the `aiidalab` namespace. 
I think we can also push the image to `aiidateam/base-with-services` and keep it a clone of `aiidalab/base-with-services`?

@yakutovicha @chrisjsewell @giovannipizzi @ltalirz @csadorf any thoughts?