### PR TITLE
`Process`: properly cleanup when exception in state transition

### DIFF
--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -402,10 +402,6 @@ class Process(plumpy.processes.Process):
         self._pid = self._create_and_setup_db_record()  # pylint: disable=attribute-defined-outside-init
 
     @override
-    def on_entering(self, state: plumpy.process_states.State) -> None:
-        super().on_entering(state)
-        # Update the node attributes every time we enter a new state
-
     def on_entered(self, from_state: Optional[plumpy.process_states.State]) -> None:
         """After entering a new state, save a checkpoint and update the latest process state change timestamp."""
         # pylint: disable=cyclic-import
@@ -635,8 +631,8 @@ class Process(plumpy.processes.Process):
         return serialize.deserialize_unsafe(encoded)
 
     def update_node_state(self, state: plumpy.process_states.State) -> None:
-        self.update_outputs()
         self.node.set_process_state(state.LABEL)
+        self.update_outputs()
 
     def update_outputs(self) -> None:
         """Attach new outputs to the node since the last call.

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
 - importlib-metadata~=4.3
 - numpy~=1.19
 - paramiko>=2.7.2,~=2.7
-- plumpy~=0.21.0
+- plumpy~=0.21.1
 - pgsu~=0.2.1
 - psutil~=5.6
 - psycopg2-binary~=2.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "importlib-metadata~=4.3",
     "numpy~=1.19",
     "paramiko~=2.7,>=2.7.2",
-    "plumpy~=0.21.0",
+    "plumpy~=0.21.1",
     "pgsu~=0.2.1",
     "psutil~=5.6",
     "psycopg2-binary~=2.8",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -90,7 +90,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.0
+plumpy==0.21.1
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 psutil==5.8.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -91,7 +91,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.0
+plumpy==0.21.1
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 psutil==5.8.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -90,7 +90,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.0
+plumpy==0.21.1
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 psutil==5.8.0


### PR DESCRIPTION
Fixes #2861 
Fixes #3334 

If a process would hit an exception during a state transition, the node would not always be cleaned up properly. For example, when a process registers invalid outputs, the process would except in `update_outputs` which is called by `on_entered` which is called once the process has entered a new state.

This exception would not be dealt with, skipping the code that is responsible for updating the process state on the node. This would lead to the node of the excepted node to still show the previous incorrect state. Typically, users would see processes as `Running` in the output of `verdi process list`. This is because that value is taken from the `process_state` attribute, but this simply contained the incorrect state.

The solution requires a fix in `plumpy`, which was released with `v0.21.` but it also requires an update in `update_node_state` of the `Process` class to make sure the `set_process_state` call is made before the `update_outputs` which is prone to excepting in the case of invalid outputs having been registered by the process implementation.