### PR TITLE
Bump wrapt version to 1.14 fix conda install issue for py310

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Create commit comment
       if: failure() && steps.check_reqs.outputs.error
-      uses: peter-evans/commit-comment@v1
+      uses: peter-evans/commit-comment@v2
       with:
         path: pyproject.toml
         body: |

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      packages: none
+      security-events: write
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -294,7 +294,7 @@ jobs:
 #
     - name: Create commit comment
       if: steps.check_reqs.outcome == 'Failure'  # only run if requirements/ are inconsistent
-      uses: peter-evans/commit-comment@v1
+      uses: peter-evans/commit-comment@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: pyproject.toml

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -273,6 +273,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      packages: none
+      security-events: write
+
     steps:
     - uses: actions/checkout@v2
 
@@ -296,7 +303,6 @@ jobs:
       if: steps.check_reqs.outcome == 'Failure'  # only run if requirements/ are inconsistent
       uses: peter-evans/commit-comment@v2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
         path: pyproject.toml
         body: |
           The requirements/ files are inconsistent!

--- a/environment.yml
+++ b/environment.yml
@@ -34,4 +34,4 @@ dependencies:
 - tqdm~=4.45
 - upf_to_json~=0.9.2
 - werkzeug<2.2
-- wrapt~=1.11
+- wrapt~=1.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
         "tqdm~=4.45",
         "upf_to_json~=0.9.2",
         "werkzeug<2.2",
-        "wrapt~=1.11"
+        "wrapt~=1.14"
 ]
 
 [project.urls]


### PR DESCRIPTION
[`wrapt` conda forge](https://anaconda.org/conda-forge/wrapt/files?page=2) don't have py3.10 support for the wrapt=1.11. 
Bump it to `1.14` so can be installed by conda with python 3.10.