### PR TITLE
DevOps: Remove `--use-feature` flag in `pip install` of CI

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -110,8 +110,8 @@ jobs:
 
     - name: Install aiida-core
       run: |
-        pip install --use-feature=2020-resolver -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip install --use-feature=2020-resolver --no-deps -e .
+        pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
+        pip install --no-deps -e .
         pip freeze
 
     - name: Setup environment


### PR DESCRIPTION
The `tests` job of the CI workflow used the `--use-feature=2020-resolver` flag in the `pip install` call to force using a specific package dependency resolver. We adopted this way back when `pip` introduced this new dependency resolver to be early-adopters to detect problems as soon as possible. In latest versions of `pip` this option is no longer available since the resolver is now the default, so we simply remove the flag.