### PR TITLE
Docs: Replace verdi code setup with `verdi code create`

### DIFF
--- a/.molecule/default/test_polish_workchains.yml
+++ b/.molecule/default/test_polish_workchains.yml
@@ -22,10 +22,10 @@
   - name: verdi add code setup
     when: aiida_check_code.rc != 0
     command: >
-      {{ venv_bin }}/verdi -p {{ aiida_backend }} code setup
-      -D "simple script that adds two numbers"
-      -n -L add -P core.arithmetic.add
-      -Y localhost --remote-abs-path=/bin/bash
+      {{ venv_bin }}/verdi -p {{ aiida_backend }} code create core.code.installed
+      --description "simple script that adds two numbers"
+      -n --label add --default-calc-job-plugin core.arithmetic.add
+      --computer localhost --filepath-executable=/bin/bash
 
   - name: Copy workchain files
     copy:

--- a/docs/source/intro/tutorial.md
+++ b/docs/source/intro/tutorial.md
@@ -289,7 +289,7 @@ For both commands, the *non-interactive* option (`-n`) is added to not prompt fo
 Next, let's set up the code we're going to use for the tutorial:
 
 ```console
-$ verdi code setup -L add --on-computer --computer=tutor -P core.arithmetic.add --remote-abs-path=/bin/bash -n
+$ verdi code create core.code.installed --label add --computer=tutor --default-calc-job-plugin core.arithmetic.add --filepath-executable=/bin/bash -n
 ```
 
 This command sets up a code with *label* `add` on the *computer* `tutor`, using the *plugin* `core.arithmetic.add`.
@@ -301,7 +301,7 @@ This command sets up a code with *label* `add` on the *computer* `tutor`, using 
 
 %verdi computer setup -L tutor -H localhost -T core.local -S core.direct -w /tmp -n
 %verdi computer configure core.local tutor --safe-interval 0 -n
-%verdi code setup -L add --on-computer --computer=tutor -P core.arithmetic.add --remote-abs-path=/bin/bash -n
+%verdi code create core.code.installed --label add --computer=tutor --default-calc-job-plugin core.arithmetic.add --filepath-executable=/bin/bash -n
 ```
 
 A typical real-world example of a computer is a remote supercomputing facility.

--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -420,11 +420,12 @@ AbstractCode
 .. versionadded:: 2.1
 
 The :class:`aiida.orm.nodes.data.code.abstract.AbstractCode` class provides the abstract class for objects that represent a "code" that can be executed through a :class:`aiida.engine.processes.calcjobs.calcjob.CalcJob` plugin.
-There are currently three implementations of this abstract class:
+There are currently four implementations of this abstract class:
 
  * :class:`~aiida.orm.nodes.data.code.legacy.Code` (see :ref:`Code <topics:data_types:core:code:legacy>`)
  * :class:`~aiida.orm.nodes.data.code.installed.InstalledCode` (see :ref:`InstalledCode <topics:data_types:core:code:installed>`)
  * :class:`~aiida.orm.nodes.data.code.portable.PortableCode` (see :ref:`PortableCode <topics:data_types:core:code:portable>`)
+ * :class:`~aiida.orm.nodes.data.code.containerized.ContainerizedCode` (see :ref:`ContainerizedCode <topics:data_types:core:code:containerized>`)
 
 
 .. _topics:data_types:core:code:legacy:


### PR DESCRIPTION
The `verdi code setup` command was deprecated but the how-to on running
an external code had not yet been adapted accordingly. Any remaining use
of `verdi code setup` is now replaced by `verdi code create`.