### PR TITLE
Mark relevant `Process` exit codes as `invalidates_cache=True`

### DIFF
--- a/aiida/calculations/arithmetic/add.py
+++ b/aiida/calculations/arithmetic/add.py
@@ -34,8 +34,12 @@ class ArithmeticAddCalculation(CalcJob):
         spec.inputs['metadata']['options']['output_filename'].default = 'aiida.out'
         spec.inputs['metadata']['options']['resources'].default = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
         # start exit codes - marker for docs
-        spec.exit_code(310, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read.')
-        spec.exit_code(320, 'ERROR_INVALID_OUTPUT', message='The output file contains invalid output.')
+        spec.exit_code(
+            310, 'ERROR_READING_OUTPUT_FILE', invalidates_cache=True, message='The output file could not be read.'
+        )
+        spec.exit_code(
+            320, 'ERROR_INVALID_OUTPUT', invalidates_cache=True, message='The output file contains invalid output.'
+        )
         spec.exit_code(410, 'ERROR_NEGATIVE_NUMBER', message='The sum of the operands is a negative number.')
         # end exit codes - marker for docs
 

--- a/aiida/calculations/templatereplacer.py
+++ b/aiida/calculations/templatereplacer.py
@@ -76,31 +76,31 @@ class TemplatereplacerCalculation(CalcJob):
         spec.default_output_node = 'output_parameters'
 
         spec.exit_code(
-            101,
+            301,
             'ERROR_NO_TEMPORARY_RETRIEVED_FOLDER',
             invalidates_cache=True,
             message='The temporary retrieved folder data node could not be accessed.'
         )
         spec.exit_code(
-            105,
+            305,
             'ERROR_NO_OUTPUT_FILE_NAME_DEFINED',
             invalidates_cache=True,
             message='The `template` input node did not specify the key `output_file_name`.'
         )
         spec.exit_code(
-            110,
+            310,
             'ERROR_READING_OUTPUT_FILE',
             invalidates_cache=True,
             message='The output file could not be read from the retrieved folder.'
         )
         spec.exit_code(
-            111,
+            311,
             'ERROR_READING_TEMPORARY_RETRIEVED_FILE',
             invalidates_cache=True,
             message='A temporary retrieved file could not be read from the temporary retrieved folder.'
         )
         spec.exit_code(
-            120, 'ERROR_INVALID_OUTPUT', invalidates_cache=True, message='The output file contains invalid output.'
+            320, 'ERROR_INVALID_OUTPUT', invalidates_cache=True, message='The output file contains invalid output.'
         )
 
     def prepare_for_submission(self, folder):

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -283,14 +283,20 @@ class CalcJob(Process):
             help='Files that are retrieved by the daemon will be stored in this node. By default the stdout and stderr '
                  'of the scheduler will be added, but one can add more by specifying them in `CalcInfo.retrieve_list`.')
 
-        # Errors caused or returned by the scheduler
-        spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The process did not have the required `retrieved` output.')
-        spec.exit_code(110, 'ERROR_SCHEDULER_OUT_OF_MEMORY',
-            message='The job ran out of memory.')
-        spec.exit_code(120, 'ERROR_SCHEDULER_OUT_OF_WALLTIME',
-            message='The job ran out of walltime.')
         # yapf: enable
+        # Errors caused or returned by the scheduler
+        spec.exit_code(
+            100,
+            'ERROR_NO_RETRIEVED_FOLDER',
+            invalidates_cache=True,
+            message='The process did not have the required `retrieved` output.'
+        )
+        spec.exit_code(
+            110, 'ERROR_SCHEDULER_OUT_OF_MEMORY', invalidates_cache=True, message='The job ran out of memory.'
+        )
+        spec.exit_code(
+            120, 'ERROR_SCHEDULER_OUT_OF_WALLTIME', invalidates_cache=True, message='The job ran out of walltime.'
+        )
 
     @classproperty
     def spec_options(cls):  # pylint: disable=no-self-argument

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -115,10 +115,21 @@ class Process(plumpy.processes.Process):
         )
         spec.inputs.valid_type = orm.Data
         spec.inputs.dynamic = False  # Settings a ``valid_type`` automatically makes it dynamic, so we reset it again
-        spec.exit_code(1, 'ERROR_UNSPECIFIED', message='The process has failed with an unspecified error.')
-        spec.exit_code(2, 'ERROR_LEGACY_FAILURE', message='The process failed with legacy failure mode.')
-        spec.exit_code(10, 'ERROR_INVALID_OUTPUT', message='The process returned an invalid output.')
-        spec.exit_code(11, 'ERROR_MISSING_OUTPUT', message='The process did not register a required output.')
+        spec.exit_code(
+            1, 'ERROR_UNSPECIFIED', invalidates_cache=True, message='The process has failed with an unspecified error.'
+        )
+        spec.exit_code(
+            2, 'ERROR_LEGACY_FAILURE', invalidates_cache=True, message='The process failed with legacy failure mode.'
+        )
+        spec.exit_code(
+            10, 'ERROR_INVALID_OUTPUT', invalidates_cache=True, message='The process returned an invalid output.'
+        )
+        spec.exit_code(
+            11,
+            'ERROR_MISSING_OUTPUT',
+            invalidates_cache=True,
+            message='The process did not register a required output.'
+        )
 
     @classmethod
     def get_builder(cls) -> ProcessBuilder:


### PR DESCRIPTION
Fixes #5708 

The `Process` and `CalcJob` classes define various exit codes, all of
which will correspond to processes that should not be used as a source
for caching. Therefore, these exit codes should properly declare
`invalidate_cache=True` which will automatically prevent any node with
that exit code from being cached from.

The `ArithmeticAddCalculation` and `TemplatereplacerCalculation plugins
are also updated to properly mark exit codes that should not be cached
from.