### PR TITLE
`verdi plugin list`: Show which exit codes invalidate cache 

### DIFF
--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -13,6 +13,7 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
+from click import style
 from tabulate import tabulate
 
 from . import echo
@@ -472,10 +473,19 @@ def print_process_spec(process_spec):
             echo.echo(template.format(*entry, width_name=max_width_name, width_type=max_width_type))
 
     if process_spec.exit_codes:
-        echo.echo('Exit codes:', fg=echo.COLORS['report'], bold=True)
-    for exit_code in sorted(process_spec.exit_codes.values(), key=lambda exit_code: exit_code.status):
-        message = exit_code.message
-        echo.echo('{:>{width_name}d}:  {}'.format(exit_code.status, message, width_name=max_width_name))
+        echo.echo('\nExit codes:\n', fg=echo.COLORS['report'], bold=True)
+
+        table = [('0', 'The process finished successfully.')]
+
+        for exit_code in sorted(process_spec.exit_codes.values(), key=lambda exit_code: exit_code.status):
+            if exit_code.invalidates_cache:
+                status = style(exit_code.status, bold=True, fg='red')
+            else:
+                status = exit_code.status
+            table.append((status, exit_code.message))
+
+        echo.echo(tabulate(table, tablefmt='plain'))
+        echo.echo(style('\nExit codes that invalidate the cache are marked in bold red.\n', italic=True))
 
 
 def get_num_workers():


### PR DESCRIPTION
Fixes #5707 

For `Process` entry points, the `verdi plugin list` command will show a
formatted rendering of the process specification. Here we mark exit
codes that invalidate the cache by printing in bold red. For example,
the `ArithmeticAddCalculation` will now display as:

    $ verdi plugin list aiida.calculations core.arithmetic.add
    ...
    Exit codes:
    Exit codes that invalidate the cache are marked in bold red

      1  The process has failed with an unspecified error.
      2  The process failed with legacy failure mode.
     11  The process did not register a required output.
    100  The process did not have the required `retrieved` output.
    110  The job ran out of memory.
    120  The job ran out of walltime.
    310  The output file could not be read.
    320  The output file contains invalid output.
    410  The sum of the operands is a negative number.