### PR TITLE
Engine: Do not let `DuplicateSubcriberError` except a `Process`

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -241,7 +241,7 @@ def aiida_local_code_factory(aiida_localhost):
     return get_code
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def daemon_client(aiida_profile):
     """Return a daemon client for the configured test profile for the test session.
 


### PR DESCRIPTION
Fixes #4598 
Fixes #3973 

It is possible that when a daemon worker tries to continue a process, that a ``kiwipy.DuplicateSubscriberError`` is raised, which means that there already is another system process that has subscribed to be running that process. This can occur for at least two reasons:

 * The user manually recreated the process task, mistakenly thinking it had been lost.
 * The daemon worker running the original task failed to respond to heartbeats of RabbitMQ in time and so RabbitMQ assumed the worker to be dead and rescheduled the task, sending it to another worker.

In both cases, the actual task is still actually being run and we should not let this exception except the entire process. Unfortunately, these duplicate tasks still happen quite a lot when the daemon workers are under heavy load and we don't want a bunch of processes to be excepted because of this.

In most cases, just ignoring the task wil be the best solution. In the end, the original task is likely to complete. If it turns out that the task actually got lost and the process is stuck, the user can find this error message in the logs and manually recreate the task, using for example ``verdi devel revive``.