### PR TITLE
Fixtures: Fix bug in reset of `empty_config` fixture

### DIFF
--- a/aiida/manage/configuration/settings.py
+++ b/aiida/manage/configuration/settings.py
@@ -66,14 +66,15 @@ def create_instance_directories():
         os.umask(umask)
 
 
-def set_configuration_directory():
-    """Determine the location of the configuration directory and set the related global variables.
+def set_configuration_directory(aiida_config_folder: pathlib.Path = None):
+    """Determine location of configuration directory, set related global variables and create instance directories.
 
     The location of the configuration folder will be determined and optionally created following these heuristics:
 
-        * If the `AIIDA_PATH` variable is set, all the paths will be checked to see if they contain a configuration
-          folder. The first one to be encountered will be set as `AIIDA_CONFIG_FOLDER`. If none of them contain one,
-          a configuration folder will be created in the last path considered.
+        * If an explicit path is provided by `aiida_config_folder`, that will be set as the configuration folder.
+        * Otherwise, if the `AIIDA_PATH` variable is set, all the paths will be checked to see if they contain a
+          configuration folder. The first one to be encountered will be set as `AIIDA_CONFIG_FOLDER`. If none of them
+          contain one, a configuration folder will be created in the last path considered.
         * If the `AIIDA_PATH` variable is not set the `DEFAULT_AIIDA_PATH` value will be used as base path and if it
           does not yet contain a configuration folder, one will be created.
 
@@ -87,7 +88,9 @@ def set_configuration_directory():
 
     environment_variable = os.environ.get(DEFAULT_AIIDA_PATH_VARIABLE, None)
 
-    if environment_variable:
+    if aiida_config_folder is not None:
+        AIIDA_CONFIG_FOLDER = aiida_config_folder
+    elif environment_variable:
 
         # Loop over all the paths in the `AIIDA_PATH` variable to see if any of them contain a configuration folder
         for base_dir_path in [path for path in environment_variable.split(':') if path]:

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -24,6 +24,7 @@ from aiida.manage.configuration.options import get_option
 def cache_aiida_path_variable():
     """Fixture that will store the ``AIIDA_PATH`` environment variable and restore it after the yield."""
     aiida_path_original = os.environ.get(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
+
     try:
         yield
     finally:
@@ -35,17 +36,21 @@ def cache_aiida_path_variable():
             except KeyError:
                 pass
 
+    # Make sure to reset the global variables set by the following call that are dependent on the environment variable
+    # ``DEFAULT_AIIDA_PATH_VARIABLE``. It may have been changed by a test using this fixture.
+    settings.set_configuration_directory()
+
 
 @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
 @pytest.mark.usefixtures('cache_aiida_path_variable')
-def test_environment_variable_not_set(tmp_path):
+def test_environment_variable_not_set(tmp_path, monkeypatch):
     """Check that if the environment variable is not set, config folder will be created in `DEFAULT_AIIDA_PATH`.
 
     To make sure we do not mess with the actual default `.aiida` folder, which often lives in the home folder
     we create a temporary directory and set the `DEFAULT_AIIDA_PATH` to it.
     """
     # Change the default configuration folder path to temp folder instead of probably `~`.
-    settings.DEFAULT_AIIDA_PATH = tmp_path
+    monkeypatch.setattr(settings, 'DEFAULT_AIIDA_PATH', tmp_path)
 
     # Make sure that the environment variable is not set
     try:

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -89,7 +89,7 @@ def test_get_unreferenced_keyset():
     ),
 ))
 # yapf: enable
-@pytest.mark.usefixtures('clear_storage_before_test')
+@pytest.mark.usefixtures('clear_storage_before_test', 'stopped_daemon_client')
 def test_maintain(caplog, monkeypatch, kwargs, logged_texts):
     """Test the ``maintain`` method."""
     import logging


### PR DESCRIPTION
The `empty_config` fixture creates a completely independent configuration directory which allows test to manipulate the config and its contents, such as the profiles, for the duration of the test without affecting pre-existing config directories.

To accomplish this, the `AIIDA_PATH` environment variable, which indicates the location of the configuration directory, is set to a temporary directory. The fixture then calls the method `aiida.manage.configuration.settings.set_configuration_directory` which will set a number of global variables that define important directory and file locations within the configuration folder, for example the location of important daemon files.

The bug was that these global variables weren't reset after the end of the fixture. This means that operations performed by the daemon client, such as checking whether the daemon is running, which rely on these filepaths being set correctly, would fail. The solution therefore is to call `set_configuration_directory` once again, to revert the global variables to their previous values.

This same problem also occurred in the `cache_aiida_path_variable` fixture defined and used in `tests/manage/configuration/test_config.py`. An explicit call after the `finally` in the fixture is necessary to reset the global variables.

Finally, `test_environment_variable_not_set` set the value of the `DEFAULT_AIIDA_PATH` variable to a temporary directory, however, it never changed it back to the default `~`. This would essentially cause the `set_configuration_directory` be ineffective if the `AIIDA_PATH` variable was never set before running the tests, as then the value of `DEFAULT_AIIDA_PATH` would be used, which was still the temporary directory of the test. This would break any following tests that rely on the global variables in the `settings` module to be properly set.