### PR TITLE
CI: Fix the `benchmark.yml` workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,15 +4,13 @@ on:
   push:
     branches: [main]
     paths-ignore: ['docs/**']
-  pull_request:
-    branches: [main]
 
 jobs:
 
   run-and-upload:
 
     # Only run on pushes and when the job is on the main repository and not on forks
-    if: ${{ github.event_name == 'push' && github.repository == 'aiidateam/aiida-core' }}
+    if: github.repository == 'aiidateam/aiida-core'
 
     strategy:
       fail-fast: false

--- a/tests/workflows/arithmetic/test_add_multiply.py
+++ b/tests/workflows/arithmetic/test_add_multiply.py
@@ -22,7 +22,7 @@ def test_factory():
 
 
 @pytest.mark.requires_rmq
-@pytest.mark.usefixtures('aiida_profile_clean', 'temporary_event_loop')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_run():
     """Test running the work function."""
     x = Int(1)


### PR DESCRIPTION
This workflow is run on pushed to the main repository and will run some benchmark tests. These were failing in the `reset_event_loop_policy` method of `aiida.engine.runners` where it is trying to undo the changes applied by the application of `nest_asyncio`.

The problem is with the engine benchmarks hacking around with the event loop in order to start a daemon worker running on the same loop. This loop won't be patched with `nest_asyncio` but the cleanup will still be called, resulting in the `AttributeError`.

The custom hack is replaced with the `started_daemon_client` fixture which also provides a running daemon but without the event loop hacks. The process is launched using the `submit_and_await` fixture which will submit the process and wait for it to be finished. The timeout is increased as these workchains can take a bit and the default wasn't long enough.