### PR TITLE
feat: `verdi process status --max-depth` (#5568)

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -174,13 +174,16 @@ def process_report(processes, levelname, indent_size, max_depth):
 
 
 @verdi_process.command('status')
+@click.option(
+    '-m', '--max-depth', 'max_depth', type=int, default=None, help='Limit the number of levels to be printed.'
+)
 @arguments.PROCESSES()
-def process_status(processes):
+def process_status(max_depth, processes):
     """Print the status of one or multiple processes."""
     from aiida.cmdline.utils.ascii_vis import format_call_graph
 
     for process in processes:
-        graph = format_call_graph(process)
+        graph = format_call_graph(process, max_depth=max_depth)
         echo.echo(graph)
 
 

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -18,7 +18,7 @@ from aiida.cmdline.commands import cmd_process
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 from aiida.engine import ProcessState
-from aiida.orm import CalcJobNode, WorkChainNode, WorkflowNode, WorkFunctionNode, Group
+from aiida.orm import CalcJobNode, Group, WorkChainNode, WorkflowNode, WorkFunctionNode
 from tests.utils.processes import WaitProcess
 
 

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -18,7 +18,7 @@ from aiida.cmdline.commands import cmd_process
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 from aiida.engine import ProcessState
-from aiida.orm import CalcJobNode, WorkChainNode, WorkflowNode, WorkFunctionNode
+from aiida.orm import CalcJobNode, WorkChainNode, WorkflowNode, WorkFunctionNode, Group
 from tests.utils.processes import WaitProcess
 
 
@@ -44,7 +44,6 @@ class TestVerdiProcess:
     def init_profile(self, aiida_profile_clean, run_cli_command):  # pylint: disable=unused-argument
         """Initialize the profile."""
         # pylint: disable=attribute-defined-outside-init
-        from aiida.orm.groups import Group
 
         self.calcs = []
         self.process_label = 'SomeDummyWorkFunctionNode'
@@ -250,6 +249,29 @@ class TestVerdiProcess:
         result = self.cli_runner(cmd_process.process_report, options)
 
         assert len(get_result_lines(result)) > 0
+
+    def test_process_status(self):
+        """Test verdi process status"""
+        node = WorkflowNode().store()
+        node.set_process_state(ProcessState.RUNNING)
+
+        # Running without identifiers should not except and not print anything
+        options = []
+        result = self.cli_runner(cmd_process.process_status, options)
+        assert result.exception is None, result.output
+        assert len(get_result_lines(result)) == 0
+
+        # Giving a single identifier should print a non empty string message
+        options = [str(node.pk)]
+        result = self.cli_runner(cmd_process.process_status, options)
+        assert result.exception is None, result.output
+        assert len(get_result_lines(result)) > 0
+
+        # With max depth 0, the output should be empty
+        options = ['--max-depth', 0, str(node.pk)]
+        result = self.cli_runner(cmd_process.process_status, options)
+        assert result.exception is None, result.output
+        assert len(get_result_lines(result)) == 0
 
     def test_report(self):
         """Test the report command."""


### PR DESCRIPTION
AiiDA workflows can get very complex with many layers, leading `verdi process status` to print hundreds of lines of text.

The `--max-depth` allows the user to "zoom out" and look at the bigger picture, while still being able to "zoom in" on subworkflows of interest by calling `verdi process status` on those.