### PR TITLE
fix: close sqla connections when unloading profile

### DIFF
--- a/aiida/storage/psql_dos/backend.py
+++ b/aiida/storage/psql_dos/backend.py
@@ -11,6 +11,7 @@
 # pylint: disable=missing-function-docstring
 from contextlib import contextmanager, nullcontext
 import functools
+import gc
 import pathlib
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Set, Union
 
@@ -143,6 +144,10 @@ class PsqlDosBackend(StorageBackend):  # pylint: disable=too-many-public-methods
         self._session_factory.expunge_all()
         self._session_factory.close()
         self._session_factory = None
+
+        # Without this, sqlalchemy keeps a weakref to a session
+        # in sqlalchemy.orm.session._sessions
+        gc.collect()
 
     def _clear(self, recreate_user: bool = True) -> None:
         from aiida.storage.psql_dos.models.settings import DbSetting

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -144,3 +144,24 @@ def test_get_info(monkeypatch):
     assert 'extra_value' in repository_info_out
     assert repository_info_out['value'] == 42
     assert repository_info_out['extra_value'] == 0
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_unload_profile():
+    """Test that unloading the profile closes all sqla sessions.
+
+    This is a regression test for #5506.
+    """
+    from sqlalchemy.orm.session import _sessions  # pylint: disable=import-outside-toplevel
+
+    # Just running the test suite itself should have opened at least one session
+    assert len(_sessions) != 0, str(_sessions)
+
+    manager = get_manager()
+    profile_name = manager.get_profile().name
+
+    try:
+        manager.unload_profile()
+        assert len(_sessions) == 0, str(_sessions)
+    finally:
+        manager.load_profile(profile_name)


### PR DESCRIPTION
Fixes #5506 

After unloading an AiiDA profile in the psql_dos backend, sqlalchemy would keep a weakref to a connection alive (which points to a reference cycle somewhere).
Calling the garbage collector explicitly cleares the connections.