### PR TITLE
fix: store user info early

### DIFF
--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -115,6 +115,10 @@ email: 123@234.de"""
 
         self.cli_runner(cmd_setup.quicksetup, options, raises=True)
 
+        # test
+        config = configuration.get_config()
+        assert config.get_option('autofill.user.email', scope=None) == user_email
+
     def test_setup(self):
         """Test `verdi setup` (non-interactive)."""
         postgres = Postgres(interactive=False, quiet=True, dbinfo=self.pg_test.dsn)

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -99,6 +99,34 @@ email: 123@234.de"""
             handle.flush()
             self.cli_runner(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)])
 
+    def test_quicksetup_autofill_on_early_exit(self):
+        """Test `verdi quicksetup` stores user information even if command fails."""
+        config = configuration.get_config()
+        assert config.get_option('autofill.user.email', scope=None) is None
+        assert config.get_option('autofill.user.first_name', scope=None) is None
+        assert config.get_option('autofill.user.last_name', scope=None) is None
+        assert config.get_option('autofill.user.institution', scope=None) is None
+
+        user_email = 'some@email.com'
+        user_first_name = 'John'
+        user_last_name = 'Smith'
+        user_institution = 'ECMA'
+
+        # The incorrect port will cause the command to fail, but the user information should have been stored on the
+        # configuration such that the user won't have to retype it but can use the pre-stored defaults.
+        options = [
+            '--non-interactive', '--profile', 'testing', '--email', user_email, '--first-name', user_first_name,
+            '--last-name', user_last_name, '--institution', user_institution, '--db-port',
+            self.pg_test.dsn['port'] + 100
+        ]
+
+        self.cli_runner(cmd_setup.quicksetup, options, raises=True)
+
+        assert config.get_option('autofill.user.email', scope=None) == user_email
+        assert config.get_option('autofill.user.first_name', scope=None) == user_first_name
+        assert config.get_option('autofill.user.last_name', scope=None) == user_last_name
+        assert config.get_option('autofill.user.institution', scope=None) == user_institution
+
     def test_quicksetup_wrong_port(self):
         """Test `verdi quicksetup` exits if port is wrong."""
         profile_name = 'testing'
@@ -114,10 +142,6 @@ email: 123@234.de"""
         ]
 
         self.cli_runner(cmd_setup.quicksetup, options, raises=True)
-
-        # test
-        config = configuration.get_config()
-        assert config.get_option('autofill.user.email', scope=None) == user_email
 
     def test_setup(self):
         """Test `verdi setup` (non-interactive)."""


### PR DESCRIPTION
`verdi setup` and `verdi quicksetup` store information about the user, such as their name, email, and institution, but they only do so when the setup finishes successfully.
This is tedious when setup fails as the user is forced to re-enter this information anew for every try. Here we simply make sure to store this information early.