### PR TITLE
`QueryBuilder`: Fix bug when mutating nodes during `iterall`

### DIFF
--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -164,10 +164,13 @@ class ProfileManager:
     def clear_profile():
         """Reset the global profile, clearing all its data and closing any open resources."""
         manager = get_manager()
-        manager.get_profile_storage()._clear(recreate_user=True)  # pylint: disable=protected-access
-        manager.get_profile_storage()  # reload the storage connection
         manager.reset_communicator()
         manager.reset_runner()
+
+        # Make sure profile storage is reset, closing any open sessions and connections and then recreate it, emptying
+        # the contents, except for the user.
+        manager.reset_profile_storage()
+        manager.get_profile_storage()._clear(recreate_user=True)  # pylint: disable=protected-access
 
     def has_profile_open(self):
         return self._profile is not None

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1470,6 +1470,21 @@ class TestConsistency:
             qb.append(orm.Data, with_incoming='parent')
             assert len(qb.all()) == qb.count()
 
+    @pytest.mark.usefixtures('aiida_profile_clean')
+    def test_iterall_with_mutation(self):
+        """Test that nodes can be mutated while being iterated using ``QueryBuilder.iterall``."""
+        for node in range(2):
+            orm.Data().store()
+
+        pks = []
+
+        for [node] in orm.QueryBuilder().append(orm.Data).iterall():
+            node.base.extras.set('key', 'value')
+            pks.append(node.pk)
+
+        for pk in pks:
+            assert orm.load_node(pk).get_extra('key') == 'value'
+
 
 class TestManager:
 

--- a/tests/tools/archive/orm/test_extras.py
+++ b/tests/tools/archive/orm/test_extras.py
@@ -31,11 +31,7 @@ def new_archive(aiida_profile_clean, tmp_path):
 def import_extras(path, import_new_extras=True) -> orm.Data:
     """Import an aiida database"""
     import_archive(path, import_new_extras=import_new_extras, merge_extras=('k', 'c', 'l'))
-
-    builder = orm.QueryBuilder().append(orm.Data, filters={'label': 'my_test_data_node'})
-    data = builder.all()
-    assert builder.count() == 1, data
-    return data[0][0]
+    return orm.QueryBuilder().append(orm.Data, filters={'label': 'my_test_data_node'}).one()[0]
 
 
 def modify_extras(path, imported_node, mode_existing) -> orm.Data:
@@ -47,9 +43,7 @@ def modify_extras(path, imported_node, mode_existing) -> orm.Data:
     import_archive(path, merge_extras=mode_existing)
 
     # Query again the database
-    builder = orm.QueryBuilder().append(orm.Data, filters={'label': 'my_test_data_node'})
-    assert builder.count() == 1
-    return builder.all()[0][0]
+    return orm.QueryBuilder().append(orm.Data, filters={'label': 'my_test_data_node'}).one()[0]
 
 
 def test_import_of_extras(new_archive):


### PR DESCRIPTION
Fixes #5672 

While iterating over a collection of nodes returned by the `QueryBuilder.iterall` method, trying to mutate the state of a node, for example by storing an extra, would raise an exception. The reason is that the `ModelWrapper` calls `commit` on the session once a field of a stored node is mutated, unless the session is within a transaction. In most user use-cases, however, where they are iterating over nodes to set some extras, they do no open an explicit transaction and we cannot expect them to, and so the code excepts.

This bug has existed for the sqlalchemy backend going as far back as at least v1.6.9 (which is confirmed) but probably it has been there for much longer. For Django this used to work, but that was dropped in v2.0.

The reason for the exception is that the cursor that is being used for iterating over the rows of the query is no longer valid. This is an error raised by the DBAPI, which is psycopg2 in our case, and occurs often when commiting on a cursor that is in the middle of fetching rows from a query and this is therefore strongly discouraged.

One solution is to remove the explicit commit in the `ModelWrapper.save` method. To still ensure that changes to stored nodes get flushed, we enable `autoflush=True` on the `sessionmaker`. This is a recommended way of letting the engine control that changes are flushed to the database whenever it needs to.

However, this change will have consequences for other usage though that will render it unusable. For example, it would become possible for a user to load a node in an interactive shell, change its state and exit immediately. The autoflush will not have had the opportunity to flush the changes to the database and the changes would be lost.

The solution chosen here is to open a transaction in the `QueryBuilder` endpoints that fetch rows using `yield_per`, i.e., in `iterall` and `iterdict`. This nested session will prevent `ModelWrapper.save` from calling `commit` on the cursor when a node is mutated during the iteration over the row collection.