### PR TITLE
CLI: Add the `devel launch-add` command

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -216,6 +216,7 @@ Below is a list with all available subcommands.
     Commands:
       check-load-time          Check for common indicators that slowdown `verdi`.
       check-undesired-imports  Check that verdi does not import python modules it shouldn't.
+      launch-add               Launch an ``ArithmeticAddCalculation``.
       revive                   Revive processes that seem stuck and are no longer reachable.
       run-sql                  Run a raw SQL command on the profile database (only...
       validate-plugins         Validate all plugins by checking they can be loaded.

--- a/tests/cmdline/commands/test_devel.py
+++ b/tests/cmdline/commands/test_devel.py
@@ -8,12 +8,14 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for ``verdi devel``."""
+import re
+
 from plumpy.process_comms import RemoteProcessThreadController
 import pytest
 
 from aiida.cmdline.commands import cmd_devel
 from aiida.engine import ProcessState, submit
-from aiida.orm import Int, Node
+from aiida.orm import Int, Node, ProcessNode, QueryBuilder
 
 
 def test_run_sql(run_cli_command):
@@ -60,3 +62,40 @@ def test_revive(run_cli_command, monkeypatch, aiida_local_code_factory, submit_a
     # understood how, but leaving the daemon running, a following test that will submit to the daemon may hit an
     # an exception because the node submitted here would no longer exist and the daemon would try to operate on it.
     started_daemon_client.stop_daemon(wait=True)
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_launch_add(run_cli_command):
+    """Test ``verdi devel launch-add``.
+
+    Start with a clean profile such that the functionality that automatically sets up the localhost computer and code is
+    tested properly.
+    """
+    result = run_cli_command(cmd_devel.devel_launch_arithmetic_add)
+    assert re.search(r'Warning: No `localhost` computer exists yet: creating and configuring', result.stdout)
+    assert re.search(r'Success: ArithmeticAddCalculation<.*> finished successfully', result.stdout)
+
+    node = QueryBuilder().append(ProcessNode).one()[0]
+    assert node.is_finished_ok
+
+
+@pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+def test_launch_add_daemon(run_cli_command, submit_and_await):
+    """Test ``verdi devel launch-add`` with the ``--daemon`` flag."""
+    result = run_cli_command(cmd_devel.devel_launch_arithmetic_add, ['--daemon'])
+    assert re.search(r'Submitted calculation', result.stdout)
+
+    node = QueryBuilder().append(ProcessNode).one()[0]
+    submit_and_await(node)
+    assert node.is_finished_ok
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_launch_add_code(run_cli_command, aiida_local_code_factory):
+    """Test ``verdi devel launch-add`` passing an explicit ``Code``."""
+    code = aiida_local_code_factory('core.arithmetic.add', '/bin/bash')
+    result = run_cli_command(cmd_devel.devel_launch_arithmetic_add, ['-X', str(code.pk)])
+    assert not re.search(r'Warning: No `localhost` computer exists yet: creating and configuring', result.stdout)
+
+    node = QueryBuilder().append(ProcessNode).one()[0]
+    assert node.is_finished_ok


### PR DESCRIPTION
This command will launch an `ArithmeticAddCalculation`. By default the job is run blockingly, but with the `--daemon` switch it can be sent to the daemon instead.

This command is useful for debugging purposes as it requires zero setup. All that is needed is an AiiDA profile. The command will automatically configure the localhost computer, if not already done, and create a `Code` instance for `bash`, likewise if it doesn't already exist. This makes it very useful when helping users to debug their installation as with a single command and no setup it can be verified whether there is a problem with the installation or with the plugins they are running. Also for development it is easy in scenarios where arbitrary calculation jobs need to be run.