### PR TITLE
`QueryBuilder`: Use a nested session in `iterall` and `iterdict`

### DIFF
--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1470,6 +1470,23 @@ class TestConsistency:
             qb.append(orm.Data, with_incoming='parent')
             assert len(qb.all()) == qb.count()
 
+    @pytest.mark.usefixtures('aiida_profile_clean')
+    def test_iterall_with_mutation(self):
+        """Test that nodes can be mutated while being iterated using ``QueryBuilder.iterall``."""
+        count = 10
+        pks = []
+
+        for _ in range(count):
+            node = orm.Data().store()
+            pks.append(node.pk)
+
+        # Ensure that batch size is smaller than the total rows yielded
+        for [node] in orm.QueryBuilder().append(orm.Data).iterall(batch_size=2):
+            node.base.extras.set('key', 'value')
+
+        for pk in pks:
+            assert orm.load_node(pk).get_extra('key') == 'value'
+
 
 class TestManager:
 


### PR DESCRIPTION
Fixes #5672 

This is a minimal alternative to #5731 . It adds a test that reproduces the bug reported in #5672 and then adds the fix.

This will prevent the `ModelWrapper` from calling commit on the session
when any of the yielded results is mutated as this will cause the cursor
of the connection to be reset and it to become invalid. In the next
iteration of the yield an exception will be raised.

Note that a session transaction should only be opened if we are not
already inside one, in which case a `nullcontext` is used.
