### PR TITLE
Process functions: Add serialization for Python base type defaults

### DIFF
--- a/docs/source/howto/run_workflows.rst
+++ b/docs/source/howto/run_workflows.rst
@@ -64,6 +64,18 @@ Just calling the ``add_and_multiply`` function with regular integers will result
         result = add_and_multiply(2, 3, 5)
 
     and AiiDA will recognize that the arguments are of type ``int`` and automatically wrap them in an ``Int`` node.
+    The same goes for argument defaults; if the argument accepts a Python base type it can specify a default value for it.
+    This will be automatically converted to the corresponding AiiDA data type when the function is called:
+
+    .. code-block:: python
+
+        @calcfunction
+        def add(a, b: int = 10):
+            return a + b
+
+        add(10)
+
+    The result will be an ``Int`` node with the value ``20``.
 
 
 .. note::


### PR DESCRIPTION
Fixes #5743 

As of 06802099fad32fb113b52fca40c867674aa7ea94, process functions will automatically add the `to_aiida_type` serializer for arguments such that Python base types are automatically converted to the corresponding AiiDA data type if not already a `Data` instance.

The same was not added for defaults however, so if a user defined a calcfunction with a Python base type default, an exception would be raised once the dynamic `FunctionProcess` would be constructed. The default would be passed to the `InputPort` constructor as is and so would not validate against the type check.

Here we update the dynamic process spec generation to detect if a default is provided for an argument and if so serialize it to the node equivalent. Note that this is done indirectly through a lambda as using constructed node instances as defaults in process specs can cause issues for example when the spec is exposed into another process spec, the ports are deep copied, including the defaults of the ports and deep copying of data nodes is not supported.