### PR TITLE
CLI: Make filename in `verdi node repo cat` optional for `SinglefileData`

### DIFF
--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -178,6 +178,16 @@ class TestVerdiNode:
         result = self.cli_runner(cmd_node.repo_cat, options)
         assert gzip.decompress(result.stdout_bytes) == b'COMPRESS'
 
+    def test_node_repo_cat_singlefile(self):
+        """Test ``verdi node repo cat`` for a ``SinglefileNode``.
+
+        Here the relative path argument should be optional and the command should determine it automatically.
+        """
+        node = orm.SinglefileData(io.BytesIO(b'content')).store()
+        options = [str(node.pk)]
+        result = self.cli_runner(cmd_node.repo_cat, options)
+        assert result.stdout_bytes == b'content'
+
     def test_node_repo_dump(self, tmp_path):
         """Test 'verdi node repo dump' command."""
         folder_node = self.get_unstored_folder_node().store()


### PR DESCRIPTION
Fixes #5746 

The `verdi node repo cat` requires the relative path of the file that is to be displayed. For a `SinglefileData`, however, there only is a single path. The `RELATIVE_PATH` argument is now made optional if the node is a `SinglefileData`, otherwise it will raise like it always did.