### PR TITLE
CLI: Improve the quality of `verdi code list` output

### DIFF
--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -52,7 +52,7 @@ def test_help(run_cli_command):
 def test_code_list_no_codes_error_message(run_cli_command):
     """Test ``verdi code list`` when no codes exist."""
     result = run_cli_command(cmd_code.code_list)
-    assert '# No codes found matching the specified criteria.' in result.output
+    assert 'No codes found matching the specified criteria.' in result.output
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
@@ -66,12 +66,12 @@ def test_code_list(run_cli_command, code):
     code2.label = 'code2'
     code2.store()
 
-    options = ['-A', '-a', '-o', '--input-plugin=core.arithmetic.add', f'--computer={code.computer.label}']
+    options = ['-A', '-a', '-o', '-d', 'core.arithmetic.add', f'--computer={code.computer.label}']
     result = run_cli_command(cmd_code.code_list, options)
     assert str(code.pk) in result.output
     assert code2.label not in result.output
     assert code.computer.label in result.output
-    assert '# No codes found matching the specified criteria.' not in result.output
+    assert 'No codes found matching the specified criteria.' not in result.output
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')


### PR DESCRIPTION
The output of `verdi code list` was being formatted "by hand" and as a result was quite different from the output of other commands that typically use the `tabulate` library to do the formatting.

The command is refactored to use `tabulate`. A single query is created which is more readable compared to the old logic and filters for each of the entities are built up consistently based on the options passed to the command.

The `-P/--project` option is added. Just as for `verdi proces list` this option allows to control which properties of the query are projected and printed to stdout. This means that the `-o/--show-owner` option is no longer needed and so is deprecated. It can be replaced by using `-P user` with the new option.

The new option also allows projecting the "entry_point" of the `Code` instances that are matched by the query. This has become interesting since recently the `AbstractCode` class allows plugins to provide custom implementations registered through an entry point.