### PR TITLE
Engine: Remove `*args` from the `Process.submit` method

### DIFF
--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -513,14 +513,14 @@ class Process(plumpy.processes.Process):
         super().set_status(status)
         self.node.set_process_status(status)
 
-    def submit(self, process: Type['Process'], *args, **kwargs) -> orm.ProcessNode:
+    def submit(self, process: Type['Process'], **kwargs) -> orm.ProcessNode:
         """Submit process for execution.
 
         :param process: process
         :return: the calculation node of the process
 
         """
-        return self.runner.submit(process, *args, **kwargs)
+        return self.runner.submit(process, **kwargs)
 
     @property
     def runner(self) -> 'Runner':

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -164,11 +164,11 @@ class Runner:  # pylint: disable=too-many-public-methods
         reset_event_loop_policy()
         self._closed = True
 
-    def instantiate_process(self, process: TYPE_RUN_PROCESS, *args, **inputs):
+    def instantiate_process(self, process: TYPE_RUN_PROCESS, **inputs):
         from .utils import instantiate_process  # pylint: disable=no-name-in-module
-        return instantiate_process(self, process, *args, **inputs)
+        return instantiate_process(self, process, **inputs)
 
-    def submit(self, process: TYPE_SUBMIT_PROCESS, *args: Any, **inputs: Any):
+    def submit(self, process: TYPE_SUBMIT_PROCESS, **inputs: Any):
         """
         Submit the process with the supplied inputs to this runner immediately returning control to
         the interpreter. The return value will be the calculation node of the submitted process
@@ -180,7 +180,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         assert not utils.is_process_function(process), 'Cannot submit a process function'
         assert not self._closed
 
-        process_inited = self.instantiate_process(process, *args, **inputs)
+        process_inited = self.instantiate_process(process, **inputs)
 
         if not process_inited.metadata.store_provenance:
             raise exceptions.InvalidOperation('cannot submit a process with `store_provenance=False`')

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -27,7 +27,7 @@ PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed 
 
 
 def instantiate_process(
-    runner: 'Runner', process: Union['Process', Type['Process'], 'ProcessBuilder'], *args, **inputs
+    runner: 'Runner', process: Union['Process', Type['Process'], 'ProcessBuilder'], **inputs
 ) -> 'Process':
     """
     Return an instance of the process with the given inputs. The function can deal with various types
@@ -45,7 +45,6 @@ def instantiate_process(
     from .processes import Process, ProcessBuilder
 
     if isinstance(process, Process):
-        assert not args
         assert not inputs
         assert runner is process.runner
         return process

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -17,24 +17,25 @@ import pytest
 
 from aiida.engine import Process
 from aiida.manage import get_manager
-from aiida.orm import WorkflowNode
+from aiida.orm import Str, WorkflowNode
 
 
 @pytest.fixture
-def create_runner():
+def runner():
     """Construct and return a `Runner`."""
-
-    def _create_runner(poll_interval=0.5):
-        loop = asyncio.new_event_loop()
-        return get_manager().create_runner(poll_interval=poll_interval, loop=loop)
-
-    return _create_runner
+    loop = asyncio.new_event_loop()
+    return get_manager().create_runner(poll_interval=0.5, loop=loop)
 
 
 class Proc(Process):
     """Process class."""
 
     _node_class = WorkflowNode
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input('a')
 
     def run(self):
         pass
@@ -46,11 +47,10 @@ def the_hans_klok_comeback(loop):
 
 @pytest.mark.requires_rmq
 @pytest.mark.usefixtures('aiida_profile_clean')
-def test_call_on_process_finish(create_runner):
+def test_call_on_process_finish(runner):
     """Test call on calculation finish."""
-    runner = create_runner()
     loop = runner.loop
-    proc = Proc(runner=runner)
+    proc = Proc(runner=runner, inputs={'a': Str('input')})
     future = plumpy.Future()
     event = threading.Event()
 
@@ -71,3 +71,14 @@ def test_call_on_process_finish(create_runner):
 
     assert not future.exception()
     assert future.result()
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_submit_args(runner):
+    """Test that a useful exception is raised when the inputs are passed as a dictionary instead of expanded kwargs.
+
+    Regression test for #3609. Before, it would throw the validation exception of the first port to be validated. If
+    a user accidentally forgot to expand the inputs with `**` it would be a misleading error.
+    """
+    with pytest.raises(TypeError, match=r'takes 2 positional arguments but 3 were given'):
+        runner.submit(Proc, {'a': Str('input')})


### PR DESCRIPTION
Fixes #3609 

This method erroneously accepted variable arguments, however, they would simply be passed down the stack to ultimately be ignored in the function `aiida.engine.utils.instantiate_process`. This silently ignoring of arguments led to problems with users accidentally forgetting to expand a dictionary of inputs when calling submit. For example they called:

    self.submit(cls, inputs)

inside of a workchain step, instead of:

    self.submit(cls, **inputs)

The exception that would be raised is the validation error of the first required input port that would be parsed:

    Error occurred validating port: required value was not provided

Instead, the passing of unsupported argument should be detected way earlier. This is now the case by removing the variable arguments from the signature of the `Process.submit` method and all the methods it calls downstream. This will now cause a `TypeError` to be raised:

    submit() takes 2 positional arguments but 3 were given