### PR TITLE
Process control: Reinstate process status for paused/killed processes

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -198,7 +198,8 @@ def process_kill(processes, timeout, wait):
     from aiida.engine.processes import control
 
     try:
-        control.kill_processes(processes, timeout=timeout, wait=wait)
+        message = 'Killed through `verdi process kill`'
+        control.kill_processes(processes, timeout=timeout, wait=wait, message=message)
     except control.ProcessTimeoutException as exception:
         echo.echo_critical(str(exception) + '\nFrom the CLI you can call `verdi devel revive <PID>`.')
 
@@ -218,7 +219,8 @@ def process_pause(processes, all_entries, timeout, wait):
         raise click.BadOptionUsage('all', 'cannot specify individual processes and the `--all` flag at the same time.')
 
     try:
-        control.pause_processes(processes, all_entries=all_entries, timeout=timeout, wait=wait)
+        message = 'Paused through `verdi process pause`'
+        control.pause_processes(processes, all_entries=all_entries, timeout=timeout, wait=wait, message=message)
     except control.ProcessTimeoutException as exception:
         echo.echo_critical(str(exception) + '\nFrom the CLI you can call `verdi devel revive <PID>`.')
 

--- a/aiida/engine/processes/control.py
+++ b/aiida/engine/processes/control.py
@@ -112,6 +112,7 @@ def play_processes(
 def pause_processes(
     processes: list[ProcessNode] | None = None,
     *,
+    message: str = 'Paused through `aiida.engine.processes.control.pause_processes`',
     all_entries: bool = False,
     timeout: float = 5.0,
     wait: bool = False
@@ -140,12 +141,13 @@ def pause_processes(
         return
 
     controller = get_manager().get_process_controller()
-    _perform_actions(processes, controller.pause_process, 'pause', 'pausing', 'paused', timeout, wait)
+    _perform_actions(processes, controller.pause_process, 'pause', 'pausing', 'paused', timeout, wait, msg=message)
 
 
 def kill_processes(
     processes: list[ProcessNode] | None = None,
     *,
+    message: str = 'Killed through `aiida.engine.processes.control.kill_processes`',
     all_entries: bool = False,
     timeout: float = 5.0,
     wait: bool = False
@@ -174,7 +176,7 @@ def kill_processes(
         return
 
     controller = get_manager().get_process_controller()
-    _perform_actions(processes, controller.kill_process, 'kill', 'killing', 'killed', timeout, wait)
+    _perform_actions(processes, controller.kill_process, 'kill', 'killing', 'killed', timeout, wait, msg=message)
 
 
 def _perform_actions(
@@ -184,7 +186,8 @@ def _perform_actions(
     present: str,
     past: str,
     timeout: float = None,
-    wait: bool = False
+    wait: bool = False,
+    **kwargs: t.Any
 ) -> None:
     """Perform an action on a list of processes.
 
@@ -195,6 +198,7 @@ def _perform_actions(
     :param past: The past tense of the verb that represents the action.
     :param timeout: Raise a ``ProcessTimeoutException`` if the process does not respond within this amount of seconds.
     :param wait: Set to ``True`` to wait for process response, for ``False`` the action is fire-and-forget.
+    :param kwargs: Keyword arguments that will be passed to the method ``action``.
     :raises ``ProcessTimeoutException``: If the processes do not respond within the timeout.
     """
     futures = {}
@@ -206,7 +210,7 @@ def _perform_actions(
             continue
 
         try:
-            future = action(process.pk)
+            future = action(process.pk, **kwargs)
         except communications.UnroutableError:
             LOGGER.error(f'Process<{process.pk}> is unreachable.')
         else:

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -22,7 +22,7 @@ __all__ = ('Code',)
 
 warn_deprecation(
     'The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode`'
-    ' or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respetively. If you are '
+    ' or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respectively. If you are '
     'using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
     version=3
 )

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -452,6 +452,8 @@ def test_process_kill(submit_and_await, run_cli_command):
 
     run_cli_command(cmd_process.process_pause, [str(node.pk), '--wait'])
     await_condition(lambda: node.paused)
+    assert node.process_status == 'Paused through `verdi process pause`'
 
     run_cli_command(cmd_process.process_kill, [str(node.pk), '--wait'])
     await_condition(lambda: node.is_killed)
+    assert node.process_status == 'Killed through `verdi process kill`'

--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -38,6 +38,7 @@ def test_pause_processes(submit_and_await):
 
     control.pause_processes([node], wait=True)
     assert node.paused
+    assert node.process_status == 'Paused through `aiida.engine.processes.control.pause_processes`'
 
 
 @pytest.mark.usefixtures('started_daemon_client')
@@ -84,6 +85,7 @@ def test_kill_processes(submit_and_await):
     control.kill_processes([node], wait=True)
     assert node.is_terminated
     assert node.is_killed
+    assert node.process_status == 'Killed through `aiida.engine.processes.control.kill_processes`'
 
 
 @pytest.mark.usefixtures('started_daemon_client')


### PR DESCRIPTION
The recent commit 8bb7b343198370e1d23983f3e8b7dfb5b50304df accidentally removed the `process_status` being set on nodes when they were being paused or killed through `verdi process pause/kill`.

This behavior is reinstated with tests to prevent future regression. The process status is now also set when done directly through the Python API.