### PR TITLE
`BaseRestartWorkChain`: Fix bug in `_wrap_bare_dict_inputs`

### DIFF
--- a/aiida/engine/processes/workchains/restart.py
+++ b/aiida/engine/processes/workchains/restart.py
@@ -427,10 +427,11 @@ class BaseRestartWorkChain(WorkChain):
                 continue
 
             port = port_namespace[key]
+            valid_types = port.valid_type if isinstance(port.valid_type, (list, tuple)) else (port.valid_type,)
 
             if isinstance(port, PortNamespace):
                 wrapped[key] = self._wrap_bare_dict_inputs(port, value)
-            elif port.valid_type == orm.Dict and isinstance(value, dict):
+            elif orm.Dict in valid_types and isinstance(value, dict):
                 wrapped[key] = orm.Dict(dict=value)
             else:
                 wrapped[key] = value


### PR DESCRIPTION
In ae79c89ecb0f8c72b6429c4a453408d02dffc471, released with `v2.1.0`, the `InputPort` class was updated to automatically add `None` as a valid type to the `valid_type` tuple if the port is not required. This unintentionally broke the `BaseRestartWorkChain._wrap_bare_dict_inputs` method which is supposed to wrap bare dictionaries in the inputs if the corresponding port accepts a `Dict` node. However, it was checking that the `valid_type` was equal to `Dict` instead of checking that the tuple contains the `Dict` type. As a results, bare dictionaries were no longer automatically wrapped in `Dict` node after the change mentioned above.

Here the logic is updated to check whether the `Dict` type is in the `valid_type` tuple.