### PR TITLE
Fix legacy Code deprecation warning

### DIFF
--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -20,13 +20,6 @@ from .abstract import AbstractCode
 
 __all__ = ('Code',)
 
-warn_deprecation(
-    'The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode`'
-    ' or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respectively. If you are '
-    'using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
-    version=3
-)
-
 
 class Code(AbstractCode):
     """

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -41,6 +41,16 @@ class Code(AbstractCode):
     # pylint: disable=too-many-public-methods
 
     def __init__(self, remote_computer_exec=None, local_executable=None, input_plugin_name=None, files=None, **kwargs):
+        
+        if self.__class__ == Code:
+            warn_deprecation(
+                'The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode`'
+                ' or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respectively. If you are '
+                'using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
+                version=3,
+                stacklevel=3
+            )
+     
         super().__init__(**kwargs)
 
         if remote_computer_exec and local_executable:

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -41,7 +41,7 @@ class Code(AbstractCode):
     # pylint: disable=too-many-public-methods
 
     def __init__(self, remote_computer_exec=None, local_executable=None, input_plugin_name=None, files=None, **kwargs):
-        
+
         if self.__class__ == Code:
             warn_deprecation(
                 'The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode`'
@@ -50,7 +50,7 @@ class Code(AbstractCode):
                 version=3,
                 stacklevel=3
             )
-     
+
         super().__init__(**kwargs)
 
         if remote_computer_exec and local_executable:


### PR DESCRIPTION
`InstalledCode` now inherits from (and thus imports) `Code`,
so this deprecation warning was emitted incorrectly.

It is now triggered only when a `Code` is directly initialised (and not by an inherited class)