### PR TITLE
Rename `PsqlDostoreMigrator` to `PsqlDosMigrator`

### DIFF
--- a/aiida/storage/psql_dos/alembic_cli.py
+++ b/aiida/storage/psql_dos/alembic_cli.py
@@ -16,7 +16,7 @@ from sqlalchemy.util.compat import nullcontext
 from aiida.cmdline import is_verbose
 from aiida.cmdline.groups.verdi import VerdiCommandGroup
 from aiida.cmdline.params import options
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
 class AlembicRunner:
@@ -33,7 +33,7 @@ class AlembicRunner:
         """
         if self.profile is None:
             raise click.ClickException('No profile specified')
-        migrator = PsqlDostoreMigrator(self.profile)
+        migrator = PsqlDosMigrator(self.profile)
 
         context = migrator._alembic_connect() if connect else nullcontext(migrator._alembic_config())  # pylint: disable=protected-access
         with context as config:

--- a/aiida/storage/psql_dos/backend.py
+++ b/aiida/storage/psql_dos/backend.py
@@ -24,7 +24,7 @@ from aiida.manage.configuration.profile import Profile
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import BackendEntity, StorageBackend
 from aiida.storage.log import STORAGE_LOGGER
-from aiida.storage.psql_dos.migrator import REPOSITORY_UUID_KEY, PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import REPOSITORY_UUID_KEY, PsqlDosMigrator
 from aiida.storage.psql_dos.models import base
 
 from .orm import authinfos, comments, computers, convert, groups, logs, nodes, querybuilder, users
@@ -71,7 +71,7 @@ class PsqlDosBackend(StorageBackend):  # pylint: disable=too-many-public-methods
     The `django` backend was removed, to consolidate access to this storage.
     """
 
-    migrator = PsqlDostoreMigrator
+    migrator = PsqlDosMigrator
 
     @classmethod
     def version_head(cls) -> str:

--- a/aiida/storage/psql_dos/migrator.py
+++ b/aiida/storage/psql_dos/migrator.py
@@ -55,7 +55,7 @@ ALEMBIC_REL_PATH = 'migrations'
 REPOSITORY_UUID_KEY = 'repository|uuid'
 
 
-class PsqlDostoreMigrator:
+class PsqlDosMigrator:
     """Class for validating and migrating `psql_dos` storage instances.
 
     .. important:: This class should only be accessed via the storage backend class (apart from for test purposes)

--- a/docs/source/internals/storage/psql_dos.rst
+++ b/docs/source/internals/storage/psql_dos.rst
@@ -99,7 +99,7 @@ Between nodes themselves (Links)
 Storage schema migrations
 =========================
 
-Migrations of the storage schema, to bring it inline with updates to the ``aiida-core`` API, are implemented by :py:class:`~aiida.storage.psql_dos.migrator.PsqlDostoreMigrator` , using `alembic <https://alembic.sqlalchemy.org>`_.
+Migrations of the storage schema, to bring it inline with updates to the ``aiida-core`` API, are implemented by :py:class:`~aiida.storage.psql_dos.migrator.PsqlDosMigrator` , using `alembic <https://alembic.sqlalchemy.org>`_.
 
 Legacy schema
 -------------

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -76,7 +76,7 @@ def test_storage_incompatible(run_cli_command, monkeypatch):
         from aiida.common.exceptions import IncompatibleStorageSchema
         raise IncompatibleStorageSchema()
 
-    monkeypatch.setattr(migrator.PsqlDostoreMigrator, 'validate_storage', storage_cls)
+    monkeypatch.setattr(migrator.PsqlDosMigrator, 'validate_storage', storage_cls)
 
     result = run_cli_command(cmd_status.verdi_status, raises=True)
     assert 'verdi storage migrate' in result.output
@@ -90,7 +90,7 @@ def test_storage_corrupted(run_cli_command, monkeypatch):
         from aiida.common.exceptions import CorruptStorage
         raise CorruptStorage()
 
-    monkeypatch.setattr(migrator.PsqlDostoreMigrator, 'validate_storage', storage_cls)
+    monkeypatch.setattr(migrator.PsqlDosMigrator, 'validate_storage', storage_cls)
 
     result = run_cli_command(cmd_status.verdi_status, raises=True)
     assert 'Storage is corrupted' in result.output

--- a/tests/storage/psql_dos/migrations/conftest.py
+++ b/tests/storage/psql_dos/migrations/conftest.py
@@ -16,7 +16,7 @@ import pytest
 from sqlalchemy import text
 
 from aiida.manage.configuration import Profile
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 from aiida.storage.psql_dos.utils import create_sqlalchemy_engine
 
 
@@ -114,7 +114,7 @@ def uninitialised_profile(empty_pg_cluster: PGTest, tmp_path):  # pylint: disabl
 @pytest.fixture()
 def perform_migrations(uninitialised_profile):  # pylint: disable=redefined-outer-name
     """A fixture to setup a database for migration tests."""
-    yield PsqlDostoreMigrator(uninitialised_profile)
+    yield PsqlDosMigrator(uninitialised_profile)
 
 
 def _generate_column_schema(profile: Profile) -> dict:

--- a/tests/storage/psql_dos/migrations/django_branch/test_0024_dblog_update.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0024_dblog_update.py
@@ -12,10 +12,10 @@ import json
 
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_dblog_update(perform_migrations: PsqlDostoreMigrator):  # pylint: disable=too-many-locals
+def test_dblog_update(perform_migrations: PsqlDosMigrator):  # pylint: disable=too-many-locals
     """Test the update to the ``DbLog`` table."""
     # starting revision
     perform_migrations.migrate_up('django@django_0023')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
@@ -16,10 +16,10 @@ from aiida.common.utils import get_new_uuid
 from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
 from aiida.storage.psql_dos.migrations.utils.create_dbattribute import create_rows
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_traj_data(perform_migrations: PsqlDostoreMigrator):
+def test_traj_data(perform_migrations: PsqlDosMigrator):
     """Test `TrajectoryData` nodes migration, moving symbol lists from repository array to attributes."""
     # starting revision
     perform_migrations.migrate_up('django@django_0025')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0028_0029_node_type.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0028_0029_node_type.py
@@ -10,10 +10,10 @@
 """Test alterations to `db_dbnode.type`values."""
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_node_repository(perform_migrations: PsqlDostoreMigrator):
+def test_node_repository(perform_migrations: PsqlDosMigrator):
     """Test migration adding the `repository_metadata` column to the `Node` model."""
     # starting revision
     perform_migrations.migrate_up('django@django_0027')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0032_remove_legacy_workflows.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0032_remove_legacy_workflows.py
@@ -10,10 +10,10 @@
 """Test removing legacy workflows."""
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_node_repository(perform_migrations: PsqlDostoreMigrator):
+def test_node_repository(perform_migrations: PsqlDosMigrator):
     """Test removing legacy workflows."""
     # starting revision
     perform_migrations.migrate_up('django@django_0031')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0033_replace_text_field_with_json_field.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0033_replace_text_field_with_json_field.py
@@ -12,10 +12,10 @@ import json
 
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_text_to_jsonb(perform_migrations: PsqlDostoreMigrator):  # pylint: disable=too-many-locals
+def test_text_to_jsonb(perform_migrations: PsqlDosMigrator):  # pylint: disable=too-many-locals
     """Test replacing the use of text fields to store JSON data with JSONB fields.
 
     `db_dbauthinfo.auth_params`, `db_dbauthinfo.metadata`,

--- a/tests/storage/psql_dos/migrations/django_branch/test_0037_attributes_extras_settings_json.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0037_attributes_extras_settings_json.py
@@ -13,10 +13,10 @@ from datetime import datetime
 from sqlalchemy import select
 
 from aiida.common import timezone
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_attr_extra_migration(perform_migrations: PsqlDostoreMigrator):
+def test_attr_extra_migration(perform_migrations: PsqlDosMigrator):
     """
     A "simple" test for the attributes and extra migration from EAV to JSONB.
     It stores a sample dictionary using the EAV deserialization of AiiDA Django
@@ -93,7 +93,7 @@ def test_attr_extra_migration(perform_migrations: PsqlDostoreMigrator):
     assert extras == {'extra_0': 'test', 'extra_1': 1, 'extra_2': True, 'extra_3': 1.0, 'extra_4': 2022}
 
 
-def test_settings_migration(perform_migrations: PsqlDostoreMigrator):
+def test_settings_migration(perform_migrations: PsqlDosMigrator):
     """
     This test checks the correct migration of the settings.
     Setting records were used as an example from a typical settings table of Django EAV.

--- a/tests/storage/psql_dos/migrations/django_branch/test_0038_data_migration_legacy_job_calculations.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0038_data_migration_legacy_job_calculations.py
@@ -14,10 +14,10 @@ from uuid import uuid4
 
 from aiida.common import timezone
 from aiida.storage.psql_dos.migrations.utils.calc_state import STATE_MAPPING, StateMapping
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_legacy_jobcalcstate(perform_migrations: PsqlDostoreMigrator):
+def test_legacy_jobcalcstate(perform_migrations: PsqlDosMigrator):
     """Test the migration that performs a data migration of legacy `JobCalcState`."""
     # starting revision
     perform_migrations.migrate_up('django@django_0037')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0039_reset_hash.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0039_reset_hash.py
@@ -10,10 +10,10 @@
 """Test the node hash reset."""
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_reset_hash(perform_migrations: PsqlDostoreMigrator):
+def test_reset_hash(perform_migrations: PsqlDosMigrator):
     """Test the node hash reset."""
     # starting revision
     perform_migrations.migrate_up('django@django_0038')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0040_data_migration_legacy_process_attributes.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0040_data_migration_legacy_process_attributes.py
@@ -11,10 +11,10 @@
 from uuid import uuid4
 
 from aiida.common import timezone
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_legacy_jobcalc_attrs(perform_migrations: PsqlDostoreMigrator):
+def test_legacy_jobcalc_attrs(perform_migrations: PsqlDosMigrator):
     """Test the migration that performs a data migration of legacy `JobCalcState`."""
     # starting revision
     perform_migrations.migrate_up('django@django_0039')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0041_seal_unsealed_processes.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0041_seal_unsealed_processes.py
@@ -11,10 +11,10 @@
 from uuid import uuid4
 
 from aiida.common import timezone
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_legacy_jobcalc_attrs(perform_migrations: PsqlDostoreMigrator):
+def test_legacy_jobcalc_attrs(perform_migrations: PsqlDosMigrator):
     """Test sealing of unsealed processes."""
     # starting revision
     perform_migrations.migrate_up('django@django_0040')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0043_default_link_label.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0043_default_link_label.py
@@ -11,10 +11,10 @@
 from uuid import uuid4
 
 from aiida.common import timezone
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_legacy_jobcalc_attrs(perform_migrations: PsqlDostoreMigrator):
+def test_legacy_jobcalc_attrs(perform_migrations: PsqlDosMigrator):
     """Test update of link labels."""
     # starting revision
     perform_migrations.migrate_up('django@django_0042')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0044_dbgroup_type_string.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0044_dbgroup_type_string.py
@@ -11,10 +11,10 @@
 from uuid import uuid4
 
 from aiida.common import timezone
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_group_type_string(perform_migrations: PsqlDostoreMigrator):
+def test_group_type_string(perform_migrations: PsqlDosMigrator):
     """Test migration of `type_string` after the `Group` class became pluginnable."""
     # starting revision
     perform_migrations.migrate_up('django@django_0043')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0045_dbgroup_extras.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0045_dbgroup_extras.py
@@ -11,10 +11,10 @@
 from uuid import uuid4
 
 from aiida.common import timezone
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_group_extras(perform_migrations: PsqlDostoreMigrator):
+def test_group_extras(perform_migrations: PsqlDosMigrator):
     """Test migration to add the `extras` JSONB column to the `DbGroup` model."""
     # starting revision
     perform_migrations.migrate_up('django@django_0044')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0046_add_node_repository_metadata.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0046_add_node_repository_metadata.py
@@ -10,10 +10,10 @@
 """Test migration adding the `repository_metadata` column to the `Node` model."""
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_node_repository(perform_migrations: PsqlDostoreMigrator):
+def test_node_repository(perform_migrations: PsqlDosMigrator):
     """Test migration adding the `repository_metadata` column to the `Node` model."""
     # starting revision
     perform_migrations.migrate_up('django@django_0045')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0047_migrate_repository.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0047_migrate_repository.py
@@ -15,12 +15,12 @@ from uuid import uuid4
 from aiida.common import timezone
 from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 REPOSITORY_UUID_KEY = 'repository|uuid'
 
 
-def test_node_repository(perform_migrations: PsqlDostoreMigrator):  # pylint: disable=too-many-locals
+def test_node_repository(perform_migrations: PsqlDosMigrator):  # pylint: disable=too-many-locals
     """Test migration of the old file repository to the disk object store."""
     # starting revision
     perform_migrations.migrate_up('django@django_0046')

--- a/tests/storage/psql_dos/migrations/django_branch/test_0048_computer_name_to_label.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0048_computer_name_to_label.py
@@ -9,10 +9,10 @@
 ###########################################################################
 """Test the renaming of `name` to `label` for `db_dbcomputer`."""
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_computer_name_to_label(perform_migrations: PsqlDostoreMigrator):
+def test_computer_name_to_label(perform_migrations: PsqlDosMigrator):
     """Test the renaming of `name` to `label` for `db_dbcomputer`.
 
     Verify that the column was successfully renamed.

--- a/tests/storage/psql_dos/migrations/django_branch/test_0049_entry_point_core_prefix.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0049_entry_point_core_prefix.py
@@ -10,10 +10,10 @@
 """Test migration that updates node types after `core.` prefix was added to entry point names."""
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_entry_point_core_prefix(perform_migrations: PsqlDostoreMigrator):
+def test_entry_point_core_prefix(perform_migrations: PsqlDosMigrator):
     """Test the renaming of `name` to `label` for `db_dbcomputer`.
 
     Verify that the column was successfully renamed.

--- a/tests/storage/psql_dos/migrations/django_branch/test_0050_schema_parity.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0050_schema_parity.py
@@ -10,10 +10,10 @@
 """Test migration that renames all index/constraint names, to have parity between django/sqlalchemy."""
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_schema_parity(perform_migrations: PsqlDostoreMigrator):
+def test_schema_parity(perform_migrations: PsqlDosMigrator):
     """Test the renaming of indexes and constaints works, when data is in the database."""
     # starting revision
     perform_migrations.migrate_up('django@django_0049')

--- a/tests/storage/psql_dos/migrations/django_branch/test_legacy.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_legacy.py
@@ -20,10 +20,10 @@ Therefore, we need to check that the migration code handles this correctly.
 """
 import sqlalchemy as sa
 
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_v0x_django_0003(perform_migrations: PsqlDostoreMigrator, reflect_schema, data_regression):  # pylint: disable=too-many-locals
+def test_v0x_django_0003(perform_migrations: PsqlDosMigrator, reflect_schema, data_regression):  # pylint: disable=too-many-locals
     """Test against an archive database schema, created in aiida-core v0.x, at revision django_0003."""
     metadata = generate_schema()
     with perform_migrations._connection_context() as conn:  # pylint: disable=protected-access

--- a/tests/storage/psql_dos/migrations/django_branch/test_migrate_to_head.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_migrate_to_head.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Test migrating from the base of the django branch, to the main head."""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_migrate(perform_migrations: PsqlDostoreMigrator):
+def test_migrate(perform_migrations: PsqlDosMigrator):
     """Test that the migrator can migrate from the base of the django branch, to the main head."""
     perform_migrations.migrate_up('django@django_0001')  # the base of the django branch
     perform_migrations.migrate()

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_10_group_update.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_10_group_update.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for group migrations: 118349c10896 -> 0edcdd5a30f0"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_group_typestring(perform_migrations: PsqlDostoreMigrator):
+def test_group_typestring(perform_migrations: PsqlDosMigrator):
     """Test the migration that renames the DbGroup type strings.
 
     Verify that the type strings are properly migrated.
@@ -70,7 +70,7 @@ def test_group_typestring(perform_migrations: PsqlDostoreMigrator):
         assert group_autorun.type_string == 'core.auto'
 
 
-def test_group_extras(perform_migrations: PsqlDostoreMigrator):
+def test_group_extras(perform_migrations: PsqlDosMigrator):
     """Test migration to add the `extras` JSONB column to the `DbGroup` model.
 
     Verify that the model now has an extras column with empty dictionary as default.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_11_v2_repository.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_11_v2_repository.py
@@ -14,10 +14,10 @@ import os
 from aiida.common.utils import get_new_uuid
 from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_node_repository_metadata(perform_migrations: PsqlDostoreMigrator):
+def test_node_repository_metadata(perform_migrations: PsqlDosMigrator):
     """Test migration adding the `repository_metadata` column to the `Node` model.
 
     Verify that the column is added and null by default.
@@ -49,7 +49,7 @@ def test_node_repository_metadata(perform_migrations: PsqlDostoreMigrator):
         assert node.repository_metadata == {}
 
 
-def test_entry_point_core_prefix(perform_migrations: PsqlDostoreMigrator):
+def test_entry_point_core_prefix(perform_migrations: PsqlDosMigrator):
     """Test migration that updates node types after `core.` prefix was added to entry point names.
 
     Verify that the column was successfully renamed.
@@ -109,7 +109,7 @@ def test_entry_point_core_prefix(perform_migrations: PsqlDostoreMigrator):
         assert workflow.process_type == 'aiida.workflows:core.arithmetic.add_multiply'
 
 
-def test_repository_migration(perform_migrations: PsqlDostoreMigrator):  # pylint: disable=too-many-statements,too-many-locals
+def test_repository_migration(perform_migrations: PsqlDosMigrator):  # pylint: disable=too-many-statements,too-many-locals
     """Test migration of the old file repository to the disk object store.
 
     Verify that the files are correctly migrated.
@@ -231,7 +231,7 @@ def test_repository_migration(perform_migrations: PsqlDostoreMigrator):  # pylin
         assert isinstance(repository_uuid.val, str)
 
 
-def test_computer_name_to_label(perform_migrations: PsqlDostoreMigrator):
+def test_computer_name_to_label(perform_migrations: PsqlDosMigrator):
     """Test the renaming of `name` to `label` for `DbComputer.
 
     Verify that the column was successfully renamed.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_12_sqla_django_parity.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_12_sqla_django_parity.py
@@ -9,10 +9,10 @@
 ###########################################################################
 """Tests for migrations to bring parity between SQLAlchemy and Django."""
 # pylint: disable=invalid-name,too-many-locals,too-many-statements
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_non_nullable(perform_migrations: PsqlDostoreMigrator):
+def test_non_nullable(perform_migrations: PsqlDosMigrator):
     """Test making columns non-nullable."""
     # starting revision
     perform_migrations.migrate_up('sqlalchemy@34a831f4286d')

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_1_provenance_redesign.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_1_provenance_redesign.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for the provenance redesign: 140c971ae0a3 -> 239cea6d2452"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_provenance_redesign(perform_migrations: PsqlDostoreMigrator):
+def test_provenance_redesign(perform_migrations: PsqlDosMigrator):
     """Test the data migration part of the provenance redesign migration.
 
     Verify that type string of the Data node are successfully adapted.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_2_group_renaming.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_2_group_renaming.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Test renaming of type strings: b8b23ddefad4 -> e72ad251bcdb"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_group_renaming(perform_migrations: PsqlDostoreMigrator):
+def test_group_renaming(perform_migrations: PsqlDosMigrator):
     """Test the migration that renames the DbGroup type strings."""
     # starting revision
     perform_migrations.migrate_up(

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_3_calc_attributes_keys.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_3_calc_attributes_keys.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests migration of the keys of certain attribute for ProcessNodes and CalcJobNodes: e72ad251bcdb -> 7ca08c391c49"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 KEY_RESOURCES_OLD = 'jobresource_params'
 KEY_RESOURCES_NEW = 'resources'
@@ -22,7 +22,7 @@ PARSER_NAME = 'aiida.parsers:parser'
 PROCESS_LABEL = 'TestLabel'
 
 
-def test_calc_attributes_keys(perform_migrations: PsqlDostoreMigrator):
+def test_calc_attributes_keys(perform_migrations: PsqlDosMigrator):
     """Test the migration of the keys of certain attribute for ProcessNodes and CalcJobNodes."""
     # starting revision
     perform_migrations.migrate_up('sqlalchemy@e72ad251bcdb')  # e72ad251bcdb_dbgroup_class_change_type_string_values

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_4_dblog_update.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_4_dblog_update.py
@@ -14,7 +14,7 @@ import pytest
 from sqlalchemy import column
 
 from aiida.storage.psql_dos.migrations.utils import dblog_update
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 # The values that will be exported for the log records that will be deleted
 values_to_export = ('id', 'time', 'loggername', 'levelname', 'objpk', 'objname', 'message', 'metadata')
@@ -23,10 +23,10 @@ values_to_export = ('id', 'time', 'loggername', 'levelname', 'objpk', 'objname',
 class TestDbLogMigrationRecordCleaning:
     """Test the migration of the keys of certain attribute for ProcessNodes and CalcJobNodes."""
 
-    migrator: PsqlDostoreMigrator
+    migrator: PsqlDosMigrator
 
     @pytest.fixture(autouse=True)
-    def setup_db(self, perform_migrations: PsqlDostoreMigrator):  # pylint: disable=too-many-locals,too-many-statements
+    def setup_db(self, perform_migrations: PsqlDosMigrator):  # pylint: disable=too-many-locals,too-many-statements
         """Setup the database schema."""
         from aiida.storage.psql_dos.migrations.utils.utils import dumps_json
 
@@ -258,7 +258,7 @@ class TestDbLogMigrationRecordCleaning:
                 assert 'objname' not in m_res.keys(), 'objname should not exist any more in metadata'
 
 
-def test_dblog_uuid_addition(perform_migrations: PsqlDostoreMigrator):
+def test_dblog_uuid_addition(perform_migrations: PsqlDosMigrator):
     """Test that the UUID column is correctly added to the DbLog table,
     and that the uniqueness constraint is added without problems
     (if the migration arrives until 375c2db70663 then the constraint is added properly).

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_5_data_move_with_node.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_5_data_move_with_node.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests 041a79fc615f -> 6a5c2ea1439d"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_data_move_with_node(perform_migrations: PsqlDostoreMigrator):
+def test_data_move_with_node(perform_migrations: PsqlDosMigrator):
     """Test the migration of Data nodes after the data module was moved within the node module.
 
     Verify that type string of the Data node was successfully adapted.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
@@ -13,7 +13,7 @@ import pytest
 
 from aiida.storage.psql_dos.backend import get_filepath_container
 from aiida.storage.psql_dos.migrations.utils import utils
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 from aiida.storage.psql_dos.utils import flag_modified
 
 
@@ -39,7 +39,7 @@ def get_node_array(node, repo_path, name):
     return utils.load_numpy_array_from_repository(repo_path, node.uuid, name)
 
 
-def test_trajectory_data(perform_migrations: PsqlDostoreMigrator):
+def test_trajectory_data(perform_migrations: PsqlDosMigrator):
     """Test the migration of the symbols from numpy array to attribute for TrajectoryData nodes.
 
     Verify that migration of symbols from repository array to attribute works properly.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_7_node_prefix_removal.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_7_node_prefix_removal.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests ce56d84bcc35 -> 61fc0913fae9"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_node_prefix_removal(perform_migrations: PsqlDostoreMigrator):
+def test_node_prefix_removal(perform_migrations: PsqlDosMigrator):
     """Test the migration of Data nodes after the data module was moved within the node module.
 
     Verify that type string of the Data node was successfully adapted.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_8_parameter_data_to_dict.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_8_parameter_data_to_dict.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests 61fc0913fae9 -> d254fdfed416"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_parameter_data_to_dict(perform_migrations: PsqlDostoreMigrator):
+def test_parameter_data_to_dict(perform_migrations: PsqlDosMigrator):
     """Test the data migration after `ParameterData` was renamed to `Dict`.
 
     Verify that type string of the Data node was successfully adapted.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_9_legacy_process.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_9_legacy_process.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for legacy process migrations: 07fac78e6209 -> 118349c10896"""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_legacy_jobcalcstate_data(perform_migrations: PsqlDostoreMigrator):
+def test_legacy_jobcalcstate_data(perform_migrations: PsqlDosMigrator):
     """Test the migration that performs a data migration of legacy `JobCalcState`.
 
     Verify that the `process_state`, `process_status` and `exit_status` are set correctly.
@@ -59,7 +59,7 @@ def test_legacy_jobcalcstate_data(perform_migrations: PsqlDostoreMigrator):
                 assert isinstance(exit_status, int)
 
 
-def test_reset_hash(perform_migrations: PsqlDostoreMigrator):
+def test_reset_hash(perform_migrations: PsqlDosMigrator):
     """Test the migration that resets the node hash.
 
     Verify that only the _aiida_hash extra has been removed.
@@ -100,7 +100,7 @@ def test_reset_hash(perform_migrations: PsqlDostoreMigrator):
         assert '_aiida_hash' not in extras  # The hash extra should have been removed
 
 
-def test_legacy_process_attribute(perform_migrations: PsqlDostoreMigrator):
+def test_legacy_process_attribute(perform_migrations: PsqlDosMigrator):
     """Test the migration that performs a data migration of legacy process attributes.
 
     Verify that the attributes for process node have been deleted and `_sealed` has been changed to `sealed`.
@@ -189,7 +189,7 @@ def test_legacy_process_attribute(perform_migrations: PsqlDostoreMigrator):
             assert key in node_data.attributes
 
 
-def test_seal_unsealed_processes(perform_migrations: PsqlDostoreMigrator):
+def test_seal_unsealed_processes(perform_migrations: PsqlDosMigrator):
     """Test the migration that performs a data migration of legacy process attributes.
 
     Verify that the attributes for process node have been deleted and `_sealed` has been changed to `sealed`.
@@ -263,7 +263,7 @@ def test_seal_unsealed_processes(perform_migrations: PsqlDostoreMigrator):
         assert 'sealed' not in node_data.attributes
 
 
-def test_default_link_label(perform_migrations: PsqlDostoreMigrator):
+def test_default_link_label(perform_migrations: PsqlDosMigrator):
     """Test the migration that performs a data migration of legacy default link labels.
 
     Verify that the attributes for process node have been deleted and `_sealed` has been changed to `sealed`.

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_migrate_to_head.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_migrate_to_head.py
@@ -8,10 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Test migrating from the base of the sqlalchemy branch, to the main head."""
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-def test_migrate(perform_migrations: PsqlDostoreMigrator):
+def test_migrate(perform_migrations: PsqlDosMigrator):
     """Test that the migrator can migrate from the base of the sqlalchemy branch, to the main head."""
     perform_migrations.migrate_up('sqlalchemy@e15ef2630a1b')  # the base of the sqlalchemy branch
     perform_migrations.migrate()

--- a/tests/storage/psql_dos/migrations/test_all_schema.py
+++ b/tests/storage/psql_dos/migrations/test_all_schema.py
@@ -10,32 +10,30 @@
 """Basic tests for all migrations"""
 import pytest
 
-from aiida.storage.psql_dos.migrator import PsqlDostoreMigrator
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 
-@pytest.mark.parametrize('version', list(v for v in PsqlDostoreMigrator.get_schema_versions() if v.startswith('main')))
+@pytest.mark.parametrize('version', list(v for v in PsqlDosMigrator.get_schema_versions() if v.startswith('main')))
 def test_main(version, uninitialised_profile, reflect_schema, data_regression):
     """Test that the migrations produce the expected database schema."""
-    migrator = PsqlDostoreMigrator(uninitialised_profile)
+    migrator = PsqlDosMigrator(uninitialised_profile)
     migrator.migrate_up(f'main@{version}')
     data_regression.check(reflect_schema(uninitialised_profile))
 
 
 def test_head_vs_orm(uninitialised_profile, reflect_schema, data_regression):
     """Test that the migrations produce the same database schema as the models."""
-    migrator = PsqlDostoreMigrator(uninitialised_profile)
+    migrator = PsqlDosMigrator(uninitialised_profile)
     head_version = migrator.get_schema_version_head()
     migrator.initialise()
     data_regression.check(reflect_schema(uninitialised_profile), basename=f'test_main_{head_version}_')
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize(
-    'version', list(v for v in PsqlDostoreMigrator.get_schema_versions() if v.startswith('django'))
-)
+@pytest.mark.parametrize('version', list(v for v in PsqlDosMigrator.get_schema_versions() if v.startswith('django')))
 def test_django(version, uninitialised_profile, reflect_schema, data_regression):
     """Test that the migrations (along the legacy django branch) produce the expected database schema."""
-    migrator = PsqlDostoreMigrator(uninitialised_profile)
+    migrator = PsqlDosMigrator(uninitialised_profile)
     migrator.migrate_up(f'django@{version}')
     data_regression.check(reflect_schema(uninitialised_profile))
 
@@ -43,12 +41,10 @@ def test_django(version, uninitialised_profile, reflect_schema, data_regression)
 @pytest.mark.nightly
 @pytest.mark.parametrize(
     '_id,version',
-    enumerate(
-        v for v in PsqlDostoreMigrator.get_schema_versions() if not (v.startswith('django') or v.startswith('main'))
-    )
+    enumerate(v for v in PsqlDosMigrator.get_schema_versions() if not (v.startswith('django') or v.startswith('main')))
 )
 def test_sqla(_id, version, uninitialised_profile, reflect_schema, data_regression):
     """Test that the migrations produce the expected database schema."""
-    migrator = PsqlDostoreMigrator(uninitialised_profile)
+    migrator = PsqlDosMigrator(uninitialised_profile)
     migrator.migrate_up(f'sqlalchemy@{version}')
     data_regression.check(reflect_schema(uninitialised_profile))


### PR DESCRIPTION
This makes the naming consistent with the `PsqlDosBackend` storage backend implementation to which it belongs.

It is also made importable from the `aiida.storage.psql_dos` module just as the storage backend implementation.