### PR TITLE
`StorageBackend`: Remove `recreate_user` from `_clear`

### DIFF
--- a/aiida/manage/tests/__init__.py
+++ b/aiida/manage/tests/__init__.py
@@ -25,7 +25,6 @@ __all__ = (
     'TestManagerError',
     'get_test_backend_name',
     'get_test_profile_name',
-    'get_user_dict',
     'test_manager',
 )
 

--- a/aiida/manage/tests/main.py
+++ b/aiida/manage/tests/main.py
@@ -22,11 +22,11 @@ from aiida.common.warnings import warn_deprecation
 from aiida.manage import configuration, get_manager
 from aiida.manage.configuration import settings
 from aiida.manage.external.postgres import Postgres
+from aiida.orm import User
 
 __all__ = (
     'get_test_profile_name',
     'get_test_backend_name',
-    'get_user_dict',
     'test_manager',
     'TestManager',
     'TestManagerError',
@@ -164,8 +164,13 @@ class ProfileManager:
         if not self._profile.is_test_profile:
             raise TestManagerError(f'Profile `{profile_name}` is not a valid test profile.')
 
-    @staticmethod
-    def clear_profile():
+    def ensure_default_user(self):
+        """Ensure that the default user defined by the profile exists in the database."""
+        created, user = User.collection.get_or_create(self._profile.default_user_email)
+        if created:
+            user.store()
+
+    def clear_profile(self):
         """Reset the global profile, clearing all its data and closing any open resources.
 
         If the daemon is running, it will be stopped because it might be holding on to entities that will be cleared
@@ -179,10 +184,12 @@ class ProfileManager:
             daemon_client.stop_daemon(wait=True)
 
         manager = get_manager()
-        manager.get_profile_storage()._clear(recreate_user=True)  # pylint: disable=protected-access
+        manager.get_profile_storage()._clear()  # pylint: disable=protected-access
         manager.get_profile_storage()  # reload the storage connection
         manager.reset_communicator()
         manager.reset_runner()
+
+        self.ensure_default_user()
 
     def has_profile_open(self):
         return self._profile is not None
@@ -268,6 +275,7 @@ class TemporaryProfileManager(ProfileManager):
         Used to set up AiiDA profile from self.profile_info dictionary.
         """
         dictionary = {
+            'default_user_email': 'test@aiida.net',
             'test_profile': True,
             'storage': {
                 'backend': self.profile_info.get('storage_backend'),
@@ -334,7 +342,6 @@ class TemporaryProfileManager(ProfileManager):
         Warning: the AiiDA dbenv must not be loaded when this is called!
         """
         from aiida.manage.configuration import Profile
-        from aiida.orm import User
 
         manager = get_manager()
 
@@ -365,17 +372,13 @@ class TemporaryProfileManager(ProfileManager):
             profile = manager.load_profile(profile_name)
             profile.storage_cls.initialise(profile, reset=True)
 
-        # create the default user for the profile
-        created, user = User.collection.get_or_create(**get_user_dict(_DEFAULT_PROFILE_INFO))
-        if created:
-            user.store()
-        profile.default_user_email = user.email
-
         # Set options to suppress certain warnings
         config.set_option('warnings.development_version', False)
         config.set_option('warnings.rabbitmq_version', False)
 
         config.store()
+
+        self.ensure_default_user()
 
     def repo_ok(self):
         return bool(self.repo and os.path.isdir(os.path.dirname(self.repo)))
@@ -530,8 +533,3 @@ def get_test_profile_name():
     :returns: content of environment variable or `None`
     """
     return os.environ.get('AIIDA_TEST_PROFILE', None)
-
-
-def get_user_dict(profile_dict):
-    """Collect parameters required for creating users."""
-    return {k: profile_dict[k] for k in ('email', 'first_name', 'last_name', 'institution')}

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -224,10 +224,11 @@ def clear_profile():
         daemon_client.stop_daemon(wait=True)
 
     manager = get_manager()
-    manager.get_profile_storage()._clear(recreate_user=True)  # pylint: disable=protected-access
-    manager.get_profile_storage()  # reload the storage connection
+    manager.get_profile_storage()._clear()  # pylint: disable=protected-access
     manager.reset_communicator()
     manager.reset_runner()
+
+    User(get_manager().get_profile().default_user_email).store()
 
 
 @pytest.fixture(scope='session')

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -133,15 +133,14 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         """Return whether the storage is closed."""
 
     @abc.abstractmethod
-    def _clear(self, recreate_user: bool = True) -> None:
+    def _clear(self) -> None:
         """Clear the storage, removing all data.
 
         .. warning:: This is a destructive operation, and should only be used for testing purposes.
-
-        :param recreate_user: Re-create the default `User` for the profile, after clearing the storage.
         """
         from aiida.orm.autogroup import AutogroupManager
         self._autogroup = AutogroupManager(self)
+        self._default_user = None
 
     @property
     @abc.abstractmethod

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -153,7 +153,7 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
                 with session.begin_nested():
                     yield session
 
-    def _clear(self, recreate_user: bool = True) -> None:
+    def _clear(self) -> None:
         raise NotImplementedError
 
     def maintain(self, dry_run: bool = False, live: bool = True, **kwargs) -> None:

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -250,7 +250,7 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
     def users(self):
         return orm.SqliteUserCollection(self)
 
-    def _clear(self, recreate_user: bool = True) -> None:
+    def _clear(self) -> None:
         raise ReadOnlyError()
 
     def transaction(self):


### PR DESCRIPTION
The `_clear` method on the `StorageBackend` deletes all data in the storage. This is used by the unit tests when a test requires a clean storage to test against. However, the ORM assumes that a `User` instance, designated by the profile as the default user, is always present. As soon as an ORM entity is stored that requires a user but that is not explicitly defined, the default user is retrieved.

When a new profile is configured, the setup command ensures that the default user is properly created. However, when the storage is cleared, the user is also deleted and so it needs to be recreated. This job had been assigned to the `StorageBackend` but really this should not be its responsibility. It is specific to the use case of the test cases that reset the storage and need to reconstruct the user, so it should take care of that.

The `recreate_user` argument is removed from `StorageBackend._clear` and the logic to recreate a user after storage reset is moved to the `ProfileManager`. The `clear_profile` method, which calls the storage clear, recreates the user at the end. The `TemporaryProfileManager`, which subclasses the `ProfileManager` does the same when a temporary test profile is created at the start of a test session.