### PR TITLE
CI: Increase load limit for `verdi` to 0.5 seconds

### DIFF
--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -9,7 +9,7 @@ VERDI=`which verdi`
 # tends to go towards ~0.8 seconds. Since these timings are obviously machine and environment dependent, typically these
 # types of tests are fragile. But with a load limit of more than twice the ideal loading time, if exceeded, should give
 # a reasonably sure indication that the loading of `verdi` is unacceptably slowed down.
-LOAD_LIMIT=0.4
+LOAD_LIMIT=0.5
 MAX_NUMBER_ATTEMPTS=5
 
 iteration=0


### PR DESCRIPTION
Fixes #5771 

Recently, the verdi load-time test has been failing frequently because the load time often exceeds the current limit of 0.4 seconds. For now we raise the limit to 0.5 to reduce the false positives while we find a permanent fix of reducing the load time.