### PR TITLE
ORM: Remove `pymatgen` version check in `StructureData.set_pymatgen_structure`

### DIFF
--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -16,6 +16,7 @@ import copy
 import functools
 import itertools
 import json
+from pkg_resources import parse_version
 
 from aiida.common.constants import elements
 from aiida.common.exceptions import UnsupportedSpeciesError
@@ -823,8 +824,6 @@ class StructureData(Data):
 
         :raise ValueError: if there are partial occupancies together with spins.
         """
-
-        from pkg_resources import parse_version
 
         def build_kind_name(species_and_occu):
             """

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -16,6 +16,7 @@ import copy
 import functools
 import itertools
 import json
+
 from pkg_resources import parse_version
 
 from aiida.common.constants import elements

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -17,8 +17,6 @@ import functools
 import itertools
 import json
 
-from pkg_resources import parse_version
-
 from aiida.common.constants import elements
 from aiida.common.exceptions import UnsupportedSpeciesError
 
@@ -866,15 +864,9 @@ class StructureData(Data):
         self.pbc = [True, True, True]
         self.clear_kinds()
 
-        required_pmg_version = parse_version('2019.3.13')
-        current_pmg_version = parse_version(get_pymatgen_version())
         for site in struct.sites:
 
-            # site.species property first introduced in pymatgen version 2019.3.13
-            if current_pmg_version < required_pmg_version:
-                species_and_occu = site.species_and_occu
-            else:
-                species_and_occu = site.species
+            species_and_occu = site.species
 
             if 'kind_name' in site.properties:
                 kind_name = site.properties['kind_name']


### PR DESCRIPTION
Don't know what happened exactly, but if I don't do this, I'll get the exception:

```
...
 File "/home/jovyan/aiida-core/aiida/orm/nodes/data/cif.py", line 764, in get_structure
    result = convert_function(cif=self, parameters=parameters, metadata={'store_provenance': store})
  File "/home/jovyan/aiida-core/aiida/engine/processes/functions.py", line 179, in decorated_function
    result, _ = run_get_node(*args, **kwargs)
  File "/home/jovyan/aiida-core/aiida/engine/processes/functions.py", line 152, in run_get_node
    result = process.execute()
  File "/home/jovyan/aiida-core/aiida/engine/processes/functions.py", line 366, in execute
    result = super().execute()
  File "/opt/conda/lib/python3.9/site-packages/plumpy/processes.py", line 86, in func_wrapper
    return func(self, *args, **kwargs)
  File "/opt/conda/lib/python3.9/site-packages/plumpy/processes.py", line 1172, in execute
    return self.future().result()
  File "/opt/conda/lib/python3.9/site-packages/plumpy/process_states.py", line 228, in execute
    result = self.run_fn(*self.args, **self.kwargs)
  File "/home/jovyan/aiida-core/aiida/engine/processes/functions.py", line 410, in run
    result = self._func(*args, **kwargs)
  File "/home/jovyan/aiida-core/aiida/tools/data/cif.py", line 152, in _get_aiida_structure_pymatgen_inline
    return {'structure': StructureData(pymatgen_structure=structures[0])}
  File "/home/jovyan/aiida-core/aiida/orm/nodes/data/structure.py", line 742, in __init__
    self.set_pymatgen_structure(pymatgen_structure)
  File "/home/jovyan/aiida-core/aiida/orm/nodes/data/structure.py", line 827, in set_pymatgen_structure
    from pkg_resources import parse_version
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3268, in <module>
    def _initialize_master_working_set():
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3251, in _call_aside
    f(*args, **kwargs)
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3293, in _initialize_master_working_set
    tuple(
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3294, in <genexpr>
    dist.activate(replace=False)
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2805, in activate
    declare_namespace(pkg)
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2304, in declare_namespace
    _handle_ns(packageName, path_item)
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2221, in _handle_ns
    loader = importer.find_module(packageName)
  File "<frozen importlib._bootstrap_external>", line 493, in _find_module_shim
  File "<frozen importlib._bootstrap_external>", line 1428, in find_loader
  File "<frozen importlib._bootstrap_external>", line 1473, in find_spec
  File "<frozen importlib._bootstrap_external>", line 64, in _path_join
  File "<frozen importlib._bootstrap_external>", line 64, in <listcomp>
AttributeError: 'PosixPath' object has no attribute 'rstrip'
```