### PR TITLE
DevOps: Pin version of `setuptools` as it breaks dependencies

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -87,8 +87,10 @@ jobs:
       run: sudo apt update && sudo apt install postgresql graphviz
 
     - name: Upgrade pip and setuptools
+      # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy
       run: |
-        pip install --upgrade pip setuptools
+        pip install --upgrade pip
+        pip install setuptools==65.5.0
         pip --version
 
     - name: Build pymatgen with compatible numpy

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -63,8 +63,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Upgrade pip and setuptools
+      # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy
       run: |
-        pip install --upgrade pip setuptools
+        pip install --upgrade pip
+        pip install setuptools==65.5.0
         pip --version
 
     - name: Create environment from requirements file.
@@ -229,8 +231,10 @@ jobs:
 
     - name: Upgrade pip and setuptools
       # It is crucial to update `setuptools` or the installation of `pymatgen` can break
+      # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy
       run: |
-        pip install --upgrade pip setuptools
+        pip install --upgrade pip
+        pip install setuptools==65.5.0
         pip --version
 
     - name: Install aiida-core


### PR DESCRIPTION
The last version `setuptools==65.6.0` that was released today, breaks a number of packages, e.g., `numpy`, because it removed the `Log` resource from the `distutils.log` module. We temporarily pin the version to `setuptools==65.5.0` in the CI pipeline until a more permanent fix upstream is released.