### PR TITLE
Fixtures: Add `aiida_computer_localhost` and `aiida_computer_ssh`

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -265,7 +265,6 @@ def computer_setup(ctx, non_interactive, **kwargs):
 @with_dbenv()
 def computer_duplicate(ctx, computer, non_interactive, **kwargs):
     """Duplicate a computer allowing to change some parameters."""
-    from aiida import orm
     from aiida.orm.utils.builders.computer import ComputerBuilder
 
     if kwargs['label'] in get_computer_names():
@@ -293,9 +292,7 @@ def computer_duplicate(ctx, computer, non_interactive, **kwargs):
     else:
         echo.echo_success(f'Computer<{computer.pk}> {computer.label} created')
 
-    is_configured = computer.is_user_configured(orm.User.collection.get_default())
-
-    if not is_configured:
+    if not computer.is_configured:
         echo.echo_report('Note: before the computer can be used, it has to be configured with the command:')
 
         profile = ctx.obj['profile']
@@ -367,8 +364,8 @@ def computer_list(all_entries, raw):
         echo.echo_report("No computers configured yet. Use 'verdi computer setup'")
 
     sort = lambda computer: computer.label
-    highlight = lambda comp: comp.is_user_configured(user) and comp.is_user_enabled(user)
-    hide = lambda comp: not (comp.is_user_configured(user) and comp.is_user_enabled(user)) and not all_entries
+    highlight = lambda comp: comp.is_configured and comp.is_user_enabled(user)
+    hide = lambda comp: not (comp.is_configured and comp.is_user_enabled(user)) and not all_entries
     echo.echo_formatted_list(computers, ['label'], sort=sort, highlight=highlight, hide=hide)
 
 

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -193,9 +193,7 @@ def prepare_localhost():
         computer.configure(safe_interval=0.)
         computer.set_minimum_job_poll_interval(0.)
 
-    default_user = computer.backend.default_user
-
-    if default_user and not computer.is_user_configured(default_user):
-        computer.configure(default_user)
+    if not computer.is_configured:
+        computer.configure()
 
     return computer

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -38,6 +38,7 @@ import pytest
 import wrapt
 
 from aiida import plugins
+from aiida.common.exceptions import NotExistent
 from aiida.common.lang import type_check
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.warnings import warn_deprecation
@@ -45,7 +46,7 @@ from aiida.engine import Process, ProcessBuilder, submit
 from aiida.engine.daemon.client import DaemonClient
 from aiida.manage import Config, Profile, get_manager, get_profile
 from aiida.manage.manager import Manager
-from aiida.orm import ProcessNode, User
+from aiida.orm import Computer, ProcessNode, User
 
 
 def recursive_merge(left: dict[t.Any, t.Any], right: dict[t.Any, t.Any]) -> None:
@@ -412,44 +413,6 @@ def temp_dir():
 
 
 @pytest.fixture(scope='function')
-def aiida_localhost(tmp_path):
-    """Get an AiiDA computer for localhost.
-
-    Usage::
-
-      def test_1(aiida_localhost):
-          label = aiida_localhost.label
-          # proceed to set up code or use 'aiida_local_code_factory' instead
-
-
-    :return: The computer node
-    :rtype: :py:class:`~aiida.orm.Computer`
-    """
-    from aiida.common.exceptions import NotExistent
-    from aiida.orm import Computer
-
-    label = 'localhost-test'
-
-    try:
-        computer = Computer.collection.get(label=label)
-    except NotExistent:
-        computer = Computer(
-            label=label,
-            description='localhost computer set up by test manager',
-            hostname=label,
-            workdir=str(tmp_path),
-            transport_type='core.local',
-            scheduler_type='core.direct'
-        )
-        computer.store()
-        computer.set_minimum_job_poll_interval(0.)
-        computer.set_default_mpiprocs_per_machine(1)
-        computer.configure()
-
-    return computer
-
-
-@pytest.fixture(scope='function')
 def aiida_local_code_factory(aiida_localhost):
     """Get an AiiDA code on localhost.
 
@@ -479,7 +442,7 @@ def aiida_local_code_factory(aiida_localhost):
         :rtype: :py:class:`~aiida.orm.Code`
         """
         from aiida.common import exceptions
-        from aiida.orm import Computer, InstalledCode, QueryBuilder
+        from aiida.orm import InstalledCode, QueryBuilder
 
         if label is None:
             label = executable
@@ -520,6 +483,172 @@ def aiida_local_code_factory(aiida_localhost):
         return code.store()
 
     return get_code
+
+
+@pytest.fixture(scope='session')
+def ssh_key(tmp_path_factory) -> t.Generator[pathlib.Path, None, None]:
+    """Generate a temporary SSH key pair for the test session and return the filepath of the private key.
+
+    The filepath of the public key is the same as the private key, but it adds the ``.pub`` file extension.
+    """
+    from cryptography.hazmat.backends import default_backend as crypto_default_backend
+    from cryptography.hazmat.primitives import serialization as crypto_serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(
+        backend=crypto_default_backend(),
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+    private_key = key.private_bytes(
+        crypto_serialization.Encoding.PEM,
+        crypto_serialization.PrivateFormat.PKCS8,
+        crypto_serialization.NoEncryption(),
+    )
+
+    public_key = key.public_key().public_bytes(
+        crypto_serialization.Encoding.OpenSSH,
+        crypto_serialization.PublicFormat.OpenSSH,
+    )
+
+    dirpath = tmp_path_factory.mktemp('keys')
+    filename = uuid.uuid4().hex
+    filepath_private_key = dirpath / filename
+    filepath_public_key = dirpath / f'{filename}.pub'
+
+    filepath_private_key.write_bytes(private_key)
+    filepath_public_key.write_bytes(public_key)
+
+    try:
+        yield filepath_private_key
+    finally:
+        filepath_private_key.unlink(missing_ok=True)
+        filepath_public_key.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def aiida_computer(tmp_path) -> t.Callable[[], Computer]:
+    """Factory to return a :class:`aiida.orm.computers.Computer` instance."""
+
+    def factory(
+        label: str = None,
+        minimum_job_poll_interval: int = 0,
+        default_mpiprocs_per_machine: int = 1,
+        configuration_kwargs: dict[t.Any, t.Any] = None,
+        **kwargs
+    ) -> Computer:
+        """Return a :class:`aiida.orm.computers.Computer` instance.
+
+        The database is queried for an existing computer with the given label. If it exists, it means it was probably
+        created by this fixture in a previous call and it is simply returned. Otherwise a new instance is created.
+        Note that the computer is not explicitly configured, unless ``configure_kwargs`` are specified.
+
+        :param label: The computer label. If not specified, a random UUID4 is used.
+        :param minimum_job_poll_interval: The default minimum job poll interval to set.
+        :param configuration_kwargs: Optional keyword arguments that, if defined, are used to configure the computer
+            by calling :meth:`aiida.orm.computers.Computer.configure`.
+        :param kwargs: Optional keyword arguments that are passed to the :class:`aiida.orm.computers.Computer`
+            constructor if a computer with the given label doesn't already exist.
+        :return: A stored computer instance.
+        """
+        label = label or str(uuid.uuid4())
+
+        try:
+            computer = Computer.collection.get(label=label)
+        except NotExistent:
+            computer = Computer(
+                label=label,
+                description=kwargs.pop('description', 'computer created by `aiida_computer` fixture'),
+                hostname=kwargs.pop('hostname', 'localhost'),
+                workdir=kwargs.pop('workdir', str(tmp_path)),
+                transport_type=kwargs.pop('transport_type', 'core.local'),
+                scheduler_type=kwargs.pop('scheduler_type', 'core.direct'),
+            )
+            computer.store()
+            computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
+            computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)
+
+        if configuration_kwargs:
+            computer.configure(**configuration_kwargs)
+
+        return computer
+
+    return factory
+
+
+@pytest.fixture
+def aiida_computer_local(aiida_computer) -> t.Callable[[], Computer]:
+    """Factory to return a :class:`aiida.orm.computers.Computer` instance with ``core.local`` transport."""
+
+    def factory(label: str = None, configure: bool = True) -> Computer:
+        """Return a :class:`aiida.orm.computers.Computer` instance representing localhost with ``core.local`` transport.
+
+        The database is queried for an existing computer with the given label. If it exists, it is returned, otherwise a
+        new instance is created.
+
+        :param label: The computer label. If not specified, a random UUID4 is used.
+        :param configure: Boolean, if ``True``, ensures the computer is configured, otherwise the computer is returned
+            as is. Note that if a computer with the given label already exists and it was configured before, the
+            computer will not be "un-"configured. If an unconfigured computer is absolutely required, make sure to first
+            delete the existing computer or specify another label.
+        :return: A stored computer instance.
+        """
+        computer = aiida_computer(label=label, hostname='localhost', transport_type='core.local')
+
+        if configure:
+            computer.configure()
+
+        return computer
+
+    return factory
+
+
+@pytest.fixture
+def aiida_computer_ssh(aiida_computer, ssh_key) -> t.Callable[[], Computer]:
+    """Factory to return a :class:`aiida.orm.computers.Computer` instance with ``core.ssh`` transport."""
+
+    def factory(label: str = None, configure: bool = True) -> Computer:
+        """Return a :class:`aiida.orm.computers.Computer` instance representing localhost with ``core.ssh`` transport.
+
+        The database is queried for an existing computer with the given label. If it exists, it is returned, otherwise a
+        new instance is created.
+
+        If ``configure=True``, an SSH key pair is automatically added to the ``.ssh`` folder of the user, allowing an
+        actual SSH connection to be made to the localhost.
+
+        :param label: The computer label. If not specified, a random UUID4 is used.
+        :param configure: Boolean, if ``True``, ensures the computer is configured, otherwise the computer is returned
+            as is. Note that if a computer with the given label already exists and it was configured before, the
+            computer will not be "un-"configured. If an unconfigured computer is absolutely required, make sure to first
+            delete the existing computer or specify another label.
+        :return: A stored computer instance.
+        """
+        computer = aiida_computer(label=label, hostname='localhost', transport_type='core.ssh')
+
+        if configure:
+            computer.configure(
+                key_filename=str(ssh_key),
+                key_policy='AutoAddPolicy',
+            )
+
+        return computer
+
+    return factory
+
+
+@pytest.fixture(scope='function')
+def aiida_localhost(aiida_computer_local) -> Computer:
+    """Return a :class:`aiida.orm.computers.Computer` instance representing localhost with ``core.local`` transport.
+
+    Usage::
+
+        def test(aiida_localhost):
+            assert aiida_localhost.transport_type == 'core.local'
+
+    :return: The computer.
+    """
+    return aiida_computer_local(label='localhost')
 
 
 @pytest.fixture(scope='session')

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -580,6 +580,14 @@ class Computer(entities.Entity['BackendComputer']):
 
         return authinfo
 
+    @property
+    def is_configured(self) -> bool:
+        """Return whether the computer is configured for the current default user.
+
+        :return: Boolean, ``True`` if the computer is configured for the current default user, ``False`` otherwise.
+        """
+        return self.is_user_configured(users.User.collection(self.backend).get_default())
+
     def is_user_configured(self, user: 'User') -> bool:
         """
         Is the user configured on this computer?

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -391,7 +391,7 @@ class TestVerdiComputerConfigure:
 
         options = ['core.local', comp.label, '--non-interactive', '--safe-interval', '0']
         result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        assert comp.is_user_configured(self.user), result.output
+        assert comp.is_configured, result.output
 
         self.comp_builder.label = 'test_local_ni_empty_mismatch'
         self.comp_builder.transport = 'core.ssh'
@@ -416,7 +416,7 @@ class TestVerdiComputerConfigure:
         result = self.cli_runner(
             computer_configure, ['core.local', comp.label], user_input=f'{invalid}\n{valid}\n', catch_exceptions=False
         )
-        assert comp.is_user_configured(self.user), result.output
+        assert comp.is_configured, result.output
 
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
         assert new_auth_params['use_login_shell'] is False
@@ -454,7 +454,7 @@ class TestVerdiComputerConfigure:
         result = self.cli_runner(
             computer_configure, ['core.ssh', comp.label], user_input=command_input, catch_exceptions=False
         )
-        assert comp.is_user_configured(self.user), result.output
+        assert comp.is_configured, result.output
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
         assert new_auth_params['username'] == remote_username
         assert new_auth_params['port'] == port
@@ -499,7 +499,7 @@ safe_interval: {interval}
 
         options = ['core.ssh', comp.label, '--non-interactive', '--safe-interval', '1']
         result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        assert comp.is_user_configured(self.user), result.output
+        assert comp.is_configured, result.output
 
         self.comp_builder.label = 'test_ssh_ni_empty_mismatch'
         self.comp_builder.transport = 'core.local'
@@ -523,7 +523,7 @@ safe_interval: {interval}
         options = ['core.ssh', comp.label, '--non-interactive', f'--username={username}', '--safe-interval', '1']
         result = self.cli_runner(computer_configure, options, catch_exceptions=False)
         auth_info = orm.AuthInfo.collection.get(dbcomputer_id=comp.pk, aiidauser_id=self.user.pk)
-        assert comp.is_user_configured(self.user), result.output
+        assert comp.is_configured, result.output
         assert auth_info.get_auth_params()['username'] == username
 
     def test_show(self):
@@ -546,7 +546,7 @@ safe_interval: {interval}
         config_cmd = ['core.ssh', comp.label, '--non-interactive']
         config_cmd.extend(result.output.replace("'", '').split(' '))
         result_config = self.cli_runner(computer_configure, config_cmd, catch_exceptions=False)
-        assert comp.is_user_configured(self.user), result_config.output
+        assert comp.is_configured, result_config.output
 
         result_cur = self.cli_runner(
             computer_configure, ['show', comp.label, '--as-option-string'], catch_exceptions=False
@@ -580,7 +580,7 @@ class TestVerdiComputerCommands:
         self.comp.store()
         self.comp.configure()
         self.user = orm.User.collection.get_default()
-        assert self.comp.is_user_configured(self.user), 'There was a problem configuring the test computer'
+        assert self.comp.is_configured, 'There was a problem configuring the test computer'
         self.cli_runner = run_cli_command
 
     def test_computer_test(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import copy
 import os
 import pathlib
-from typing import IO, List, Optional, Union
+import typing as t
 import warnings
 
 import click
@@ -415,8 +415,8 @@ def run_cli_command(reset_log_level):  # pylint: disable=unused-argument
 
     def _run_cli_command(
         command: click.Command,
-        options: Optional[List] = None,
-        user_input: Optional[Union[str, bytes, IO]] = None,
+        options: list | None = None,
+        user_input: str | bytes | t.IO | None = None,
         raises: bool = False,
         catch_exceptions: bool = True,
         **kwargs

--- a/tests/manage/tests/test_pytest_fixtures.py
+++ b/tests/manage/tests/test_pytest_fixtures.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.manage.tests.pytest_fixtures` module."""
+import uuid
+
 import pytest
 
 from aiida.manage.configuration import get_config
 from aiida.manage.configuration.config import Config
+from aiida.orm import Computer
+from aiida.transports import Transport
 
 
 @pytest.mark.usefixtures('aiida_profile')
@@ -14,10 +18,56 @@ def test_profile_config():
 
 def test_aiida_localhost(aiida_localhost):
     """Test the ``aiida_localhost`` fixture."""
-    assert aiida_localhost.label == 'localhost-test'
+    assert aiida_localhost.label == 'localhost'
 
 
 def test_aiida_local_code(aiida_local_code_factory):
     """Test the ``aiida_local_code_factory`` fixture."""
     code = aiida_local_code_factory(entry_point='core.templatereplacer', executable='diff')
-    assert code.computer.label == 'localhost-test'
+    assert code.computer.label == 'localhost'
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_aiida_computer_local(aiida_computer_local):
+    """Test the ``aiida_computer_local`` fixture."""
+    computer = aiida_computer_local()
+    assert isinstance(computer, Computer)
+    assert computer.is_configured
+    assert computer.hostname == 'localhost'
+    assert computer.transport_type == 'core.local'
+
+    with computer.get_transport() as transport:
+        assert isinstance(transport, Transport)
+
+    # Calling it again with the same label should simply return the existing computer
+    computer_alt = aiida_computer_local(label=computer.label)
+    assert computer_alt.uuid == computer.uuid
+
+    computer_new = aiida_computer_local(label=str(uuid.uuid4()))
+    assert computer_new.uuid != computer.uuid
+
+    computer_unconfigured = aiida_computer_local(label=str(uuid.uuid4()), configure=False)
+    assert not computer_unconfigured.is_configured
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_aiida_computer_ssh(aiida_computer_ssh):
+    """Test the ``aiida_computer_ssh`` fixture."""
+    computer = aiida_computer_ssh()
+    assert isinstance(computer, Computer)
+    assert computer.is_configured
+    assert computer.hostname == 'localhost'
+    assert computer.transport_type == 'core.ssh'
+
+    with computer.get_transport() as transport:
+        assert isinstance(transport, Transport)
+
+    # Calling it again with the same label should simply return the existing computer
+    computer_alt = aiida_computer_ssh(label=computer.label)
+    assert computer_alt.uuid == computer.uuid
+
+    computer_new = aiida_computer_ssh(label=str(uuid.uuid4()))
+    assert computer_new.uuid != computer.uuid
+
+    computer_unconfigured = aiida_computer_ssh(label=str(uuid.uuid4()), configure=False)
+    assert not computer_unconfigured.is_configured

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -106,6 +106,15 @@ class TestComputerConfigure:
         self.comp_builder.shebang = '#!xonsh'
         self.user = User.collection.get_default()
 
+    def test_is_configured(self):
+        """Test the :meth:`aiida.orm.computers.Computer.is_configured`."""
+        self.comp_builder.label = 'test_configure_local'
+        self.comp_builder.transport = 'core.local'
+        comp = self.comp_builder.new()
+        comp.store()
+        comp.configure()
+        assert comp.is_configured
+
     def test_configure_local(self):
         """Configure a computer for local transport and check it is configured."""
         self.comp_builder.label = 'test_configure_local'

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -196,7 +196,7 @@ class TestVisGraph:
 
         expected_diff = """\
         +State: running" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]
-        +@localhost-test" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]
+        +@localhost" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]
         +Exit Code: 200" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]
         +\tN{fd1} [label="FolderData ({fd1})" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]
         +++""".format(**{k: v.pk for k, v in nodes.items()})
@@ -250,7 +250,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=rectangle style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @localhost-test" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
+                    @localhost" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -292,7 +292,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=polygon sides=6 style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @localhost-test" pencolor=black shape=rectangle]
+                    @localhost" pencolor=black shape=rectangle]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" pencolor=black shape=rectangle]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]


### PR DESCRIPTION
These fixtures return an instance of `Computer` that represents the
localhost computer with `core.local` and `core.ssh` as the transport
type, respectively. By default, the computers are also configured. The
`aiida_computer_ssh` will even create an SSH key pair automatically for
the session such that the SSH transport can actually be opened.

The fixtures both call the more generic `aiida_computer` which returns a
factory that gives greater control on how the computer is created and
configured. Usuallly the two wrappers are all that is needed for the
majority of tests.

The fixtures are placed in `pytest_fixtures` instead of the `conftest.py`
of `aiida-core`, because `aiida_computer` and `aiida_computer_localhost`
should be available to plugins. The `aiida_computer_ssh` is probably
mostly useful for tests in `aiida-core`, but for clarity it is kept
together with `aiida_computer_localhost`.

These new fixtures provide the same functionality as `aiida_localhost`
but are more flexible. The `aiida_localhost` fixture is therefore
deprecated.