### PR TITLE
CLI: Add the `-h` short-hand flag for `--help` to `verdi`

### DIFF
--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -17,7 +17,7 @@ from ..params import options, types
 
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
-@click.command(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help']})
+@click.command(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
 @options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
 @options.VERBOSITY()
 @click.version_option(__version__, package_name='aiida_core', message='AiiDA version %(version)s')


### PR DESCRIPTION
Fixes #5792
