### PR TITLE
Plugins: Add `aiida.storage` to `ENTRY_POINT_GROUP_FACTORY_MAPPING`

### DIFF
--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -97,6 +97,7 @@ ENTRY_POINT_GROUP_FACTORY_MAPPING = {
     'aiida.groups': factories.GroupFactory,
     'aiida.parsers': factories.ParserFactory,
     'aiida.schedulers': factories.SchedulerFactory,
+    'aiida.storage': factories.StorageFactory,
     'aiida.transports': factories.TransportFactory,
     'aiida.tools.dbimporters': factories.DbImporterFactory,
     'aiida.tools.data.orbital': factories.OrbitalFactory,


### PR DESCRIPTION
This is required for functions like `get_entry_point_from_class` from `aiida.plugins.entry_point` to properly resolve classes that are registered with an entry point in the `aiida.storage` group.