### PR TITLE
CLI: Add short option names for `verdi code create`

### DIFF
--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -117,6 +117,13 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
         name_dashed = name.replace('_', '-')
         option_name = f'--{name_dashed}/--no-{name_dashed}' if is_flag else f'--{name_dashed}'
 
+        option_short_name = spec.pop('short_name', None)
+
         kwargs = {'cls': spec.pop('cls', InteractiveOption), 'show_default': True, 'is_flag': is_flag, **spec}
 
-        return click.option(option_name, **kwargs)
+        if option_short_name:
+            option = click.option(option_short_name, option_name, **kwargs)
+        else:
+            option = click.option(option_name, **kwargs)
+
+        return option

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -278,6 +278,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         """Return the CLI options that would allow to create an instance of this class."""
         return {
             'label': {
+                'short_name': '-L',
                 'required': True,
                 'type': click.STRING,
                 'prompt': 'Label',
@@ -285,11 +286,13 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
                 'callback': cls.cli_validate_label_uniqueness,
             },
             'description': {
+                'short_name': '-D',
                 'type': click.STRING,
                 'prompt': 'Description',
                 'help': 'Human-readable description of this code ideally including version and compilation environment.'
             },
             'default_calc_job_plugin': {
+                'short_name': '-P',
                 'type': click.STRING,
                 'prompt': 'Default `CalcJob` plugin',
                 'help': 'Entry point name of the default plugin (as listed in `verdi plugin list aiida.calculations`).'

--- a/aiida/orm/nodes/data/code/containerized.py
+++ b/aiida/orm/nodes/data/code/containerized.py
@@ -111,18 +111,15 @@ class ContainerizedCode(InstalledCode):
         """Return the CLI options that would allow to create an instance of this class."""
         options = {
             'engine_command': {
-                'required':
-                True,
-                'prompt':
-                'Engine command',
-                'help': (
-                    'The command to run the container. It must contain the placeholder '
-                    '{image_name} that will be replaced with the `image_name`.'
-                ),
-                'type':
-                click.STRING,
+                'short_name': '-E',
+                'required': True,
+                'prompt': 'Engine command',
+                'help': 'The command to run the container. It must contain the placeholder {image_name} that will be '
+                'replaced with the `image_name`.',
+                'type': click.STRING,
             },
             'image_name': {
+                'short_name': '-I',
                 'required': True,
                 'type': click.STRING,
                 'prompt': 'Image name',

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -159,12 +159,14 @@ class InstalledCode(Code):
         """Return the CLI options that would allow to create an instance of this class."""
         options = {
             'computer': {
+                'short_name': '-Y',
                 'required': True,
                 'prompt': 'Computer',
                 'help': 'The remote computer on which the executable resides.',
                 'type': ComputerParamType(),
             },
             'filepath_executable': {
+                'short_name': '-X',
                 'required': True,
                 'type': click.Path(exists=False),
                 'prompt': 'Absolute filepath executable',

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -148,12 +148,14 @@ class PortableCode(Code):
         """Return the CLI options that would allow to create an instance of this class."""
         options = {
             'filepath_executable': {
+                'short_name': '-X',
                 'required': True,
                 'type': click.STRING,
                 'prompt': 'Relative filepath executable',
                 'help': 'Relative filepath of executable with directory of code files.',
             },
             'filepath_files': {
+                'short_name': '-F',
                 'required': True,
                 'type': click.Path(exists=True, file_okay=False, dir_okay=True, path_type=pathlib.Path),
                 'prompt': 'Code directory',


### PR DESCRIPTION
Fixes #5791 

The `verdi code create` command replaced `verdi code setup` but unlike its predecessor it only has long option names. To provide short options as well, the `DynamicEntryPointCommandGroup` is extended to support the `short_name` key in an option specification. If specified, the option will provide this short option as well as the automatically determined long option.

The `InstalledCode`, `PortableCode` and `ContainerizedCode` are updated to provide short options for those that used to have one in the replaced `verdi code setup` command.