### PR TITLE
Process functions: Restore support for dynamic nested input namespaces

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - importlib-resources~=5.0
 - numpy~=1.19
 - paramiko>=2.7.2,~=2.7
-- plumpy~=0.21.2
+- plumpy~=0.21.3
 - pgsu~=0.2.1
 - psutil~=5.6
 - psycopg2-binary~=2.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "importlib-resources~=5.0;python_version<'3.9'",
     "numpy~=1.19",
     "paramiko~=2.7,>=2.7.2",
-    "plumpy~=0.21.2",
+    "plumpy~=0.21.3",
     "pgsu~=0.2.1",
     "psutil~=5.6",
     "psycopg2-binary~=2.8",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -90,7 +90,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.2
+plumpy==0.21.3
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 psutil==5.8.0

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -107,7 +107,7 @@ Pillow==9.3.0
 platformdirs==2.5.4
 plotly==5.11.0
 pluggy==1.0.0
-plumpy==0.21.2
+plumpy==0.21.3
 prometheus-client==0.15.0
 prompt-toolkit==3.0.33
 psutil==5.9.4

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -91,7 +91,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.2
+plumpy==0.21.3
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 psutil==5.8.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -90,7 +90,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.2
+plumpy==0.21.3
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 psutil==5.8.0


### PR DESCRIPTION
Fixes #5806 

This behavior was supported before v2.0.4 but was accidentally removed by
putting more strict type validation on inputs passed to process
functions. In d2323d462a9c84ba83f24117fb78e5b102a53e85, a bug was fixed
where it was possible to pass non-storable inputs to dynamic port
namespaces. For example, the following was allowed:

    @calcfunction
    def sum(**kwargs):
        return sum(kwargs.values())

    sum(**{'a': 1, 'b': 2})

However, since the values in the `kwargs` are not `Data` nodes (and this
was before automatic input serialization was added for process functions)
and so they could not be stored in the provenance graph. This would
therefore cause accidental provenance loss.

This bug was fixed in the aforementioned commit by explicitly setting
`valid_type=Data` on the inputs namespace of the `Process` base class.

The fix, however, inadvertently also removed support for arbitrarily
nested keyword arguments in process functions. While this would work
before, it would now raise a `ValidationError` saying that the dynamic
namespace received a `dict` instead of a `Data` node. The cause is that
the `PortNamespace.validate_dynamic_ports` did not recurse down nested
namespaces, but only validated top-level values.

This behavior is fixed in `plumpy==0.21.3` where now the validation
method will recursively go down any nested namespaces for a dynamic port
namespace and validate as long as all leaf-values match the `valid_type`
of the `PortNamespace`.