### PR TITLE
`verdi run`: Do not add `pathlib.Path` instance to `sys.path`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,6 @@ repos:
                 aiida/cmdline/commands/cmd_devel.py|
                 aiida/cmdline/commands/cmd_group.py|
                 aiida/cmdline/commands/cmd_node.py|
-                aiida/cmdline/commands/cmd_run.py|
                 aiida/cmdline/commands/cmd_shell.py|
                 aiida/cmdline/commands/cmd_storage.py|
                 aiida/cmdline/groups/dynamic.py|

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -28,7 +28,7 @@ def update_environment(argv):
         _argv = sys.argv[:]
 
         # Add the current working directory to the path, such that local modules can be imported
-        sys.path.append(pathlib.Path.cwd().resolve())
+        sys.path.append(str(pathlib.Path.cwd().resolve()))
         sys.argv = argv[:]
         yield
     finally:


### PR DESCRIPTION
Fixes #5809 

The `verdi run` command updates `sys.path` to include the current working directory such that modules in it can be imported by the script being run. However, it was using `pathlib` to get the CWD and was adding a `Path` instance to the path, which should only contain `str` instances. This was uncovered by trying to import `tensorflow` which also manipulates the `sys.path` and was raising an error since it was trying to iterate over all elements and `pathlib.Path` is not iterable, unlike `str`.