### PR TITLE
Process: Update outputs before updating node process state

### DIFF
--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -138,7 +138,12 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
             inputs['code'] = code
 
         if daemon:
-            result, workchain, total_time = run_via_daemon(workchains, inputs, sleep, timeout)
+            response = run_via_daemon(workchains, inputs, sleep, timeout)
+
+            if response is None:
+                sys.exit(1)
+
+            result, workchain, total_time = response
 
         else:
             start_time = time.time()

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -406,7 +406,20 @@ class Process(plumpy.processes.Process):
         """After entering a new state, save a checkpoint and update the latest process state change timestamp."""
         # pylint: disable=cyclic-import
         from aiida.engine.utils import set_process_state_change_timestamp
-        self.update_node_state(self._state)
+
+        # For reasons unknown, it is important to update the outputs first, before doing anything else, otherwise there
+        # is the risk that certain outputs do not get attached before the process reaches a terminal state. Nevertheless
+        # we need to guarantee that the process state gets updated even if the ``update_outputs`` call excepts, for
+        # example if the process implementation attaches an invalid output through ``Process.out``, and so we call the
+        # ``ProcessNode.set_process_state`` in the finally-clause. This way the state gets properly set on the node even
+        # if the process is transitioning to the terminal excepted state.
+        try:
+            self.update_outputs()
+        except ValueError:  # pylint: disable=try-except-raise
+            raise
+        finally:
+            self.node.set_process_state(self._state.LABEL)
+
         self._save_checkpoint()
         set_process_state_change_timestamp(self)
         super().on_entered(from_state)
@@ -629,10 +642,6 @@ class Process(plumpy.processes.Process):
         :return: The decoded input args
         """
         return serialize.deserialize_unsafe(encoded)
-
-    def update_node_state(self, state: plumpy.process_states.State) -> None:
-        self.node.set_process_state(state.LABEL)
-        self.update_outputs()
 
     def update_outputs(self) -> None:
         """Attach new outputs to the node since the last call.


### PR DESCRIPTION
Fixes #5812 

In `a7be795a26aea9fdff1d6f762582f1b77801ff3d` the order of the two
method calls in `Process.update_node_state` was reversed. The idea was
that the `update_outputs` call can except, for example if a `Process`
implementation adds an invalid output by calling `Process.out`. In this
case the process will go into the excepted state and the process state
would sometimes not be updated on the node. By reversing the two actions
the process state was hoped to be more accurate in these cases.

However, since this change, the `nightly` workflow started failing where
nested workchains would except because a subprocess didn't have an
output that they expected. It is not clear at all what the relation is
but it seems that reverting the change described above resolves the
problem. Unfortunately, the bug does not seem to be deterministic and
doesn't always manifest.

Here, we reverse the order to the original state, updating the outputs
first, but in order to guarantee that the process state is always
updated, even if the output update excepts, it is called in the finally
clause of the try-except in which the `update_outputs` is wrapped.