### PR TITLE
Dependencies: Update requirement `spglib>=1.14,<3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ atomic_tools = [
     "pymatgen>=2022.1.20",
     "pymysql~=0.9.3",
     "seekpath~=1.9,>=1.9.3",
-    "spglib~=1.14"
+    "spglib>=1.14,<3.0"
 ]
 notebook = [
     "jupyter-client~=6.1,<6.1.13",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -134,7 +134,7 @@ shortuuid==1.0.8
 six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.3.1
-spglib==1.16.1
+spglib==2.0.2
 sphinx==4.4.0
 sphinx-copybutton==0.5.0
 sphinx-design==0.0.13

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -35,7 +35,7 @@ defusedxml==0.7.1
 deprecation==2.1.0
 disk-objectstore==0.6.0
 docutils==0.16
-emmet-core==0.38.4
+emmet-core==0.39.0
 fastjsonschema==2.16.2
 Flask==2.1.3
 Flask-Cors==3.0.10
@@ -154,7 +154,7 @@ six==1.16.0
 sniffio==1.3.0
 snowballstemmer==2.2.0
 soupsieve==2.3.2.post1
-spglib==1.16.5
+spglib==2.0.2
 Sphinx==4.5.0
 sphinx-copybutton==0.5.1
 sphinx-design==0.0.13

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -136,7 +136,7 @@ shortuuid==1.0.8
 six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.3.1
-spglib==1.16.1
+spglib==2.0.2
 sphinx==4.4.0
 sphinx-copybutton==0.5.0
 sphinx-design==0.0.13

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -135,7 +135,7 @@ shortuuid==1.0.8
 six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.3.1
-spglib==1.16.1
+spglib==2.0.2
 sphinx==4.4.0
 sphinx-copybutton==0.5.0
 sphinx-design==0.0.13


### PR DESCRIPTION
Fixes #5623 

As you can see, the current code base is already compatible with `spglib~=2.0`, or at least the code covered by tests. We might want to just leave the current dependency and not unnecessarily restrict the compatibility range if there is no real need. Think the release pace of `spglib` is quite slow so I don't think there is an immediate risk of things breaking if we don't upgrade.