### PR TITLE
🔀 REFACTOR: workchain subprocess queing

### DIFF
--- a/aiida/engine/__init__.py
+++ b/aiida/engine/__init__.py
@@ -24,9 +24,6 @@ from .utils import *
 
 __all__ = (
     'AiiDAPersister',
-    'Awaitable',
-    'AwaitableAction',
-    'AwaitableTarget',
     'BaseRestartWorkChain',
     'CalcJob',
     'CalcJobImporter',
@@ -60,7 +57,6 @@ __all__ = (
     'append_',
     'assign_',
     'calcfunction',
-    'construct_awaitable',
     'get_object_loader',
     'if_',
     'interruptable_task',

--- a/aiida/engine/processes/__init__.py
+++ b/aiida/engine/processes/__init__.py
@@ -25,9 +25,6 @@ from .process_spec import *
 from .workchains import *
 
 __all__ = (
-    'Awaitable',
-    'AwaitableAction',
-    'AwaitableTarget',
     'BaseRestartWorkChain',
     'CalcJob',
     'CalcJobImporter',
@@ -56,7 +53,6 @@ __all__ = (
     'append_',
     'assign_',
     'calcfunction',
-    'construct_awaitable',
     'if_',
     'process_handler',
     'return_',

--- a/aiida/engine/processes/workchains/__init__.py
+++ b/aiida/engine/processes/workchains/__init__.py
@@ -21,16 +21,12 @@ from .utils import *
 from .workchain import *
 
 __all__ = (
-    'Awaitable',
-    'AwaitableAction',
-    'AwaitableTarget',
     'BaseRestartWorkChain',
     'ProcessHandlerReport',
     'ToContext',
     'WorkChain',
     'append_',
     'assign_',
-    'construct_awaitable',
     'if_',
     'process_handler',
     'return_',

--- a/aiida/engine/processes/workchains/context.py
+++ b/aiida/engine/processes/workchains/context.py
@@ -8,44 +8,34 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Convenience functions to add awaitables to the Context of a WorkChain."""
-from typing import Union
+from __future__ import annotations
 
 from aiida.orm import ProcessNode
 
-from .awaitable import Awaitable, AwaitableAction, construct_awaitable
+from .awaitable import SubProcessRef, construct_sub_ref
 
 __all__ = ('ToContext', 'assign_', 'append_')
 
 ToContext = dict
 
 
-def assign_(target: Union[Awaitable, ProcessNode]) -> Awaitable:
+def assign_(target: ProcessNode) -> SubProcessRef:
+    """Construct a pointer for a given sub-process of a workchain step.
+
+    When the sub-process is completed,
+    it will be assigned to a key within the context (the key is defined later).
     """
-    Convenience function that will construct an Awaitable for a given class instance
-    with the context action set to ASSIGN. When the awaitable target is completed
-    it will be assigned to the context for a key that is to be defined later
+    process_ref = construct_sub_ref(target)
+    process_ref.action = 'assign'
+    return process_ref
 
-    :param target: an instance of a Process or Awaitable
 
-    :returns: the awaitable
+def append_(target: ProcessNode) -> SubProcessRef:
+    """Construct a pointer for a given sub-process of a workchain step.
 
+    When the sub-process is completed,
+    it will be appended to a list that is assigned toa  key within the context  (the key is defined later).
     """
-    awaitable = construct_awaitable(target)
-    awaitable.action = AwaitableAction.ASSIGN
-    return awaitable
-
-
-def append_(target: Union[Awaitable, ProcessNode]) -> Awaitable:
-    """
-    Convenience function that will construct an Awaitable for a given class instance
-    with the context action set to APPEND. When the awaitable target is completed
-    it will be appended to a list in the context for a key that is to be defined later
-
-    :param target: an instance of a Process or Awaitable
-
-    :returns: the awaitable
-
-    """
-    awaitable = construct_awaitable(target)
-    awaitable.action = AwaitableAction.APPEND
-    return awaitable
+    process_ref = construct_sub_ref(target)
+    process_ref.action = 'append'
+    return process_ref

--- a/tests/benchmark/test_engine.py
+++ b/tests/benchmark/test_engine.py
@@ -50,8 +50,7 @@ class WorkchainLoopWcSerial(WorkchainLoop):
     """A WorkChain that submits another WorkChain n times in different steps."""
 
     def run_task(self):
-        future = self.submit(WorkchainLoop, iterations=Int(1))
-        return self.to_context(**{f'wkchain{str(self.ctx.counter)}': future})
+        self.queue_subprocess(f'wkchain{str(self.ctx.counter)}', WorkchainLoop, {'iterations': Int(1)})
 
 
 class WorkchainLoopWcThreaded(WorkchainLoop):

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -12,7 +12,7 @@
 import pytest
 
 from aiida import engine, orm
-from aiida.engine.processes.workchains.awaitable import Awaitable
+from aiida.engine.processes.workchains.awaitable import SubProcessRef
 
 
 class SomeWorkChain(engine.BaseRestartWorkChain):
@@ -167,7 +167,7 @@ def test_run_process(generate_work_chain, generate_calculation_node, monkeypatch
     result = process.run_process()
 
     assert isinstance(result, engine.ToContext)
-    assert isinstance(result['children'], Awaitable)
+    assert isinstance(result['children'], SubProcessRef)
     assert process.node.base.extras.get(SomeWorkChain._considered_handlers_extra) == [[]]  # pylint: disable=protected-access
 
 


### PR DESCRIPTION
A proposal to change how to add a subprocess in a workchain step
(sidenote: this PR is fully back-compatible)

On the user side, basically I think we should replace the use of `self.submit`/`self.to_context`/`ToContext`, with simply `self.queue_subprocess`.
This better describes what we are actually intending the user to do:
> define a (sub/child)process, which will be run until termination, before the next step of the workchain commences, and whose resultant node/outputs will be available to the user in the next step, via a key on the workchain `ctx`

e.g. change this:

```python
            def step(self):
                self.to_context(child1=append_(self.submit(SimpleWc, val=Int(1))))
                return ToContext(**{'nested.key.child2': self.submit(SimpleWc, val=Int(1))})
```

to this:

```python
            def step(self):
                self.queue_subprocess("child1", SimpleWc, {"val": Int(1)}, ctx_append=True)
                self.queue_subprocess("nested.key.child2", SimpleWc, {"val": Int(1)})
```

 On the internal code side:

1. renamed some things to not use the term `awaitable`, which has a very definite meaning in python/plumpy (https://docs.python.org/3/library/collections.abc.html#collections.abc.Awaitable, https://docs.python.org/3/library/typing.html#typing.Awaitable) and instead refer to "process references"

2. Use a `dataclass` instead of an `AttributeDict`, since this has various issues for type safety

---

Notes:

- This currently is fully backward-compatible; it doesn't actually remove any of `self.submit`/`self.to_context`/`ToContext`.
   deprecation warnings could be added though.

- Currently `self.queue_subprocess` works exactly the same as if you did `self.submit` then `self.to_context`.
   I don't think this technically correct, though, since I think subprocess submission should only really happen after all the code in the step has been run. Otherwise, you can submit a process, then except the step, and now you have a subprocess running that you don't actually want.