### PR TITLE
`verdi computer test`: Add test for login shell being slow

### DIFF
--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -791,8 +791,8 @@ def test_computer_test_use_login_shell(run_cli_command, aiida_localhost, monkeyp
 
     def time_use_login_shell(authinfo, auth_params, use_login_shell, iterations) -> float:  # pylint: disable=unused-argument
         if use_login_shell:
-            return 5.0
-        return 1.0
+            return 0.21
+        return 0.10
 
     monkeypatch.setattr(cmd_computer, 'time_use_login_shell', time_use_login_shell)
 

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -762,7 +762,7 @@ def test_computer_test_stderr(run_cli_command, aiida_localhost, monkeypatch):
     monkeypatch.setattr(LocalTransport, 'exec_command_wait', exec_command_wait)
 
     result = run_cli_command(computer_test, [aiida_localhost.label])
-    assert 'Warning: 1 out of 5 tests failed' in result.output
+    assert 'Warning: 1 out of 6 tests failed' in result.output
     assert stderr in result.output
 
 
@@ -779,5 +779,23 @@ def test_computer_test_stdout(run_cli_command, aiida_localhost, monkeypatch):
     monkeypatch.setattr(LocalTransport, 'exec_command_wait', exec_command_wait)
 
     result = run_cli_command(computer_test, [aiida_localhost.label])
-    assert 'Warning: 1 out of 5 tests failed' in result.output
+    assert 'Warning: 1 out of 6 tests failed' in result.output
     assert stdout in result.output
+
+
+def test_computer_test_use_login_shell(run_cli_command, aiida_localhost, monkeypatch):
+    """Test ``verdi computer test`` where ``use_login_shell=True`` is much slower."""
+    from aiida.cmdline.commands import cmd_computer
+
+    aiida_localhost.configure()
+
+    def time_use_login_shell(authinfo, auth_params, use_login_shell: bool) -> float:  # pylint: disable=unused-argument
+        if use_login_shell:
+            return 5.0
+        return 1.0
+
+    monkeypatch.setattr(cmd_computer, 'time_use_login_shell', time_use_login_shell)
+
+    result = run_cli_command(computer_test, [aiida_localhost.label])
+    assert 'Warning: 1 out of 6 tests failed' in result.output
+    assert 'computer is configured with `use_login_shell=True` which is slower by a factor' in result.output

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -789,7 +789,7 @@ def test_computer_test_use_login_shell(run_cli_command, aiida_localhost, monkeyp
 
     aiida_localhost.configure()
 
-    def time_use_login_shell(authinfo, auth_params, use_login_shell: bool) -> float:  # pylint: disable=unused-argument
+    def time_use_login_shell(authinfo, auth_params, use_login_shell, iterations) -> float:  # pylint: disable=unused-argument
         if use_login_shell:
             return 5.0
         return 1.0
@@ -798,4 +798,4 @@ def test_computer_test_use_login_shell(run_cli_command, aiida_localhost, monkeyp
 
     result = run_cli_command(computer_test, [aiida_localhost.label])
     assert 'Warning: 1 out of 6 tests failed' in result.output
-    assert 'computer is configured with `use_login_shell=True` which is slower by a factor' in result.output
+    assert 'computer is configured to use a login shell, which is slower compared to a normal shell' in result.output


### PR DESCRIPTION
Fixes #5844 

By default computers are configured to use a login shell, setting the `use_login_shell` configuration option to `True`, which ensures that the `Transport` always uses the `-l` option for bash when executing a command. This can be important for certain compute environments where the login script contains commands that are necessary for calculation jobs to execute successfully.

However, this can incur significant slowdowns if the login script loading is slow. This will affect the throughput of calculation jobs significantly the source of which can be difficult to track down. That is why a test is added to `verdi computer test`. It will execute `whoami` over the transport with and without a login shell and if the ratio exceeds 2, a warning is emitted, suggesting to turn off the option unless strictly necessary.