### PR TITLE
Fixtures: Add argument `use_subprocess` to `run_cli_command`

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -44,7 +44,7 @@ jobs:
     needs: [check-requirements]
 
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false

--- a/aiida/cmdline/commands/cmd_data/cmd_array.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_array.py
@@ -13,7 +13,7 @@ from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, options, types
 
 
-@verdi_data.group('array')
+@verdi_data.group('core.array')
 def array():
     """Manipulate ArrayData objects (numpy arrays)."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -26,7 +26,7 @@ EXPORT_FORMATS = [
 VISUALIZATION_FORMATS = ['xmgrace']
 
 
-@verdi_data.group('bands')
+@verdi_data.group('core.bands')
 def bands():
     """Manipulate BandsData objects (band structures)."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -22,7 +22,7 @@ EXPORT_FORMATS = ['cif']
 VISUALIZATION_FORMATS = ['jmol', 'vesta']
 
 
-@verdi_data.group('cif')
+@verdi_data.group('core.cif')
 def cif():
     """Manipulate CifData objects (crystal structures in .cif format)."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_dict.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_dict.py
@@ -13,7 +13,7 @@ from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, options, types
 
 
-@verdi_data.group('dict')
+@verdi_data.group('core.dict')
 def dictionary():
     """Manipulate Dict objects (python dictionaries)."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -17,7 +17,7 @@ from aiida.cmdline.params import arguments, types
 from aiida.cmdline.utils import echo
 
 
-@verdi_data.group('remote')
+@verdi_data.group('core.remote')
 def remote():
     """Manipulate RemoteData objects (reference to remote folders).
 

--- a/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
@@ -14,7 +14,7 @@ from aiida.cmdline.params import arguments, types
 from aiida.cmdline.utils import decorators, echo
 
 
-@verdi_data.group('singlefile')
+@verdi_data.group('core.singlefile')
 def singlefile():
     """Work with SinglefileData nodes."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -41,7 +41,7 @@ def _store_structure(new_structure, dry_run):
         echo.echo(f'  Successfully imported structure {new_structure.get_formula()} (PK = {new_structure.pk})')
 
 
-@verdi_data.group('structure')
+@verdi_data.group('core.structure')
 def structure():
     """Manipulate StructureData objects (crystal structures)."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -23,7 +23,7 @@ EXPORT_FORMATS = ['cif', 'xsf']
 VISUALIZATION_FORMATS = ['jmol', 'xcrysden', 'mpl_heatmap', 'mpl_pos']
 
 
-@verdi_data.group('trajectory')
+@verdi_data.group('core.trajectory')
 def trajectory():
     """Manipulate TrajectoryData objects (molecular trajectories)."""
 

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -19,7 +19,7 @@ from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
 
 
-@verdi_data.group('upf')
+@verdi_data.group('core.upf')
 def upf():
     """Manipulate UpfData objects (UPF-format pseudopotentials)."""
 

--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -159,7 +159,7 @@ def test_migrate_low_verbosity(run_cli_command, tmp_path):
     filename_output = tmp_path / 'archive.aiida'
 
     options = ['--verbosity', 'WARNING', filename_input, filename_output]
-    result = run_cli_command(cmd_archive.migrate, options)
+    result = run_cli_command(cmd_archive.migrate, options, suppress_warnings=True)
     assert result.output == ''
     assert filename_output.is_file()
     assert ArchiveFormatSqlZip().read_version(filename_output) == ArchiveFormatSqlZip().latest_version

--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -46,7 +46,7 @@ def test_create_all(run_cli_command, tmp_path, aiida_localhost):
     filename_output = tmp_path / 'archive.aiida'
 
     options = ['--all', filename_output]
-    run_cli_command(cmd_archive.create, options)
+    run_cli_command(cmd_archive.create, options, use_subprocess=True)
     assert filename_output.is_file()
     assert ArchiveFormatSqlZip().read_version(filename_output) == ArchiveFormatSqlZip().latest_version
     with ArchiveFormatSqlZip().open(filename_output, 'r') as archive:

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -104,7 +104,7 @@ def test_import_make_new_group(run_cli_command, newest_archive):
 
     # Invoke `verdi import`, making sure there are no exceptions
     options = ['-G', group_label] + archives
-    run_cli_command(cmd_archive.import_archive, options)
+    run_cli_command(cmd_archive.import_archive, options, use_subprocess=True)
 
     # Make sure new Group was created
     (group, new_group) = Group.collection.get_or_create(group_label)

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -180,7 +180,7 @@ def test_noninteractive_upload(run_cli_command, non_interactive_editor):
 def test_interactive_remote(run_cli_command, aiida_localhost, non_interactive_editor):
     """Test interactive remote code setup."""
     label = 'interactive_remote'
-    user_input = '\n'.join(['yes', aiida_localhost.label, label, 'desc', 'core.arithmetic.add', '/remote/abs/path'])
+    user_input = '\n'.join(['yes', aiida_localhost.label, label, 'desc', 'core.arithmetic.add', '/remote/path', 'y'])
     run_cli_command(cmd_code.setup_code, user_input=user_input)
     assert isinstance(load_code(label), InstalledCode)
 
@@ -191,7 +191,7 @@ def test_interactive_upload(run_cli_command, non_interactive_editor):
     label = 'interactive_upload'
     dirname = os.path.dirname(__file__)
     basename = os.path.basename(__file__)
-    user_input = '\n'.join(['no', label, 'description', 'core.arithmetic.add', dirname, basename])
+    user_input = '\n'.join(['no', label, 'description', 'core.arithmetic.add', dirname, basename, 'y'])
     run_cli_command(cmd_code.setup_code, user_input=user_input)
     assert isinstance(load_code(label), PortableCode)
 
@@ -200,8 +200,8 @@ def test_interactive_upload(run_cli_command, non_interactive_editor):
 def test_mixed(run_cli_command, aiida_localhost, non_interactive_editor):
     """Test mixed (interactive/from config) code setup."""
     label = 'mixed_remote'
-    options = ['--description=description', '--on-computer', '--remote-abs-path=/remote/abs/path']
-    user_input = '\n'.join([aiida_localhost.label, label, 'core.arithmetic.add'])
+    options = ['--description=description', '--on-computer', '--remote-abs-path=/remote/path']
+    user_input = '\n'.join([aiida_localhost.label, label, 'core.arithmetic.add', 'y'])
     run_cli_command(cmd_code.setup_code, options, user_input=user_input)
     assert isinstance(load_code(label), InstalledCode)
 
@@ -316,7 +316,9 @@ def test_code_setup_remote_duplicate_full_label_interactive(
     assert isinstance(load_code(label), InstalledCode)
 
     label_unique = 'label-unique'
-    user_input = '\n'.join(['yes', aiida_localhost.label, label, label_unique, 'd', 'core.arithmetic.add', '/bin/bash'])
+    user_input = '\n'.join([
+        'yes', aiida_localhost.label, label, label_unique, 'd', 'core.arithmetic.add', '/bin/bash', 'y'
+    ])
     run_cli_command(cmd_code.setup_code, user_input=user_input)
     assert isinstance(load_code(label_unique), InstalledCode)
 
@@ -357,7 +359,7 @@ def test_code_setup_local_duplicate_full_label_interactive(
     assert isinstance(load_code(label), PortableCode)
 
     label_unique = 'label-unique'
-    user_input = '\n'.join(['no', label, label_unique, 'd', 'core.arithmetic.add', str(tmp_path), filepath.name])
+    user_input = '\n'.join(['no', label, label_unique, 'd', 'core.arithmetic.add', str(tmp_path), filepath.name, 'y'])
     run_cli_command(cmd_code.setup_code, user_input=user_input)
     assert isinstance(load_code(label_unique), PortableCode)
 

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -302,7 +302,7 @@ def test_from_config_url(non_interactive_editor, run_cli_command, aiida_localhos
 
     label = 'noninteractive_config_url'
     fake_url = 'https://my.url.com'
-    run_cli_command(cmd_code.setup_code, ['--non-interactive', '--config', fake_url])
+    run_cli_command(cmd_code.setup_code, ['--non-interactive', '--config', fake_url], use_subprocess=False)
     assert isinstance(load_code(label), InstalledCode)
 
 

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -123,7 +123,7 @@ def test_relabel_code_full_bad(run_cli_command, code):
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_code_delete_one_force(run_cli_command, code):
     """Test force code deletion."""
-    run_cli_command(cmd_code.delete, [str(code.pk), '--force'])
+    run_cli_command(cmd_code.delete, [str(code.pk), '--force'], use_subprocess=True)
 
     with pytest.raises(NotExistent):
         load_code('code')

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -109,7 +109,7 @@ def generate_setup_options_interactive(ordereddict):
 
 def test_help(run_cli_command):
     """Test the help of verdi computer setup."""
-    run_cli_command(computer_setup, ['--help'], catch_exceptions=False)
+    run_cli_command(computer_setup, ['--help'])
 
 
 def test_reachable():
@@ -144,7 +144,7 @@ def test_mixed(run_cli_command):
     user_input = '\n'.join(generate_setup_options_interactive(options_dict))
     options = generate_setup_options(non_interactive_options_dict)
 
-    result = run_cli_command(computer_setup, options, user_input=user_input, catch_exceptions=False)
+    result = run_cli_command(computer_setup, options, user_input=user_input)
     assert result.exception is None, f'There was an unexpected exception. Output: {result.output}'
 
     new_computer = orm.Computer.collection.get(label=label)
@@ -204,7 +204,7 @@ def test_noninteractive_optional_default_mpiprocs(run_cli_command):
     options_dict = generate_setup_options_dict({'label': 'computer_default_mpiprocs'})
     options_dict.pop('mpiprocs-per-machine')
     options = generate_setup_options(options_dict)
-    run_cli_command(computer_setup, options, catch_exceptions=False)
+    run_cli_command(computer_setup, options)
 
     new_computer = orm.Computer.collection.get(label=options_dict['label'])
     assert isinstance(new_computer, orm.Computer)
@@ -218,7 +218,7 @@ def test_noninteractive_optional_default_mpiprocs_2(run_cli_command):
     options_dict = generate_setup_options_dict({'label': 'computer_default_mpiprocs_2'})
     options_dict['mpiprocs-per-machine'] = 0
     options = generate_setup_options(options_dict)
-    run_cli_command(computer_setup, options, catch_exceptions=False)
+    run_cli_command(computer_setup, options)
 
     new_computer = orm.Computer.collection.get(label=options_dict['label'])
     assert isinstance(new_computer, orm.Computer)
@@ -301,10 +301,8 @@ def test_noninteractive_invalid_mpirun_fail(run_cli_command):
     options_dict = generate_setup_options_dict(replace_args={'label': 'fail_computer'})
     options_dict['mpirun-command'] = 'mpirun -np {unknown_key}'
     options = generate_setup_options(options_dict)
-    result = run_cli_command(computer_setup, options, catch_exceptions=False)
-
-    assert isinstance(result.exception, SystemExit)
-    assert "unknown replacement field 'unknown_key'" in str(result.output)
+    result = run_cli_command(computer_setup, options, raises=True)
+    assert "unknown replacement field 'unknown_key'" in result.output
 
 
 def test_noninteractive_from_config(run_cli_command):
@@ -351,7 +349,7 @@ class TestVerdiComputerConfigure:
 
     def test_top_help(self):
         """Test help option of verdi computer configure."""
-        result = self.cli_runner(computer_configure, ['--help'], catch_exceptions=False)
+        result = self.cli_runner(computer_configure, ['--help'])
         assert 'core.ssh' in result.output
         assert 'core.local' in result.output
 
@@ -378,7 +376,7 @@ class TestVerdiComputerConfigure:
         comp.store()
 
         options = ['core.local', comp.label, '--non-interactive', '--safe-interval', '0']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
+        result = self.cli_runner(computer_configure, options)
         assert comp.is_configured, result.output
 
         self.comp_builder.label = 'test_local_ni_empty_mismatch'
@@ -387,8 +385,7 @@ class TestVerdiComputerConfigure:
         comp_mismatch.store()
 
         options = ['core.local', comp_mismatch.label, '--non-interactive']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        assert result.exception is not None
+        result = self.cli_runner(computer_configure, options, raises=True)
         assert 'core.ssh' in result.output
         assert 'core.local' in result.output
 
@@ -401,9 +398,7 @@ class TestVerdiComputerConfigure:
 
         invalid = 'n'
         valid = '1.0'
-        result = self.cli_runner(
-            computer_configure, ['core.local', comp.label], user_input=f'{invalid}\n{valid}\n', catch_exceptions=False
-        )
+        result = self.cli_runner(computer_configure, ['core.local', comp.label], user_input=f'{invalid}\n{valid}\n')
         assert comp.is_configured, result.output
 
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
@@ -439,9 +434,7 @@ class TestVerdiComputerConfigure:
             key_filename=key_filename
         )
 
-        result = self.cli_runner(
-            computer_configure, ['core.ssh', comp.label], user_input=command_input, catch_exceptions=False
-        )
+        result = self.cli_runner(computer_configure, ['core.ssh', comp.label], user_input=command_input)
         assert comp.is_configured, result.output
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
         assert new_auth_params['username'] == remote_username
@@ -486,7 +479,7 @@ safe_interval: {interval}
         comp.store()
 
         options = ['core.ssh', comp.label, '--non-interactive', '--safe-interval', '1']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
+        result = self.cli_runner(computer_configure, options)
         assert comp.is_configured, result.output
 
         self.comp_builder.label = 'test_ssh_ni_empty_mismatch'
@@ -495,8 +488,7 @@ safe_interval: {interval}
         comp_mismatch.store()
 
         options = ['core.ssh', comp_mismatch.label, '--non-interactive']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        assert result.exception is not None
+        result = self.cli_runner(computer_configure, options, raises=True)
         assert 'core.local' in result.output
         assert 'core.ssh' in result.output
 
@@ -509,7 +501,7 @@ safe_interval: {interval}
 
         username = 'TEST'
         options = ['core.ssh', comp.label, '--non-interactive', f'--username={username}', '--safe-interval', '1']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
+        result = self.cli_runner(computer_configure, options)
         auth_info = orm.AuthInfo.collection.get(dbcomputer_id=comp.pk, aiidauser_id=self.user.pk)
         assert comp.is_configured, result.output
         assert auth_info.get_auth_params()['username'] == username
@@ -521,24 +513,20 @@ safe_interval: {interval}
         comp = self.comp_builder.new()
         comp.store()
 
-        result = self.cli_runner(computer_configure, ['show', comp.label], catch_exceptions=False)
+        result = self.cli_runner(computer_configure, ['show', comp.label])
 
-        result = self.cli_runner(computer_configure, ['show', comp.label, '--defaults'], catch_exceptions=False)
+        result = self.cli_runner(computer_configure, ['show', comp.label, '--defaults'])
         assert '* username' in result.output
 
-        result = self.cli_runner(
-            computer_configure, ['show', comp.label, '--defaults', '--as-option-string'], catch_exceptions=False
-        )
+        result = self.cli_runner(computer_configure, ['show', comp.label, '--defaults', '--as-option-string'])
         assert '--username=' in result.output
 
         config_cmd = ['core.ssh', comp.label, '--non-interactive']
         config_cmd.extend(result.output.replace("'", '').split(' '))
-        result_config = self.cli_runner(computer_configure, config_cmd, catch_exceptions=False)
+        result_config = self.cli_runner(computer_configure, config_cmd)
         assert comp.is_configured, result_config.output
 
-        result_cur = self.cli_runner(
-            computer_configure, ['show', comp.label, '--as-option-string'], catch_exceptions=False
-        )
+        result_cur = self.cli_runner(computer_configure, ['show', comp.label, '--as-option-string'])
         assert '--username=' in result.output
         assert result_cur.output == result.output
 
@@ -661,7 +649,7 @@ class TestVerdiComputerCommands:
         ).store()
         # and configure it
         options = ['core.local', label, '--non-interactive', '--safe-interval', '0']
-        self.cli_runner(computer_configure, options, catch_exceptions=False)
+        self.cli_runner(computer_configure, options)
 
         # See if the command complains about not getting an invalid computer
         self.cli_runner(computer_delete, ['computer_that_does_not_exist'], raises=True)
@@ -679,7 +667,7 @@ def test_computer_duplicate_interactive(run_cli_command, aiida_localhost, non_in
     label = 'computer_duplicate_interactive'
     computer = aiida_localhost
     user_input = f'{label}\n\n\n\n\n\n\n\n\n\n'
-    result = run_cli_command(computer_duplicate, [str(computer.pk)], user_input=user_input, catch_exceptions=False)
+    result = run_cli_command(computer_duplicate, [str(computer.pk)], user_input=user_input)
     assert result.exception is None, result.output
 
     new_computer = orm.Computer.collection.get(label=label)

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -141,6 +141,7 @@ def test_mixed(run_cli_command):
     non_interactive_options_dict['shebang'] = options_dict.pop('shebang')
     non_interactive_options_dict['scheduler'] = options_dict.pop('scheduler')
 
+    options_dict['use-login-shell'] = 'y'
     # In any case, these would be managed by the visual editor
     user_input = '\n'.join(generate_setup_options_interactive(options_dict))
     options = generate_setup_options(non_interactive_options_dict)
@@ -403,8 +404,8 @@ class TestVerdiComputerConfigure:
         assert comp.is_configured, result.output
 
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
+        assert new_auth_params['safe_interval'] == 1.0
         assert new_auth_params['use_login_shell'] is False
-        assert new_auth_params['use_login_shell'] == 1.0
 
     def test_ssh_interactive(self):
         """
@@ -423,16 +424,14 @@ class TestVerdiComputerConfigure:
         remote_username = 'some_remote_user'
         port = 345
         look_for_keys = False
-        key_filename = ''
 
         # I just pass the first four arguments:
         # the username, the port, look_for_keys, and the key_filename
         # This testing also checks that an empty key_filename is ok
-        command_input = ('{remote_username}\n{port}\n{look_for_keys}\n{key_filename}\n').format(
+        command_input = ('{remote_username}\n{port}\n{look_for_keys}\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n').format(
             remote_username=remote_username,
             port=port,
             look_for_keys='yes' if look_for_keys else 'no',
-            key_filename=key_filename
         )
 
         result = self.cli_runner(computer_configure, ['core.ssh', comp.label], user_input=command_input)
@@ -441,7 +440,6 @@ class TestVerdiComputerConfigure:
         assert new_auth_params['username'] == remote_username
         assert new_auth_params['port'] == port
         assert new_auth_params['look_for_keys'] == look_for_keys
-        assert new_auth_params['key_filename'] == key_filename
         assert new_auth_params['use_login_shell'] is True
 
     def test_local_from_config(self):
@@ -728,6 +726,7 @@ def test_direct_interactive(run_cli_command, non_interactive_editor):
     # In any case, these would be managed by the visual editor
     options_dict.pop('prepend-text')
     options_dict.pop('append-text')
+    options_dict['use-login-shell'] = 'y'
     user_input = '\n'.join(generate_setup_options_interactive(options_dict))
 
     result = run_cli_command(computer_setup, user_input=user_input)

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -20,7 +20,7 @@ def test_config_set_option_no_profile(run_cli_command, empty_config):
     option_value = str(10)
 
     options = ['config', 'set', option_name, str(option_value)]
-    run_cli_command(cmd_verdi.verdi, options)
+    run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert str(config.get_option(option_name, scope=None)) == option_value
 
 
@@ -33,7 +33,7 @@ def test_config_set_option(run_cli_command, config_with_profile_factory):
 
     for option_value in option_values:
         options = ['config', 'set', option_name, option_value]
-        run_cli_command(cmd_verdi.verdi, options)
+        run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
         assert str(config.get_option(option_name, scope=get_profile().name)) == option_value
 
 
@@ -43,7 +43,7 @@ def test_config_append_option(run_cli_command, config_with_profile_factory):
     option_name = 'caching.enabled_for'
     for value in ['x', 'y']:
         options = ['config', 'set', '--append', option_name, value]
-        run_cli_command(cmd_verdi.verdi, options)
+        run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert config.get_option(option_name, scope=get_profile().name) == ['x', 'y']
 
 
@@ -55,7 +55,7 @@ def test_config_remove_option(run_cli_command, config_with_profile_factory):
     config.set_option(option_name, ['x', 'y'], scope=get_profile().name)
 
     options = ['config', 'set', '--remove', option_name, 'x']
-    run_cli_command(cmd_verdi.verdi, options)
+    run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert config.get_option(option_name, scope=get_profile().name) == ['y']
 
 
@@ -66,10 +66,10 @@ def test_config_get_option(run_cli_command, config_with_profile_factory):
     option_value = str(30)
 
     options = ['config', 'set', option_name, option_value]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
 
     options = ['config', 'get', option_name]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert option_value in result.output.strip()
 
 
@@ -80,18 +80,18 @@ def test_config_unset_option(run_cli_command, config_with_profile_factory):
     option_value = str(30)
 
     options = ['config', 'set', option_name, str(option_value)]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
 
     options = ['config', 'get', option_name]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert option_value in result.output.strip()
 
     options = ['config', 'unset', option_name]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert f"'{option_name}' unset" in result.output.strip()
 
     options = ['config', 'get', option_name]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert result.output.strip() == str(20)  # back to the default
 
 
@@ -102,10 +102,10 @@ def test_config_set_option_global_only(run_cli_command, config_with_profile_fact
     option_value = 'some@email.com'
 
     options = ['config', 'set', option_name, str(option_value)]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
 
     options = ['config', 'get', option_name]
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
 
     # Check that the current profile name is not in the output
     assert option_value in result.output.strip()
@@ -116,7 +116,7 @@ def test_config_list(run_cli_command, config_with_profile_factory):
     """Test `verdi config list`"""
     config_with_profile_factory()
     options = ['config', 'list']
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
 
     assert 'daemon.timeout' in result.output
     assert 'Timeout in seconds' not in result.output
@@ -127,7 +127,7 @@ def test_config_list_description(run_cli_command, config_with_profile_factory):
     config_with_profile_factory()
     for flag in ['-d', '--description']:
         options = ['config', 'list', flag]
-        result = run_cli_command(cmd_verdi.verdi, options)
+        result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
 
         assert 'daemon.timeout' in result.output
         assert 'Timeout in seconds' in result.output
@@ -137,7 +137,7 @@ def test_config_show(run_cli_command, config_with_profile_factory):
     """Test `verdi config show`"""
     config_with_profile_factory()
     options = ['config', 'show', 'daemon.timeout']
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert 'schema' in result.output
 
 
@@ -145,18 +145,18 @@ def test_config_caching(run_cli_command, config_with_profile_factory):
     """Test `verdi config caching`"""
     config = config_with_profile_factory()
 
-    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'])
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'], use_subprocess=False)
     assert result.output.strip() == ''
 
-    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'])
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'], use_subprocess=False)
     assert 'core.arithmetic.add' in result.output.strip()
 
     config.set_option('caching.default_enabled', True, scope=get_profile().name)
 
-    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'])
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching'], use_subprocess=False)
     assert 'core.arithmetic.add' in result.output.strip()
 
-    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'])
+    result = run_cli_command(cmd_verdi.verdi, ['config', 'caching', '--disabled'], use_subprocess=False)
     assert result.output.strip() == ''
 
 
@@ -164,5 +164,5 @@ def test_config_downgrade(run_cli_command, config_with_profile_factory):
     """Test `verdi config downgrade`"""
     config_with_profile_factory()
     options = ['config', 'downgrade', '1']
-    result = run_cli_command(cmd_verdi.verdi, options)
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert 'Success: Downgraded' in result.output.strip()

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -65,7 +65,7 @@ def test_daemon_start_number_config(run_cli_command, stopped_daemon_client, isol
     isolated_config.set_option('daemon.default_workers', number, scope=get_profile().name)
     isolated_config.store()
 
-    run_cli_command(cmd_daemon.start)
+    run_cli_command(cmd_daemon.start, use_subprocess=False)
 
     daemon_response = stopped_daemon_client.get_daemon_info()
     worker_response = stopped_daemon_client.get_worker_info()

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -833,7 +833,7 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_content(self):
         """Test that `verdi data cif content` returns the content of the file."""
         options = [str(self.cif.uuid)]
-        result = self.cli_runner(cmd_cif.cif_content, options)
+        result = self.cli_runner(cmd_cif.cif_content, options, suppress_warnings=True)
 
         for line in result.output.split('\n'):
             assert line in self.valid_sample_cif_str
@@ -866,7 +866,7 @@ class TestVerdiDataSinglefile(DummyVerdiDataListable, DummyVerdiDataExportable):
         singlefile = orm.SinglefileData(file=io.BytesIO(content.encode('utf8'))).store()
 
         options = [str(singlefile.uuid)]
-        result = self.cli_runner(cmd_singlefile.singlefile_content, options)
+        result = self.cli_runner(cmd_singlefile.singlefile_content, options, suppress_warnings=True)
 
         for line in result.output.split('\n'):
             assert line in content

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -63,29 +63,29 @@ class DummyVerdiDataExportable:
 
         # Check that the simple command works as expected
         options = [str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options)
         assert res.exit_code == 0, 'The command did not finish correctly'
 
         for flag in ['-F', '--format']:
             for frmt in supported_formats:
                 options = [flag, frmt, str(ids[self.NODE_ID_STR])]
-                res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+                res = self.cli_runner(export_cmd, options)
                 assert res.exit_code == 0, f'The command did not finish correctly. Output:\n{res.output}'
 
         filepath = tmp_path / 'output_file.txt'
         options = [output_flag, str(filepath), str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options)
         assert res.exit_code == 0, f'The command should finish correctly.Output:\n{res.output}'
 
         # Try to export it again. It should fail because the
         # file exists
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options, raises=True)
         assert res.exit_code != 0, 'The command should fail because the file already exists'
 
         # Now we force the export of the file and it should overwrite
         # existing files
         options = [output_flag, str(filepath), '-f', str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options)
         assert res.exit_code == 0, f'The command should finish correctly.Output: {res.output}'
 
 
@@ -125,18 +125,18 @@ class DummyVerdiDataListable:
         search_string_bytes = search_string.encode('utf-8')
 
         # Check that the normal listing works as expected
-        res = self.cli_runner(listing_cmd, [], catch_exceptions=False)
+        res = self.cli_runner(listing_cmd, [])
         assert search_string_bytes in res.stdout_bytes, f'The string {search_string} was not found in the listing'
 
         # Check that the past days filter works as expected
         past_days_flags = ['-p', '--past-days']
         for flag in past_days_flags:
             options = [flag, '1']
-            res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+            res = self.cli_runner(listing_cmd, options)
             assert search_string_bytes in res.stdout_bytes, f'The string {search_string} was not found in the listing'
 
             options = [flag, '0']
-            res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+            res = self.cli_runner(listing_cmd, options)
             assert search_string_bytes not in res.stdout_bytes, (
                 f'A not expected string {search_string} was found in the listing'
             )
@@ -148,27 +148,27 @@ class DummyVerdiDataListable:
             # Non empty group
             for non_empty in [self.NON_EMPTY_GROUP_NAME_STR, str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
                 options = [flag, non_empty]
-                res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+                res = self.cli_runner(listing_cmd, options)
                 assert search_string_bytes in res.stdout_bytes, 'The string {} was not found in the listing'
 
             # Empty group
             for empty in [self.EMPTY_GROUP_NAME_STR, str(ids[self.EMPTY_GROUP_ID_STR])]:
                 options = [flag, empty]
-                res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+                res = self.cli_runner(listing_cmd, options)
                 assert search_string_bytes not in res.stdout_bytes, 'A not expected string {} was found in the listing'
 
             # Group combination
             for non_empty in [self.NON_EMPTY_GROUP_NAME_STR, str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
                 for empty in [self.EMPTY_GROUP_NAME_STR, str(ids[self.EMPTY_GROUP_ID_STR])]:
                     options = [flag, non_empty, empty]
-                    res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+                    res = self.cli_runner(listing_cmd, options)
                     assert search_string_bytes in res.stdout_bytes, 'The string {} was not found in the listing'
 
         # Check raw flag
         raw_flags = ['-r', '--raw']
         for flag in raw_flags:
             options = [flag]
-            res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+            res = self.cli_runner(listing_cmd, options)
             for header in headers_mapping[datatype]:
                 assert header.encode('utf-8') not in res.stdout_bytes
 
@@ -213,7 +213,7 @@ class TestVerdiDataArray:
 
     def test_arrayshow(self):
         options = [str(self.arr.pk)]
-        res = self.cli_runner(cmd_array.array_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_array.array_show, options)
         assert res.exit_code == 0, 'The command did not finish correctly'
 
 
@@ -310,7 +310,7 @@ class TestVerdiDataBands(DummyVerdiDataListable):
 
     def test_bandslist_with_elements(self):
         options = ['-e', 'Fe']
-        res = self.cli_runner(cmd_bands.bands_list, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_bands.bands_list, options)
         assert b'FeO' in res.stdout_bytes, 'The string "FeO" was not found in the listing'
         assert b'<<NOT FOUND>>' not in res.stdout_bytes, 'The string "<<NOT FOUND>>" should not in the listing'
 
@@ -320,7 +320,7 @@ class TestVerdiDataBands(DummyVerdiDataListable):
 
     def test_bandsexport(self):
         options = [str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
-        res = self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_bands.bands_export, options)
         assert res.exit_code == 0, 'The command did not finish correctly'
         assert b'[1.0, 3.0]' in res.stdout_bytes, 'The string [1.0, 3.0] was not found in the bands export'
 
@@ -338,14 +338,14 @@ class TestVerdiDataBands(DummyVerdiDataListable):
 
         # matplotlib
         options = [str(bands.pk), '--format', 'mpl_singlefile']
-        res = self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_bands.bands_export, options)
         assert b'p.scatter' in res.stdout_bytes, 'The string p.scatter was not found in the bands mpl export'
 
         # gnuplot
         from click.testing import CliRunner
         with CliRunner().isolated_filesystem():
             options = [str(bands.pk), '--format', 'gnuplot', '-o', 'bands.gnu']
-            self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
+            self.cli_runner(cmd_bands.bands_export, options)
             with open('bands.gnu', 'r', encoding='utf8') as gnu_file:
                 res = gnu_file.read()
                 assert 'vectors nohead' in res, 'The string "vectors nohead" was not found in the gnuplot script'
@@ -370,7 +370,7 @@ class TestVerdiDataDict:
     def test_dictshow(self):
         """Test verdi data dict show."""
         options = [str(self.dct.pk)]
-        res = self.cli_runner(cmd_dict.dictionary_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_dict.dictionary_show, options)
         assert res.exit_code == 0, 'The command verdi data dict show did not finish correctly'
         assert b'"a": 1' in res.stdout_bytes, 'The string "a": 1 was not found in the output' \
             ' of verdi data dict show'
@@ -397,7 +397,7 @@ class TestVerdiDataRemote:
     def test_remoteshow(self):
         """Test verdi data remote show."""
         options = [str(self.rmt.pk)]
-        res = self.cli_runner(cmd_remote.remote_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_remote.remote_show, options)
         assert res.exit_code == 0, 'The command verdi data remote show did not finish correctly'
         assert b'Remote computer name:' in res.stdout_bytes, (
             'The string "Remote computer name:" was not found in the output of verdi data remote show'
@@ -412,7 +412,7 @@ class TestVerdiDataRemote:
 
     def test_remotels(self):
         options = ['--long', str(self.rmt.pk)]
-        res = self.cli_runner(cmd_remote.remote_ls, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_remote.remote_ls, options)
         assert res.exit_code == 0, 'The command verdi data remote ls did not finish correctly'
         assert b'file.txt' in res.stdout_bytes, 'The file "file.txt" was not found in the output' \
             ' of verdi data remote ls'
@@ -423,7 +423,7 @@ class TestVerdiDataRemote:
 
     def test_remotecat(self):
         options = [str(self.rmt.pk), 'file.txt']
-        res = self.cli_runner(cmd_remote.remote_cat, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_remote.remote_cat, options)
         assert res.exit_code == 0, 'The command verdi data remote cat did not finish correctly'
         assert b'test string' in res.stdout_bytes, 'The string "test string" was not found in the output' \
             ' of verdi data remote cat file.txt'
@@ -616,7 +616,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
                 '1',
                 '1',
             ]
-            res = self.cli_runner(cmd_structure.import_aiida_xyz, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -638,7 +638,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
                 fhandle.name,
                 '-n'  # dry-run
             ]
-            res = self.cli_runner(cmd_structure.import_aiida_xyz, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -672,7 +672,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
                 '--group',
                 group_label,
             ]
-            res = self.cli_runner(cmd_structure.import_aiida_xyz, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -701,7 +701,7 @@ PRIMVEC
             options = [
                 fhandle.name,
             ]
-            res = self.cli_runner(cmd_structure.import_ase, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_ase, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -726,7 +726,7 @@ PRIMVEC
             fhandle.write(xsfcontent)
             fhandle.flush()
             options = [fhandle.name, '--label', 'another  structure', '--group', group_label]
-            res = self.cli_runner(cmd_structure.import_ase, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_ase, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -810,13 +810,13 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
 
     def test_showhelp(self):
         options = ['--help']
-        res = self.cli_runner(cmd_cif.cif_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_cif.cif_show, options)
         assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output' \
             ' of verdi data show help'
 
     def test_importhelp(self):
         options = ['--help']
-        res = self.cli_runner(cmd_cif.cif_import, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_cif.cif_import, options)
         assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output' \
             ' of verdi data import help'
 
@@ -826,14 +826,14 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
             fhandle.write(self.valid_sample_cif_str)
             fhandle.flush()
             options = [fhandle.name]
-            res = self.cli_runner(cmd_cif.cif_import, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_cif.cif_import, options)
             assert b'imported uuid' in res.stdout_bytes, 'The string "imported uuid" was not found in the output' \
                 ' of verdi data import.'
 
     def test_content(self):
         """Test that `verdi data cif content` returns the content of the file."""
         options = [str(self.cif.uuid)]
-        result = self.cli_runner(cmd_cif.cif_content, options, catch_exceptions=False)
+        result = self.cli_runner(cmd_cif.cif_content, options)
 
         for line in result.output.split('\n'):
             assert line in self.valid_sample_cif_str
@@ -866,7 +866,7 @@ class TestVerdiDataSinglefile(DummyVerdiDataListable, DummyVerdiDataExportable):
         singlefile = orm.SinglefileData(file=io.BytesIO(content.encode('utf8'))).store()
 
         options = [str(singlefile.uuid)]
-        result = self.cli_runner(cmd_singlefile.singlefile_content, options, catch_exceptions=False)
+        result = self.cli_runner(cmd_singlefile.singlefile_content, options)
 
         for line in result.output.split('\n'):
             assert line in content
@@ -884,7 +884,7 @@ class TestVerdiDataUpf:
 
     def upload_family(self):
         options = [self.filepath_pseudos, 'test_group', 'test description']
-        res = self.cli_runner(cmd_upf.upf_uploadfamily, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_uploadfamily, options)
         assert b'UPF files found: 4' in res.stdout_bytes, 'The string "UPF files found: 4" was not found in the' \
             ' output of verdi data upf uploadfamily'
 
@@ -906,7 +906,7 @@ class TestVerdiDataUpf:
         self.upload_family()
 
         options = [tmp_path, 'test_group']
-        self.cli_runner(cmd_upf.upf_exportfamily, options, catch_exceptions=False)
+        self.cli_runner(cmd_upf.upf_exportfamily, options)
         output = sp.check_output(['ls', tmp_path])
         assert b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output, \
             f'Sub-command verdi data upf exportfamily --help failed: {output}'
@@ -925,7 +925,7 @@ class TestVerdiDataUpf:
         self.upload_family()
 
         options = ['-d', '-e', 'Ba']
-        res = self.cli_runner(cmd_upf.upf_listfamilies, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_listfamilies, options)
 
         assert b'test_group' in res.stdout_bytes, 'The string "test_group" was not found in the' \
             ' output of verdi data upf listfamilies: {}'.format(res.output)
@@ -934,7 +934,7 @@ class TestVerdiDataUpf:
             ' output of verdi data upf listfamilies'
 
         options = ['-d', '-e', 'Fe']
-        res = self.cli_runner(cmd_upf.upf_listfamilies, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_listfamilies, options)
         assert b'No valid UPF pseudopotential' in res.stdout_bytes, (
             'The string "No valid UPF pseudopotential" was not found in the output of verdi data upf listfamilies'
         )
@@ -945,7 +945,7 @@ class TestVerdiDataUpf:
 
     def test_import(self):
         options = [os.path.join(self.filepath_pseudos, 'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF')]
-        res = self.cli_runner(cmd_upf.upf_import, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_import, options)
 
         assert b'Imported' in res.stdout_bytes, 'The string "Imported" was not' \
             ' found in the output of verdi data import: {}'.format(res.output)

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -70,7 +70,7 @@ class TestVerdiGroup:
 
     def test_create(self, run_cli_command):
         """Test `verdi group create` command."""
-        result = run_cli_command(cmd_group.group_create, ['dummygroup5'])
+        result = run_cli_command(cmd_group.group_create, ['dummygroup5'], use_subprocess=True)
 
         # check if newly added group in present in list
         result = run_cli_command(cmd_group.group_list)
@@ -78,7 +78,7 @@ class TestVerdiGroup:
 
     def test_list(self, run_cli_command):
         """Test `verdi group list` command."""
-        result = run_cli_command(cmd_group.group_list)
+        result = run_cli_command(cmd_group.group_list, use_subprocess=True)
         for grp in ['dummygroup1', 'dummygroup2']:
             assert grp in result.output
 
@@ -87,23 +87,23 @@ class TestVerdiGroup:
         orm.Group(label='agroup').store()
 
         options = []
-        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True)
+        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True, use_subprocess=True)
         group_ordering = [l.split()[1] for l in result.output.split('\n')[3:] if l]
         assert ['agroup', 'dummygroup1', 'dummygroup2', 'dummygroup3', 'dummygroup4'] == group_ordering
 
         options = ['--order-by', 'id']
-        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True)
+        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True, use_subprocess=True)
         group_ordering = [l.split()[1] for l in result.output.split('\n')[3:] if l]
         assert ['dummygroup1', 'dummygroup2', 'dummygroup3', 'dummygroup4', 'agroup'] == group_ordering
 
         options = ['--order-by', 'id', '--order-direction', 'desc']
-        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True)
+        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True, use_subprocess=True)
         group_ordering = [l.split()[1] for l in result.output.split('\n')[3:] if l]
         assert ['agroup', 'dummygroup4', 'dummygroup3', 'dummygroup2', 'dummygroup1'] == group_ordering
 
     def test_copy(self, run_cli_command):
         """Test `verdi group copy` command."""
-        result = run_cli_command(cmd_group.group_copy, ['dummygroup1', 'dummygroup2'])
+        result = run_cli_command(cmd_group.group_copy, ['dummygroup1', 'dummygroup2'], use_subprocess=True)
         assert 'Success' in result.output
 
     def test_delete(self, run_cli_command):
@@ -113,13 +113,13 @@ class TestVerdiGroup:
         orm.Group(label='group_test_delete_03').store()
 
         # dry run
-        result = run_cli_command(cmd_group.group_delete, ['--dry-run', 'group_test_delete_01'])
+        result = run_cli_command(cmd_group.group_delete, ['--dry-run', 'group_test_delete_01'], use_subprocess=True)
         orm.load_group(label='group_test_delete_01')
 
-        result = run_cli_command(cmd_group.group_delete, ['--force', 'group_test_delete_01'])
+        result = run_cli_command(cmd_group.group_delete, ['--force', 'group_test_delete_01'], use_subprocess=True)
 
         # Verify that removed group is not present in list
-        result = run_cli_command(cmd_group.group_list)
+        result = run_cli_command(cmd_group.group_list, use_subprocess=True)
         assert 'group_test_delete_01' not in result.output
 
         node_01 = orm.CalculationNode().store()
@@ -131,7 +131,7 @@ class TestVerdiGroup:
         group.add_nodes([node_01, node_02])
         assert group.count() == 2
 
-        result = run_cli_command(cmd_group.group_delete, ['--force', 'group_test_delete_02'])
+        result = run_cli_command(cmd_group.group_delete, ['--force', 'group_test_delete_02'], use_subprocess=True)
 
         with pytest.raises(exceptions.NotExistent):
             orm.load_group(label='group_test_delete_02')
@@ -143,7 +143,9 @@ class TestVerdiGroup:
         # delete the group and the nodes it contains
         group = orm.load_group(label='group_test_delete_03')
         group.add_nodes([node_01, node_02])
-        result = run_cli_command(cmd_group.group_delete, ['--force', '--delete-nodes', 'group_test_delete_03'])
+        result = run_cli_command(
+            cmd_group.group_delete, ['--force', '--delete-nodes', 'group_test_delete_03'], use_subprocess=True
+        )
 
         # check group and nodes no longer exist
         with pytest.raises(exceptions.NotExistent):
@@ -154,7 +156,7 @@ class TestVerdiGroup:
 
     def test_show(self, run_cli_command):
         """Test `verdi group show` command."""
-        result = run_cli_command(cmd_group.group_show, ['dummygroup1'])
+        result = run_cli_command(cmd_group.group_show, ['dummygroup1'], use_subprocess=True)
         for grpline in [
             'Group label', 'dummygroup1', 'Group type_string', 'core', 'Group description', '<no description>'
         ]:
@@ -168,12 +170,14 @@ class TestVerdiGroup:
         group.add_nodes(nodes)
 
         # Default should include all nodes in the output
-        result = run_cli_command(cmd_group.group_show, [label])
+        result = run_cli_command(cmd_group.group_show, [label], use_subprocess=True)
         for node in nodes:
             assert str(node.pk) in result.output
 
         # Repeat test with `limit=1`, use also the `--raw` option to only display nodes
-        result = run_cli_command(cmd_group.group_show, [label, '--limit', '1', '--raw'], suppress_warnings=True)
+        result = run_cli_command(
+            cmd_group.group_show, [label, '--limit', '1', '--raw'], suppress_warnings=True, use_subprocess=True
+        )
 
         # The current `verdi group show` does not support ordering so we cannot rely on that for now to test if only
         # one of the nodes is shown
@@ -181,7 +185,7 @@ class TestVerdiGroup:
         assert str(nodes[0].pk) in result.output or str(nodes[1].pk) in result.output
 
         # Repeat test with `limit=1` but without the `--raw` flag as it has a different code path that is affected
-        result = run_cli_command(cmd_group.group_show, [label, '--limit', '1'])
+        result = run_cli_command(cmd_group.group_show, [label, '--limit', '1'], use_subprocess=True)
 
         # Check that one, and only one pk appears in the output
         assert str(nodes[0].pk) in result.output or str(nodes[1].pk) in result.output
@@ -217,19 +221,23 @@ class TestVerdiGroup:
         node_02 = orm.CalculationNode().store()
         node_03 = orm.CalculationNode().store()
 
-        result = run_cli_command(cmd_group.group_add_nodes, ['--force', '--group=dummygroup1', node_01.uuid])
+        result = run_cli_command(
+            cmd_group.group_add_nodes, ['--force', '--group=dummygroup1', node_01.uuid], use_subprocess=True
+        )
 
         # Check if node is added in group using group show command
-        result = run_cli_command(cmd_group.group_show, ['dummygroup1'])
+        result = run_cli_command(cmd_group.group_show, ['dummygroup1'], use_subprocess=True)
 
         assert 'CalculationNode' in result.output
         assert str(node_01.pk) in result.output
 
         # Remove same node
-        result = run_cli_command(cmd_group.group_remove_nodes, ['--force', '--group=dummygroup1', node_01.uuid])
+        result = run_cli_command(
+            cmd_group.group_remove_nodes, ['--force', '--group=dummygroup1', node_01.uuid], use_subprocess=True
+        )
 
         # Check that the node is no longer in the group
-        result = run_cli_command(cmd_group.group_show, ['-r', 'dummygroup1'])
+        result = run_cli_command(cmd_group.group_show, ['-r', 'dummygroup1'], use_subprocess=True)
 
         assert 'CalculationNode' not in result.output
         assert str(node_01.pk) not in result.output
@@ -239,16 +247,22 @@ class TestVerdiGroup:
         group.add_nodes([node_01, node_02, node_03])
         assert group.count() == 3
 
-        result = run_cli_command(cmd_group.group_remove_nodes, ['--force', '--clear', '--group=dummygroup1'])
+        result = run_cli_command(
+            cmd_group.group_remove_nodes, ['--force', '--clear', '--group=dummygroup1'], use_subprocess=True
+        )
 
         assert group.count() == 0
 
         # Try to remove node that isn't in the group
-        result = run_cli_command(cmd_group.group_remove_nodes, ['--group=dummygroup1', node_01.uuid], raises=True)
+        result = run_cli_command(
+            cmd_group.group_remove_nodes, ['--group=dummygroup1', node_01.uuid], raises=True, use_subprocess=True
+        )
         assert result.exit_code == ExitCode.CRITICAL
 
         # Try to remove no nodes nor clear the group
-        result = run_cli_command(cmd_group.group_remove_nodes, ['--group=dummygroup1'], raises=True)
+        result = run_cli_command(
+            cmd_group.group_remove_nodes, ['--group=dummygroup1'], raises=True, use_subprocess=True
+        )
         assert result.exit_code == ExitCode.CRITICAL
 
         # Try to remove both nodes and clear the group
@@ -258,21 +272,27 @@ class TestVerdiGroup:
         assert result.exit_code == ExitCode.CRITICAL
 
         # Add a node with confirmation
-        result = run_cli_command(cmd_group.group_add_nodes, ['--group=dummygroup1', node_01.uuid], user_input='y')
+        result = run_cli_command(
+            cmd_group.group_add_nodes, ['--group=dummygroup1', node_01.uuid], user_input='y', use_subprocess=True
+        )
         assert group.count() == 1
 
         # Try to remove two nodes, one that isn't in the group, but abort
         result = run_cli_command(
             cmd_group.group_remove_nodes, ['--group=dummygroup1', node_01.uuid, node_02.uuid],
             user_input='N',
-            raises=True
+            raises=True,
+            use_subprocess=True
         )
         assert 'Warning' in result.output
         assert group.count() == 1
 
         # Try to clear all nodes from the group, but abort
         result = run_cli_command(
-            cmd_group.group_remove_nodes, ['--group=dummygroup1', '--clear'], user_input='N', raises=True
+            cmd_group.group_remove_nodes, ['--group=dummygroup1', '--clear'],
+            user_input='N',
+            raises=True,
+            use_subprocess=True
         )
         assert 'Are you sure you want to remove ALL' in result.output
         assert 'Aborted' in result.output
@@ -292,31 +312,36 @@ class TestVerdiGroup:
         # Moving the nodes to the same group
         result = run_cli_command(
             cmd_group.group_move_nodes, ['-s', 'dummygroup1', '-t', 'dummygroup1', node_01.uuid, node_02.uuid],
-            raises=True
+            raises=True,
+            use_subprocess=True
         )
         assert 'Source and target group are the same:' in result.output
 
         # Not specifying NODES or `--all`
-        result = run_cli_command(cmd_group.group_move_nodes, ['-s', 'dummygroup1', '-t', 'dummygroup2'], raises=True)
+        result = run_cli_command(
+            cmd_group.group_move_nodes, ['-s', 'dummygroup1', '-t', 'dummygroup2'], raises=True, use_subprocess=True
+        )
         assert 'Neither NODES or the `-a, --all` option was specified.' in result.output
 
         # Moving the nodes from the empty group
         result = run_cli_command(
             cmd_group.group_move_nodes, ['-s', 'dummygroup2', '-t', 'dummygroup1', node_01.uuid, node_02.uuid],
-            raises=True
+            raises=True,
+            use_subprocess=True
         )
         assert 'None of the specified nodes are in' in result.output
 
         # Move two nodes to the second dummy group, but specify a missing uuid
         result = run_cli_command(
             cmd_group.group_move_nodes, ['-s', 'dummygroup1', '-t', 'dummygroup2', node_01.uuid, node_03.uuid],
-            raises=True
+            raises=True,
+            use_subprocess=True
         )
         assert f'1 nodes with PK {{{node_03.pk}}} are not in' in result.output
         # Check that the node that is present is actually moved
         result = run_cli_command(
-            cmd_group.group_move_nodes,
-            ['-f', '-s', 'dummygroup1', '-t', 'dummygroup2', node_01.uuid, node_03.uuid],
+            cmd_group.group_move_nodes, ['-f', '-s', 'dummygroup1', '-t', 'dummygroup2', node_01.uuid, node_03.uuid],
+            use_subprocess=True
         )
         assert node_01 not in group1.nodes
         assert node_01 in group2.nodes
@@ -324,25 +349,30 @@ class TestVerdiGroup:
         # Add the first node back to the first group, and try to move it from the second one
         group1.add_nodes(node_01)
         result = run_cli_command(
-            cmd_group.group_move_nodes, ['-s', 'dummygroup2', '-t', 'dummygroup1', node_01.uuid], raises=True
+            cmd_group.group_move_nodes, ['-s', 'dummygroup2', '-t', 'dummygroup1', node_01.uuid],
+            raises=True,
+            use_subprocess=True
         )
         assert f'1 nodes with PK {{{node_01.pk}}} are already' in result.output
         # Check that it is still removed from the second group
         result = run_cli_command(
-            cmd_group.group_move_nodes,
-            ['-f', '-s', 'dummygroup2', '-t', 'dummygroup1', node_01.uuid],
+            cmd_group.group_move_nodes, ['-f', '-s', 'dummygroup2', '-t', 'dummygroup1', node_01.uuid],
+            use_subprocess=True
         )
         assert node_01 not in group2.nodes
 
         # Force move the two nodes to the second dummy group
         result = run_cli_command(
-            cmd_group.group_move_nodes, ['-f', '-s', 'dummygroup1', '-t', 'dummygroup2', node_01.uuid, node_02.uuid]
+            cmd_group.group_move_nodes, ['-f', '-s', 'dummygroup1', '-t', 'dummygroup2', node_01.uuid, node_02.uuid],
+            use_subprocess=True
         )
         assert node_01 in group2.nodes
         assert node_02 in group2.nodes
 
         # Force move all nodes back to the first dummy group
-        result = run_cli_command(cmd_group.group_move_nodes, ['-f', '-s', 'dummygroup2', '-t', 'dummygroup1', '--all'])
+        result = run_cli_command(
+            cmd_group.group_move_nodes, ['-f', '-s', 'dummygroup2', '-t', 'dummygroup1', '--all'], use_subprocess=True
+        )
         assert node_01 not in group2.nodes
         assert node_02 not in group2.nodes
         assert node_01 in group1.nodes
@@ -362,7 +392,7 @@ class TestVerdiGroup:
 
         # Copy using `verdi group copy` - making sure all is successful
         options = [source_label, dest_label]
-        result = run_cli_command(cmd_group.group_copy, options)
+        result = run_cli_command(cmd_group.group_copy, options, use_subprocess=True)
         assert f'Success: Nodes copied from {source_group} to {source_group.__class__.__name__}<{dest_label}>.' in \
             result.output, result.exception
 
@@ -373,7 +403,7 @@ class TestVerdiGroup:
         assert nodes_source_group == nodes_dest_group
 
         # Copy again, making sure an abort error is raised, since no user input can be made and default is abort
-        result = run_cli_command(cmd_group.group_copy, options, raises=True)
+        result = run_cli_command(cmd_group.group_copy, options, raises=True, use_subprocess=True)
         assert f'Warning: Destination {dest_group} already exists and is not empty.' in result.output, result.exception
 
         # Check destination group is unchanged

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -87,17 +87,17 @@ class TestVerdiGroup:
         orm.Group(label='agroup').store()
 
         options = []
-        result = run_cli_command(cmd_group.group_list, options)
+        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True)
         group_ordering = [l.split()[1] for l in result.output.split('\n')[3:] if l]
         assert ['agroup', 'dummygroup1', 'dummygroup2', 'dummygroup3', 'dummygroup4'] == group_ordering
 
         options = ['--order-by', 'id']
-        result = run_cli_command(cmd_group.group_list, options)
+        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True)
         group_ordering = [l.split()[1] for l in result.output.split('\n')[3:] if l]
         assert ['dummygroup1', 'dummygroup2', 'dummygroup3', 'dummygroup4', 'agroup'] == group_ordering
 
         options = ['--order-by', 'id', '--order-direction', 'desc']
-        result = run_cli_command(cmd_group.group_list, options)
+        result = run_cli_command(cmd_group.group_list, options, suppress_warnings=True)
         group_ordering = [l.split()[1] for l in result.output.split('\n')[3:] if l]
         assert ['agroup', 'dummygroup4', 'dummygroup3', 'dummygroup2', 'dummygroup1'] == group_ordering
 
@@ -173,7 +173,7 @@ class TestVerdiGroup:
             assert str(node.pk) in result.output
 
         # Repeat test with `limit=1`, use also the `--raw` option to only display nodes
-        result = run_cli_command(cmd_group.group_show, [label, '--limit', '1', '--raw'])
+        result = run_cli_command(cmd_group.group_show, [label, '--limit', '1', '--raw'], suppress_warnings=True)
 
         # The current `verdi group show` does not support ordering so we cannot rely on that for now to test if only
         # one of the nodes is shown

--- a/tests/cmdline/commands/test_help.py
+++ b/tests/cmdline/commands/test_help.py
@@ -7,34 +7,24 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=no-self-use
 """Tests for `verdi help`."""
-import pytest
-
 from aiida.cmdline.commands import cmd_verdi
 
 
 class TestVerdiHelpCommand:
     """Tests for `verdi help`."""
 
-    @pytest.fixture(autouse=True)
-    def init_profile(self, config_with_profile, run_cli_command):  # pylint: disable=unused-argument
-        """Initialize the profile."""
-        # pylint: disable=attribute-defined-outside-init
-        self.cli_runner = run_cli_command
-
-    def test_without_arg(self):
-        """
-        Ensure we get the same help for `verdi` (which gives the same as `verdi --help`)
-        and `verdi help`
-        """
+    def test_without_arg(self, run_cli_command):
+        """Ensure we get the same help for `verdi` (which gives the same as `verdi --help`) and `verdi help`."""
         # don't invoke the cmd directly to make sure ctx.parent is properly populated
         # as it would be when called as a cli
-        result_help = self.cli_runner(cmd_verdi.verdi, ['help'])
-        result_verdi = self.cli_runner(cmd_verdi.verdi, [])
+        result_help = run_cli_command(cmd_verdi.verdi, ['help'], use_subprocess=False)
+        result_verdi = run_cli_command(cmd_verdi.verdi, [], use_subprocess=False)
         assert result_help.output == result_verdi.output
 
-    def test_cmd_help(self):
+    def test_cmd_help(self, run_cli_command):
         """Ensure we get the same help for `verdi user --help` and `verdi help user`"""
-        result_help = self.cli_runner(cmd_verdi.verdi, ['help', 'user'])
-        result_user = self.cli_runner(cmd_verdi.verdi, ['user', '--help'])
+        result_help = run_cli_command(cmd_verdi.verdi, ['help', 'user'])
+        result_user = run_cli_command(cmd_verdi.verdi, ['user', '--help'])
         assert result_help.output == result_user.output

--- a/tests/cmdline/commands/test_help.py
+++ b/tests/cmdline/commands/test_help.py
@@ -29,12 +29,12 @@ class TestVerdiHelpCommand:
         """
         # don't invoke the cmd directly to make sure ctx.parent is properly populated
         # as it would be when called as a cli
-        result_help = self.cli_runner(cmd_verdi.verdi, ['help'], catch_exceptions=False)
-        result_verdi = self.cli_runner(cmd_verdi.verdi, [], catch_exceptions=False)
+        result_help = self.cli_runner(cmd_verdi.verdi, ['help'])
+        result_verdi = self.cli_runner(cmd_verdi.verdi, [])
         assert result_help.output == result_verdi.output
 
     def test_cmd_help(self):
         """Ensure we get the same help for `verdi user --help` and `verdi help user`"""
-        result_help = self.cli_runner(cmd_verdi.verdi, ['help', 'user'], catch_exceptions=False)
-        result_user = self.cli_runner(cmd_verdi.verdi, ['user', '--help'], catch_exceptions=False)
+        result_help = self.cli_runner(cmd_verdi.verdi, ['help', 'user'])
+        result_user = self.cli_runner(cmd_verdi.verdi, ['user', '--help'])
         assert result_help.output == result_user.output

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -71,7 +71,7 @@ class TestVerdiNode:
         node = orm.Data().store()
         node.label = 'SOMELABEL'
         options = [str(node.pk)]
-        result = run_cli_command(cmd_node.node_show, options)
+        result = run_cli_command(cmd_node.node_show, options, use_subprocess=True)
 
         # Let's check some content in the output. At least the UUID and the label should be in there
         assert node.label in result.output
@@ -79,7 +79,7 @@ class TestVerdiNode:
 
         # Let's now test the '--print-groups' option
         options.append('--print-groups')
-        result = run_cli_command(cmd_node.node_show, options)
+        result = run_cli_command(cmd_node.node_show, options, use_subprocess=True)
         # I don't check the list of groups - it might be in an autogroup
 
         # Let's create a group and put the node in there
@@ -87,7 +87,7 @@ class TestVerdiNode:
         group = orm.Group(group_name).store()
         group.add_nodes(node)
 
-        result = run_cli_command(cmd_node.node_show, options)
+        result = run_cli_command(cmd_node.node_show, options, use_subprocess=True)
 
         # Now the group should be in there
         assert group_name in result.output
@@ -591,10 +591,10 @@ def test_node_delete_basics(run_cli_command, options):
     node = orm.Data().store()
     pk = node.pk
 
-    run_cli_command(cmd_node.node_delete, options + [str(pk), '--dry-run'])
+    run_cli_command(cmd_node.node_delete, options + [str(pk), '--dry-run'], use_subprocess=True)
 
     # To delete the created node
-    run_cli_command(cmd_node.node_delete, [str(pk), '--force'])
+    run_cli_command(cmd_node.node_delete, [str(pk), '--force'], use_subprocess=True)
 
     with pytest.raises(NotExistent):
         orm.load_node(pk)

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -95,7 +95,7 @@ class TestVerdiNode:
     def test_node_attributes(self, run_cli_command):
         """Test verdi node attributes"""
         options = [str(self.node.uuid)]
-        result = run_cli_command(cmd_node.attributes, options)
+        result = run_cli_command(cmd_node.attributes, options, suppress_warnings=True)
         assert self.ATTR_KEY_ONE in result.output
         assert self.ATTR_VAL_ONE in result.output
         assert self.ATTR_KEY_TWO in result.output
@@ -103,7 +103,7 @@ class TestVerdiNode:
 
         for flag in ['-k', '--keys']:
             options = [flag, self.ATTR_KEY_ONE, '--', str(self.node.uuid)]
-            result = run_cli_command(cmd_node.attributes, options)
+            result = run_cli_command(cmd_node.attributes, options, suppress_warnings=True)
             assert self.ATTR_KEY_ONE in result.output
             assert self.ATTR_VAL_ONE in result.output
             assert self.ATTR_KEY_TWO not in result.output
@@ -111,22 +111,22 @@ class TestVerdiNode:
 
         for flag in ['-r', '--raw']:
             options = [flag, str(self.node.uuid)]
-            run_cli_command(cmd_node.attributes, options)
+            run_cli_command(cmd_node.attributes, options, suppress_warnings=True)
 
         for flag in ['-f', '--format']:
             for fmt in ['json+date', 'yaml', 'yaml_expanded']:
                 options = [flag, fmt, str(self.node.uuid)]
-                run_cli_command(cmd_node.attributes, options)
+                run_cli_command(cmd_node.attributes, options, suppress_warnings=True)
 
         for flag in ['-i', '--identifier']:
             for fmt in ['pk', 'uuid']:
                 options = [flag, fmt, str(self.node.uuid)]
-                run_cli_command(cmd_node.attributes, options)
+                run_cli_command(cmd_node.attributes, options, suppress_warnings=True)
 
     def test_node_extras(self, run_cli_command):
         """Test verdi node extras"""
         options = [str(self.node.uuid)]
-        result = run_cli_command(cmd_node.extras, options)
+        result = run_cli_command(cmd_node.extras, options, suppress_warnings=True)
         assert self.EXTRA_KEY_ONE in result.output
         assert self.EXTRA_VAL_ONE in result.output
         assert self.EXTRA_KEY_TWO in result.output
@@ -134,7 +134,7 @@ class TestVerdiNode:
 
         for flag in ['-k', '--keys']:
             options = [flag, self.EXTRA_KEY_ONE, '--', str(self.node.uuid)]
-            result = run_cli_command(cmd_node.extras, options)
+            result = run_cli_command(cmd_node.extras, options, suppress_warnings=True)
             assert self.EXTRA_KEY_ONE in result.output
             assert self.EXTRA_VAL_ONE in result.output
             assert self.EXTRA_KEY_TWO not in result.output
@@ -142,17 +142,17 @@ class TestVerdiNode:
 
         for flag in ['-r', '--raw']:
             options = [flag, str(self.node.uuid)]
-            result = run_cli_command(cmd_node.extras, options)
+            result = run_cli_command(cmd_node.extras, options, suppress_warnings=True)
 
         for flag in ['-f', '--format']:
             for fmt in ['json+date', 'yaml', 'yaml_expanded']:
                 options = [flag, fmt, str(self.node.uuid)]
-                run_cli_command(cmd_node.extras, options)
+                run_cli_command(cmd_node.extras, options, suppress_warnings=True)
 
         for flag in ['-i', '--identifier']:
             for fmt in ['pk', 'uuid']:
                 options = [flag, fmt, str(self.node.uuid)]
-                run_cli_command(cmd_node.extras, options)
+                run_cli_command(cmd_node.extras, options, suppress_warnings=True)
 
     def test_node_repo_ls(self, run_cli_command):
         """Test 'verdi node repo ls' command."""
@@ -437,7 +437,7 @@ class TestVerdiUserCommand:
 
     def test_comment_show_simple(self, run_cli_command):
         """Test simply calling the show command (without data to show)."""
-        result = run_cli_command(cmd_node.comment_show, [])
+        result = run_cli_command(cmd_node.comment_show, [], suppress_warnings=True)
         assert result.output == ''
         assert result.exit_code == 0
 
@@ -498,7 +498,6 @@ class TestVerdiRehash:
         """Passing no options and answering 'N' to the command will abort the command."""
         options = []  # no option, will ask in the prompt
         result = run_cli_command(cmd_node.rehash, options, user_input='n', raises=True)
-        assert isinstance(result.exception, SystemExit)
         assert result.exit_code == ExitCode.CRITICAL
 
     def test_rehash(self, run_cli_command):

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -9,6 +9,7 @@
 ###########################################################################
 # pylint: disable=no-self-use
 """Tests for `verdi process`."""
+import functools
 import time
 import typing as t
 import uuid
@@ -86,6 +87,8 @@ class TestVerdiProcess:
 
         group = Group(str(uuid.uuid4())).store()
         group.add_nodes(calcs[0])
+
+        run_cli_command = functools.partial(run_cli_command, suppress_warnings=True)
 
         # Default behavior should yield all active states (CREATED, RUNNING and WAITING) so six in total
         result = run_cli_command(cmd_process.process_list, ['-r'])
@@ -338,7 +341,7 @@ def test_list_worker_slot_warning(run_cli_command, monkeypatch):
         calc.store()
 
     # Default cmd should not throw the warning as we are below the limit
-    result = run_cli_command(cmd_process.process_list)
+    result = run_cli_command(cmd_process.process_list, use_subprocess=False)
     warning_phrase = 'of the available daemon worker slots have been used!'
     assert all(warning_phrase not in line for line in result.output_lines), result.output
 
@@ -348,7 +351,7 @@ def test_list_worker_slot_warning(run_cli_command, monkeypatch):
     calc.store()
 
     # Now the warning should fire
-    result = run_cli_command(cmd_process.process_list)
+    result = run_cli_command(cmd_process.process_list, use_subprocess=False)
     warning_phrase = '% of the available daemon worker slots have been used!'
     assert any(warning_phrase in line for line in result.output_lines)
 

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -53,14 +53,14 @@ def mock_profiles(empty_config, profile_factory):
 )
 def test_help(run_cli_command, command):
     """Tests help text for all ``verdi profile`` commands."""
-    result = run_cli_command(command, ['--help'])
+    result = run_cli_command(command, ['--help'], use_subprocess=False)
     assert 'Usage' in result.output
 
 
 def test_list(run_cli_command, mock_profiles):
     """Test the ``verdi profile list`` command."""
     profile_list = mock_profiles()
-    result = run_cli_command(cmd_profile.profile_list)
+    result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
     assert 'Report: configuration folder:' in result.output
     assert f'* {profile_list[0]}' in result.output
     assert profile_list[1] in result.output
@@ -69,8 +69,8 @@ def test_list(run_cli_command, mock_profiles):
 def test_setdefault(run_cli_command, mock_profiles):
     """Test the ``verdi profile setdefault`` command."""
     profile_list = mock_profiles()
-    run_cli_command(cmd_profile.profile_setdefault, [profile_list[1]])
-    result = run_cli_command(cmd_profile.profile_list)
+    run_cli_command(cmd_profile.profile_setdefault, [profile_list[1]], use_subprocess=False)
+    result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
 
     assert 'Report: configuration folder:' in result.output
     assert f'* {profile_list[1]}' in result.output
@@ -83,7 +83,7 @@ def test_show(run_cli_command, mock_profiles):
     profile_name = profile_list[0]
     profile = config.get_profile(profile_name)
 
-    result = run_cli_command(cmd_profile.profile_show, [profile_name])
+    result = run_cli_command(cmd_profile.profile_show, [profile_name], use_subprocess=False)
     for key, value in profile.dictionary.items():
         if isinstance(value, str):
             assert key in result.output
@@ -96,11 +96,11 @@ def test_show_with_profile_option(run_cli_command, mock_profiles):
     profile_name_non_default = profile_list[1]
 
     # Specifying the non-default profile as argument should override the default
-    result = run_cli_command(cmd_profile.profile_show, [profile_name_non_default])
+    result = run_cli_command(cmd_profile.profile_show, [profile_name_non_default], use_subprocess=False)
     assert profile_name_non_default in result.output
 
     # Specifying ``-p/--profile`` should not override the argument default (which should be the default profile)
-    result = run_cli_command(cmd_verdi.verdi, ['-p', profile_name_non_default, 'profile', 'show'])
+    result = run_cli_command(cmd_verdi.verdi, ['-p', profile_name_non_default, 'profile', 'show'], use_subprocess=False)
     assert profile_name_non_default not in result.output
 
 
@@ -111,8 +111,8 @@ def test_delete_partial(run_cli_command, mock_profiles):
         defined in the file ``.github/system_tests/test_profile.py``
     """
     profile_list = mock_profiles()
-    run_cli_command(cmd_profile.profile_delete, ['--force', '--skip-db', profile_list[1]])
-    result = run_cli_command(cmd_profile.profile_list)
+    run_cli_command(cmd_profile.profile_delete, ['--force', '--skip-db', profile_list[1]], use_subprocess=False)
+    result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
     assert profile_list[1] not in result.output
 
 
@@ -122,12 +122,12 @@ def test_delete(run_cli_command, mock_profiles, pg_test_cluster):
     profile_list = mock_profiles(**kwargs)
 
     # Delete single profile
-    run_cli_command(cmd_profile.profile_delete, ['--force', profile_list[1]])
-    result = run_cli_command(cmd_profile.profile_list)
+    run_cli_command(cmd_profile.profile_delete, ['--force', profile_list[1]], use_subprocess=False)
+    result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
     assert profile_list[1] not in result.output
 
     # Delete multiple profiles
-    run_cli_command(cmd_profile.profile_delete, ['--force', profile_list[2], profile_list[3]])
-    result = run_cli_command(cmd_profile.profile_list)
+    run_cli_command(cmd_profile.profile_delete, ['--force', profile_list[2], profile_list[3]], use_subprocess=False)
+    result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
     assert profile_list[2] not in result.output
     assert profile_list[3] not in result.output

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -34,14 +34,14 @@ def test_tasks_list(monkeypatch, run_cli_command):
     """Test the ``tasks list`` command when everything is consistent."""
     monkeypatch.setattr(cmd_rabbitmq, 'get_process_tasks', lambda *args: [1, 2, 3])
 
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_list)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_list, use_subprocess=False)
     assert result.output == '1\n2\n3\n'
 
 
 @pytest.mark.usefixtures('started_daemon_client')
 def test_tasks_analyze_running_daemon(run_cli_command):
     """Test the ``tasks analyze`` command excepts when the daemon is running."""
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True, use_subprocess=False)
     assert 'The daemon needs to be stopped before running this command.' in result.output
 
 
@@ -51,7 +51,7 @@ def test_tasks_analyze_consistent(monkeypatch, run_cli_command):
     monkeypatch.setattr(cmd_rabbitmq, 'get_active_processes', lambda *args: [1, 2, 3])
     monkeypatch.setattr(cmd_rabbitmq, 'get_process_tasks', lambda *args: [1, 2, 3])
 
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, use_subprocess=False)
     assert 'No inconsistencies detected between database and RabbitMQ.' in result.output
 
 
@@ -61,7 +61,7 @@ def test_tasks_analyze_duplicate_tasks(monkeypatch, run_cli_command):
     monkeypatch.setattr(cmd_rabbitmq, 'get_active_processes', lambda *args: [1, 2])
     monkeypatch.setattr(cmd_rabbitmq, 'get_process_tasks', lambda *args: [1, 2, 2])
 
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True, use_subprocess=False)
     assert 'There are duplicates process tasks:' in result.output
     assert 'Inconsistencies detected between database and RabbitMQ.' in result.output
 
@@ -72,7 +72,7 @@ def test_tasks_analyze_additional_tasks(monkeypatch, run_cli_command):
     monkeypatch.setattr(cmd_rabbitmq, 'get_active_processes', lambda *args: [1, 2])
     monkeypatch.setattr(cmd_rabbitmq, 'get_process_tasks', lambda *args: [1, 2, 3])
 
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True, use_subprocess=False)
     assert 'There are process tasks for terminated processes:' in result.output
     assert 'Inconsistencies detected between database and RabbitMQ.' in result.output
 
@@ -83,7 +83,7 @@ def test_tasks_analyze_missing_tasks(monkeypatch, run_cli_command):
     monkeypatch.setattr(cmd_rabbitmq, 'get_active_processes', lambda *args: [1, 2, 3])
     monkeypatch.setattr(cmd_rabbitmq, 'get_process_tasks', lambda *args: [1, 2])
 
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, raises=True, use_subprocess=False)
     assert 'There are active processes without process task:' in result.output
     assert 'Inconsistencies detected between database and RabbitMQ.' in result.output
 
@@ -94,7 +94,7 @@ def test_tasks_analyze_verbosity(monkeypatch, run_cli_command):
     monkeypatch.setattr(cmd_rabbitmq, 'get_active_processes', lambda *args: [1, 2, 3, 4])
     monkeypatch.setattr(cmd_rabbitmq, 'get_process_tasks', lambda *args: [1, 2])
 
-    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, ['-v', 'INFO'], raises=True)
+    result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, ['-v', 'INFO'], raises=True, use_subprocess=False)
     assert 'Active processes: [1, 2, 3, 4]' in result.output
     assert 'Process tasks: [1, 2]' in result.output
 
@@ -125,7 +125,7 @@ def test_revive(run_cli_command, monkeypatch, aiida_local_code_factory, submit_a
     assert node.process_state == ProcessState.CREATED
 
     # Time to revive it by recreating the task and send it to RabbitMQ
-    run_cli_command(cmd_rabbitmq.cmd_tasks_revive, [str(node.pk), '--force'])
+    run_cli_command(cmd_rabbitmq.cmd_tasks_revive, [str(node.pk), '--force'], use_subprocess=False)
 
     # Wait for the process to be picked up by the daemon and completed. If there is a problem with the code, this call
     # should timeout and raise an exception

--- a/tests/cmdline/commands/test_restapi.py
+++ b/tests/cmdline/commands/test_restapi.py
@@ -21,7 +21,7 @@ def test_run_restapi(run_cli_command, monkeypatch):
     monkeypatch.setattr(run_api, 'run_api', run_api_noop)
 
     options = ['--hostname', 'localhost', '--port', '6000', '--debug', '--wsgi-profile']
-    run_cli_command(restapi, options)
+    run_cli_command(restapi, options, use_subprocess=False)
 
 
 def test_help(run_cli_command):

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -207,12 +207,7 @@ class TestAutoGroups:
             node4 = CalculationNode().store()
             node5 = WorkflowNode().store()
             _, node6 = run_get_node(ArithmeticAdd, **inputs)
-            print(node1.pk)
-            print(node2.pk)
-            print(node3.pk)
-            print(node4.pk)
-            print(node5.pk)
-            print(node6.pk)
+            print(node1.pk, node2.pk, node3.pk, node4.pk, node5.pk, node6.pk)
             """
         )
 
@@ -262,7 +257,7 @@ class TestAutoGroups:
                 with override_log_level():
                     result = run_cli_command(cmd_run.run, options)
 
-                pk1_str, pk2_str, pk3_str, pk4_str, pk5_str, pk6_str = result.output.split()
+                pk1_str, pk2_str, pk3_str, pk4_str, pk5_str, pk6_str = result.output_lines[-1].split()
                 pk1 = int(pk1_str)
                 pk2 = int(pk2_str)
                 pk3 = int(pk3_str)

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=no-self-use
 """Tests for `verdi run`."""
 import tempfile
 import textwrap
@@ -20,14 +21,8 @@ from aiida.common.log import override_log_level
 class TestVerdiRun:
     """Tests for `verdi run`."""
 
-    @pytest.fixture(autouse=True)
-    def init_profile(self, run_cli_command):  # pylint: disable=unused-argument
-        """Initialize the profile."""
-        # pylint: disable=attribute-defined-outside-init
-        self.cli_runner = run_cli_command
-
     @pytest.mark.requires_rmq
-    def test_run_workfunction(self):
+    def test_run_workfunction(self, run_cli_command):
         """Regression test for #2165
 
         If the script that is passed to `verdi run` is not compiled correctly, running workfunctions from the script
@@ -66,7 +61,7 @@ class TestVerdiRun:
             fhandle.flush()
 
             options = [fhandle.name]
-            result = self.cli_runner(cmd_run.run, options)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
 
             # Try to load the function calculation node from the printed pk in the output
             pk = int(result.output.splitlines()[-1])
@@ -82,13 +77,7 @@ class TestVerdiRun:
 class TestAutoGroups:
     """Test the autogroup functionality."""
 
-    @pytest.fixture(autouse=True)
-    def init_profile(self, run_cli_command):  # pylint: disable=unused-argument
-        """Initialize the profile."""
-        # pylint: disable=attribute-defined-outside-init
-        self.cli_runner = run_cli_command
-
-    def test_autogroup(self):
+    def test_autogroup(self, run_cli_command):
         """Check if the autogroup is properly generated."""
         from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
@@ -105,7 +94,7 @@ class TestAutoGroups:
             fhandle.flush()
 
             options = ['--auto-group', fhandle.name]
-            result = self.cli_runner(cmd_run.run, options)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -115,7 +104,7 @@ class TestAutoGroups:
             all_auto_groups = queryb.all()
             assert len(all_auto_groups) == 1, 'There should be only one autogroup associated with the node just created'
 
-    def test_autogroup_custom_label(self):
+    def test_autogroup_custom_label(self, run_cli_command):
         """Check if the autogroup is properly generated with the label specified."""
         from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
@@ -133,7 +122,7 @@ class TestAutoGroups:
             fhandle.flush()
 
             options = [fhandle.name, '--auto-group', '--auto-group-label-prefix', autogroup_label]
-            result = self.cli_runner(cmd_run.run, options)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -144,7 +133,7 @@ class TestAutoGroups:
             assert len(all_auto_groups) == 1, 'There should be only one autogroup associated with the node just created'
             assert all_auto_groups[0][0].label == autogroup_label
 
-    def test_no_autogroup(self):
+    def test_no_autogroup(self, run_cli_command):
         """Check if the autogroup is not generated if ``verdi run`` is asked not to."""
         from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
@@ -161,7 +150,7 @@ class TestAutoGroups:
             fhandle.flush()
 
             options = [fhandle.name]  # Not storing an autogroup by default
-            result = self.cli_runner(cmd_run.run, options)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -172,7 +161,7 @@ class TestAutoGroups:
             assert len(all_auto_groups) == 0, 'There should be no autogroup generated'
 
     @pytest.mark.requires_rmq
-    def test_autogroup_filter_class(self):  # pylint: disable=too-many-locals
+    def test_autogroup_filter_class(self, run_cli_command):  # pylint: disable=too-many-locals
         """Check if the autogroup is properly generated but filtered classes are skipped."""
         from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
@@ -271,7 +260,7 @@ class TestAutoGroups:
 
                 options = ['--auto-group'] + flags + ['--', fhandle.name, str(idx)]
                 with override_log_level():
-                    result = self.cli_runner(cmd_run.run, options)
+                    result = run_cli_command(cmd_run.run, options)
 
                 pk1_str, pk2_str, pk3_str, pk4_str, pk5_str, pk6_str = result.output.split()
                 pk1 = int(pk1_str)
@@ -330,7 +319,7 @@ class TestAutoGroups:
                     'Wrong number of nodes in autogroup associated with the ArithmeticAdd CalcJobNode ' \
                     "just created with flags '{}'".format(' '.join(flags))
 
-    def test_autogroup_clashing_label(self):
+    def test_autogroup_clashing_label(self, run_cli_command):
         """Check if the autogroup label is properly (re)generated when it clashes with an existing group name."""
         from aiida.orm import AutoGroup, Node, QueryBuilder, load_node
 
@@ -349,7 +338,7 @@ class TestAutoGroups:
 
             # First run
             options = [fhandle.name, '--auto-group', '--auto-group-label-prefix', autogroup_label]
-            result = self.cli_runner(cmd_run.run, options)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -362,7 +351,7 @@ class TestAutoGroups:
             # A few more runs with the same label - it should not crash but append something to the group name
             for _ in range(10):
                 options = [fhandle.name, '--auto-group', '--auto-group-label-prefix', autogroup_label]
-                result = self.cli_runner(cmd_run.run, options)
+                result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
 
                 pk = int(result.output)
                 _ = load_node(pk)  # Check if the node can be loaded

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -61,7 +61,7 @@ class TestVerdiRun:
             fhandle.flush()
 
             options = [fhandle.name]
-            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True, use_subprocess=True)
 
             # Try to load the function calculation node from the printed pk in the output
             pk = int(result.output.splitlines()[-1])
@@ -94,7 +94,7 @@ class TestAutoGroups:
             fhandle.flush()
 
             options = ['--auto-group', fhandle.name]
-            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True, use_subprocess=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -122,7 +122,7 @@ class TestAutoGroups:
             fhandle.flush()
 
             options = [fhandle.name, '--auto-group', '--auto-group-label-prefix', autogroup_label]
-            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True, use_subprocess=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -333,7 +333,7 @@ class TestAutoGroups:
 
             # First run
             options = [fhandle.name, '--auto-group', '--auto-group-label-prefix', autogroup_label]
-            result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
+            result = run_cli_command(cmd_run.run, options, suppress_warnings=True, use_subprocess=True)
 
             pk = int(result.output)
             _ = load_node(pk)  # Check if the node can be loaded
@@ -346,7 +346,7 @@ class TestAutoGroups:
             # A few more runs with the same label - it should not crash but append something to the group name
             for _ in range(10):
                 options = [fhandle.name, '--auto-group', '--auto-group-label-prefix', autogroup_label]
-                result = run_cli_command(cmd_run.run, options, suppress_warnings=True)
+                result = run_cli_command(cmd_run.run, options, suppress_warnings=True, use_subprocess=True)
 
                 pk = int(result.output)
                 _ = load_node(pk)  # Check if the node can be loaded

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -46,8 +46,8 @@ class TestVerdiSetup:
         If this test hangs, most likely the `--help` eagerness is overruled by another option that has started the
         prompt cycle, which by waiting for input, will block the test from continuing.
         """
-        self.cli_runner(cmd_setup.setup, ['--help'], catch_exceptions=False)
-        self.cli_runner(cmd_setup.quicksetup, ['--help'], catch_exceptions=False)
+        self.cli_runner(cmd_setup.setup, ['--help'])
+        self.cli_runner(cmd_setup.quicksetup, ['--help'])
 
     def test_quicksetup(self):
         """Test `verdi quicksetup`."""

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -63,7 +63,7 @@ class TestVerdiSetup:
             '--db-backend', self.storage_backend_name
         ]
 
-        self.cli_runner(cmd_setup.quicksetup, options)
+        self.cli_runner(cmd_setup.quicksetup, options, use_subprocess=False)
 
         config = configuration.get_config()
         assert profile_name in config.profile_names
@@ -97,7 +97,7 @@ db_port: {self.pg_test.dsn['port']}
 email: 123@234.de"""
             )
             handle.flush()
-            self.cli_runner(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)])
+            self.cli_runner(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)], use_subprocess=False)
 
     def test_quicksetup_autofill_on_early_exit(self):
         """Test `verdi quicksetup` stores user information even if command fails."""
@@ -120,7 +120,7 @@ email: 123@234.de"""
             self.pg_test.dsn['port'] + 100
         ]
 
-        self.cli_runner(cmd_setup.quicksetup, options, raises=True)
+        self.cli_runner(cmd_setup.quicksetup, options, raises=True, use_subprocess=False)
 
         assert config.get_option('autofill.user.email', scope=None) == user_email
         assert config.get_option('autofill.user.first_name', scope=None) == user_first_name
@@ -141,7 +141,7 @@ email: 123@234.de"""
             self.pg_test.dsn['port'] + 100
         ]
 
-        self.cli_runner(cmd_setup.quicksetup, options, raises=True)
+        self.cli_runner(cmd_setup.quicksetup, options, raises=True, use_subprocess=False)
 
     def test_setup(self):
         """Test `verdi setup` (non-interactive)."""
@@ -168,7 +168,7 @@ email: 123@234.de"""
             '--db-port', self.pg_test.dsn['port'], '--db-backend', self.storage_backend_name, '--profile', profile_name
         ]
 
-        self.cli_runner(cmd_setup.setup, options)
+        self.cli_runner(cmd_setup.setup, options, use_subprocess=False)
 
         config = configuration.get_config()
         assert profile_name in config.profile_names
@@ -209,7 +209,7 @@ email: 123@234.de"""
             '--db-port', self.pg_test.dsn['port']
         ]
 
-        self.cli_runner(cmd_setup.setup, options)
+        self.cli_runner(cmd_setup.setup, options, use_subprocess=False)
 
         config = configuration.get_config()
         assert profile_name in config.profile_names

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -37,7 +37,7 @@ def test_status(run_cli_command):
 def test_status_no_profile(run_cli_command):
     """Test `verdi status` when there is no profile."""
     options = []
-    result = run_cli_command(cmd_status.verdi_status, options)
+    result = run_cli_command(cmd_status.verdi_status, options, use_subprocess=False)
     assert 'no profile configured yet' in result.output
 
 
@@ -62,7 +62,7 @@ def test_storage_unable_to_connect(run_cli_command):
     profile._attributes['storage']['config']['database_port'] = 123
 
     try:
-        result = run_cli_command(cmd_status.verdi_status, raises=True)
+        result = run_cli_command(cmd_status.verdi_status, raises=True, use_subprocess=False)
         assert 'Unable to connect to profile\'s storage' in result.output
         assert result.exit_code is ExitCode.CRITICAL
     finally:
@@ -78,7 +78,7 @@ def test_storage_incompatible(run_cli_command, monkeypatch):
 
     monkeypatch.setattr(migrator.PsqlDosMigrator, 'validate_storage', storage_cls)
 
-    result = run_cli_command(cmd_status.verdi_status, raises=True)
+    result = run_cli_command(cmd_status.verdi_status, raises=True, use_subprocess=False)
     assert 'verdi storage migrate' in result.output
     assert result.exit_code is ExitCode.CRITICAL
 
@@ -92,6 +92,6 @@ def test_storage_corrupted(run_cli_command, monkeypatch):
 
     monkeypatch.setattr(migrator.PsqlDosMigrator, 'validate_storage', storage_cls)
 
-    result = run_cli_command(cmd_status.verdi_status, raises=True)
+    result = run_cli_command(cmd_status.verdi_status, raises=True, use_subprocess=False)
     assert 'Storage is corrupted' in result.output
     assert result.exit_code is ExitCode.CRITICAL

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -27,7 +27,7 @@ def tests_storage_info(aiida_localhost, run_cli_command):
     from aiida import orm
     node = orm.Dict().store()
 
-    result = run_cli_command(cmd_storage.storage_info, options=['--detailed'])
+    result = run_cli_command(cmd_storage.storage_info, parameters=['--detailed'])
 
     assert aiida_localhost.label in result.output
     assert node.node_type in result.output
@@ -36,7 +36,7 @@ def tests_storage_info(aiida_localhost, run_cli_command):
 @pytest.mark.usefixtures('stopped_daemon_client')
 def tests_storage_migrate_force(run_cli_command):
     """Test the ``verdi storage migrate`` command (with force option)."""
-    result = run_cli_command(cmd_storage.storage_migrate, options=['--force'])
+    result = run_cli_command(cmd_storage.storage_migrate, parameters=['--force'])
     assert 'Migrating to the head of the main branch' in result.output
 
 
@@ -86,7 +86,7 @@ def tests_storage_migrate_cancel_prompt(run_cli_command, monkeypatch):
         },
         {
             'raises': True,
-            'options': ['--force']
+            'parameters': ['--force']
         },
     ]
 )
@@ -145,14 +145,14 @@ def tests_storage_maintain_logging(run_cli_command, monkeypatch, caplog):
     assert ' > dry_run: False' in message_list
 
     with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, options=['--dry-run'])
+        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--dry-run'])
 
     message_list = caplog.records[1].msg.splitlines()
     assert ' > full: False' in message_list
     assert ' > dry_run: True' in message_list
 
     with caplog.at_level(logging.INFO):
-        run_cli_command(cmd_storage.storage_maintain, options=['--full'], user_input='Y')
+        run_cli_command(cmd_storage.storage_maintain, parameters=['--full'], user_input='Y')
 
     message_list = caplog.records[2].msg.splitlines()
     assert ' > full: True' in message_list

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -69,7 +69,7 @@ def tests_storage_migrate_cancel_prompt(run_cli_command, monkeypatch):
     import click
 
     monkeypatch.setattr(click, 'prompt', lambda text, **kwargs: exec('import click\nraise click.Abort()'))  # pylint: disable=exec-used
-    result = run_cli_command(cmd_storage.storage_migrate, raises=True)
+    result = run_cli_command(cmd_storage.storage_migrate, raises=True, use_subprocess=False)
 
     assert 'aborted' in result.output.lower()
 
@@ -107,7 +107,7 @@ def tests_storage_migrate_raises(run_cli_command, raise_type, call_kwargs, monke
         raise raise_type('passed error message')
 
     monkeypatch.setattr(manager.get_profile_storage().__class__, 'migrate', mocked_migrate)
-    result = run_cli_command(cmd_storage.storage_migrate, **call_kwargs)
+    result = run_cli_command(cmd_storage.storage_migrate, **call_kwargs, use_subprocess=False)
 
     assert result.exc_info[0] is SystemExit
     assert 'Critical:' in result.output
@@ -138,21 +138,21 @@ def tests_storage_maintain_logging(run_cli_command, monkeypatch, caplog):
     monkeypatch.setattr(storage, 'maintain', mock_maintain)
 
     with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, user_input='Y')
+        _ = run_cli_command(cmd_storage.storage_maintain, user_input='Y', use_subprocess=False)
 
     message_list = caplog.records[0].msg.splitlines()
     assert ' > full: False' in message_list
     assert ' > dry_run: False' in message_list
 
     with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--dry-run'])
+        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--dry-run'], use_subprocess=False)
 
     message_list = caplog.records[1].msg.splitlines()
     assert ' > full: False' in message_list
     assert ' > dry_run: True' in message_list
 
     with caplog.at_level(logging.INFO):
-        run_cli_command(cmd_storage.storage_maintain, parameters=['--full'], user_input='Y')
+        run_cli_command(cmd_storage.storage_maintain, parameters=['--full'], user_input='Y', use_subprocess=False)
 
     message_list = caplog.records[2].msg.splitlines()
     assert ' > full: True' in message_list

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=no-self-use
 """Tests for `verdi user`."""
 import pytest
 
@@ -31,11 +32,9 @@ class TestVerdiUserCommand:
     """Test verdi user."""
 
     @pytest.fixture(autouse=True)
-    def init_profile(self, run_cli_command):  # pylint: disable=unused-argument
+    def init_profile(self):  # pylint: disable=unused-argument
         """Initialize the profile."""
         # pylint: disable=attribute-defined-outside-init
-        self.cli_runner = run_cli_command
-
         created, user = orm.User.collection.get_or_create(email=USER_1['email'])
         for key, value in USER_1.items():
             if key != 'email':
@@ -43,14 +42,14 @@ class TestVerdiUserCommand:
         if created:
             orm.User(**USER_1).store()
 
-    def test_user_list(self):
+    def test_user_list(self, run_cli_command):
         """Test `verdi user list`."""
         from aiida.cmdline.commands.cmd_user import user_list as list_user
 
-        result = self.cli_runner(list_user, [])
+        result = run_cli_command(list_user, [])
         assert USER_1['email'] in result.output
 
-    def test_user_create(self):
+    def test_user_create(self, run_cli_command):
         """Create a new user with `verdi user configure`."""
         cli_options = [
             '--email',
@@ -61,9 +60,10 @@ class TestVerdiUserCommand:
             USER_2['last_name'],
             '--institution',
             USER_2['institution'],
+            '--set-default',
         ]
 
-        result = self.cli_runner(cmd_user.user_configure, cli_options)
+        result = run_cli_command(cmd_user.user_configure, cli_options)
         assert USER_2['email'] in result.output
         assert 'created' in result.output
         assert 'updated' not in result.output
@@ -72,7 +72,7 @@ class TestVerdiUserCommand:
         for key, val in USER_2.items():
             assert val == getattr(user_obj, key)
 
-    def test_user_update(self):
+    def test_user_update(self, run_cli_command):
         """Reconfigure an existing user with `verdi user configure`."""
         email = USER_1['email']
 
@@ -85,9 +85,10 @@ class TestVerdiUserCommand:
             USER_2['last_name'],
             '--institution',
             USER_2['institution'],
+            '--set-default',
         ]
 
-        result = self.cli_runner(cmd_user.user_configure, cli_options)
+        result = run_cli_command(cmd_user.user_configure, cli_options)
         assert email in result.output
         assert 'updated' in result.output
         assert 'created' not in result.output

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -47,7 +47,7 @@ class TestVerdiUserCommand:
         """Test `verdi user list`."""
         from aiida.cmdline.commands.cmd_user import user_list as list_user
 
-        result = self.cli_runner(list_user, [], catch_exceptions=False)
+        result = self.cli_runner(list_user, [])
         assert USER_1['email'] in result.output
 
     def test_user_create(self):
@@ -63,7 +63,7 @@ class TestVerdiUserCommand:
             USER_2['institution'],
         ]
 
-        result = self.cli_runner(cmd_user.user_configure, cli_options, catch_exceptions=False)
+        result = self.cli_runner(cmd_user.user_configure, cli_options)
         assert USER_2['email'] in result.output
         assert 'created' in result.output
         assert 'updated' not in result.output
@@ -87,7 +87,7 @@ class TestVerdiUserCommand:
             USER_2['institution'],
         ]
 
-        result = self.cli_runner(cmd_user.user_configure, cli_options, catch_exceptions=False)
+        result = self.cli_runner(cmd_user.user_configure, cli_options)
         assert email in result.output
         assert 'updated' in result.output
         assert 'created' not in result.output

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -29,7 +29,7 @@ def test_verdi_with_empty_profile_list(run_cli_command):
 
     # Run verdi command with updated CONFIG featuring an empty profile list
     CONFIG.dictionary[CONFIG.KEY_PROFILES] = {}
-    run_cli_command(cmd_verdi.verdi, [])
+    run_cli_command(cmd_verdi.verdi, [], use_subprocess=False)
 
 
 @pytest.mark.usefixtures('config_with_profile')

--- a/tests/cmdline/params/options/test_conditional.py
+++ b/tests/cmdline/params/options/test_conditional.py
@@ -7,11 +7,20 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida.cmdline.params.options.conditional` module."""
+import functools
+
 import click
 import pytest
 
 from aiida.cmdline.params.options.conditional import ConditionalOption
+
+
+@pytest.fixture
+def run_cli_command(run_cli_command):
+    """Override the ``run_cli_command`` fixture to always run with ``use_subprocess=False`` for tests in this module."""
+    return functools.partial(run_cli_command, use_subprocess=False)
 
 
 def construct_simple_cmd(pname, required_fn=lambda ctx: ctx.params.get('on'), **kwargs):

--- a/tests/cmdline/params/options/test_interactive.py
+++ b/tests/cmdline/params/options/test_interactive.py
@@ -7,13 +7,22 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name
 """Unit tests for the InteractiveOption."""
+import functools
+
 import click
 import pytest
 
 from aiida.cmdline.params.options import NON_INTERACTIVE
 from aiida.cmdline.params.options.interactive import InteractiveOption
 from aiida.cmdline.params.types.plugin import PluginParamType
+
+
+@pytest.fixture
+def run_cli_command(run_cli_command):
+    """Override the ``run_cli_command`` fixture to always run with ``use_subprocess=False`` for tests in this module."""
+    return functools.partial(run_cli_command, use_subprocess=False)
 
 
 class Only42IntParamType(click.types.IntParamType):

--- a/tests/cmdline/params/options/test_verbosity.py
+++ b/tests/cmdline/params/options/test_verbosity.py
@@ -7,7 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=redefined-outer-name
 """Tests for the :class:`~aiida.cmdline.params.options.main.VERBOSITY` option."""
+import functools
 import logging
 
 import click
@@ -16,6 +18,12 @@ import pytest
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import echo
 from aiida.common.log import AIIDA_LOGGER, LOG_LEVELS
+
+
+@pytest.fixture
+def run_cli_command(run_cli_command):
+    """Override the ``run_cli_command`` fixture to always run with ``use_subprocess=False`` for tests in this module."""
+    return functools.partial(run_cli_command, use_subprocess=False)
 
 
 @click.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,10 @@ loaded in this file as well, such that they can also be used for the tests of ``
 from __future__ import annotations
 
 import copy
+import dataclasses
 import os
 import pathlib
+import types
 import typing as t
 import warnings
 
@@ -412,68 +414,178 @@ def chdir_tmp_path(request, tmp_path):
     os.chdir(request.config.invocation_dir)
 
 
+def cli_command_map() -> dict[click.Command, list[str]]:
+    """Return a map of all ``verdi`` subcommands and their path in the command tree."""
+    from aiida.cmdline.commands.cmd_verdi import verdi
+
+    def recurse_commands(ctx, command: click.Command, breadcrumbs: list[str] | None = None):
+        """Recursively return all subcommands that are part of ``command``.
+
+        :param command: The click command to start with.
+        :param parents: A list of strings that represent the parent commands leading up to the current command.
+        :returns: A list of strings denoting the full path to the current command.
+        """
+        breadcrumbs = (breadcrumbs or []) + [command.name]
+
+        yield command, breadcrumbs
+
+        if isinstance(command, click.Group):
+            for command_name in command.commands:
+                yield from recurse_commands(ctx, command.get_command(ctx, command_name), breadcrumbs)
+
+    ctx = click.Context(verdi)
+    command_map = {}
+
+    for command, breadcrumbs in recurse_commands(ctx, verdi):
+        command_map[command] = breadcrumbs
+
+    return command_map
+
+
+@dataclasses.dataclass
+class CliResult:
+    """Dataclass representing the result of a command line interface invocation."""
+
+    stderr_bytes: bytes
+    stdout_bytes: bytes
+    exc_info: tuple[t.Type[BaseException], BaseException, types.TracebackType] | tuple[None, None,
+                                                                                       None] = (None, None, None)
+    exception: BaseException | None = None
+    exit_code: int | None = 0
+
+    @property
+    def stdout(self) -> str:
+        """Return the output that was written to stdout."""
+        return self.stdout_bytes.decode('utf-8', 'replace').replace('\r\n', '\n')
+
+    @property
+    def stderr(self) -> str:
+        """Return the output that was written to stderr."""
+        return self.stderr_bytes.decode('utf-8', 'replace').replace('\r\n', '\n')
+
+    @property
+    def output(self) -> str:
+        """Return the output that was written to stdout."""
+        return self.stdout + self.stderr
+
+    @property
+    def output_lines(self) -> list[str]:
+        """Return the output that was written to stdout as a list of lines."""
+        return [line for line in self.output.split('\n') if line.strip()]
+
+
 @pytest.fixture
-def run_cli_command(reset_log_level):  # pylint: disable=unused-argument
-    """Run a `click` command with the given options.
+def run_cli_command(reset_log_level, aiida_instance, aiida_profile):  # pylint: disable=unused-argument
+    """Run a ``click`` command with the given options.
 
     The call will raise if the command triggered an exception or the exit code returned is non-zero.
     """
-    from click.testing import Result
 
-    def _run_cli_command(
+    def factory(
         command: click.Command,
-        options: list | None = None,
+        parameters: list[str] | None = None,
         user_input: str | bytes | t.IO | None = None,
         raises: bool = False,
-        catch_exceptions: bool = True,
+        use_subprocess: bool = True,
         **kwargs
-    ) -> Result:
+    ) -> CliResult:
         """Run the command and check the result.
 
-        .. note:: the `output_lines` attribute is added to return value containing list of stripped output lines.
-
-        :param options: the list of command line options to pass to the command invocation.
+        :param command: The base command to invoke.
+        :param parameters: The command line parameters to pass to the invocation.
         :param user_input: string with data to be provided at the prompt. Can include newline characters to simulate
             responses to multiple prompts.
-        :param raises: whether the command is expected to raise an exception.
-        :param catch_exceptions: if True and ``raise is False``, will assert that the exception is ``None`` and the exit
-            code of the result of the invoked command equals zero.
-        :param kwargs: keyword arguments that will be psased to the command invocation.
-        :return: test result.
+        :param raises: Boolean, if ``True``, the command should raise an exception.
+        :param use_subprocess: Boolean, if ``True``, runs the command in a subprocess, otherwise it is run in the same
+            interpreter using :class:`click.testing.CliRunner`. The advantage of running in a subprocess is that it
+            simulates exactly what a user would invoke through the CLI. The test runner provided by ``click`` invokes
+            commands in a way that is not always a 100% analogous to an actual CLI call and so tests may not cover the
+            exact behavior. The direct reason for adding this argument was when a bug was introduced that was not caught
+            because of this problem. The changes made by the command to the database were properly added to the session
+            but were never flushed to the database, meaning the changes were not persisted. This was not caught by the
+            test runner, since the test saw the correct changes but didn't know they wouldn't be persisted. Finally, if
+            a test monkeypatches the behavior of code that is called by the command being tested, then a subprocess
+            cannot be used, since the monkeypatch only applies to the current interpreter. In these cases it is
+            necessary to set ``use_subprocesses = False``.
+        :returns: Instance of ``CliResult``.
+        :raises AssertionError: If ``raises == True`` and the command didn't except, or if ``raises == True`` and the
+            the command did except.
         """
-        import traceback
+        # Cast all elements in ``parameters`` to strings as that is required by ``subprocess.run``.
+        parameters = [str(param) for param in parameters or []]
 
-        from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup
-        from aiida.common import AttributeDict
-
-        config = get_config()
-        profile = get_profile()
-        obj = AttributeDict({'config': config, 'profile': profile})
-
-        # Convert any ``pathlib.Path`` objects in the ``options`` to their absolute filepath string representation.
-        # This is necessary because the ``invoke`` command does not support these path objects.
-        options = [str(option) if isinstance(option, pathlib.Path) else option for option in options or []]
-
-        # We need to apply the ``VERBOSITY`` option. When invoked through the command line, this is done by the logic
-        # of the ``VerdiCommandGroup``, but when testing commands, the command is retrieved directly from the module
-        # which circumvents this machinery.
-        command = VerdiCommandGroup.add_verbosity_option(command)
-
-        runner = click.testing.CliRunner()
-        result = runner.invoke(command, options, input=user_input, obj=obj, **kwargs)
+        if use_subprocess:
+            result = run_cli_command_subprocess(command, parameters, user_input, aiida_profile.name)
+        else:
+            result = run_cli_command_runner(command, parameters, user_input, kwargs)
 
         if raises:
             assert result.exception is not None, result.output
-            assert result.exit_code != 0
-        elif catch_exceptions:
-            assert result.exception is None, ''.join(traceback.format_exception(*result.exc_info))
-            assert result.exit_code == 0, result.output
-
-        result.output_lines = [line.strip() for line in result.output.split('\n') if line.strip()]
+            assert result.exit_code != 0, result.exit_code
+        else:
+            assert result.exception is None, result.output
+            assert result.exit_code == 0, result.exit_code
 
         return result
 
-    return _run_cli_command
+    return factory
+
+
+def run_cli_command_subprocess(command, parameters, user_input, profile_name):
+    """Run CLI command through ``subprocess``."""
+    import subprocess
+    import sys
+
+    env = os.environ.copy()
+    command_path = cli_command_map()[command]
+    args = command_path[:1] + ['-p', profile_name] + command_path[1:] + parameters
+
+    try:
+        completed_process = subprocess.run(
+            args, capture_output=True, check=True, input=user_input.encode('utf-8') if user_input else None, env=env
+        )
+    except subprocess.CalledProcessError as exception:
+        result = CliResult(
+            exc_info=sys.exc_info(),
+            exception=exception,
+            exit_code=exception.returncode,
+            stderr_bytes=exception.stderr,
+            stdout_bytes=exception.stdout,
+        )
+    else:
+        result = CliResult(
+            stderr_bytes=completed_process.stderr,
+            stdout_bytes=completed_process.stdout,
+        )
+
+    return result
+
+
+def run_cli_command_runner(command, parameters, user_input, kwargs):
+    """Run CLI command through ``click.testing.CliRunner``."""
+    from click.testing import CliRunner
+
+    from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup
+    from aiida.common import AttributeDict
+
+    config = get_config()
+    profile = get_profile()
+    obj = AttributeDict({'config': config, 'profile': profile})
+
+    # We need to apply the ``VERBOSITY`` option. When invoked through the command line, this is done by the logic of the
+    # ``VerdiCommandGroup``, but when testing commands, the command is retrieved directly from the module which
+    # circumvents this machinery.
+    command = VerdiCommandGroup.add_verbosity_option(command)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(command, parameters, input=user_input, obj=obj, **kwargs)
+    return CliResult(
+        exc_info=result.exc_info or (None, None, None),
+        exception=result.exception,
+        exit_code=result.exit_code,
+        stderr_bytes=result.stderr_bytes or b'',
+        stdout_bytes=result.stdout_bytes,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -486,7 +486,7 @@ def run_cli_command(reset_log_level, aiida_instance, aiida_profile):  # pylint: 
         parameters: list[str] | None = None,
         user_input: str | bytes | t.IO | None = None,
         raises: bool = False,
-        use_subprocess: bool = True,
+        use_subprocess: bool = False,
         suppress_warnings: bool = False,
         **kwargs
     ) -> CliResult:


### PR DESCRIPTION
Fixes #5843 

Release `v2.2.0` was broken in a bad way because of a bug that was introduced in the `PsqlDosBackend` that was not caught by any of the tests. The problem is that changes made by `verdi` commands were no longer automatically committed and persisted to the database.

This went unnoticed by the tests because in the unit tests the commands are run through the `click.testing.CliRunner` utility. This suffers from a number of problems. We already knew that it only executed the (sub)command that was passed to the runner, and any code that was part of the parents would not be executed. The `run_cli_command` already had to deal with and, for example, manually added the verbosity option to each command, which normally is done automatically by the `verdi` top-level command when invoking through the command line. The `v2.2.0` release highlighted another problem, namely that the assertions of the tests do so against the state of the interpreter of the test, which in this case would contain the correct changes after the command was executed, but this did of course not require the changes to be persisted and so didn't notice the problem.

To avoid these problems of the tests not executing the exact pathway as a real invocation over the command line, the `run_cli_command` fixture was updated with the keyword `use_subprocess` which when set to `True` would invoke the command as an actual subprocess using the `subprocess` module. This would force the command to be tested as in a real-life situation.

Running the tests with this mode caused a number of tests to fail. A number of these were due to unrelated bugs that were hidden through the use of the `CliRunner`, but 32 tests failed due to the bug in the `PsqlDosBackend`. Had these tests been run with `use_subprocess=True` before the release, we would have caught the bug before shipping it with `v2.2.0`.

Now ideally then we would always run all tests with `use_subprocess=True` but this is quite a bit slower and would add another 30 minutes roughly to the unit test suite, which is unaccepatble. Therefore, I have gone through a procedure to determine exactly those tests that fail because of the session bug and run only those with `use_subprocess=True`. This should give us a lot more confidence that we will catch similar bugs in future PRs.

The PR consists of the following commits (see commit messages for more details):

1. Refactor the `run_cli_command` fixture to add the `use_subprocess` and set `True` as the default
2. Switch certain tests to `use_subprocess=False` that use monkeypatching or other strategies to change things for the test that are only visible in the current interpreter. They would fail when using the subprocess since that uses a differnt interpreter where the monkeypatch is not applied. Similarly, certain tests are run with `suppress_warnings=True` since their assertions strictly check output and the printing of deprecation warnings would cause them to fail. This wasn't a problem with the test runner since in that case the warning would already have been printed on test startup and wouldn't be printed again.
3. Fix a number of minor bugs in the tests that were not related to the `PsqlDosBackend` bug but were related to how defaults are processed by the `CliRunner` and when running as a subprocess.
4. The `use_subprocess=True` pathway tries to determine the full command line arguments from the `click.Command` which failed for the `verdi data` comands as their the actual name is not taken from the command definition but the entry point with which they are registered.
5. Change the default for `use_subprocess` to `False` but set `use_subprocess=True` for all 32 tests that failed because of the `PsqlDosBackend` session bug

Note that when these 5 commits are run on top of `v2.2.0` there are 32 tests that fail because of the session bug (and 2 that hang for the same reason). This branch, however, puts these commits on top of `main` where the session bug has already been reverted and so should pass. The branch of the broken tests can be found here: https://github.com/sphuber/aiida-core/tree/feature/5843/run-cli-command-subprocess-broken