### PR TITLE
CLI: Fix results not being committed in `verdi code delete`

### DIFF
--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -46,6 +46,8 @@ def load_backend_if_not_loaded():
             manager.load_profile()  # This will load the default profile if no profile has already been loaded
             manager.get_profile_storage()  # This will load the backend of the loaded profile, if not already loaded
 
+    return manager.get_profile_storage()
+
 
 def with_dbenv():
     """Function decorator that will load the database environment for the currently loaded profile.
@@ -66,11 +68,12 @@ def with_dbenv():
         from aiida.common.exceptions import ConfigurationError, IntegrityError, LockedProfileError
 
         try:
-            load_backend_if_not_loaded()
+            storage = load_backend_if_not_loaded()
         except (IntegrityError, ConfigurationError, LockedProfileError) as exception:
             echo.echo_critical(str(exception))
 
-        return wrapped(*args, **kwargs)
+        with storage.transaction():
+            return wrapped(*args, **kwargs)
 
     return wrapper
 

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -46,8 +46,6 @@ def load_backend_if_not_loaded():
             manager.load_profile()  # This will load the default profile if no profile has already been loaded
             manager.get_profile_storage()  # This will load the backend of the loaded profile, if not already loaded
 
-    return manager.get_profile_storage()
-
 
 def with_dbenv():
     """Function decorator that will load the database environment for the currently loaded profile.
@@ -68,12 +66,11 @@ def with_dbenv():
         from aiida.common.exceptions import ConfigurationError, IntegrityError, LockedProfileError
 
         try:
-            storage = load_backend_if_not_loaded()
+            load_backend_if_not_loaded()
         except (IntegrityError, ConfigurationError, LockedProfileError) as exception:
             echo.echo_critical(str(exception))
 
-        with storage.transaction():
-            return wrapped(*args, **kwargs)
+        return wrapped(*args, **kwargs)
 
     return wrapper
 

--- a/aiida/tools/graph/deletions.py
+++ b/aiida/tools/graph/deletions.py
@@ -104,7 +104,9 @@ def delete_nodes(
         return (pks_set_to_delete, True)
 
     DELETE_LOGGER.report('Starting node deletion...')
-    backend.delete_nodes_and_connections(pks_set_to_delete)
+    with backend.transaction() as session:
+        backend.delete_nodes_and_connections(pks_set_to_delete)
+        session.commit()
     DELETE_LOGGER.report('Deletion of nodes completed.')
 
     return (pks_set_to_delete, True)

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -123,7 +123,7 @@ def test_relabel_code_full_bad(run_cli_command, code):
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_code_delete_one_force(run_cli_command, code):
     """Test force code deletion."""
-    run_cli_command(cmd_code.delete, [str(code.pk), '--force'])
+    run_cli_command(cmd_code.delete, [str(code.pk), '--force'], use_subprocess=True)
 
     with pytest.raises(NotExistent):
         load_code('code')

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -109,7 +109,7 @@ def generate_setup_options_interactive(ordereddict):
 
 def test_help(run_cli_command):
     """Test the help of verdi computer setup."""
-    run_cli_command(computer_setup, ['--help'], catch_exceptions=False)
+    run_cli_command(computer_setup, ['--help'])
 
 
 def test_reachable():
@@ -144,7 +144,7 @@ def test_mixed(run_cli_command):
     user_input = '\n'.join(generate_setup_options_interactive(options_dict))
     options = generate_setup_options(non_interactive_options_dict)
 
-    result = run_cli_command(computer_setup, options, user_input=user_input, catch_exceptions=False)
+    result = run_cli_command(computer_setup, options, user_input=user_input)
     assert result.exception is None, f'There was an unexpected exception. Output: {result.output}'
 
     new_computer = orm.Computer.collection.get(label=label)
@@ -204,7 +204,7 @@ def test_noninteractive_optional_default_mpiprocs(run_cli_command):
     options_dict = generate_setup_options_dict({'label': 'computer_default_mpiprocs'})
     options_dict.pop('mpiprocs-per-machine')
     options = generate_setup_options(options_dict)
-    run_cli_command(computer_setup, options, catch_exceptions=False)
+    run_cli_command(computer_setup, options)
 
     new_computer = orm.Computer.collection.get(label=options_dict['label'])
     assert isinstance(new_computer, orm.Computer)
@@ -218,7 +218,7 @@ def test_noninteractive_optional_default_mpiprocs_2(run_cli_command):
     options_dict = generate_setup_options_dict({'label': 'computer_default_mpiprocs_2'})
     options_dict['mpiprocs-per-machine'] = 0
     options = generate_setup_options(options_dict)
-    run_cli_command(computer_setup, options, catch_exceptions=False)
+    run_cli_command(computer_setup, options)
 
     new_computer = orm.Computer.collection.get(label=options_dict['label'])
     assert isinstance(new_computer, orm.Computer)
@@ -301,10 +301,8 @@ def test_noninteractive_invalid_mpirun_fail(run_cli_command):
     options_dict = generate_setup_options_dict(replace_args={'label': 'fail_computer'})
     options_dict['mpirun-command'] = 'mpirun -np {unknown_key}'
     options = generate_setup_options(options_dict)
-    result = run_cli_command(computer_setup, options, catch_exceptions=False)
-
-    assert isinstance(result.exception, SystemExit)
-    assert "unknown replacement field 'unknown_key'" in str(result.output)
+    result = run_cli_command(computer_setup, options, raises=True)
+    assert "unknown replacement field 'unknown_key'" in result.output
 
 
 def test_noninteractive_from_config(run_cli_command):
@@ -351,7 +349,7 @@ class TestVerdiComputerConfigure:
 
     def test_top_help(self):
         """Test help option of verdi computer configure."""
-        result = self.cli_runner(computer_configure, ['--help'], catch_exceptions=False)
+        result = self.cli_runner(computer_configure, ['--help'])
         assert 'core.ssh' in result.output
         assert 'core.local' in result.output
 
@@ -378,7 +376,7 @@ class TestVerdiComputerConfigure:
         comp.store()
 
         options = ['core.local', comp.label, '--non-interactive', '--safe-interval', '0']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
+        result = self.cli_runner(computer_configure, options)
         assert comp.is_configured, result.output
 
         self.comp_builder.label = 'test_local_ni_empty_mismatch'
@@ -387,8 +385,7 @@ class TestVerdiComputerConfigure:
         comp_mismatch.store()
 
         options = ['core.local', comp_mismatch.label, '--non-interactive']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        assert result.exception is not None
+        result = self.cli_runner(computer_configure, options, raises=True)
         assert 'core.ssh' in result.output
         assert 'core.local' in result.output
 
@@ -401,9 +398,7 @@ class TestVerdiComputerConfigure:
 
         invalid = 'n'
         valid = '1.0'
-        result = self.cli_runner(
-            computer_configure, ['core.local', comp.label], user_input=f'{invalid}\n{valid}\n', catch_exceptions=False
-        )
+        result = self.cli_runner(computer_configure, ['core.local', comp.label], user_input=f'{invalid}\n{valid}\n')
         assert comp.is_configured, result.output
 
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
@@ -439,9 +434,7 @@ class TestVerdiComputerConfigure:
             key_filename=key_filename
         )
 
-        result = self.cli_runner(
-            computer_configure, ['core.ssh', comp.label], user_input=command_input, catch_exceptions=False
-        )
+        result = self.cli_runner(computer_configure, ['core.ssh', comp.label], user_input=command_input)
         assert comp.is_configured, result.output
         new_auth_params = comp.get_authinfo(self.user).get_auth_params()
         assert new_auth_params['username'] == remote_username
@@ -486,7 +479,7 @@ safe_interval: {interval}
         comp.store()
 
         options = ['core.ssh', comp.label, '--non-interactive', '--safe-interval', '1']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
+        result = self.cli_runner(computer_configure, options)
         assert comp.is_configured, result.output
 
         self.comp_builder.label = 'test_ssh_ni_empty_mismatch'
@@ -495,8 +488,7 @@ safe_interval: {interval}
         comp_mismatch.store()
 
         options = ['core.ssh', comp_mismatch.label, '--non-interactive']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
-        assert result.exception is not None
+        result = self.cli_runner(computer_configure, options, raises=True)
         assert 'core.local' in result.output
         assert 'core.ssh' in result.output
 
@@ -509,7 +501,7 @@ safe_interval: {interval}
 
         username = 'TEST'
         options = ['core.ssh', comp.label, '--non-interactive', f'--username={username}', '--safe-interval', '1']
-        result = self.cli_runner(computer_configure, options, catch_exceptions=False)
+        result = self.cli_runner(computer_configure, options)
         auth_info = orm.AuthInfo.collection.get(dbcomputer_id=comp.pk, aiidauser_id=self.user.pk)
         assert comp.is_configured, result.output
         assert auth_info.get_auth_params()['username'] == username
@@ -521,24 +513,20 @@ safe_interval: {interval}
         comp = self.comp_builder.new()
         comp.store()
 
-        result = self.cli_runner(computer_configure, ['show', comp.label], catch_exceptions=False)
+        result = self.cli_runner(computer_configure, ['show', comp.label])
 
-        result = self.cli_runner(computer_configure, ['show', comp.label, '--defaults'], catch_exceptions=False)
+        result = self.cli_runner(computer_configure, ['show', comp.label, '--defaults'])
         assert '* username' in result.output
 
-        result = self.cli_runner(
-            computer_configure, ['show', comp.label, '--defaults', '--as-option-string'], catch_exceptions=False
-        )
+        result = self.cli_runner(computer_configure, ['show', comp.label, '--defaults', '--as-option-string'])
         assert '--username=' in result.output
 
         config_cmd = ['core.ssh', comp.label, '--non-interactive']
         config_cmd.extend(result.output.replace("'", '').split(' '))
-        result_config = self.cli_runner(computer_configure, config_cmd, catch_exceptions=False)
+        result_config = self.cli_runner(computer_configure, config_cmd)
         assert comp.is_configured, result_config.output
 
-        result_cur = self.cli_runner(
-            computer_configure, ['show', comp.label, '--as-option-string'], catch_exceptions=False
-        )
+        result_cur = self.cli_runner(computer_configure, ['show', comp.label, '--as-option-string'])
         assert '--username=' in result.output
         assert result_cur.output == result.output
 
@@ -661,7 +649,7 @@ class TestVerdiComputerCommands:
         ).store()
         # and configure it
         options = ['core.local', label, '--non-interactive', '--safe-interval', '0']
-        self.cli_runner(computer_configure, options, catch_exceptions=False)
+        self.cli_runner(computer_configure, options)
 
         # See if the command complains about not getting an invalid computer
         self.cli_runner(computer_delete, ['computer_that_does_not_exist'], raises=True)
@@ -679,7 +667,7 @@ def test_computer_duplicate_interactive(run_cli_command, aiida_localhost, non_in
     label = 'computer_duplicate_interactive'
     computer = aiida_localhost
     user_input = f'{label}\n\n\n\n\n\n\n\n\n\n'
-    result = run_cli_command(computer_duplicate, [str(computer.pk)], user_input=user_input, catch_exceptions=False)
+    result = run_cli_command(computer_duplicate, [str(computer.pk)], user_input=user_input)
     assert result.exception is None, result.output
 
     new_computer = orm.Computer.collection.get(label=label)

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -63,29 +63,29 @@ class DummyVerdiDataExportable:
 
         # Check that the simple command works as expected
         options = [str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options)
         assert res.exit_code == 0, 'The command did not finish correctly'
 
         for flag in ['-F', '--format']:
             for frmt in supported_formats:
                 options = [flag, frmt, str(ids[self.NODE_ID_STR])]
-                res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+                res = self.cli_runner(export_cmd, options)
                 assert res.exit_code == 0, f'The command did not finish correctly. Output:\n{res.output}'
 
         filepath = tmp_path / 'output_file.txt'
         options = [output_flag, str(filepath), str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options)
         assert res.exit_code == 0, f'The command should finish correctly.Output:\n{res.output}'
 
         # Try to export it again. It should fail because the
         # file exists
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options, raises=True)
         assert res.exit_code != 0, 'The command should fail because the file already exists'
 
         # Now we force the export of the file and it should overwrite
         # existing files
         options = [output_flag, str(filepath), '-f', str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner(export_cmd, options, catch_exceptions=False)
+        res = self.cli_runner(export_cmd, options)
         assert res.exit_code == 0, f'The command should finish correctly.Output: {res.output}'
 
 
@@ -125,18 +125,18 @@ class DummyVerdiDataListable:
         search_string_bytes = search_string.encode('utf-8')
 
         # Check that the normal listing works as expected
-        res = self.cli_runner(listing_cmd, [], catch_exceptions=False)
+        res = self.cli_runner(listing_cmd, [])
         assert search_string_bytes in res.stdout_bytes, f'The string {search_string} was not found in the listing'
 
         # Check that the past days filter works as expected
         past_days_flags = ['-p', '--past-days']
         for flag in past_days_flags:
             options = [flag, '1']
-            res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+            res = self.cli_runner(listing_cmd, options)
             assert search_string_bytes in res.stdout_bytes, f'The string {search_string} was not found in the listing'
 
             options = [flag, '0']
-            res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+            res = self.cli_runner(listing_cmd, options)
             assert search_string_bytes not in res.stdout_bytes, (
                 f'A not expected string {search_string} was found in the listing'
             )
@@ -148,27 +148,27 @@ class DummyVerdiDataListable:
             # Non empty group
             for non_empty in [self.NON_EMPTY_GROUP_NAME_STR, str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
                 options = [flag, non_empty]
-                res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+                res = self.cli_runner(listing_cmd, options)
                 assert search_string_bytes in res.stdout_bytes, 'The string {} was not found in the listing'
 
             # Empty group
             for empty in [self.EMPTY_GROUP_NAME_STR, str(ids[self.EMPTY_GROUP_ID_STR])]:
                 options = [flag, empty]
-                res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+                res = self.cli_runner(listing_cmd, options)
                 assert search_string_bytes not in res.stdout_bytes, 'A not expected string {} was found in the listing'
 
             # Group combination
             for non_empty in [self.NON_EMPTY_GROUP_NAME_STR, str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
                 for empty in [self.EMPTY_GROUP_NAME_STR, str(ids[self.EMPTY_GROUP_ID_STR])]:
                     options = [flag, non_empty, empty]
-                    res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+                    res = self.cli_runner(listing_cmd, options)
                     assert search_string_bytes in res.stdout_bytes, 'The string {} was not found in the listing'
 
         # Check raw flag
         raw_flags = ['-r', '--raw']
         for flag in raw_flags:
             options = [flag]
-            res = self.cli_runner(listing_cmd, options, catch_exceptions=False)
+            res = self.cli_runner(listing_cmd, options)
             for header in headers_mapping[datatype]:
                 assert header.encode('utf-8') not in res.stdout_bytes
 
@@ -213,7 +213,7 @@ class TestVerdiDataArray:
 
     def test_arrayshow(self):
         options = [str(self.arr.pk)]
-        res = self.cli_runner(cmd_array.array_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_array.array_show, options)
         assert res.exit_code == 0, 'The command did not finish correctly'
 
 
@@ -310,7 +310,7 @@ class TestVerdiDataBands(DummyVerdiDataListable):
 
     def test_bandslist_with_elements(self):
         options = ['-e', 'Fe']
-        res = self.cli_runner(cmd_bands.bands_list, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_bands.bands_list, options)
         assert b'FeO' in res.stdout_bytes, 'The string "FeO" was not found in the listing'
         assert b'<<NOT FOUND>>' not in res.stdout_bytes, 'The string "<<NOT FOUND>>" should not in the listing'
 
@@ -320,7 +320,7 @@ class TestVerdiDataBands(DummyVerdiDataListable):
 
     def test_bandsexport(self):
         options = [str(self.pks[DummyVerdiDataListable.NODE_ID_STR])]
-        res = self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_bands.bands_export, options)
         assert res.exit_code == 0, 'The command did not finish correctly'
         assert b'[1.0, 3.0]' in res.stdout_bytes, 'The string [1.0, 3.0] was not found in the bands export'
 
@@ -338,14 +338,14 @@ class TestVerdiDataBands(DummyVerdiDataListable):
 
         # matplotlib
         options = [str(bands.pk), '--format', 'mpl_singlefile']
-        res = self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_bands.bands_export, options)
         assert b'p.scatter' in res.stdout_bytes, 'The string p.scatter was not found in the bands mpl export'
 
         # gnuplot
         from click.testing import CliRunner
         with CliRunner().isolated_filesystem():
             options = [str(bands.pk), '--format', 'gnuplot', '-o', 'bands.gnu']
-            self.cli_runner(cmd_bands.bands_export, options, catch_exceptions=False)
+            self.cli_runner(cmd_bands.bands_export, options)
             with open('bands.gnu', 'r', encoding='utf8') as gnu_file:
                 res = gnu_file.read()
                 assert 'vectors nohead' in res, 'The string "vectors nohead" was not found in the gnuplot script'
@@ -370,7 +370,7 @@ class TestVerdiDataDict:
     def test_dictshow(self):
         """Test verdi data dict show."""
         options = [str(self.dct.pk)]
-        res = self.cli_runner(cmd_dict.dictionary_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_dict.dictionary_show, options)
         assert res.exit_code == 0, 'The command verdi data dict show did not finish correctly'
         assert b'"a": 1' in res.stdout_bytes, 'The string "a": 1 was not found in the output' \
             ' of verdi data dict show'
@@ -397,7 +397,7 @@ class TestVerdiDataRemote:
     def test_remoteshow(self):
         """Test verdi data remote show."""
         options = [str(self.rmt.pk)]
-        res = self.cli_runner(cmd_remote.remote_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_remote.remote_show, options)
         assert res.exit_code == 0, 'The command verdi data remote show did not finish correctly'
         assert b'Remote computer name:' in res.stdout_bytes, (
             'The string "Remote computer name:" was not found in the output of verdi data remote show'
@@ -412,7 +412,7 @@ class TestVerdiDataRemote:
 
     def test_remotels(self):
         options = ['--long', str(self.rmt.pk)]
-        res = self.cli_runner(cmd_remote.remote_ls, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_remote.remote_ls, options)
         assert res.exit_code == 0, 'The command verdi data remote ls did not finish correctly'
         assert b'file.txt' in res.stdout_bytes, 'The file "file.txt" was not found in the output' \
             ' of verdi data remote ls'
@@ -423,7 +423,7 @@ class TestVerdiDataRemote:
 
     def test_remotecat(self):
         options = [str(self.rmt.pk), 'file.txt']
-        res = self.cli_runner(cmd_remote.remote_cat, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_remote.remote_cat, options)
         assert res.exit_code == 0, 'The command verdi data remote cat did not finish correctly'
         assert b'test string' in res.stdout_bytes, 'The string "test string" was not found in the output' \
             ' of verdi data remote cat file.txt'
@@ -616,7 +616,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
                 '1',
                 '1',
             ]
-            res = self.cli_runner(cmd_structure.import_aiida_xyz, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -638,7 +638,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
                 fhandle.name,
                 '-n'  # dry-run
             ]
-            res = self.cli_runner(cmd_structure.import_aiida_xyz, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -672,7 +672,7 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
                 '--group',
                 group_label,
             ]
-            res = self.cli_runner(cmd_structure.import_aiida_xyz, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -701,7 +701,7 @@ PRIMVEC
             options = [
                 fhandle.name,
             ]
-            res = self.cli_runner(cmd_structure.import_ase, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_ase, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -726,7 +726,7 @@ PRIMVEC
             fhandle.write(xsfcontent)
             fhandle.flush()
             options = [fhandle.name, '--label', 'another  structure', '--group', group_label]
-            res = self.cli_runner(cmd_structure.import_ase, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_structure.import_ase, options)
             assert b'Successfully imported' in res.stdout_bytes, \
                 'The string "Successfully imported" was not found in the output' \
                 ' of verdi data structure import.'
@@ -810,13 +810,13 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
 
     def test_showhelp(self):
         options = ['--help']
-        res = self.cli_runner(cmd_cif.cif_show, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_cif.cif_show, options)
         assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output' \
             ' of verdi data show help'
 
     def test_importhelp(self):
         options = ['--help']
-        res = self.cli_runner(cmd_cif.cif_import, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_cif.cif_import, options)
         assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output' \
             ' of verdi data import help'
 
@@ -826,14 +826,14 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
             fhandle.write(self.valid_sample_cif_str)
             fhandle.flush()
             options = [fhandle.name]
-            res = self.cli_runner(cmd_cif.cif_import, options, catch_exceptions=False)
+            res = self.cli_runner(cmd_cif.cif_import, options)
             assert b'imported uuid' in res.stdout_bytes, 'The string "imported uuid" was not found in the output' \
                 ' of verdi data import.'
 
     def test_content(self):
         """Test that `verdi data cif content` returns the content of the file."""
         options = [str(self.cif.uuid)]
-        result = self.cli_runner(cmd_cif.cif_content, options, catch_exceptions=False)
+        result = self.cli_runner(cmd_cif.cif_content, options)
 
         for line in result.output.split('\n'):
             assert line in self.valid_sample_cif_str
@@ -866,7 +866,7 @@ class TestVerdiDataSinglefile(DummyVerdiDataListable, DummyVerdiDataExportable):
         singlefile = orm.SinglefileData(file=io.BytesIO(content.encode('utf8'))).store()
 
         options = [str(singlefile.uuid)]
-        result = self.cli_runner(cmd_singlefile.singlefile_content, options, catch_exceptions=False)
+        result = self.cli_runner(cmd_singlefile.singlefile_content, options)
 
         for line in result.output.split('\n'):
             assert line in content
@@ -884,7 +884,7 @@ class TestVerdiDataUpf:
 
     def upload_family(self):
         options = [self.filepath_pseudos, 'test_group', 'test description']
-        res = self.cli_runner(cmd_upf.upf_uploadfamily, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_uploadfamily, options)
         assert b'UPF files found: 4' in res.stdout_bytes, 'The string "UPF files found: 4" was not found in the' \
             ' output of verdi data upf uploadfamily'
 
@@ -906,7 +906,7 @@ class TestVerdiDataUpf:
         self.upload_family()
 
         options = [tmp_path, 'test_group']
-        self.cli_runner(cmd_upf.upf_exportfamily, options, catch_exceptions=False)
+        self.cli_runner(cmd_upf.upf_exportfamily, options)
         output = sp.check_output(['ls', tmp_path])
         assert b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output, \
             f'Sub-command verdi data upf exportfamily --help failed: {output}'
@@ -925,7 +925,7 @@ class TestVerdiDataUpf:
         self.upload_family()
 
         options = ['-d', '-e', 'Ba']
-        res = self.cli_runner(cmd_upf.upf_listfamilies, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_listfamilies, options)
 
         assert b'test_group' in res.stdout_bytes, 'The string "test_group" was not found in the' \
             ' output of verdi data upf listfamilies: {}'.format(res.output)
@@ -934,7 +934,7 @@ class TestVerdiDataUpf:
             ' output of verdi data upf listfamilies'
 
         options = ['-d', '-e', 'Fe']
-        res = self.cli_runner(cmd_upf.upf_listfamilies, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_listfamilies, options)
         assert b'No valid UPF pseudopotential' in res.stdout_bytes, (
             'The string "No valid UPF pseudopotential" was not found in the output of verdi data upf listfamilies'
         )
@@ -945,7 +945,7 @@ class TestVerdiDataUpf:
 
     def test_import(self):
         options = [os.path.join(self.filepath_pseudos, 'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF')]
-        res = self.cli_runner(cmd_upf.upf_import, options, catch_exceptions=False)
+        res = self.cli_runner(cmd_upf.upf_import, options)
 
         assert b'Imported' in res.stdout_bytes, 'The string "Imported" was not' \
             ' found in the output of verdi data import: {}'.format(res.output)

--- a/tests/cmdline/commands/test_help.py
+++ b/tests/cmdline/commands/test_help.py
@@ -29,12 +29,12 @@ class TestVerdiHelpCommand:
         """
         # don't invoke the cmd directly to make sure ctx.parent is properly populated
         # as it would be when called as a cli
-        result_help = self.cli_runner(cmd_verdi.verdi, ['help'], catch_exceptions=False)
-        result_verdi = self.cli_runner(cmd_verdi.verdi, [], catch_exceptions=False)
+        result_help = self.cli_runner(cmd_verdi.verdi, ['help'])
+        result_verdi = self.cli_runner(cmd_verdi.verdi, [])
         assert result_help.output == result_verdi.output
 
     def test_cmd_help(self):
         """Ensure we get the same help for `verdi user --help` and `verdi help user`"""
-        result_help = self.cli_runner(cmd_verdi.verdi, ['help', 'user'], catch_exceptions=False)
-        result_user = self.cli_runner(cmd_verdi.verdi, ['user', '--help'], catch_exceptions=False)
+        result_help = self.cli_runner(cmd_verdi.verdi, ['help', 'user'])
+        result_user = self.cli_runner(cmd_verdi.verdi, ['user', '--help'])
         assert result_help.output == result_user.output

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -159,12 +159,12 @@ class TestVerdiNode:
         folder_node = self.get_unstored_folder_node().store()
 
         options = [str(folder_node.pk), 'some/nested/folder']
-        result = run_cli_command(cmd_node.repo_ls, options, catch_exceptions=False)
+        result = run_cli_command(cmd_node.repo_ls, options)
 
         assert 'filename.txt' in result.output
 
         options = [str(folder_node.pk), 'some/non-existing-folder']
-        result = run_cli_command(cmd_node.repo_ls, options, catch_exceptions=False, raises=True)
+        result = run_cli_command(cmd_node.repo_ls, options, raises=True)
         assert 'does not exist for the given node' in result.output
 
     def test_node_repo_cat(self, run_cli_command):
@@ -194,7 +194,7 @@ class TestVerdiNode:
         folder_node = self.get_unstored_folder_node().store()
         out_path = tmp_path / 'out_dir'
         options = [str(folder_node.uuid), str(out_path)]
-        res = run_cli_command(cmd_node.repo_dump, options, catch_exceptions=False)
+        res = run_cli_command(cmd_node.repo_dump, options)
         assert not res.stdout
 
         for file_key, content in [(self.key_file1, self.content_file1), (self.key_file2, self.content_file2)]:
@@ -210,7 +210,7 @@ class TestVerdiNode:
         folder_node = self.get_unstored_folder_node().store()
         out_path = tmp_path / 'out_dir' / 'nested' / 'path'
         options = [str(folder_node.uuid), str(out_path)]
-        res = run_cli_command(cmd_node.repo_dump, options, catch_exceptions=False)
+        res = run_cli_command(cmd_node.repo_dump, options)
         assert not res.stdout
 
         for file_key, content in [(self.key_file1, self.content_file1), (self.key_file2, self.content_file2)]:
@@ -232,9 +232,8 @@ class TestVerdiNode:
         with some_file.open('w') as file_handle:
             file_handle.write(some_file_content)
         options = [str(folder_node.uuid), str(out_path)]
-        res = run_cli_command(cmd_node.repo_dump, options, catch_exceptions=False)
-        assert 'exists' in res.stdout
-        assert 'Critical:' in res.stdout
+        res = run_cli_command(cmd_node.repo_dump, options, raises=True)
+        assert 'exists' in res.stderr
 
         # Make sure the directory content is still there
         with some_file.open('r') as file_handle:
@@ -329,22 +328,19 @@ class TestVerdiGraph:
             delete_temporary_file(filename)
 
     def test_check_recursion_flags(self, run_cli_command):
-        """
-        Test the ancestor-depth and descendent-depth options.
-        Test that they don't fail and that, if specified, they only accept
-        positive ints
+        """Test the ancestor-depth and descendent-depth options.
+
+        Test that they don't fail if not specified and that, if specified, they only accept positive ints
         """
         root_node = str(self.node.pk)
         filename = f'{root_node}.dot.pdf'
 
-        # Test that the options don't fail
-        for opt in ['-a', '--ancestor-depth', '-d', '--descendant-depth']:
-            options = [opt, None, root_node]
-            try:
-                run_cli_command(cmd_node.graph_generate, options)
-                assert os.path.isfile(filename)
-            finally:
-                delete_temporary_file(filename)
+        # Test that not specifying them works
+        try:
+            run_cli_command(cmd_node.graph_generate, [root_node])
+            assert os.path.isfile(filename)
+        finally:
+            delete_temporary_file(filename)
 
         # Test that the options accept zero or a positive int
         for opt in ['-a', '--ancestor-depth', '-d', '--descendant-depth']:
@@ -432,7 +428,7 @@ class TestVerdiUserCommand:
 
     def test_comment_show_simple(self, run_cli_command):
         """Test simply calling the show command (without data to show)."""
-        result = run_cli_command(cmd_node.comment_show, [], catch_exceptions=False)
+        result = run_cli_command(cmd_node.comment_show, [])
         assert result.output == ''
         assert result.exit_code == 0
 
@@ -441,14 +437,14 @@ class TestVerdiUserCommand:
         self.node.base.comments.add(COMMENT)
 
         options = [str(self.node.pk)]
-        result = run_cli_command(cmd_node.comment_show, options, catch_exceptions=False)
+        result = run_cli_command(cmd_node.comment_show, options)
         assert result.output.find(COMMENT) != -1
         assert result.exit_code == 0
 
     def test_comment_add(self, run_cli_command):
         """Test adding a comment."""
         options = ['-N', str(self.node.pk), '--', f'{COMMENT}']
-        result = run_cli_command(cmd_node.comment_add, options, catch_exceptions=False)
+        result = run_cli_command(cmd_node.comment_add, options)
         assert result.exit_code == 0
 
         comment = self.node.base.comments.all()
@@ -462,7 +458,7 @@ class TestVerdiUserCommand:
         assert len(self.node.base.comments.all()) == 1
 
         options = [str(comment.pk), '--force']
-        result = run_cli_command(cmd_node.comment_remove, options, catch_exceptions=False)
+        result = run_cli_command(cmd_node.comment_remove, options)
         assert result.exit_code == 0, result.output
         assert len(self.node.base.comments.all()) == 0
 

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -586,7 +586,7 @@ def test_node_delete_basics(run_cli_command, options):
     run_cli_command(cmd_node.node_delete, options + [str(pk), '--dry-run'])
 
     # To delete the created node
-    run_cli_command(cmd_node.node_delete, [str(pk), '--force'])
+    run_cli_command(cmd_node.node_delete, [str(pk), '--force'], use_subprocess=True)
 
     with pytest.raises(NotExistent):
         orm.load_node(pk)

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -46,8 +46,8 @@ class TestVerdiSetup:
         If this test hangs, most likely the `--help` eagerness is overruled by another option that has started the
         prompt cycle, which by waiting for input, will block the test from continuing.
         """
-        self.cli_runner(cmd_setup.setup, ['--help'], catch_exceptions=False)
-        self.cli_runner(cmd_setup.quicksetup, ['--help'], catch_exceptions=False)
+        self.cli_runner(cmd_setup.setup, ['--help'])
+        self.cli_runner(cmd_setup.quicksetup, ['--help'])
 
     def test_quicksetup(self):
         """Test `verdi quicksetup`."""

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -27,7 +27,7 @@ def tests_storage_info(aiida_localhost, run_cli_command):
     from aiida import orm
     node = orm.Dict().store()
 
-    result = run_cli_command(cmd_storage.storage_info, options=['--detailed'])
+    result = run_cli_command(cmd_storage.storage_info, parameters=['--detailed'])
 
     assert aiida_localhost.label in result.output
     assert node.node_type in result.output
@@ -36,7 +36,7 @@ def tests_storage_info(aiida_localhost, run_cli_command):
 @pytest.mark.usefixtures('stopped_daemon_client')
 def tests_storage_migrate_force(run_cli_command):
     """Test the ``verdi storage migrate`` command (with force option)."""
-    result = run_cli_command(cmd_storage.storage_migrate, options=['--force'])
+    result = run_cli_command(cmd_storage.storage_migrate, parameters=['--force'])
     assert 'Migrating to the head of the main branch' in result.output
 
 
@@ -86,7 +86,7 @@ def tests_storage_migrate_cancel_prompt(run_cli_command, monkeypatch):
         },
         {
             'raises': True,
-            'options': ['--force']
+            'parameters': ['--force']
         },
     ]
 )
@@ -145,14 +145,14 @@ def tests_storage_maintain_logging(run_cli_command, monkeypatch, caplog):
     assert ' > dry_run: False' in message_list
 
     with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, options=['--dry-run'])
+        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--dry-run'])
 
     message_list = caplog.records[1].msg.splitlines()
     assert ' > full: False' in message_list
     assert ' > dry_run: True' in message_list
 
     with caplog.at_level(logging.INFO):
-        run_cli_command(cmd_storage.storage_maintain, options=['--full'], user_input='Y')
+        run_cli_command(cmd_storage.storage_maintain, parameters=['--full'], user_input='Y')
 
     message_list = caplog.records[2].msg.splitlines()
     assert ' > full: True' in message_list

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -47,7 +47,7 @@ class TestVerdiUserCommand:
         """Test `verdi user list`."""
         from aiida.cmdline.commands.cmd_user import user_list as list_user
 
-        result = self.cli_runner(list_user, [], catch_exceptions=False)
+        result = self.cli_runner(list_user, [])
         assert USER_1['email'] in result.output
 
     def test_user_create(self):
@@ -63,7 +63,7 @@ class TestVerdiUserCommand:
             USER_2['institution'],
         ]
 
-        result = self.cli_runner(cmd_user.user_configure, cli_options, catch_exceptions=False)
+        result = self.cli_runner(cmd_user.user_configure, cli_options)
         assert USER_2['email'] in result.output
         assert 'created' in result.output
         assert 'updated' not in result.output
@@ -87,7 +87,7 @@ class TestVerdiUserCommand:
             USER_2['institution'],
         ]
 
-        result = self.cli_runner(cmd_user.user_configure, cli_options, catch_exceptions=False)
+        result = self.cli_runner(cmd_user.user_configure, cli_options)
         assert email in result.output
         assert 'updated' in result.output
         assert 'created' not in result.output


### PR DESCRIPTION
Fixes #5842 

The `verdi code delete` command would report that the `Code` was deleted
but the changes were actually not committed. This went unnoticed since
the test for it used the `click.CliRunner` which doesn't follow the
exact same path as a real invocation on the command line. In particular,
in this example the treatment of the session is different with it not
being committed properly in the command line invocation pathway. The
problem is shown by using `use_subprocess=True` when calling the command
using the `run_cli_command` fixture, after which the test fails.