### PR TITLE
reduce to 10 iterations in performance benchmark

### DIFF
--- a/docs/source/howto/include/scripts/performance_benchmark_base.py
+++ b/docs/source/howto/include/scripts/performance_benchmark_base.py
@@ -9,7 +9,7 @@ from aiida.cmdline.utils import decorators, echo
 
 @click.command()
 @options.CODE(required=False, help='A code that can run the ``ArithmeticAddCalculation``, for example bash.')
-@click.option('-n', 'number', type=int, default=100, show_default=True, help='The number of processes to submit.')
+@click.option('-n', 'number', type=int, default=10, show_default=True, help='The number of processes to submit.')
 @click.option('--daemon/--without-daemon', default=False, is_flag=True, help='Submit to daemon or run synchronously.')
 @decorators.with_dbenv()
 def main(code, number, daemon):

--- a/docs/source/howto/include/scripts/performance_benchmark_base.py
+++ b/docs/source/howto/include/scripts/performance_benchmark_base.py
@@ -9,7 +9,7 @@ from aiida.cmdline.utils import decorators, echo
 
 @click.command()
 @options.CODE(required=False, help='A code that can run the ``ArithmeticAddCalculation``, for example bash.')
-@click.option('-n', 'number', type=int, default=10, show_default=True, help='The number of processes to submit.')
+@click.option('-n', 'number', type=int, default=10, show_default=True, help='The number of processes to launch.')
 @click.option('--daemon/--without-daemon', default=False, is_flag=True, help='Submit to daemon or run synchronously.')
 @decorators.with_dbenv()
 def main(code, number, daemon):

--- a/docs/source/howto/include/scripts/performance_benchmark_base.py
+++ b/docs/source/howto/include/scripts/performance_benchmark_base.py
@@ -28,9 +28,9 @@ def main(code, number, daemon):
     import uuid
 
     from aiida import orm
-    from aiida.common import exceptions
     from aiida.engine import run_get_node, submit
     from aiida.engine.daemon.client import get_daemon_client
+    from aiida.manage import get_manager
     from aiida.plugins import CalculationFactory
     from aiida.tools.graph.deletions import delete_nodes
 
@@ -41,6 +41,8 @@ def main(code, number, daemon):
 
     computer_created = False
     code_created = False
+
+    echo.echo(f'Running on profile {get_manager().get_profile().name}')
 
     if not code:
         label = f'benchmark-{uuid.uuid4().hex[:8]}'

--- a/docs/source/topics/performance.rst
+++ b/docs/source/topics/performance.rst
@@ -52,10 +52,11 @@ Benchmarks
 
 The :download:`benchmark script <../howto/include/scripts/performance_benchmark_base.py>` :fa:`download` provides a basic way of assessing performance of the workflow engine that involves all components (CPU, file system, postgresql, rabbitmq).
 
-It launches 100 ``ArithmeticAddCalculation`` jobs on the localhost and measures the time until completion.
+It launches ``ArithmeticAddCalculation``s on the localhost and measures the time until completion.
 Since the workload of the ``ArithmeticAddCalculation`` (summing two numbers) completes instantly, the time per process is a reasonable measure of the overhead incurred from the workflow engine.
 
-The numbers reported in the :ref:`howto section<how-to:installation:performance>` were obtained using a single daemon worker and can be reduced by increasing the number of daemon workers:
+The numbers reported in the :ref:`howto section<how-to:installation:performance>` were obtained by running the processes through the Python interpreter.
+The ``--daemon`` option can be used to run the calculations through the AiiDA daemon instead, and to look at parallelizing over multiple daemon workers:
 
 .. table::
     :widths: auto

--- a/docs/source/topics/performance.rst
+++ b/docs/source/topics/performance.rst
@@ -55,7 +55,7 @@ The :download:`benchmark script <../howto/include/scripts/performance_benchmark_
 It launches ``ArithmeticAddCalculation``s on the localhost and measures the time until completion.
 Since the workload of the ``ArithmeticAddCalculation`` (summing two numbers) completes instantly, the time per process is a reasonable measure of the overhead incurred from the workflow engine.
 
-The numbers reported in the :ref:`howto section<how-to:installation:performance>` were obtained by running the processes through the Python interpreter.
+The numbers reported in the :ref:`howto section<how-to:installation:performance>` were obtained by running the processes in the current shell, which is the default.
 The ``--daemon`` option can be used to run the calculations through the AiiDA daemon instead, and to look at parallelizing over multiple daemon workers:
 
 .. table::


### PR DESCRIPTION
In "slow" setups, the overhead per process can be of the order of 2s. No need to make the user wait 3 minutes.
Even for the fastest machines with ~0.2s per process, 10 iterations are plenty.