### PR TITLE
CLI: verdi export to a yaml file with keys from code class

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -13,6 +13,7 @@ from functools import partial
 
 import click
 import tabulate
+import yaml
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.groups.dynamic import DynamicEntryPointCommandGroup
@@ -233,6 +234,26 @@ def show(code):
         table.append(['Calculations', len(code.base.links.get_outgoing().all())])
 
     echo.echo(tabulate.tabulate(table))
+
+
+@verdi_code.command()
+@arguments.CODE()
+@arguments.OUTPUT_FILE(type=click.Path(exists=False))
+@with_dbenv()
+def export(code, output_file):
+    """Export code to a yaml file."""
+    code_data = {}
+
+    for key in code.get_cli_options().keys():
+        if key == 'computer':
+            value = getattr(code, key).label
+        else:
+            value = getattr(code, key)
+
+        code_data[key] = str(value)
+
+    with open(output_file, 'w', encoding='utf-8') as yfhandle:
+        yaml.dump(code_data, yfhandle)
 
 
 @verdi_code.command()

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -64,7 +64,6 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         self.append_text = append_text
         self.prepend_text = prepend_text
         self.use_double_quotes = use_double_quotes
-        self.use_double_quotes = use_double_quotes
         self.is_hidden = is_hidden
 
     @abc.abstractmethod

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -75,6 +75,7 @@ Below is a list with all available subcommands.
       create     Create a new code.
       delete     Delete a code.
       duplicate  Duplicate a code allowing to change some parameters.
+      export     Export code to a yaml file.
       hide       Hide one or more codes from `verdi code list`.
       list       List the available codes.
       relabel    Relabel a code.

--- a/tests/cmdline/commands/test_code/test_code_export.yml
+++ b/tests/cmdline/commands/test_code/test_code_export.yml
@@ -1,0 +1,8 @@
+append_text: ''
+computer: localhost
+default_calc_job_plugin: core.arithmetic.add
+description: code
+filepath_executable: /bin/cat
+label: code
+prepend_text: "module load something\n    some command"
+use_double_quotes: 'False'


### PR DESCRIPTION
Addresses #3521 partially.

This is mentioned in usability improvement as well as having a command to export the code and computer setup. 
Keys of YAML file are read from the cli option of the corresponding code class.

However, for the `prepend_text` and `append_text` I did not implement polish of the yaml output. If they are multiline content, the value of the text in YAML file won't be properly indented. For example, see the output YAML below:
```YAML
append_text: ''
computer: localhost
default_calc_job_plugin: core.templatereplacer
description: doubler
filepath_executable: /min
label: doubler1
prepend_text: 'module load daint-gpu

    module load CP2K

    '
use_double_quotes: 'False'
```

where the `prepend_text` of original config yaml file is:

```YAML
prepend_text: |
    module load daint-gpu
    module load CP2K
```

When I look at #3616, I find @sphuber tried to put into subcommand `show` format options to dump as YAML. It can also be an option. 