### PR TITLE
fix: more flexible verdi status check

### DIFF
--- a/aiida/cmdline/utils/daemon.py
+++ b/aiida/cmdline/utils/daemon.py
@@ -12,7 +12,9 @@ from tabulate import tabulate
 
 from aiida.cmdline.utils import echo
 
-_START_CIRCUS_COMMAND = 'start-circus'
+# circus daemon process can appear as 'start-circus' or 'circusd'
+# see https://github.com/aiidateam/aiida-core/issues/5336#issuecomment-1376093322
+_START_CIRCUS_COMMANDS = ['start-circus', 'circusd']
 
 
 def print_client_response_status(response):
@@ -127,7 +129,7 @@ def delete_stale_pid_file(client):
         try:
             process = psutil.Process(pid)
             # the PID got recycled, but a different process
-            if _START_CIRCUS_COMMAND not in process.cmdline():
+            if not any(cmd in process.cmdline() for cmd in _START_CIRCUS_COMMANDS):
                 raise StartCircusNotFound()  # Also this is a case in which the process is not there anymore
 
             # the PID got recycled, but for a daemon of someone else


### PR DESCRIPTION
`verdi status` was checking for the presence of the daemon by the name of the corresponding process. If the name was not as expected, it deleted (!) the PID file.

On some systems, the name of the daemon process differed from the name expected by AiiDA, causing `verdi status` to delete the PID file of a correctly operating daemon.