### PR TITLE
`InstalledCode`: Allow relative path for `filepath_executable`

### DIFF
--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -69,9 +69,14 @@ class InstalledCode(Code):
         is intentionally not called in ``_validate`` as to allow the creation of ``Code`` instances whose computers can
         not yet be connected to and as to not require the overhead of opening transports in storing a new code.
 
+        .. note:: If the ``filepath_executable`` is not an absolute path, the check is skipped.
+
         :raises `~aiida.common.exceptions.ValidationError`: if no transport could be opened or if the defined executable
             does not exist on the remote computer.
         """
+        if not self.filepath_executable.is_absolute():
+            return
+
         try:
             with override_log_level():  # Temporarily suppress noisy logging
                 with self.computer.get_transport() as transport:
@@ -146,10 +151,6 @@ class InstalledCode(Code):
         :param value: The absolute filepath of the executable.
         """
         type_check(value, str)
-
-        if not pathlib.PurePosixPath(value).is_absolute():
-            raise ValueError('the `filepath_executable` should be absolute.')
-
         self.base.attributes.set(self._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE, value)
 
     @staticmethod

--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -456,7 +456,7 @@ InstalledCode
 
 The :class:`~aiida.orm.nodes.data.code.installed.InstalledCode` class is an implementation of the :class:`~aiida.orm.nodes.data.code.abstract.AbstractCode` class that represents an executable code on a remote computer.
 This plugin should be used if an executable is pre-installed on a computer.
-The ``InstalledCode`` represents the code by storing the absolute filepath of the relevant executable and the computer on which it is installed.
+The ``InstalledCode`` represents the code by storing the filepath of the relevant executable and the computer on which it is installed.
 The computer is represented by an instance of :class:`~aiida.orm.computers.Computer`.
 Each time a :class:`~aiida.engine.CalcJob` is run using an ``InstalledCode``, it will run its executable on the associated computer.
 Example of creating an ``InstalledCode``:
@@ -469,6 +469,9 @@ Example of creating an ``InstalledCode``:
         computer=load_computer('localhost'),
         filepath_executable='/usr/bin/bash'
     )
+
+.. versionchanged:: 2.3
+    The ``filepath_executable`` is no longer required to be an absolute path but can be just the executable name.
 
 
 .. _topics:data_types:core:code:portable:

--- a/tests/orm/data/code/test_installed.py
+++ b/tests/orm/data/code/test_installed.py
@@ -69,6 +69,12 @@ def test_filepath_executable(aiida_localhost):
     code = InstalledCode(computer=aiida_localhost, filepath_executable=filepath_executable)
     assert code.filepath_executable == pathlib.PurePath(filepath_executable)
 
+    # Relative path
+    filepath_executable = 'bash'
+    code = InstalledCode(computer=aiida_localhost, filepath_executable=filepath_executable)
+    assert code.filepath_executable == pathlib.PurePath(filepath_executable)
+
+    # Change through the property
     filepath_executable = '/usr/bin/cat'
     code.filepath_executable = filepath_executable
     assert code.filepath_executable == pathlib.PurePath(filepath_executable)


### PR DESCRIPTION
Fixes #5867 

The `InstalledCode` required the `filepath_executable` to be an absolute path. The original reasoning behind this design choice was that this improves the provenance of data produced with this code slightly as it would be more difficult to accidentally change the version of the code that was associated with the executable. For relative paths, the actual linked code could be easily changed through, for example, environment variables.

However, this restriction also has downsides. On many compute clusters the preferred approach is to load specific modules that provide the software of interest in which relative executables are provided. The absolute paths can change depending on microarchitecture of the system or other system variables. Requiring the user to provide the absolute path to the executable defeats the purpose of this system.

Therefore the requirement of the executable path having to be absolute is dropped.