### PR TITLE
File name can now be specified for `verdi node graph generate`

### DIFF
--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -435,11 +435,11 @@ def verdi_graph():
     multiple=True
 )
 @click.option('-s', '--show', is_flag=True, help='Open the rendered result with the default application.')
-@click.option('--basename', default=None, help='Select file name')
+@arguments.OUTPUT_FILE(required=False)
 @decorators.with_dbenv()
 def graph_generate(
     root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine, output_format,
-    highlight_classes, show, basename
+    highlight_classes, show, output_file
 ):
     """
     Generate a graph from a ROOT_NODE (specified by pk or uuid).
@@ -471,7 +471,7 @@ def graph_generate(
     )
     basename = basename if basename else root_node.pk
     output_file_name = graph.graphviz.render(
-        filename=f'{basename}.{engine}', format=output_format, view=show, cleanup=True
+        filename=output_file or f'{root_node.pk}.{engine}', format=output_format, view=show, cleanup=True
     )
 
     echo.echo_success(f'Output file: {output_file_name}')

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -435,10 +435,11 @@ def verdi_graph():
     multiple=True
 )
 @click.option('-s', '--show', is_flag=True, help='Open the rendered result with the default application.')
+@click.option('--basename', default=None, help='Select file name')
 @decorators.with_dbenv()
 def graph_generate(
     root_node, link_types, identifier, ancestor_depth, descendant_depth, process_out, process_in, engine, output_format,
-    highlight_classes, show
+    highlight_classes, show, basename
 ):
     """
     Generate a graph from a ROOT_NODE (specified by pk or uuid).
@@ -468,8 +469,9 @@ def graph_generate(
         include_process_inputs=process_in,
         highlight_classes=highlight_classes,
     )
+    basename = basename if basename else root_node.pk
     output_file_name = graph.graphviz.render(
-        filename=f'{root_node.pk}.{engine}', format=output_format, view=show, cleanup=True
+        filename=f'{basename}.{engine}', format=output_format, view=show, cleanup=True
     )
 
     echo.echo_success(f'Output file: {output_file_name}')

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -469,7 +469,6 @@ def graph_generate(
         include_process_inputs=process_in,
         highlight_classes=highlight_classes,
     )
-    basename = basename if basename else root_node.pk
     output_file_name = graph.graphviz.render(
         filename=output_file or f'{root_node.pk}.{engine}', format=output_format, view=show, cleanup=True
     )

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -469,11 +469,13 @@ def graph_generate(
         include_process_inputs=process_in,
         highlight_classes=highlight_classes,
     )
-    output_file_name = graph.graphviz.render(
-        filename=output_file or f'{root_node.pk}.{engine}', format=output_format, view=show, cleanup=True
-    )
 
-    echo.echo_success(f'Output file: {output_file_name}')
+    if not output_file:
+        output_file = pathlib.Path(f'{root_node.pk}.{engine}.{output_format}')
+
+    output_file_name = graph.graphviz.render(outfile=output_file, format=output_format, view=show, cleanup=True)
+
+    echo.echo_success(f'Output written to `{output_file_name}`')
 
 
 @verdi_node.group('comment')

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -417,21 +417,15 @@ class TestVerdiGraph:
             finally:
                 delete_temporary_file(filename)
 
-    def test_file_base_name(self, run_cli_command):
-        """
-        Test that the output file base name can be specified.
-        """
+    @pytest.mark.parametrize('output_file', ['output_filename', 'with_extension.dot'])
+    def test_file_base_name(self, run_cli_command, output_file):
+        """Test that the output file base name can be specified through an argument."""
         root_node = str(self.node.pk)
-        option = '--basename'
-
-        for basename in ['name1', 'name2']:
-            filename = f'{basename}.dot.pdf'
-            options = [option, basename, root_node]
-            try:
-                run_cli_command(cmd_node.graph_generate, options)
-                assert os.path.isfile(filename)
-            finally:
-                delete_temporary_file(filename)
+        try:
+            run_cli_command(cmd_node.graph_generate, [root_node, output_file])
+            assert os.path.isfile(output_file)
+        finally:
+            delete_temporary_file(output_file)
 
 
 COMMENT = 'Well I never...'

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -417,6 +417,22 @@ class TestVerdiGraph:
             finally:
                 delete_temporary_file(filename)
 
+    def test_file_base_name(self, run_cli_command):
+        """
+        Test that the output file base name can be specified.
+        """
+        root_node = str(self.node.pk)
+        option = '--basename'
+
+        for basename in ['name1', 'name2']:
+            filename = f'{basename}.dot.pdf'
+            options = [option, basename, root_node]
+            try:
+                run_cli_command(cmd_node.graph_generate, options)
+                assert os.path.isfile(filename)
+            finally:
+                delete_temporary_file(filename)
+
 
 COMMENT = 'Well I never...'
 

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -417,12 +417,11 @@ class TestVerdiGraph:
             finally:
                 delete_temporary_file(filename)
 
-    @pytest.mark.parametrize('output_file', ['output_filename.pdf', 'with_extension.dot.pdf'])
-    def test_file_base_name(self, run_cli_command, output_file):
-        """Test that the output file base name can be specified through an argument."""
-        root_node = str(self.node.pk)
+    @pytest.mark.parametrize('output_file', ('without_extension', 'without_extension.pdf'))
+    def test_output_file(self, run_cli_command, output_file):
+        """Test that the output file can be specified through an argument."""
         try:
-            run_cli_command(cmd_node.graph_generate, [root_node, output_file])
+            run_cli_command(cmd_node.graph_generate, [str(self.node.pk), output_file])
             assert os.path.isfile(output_file)
         finally:
             delete_temporary_file(output_file)

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -417,7 +417,7 @@ class TestVerdiGraph:
             finally:
                 delete_temporary_file(filename)
 
-    @pytest.mark.parametrize('output_file', ['output_filename', 'with_extension.dot'])
+    @pytest.mark.parametrize('output_file', ['output_filename.pdf', 'with_extension.dot.pdf'])
     def test_file_base_name(self, run_cli_command, output_file):
         """Test that the output file base name can be specified through an argument."""
         root_node = str(self.node.pk)


### PR DESCRIPTION
Closes #5692
Added a `--basename` option so that the user could specify a file base name.
if not specified, the default file base name would be the node PK.