### PR TITLE
Dependencies: Remove upper limit on `werkzeug`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,5 +34,4 @@ dependencies:
 - tabulate~=0.8.5
 - tqdm~=4.45
 - upf_to_json~=0.9.2
-- werkzeug<2.2
 - wrapt~=1.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "tabulate~=0.8.5",
     "tqdm~=4.45",
     "upf_to_json~=0.9.2",
-    "werkzeug<2.2",
     "wrapt~=1.11"
 ]
 

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -61,7 +61,7 @@ jupyterlab-widgets==1.0.2
 kiwipy==0.7.7
 kiwisolver==1.3.2
 Mako==1.2.2
-MarkupSafe==2.0.1
+MarkupSafe==2.1.1
 matplotlib==3.5.0
 matplotlib-inline==0.1.3
 mistune==0.8.4
@@ -166,7 +166,7 @@ upf-to-json==0.9.3
 urllib3==1.26.7
 wcwidth==0.2.5
 webencodings==0.5.1
-Werkzeug==2.0.2
+Werkzeug==2.2.3
 widgetsnbextension==3.5.2
 wrapt==1.11.2
 yarl==1.7.2

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -188,7 +188,7 @@ urllib3==1.26.13
 wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==1.4.2
-Werkzeug==2.1.2
+Werkzeug==2.2.3
 widgetsnbextension==4.0.3
 wrapt==1.14.1
 yarl==1.8.1

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -62,7 +62,7 @@ jupyterlab-widgets==1.0.2
 kiwipy==0.7.7
 kiwisolver==1.3.2
 Mako==1.2.2
-MarkupSafe==2.0.1
+MarkupSafe==2.1.1
 matplotlib==3.5.0
 matplotlib-inline==0.1.3
 mistune==0.8.4
@@ -168,7 +168,7 @@ upf-to-json==0.9.3
 urllib3==1.26.7
 wcwidth==0.2.5
 webencodings==0.5.1
-Werkzeug==2.0.2
+Werkzeug==2.2.3
 widgetsnbextension==3.5.2
 wrapt==1.11.2
 yarl==1.7.2

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -61,7 +61,7 @@ jupyterlab-widgets==1.0.2
 kiwipy==0.7.7
 kiwisolver==1.3.2
 Mako==1.2.2
-MarkupSafe==2.0.1
+MarkupSafe==2.1.1
 matplotlib==3.5.0
 matplotlib-inline==0.1.3
 mistune==0.8.4
@@ -167,7 +167,7 @@ upf-to-json==0.9.3
 urllib3==1.26.7
 wcwidth==0.2.5
 webencodings==0.5.1
-Werkzeug==2.0.2
+Werkzeug==2.2.3
 widgetsnbextension==3.5.2
 wrapt==1.11.2
 yarl==1.7.2


### PR DESCRIPTION
The limit was added in https://github.com/aiidateam/aiida-core/pull/5606 because the release of `werkzeug.2.2.0` was causing the REST API tests to fail, but it seems the patch releases have solved the problem.

Note that for posterity, the cause of the failures was the change in default behavior of trailing slashes in route resolution (see https://github.com/pallets/werkzeug/pull/2487)