### PR TITLE
Docs: Notify that an entry point is required for creating a data plugin

### DIFF
--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -1124,7 +1124,8 @@ Creating a new data type is as simple as creating a new sub class of the base :c
 
 .. note::
 
-    You must register a new data entry point. See `aiida.data <https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/plugins.html#aiida-data>`
+    To be able to use the new ``Data`` plugin, it must be registered using an entry point.
+	    See :ref:`What is an entry point?<topics:plugins:entrypoints>` for details.
 
 At this point, our new data type does nothing special.
 Typically, one creates a new data type to represent a specific type of data.

--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -1122,6 +1122,10 @@ Creating a new data type is as simple as creating a new sub class of the base :c
     class NewData(Data):
         """A new data type that wraps a single value."""
 
+.. note::
+
+    You must register a new data entry point. See `aiida.data <https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/plugins.html#aiida-data>`
+
 At this point, our new data type does nothing special.
 Typically, one creates a new data type to represent a specific type of data.
 For the purposes of this example, let's assume that the goal of our ``NewData`` type is to store a single numerical value.

--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -1125,7 +1125,7 @@ Creating a new data type is as simple as creating a new sub class of the base :c
 .. note::
 
     To be able to use the new ``Data`` plugin, it must be registered using an entry point.
-	    See :ref:`What is an entry point?<topics:plugins:entrypoints>` for details.
+    See :ref:`What is an entry point?<topics:plugins:entrypoints>` for details.
 
 At this point, our new data type does nothing special.
 Typically, one creates a new data type to represent a specific type of data.


### PR DESCRIPTION
Fixes #5456

Walking through the examples [here](https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/data_types.html?highlight=#creating-a-data-plugin) will fail because the data entry point registering step is required but not mentioned.

I added a simple note for registering with an entry point.