### PR TITLE
Fix: make it compatible with the latest version of PBSPro

### DIFF
--- a/aiida/schedulers/plugins/pbspro.py
+++ b/aiida/schedulers/plugins/pbspro.py
@@ -66,7 +66,7 @@ class PbsproScheduler(PbsBaseClass):
         if num_mpiprocs_per_machine:
             select_string += f':mpiprocs={num_mpiprocs_per_machine}'
         if num_cores_per_machine:
-            select_string += f':ppn={num_cores_per_machine}'
+            select_string += f':ncpus={num_cores_per_machine}'
 
         if max_wallclock_seconds is not None:
             try:

--- a/tests/schedulers/test_pbspro.py
+++ b/tests/schedulers/test_pbspro.py
@@ -1008,7 +1008,7 @@ class TestSubmitScript(unittest.TestCase):
         self.assertTrue('#PBS -r n' in submit_script_text)
         self.assertTrue(submit_script_text.startswith('#!/bin/bash'))
 
-        self.assertTrue('#PBS -l select=1:mpiprocs=1:ppn=24' in submit_script_text)
+        self.assertTrue('#PBS -l select=1:mpiprocs=1:ncpus=24' in submit_script_text)
         # Note: here 'num_cores_per_machine' should NOT override the mpiprocs
 
         self.assertTrue("'mpirun' '-np' '23' 'pw.x' '-npool' '1' < 'aiida.in'" in submit_script_text)
@@ -1042,7 +1042,7 @@ class TestSubmitScript(unittest.TestCase):
 
         self.assertTrue('#PBS -r n' in submit_script_text)
         self.assertTrue(submit_script_text.startswith('#!/bin/bash'))
-        self.assertTrue('#PBS -l select=1:mpiprocs=1:ppn=24' in submit_script_text)
+        self.assertTrue('#PBS -l select=1:mpiprocs=1:ncpus=24' in submit_script_text)
         # Note: here 'num_cores_per_machine' should NOT override the mpiprocs
 
         self.assertTrue("'mpirun' '-np' '23' 'pw.x' '-npool' '1' < 'aiida.in'" in submit_script_text)


### PR DESCRIPTION
Try to make it compatible with the latest version of PBS.

The nodes+ppn combination will be internally converted to the select+ncpus+mpiprocs pattern. 
However, the select+ppn combination doesn't work on the latest PBS implementations. (Tested on OpenPBS 20.0.0)
Since I have a very limited test environment, I appreciate any of your feedback.

Thanks!