### PR TITLE
Docs: point to CalcJob input documentation

### DIFF
--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -430,6 +430,9 @@ After :ref:`setting up your computer <how-to:run-codes:computer>` and :ref:`sett
         print(submit(builder))
 
     Of course, the code label and builder inputs need to be adapted to your code and calculation.
+    
+    .. note::
+       See also the :ref:`complete list of metadata<topics:calculations:usage:calcjobs:options>` you can pass to a calculation.
 
 *   Submit your calculation to the AiiDA daemon:
 

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -432,6 +432,7 @@ After :ref:`setting up your computer <how-to:run-codes:computer>` and :ref:`sett
     Of course, the code label and builder inputs need to be adapted to your code and calculation.
     
     .. note::
+    
        See also the :ref:`complete list of metadata<topics:calculations:usage:calcjobs:options>` you can pass to a calculation.
 
 *   Submit your calculation to the AiiDA daemon:

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -450,7 +450,7 @@ After :ref:`setting up your computer <how-to:run-codes:computer>` and :ref:`sett
     Of course, the code label and builder inputs need to be adapted to your code and calculation.
 
     .. note::
-    
+
        See also the :ref:`complete list of metadata<topics:calculations:usage:calcjobs:options>` you can pass to a calculation.
 
 *   Submit your calculation to the AiiDA daemon:

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -430,7 +430,7 @@ After :ref:`setting up your computer <how-to:run-codes:computer>` and :ref:`sett
         print(submit(builder))
 
     Of course, the code label and builder inputs need to be adapted to your code and calculation.
-    
+
     .. note::
     
        See also the :ref:`complete list of metadata<topics:calculations:usage:calcjobs:options>` you can pass to a calculation.


### PR DESCRIPTION
The AiiDA documentation includes an automatic documentation of all CalcJob inputs but it is quite hidden. Pointing to it from the documentation on how to submit a calculation.