### PR TITLE
Docs: Fix the overindentation of lists

### DIFF
--- a/docs/source/howto/data.rst
+++ b/docs/source/howto/data.rst
@@ -101,15 +101,15 @@ Once stored, this data can always be retrieved through the ``source`` property:
 
 The following list shows all the keys that are allowed to be set in the ``source`` dictionary:
 
-    * 'db_name': The name of the external database.
-    * 'db_uri': The base URI of the external database.
-    * 'uri': The exact URI of where the data can be retrieved. Ideally this is a persistent URI.
-    * 'id': The external ID with which the data is identified in the external database.
-    * 'version': The version of the data, if any.
-    * 'extras': Optional dictionary with other fields for source description.
-    * 'source_md5': MD5 checksum of the data.
-    * 'description': Human-readable free form description of the data's source.
-    * 'license': A string with the type of license that applies to the data, if any.
+* 'db_name': The name of the external database.
+* 'db_uri': The base URI of the external database.
+* 'uri': The exact URI of where the data can be retrieved. Ideally this is a persistent URI.
+* 'id': The external ID with which the data is identified in the external database.
+* 'version': The version of the data, if any.
+* 'extras': Optional dictionary with other fields for source description.
+* 'source_md5': MD5 checksum of the data.
+* 'description': Human-readable free form description of the data's source.
+* 'license': A string with the type of license that applies to the data, if any.
 
 If any other keys are defined, an exception will be raised by the constructor.
 

--- a/docs/source/howto/data.rst
+++ b/docs/source/howto/data.rst
@@ -24,14 +24,14 @@ You can list these using the :ref:`verdi plugin<reference:command-line:verdi-plu
 Executing ``verdi plugin list aiida.data`` should display something like::
 
     Registered entry points for aiida.data:
-    * array
-    * bool
-    * code
-    * dict
-    * float
-    * folder
-    * list
-    * singlefile
+    * core.array
+    * core.bool
+    * core.code
+    * core.dict
+    * core.float
+    * core.folder
+    * core.list
+    * core.singlefile
 
     Info: Pass the entry point as an argument to display detailed information
 
@@ -101,15 +101,15 @@ Once stored, this data can always be retrieved through the ``source`` property:
 
 The following list shows all the keys that are allowed to be set in the ``source`` dictionary:
 
-* 'db_name': The name of the external database.
-* 'db_uri': The base URI of the external database.
-* 'uri': The exact URI of where the data can be retrieved. Ideally this is a persistent URI.
-* 'id': The external ID with which the data is identified in the external database.
-* 'version': The version of the data, if any.
-* 'extras': Optional dictionary with other fields for source description.
-* 'source_md5': MD5 checksum of the data.
-* 'description': Human-readable free form description of the data's source.
-* 'license': A string with the type of license that applies to the data, if any.
+* ``db_name``: The name of the external database.
+* ``db_uri``: The base URI of the external database.
+* ``uri``: The exact URI of where the data can be retrieved. Ideally this is a persistent URI.
+* ``id``: The external ID with which the data is identified in the external database.
+* ``version``: The version of the data, if any.
+* ``extras``: Optional dictionary with other fields for source description.
+* ``source_md5``: MD5 checksum of the data.
+* ``description``: Human-readable free form description of the data's source.
+* ``license``: A string with the type of license that applies to the data, if any.
 
 If any other keys are defined, an exception will be raised by the constructor.
 

--- a/docs/source/howto/installation.rst
+++ b/docs/source/howto/installation.rst
@@ -115,9 +115,9 @@ Enable tab-completion for ``verdi`` one of the following supported shells
 Place this command in your shell or virtual environment activation script to automatically enable tab completion when opening a new shell or activating an environment.
 This file is shell specific, but likely one of the following:
 
-    * the startup file of your shell (``.bashrc``, ``.zsh``, ...), if aiida is installed system-wide
-    * the `activators <https://virtualenv.pypa.io/en/latest/user_guide.html#activators>`_ of your virtual environment
-    * a `startup file <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables>`_ for your conda environment
+* the startup file of your shell (``.bashrc``, ``.zsh``, ...), if aiida is installed system-wide
+* the `activators <https://virtualenv.pypa.io/en/latest/user_guide.html#activators>`_ of your virtual environment
+* a `startup file <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables>`_ for your conda environment
 
 
 .. important::

--- a/docs/source/howto/interact.rst
+++ b/docs/source/howto/interact.rst
@@ -6,11 +6,11 @@ How to interact with AiiDA
 
 There are a variety of manners to interact with AiiDA:
 
- * :ref:`Through the command line interface <how-to:interact-cli>`
- * :ref:`Through scripts <how-to:interact-scripts>`
- * :ref:`Through interactive shells <how-to:interact-shell>`
- * :ref:`Through interactive notebooks <how-to:interact-notebook>`
- * :ref:`Through the REST API <how-to:interact-restapi>`
+* :ref:`Through the command line interface <how-to:interact-cli>`
+* :ref:`Through scripts <how-to:interact-scripts>`
+* :ref:`Through interactive shells <how-to:interact-shell>`
+* :ref:`Through interactive notebooks <how-to:interact-notebook>`
+* :ref:`Through the REST API <how-to:interact-restapi>`
 
 
 .. _how-to:interact-cli:

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -276,9 +276,9 @@ The ``DiffCalculation`` example, defines the following exit code:
 
 An ``exit_code`` defines:
 
- * an exit status (a positive integer, following the :ref:`topics:processes:usage:exit_code_conventions`),
- * a label that can be used to reference the code in the |parse| method (through the ``self.exit_codes`` property, as shown below), and
- * a message that provides a more detailed description of the problem.
+* an exit status (a positive integer, following the :ref:`topics:processes:usage:exit_code_conventions`),
+* a label that can be used to reference the code in the |parse| method (through the ``self.exit_codes`` property, as shown below), and
+* a message that provides a more detailed description of the problem.
 
 In order to inform AiiDA about a failed calculation, simply return from the ``parse`` method the exit code that corresponds to the detected issue.
 Here is a more complete version of the example |Parser| presented in the previous section:
@@ -328,7 +328,7 @@ Registering entry points
 
 With your ``calculations.py`` and ``parsers.py`` files at hand, let's register entry points for the plugins they contain:
 
- * Move your two scripts into a subfolder ``aiida_diff_tutorial``:
+* Move your two scripts into a subfolder ``aiida_diff_tutorial``:
 
    .. code-block:: console
 
@@ -338,7 +338,7 @@ With your ``calculations.py`` and ``parsers.py`` files at hand, let's register e
 
    You have just created an ``aiida_diff_tutorial`` Python *package*!
 
- * Add a minimal set of metadata for your package by writing a ``pyproject.toml`` file:
+* Add a minimal set of metadata for your package by writing a ``pyproject.toml`` file:
 
     .. code-block:: toml
 
@@ -370,7 +370,7 @@ With your ``calculations.py`` and ``parsers.py`` files at hand, let's register e
         This allows for the project metadata to be fully specified in the pyproject.toml file, using the PEP 621 format.
 
 
- * Install your new ``aiida-diff-tutorial`` plugin package.
+* Install your new ``aiida-diff-tutorial`` plugin package.
 
    .. code-block:: console
 
@@ -395,7 +395,7 @@ Running a calculation
 With the entry points set up, you are ready to launch your first calculation with the new plugin:
 
 
- * If you haven't already done so, :ref:`set up your computer<how-to:run-codes:computer>`.
+* If you haven't already done so, :ref:`set up your computer<how-to:run-codes:computer>`.
    In the following we assume it to be the localhost:
 
     .. code-block:: console
@@ -403,7 +403,7 @@ With the entry points set up, you are ready to launch your first calculation wit
         $ verdi computer setup -L localhost -H localhost -T core.local -S core.direct -w `echo $PWD/work` -n
         $ verdi computer configure core.local localhost --safe-interval 5 -n
 
- *  Create the input files for our calculation
+*  Create the input files for our calculation
 
     .. code-block:: console
 
@@ -412,7 +412,7 @@ With the entry points set up, you are ready to launch your first calculation wit
         $ mkdir input_files
         $ mv file1.txt file2.txt input_files
 
- * Write a ``launch.py`` script:
+* Write a ``launch.py`` script:
 
     .. literalinclude:: ./include/snippets/plugins/launch.py
       :language: python
@@ -423,7 +423,7 @@ With the entry points set up, you are ready to launch your first calculation wit
 
         This code is automatically set on the ``code`` input port of the builder and passed as an input to the calculation plugin.
 
- * Launch the calculation:
+* Launch the calculation:
 
     .. code-block:: console
 
@@ -449,13 +449,13 @@ With the entry points set up, you are ready to launch your first calculation wit
 
 Finally instead of running your calculation in the current shell, you can submit your calculation to the AiiDA daemon:
 
- * (Re)start the daemon to update its Python environment:
+* (Re)start the daemon to update its Python environment:
 
     .. code-block:: console
 
         $ verdi daemon restart --reset
 
- * Update your launch script to use:
+* Update your launch script to use:
 
     .. code-block:: python
 
@@ -469,7 +469,7 @@ Finally instead of running your calculation in the current shell, you can submit
         ``node`` is the |CalcJobNode| representing the state of the underlying calculation process (which may not be finished yet).
 
 
- * Launch the calculation:
+* Launch the calculation:
 
     .. code-block:: console
 

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -75,8 +75,8 @@ Start by creating a file ``calculations.py`` and subclass the |CalcJob| class:
 
 In the following, we will tell AiiDA how to run our code by implementing two key methods:
 
- #. :py:meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.define`
- #. :py:meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.prepare_for_submission`
+#. :py:meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.define`
+#. :py:meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.prepare_for_submission`
 
 Defining the spec
 -----------------
@@ -210,9 +210,9 @@ To create a parser plugin, subclass the |Parser| class in a file called ``parser
 
 Before the ``parse()`` method is called, two important attributes are set on the |Parser|  instance:
 
-  1. ``self.retrieved``: An instance of |FolderData|, which points to the folder containing all output files that the |CalcJob| instructed to retrieve, and provides the means to :py:meth:`~aiida.orm.nodes.repository.NodeRepository.open` any file it contains.
+1. ``self.retrieved``: An instance of |FolderData|, which points to the folder containing all output files that the |CalcJob| instructed to retrieve, and provides the means to :py:meth:`~aiida.orm.nodes.repository.NodeRepository.open` any file it contains.
 
-  2. ``self.node``: The :py:class:`~aiida.orm.nodes.process.calculation.calcjob.CalcJobNode` representing the finished calculation, which, among other things, provides access to all of its inputs (``self.node.inputs``).
+2. ``self.node``: The :py:class:`~aiida.orm.nodes.process.calculation.calcjob.CalcJobNode` representing the finished calculation, which, among other things, provides access to all of its inputs (``self.node.inputs``).
 
 Now implement its :py:meth:`~aiida.parsers.parser.Parser.parse` method as
 
@@ -238,9 +238,9 @@ If your code produces output in a structured format, instead of just returning t
     Consider the different output files produced by your favorite simulation code.
     Which information would you want to:
 
-     1. parse into the database for querying (e.g. as |Dict|, |StructureData|, ...)?
-     2. store in the AiiDA file repository for safe-keeping (e.g. as |SinglefileData|, ...)?
-     3. leave on the computer where the calculation ran (e.g. recording their remote location using |RemoteData| or simply ignoring them)?
+    1. parse into the database for querying (e.g. as |Dict|, |StructureData|, ...)?
+    2. store in the AiiDA file repository for safe-keeping (e.g. as |SinglefileData|, ...)?
+    3. leave on the computer where the calculation ran (e.g. recording their remote location using |RemoteData| or simply ignoring them)?
 
     Once you know the answers to these questions, you are ready to start writing a parser for your code.
 
@@ -330,61 +330,61 @@ With your ``calculations.py`` and ``parsers.py`` files at hand, let's register e
 
 * Move your two scripts into a subfolder ``aiida_diff_tutorial``:
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ mkdir aiida_diff_tutorial
-      $ mv calculations.py parsers.py aiida_diff_tutorial/
-      $ touch aiida_diff_tutorial/__init__.py
+  $ mkdir aiida_diff_tutorial
+  $ mv calculations.py parsers.py aiida_diff_tutorial/
+  $ touch aiida_diff_tutorial/__init__.py
 
-   You have just created an ``aiida_diff_tutorial`` Python *package*!
+You have just created an ``aiida_diff_tutorial`` Python *package*!
 
 * Add a minimal set of metadata for your package by writing a ``pyproject.toml`` file:
 
-    .. code-block:: toml
+.. code-block:: toml
 
-        [build-system]
-        # build the package with [flit](https://flit.readthedocs.io)
-        requires = ["flit_core >=3.4,<4"]
-        build-backend = "flit_core.buildapi"
+    [build-system]
+    # build the package with [flit](https://flit.readthedocs.io)
+    requires = ["flit_core >=3.4,<4"]
+    build-backend = "flit_core.buildapi"
 
-        [project]
-        # See https://www.python.org/dev/peps/pep-0621/
-        name = "aiida-diff-tutorial"
-        version = "0.1.0"
-        description = "AiiDA demo plugin"
-        dependencies = [
-            "aiida-core>=2.0,<3",
-        ]
+    [project]
+    # See https://www.python.org/dev/peps/pep-0621/
+    name = "aiida-diff-tutorial"
+    version = "0.1.0"
+    description = "AiiDA demo plugin"
+    dependencies = [
+        "aiida-core>=2.0,<3",
+    ]
 
-        [project.entry-points."aiida.calculations"]
-        "diff-tutorial" = "aiida_diff_tutorial.calculations:DiffCalculation"
+    [project.entry-points."aiida.calculations"]
+    "diff-tutorial" = "aiida_diff_tutorial.calculations:DiffCalculation"
 
-        [project.entry-points."aiida.parsers"]
-        "diff-tutorial" = "aiida_diff_tutorial.parsers:DiffParser"
+    [project.entry-points."aiida.parsers"]
+    "diff-tutorial" = "aiida_diff_tutorial.parsers:DiffParser"
 
-        [tool.flit.module]
-        name = "aiida_diff_tutorial"
+    [tool.flit.module]
+    name = "aiida_diff_tutorial"
 
 
-    .. note::
-        This allows for the project metadata to be fully specified in the pyproject.toml file, using the PEP 621 format.
+.. note::
+    This allows for the project metadata to be fully specified in the pyproject.toml file, using the PEP 621 format.
 
 
 * Install your new ``aiida-diff-tutorial`` plugin package.
 
-   .. code-block:: console
+.. code-block:: console
 
-       $ pip install -e .  # install package in "editable mode"
+   $ pip install -e .  # install package in "editable mode"
 
-   See the :ref:`how-to:plugins-install` section for details.
+See the :ref:`how-to:plugins-install` section for details.
 
 After this, you should see your plugins listed:
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ verdi plugin list aiida.calculations
-      $ verdi plugin list aiida.calculations diff-tutorial
-      $ verdi plugin list aiida.parsers
+  $ verdi plugin list aiida.calculations
+  $ verdi plugin list aiida.calculations diff-tutorial
+  $ verdi plugin list aiida.parsers
 
 
 .. _how-to:plugin-codes:run:
@@ -396,50 +396,50 @@ With the entry points set up, you are ready to launch your first calculation wit
 
 
 * If you haven't already done so, :ref:`set up your computer<how-to:run-codes:computer>`.
-   In the following we assume it to be the localhost:
+  In the following we assume it to be the localhost:
 
-    .. code-block:: console
+.. code-block:: console
 
-        $ verdi computer setup -L localhost -H localhost -T core.local -S core.direct -w `echo $PWD/work` -n
-        $ verdi computer configure core.local localhost --safe-interval 5 -n
+    $ verdi computer setup -L localhost -H localhost -T core.local -S core.direct -w `echo $PWD/work` -n
+    $ verdi computer configure core.local localhost --safe-interval 5 -n
 
 *  Create the input files for our calculation
 
-    .. code-block:: console
+.. code-block:: console
 
-        $ echo -e "File with content\ncontent1" > file1.txt
-        $ echo -e "File with content\ncontent2" > file2.txt
-        $ mkdir input_files
-        $ mv file1.txt file2.txt input_files
+    $ echo -e "File with content\ncontent1" > file1.txt
+    $ echo -e "File with content\ncontent2" > file2.txt
+    $ mkdir input_files
+    $ mv file1.txt file2.txt input_files
 
 * Write a ``launch.py`` script:
 
-    .. literalinclude:: ./include/snippets/plugins/launch.py
-      :language: python
+.. literalinclude:: ./include/snippets/plugins/launch.py
+  :language: python
 
-    .. note::
+.. note::
 
-        The ``launch.py`` script sets up an AiiDA |Code| instance that associates the ``/usr/bin/diff`` executable with the ``DiffCalculation`` class (through its entry point ``diff``).
+    The ``launch.py`` script sets up an AiiDA |Code| instance that associates the ``/usr/bin/diff`` executable with the ``DiffCalculation`` class (through its entry point ``diff``).
 
-        This code is automatically set on the ``code`` input port of the builder and passed as an input to the calculation plugin.
+    This code is automatically set on the ``code`` input port of the builder and passed as an input to the calculation plugin.
 
 * Launch the calculation:
 
-    .. code-block:: console
+.. code-block:: console
 
-        $ verdi run launch.py
+    $ verdi run launch.py
 
 
-    If everything goes well, this should print the results of your calculation, something like:
+If everything goes well, this should print the results of your calculation, something like:
 
-    .. code-block:: console
+.. code-block:: console
 
-        $ verdi run launch.py
-        Computed diff between files:
-        2c2
-        < content1
-        ---
-        > content2
+    $ verdi run launch.py
+    Computed diff between files:
+    2c2
+    < content1
+    ---
+    > content2
 
 .. tip::
 
@@ -451,31 +451,31 @@ Finally instead of running your calculation in the current shell, you can submit
 
 * (Re)start the daemon to update its Python environment:
 
-    .. code-block:: console
+.. code-block:: console
 
-        $ verdi daemon restart --reset
+    $ verdi daemon restart --reset
 
 * Update your launch script to use:
 
-    .. code-block:: python
+.. code-block:: python
 
-        # Submit calculation to the aiida daemon
-        node = engine.submit(builder)
-        print("Submitted calculation {}".format(node))
+    # Submit calculation to the aiida daemon
+    node = engine.submit(builder)
+    print("Submitted calculation {}".format(node))
 
 
-    .. note::
+.. note::
 
-        ``node`` is the |CalcJobNode| representing the state of the underlying calculation process (which may not be finished yet).
+    ``node`` is the |CalcJobNode| representing the state of the underlying calculation process (which may not be finished yet).
 
 
 * Launch the calculation:
 
-    .. code-block:: console
+.. code-block:: console
 
-        $ verdi run launch.py
+    $ verdi run launch.py
 
-    This should print the UUID and the PK of the submitted calculation.
+This should print the UUID and the PK of the submitted calculation.
 
 You can use the verdi command line interface to :ref:`monitor<topics:processes:usage:monitoring>` this processes:
 
@@ -604,9 +604,9 @@ Here is a simple code snippet for translating the dictionary to a list of comman
 
 Let's open our previous ``calculations.py`` file and start modifying the ``DiffCalculation`` class:
 
- 1. In the ``define`` method, add a new ``input`` to the ``spec`` with label ``'parameters'`` and type |Dict|  (``from aiida.orm import Dict``)
- 2. | In the ``prepare_for_submission`` method run the ``cli_options`` function from above on ``self.inputs.parameters.get_dict()`` to get the list of command-line options.
-    | Add them to the ``codeinfo.cmdline_params``.
+1. In the ``define`` method, add a new ``input`` to the ``spec`` with label ``'parameters'`` and type |Dict|  (``from aiida.orm import Dict``)
+2. In the ``prepare_for_submission`` method run the ``cli_options`` function from above on ``self.inputs.parameters.get_dict()`` to get the list of command-line options.
+   Add them to the ``codeinfo.cmdline_params``.
 
 .. dropdown:: Solution
 

--- a/docs/source/howto/plugins_develop.rst
+++ b/docs/source/howto/plugins_develop.rst
@@ -101,19 +101,19 @@ Registering plugins through entry points
 An AiiDA plugin is an extension of AiiDA that announces itself by means of a new *entry point* (for details, see :ref:`topics:plugins:entrypoints`).
 Adding a new entry point consists of the following steps:
 
- #. Deciding a name.
-    We *strongly* suggest to start the name of each entry point with the name of the plugin package (omitting the 'aiida-' prefix).
-    For a package ``aiida-mycode``, this will usually mean ``"mycode.<something>"``
+#. Deciding a name.
+   We *strongly* suggest to start the name of each entry point with the name of the plugin package (omitting the 'aiida-' prefix).
+   For a package ``aiida-mycode``, this will usually mean ``"mycode.<something>"``
 
- #. Finding the right entry point group. You can list the entry point groups defined by AiiDA via ``verdi plugin list``.
-    For a documentation of the groups, see :ref:`topics:plugins:entrypointgroups`.
+#. Finding the right entry point group. You can list the entry point groups defined by AiiDA via ``verdi plugin list``.
+   For a documentation of the groups, see :ref:`topics:plugins:entrypointgroups`.
 
- #. Adding the entry point to the ``entry_points`` field in the ``pyproject.toml`` file::
+#. Adding the entry point to the ``entry_points`` field in the ``pyproject.toml`` file::
 
-     ...
-     [project.entry-points."aiida.calculations"]
-     "mycode.<something>" = "aiida_mycode.calcs.some:MysomethingCalculation"
-     ...
+      ...
+      [project.entry-points."aiida.calculations"]
+      "mycode.<something>" = "aiida_mycode.calcs.some:MysomethingCalculation"
+      ...
 
 Your new entry point should now show up in ``verdi plugin list aiida.calculations``.
 

--- a/docs/source/howto/plugins_develop.rst
+++ b/docs/source/howto/plugins_develop.rst
@@ -219,9 +219,9 @@ Repository-level documentation
 
 Since the source code of most AiiDA plugins is hosted on GitHub, the first contact of a new user with your plugin package is likely the landing page of your GitHub repository.
 
- * Make sure to have a useful ``README.md``, describing what your plugin does and how to install it.
- * Leaving a contact email and adding a license is also a good idea.
- * Make sure the information in the ``pyproject.toml`` file is correct and up to date (in particular the version number), since this information is used to advertise your package on the AiiDA plugin registry.
+* Make sure to have a useful ``README.md``, describing what your plugin does and how to install it.
+* Leaving a contact email and adding a license is also a good idea.
+* Make sure the information in the ``pyproject.toml`` file is correct and up to date (in particular the version number), since this information is used to advertise your package on the AiiDA plugin registry.
 
 Source-code-level documentation
 -------------------------------
@@ -254,9 +254,9 @@ You can now use the ``aiida-process``, ``aiida-calcjob`` or ``aiida-workchain`` 
 
 Here,
 
- * ``MyWorkChain`` is the name of the workchain to be documented.
- * ``:module:`` is the python module from which the workchain can be imported.
- * ``:hide-unstored-inputs:`` hides workchain inputs that are not stored in the database (shown by default).
+* ``MyWorkChain`` is the name of the workchain to be documented.
+* ``:module:`` is the python module from which the workchain can be imported.
+* ``:hide-unstored-inputs:`` hides workchain inputs that are not stored in the database (shown by default).
 
 .. note::
 
@@ -273,8 +273,8 @@ AiiDA plugin packages are published on the `AiiDA plugin registry <registry_>`_ 
 
 Before publishing your plugin, make sure your plugin comes with:
 
- * a ``pyproject.toml`` file with the plugin metadata and for installing your plugin via ``pip``
- * a license
+* a ``pyproject.toml`` file with the plugin metadata and for installing your plugin via ``pip``
+* a license
 
 For examples of these files, see the `aiida-diff demo plugin <aiida-diff_>`_.
 

--- a/docs/source/howto/query.rst
+++ b/docs/source/howto/query.rst
@@ -310,9 +310,9 @@ Note that the :class:`~aiida.orm.utils.links.LinkManager` provides many convenie
 
 The :meth:`~aiida.orm.nodes.links.NodeLinks.get_incoming` and :meth:`~aiida.orm.nodes.links.NodeLinks.get_outgoing` methods accept various arguments that allow one to filter what neighboring nodes should be matched:
 
- * ``node_class``: accepts a subclass of :class:`~aiida.orm.nodes.node.Node`, only neighboring nodes with a class that matches this will be returned
- * ``link_type``: accepts a value of :class:`~aiida.common.links.LinkType`, only neighboring nodes that are linked with this link type will be returned
- * ``link_label_filter``: accepts a string  expression (with optional wildcards using the syntax of SQL ``LIKE`` patterns, see below), only neighboring nodes that are linked with a link label that matches the pattern will be returned
+* ``node_class``: accepts a subclass of :class:`~aiida.orm.nodes.node.Node`, only neighboring nodes with a class that matches this will be returned
+* ``link_type``: accepts a value of :class:`~aiida.common.links.LinkType`, only neighboring nodes that are linked with this link type will be returned
+* ``link_label_filter``: accepts a string  expression (with optional wildcards using the syntax of SQL ``LIKE`` patterns, see below), only neighboring nodes that are linked with a link label that matches the pattern will be returned
 
 As an example:
 
@@ -369,12 +369,12 @@ Creator, caller and called
 
 Similar to the ``inputs`` and ``outputs`` properties of process nodes, there are some more properties that make exploring the provenance graph easier:
 
-    * :meth:`~aiida.orm.nodes.process.process.ProcessNode.called`: defined for :class:`~aiida.orm.nodes.process.process.ProcessNode`'s and returns the list of process nodes called by this node.
-      If this process node did not call any other processes, this property returns an empty list.
-    * :meth:`~aiida.orm.nodes.process.process.ProcessNode.caller`: defined for :class:`~aiida.orm.nodes.process.process.ProcessNode`'s and returns the process node that called this node.
-      If this node was not called by a process, this property returns ``None``.
-    * :meth:`~aiida.orm.Data.creator`: defined for :class:`~aiida.orm.Data` nodes and returns the process node that created it.
-      If the node was not created by a process, this property returns ``None``.
+* :meth:`~aiida.orm.nodes.process.process.ProcessNode.called`: defined for :class:`~aiida.orm.nodes.process.process.ProcessNode`'s and returns the list of process nodes called by this node.
+  If this process node did not call any other processes, this property returns an empty list.
+* :meth:`~aiida.orm.nodes.process.process.ProcessNode.caller`: defined for :class:`~aiida.orm.nodes.process.process.ProcessNode`'s and returns the process node that called this node.
+  If this node was not called by a process, this property returns ``None``.
+* :meth:`~aiida.orm.Data.creator`: defined for :class:`~aiida.orm.Data` nodes and returns the process node that created it.
+  If the node was not created by a process, this property returns ``None``.
 
 .. note::
 

--- a/docs/source/howto/share_data.rst
+++ b/docs/source/howto/share_data.rst
@@ -218,13 +218,9 @@ Like all ``verdi`` commands, you can select a different AiiDA profile via the ``
 
     REST API version history:
 
-
-Version history
----------------
-
-     * ``aiida-core`` >= 1.0.0b6: ``v4``. Simplified endpoints; only ``/nodes``, ``/processes``, ``/calcjobs``, ``/groups``, ``/computers`` and ``/servers`` remain.
-     * ``aiida-core`` >= 1.0.0b3, <1.0.0b6: ``v3``. Development version, never shipped with a stable release.
-     * ``aiida-core`` <1.0.0b3: ``v2``. First API version, with new endpoints added step by step.
+    * ``aiida-core`` >= 1.0.0b6: ``v4``. Simplified endpoints; only ``/nodes``, ``/processes``, ``/calcjobs``, ``/groups``, ``/computers`` and ``/servers`` remain.
+    * ``aiida-core`` >= 1.0.0b3, <1.0.0b6: ``v3``. Development version, never shipped with a stable release.
+    * ``aiida-core`` <1.0.0b3: ``v2``. First API version, with new endpoints added step by step.
 
 
 .. _how-to:share:serve:query:
@@ -236,7 +232,7 @@ A URL to query the REST API consists of:
 
 1. The *base URL*, by default:
 
-    http://127.0.0.1:5000/api/v4
+   http://127.0.0.1:5000/api/v4
 
    Querying the base URL returns a list of all available endpoints.
 
@@ -324,21 +320,21 @@ A ``myprofile-rest.wsgi`` script for an AiiDA profile ``myprofile`` would look l
 
 In the following, we explain how to run this wsgi application using Apache on Ubuntu.
 
-    #. Install and enable the ``mod_wsgi`` `WSGI module <https://modwsgi.readthedocs.io/>`_ module:
+#. Install and enable the ``mod_wsgi`` `WSGI module <https://modwsgi.readthedocs.io/>`_ module:
 
-    .. code-block:: console
+.. code-block:: console
 
-           $ sudo apt install libapache2-mod-wsgi-py3
-           $ sudo a2enmod wsgi
+       $ sudo apt install libapache2-mod-wsgi-py3
+       $ sudo a2enmod wsgi
 
-    #. Place the WSGI script in a folder on your server, for example ``/home/ubuntu/wsgi/myprofile-rest.wsgi``.
+#. Place the WSGI script in a folder on your server, for example ``/home/ubuntu/wsgi/myprofile-rest.wsgi``.
 
-    #. Configure apache to run the WSGI application using a virtual host configuration similar to:
+#. Configure apache to run the WSGI application using a virtual host configuration similar to:
 
-       .. literalinclude:: include/snippets/aiida-rest.conf
+   .. literalinclude:: include/snippets/aiida-rest.conf
 
-       Place this ``aiida-rest.conf`` file in ``/etc/apache2/sites-enabled``
+   Place this ``aiida-rest.conf`` file in ``/etc/apache2/sites-enabled``
 
-    #. Restart apache: ``sudo service apache2 restart``.
+#. Restart apache: ``sudo service apache2 restart``.
 
 You should now be able to reach your REST API at ``localhost/myprofile/api/v4`` (Port 80).

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -268,7 +268,7 @@ Using kerberos tokens
 
 If the remote machine requires authentication through a Kerberos token (that you need to obtain before using ssh), you typically need to
 
- * install ``libffi`` (``sudo apt-get install libffi-dev`` under Ubuntu)
- * install the ``ssh_kerberos`` extra during the installation of aiida-core (see :ref:`intro:install:setup`).
+* install ``libffi`` (``sudo apt-get install libffi-dev`` under Ubuntu)
+* install the ``ssh_kerberos`` extra during the installation of aiida-core (see :ref:`intro:install:setup`).
 
 If you provide all necessary ``GSSAPI`` options in your ``~/.ssh/config`` file, ``verdi computer configure`` should already pick up the appropriate values for all the gss-related options.

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -7,8 +7,8 @@ How to setup SSH connections
 AiiDA communicates with remote computers via the SSH protocol.
 There are two ways of setting up an SSH connection for AiiDA:
 
- 1. Using a passwordless SSH key (easier, less safe)
- 2. Using a password-protected SSH key through ``ssh-agent`` (one more step, safer)
+#. Using a passwordless SSH key (easier, less safe)
+#. Using a password-protected SSH key through ``ssh-agent`` (one more step, safer)
 
 .. _how-to:ssh:passwordless:
 

--- a/docs/source/howto/write_workflows.rst
+++ b/docs/source/howto/write_workflows.rst
@@ -10,8 +10,8 @@ Writing workflows
 A workflow in AiiDA is a :ref:`process <topics:processes:concepts>` that calls other workflows and calculations and optionally *returns* data and as such can encode the logic of a typical scientific workflow.
 Currently, there are two ways of implementing a workflow process:
 
- * :ref:`work functions<topics:workflows:concepts:workfunctions>`
- * :ref:`work chains<topics:workflows:concepts:workchains>`
+* :ref:`work functions<topics:workflows:concepts:workfunctions>`
+* :ref:`work chains<topics:workflows:concepts:workchains>`
 
 Here we present a brief introduction on how to write both workflow types.
 

--- a/docs/source/internals/rest_api.rst
+++ b/docs/source/internals/rest_api.rst
@@ -9,8 +9,8 @@ REST API
 
 The AiiDA REST API is made of two main classes:
 
- * ``App``, inheriting from ``flask.Flask`` (generic class for Flask web applications).
- * ``AiidaApi``, inheriting ``flask_restful.Api``. This class defines the resources served by the REST API.
+* ``App``, inheriting from ``flask.Flask`` (generic class for Flask web applications).
+* ``AiidaApi``, inheriting ``flask_restful.Api``. This class defines the resources served by the REST API.
 
 The instances of both ``AiidaApi`` (let's call it ``api``) and ``App`` (let's call it ``app``) need to be coupled by setting ``api.app = app``.
 
@@ -28,9 +28,9 @@ The endpoint implements a ``GET`` request that retrieves the latest created ``Di
 
 In order to achieve this, we will need to:
 
- * Create the ``flask_restful.Resource`` class that will be bound to the new endpoint.
- * Extend the :py:class:`~aiida.restapi.api.AiidaApi` class in order to register the new endpoint.
- * (Optional) Extend the :py:class:`~aiida.restapi.api.App` class for additional customization.
+* Create the ``flask_restful.Resource`` class that will be bound to the new endpoint.
+* Extend the :py:class:`~aiida.restapi.api.AiidaApi` class in order to register the new endpoint.
+* (Optional) Extend the :py:class:`~aiida.restapi.api.App` class for additional customization.
 
 Let's start by putting the following code into a  file ``api.py``:
 
@@ -165,19 +165,19 @@ Consequently, the app is configured and, if required, hooked up.
 
 It takes as inputs:
 
- * the classes representing the API and the application.
+* the classes representing the API and the application.
    We strongly suggest to pass to ``run_api()`` the :py:class:`aiida.restapi.api.App` class, inheriting from ``flask.Flask``, as it handles correctly AiiDA RESTApi-specific exceptions.
 
- * positional arguments representing the command-line arguments/options, passed by the click function.
+* positional arguments representing the command-line arguments/options, passed by the click function.
    Types, defaults and help strings can be set in the ``@click.option`` definitions, and will be handled by the command line call.
 
 
 A few more things before using the script:
 
- * if you want to customize further the error handling, you can take inspiration by looking at the definition of ``App`` and create your derived class ``NewApp(App)``.
+* if you want to customize further the error handling, you can take inspiration by looking at the definition of ``App`` and create your derived class ``NewApp(App)``.
 
 
- * the supported command line options are identical to those of ``verdi restapi``.
+* the supported command line options are identical to those of ``verdi restapi``.
    Use ``verdi restapi --help`` for their full documentation.
    If you want to add more options or modify the existing ones, create you custom runner taking inspiration from ``run_api``.
 

--- a/docs/source/internals/storage/psql_dos.rst
+++ b/docs/source/internals/storage/psql_dos.rst
@@ -65,14 +65,14 @@ Although in that case the relationship is "mandatory", this doesn't need to be t
 
 The following entities have a many-to-one relationship:
 
- * Many `nodes` can be created by the same `user`.
- * Many `nodes` can point to the same `computer`.
- * Many `groups` can be created by the same `user`.
- * Many `authinfos` can be set for the same `user`.
- * Many `authinfos` can be set for the same `computer`.
- * Many `comments` can be created by the same `user`.
- * Many `comments` can be attached to the same `node`.
- * Many `logs` can be attached to the same `node`.
+* Many `nodes` can be created by the same `user`.
+* Many `nodes` can point to the same `computer`.
+* Many `groups` can be created by the same `user`.
+* Many `authinfos` can be set for the same `user`.
+* Many `authinfos` can be set for the same `computer`.
+* Many `comments` can be created by the same `user`.
+* Many `comments` can be attached to the same `node`.
+* Many `logs` can be attached to the same `node`.
 
 The way to keep track of these relationships is by inserting a `foreign key` column in the table of the "many" entity that points to the corresponding id value of the "one" entity they are related to.
 For example, there is a ``user_id`` foreign key column in the **db_dbnode** table that stores the id of the user that created each node.

--- a/docs/source/internals/storage/repository.rst
+++ b/docs/source/internals/storage/repository.rst
@@ -19,11 +19,11 @@ Design
 
 The following requirements were considered during the design of the file repository implementation:
 
- * Scalability: the repository should be able to store millions of files, all the while permitting efficient backups.
- * Heterogeneity: the repository should operate efficiently for data that is heterogeneous in size, with object of size ranging from a few bytes to multiple gigabytes.
- * Simplicity: the solution should not require an actively running server to operate.
- * Concurrency: the repository should support multiple concurrent reading and writing processes.
- * Efficiency: the repository should automatically deduplicate file content in an effort to reduce the total amount of required storage space.
+* Scalability: the repository should be able to store millions of files, all the while permitting efficient backups.
+* Heterogeneity: the repository should operate efficiently for data that is heterogeneous in size, with object of size ranging from a few bytes to multiple gigabytes.
+* Simplicity: the solution should not require an actively running server to operate.
+* Concurrency: the repository should support multiple concurrent reading and writing processes.
+* Efficiency: the repository should automatically deduplicate file content in an effort to reduce the total amount of required storage space.
 
 These are merely the requirements for the data store that persists the content of the files, or the *backend* file repository.
 The frontend interface that is employed by users to store files has another set of requirements altogether.
@@ -76,8 +76,8 @@ Note that upon constructing from a serialized file hierarchy, the :class:`~aiida
 The final integration of the :class:`~aiida.repository.repository.Repository` class with the ORM is through the :class:`~aiida.orm.nodes.repository.NodeRepository` class, which is mixed into the :class:`~aiida.orm.nodes.node.Node` class.
 This layer serves a couple of functions:
 
- * It implements the mutability rules of nodes
- * It serves as a translation layer between string and byte streams.
+* It implements the mutability rules of nodes
+* It serves as a translation layer between string and byte streams.
 
 The first is necessary because after a node has been stored, its content is considered immutable, which includes the content of its file repository.
 The :class:`~aiida.orm.utils.mixins.Sealable` mixin overrides the :class:`~aiida.repository.repository.Repository` methods that mutate repository content, to ensure that process nodes *can* mutate their content, as long as they are not sealed.

--- a/docs/source/intro/installation.rst
+++ b/docs/source/intro/installation.rst
@@ -233,9 +233,9 @@ The AiiDA daemon process runs in the background and takes care of processing you
 
 The AiiDA daemon is controlled using three simple commands:
 
- * ``verdi daemon start``: start the daemon
- * ``verdi daemon status``: check the status of the daemon
- * ``verdi daemon stop``: stop the daemon
+* ``verdi daemon start``: start the daemon
+* ``verdi daemon status``: check the status of the daemon
+* ``verdi daemon stop``: stop the daemon
 
 .. note::
 

--- a/docs/source/reference/rest_api.rst
+++ b/docs/source/reference/rest_api.rst
@@ -34,13 +34,13 @@ The HTTP response of the REST API consists of a status code, a header, and a JSO
 
 Possible status codes are:
 
-    #. 200 for successful requests.
-    #. 400 for bad requests.
-       The JSON object contains an error message describing the issue with the request.
-    #. 500 for a generic internal server error.
-       The JSON object contains a generic error message.
-    #. 404 for invalid URL.
-       The request does not match any resource, and no JSON is returned.
+#. 200 for successful requests.
+#. 400 for bad requests.
+   The JSON object contains an error message describing the issue with the request.
+#. 500 for a generic internal server error.
+   The JSON object contains a generic error message.
+#. 404 for invalid URL.
+   The request does not match any resource, and no JSON is returned.
 
 The header is a standard HTTP response header with the additional custom fields
 
@@ -155,7 +155,7 @@ Nodes
           "url_root": "http://localhost:5000/"
         }
 
-#. Get a list of all available |Node| types from the database.
+#.  Get a list of all available |Node| types from the database.
 
     REST URL::
 
@@ -184,7 +184,7 @@ Nodes
             "url_root": "http://localhost:5000/"
         }
 
-#. Get a list of all available download formats.
+#.  Get a list of all available download formats.
 
     REST URL::
 
@@ -236,7 +236,7 @@ Nodes
             "url_root": "http://localhost:5000/"
         }
 
-#. Get the details of a single |Node| object.
+#.  Get the details of a single |Node| object.
 
     REST URL::
 
@@ -273,7 +273,7 @@ Nodes
           "url_root": "http://localhost:5000/"
         }
 
-#. Get the list of incoming of a specific |Node|.
+#.  Get the list of incoming of a specific |Node|.
 
     REST URL::
 
@@ -401,7 +401,7 @@ Nodes
           "url_root": "http://localhost:5000/"
         }
 
-#. Getting the list of the attributes/extras of a specific |Node|.
+#.  Getting the list of the attributes/extras of a specific |Node|.
 
     REST URL::
 
@@ -460,7 +460,7 @@ Nodes
           "url_root": "http://localhost:5000/"
         }
 
-#. Getting a user-defined list of attributes/extras of a specific |Node|.
+#.  Getting a user-defined list of attributes/extras of a specific |Node|.
 
     REST URL::
 
@@ -514,7 +514,7 @@ Nodes
           "url_root": "http://localhost:5000/"
         }
 
-#. Get comments of specific |Node|.
+#.  Get comments of specific |Node|.
 
     REST URL::
 
@@ -539,7 +539,7 @@ Nodes
             "url_root": "http://localhost:5000/"
         }
 
-#. Get list of all the files/directories from the repository of a specific |Node|.
+#.  Get list of all the files/directories from the repository of a specific |Node|.
 
     REST URL::
 
@@ -689,7 +689,7 @@ CalcJobs
 Computers
 ---------
 
-1. Get a list of |Computer| objects.
+1.  Get a list of |Computer| objects.
 
     REST URL::
 
@@ -743,7 +743,7 @@ Computers
           "url_root": "http://localhost:5000/"
         }
 
-2. Get details of a single |Computer| object:
+2.  Get details of a single |Computer| object:
 
     REST URL::
 
@@ -782,7 +782,7 @@ Computers
 Users
 -----
 
-1. Getting a list of the |User| s
+1.  Getting a list of the |User| s
 
     REST URL::
 
@@ -820,7 +820,7 @@ Users
           "url_root": "http://localhost:5000/"
         }
 
-2. Getting a list of |User| s whose first name starts with a given string
+2.  Getting a list of |User| s whose first name starts with a given string
 
     REST URL::
 
@@ -855,7 +855,7 @@ Users
 Groups
 ------
 
-1. Getting a list of |Group| s
+1.  Getting a list of |Group| s
 
     REST URL::
 
@@ -899,7 +899,7 @@ Groups
           "url_root": "http://localhost:5000/"
         }
 
-2. Getting the details of a specific group
+2.  Getting the details of a specific group
 
     REST URL::
 
@@ -1148,14 +1148,14 @@ Examples::
 If no page number is specified, the system redirects the request to page 1.
 When pagination is used, the **header** of the response contains two more non-empty fields:
 
-    - ``X-Total-Counts`` (custom field): the total number of results returned by the query, i.e. the sum of the results of all pages.
-    - ``Links``: links to the first, previous, next, and last page. Suppose that you send a request whose results fill 8 pages.
-      Then the value of the ``Links`` field would look like::
+- ``X-Total-Counts`` (custom field): the total number of results returned by the query, i.e. the sum of the results of all pages.
+- ``Links``: links to the first, previous, next, and last page. Suppose that you send a request whose results fill 8 pages.
+  Then the value of the ``Links`` field would look like::
 
-            <\http://localhost:5000/.../page/1?... >; rel=first,
-            <\http://localhost:5000/.../page/3?... >; rel=prev,
-            <\http://localhost:5000/.../page/5?... >; rel=next,
-            <\http://localhost:5000/.../page/8?... >; rel=last
+        <\http://localhost:5000/.../page/1?... >; rel=first,
+        <\http://localhost:5000/.../page/3?... >; rel=prev,
+        <\http://localhost:5000/.../page/5?... >; rel=next,
+        <\http://localhost:5000/.../page/8?... >; rel=last
 
 Besides pagination, the number of results can also be controlled using the ``limit`` and ``offset`` filters, see :ref:`below <reference:rest-api:filtering:unique>`.
 
@@ -1365,8 +1365,8 @@ Pattern matching
 
 The pattern matching operators ``=like=`` and ``=ilike=`` must be followed by the pattern definition, namely, a string where two characters assume special meaning:
 
-    1. ``%`` is used to replace an arbitrary sequence of characters, including no characters.
-    2. ``_`` is used to replace one or zero characters.
+1. ``%`` is used to replace an arbitrary sequence of characters, including no characters.
+2. ``_`` is used to replace one or zero characters.
 
 .. note:: When special characters are required verbatim, escape them by pre-pending a backslash ``\``.
 
@@ -1413,8 +1413,8 @@ The comparison operators ``<``, ``>``, ``<=``, ``>=`` assume natural ordering fo
 
 Examples:
 
-    - ``http://localhost:5000/api/v4/nodes?id>578`` selects the nodes having an id larger than 578.
-    - ``http://localhost:5000/api/v4/users/?last_name<="m"`` selects only the users whose last name begins with a character in the range [a-m].
+- ``http://localhost:5000/api/v4/nodes?id>578`` selects the nodes having an id larger than 578.
+- ``http://localhost:5000/api/v4/users/?last_name<="m"`` selects only the users whose last name begins with a character in the range [a-m].
 
 
 Filter value types

--- a/docs/source/reference/rest_api.rst
+++ b/docs/source/reference/rest_api.rst
@@ -44,8 +44,8 @@ Possible status codes are:
 
 The header is a standard HTTP response header with the additional custom fields
 
- * ``X-Total-Counts`` and
- * ``Link`` (only if paginated results are required, see the Pagination section).
+* ``X-Total-Counts`` and
+* ``Link`` (only if paginated results are required, see the Pagination section).
 
 The ``data`` field of the JSON object contains the main payload returned by the API.
 The JSON object further contains information on the request in the ``method``, ``url``, ``url_root``, ``path``, ``query_string``, and ``resource_type`` fields.

--- a/docs/source/topics/calculations/concepts.rst
+++ b/docs/source/topics/calculations/concepts.rst
@@ -7,8 +7,8 @@ Concepts
 A calculation is a process (see the :ref:`process section<topics:processes:concepts>` for details) that *creates* new data.
 Currently, there are two ways of implementing a calculation process:
 
- * :ref:`calculation function<topics:calculations:concepts:calcfunctions>`
- * :ref:`calculation job<topics:calculations:concepts:calcjobs>`
+* :ref:`calculation function<topics:calculations:concepts:calcfunctions>`
+* :ref:`calculation job<topics:calculations:concepts:calcjobs>`
 
 The first one is the simplest of the two and is basically a python function that is magically transformed into a process.
 This is ideal for calculations that are not very computationally intensive and can be easily implemented in a python function.
@@ -155,10 +155,10 @@ Transport tasks
 To arrive at the provenance graph shown above in :numref:`fig_calculation_jobs_provenance_arithmetic_add`, the engine performed quite some tasks.
 When a calculation job is launched, the engine will take it roughly through the following steps:
 
- * **Upload**: the calculation job implementation is used to transform the input nodes into the required input files, which are uploaded to a 'working' directory on the target machine
- * **Submit**: to execute the calculation, a job is submitted to the scheduler of the computer on which the input `code` is configured.
- * **Update**: the engine will query the scheduler to check for the status of the calculation job
- * **Retrieve**: once the job has finished, the engine will retrieve the output files, specified by the calculation plugin and store them in a node attached as an output node to the calculation
+* **Upload**: the calculation job implementation is used to transform the input nodes into the required input files, which are uploaded to a 'working' directory on the target machine
+* **Submit**: to execute the calculation, a job is submitted to the scheduler of the computer on which the input `code` is configured.
+* **Update**: the engine will query the scheduler to check for the status of the calculation job
+* **Retrieve**: once the job has finished, the engine will retrieve the output files, specified by the calculation plugin and store them in a node attached as an output node to the calculation
 
 All of these tasks require the engine to interact with the computer, or machine, that will actually run the external code.
 Since the :py:class:`~aiida.orm.nodes.data.code.abstract.AbstractCode` that is used as an input for the calculation job, which is configured for a specific :py:class:`~aiida.orm.computers.Computer`, the engine knows exactly how to execute all these tasks.

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -9,8 +9,8 @@ Usage
 A calculation is a process (see the :ref:`process section<topics:processes:concepts>` for details) that *creates* new data.
 Currently, there are two ways of implementing a calculation process:
 
- * :ref:`calculation function<topics:calculations:usage:calcfunctions>`
- * :ref:`calculation job<topics:calculations:usage:calcjobs>`
+* :ref:`calculation function<topics:calculations:usage:calcfunctions>`
+* :ref:`calculation job<topics:calculations:usage:calcjobs>`
 
 This section will provide detailed information and best practices on how to implement these two calculation types.
 
@@ -83,8 +83,8 @@ Here you define, what inputs it takes and what outputs it will generate.
 
 As the snippet above demonstrates, the class method takes two arguments:
 
- * ``cls`` this is the reference of the class itself and is mandatory for any class method
- * ``spec`` which is the 'specification'
+* ``cls`` this is the reference of the class itself and is mandatory for any class method
+* ``spec`` which is the 'specification'
 
 .. warning::
     Do not forget to add the line ``super().define(spec)`` as the first line of the ``define`` method, where you replace the class name with the name of your calculation job.
@@ -125,9 +125,9 @@ We have now defined through the process specification, what inputs the calculati
 The final remaining task is to instruct the engine how the calculation job should actually be run.
 To understand what the engine would have to do to accomplish this, let's consider what one typically does when manually preparing to run a computing job through a scheduler:
 
-    * Prepare a working directory in some scratch space on the machine where the job will run
-    * Create the raw input files required by the executable
-    * Create a launch script containing scheduler directives, loading of environment variables and finally calling the executable with certain command line parameters.
+* Prepare a working directory in some scratch space on the machine where the job will run
+* Create the raw input files required by the executable
+* Create a launch script containing scheduler directives, loading of environment variables and finally calling the executable with certain command line parameters.
 
 So all we need to do now is instruct the engine how to accomplish these things for a specific calculation job.
 Since these instructions will be calculation dependent, we will implement this with the :py:meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.prepare_for_submission` method.
@@ -151,9 +151,9 @@ The raw input files that are required can be written to a sandbox folder that is
 All the other required information, such as the directives of which files to copy and what command line options to use are defined through the :py:class:`~aiida.common.datastructures.CalcInfo` datastructure, which should be returned from the method as the only value.
 In principle, this is what one **should do** in the ``prepare_for_submission`` method:
 
-    * Writing raw inputs files required for the calculation to run to the ``folder`` sandbox folder.
-    * Use a ``CalcInfo`` to instruct the engine which files to copy to the working directory
-    * Use a ``CalcInfo`` to tell which codes should run, using which command line parameters, such as standard input and output redirection.
+* Writing raw inputs files required for the calculation to run to the ``folder`` sandbox folder.
+* Use a ``CalcInfo`` to instruct the engine which files to copy to the working directory
+* Use a ``CalcInfo`` to tell which codes should run, using which command line parameters, such as standard input and output redirection.
 
 .. note::
 
@@ -179,10 +179,10 @@ With the input file written, we now have to create an instance of :py:class:`~ai
 This data structure will instruct the engine exactly what needs to be done to execute the code, such as what files should be copied to the remote computer where the code will be executed.
 In this simple example, we define four simple attributes:
 
-    * ``codes_info``: a list of :py:class:`~aiida.common.datastructures.CodeInfo` datastructures, that tell which codes to run consecutively during the job
-    * ``local_copy_list``: a list of tuples that instruct what files to copy to the working directory from the local machine
-    * ``remote_copy_list``: a list of tuples that instruct what files to copy to the working directory from the machine on which the job will run
-    * ``retrieve_list``: a list of tuples instructing which files should be retrieved from the working directory and stored in the local repository after the job has finished
+* ``codes_info``: a list of :py:class:`~aiida.common.datastructures.CodeInfo` datastructures, that tell which codes to run consecutively during the job
+* ``local_copy_list``: a list of tuples that instruct what files to copy to the working directory from the local machine
+* ``remote_copy_list``: a list of tuples that instruct what files to copy to the working directory from the machine on which the job will run
+* ``retrieve_list``: a list of tuples instructing which files should be retrieved from the working directory and stored in the local repository after the job has finished
 
 In this example we only need to run a single code, so the ``codes_info`` list has a single ``CodeInfo`` datastructure.
 This datastructure needs to define which code it needs to run, which is one of the inputs passed to the ``CalcJob``, and does so by means of its UUID.
@@ -231,9 +231,9 @@ Local copy list
 ~~~~~~~~~~~~~~~
 The local copy list takes tuples of length three, each of which represents a file or directory to be copied, defined through the following items:
 
-    * `node uuid`: the node whose repository contains the file, typically a ``SinglefileData`` or ``FolderData`` node
-    * `source relative path`: the relative path of the file or directory within the node repository
-    * `target relative path`: the relative path within the working directory to which to copy the file or directory contents
+* `node uuid`: the node whose repository contains the file, typically a ``SinglefileData`` or ``FolderData`` node
+* `source relative path`: the relative path of the file or directory within the node repository
+* `target relative path`: the relative path within the working directory to which to copy the file or directory contents
 
 As an example, consider a ``CalcJob`` implementation that receives a ``SinglefileData`` node as input with the name ``pseudopotential``, to copy its contents one can specify:
 
@@ -335,9 +335,9 @@ Remote copy list
 ~~~~~~~~~~~~~~~~
 The remote copy list takes tuples of length three, each of which represents a file to be copied on the remote machine where the calculation will run, defined through the following items:
 
-    * `computer uuid`: this is the UUID of the ``Computer`` on which the source file resides. For now the remote copy list can only copy files on the same machine where the job will run.
-    * `source absolute path`: the absolute path of the source file on the remote machine
-    * `target relative path`: the relative path within the working directory to which to copy the file
+* `computer uuid`: this is the UUID of the ``Computer`` on which the source file resides. For now the remote copy list can only copy files on the same machine where the job will run.
+* `source absolute path`: the absolute path of the source file on the remote machine
+* `target relative path`: the relative path within the working directory to which to copy the file
 
 .. code:: python
 
@@ -352,16 +352,16 @@ Retrieve list
 The retrieve list is a list of instructions of what files and folders should be retrieved by the engine once a calculation job has terminated.
 Each instruction should have one of two formats:
 
-    * a string representing a relative filepath in the remote working directory
-    * a tuple of length three that allows to control the name of the retrieved file or folder in the retrieved folder
+* a string representing a relative filepath in the remote working directory
+* a tuple of length three that allows to control the name of the retrieved file or folder in the retrieved folder
 
 The retrieve list can contain any number of instructions and can use both formats at the same time.
 The first format is obviously the simplest, however, this requires one knows the exact name of the file or folder to be retrieved and in addition any subdirectories will be ignored when it is retrieved.
 If the exact filename is not known and `glob patterns <https://en.wikipedia.org/wiki/Glob_%28programming%29>`_ should be used, or if the original folder structure should be (partially) kept, one should use the tuple format, which has the following format:
 
-    * `source relative path`: the relative path, with respect to the working directory on the remote, of the file or directory to retrieve.
-    * `target relative path`: the relative path of the directory in the retrieved folder in to which the content of the source will be copied. The string ``'.'`` indicates the top level in the retrieved folder.
-    * `depth`: the number of levels of nesting in the source path to maintain when copying, starting from the deepest file.
+* `source relative path`: the relative path, with respect to the working directory on the remote, of the file or directory to retrieve.
+* `target relative path`: the relative path of the directory in the retrieved folder in to which the content of the source will be copied. The string ``'.'`` indicates the top level in the retrieved folder.
+* `depth`: the number of levels of nesting in the source path to maintain when copying, starting from the deepest file.
 
 To illustrate the various possibilities, consider the following example file hierarchy in the remote working directory:
 
@@ -715,10 +715,10 @@ The only method that needs to be implemented is the :py:meth:`~aiida.parsers.par
 Its signature should include ``**kwargs``, the reason for which will become clear later.
 The goal of the ``parse`` method is very simple:
 
-    * Open and load the content of the output files generated by the calculation job and have been retrieved by the engine
-    * Create data nodes out of this raw data that are attached as output nodes
-    * Log human-readable warning messages in the case of worrying output
-    * Optionally return an :ref:`exit code<topics:processes:concepts:exit_codes>` to indicate that the results of the calculation was not successful
+* Open and load the content of the output files generated by the calculation job and have been retrieved by the engine
+* Create data nodes out of this raw data that are attached as output nodes
+* Log human-readable warning messages in the case of worrying output
+* Optionally return an :ref:`exit code<topics:processes:concepts:exit_codes>` to indicate that the results of the calculation was not successful
 
 The advantage of adding the raw output data in different form as output nodes, is that in that form the content becomes queryable.
 This allows one to query for calculations that produced specific outputs with a certain value, which becomes a very powerful approach for post-processing and analyses of big databases.
@@ -757,12 +757,12 @@ You might now pose the question: "what part of the raw data should I parse and i
 This not an easy question to answer in the general, because it will heavily depend on the type of raw output that is produced by the calculation and what parts you would like to be queryable.
 However, we can give you some guidelines:
 
-    *   Store data that you might want to query for, in the lightweight data nodes, such as :py:class:`~aiida.orm.nodes.data.dict.Dict`, :py:class:`~aiida.orm.nodes.data.list.List` and :py:class:`~aiida.orm.nodes.data.structure.StructureData`.
-        The contents of these nodes are stored as attributes in the database, which makes sure that they can be queried for.
-    *   Bigger data sets, such as large (multi-dimnensional) arrays, are better stored in an :py:class:`~aiida.orm.nodes.data.array.array.ArrayData` or one of its sub classes.
-        If you were to store all this data in the database, it would become unnecessarily bloated, because the chances you would have to query for this data are unlikely.
-        Instead these array type data nodes store the bulk of their content in the repository.
-        This way you still keep the data and therewith the provenance of your calculations, while keeping your database lean and fast!
+*   Store data that you might want to query for, in the lightweight data nodes, such as :py:class:`~aiida.orm.nodes.data.dict.Dict`, :py:class:`~aiida.orm.nodes.data.list.List` and :py:class:`~aiida.orm.nodes.data.structure.StructureData`.
+    The contents of these nodes are stored as attributes in the database, which makes sure that they can be queried for.
+*   Bigger data sets, such as large (multi-dimnensional) arrays, are better stored in an :py:class:`~aiida.orm.nodes.data.array.array.ArrayData` or one of its sub classes.
+    If you were to store all this data in the database, it would become unnecessarily bloated, because the chances you would have to query for this data are unlikely.
+    Instead these array type data nodes store the bulk of their content in the repository.
+    This way you still keep the data and therewith the provenance of your calculations, while keeping your database lean and fast!
 
 
 .. _topics:calculations:usage:calcjobs:scheduler-errors:

--- a/docs/source/topics/cli.rst
+++ b/docs/source/topics/cli.rst
@@ -14,8 +14,8 @@ Parameters
 ==========
 Parameters to ``verdi`` commands come in two flavors:
 
-  * Arguments: positional parameters, e.g. ``123`` in ``verdi process kill 123``
-  * Options: announced by a flag (e.g. ``-f`` or ``--flag``), potentially followed by a value. E.g. ``verdi process list --limit 10`` or ``verdi process -h``.
+* Arguments: positional parameters, e.g. ``123`` in ``verdi process kill 123``
+* Options: announced by a flag (e.g. ``-f`` or ``--flag``), potentially followed by a value. E.g. ``verdi process list --limit 10`` or ``verdi process -h``.
 
 .. _topics:cli:multi_value_options:
 
@@ -54,16 +54,16 @@ For example, ``verdi process kill --help`` shows::
 
 All help strings consist of three parts:
 
-  * A ``Usage:`` line describing how to invoke the command
-  * A description of the command's functionality
-  * A list of the available options
+* A ``Usage:`` line describing how to invoke the command
+* A description of the command's functionality
+* A list of the available options
 
 The ``Usage:`` line encodes information on the command's parameters, e.g.:
 
- * ``[OPTIONS]``: this command takes one (or more) options
- * ``PROCESSES``: this command *requires* a process as a positional argument
- * ``[PROCESSES]``: this command takes a process as an *optional* positional argument
- * ``[PROCESSES]...``: this command takes one or more processes as *optional* positional arguments
+* ``[OPTIONS]``: this command takes one (or more) options
+* ``PROCESSES``: this command *requires* a process as a positional argument
+* ``[PROCESSES]``: this command takes a process as an *optional* positional argument
+* ``[PROCESSES]...``: this command takes one or more processes as *optional* positional arguments
 
 Multi-value options are followed by ``...`` in the help string and the ``Usage:`` line of the corresponding command will contain the 'endopts' marker.
 For example::
@@ -137,9 +137,9 @@ Identifiers
 When working with AiiDA entities, you need a way to *refer* to them on the command line.
 Any entity in AiiDA can be addressed via three identifiers:
 
- * "Primary Key" (PK): An integer, e.g. ``723``, identifying your entity within your database (automatically assigned)
- * `Universally Unique Identifier <https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>`_ (UUID): A string, e.g. ``ce81c420-7751-48f6-af8e-eb7c6a30cec3`` identifying your entity globally (automatically assigned)
- * Label: A human-readable string, e.g. ``test_calculation`` (manually assigned)
+* "Primary Key" (PK): An integer, e.g. ``723``, identifying your entity within your database (automatically assigned)
+* `Universally Unique Identifier <https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>`_ (UUID): A string, e.g. ``ce81c420-7751-48f6-af8e-eb7c6a30cec3`` identifying your entity globally (automatically assigned)
+* Label: A human-readable string, e.g. ``test_calculation`` (manually assigned)
 
 .. note::
 
@@ -152,9 +152,9 @@ In almost all cases, this will work out of the box.
 Since command line parameters are passed as strings, AiiDA needs to deduce the type of identifier from its content, which can fail in edge cases (see :ref:`topics:cli:identifier_resolution` for details).
 You can take the following precautions in order to avoid such edge cases:
 
-  * PK: no precautions needed
-  * UUID: no precautions needed for full UUIDs. Partial UUIDs should include at least one non-numeric character or dash
-  * Label: add an exclamation mark ``!`` at the end of the identifier in order to force interpretation as a label
+* PK: no precautions needed
+* UUID: no precautions needed for full UUIDs. Partial UUIDs should include at least one non-numeric character or dash
+* Label: add an exclamation mark ``!`` at the end of the identifier in order to force interpretation as a label
 
 
 .. _topics:cli:identifier_resolution:
@@ -164,9 +164,9 @@ Implementation of identifier resolution
 
 The logic for deducing the identifier type is as follows:
 
- 1. Try interpreting the identifier as a PK (integer)
- 2. If this fails, try interpreting the identifier as a UUID (full or partial)
- 3. If this fails, interpret the identifier as a label
+1. Try interpreting the identifier as a PK (integer)
+2. If this fails, try interpreting the identifier as a UUID (full or partial)
+3. If this fails, interpret the identifier as a label
 
 The following example illustrates edge cases that can arise in this logic:
 
@@ -178,9 +178,9 @@ PK   UUID                                   LABEL
 12   3df34a1e-5215-4e1a-b626-7f75b9586ef5   deadbeef
 ===  =====================================  ========
 
- * trying to identify the first entity by its partial UUID ``12`` would match the third entity by its PK instead
- * trying to identify the second entity by its label ``10`` would match the first entity by its PK instead
- * trying to identify the third entity by its label ``deadbeef`` would match the second entity on its partial UUID ``deadbeef`` instead
+* trying to identify the first entity by its partial UUID ``12`` would match the third entity by its PK instead
+* trying to identify the second entity by its label ``10`` would match the first entity by its PK instead
+* trying to identify the third entity by its label ``deadbeef`` would match the second entity on its partial UUID ``deadbeef`` instead
 
 The ambiguity between a partial UUID and a PK can always be resolved by including a longer substring of the UUID, eventually rendering the identifier no longer a valid PK.
 

--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -422,10 +422,10 @@ AbstractCode
 The :class:`aiida.orm.nodes.data.code.abstract.AbstractCode` class provides the abstract class for objects that represent a "code" that can be executed through a :class:`aiida.engine.processes.calcjobs.calcjob.CalcJob` plugin.
 There are currently four implementations of this abstract class:
 
- * :class:`~aiida.orm.nodes.data.code.legacy.Code` (see :ref:`Code <topics:data_types:core:code:legacy>`)
- * :class:`~aiida.orm.nodes.data.code.installed.InstalledCode` (see :ref:`InstalledCode <topics:data_types:core:code:installed>`)
- * :class:`~aiida.orm.nodes.data.code.portable.PortableCode` (see :ref:`PortableCode <topics:data_types:core:code:portable>`)
- * :class:`~aiida.orm.nodes.data.code.containerized.ContainerizedCode` (see :ref:`ContainerizedCode <topics:data_types:core:code:containerized>`)
+* :class:`~aiida.orm.nodes.data.code.legacy.Code` (see :ref:`Code <topics:data_types:core:code:legacy>`)
+* :class:`~aiida.orm.nodes.data.code.installed.InstalledCode` (see :ref:`InstalledCode <topics:data_types:core:code:installed>`)
+* :class:`~aiida.orm.nodes.data.code.portable.PortableCode` (see :ref:`PortableCode <topics:data_types:core:code:portable>`)
+* :class:`~aiida.orm.nodes.data.code.containerized.ContainerizedCode` (see :ref:`ContainerizedCode <topics:data_types:core:code:containerized>`)
 
 
 .. _topics:data_types:core:code:legacy:
@@ -437,8 +437,8 @@ Code
 
 Historically, there was only one code implementation, the :class:`~aiida.orm.nodes.data.code.legacy.Code`, which implemented two different types of code:
 
- * An executable pre-installed on a computer, represented by a :class:`~aiida.orm.computers.Computer`.
- * A directory containing all code files including an executable which would be uploaded to
+* An executable pre-installed on a computer, represented by a :class:`~aiida.orm.computers.Computer`.
+* A directory containing all code files including an executable which would be uploaded to
 
 These two types were referred to as "remote" and "local" codes.
 However, this nomenclature would lead to confusion as a "remote" code could also refer to an executable on the localhost, i.e., the machine where AiiDA itself runs.
@@ -1161,8 +1161,8 @@ Before calling the constructor of the base class, we have to remove the ``value`
 The final step is to actually *store* the value that is passed by the caller of the constructor.
 A new node has two locations to permanently store any of its properties:
 
-    * the database
-    * the file repository
+* the database
+* the file repository
 
 The section on :ref:`design guidelines<topics:data_types:plugin:design-guidelines>` will go into more detail what the advantages and disadvantages of each option are and when to use which.
 For now, since we are storing only a single value, the easiest and best option is to use the database.

--- a/docs/source/topics/plugins.rst
+++ b/docs/source/topics/plugins.rst
@@ -358,9 +358,9 @@ The module provides the following fixtures:
 * :ref:`config_psql_dos <topics:plugins:testfixtures:config-psql-dos>`: Return a profile configuration for the :class:`~aiida.storage.psql_dos.backend.PsqlDosBackend`
 * :ref:`postgres_cluster <topics:plugins:testfixtures:postgres-cluster>`: Create a temporary and isolated PostgreSQL cluster using ``pgtest`` and cleanup after the yield
 * :ref:`aiida_local_code_factory <topics:plugins:testfixtures:aiida-local-code-factory>`: Setup a :class:`~aiida.orm.nodes.data.code.installed.InstalledCode` instance on the ``localhost`` computer
-* :ref: `aiida_computer` <topics:plugins:testfixtures:aiida-computer>`: Setup a :class:`~aiida.orm.computers.Computer` instance
-* :ref: `aiida_computer_local` <topics:plugins:testfixtures:aiida-computer-local>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using local transport
-* :ref: `aiida_computer_ssh` <topics:plugins:testfixtures:aiida-computer-ssh>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using SSH transport
+* :ref:`aiida_computer <topics:plugins:testfixtures:aiida-computer>`: Setup a :class:`~aiida.orm.computers.Computer` instance
+* :ref:`aiida_computer_local <topics:plugins:testfixtures:aiida-computer-local>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using local transport
+* :ref:`aiida_computer_ssh <topics:plugins:testfixtures:aiida-computer-ssh>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using SSH transport
 * :ref:`aiida_localhost <topics:plugins:testfixtures:aiida-localhost>`: Shortcut for <topics:plugins:testfixtures:aiida-computer-local> that immediately returns a :class:`~aiida.orm.computers.Computer` instance for the ``localhost`` computer instead of a factory
 * :ref:`submit_and_await <topics:plugins:testfixtures:submit-and-await>`: Submit a process or process builder to the daemon and wait for it to reach a certain process state
 * :ref:`started_daemon_client <topics:plugins:testfixtures:started-daemon-client>`: Same as ``daemon_client`` but the daemon is guaranteed to be running

--- a/docs/source/topics/processes/concepts.rst
+++ b/docs/source/topics/processes/concepts.rst
@@ -25,8 +25,8 @@ Process types
 
 Processes in AiiDA come in two flavors:
 
- * Calculation-like
- * Workflow-like
+* Calculation-like
+* Workflow-like
 
 The calculation-like processes have the capability to *create* data, whereas the workflow-like processes orchestrate other processes and have the ability to *return* data produced by calculations.
 Again, this is a distinction that plays a big role in AiiDA and is crucial to understand.

--- a/docs/source/topics/processes/functions.rst
+++ b/docs/source/topics/processes/functions.rst
@@ -7,8 +7,8 @@ Process functions
 A process function is a process (see the :ref:`concepts<topics:processes:concepts>` for a definition and explanation) that is implemented as a decorated python function.
 Currently, there are two types of process functions:
 
- * :ref:`calculation function<topics:calculations:concepts:calcfunctions>`
- * :ref:`work function<topics:workflows:concepts:workfunctions>`
+* :ref:`calculation function<topics:calculations:concepts:calcfunctions>`
+* :ref:`work function<topics:workflows:concepts:workfunctions>`
 
 The former can *create* new data, whereas the latter can orchestrate other processes and *return* their results.
 This section will provide detailed information and best practices on how to implement these two process types.
@@ -23,8 +23,8 @@ Function signatures
 To explain what features of python function definitions and calls are supported we first need to be clear about some terminology.
 When dealing with functions, there are two distinct parts:
 
- * `function definitions <https://docs.python.org/3/reference/compound_stmts.html#function-definitions>`_
- * `function calls <https://docs.python.org/3/reference/expressions.html#calls>`_
+* `function definitions <https://docs.python.org/3/reference/compound_stmts.html#function-definitions>`_
+* `function calls <https://docs.python.org/3/reference/expressions.html#calls>`_
 
 Consider the following code snippet that defines a simple python function:
 
@@ -250,10 +250,10 @@ Provenance
 ==========
 In addition to the basic attributes that are stored for all processes such as the process state and label, the process functions automatically store additional information that relates to the source code of the function they represent:
 
- * Function name
- * Function namespace
- * Function starting line number
- * Function source file
+* Function name
+* Function namespace
+* Function starting line number
+* Function source file
 
 The first three are retrieved by inspecting the python source code as soon as the process function is executed and are stored as attributes on the process node.
 They can be accessed through the corresponding properties on the process node as follows:
@@ -273,9 +273,9 @@ Reproducibility guidelines
 --------------------------
 Due to the nature of the way process functions are implemented, it is impossible to guarantee 100% reproducibility, but by following the following guidelines, one can come as close as possible.
 
- * Do not leak data into functions
- * Limit importing of external code
- * Keep functions self-consistent and in separate files
+* Do not leak data into functions
+* Limit importing of external code
+* Keep functions self-consistent and in separate files
 
 Leaking data into functions is accomplished for example by reading a file on the local file system in the function body and using its contents for the creation of the outputs.
 Even if you store the source code, if you don't possess the file that was read, it is impossible to reproduce the results.

--- a/docs/source/topics/processes/usage.rst
+++ b/docs/source/topics/processes/usage.rst
@@ -9,10 +9,10 @@ Usage
 This section will explain the aspects of working with processes that apply to all processes.
 Details that only pertain to a specific sub type of process, will be documented in their respective sections:
 
-    * :ref:`calculation functions<topics:calculations:usage:calcfunctions>`
-    * :ref:`calculation jobs<topics:calculations:usage:calcjobs>`
-    * :ref:`work functions<topics:workflows:usage:workfunctions>`
-    * :ref:`work chains<topics:workflows:usage:workchains>`
+* :ref:`calculation functions<topics:calculations:usage:calcfunctions>`
+* :ref:`calculation jobs<topics:calculations:usage:calcjobs>`
+* :ref:`work functions<topics:workflows:usage:workfunctions>`
+* :ref:`work chains<topics:workflows:usage:workchains>`
 
 
 .. _topics:processes:usage:defining:
@@ -32,9 +32,9 @@ For the :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob` and :py:cla
 
 The three most important attributes of the :py:class:`~aiida.engine.processes.process_spec.ProcessSpec` are:
 
-    * ``inputs``
-    * ``outputs``
-    * ``exit_codes``
+* ``inputs``
+* ``outputs``
+* ``exit_codes``
 
 Through these attributes, one can define what inputs a process takes, what outputs it will produce and what potential exit codes it can return in case of errors.
 Just by looking at a process specification then, one will know exactly *what* will happen, just not *how* it will happen.
@@ -109,10 +109,10 @@ The underlying concept that allows this nesting of ports is that the ``PortNames
 And as different subclasses of the same class, they have more properties and attributes in common, for example related to the concept of validation and default values.
 All three have the following attributes (with the exception of the ``OutputPort`` not having a ``default`` attribute):
 
-    * ``default``
-    * ``required``
-    * ``valid_type``
-    * ``validator``
+* ``default``
+* ``required``
+* ``valid_type``
+* ``validator``
 
 These attributes can all be set upon construction of the port or after the fact, as long as the spec has not been sealed, which means that they can be altered without limit as long as it is within the ``define`` method of the corresponding ``Process``.
 An example input port that explicitly sets all these attributes is the following:
@@ -279,10 +279,10 @@ Note that since the following rules are *guidelines* you can choose to ignore th
 Regardless, we advise you to follow the guidelines since it will improve the interoperability of your code with other existing plugins.
 The following integer ranges are reserved or suggested:
 
-    *   0 -  99: Reserved for internal use by `aiida-core`
-    * 100 - 199: Reserved for errors parsed from scheduler output of calculation jobs (note: this is not yet implemented)
-    * 200 - 299: Suggested to be used for process input validation errors
-    * 300 - 399: Suggested for critical process errors
+*   0 -  99: Reserved for internal use by `aiida-core`
+* 100 - 199: Reserved for errors parsed from scheduler output of calculation jobs (note: this is not yet implemented)
+* 200 - 299: Suggested to be used for process input validation errors
+* 300 - 399: Suggested for critical process errors
 
 For any other exit codes, one can use the integers from 400 and up.
 
@@ -297,9 +297,9 @@ These metadata differ from inputs in the sense that they are not nodes that will
 Rather, these are inputs that slightly modify the behavior of the process or allow to set attributes on the process node that represents its execution.
 The following metadata inputs are available for *all* process classes:
 
-    * ``label``: will set the label on the ``ProcessNode``
-    * ``description``: will set the description on the ``ProcessNode``
-    * ``store_provenance``: boolean flag, by default ``True``, that when set to ``False``, will ensure that the execution of the process **is not** stored in the provenance graph
+* ``label``: will set the label on the ``ProcessNode``
+* ``description``: will set the description on the ``ProcessNode``
+* ``store_provenance``: boolean flag, by default ``True``, that when set to ``False``, will ensure that the execution of the process **is not** stored in the provenance graph
 
 Sub classes of the :py:class:`~aiida.engine.processes.process.Process` class can specify further metadata inputs, refer to their specific documentation for details.
 To pass any of these metadata options to a process, simply pass them in a dictionary under the key ``metadata`` in the inputs when launching the process.
@@ -325,10 +325,10 @@ Process launch
 To launch a process, one can use the free functions that can be imported from the :py:mod:`aiida.engine` module.
 There are four different functions:
 
-    * :py:func:`~aiida.engine.launch.run`
-    * :py:func:`~aiida.engine.launch.run_get_node`
-    * :py:func:`~aiida.engine.launch.run_get_pk`
-    * :py:func:`~aiida.engine.launch.submit`
+* :py:func:`~aiida.engine.launch.run`
+* :py:func:`~aiida.engine.launch.run_get_node`
+* :py:func:`~aiida.engine.launch.run_get_pk`
+* :py:func:`~aiida.engine.launch.submit`
 
 As the name suggest, the first three will 'run' the process and the latter will 'submit' it to the daemon.
 Running means that the process will be executed in the same interpreter in which it is launched, blocking the interpreter, until the process is terminated.
@@ -336,8 +336,8 @@ Submitting to the daemon, in contrast, means that the process will be sent to th
 
 All functions have the exact same interface ``launch(process, **inputs)`` where:
 
-    * ``process`` is the process class or process function to launch
-    * ``inputs`` are the inputs as keyword arguments to pass to the process.
+* ``process`` is the process class or process function to launch
+* ``inputs`` are the inputs as keyword arguments to pass to the process.
 
 What inputs can be passed depends on the exact process class that is to be launched.
 For example, when we want to run an instance of the :py:class:`~aiida.calculations.arithmetic.add.ArithmeticAddCalculation` process, which takes two :py:class:`~aiida.orm.nodes.data.int.Int` nodes as inputs under the name ``x`` and ``y`` [#f1]_, we would do the following:
@@ -377,8 +377,8 @@ The examples used above would look like the following:
 Process functions, i.e. :ref:`calculation functions<topics:calculations:concepts:calcfunctions>` and :ref:`work functions<topics:workflows:concepts:workfunctions>`, can be launched like any other process as explained above.
 Process functions have two additional methods of being launched:
 
- * Simply *calling* the function
- * Using the internal run method attributes
+* Simply *calling* the function
+* Using the internal run method attributes
 
 Using a calculation function to add two numbers as an example, these two methods look like the following:
 
@@ -531,9 +531,9 @@ For a complete list of all the available options, please refer to the documentat
 
 If you are looking for information about a specific process node, the following three commands are at your disposal:
 
- * ``verdi process report`` gives a list of the log messages attached to the process
- * ``verdi process status`` print the call hierarchy of the process and status of all its nodes
- * ``verdi process show`` print details about the status, inputs, outputs, callers and callees of the process
+* ``verdi process report`` gives a list of the log messages attached to the process
+* ``verdi process status`` print the call hierarchy of the process and status of all its nodes
+* ``verdi process show`` print details about the status, inputs, outputs, callers and callees of the process
 
 In the following sections, we will explain briefly how the commands work.
 For the purpose of example, we will show the output of the commands for a completed ``PwBaseWorkChain`` from the ``aiida-quantumespresso`` plugin, which simply calls a ``PwCalculation``.
@@ -644,9 +644,9 @@ verdi process pause/play/kill
 -----------------------------
 The ``verdi`` command line interface provides three commands to interact with 'live' processes.
 
-    * ``verdi process pause``
-    * ``verdi process play``
-    * ``verdi process kill``
+* ``verdi process pause``
+* ``verdi process play``
+* ``verdi process kill``
 
 The first pauses a process temporarily, the second resumes any paused processes and the third one permanently kills them.
 The sub command names might seem to tell you this already and it might look like that is all there is to know, but the functionality underneath is quite complicated and deserves additional explanation nonetheless.

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -102,8 +102,8 @@ When a node is being stored (the `target`) and caching is enabled for its node c
 This method calls the iterator :meth:`~aiida.orm.nodes.caching.NodeCaching._iter_all_same_nodes` and takes the first one it returns if there are any.
 To find the list of `source` nodes that are equivalent to the `target` that is being stored, :meth:`~aiida.orm.nodes.caching.NodeCaching._iter_all_same_nodes` performs the following steps:
 
- 1. It queries the database for all nodes that have the same hash as the `target` node.
- 2. From the result, only those nodes are returned where the property :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` returns ``True``.
+1. It queries the database for all nodes that have the same hash as the `target` node.
+2. From the result, only those nodes are returned where the property :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` returns ``True``.
 
 The property :meth:`~aiida.orm.nodes.caching.NodeCaching.is_valid_cache` therefore allows to control whether a stored node can be used as a `source` in the caching mechanism.
 By default, for all nodes, the property returns ``True``.

--- a/docs/source/topics/provenance/implementation.rst
+++ b/docs/source/topics/provenance/implementation.rst
@@ -11,15 +11,15 @@ The **nodes** of the AiiDA provenance graph can be grouped into two main **types
 
 In particular, **process nodes** are divided into two sub categories:
 
-    - **calculation nodes** (``CalculationNode``): Represent code execution that creates new data. These are further subdivided in two subclasses:
+- **calculation nodes** (``CalculationNode``): Represent code execution that creates new data. These are further subdivided in two subclasses:
 
-        - :py:class:`~aiida.orm.nodes.process.calculation.calcjob.CalcJobNode`: Represents the execution of a calculation external to AiiDA, typically via a job batch scheduler (see the concept of :ref:`calculation jobs<topics:calculations:concepts:calcjobs>`).
-        - :py:class:`~aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode`: Represents the execution of a python function (see the concept of :ref:`calculation functions<topics:calculations:concepts:calcfunctions>`).
+    - :py:class:`~aiida.orm.nodes.process.calculation.calcjob.CalcJobNode`: Represents the execution of a calculation external to AiiDA, typically via a job batch scheduler (see the concept of :ref:`calculation jobs<topics:calculations:concepts:calcjobs>`).
+    - :py:class:`~aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode`: Represents the execution of a python function (see the concept of :ref:`calculation functions<topics:calculations:concepts:calcfunctions>`).
 
-    - **workflow nodes** (``WorkflowNode``): Represent python code that orchestrates the execution of other workflows and calculations, that optionally return the data created by the processes they called. These are further subdivided in two subclasses:
+- **workflow nodes** (``WorkflowNode``): Represent python code that orchestrates the execution of other workflows and calculations, that optionally return the data created by the processes they called. These are further subdivided in two subclasses:
 
-        - :py:class:`~aiida.orm.nodes.process.workflow.workchain.WorkChainNode`: Represents the execution of a python class instance with built-in checkpoints, such that the process may be paused/stopped/resumed (see the concept of :ref:`work chains<topics:workflows:concepts:workchains>`).
-        - :py:class:`~aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode`: Represents the execution of a python function calling other processes (see the concept of :ref:`work functions<topics:workflows:concepts:workfunctions>`).
+    - :py:class:`~aiida.orm.nodes.process.workflow.workchain.WorkChainNode`: Represents the execution of a python class instance with built-in checkpoints, such that the process may be paused/stopped/resumed (see the concept of :ref:`work chains<topics:workflows:concepts:workchains>`).
+    - :py:class:`~aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode`: Represents the execution of a python function calling other processes (see the concept of :ref:`work functions<topics:workflows:concepts:workfunctions>`).
 
 The class hierarchy of the process nodes is shown in the figure below.
 

--- a/docs/source/topics/repository.rst
+++ b/docs/source/topics/repository.rst
@@ -21,9 +21,9 @@ Writing to the repository
 
 To write files to a node, you can use one of the following three methods:
 
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.put_object_from_file`
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.put_object_from_filelike`
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.put_object_from_tree`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.put_object_from_file`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.put_object_from_filelike`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.put_object_from_tree`
 
 Let's assume that you have a file on your local file system called `/some/path/file.txt` that you want to copy to a node.
 The most straightforward solution is the following:
@@ -83,9 +83,9 @@ Listing repository content
 
 To determine the contents of a node's repository, you can use the following methods:
 
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.list_object_names`
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.list_objects`
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.walk`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.list_object_names`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.list_objects`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.walk`
 
 The first method will return a list of file objects contained within the node's repository, where an object can be either a directory or a file:
 
@@ -143,8 +143,8 @@ Reading from the repository
 
 To retrieve the content of files stored in a node's repository, you can use the following methods:
 
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.open`
- * :meth:`~aiida.orm.nodes.repository.NodeRepository.get_object_content`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.open`
+* :meth:`~aiida.orm.nodes.repository.NodeRepository.get_object_content`
 
 The first method functions exactly as Python's ``open`` built-in function:
 

--- a/docs/source/topics/schedulers.rst
+++ b/docs/source/topics/schedulers.rst
@@ -223,15 +223,15 @@ A scheduler plugin allows AiiDA to communicate with a specific type of scheduler
 The plugin should subclass the :class:`~aiida.schedulers.scheduler.Scheduler` class and implement a number of methods, that will instruct how certain key commands are to be executed, such as submitting a new job or requesting the current active jobs.
 To get you started, you can download :download:`this template <include/scheduler_template.py>` and implement the following methods:
 
-    1) ``_get_joblist_command``: returns the command to report a full information on existing jobs.
-    2) ``_get_detailed_job_info_command``: returns the command to get the detailed information on  a job, even after the job has finished.
-    3) ``_get_submit_script_header``: return the submit script header.
-    4) ``_get_submit_command``: return the string to submit a given script.
-    5) ``_parse_joblist_output``: parse the queue output string, as returned by executing the command returned by `_get_joblist_command`.
-    6) ``_parse_submit_output``: parse the output of the submit command, as returned by executing the command returned by `_get_submit_command`.
-    7) ``_get_kill_command``: return the command to kill the job with specified jobid.
-    8) ``_parse_kill_output``: parse the output of the kill command.
-    9) ``parse_output``: parse the output of the scheduler.
+#. ``_get_joblist_command``: returns the command to report a full information on existing jobs.
+#. ``_get_detailed_job_info_command``: returns the command to get the detailed information on  a job, even after the job has finished.
+#. ``_get_submit_script_header``: return the submit script header.
+#. ``_get_submit_command``: return the string to submit a given script.
+#. ``_parse_joblist_output``: parse the queue output string, as returned by executing the command returned by `_get_joblist_command`.
+#. ``_parse_submit_output``: parse the output of the submit command, as returned by executing the command returned by `_get_submit_command`.
+#. ``_get_kill_command``: return the command to kill the job with specified jobid.
+#. ``_parse_kill_output``: parse the output of the kill command.
+#. ``parse_output``: parse the output of the scheduler.
 
 All these methods *have* to be implemented, except for ``_get_detailed_job_info_command`` and ``parse_output``, which are optional.
 In addition to these methods, the ``_job_resource_class`` class attribute needs to be set to a subclass :class:`~aiida.schedulers.datastructures.JobResource`.

--- a/docs/source/topics/transport.rst
+++ b/docs/source/topics/transport.rst
@@ -37,9 +37,9 @@ The ``ssh`` logic is instead given by the property sftp.
 
 The other functions that require some care are the copying functions, called using the following terminology:
 
-    1) ``put``: from local source to remote destination
-    2) ``get``: from remote source to local destination
-    3) ``copy``: copying files from remote source to remote destination
+#. ``put``: from local source to remote destination
+#. ``get``: from remote source to local destination
+#. ``copy``: copying files from remote source to remote destination
 
 Note that these functions must accept both files and folders and internally they will fallback to functions like ``putfile`` or ``puttree``.
 

--- a/docs/source/topics/workflows/concepts.rst
+++ b/docs/source/topics/workflows/concepts.rst
@@ -7,8 +7,8 @@ Concepts
 A workflow in AiiDA is a process (see the :ref:`process section<topics:processes:concepts>` for details) that calls other workflows and calculations and optionally *returns* data and as such can encode the logic of a typical scientific workflow.
 Currently, there are two ways of implementing a workflow process:
 
- * :ref:`work functions<topics:workflows:concepts:workfunctions>`
- * :ref:`work chains<topics:workflows:concepts:workchains>`
+* :ref:`work functions<topics:workflows:concepts:workfunctions>`
+* :ref:`work chains<topics:workflows:concepts:workchains>`
 
 The first one is the simplest of the two and is basically a python function that is magically transformed into a process.
 This is ideal for workflows that are not very computationally intensive and can be easily implemented in a python function.

--- a/docs/source/topics/workflows/usage.rst
+++ b/docs/source/topics/workflows/usage.rst
@@ -9,8 +9,8 @@ Usage
 A workflow in AiiDA is a process (see the :ref:`process section<topics:processes:concepts>` for details) that calls other workflows and calculations and optionally *returns* data and as such can encode the logic of a typical scientific workflow.
 Currently, there are two ways of implementing a workflow process:
 
- * :ref:`work function<topics:workflows:usage:workfunctions>`
- * :ref:`work chain<topics:workflows:usage:workchains>`
+* :ref:`work function<topics:workflows:usage:workfunctions>`
+* :ref:`work chain<topics:workflows:usage:workchains>`
 
 This section will provide detailed information and best practices on how to implement these two workflow types.
 
@@ -22,8 +22,8 @@ Work functions
 
 The concept of work functions and the basic rules of implementation are documented in detail elsewhere:
 
-  * :ref:`concept of work functions<topics:workflows:concepts:workfunctions>`
-  * :ref:`implementation of process functions<topics:processes:functions>`
+* :ref:`concept of work functions<topics:workflows:concepts:workfunctions>`
+* :ref:`implementation of process functions<topics:processes:functions>`
 
 Since work functions are a sub type of process functions, just like calculation functions, their implementation rules are as good as identical.
 However, their intended aim and heuristics are very different.
@@ -199,9 +199,9 @@ However, the outline also supports various logical constructs, such as while-loo
 As usual, the best way to illustrate these constructs is by example.
 The currently available logical constructs for the work chain outline are:
 
-    * ``if``, ``elif``, ``else``
-    * ``while``
-    * ``return``
+* ``if``, ``elif``, ``else``
+* ``while``
+* ``return``
 
 To distinguish these constructs from the python builtins, they are suffixed with an underscore, like so ``while_``.
 To use these in your work chain design, you will have to import them:


### PR DESCRIPTION
There were a considerable number of bulleted and enumerated lists whose line markers were indented. This would cause them to be rendered as an indented code block. Instead, the lists should be indented to exactly the same level as the preceding text paragraph.