### PR TITLE
Update conf.py to remove edit this page button. 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,7 @@ html_theme_options = {
     }],
     'github_url': 'https://github.com/aiidateam/aiida-core',
     'twitter_url': 'https://twitter.com/aiidateam',
-    'use_edit_page_button': True,
+    'use_edit_page_button': False,
 }
 html_context = {
     'github_user': 'aiidateam',


### PR DESCRIPTION
Fixes #4947, where the edit this page button on the readthedocs does not make sense, so it's hidden from the users. 