### PR TITLE
`verdi config list`: Do not except if no profiles are defined 

### DIFF
--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -40,7 +40,7 @@ def verdi_config_list(ctx, prefix, description: bool):
     from aiida.manage.configuration import Config, Profile
 
     config: Config = ctx.obj.config
-    profile: Profile = ctx.obj.profile
+    profile: Profile = ctx.obj.get('profile', None)
 
     if not profile:
         echo.echo_warning('no profiles configured: run `verdi setup` to create one')

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -8,8 +8,16 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Tests for ``verdi config``."""
+import pytest
+
 from aiida import get_profile
 from aiida.cmdline.commands import cmd_verdi
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_config_list_no_profile(run_cli_command):
+    """Test the `verdi config list` command when no profile is present in the config, it should not except."""
+    run_cli_command(cmd_verdi.verdi, ['config', 'list'], initialize_ctx_obj=False)
 
 
 def test_config_set_option_no_profile(run_cli_command, empty_config):


### PR DESCRIPTION
Fixes #5920 

The command should work if no profiles exist, in which case it should
simply list the global values, however, it was excepting since it
assumed that `ctx.obj.profile` would be set. This is set by the
`ProfileParamType` which is used by the `--profile` option, but this is
not called if no profiles are defined.

To create a regression test, the `empty_config` fixture is used.
However, since this fixture works in memory, the `use_subprocess=False`
switch has to be used for `run_cli_command`. This by default would
populate the `ctx.obj.profile` object. This is normally done by the
`--profile` option, but this is not hit when using `click.CliRunner`.
This would nullify the test, as it would always pass, even without the
fix.

To solve this issue, a new argument `initialize_ctx_obj` is added to the
`run_cli_command` fixture. If set to `False`, the `ctx.obj` is not
initialized. By using this new argument, the regression test properly
failed before the test, but passes after the fix.