### PR TITLE
`WorkChains`: Raise if predicate `if_/while_` does not return boolean

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - importlib-resources~=5.0
 - numpy~=1.19
 - paramiko>=2.7.2,~=2.7
-- plumpy~=0.21.3
+- plumpy~=0.21.4
 - pgsu~=0.2.1
 - psutil~=5.6
 - psycopg2-binary~=2.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "importlib-resources~=5.0;python_version<'3.9'",
     "numpy~=1.19",
     "paramiko~=2.7,>=2.7.2",
-    "plumpy~=0.21.3",
+    "plumpy~=0.21.4",
     "pgsu~=0.2.1",
     "psutil~=5.6",
     "psycopg2-binary~=2.8",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -90,7 +90,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.3
+plumpy==0.21.4
 prometheus-client==0.12.0
 prompt-toolkit==3.0.37
 psutil==5.8.0

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -107,7 +107,7 @@ Pillow==9.3.0
 platformdirs==2.5.4
 plotly==5.11.0
 pluggy==1.0.0
-plumpy==0.21.3
+plumpy==0.21.4
 prometheus-client==0.15.0
 prompt-toolkit==3.0.37
 psutil==5.9.4

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -91,7 +91,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.3
+plumpy==0.21.4
 prometheus-client==0.12.0
 prompt-toolkit==3.0.37
 psutil==5.8.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -90,7 +90,7 @@ pickleshare==0.7.5
 Pillow==9.3.0
 plotly==5.4.0
 pluggy==1.0.0
-plumpy==0.21.3
+plumpy==0.21.4
 prometheus-client==0.12.0
 prompt-toolkit==3.0.37
 psutil==5.8.0

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -514,6 +514,40 @@ class TestWorkchain:
     def test_str(self):
         assert isinstance(str(Wf.spec()), str)
 
+    def test_invalid_if_predicate(self):
+        """Test that workchain raises if the predicate of an ``if_`` condition does not return a boolean."""
+
+        class TestWorkChain(WorkChain):
+
+            @classmethod
+            def define(cls, spec):
+                super().define(spec)
+                spec.outline(if_(cls.predicate))
+
+            def predicate(self):
+                """Invalid predicate whose return value is not a boolean."""
+                return 'true'
+
+        with pytest.raises(TypeError, match=r'The conditional predicate `predicate` did not return a boolean'):
+            launch.run(TestWorkChain)
+
+    def test_invalid_while_predicate(self):
+        """Test that workchain raises if the predicate of an ``while_`` condition does not return a boolean."""
+
+        class TestWorkChain(WorkChain):
+
+            @classmethod
+            def define(cls, spec):
+                super().define(spec)
+                spec.outline(while_(cls.predicate))
+
+            def predicate(self):
+                """Invalid predicate whose return value is not a boolean."""
+                return 'true'
+
+        with pytest.raises(TypeError, match=r'The conditional predicate `predicate` did not return a boolean'):
+            launch.run(TestWorkChain)
+
     def test_malformed_outline(self):
         """
         Test some malformed outlines


### PR DESCRIPTION
Fixes #5477 

Before the conditionals created by the `if_` and `while_` constructs would enter their body as long as the predicate returned anything that was truthy. This could lead to unexpected behavior. For example, if a user tried to abort a workchain from the predicate of a while-loop by returning an `ExitCode` instance, the while stepper would accept the exit code as truthy and continue the loop.

To prevent this, the conditionals will now raise a `TypeError` whenever the value returned by the predicate is not a boolean. Since this logic was added in `plumpy==0.21.4` the dependency requirement is updated.