### PR TITLE
CLI: Respect config log levels if `--verbosity` not explicitly passed

### DIFF
--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -11,15 +11,14 @@
 import collections
 import enum
 import json
+import logging
 import sys
 from typing import Any, Optional
 
 import click
 import yaml
 
-from aiida.common.log import AIIDA_LOGGER
-
-CMDLINE_LOGGER = AIIDA_LOGGER.getChild('cmdline')
+CMDLINE_LOGGER = logging.getLogger('verdi')
 
 __all__ = ('echo_report', 'echo_info', 'echo_success', 'echo_warning', 'echo_error', 'echo_critical', 'echo_dictionary')
 

--- a/aiida/manage/configuration/schema/config-v9.schema.json
+++ b/aiida/manage/configuration/schema/config-v9.schema.json
@@ -47,6 +47,12 @@
           "default": "REPORT",
           "description": "Minimum level to log to daemon log and the `DbLog` table for the `aiida` logger"
         },
+        "logging.verdi_loglevel": {
+          "type": "string",
+          "enum": ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"],
+          "default": "REPORT",
+          "description": "Minimum level to log to console when running a `verdi` command"
+        },
         "logging.db_loglevel": {
           "type": "string",
           "enum": ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"],

--- a/docs/source/topics/cli.rst
+++ b/docs/source/topics/cli.rst
@@ -127,6 +127,7 @@ is identical to
     verdi --verbosity debug process list
 
 When the option is specified multiple times, only the last value will be considered.
+If the `--verbosity` option is specified, it overrides the log level of all the loggers configured by AiiDA, e.g. `logging.aiida_loglevel`.
 
 
 .. _topics:cli:identifiers:

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -114,10 +114,9 @@ def tests_storage_migrate_raises(run_cli_command, raise_type, call_kwargs, monke
     assert 'passed error message' in result.output
 
 
-def tests_storage_maintain_logging(run_cli_command, monkeypatch, caplog):
+def tests_storage_maintain_logging(run_cli_command, monkeypatch):
     """Test all the information and cases of the storage maintain command."""
-    import logging
-
+    from aiida.common.log import AIIDA_LOGGER
     from aiida.manage import get_manager
     storage = get_manager().get_profile_storage()
 
@@ -133,56 +132,45 @@ def tests_storage_maintain_logging(run_cli_command, monkeypatch, caplog):
         for key, val in kwargs.items():
             log_message += f' > {key}: {val}\n'
 
-        logging.info(log_message)
+        AIIDA_LOGGER.report(log_message)
 
     monkeypatch.setattr(storage, 'maintain', mock_maintain)
 
-    # Not passing user input Y or `--force` should causing the command to exit without executing `storage.mantain`
-    # Checking that no logs are produced in the with caplog context
-    with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, use_subprocess=False)
-
-    assert len(caplog.records) == 0
+    # Not passing user input should cause the command to exit without executing `storage.mantain` and so the last
+    # message should be the prompt to continue or not.
+    result = run_cli_command(cmd_storage.storage_maintain, use_subprocess=False)
+    message_list = result.output_lines
+    assert message_list[-1] == 'Are you sure you want continue in this mode? [y/N]: '
 
     # Test `storage.mantain` with `--force`
-    with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--force'], use_subprocess=False)
-
-    message_list = caplog.records[0].msg.splitlines()
+    result = run_cli_command(cmd_storage.storage_maintain, parameters=['--force'], use_subprocess=False)
+    message_list = result.output_lines
     assert ' > full: False' in message_list
     assert ' > dry_run: False' in message_list
 
     # Test `storage.mantain` with user input Y
-    with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, user_input='Y', use_subprocess=False)
-
-    message_list = caplog.records[1].msg.splitlines()
+    result = run_cli_command(cmd_storage.storage_maintain, user_input='Y', use_subprocess=False)
+    message_list = result.output_lines
     assert ' > full: False' in message_list
     assert ' > dry_run: False' in message_list
 
     # Test `storage.mantain` with `--dry-run`
-    with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--dry-run'], use_subprocess=False)
-
-    message_list = caplog.records[2].msg.splitlines()
+    result = run_cli_command(cmd_storage.storage_maintain, parameters=['--dry-run'], use_subprocess=False)
+    message_list = result.output_lines
     assert ' > full: False' in message_list
     assert ' > dry_run: True' in message_list
 
     # Test `storage.mantain` with `--full`
-    with caplog.at_level(logging.INFO):
-        run_cli_command(cmd_storage.storage_maintain, parameters=['--full'], user_input='Y', use_subprocess=False)
-
-    message_list = caplog.records[3].msg.splitlines()
+    result = run_cli_command(cmd_storage.storage_maintain, parameters=['--full'], user_input='Y', use_subprocess=False)
+    message_list = result.output_lines
     assert ' > full: True' in message_list
     assert ' > dry_run: False' in message_list
 
     # Test `storage.mantain` with `--full` and `--no-repack`
-    with caplog.at_level(logging.INFO):
-        run_cli_command(
-            cmd_storage.storage_maintain, parameters=['--full', '--no-repack'], user_input='Y', use_subprocess=False
-        )
-
-    message_list = caplog.records[4].msg.splitlines()
+    result = run_cli_command(
+        cmd_storage.storage_maintain, parameters=['--full', '--no-repack'], user_input='Y', use_subprocess=False
+    )
+    message_list = result.output_lines
     assert ' > full: True' in message_list
     assert ' > do_repack: False' in message_list
     assert ' > dry_run: False' in message_list

--- a/tests/cmdline/params/options/test_verbosity.py
+++ b/tests/cmdline/params/options/test_verbosity.py
@@ -31,6 +31,8 @@ def cmd():
 
     The messages to the ``verdi`` are performed indirect through the utilities of the ``echo`` module.
     """
+    assert 'cli' in [handler.name for handler in AIIDA_LOGGER.handlers]
+
     for log_level in LOG_LEVELS.values():
         AIIDA_LOGGER.log(log_level, 'aiida')
 

--- a/tests/cmdline/params/options/test_verbosity.py
+++ b/tests/cmdline/params/options/test_verbosity.py
@@ -12,10 +12,9 @@
 import functools
 import logging
 
-import click
 import pytest
 
-from aiida.cmdline.params import options
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import echo
 from aiida.common.log import AIIDA_LOGGER, LOG_LEVELS
 
@@ -26,12 +25,11 @@ def run_cli_command(run_cli_command):
     return functools.partial(run_cli_command, use_subprocess=False)
 
 
-@click.command()
-@options.VERBOSITY()
+@verdi.command('test')
 def cmd():
-    """Test command prints messages through the ``AIIDA_LOGGER`` and the ``CMDLINE_LOGGER``.
+    """Test command prints messages through the ``aiida`` and the ``verdi``.
 
-    The messages to the ``CMDLINE_LOGGER`` are performed indirect through the utilities of the ``echo`` module.
+    The messages to the ``verdi`` are performed indirect through the utilities of the ``echo`` module.
     """
     for log_level in LOG_LEVELS.values():
         AIIDA_LOGGER.log(log_level, 'aiida')
@@ -44,6 +42,27 @@ def cmd():
     echo.echo_critical('verdi')
 
 
+def verify_log_output(output: str, log_level_aiida: int, log_level_verdi: int):
+    """Verify that the expected log messages are in the output for the given log levels
+
+    :param output: The output written to stdout by the command.
+    :param log_level_aiida: The expected log level of the ``aiida`` logger.
+    :param log_level_verdi: The expected log level of the ``verdi`` logger.
+    """
+    for log_level_name, log_level in LOG_LEVELS.items():
+        prefix = log_level_name.capitalize()
+
+        if log_level >= log_level_aiida:
+            assert f'{prefix}: aiida' in output
+        else:
+            assert f'{prefix}: aiida' not in output
+
+        if log_level >= log_level_verdi:
+            assert f'{prefix}: verdi' in output
+        else:
+            assert f'{prefix}: verdi' not in output
+
+
 @pytest.mark.usefixtures('reset_log_level')
 def test_default(run_cli_command):
     """Test the command without explicitly specifying the verbosity.
@@ -51,14 +70,7 @@ def test_default(run_cli_command):
     The default log level is ``REPORT`` so its messages and everything above should show and the rest not.
     """
     result = run_cli_command(cmd, raises=True)
-
-    for log_level_name, log_level in LOG_LEVELS.items():
-        if log_level >= logging.REPORT:  # pylint: disable=no-member
-            assert f'{log_level_name.capitalize()}: verdi' in result.output
-            assert f'{log_level_name.capitalize()}: aiida' in result.output
-        else:
-            assert f'{log_level_name.capitalize()}: verdi' not in result.output
-            assert f'{log_level_name.capitalize()}: aiida' not in result.output
+    verify_log_output(result.output, logging.REPORT, logging.REPORT)  # pylint: disable=no-member
 
 
 @pytest.mark.parametrize('option_log_level', [level for level in LOG_LEVELS.values() if level != logging.NOTSET])
@@ -67,42 +79,19 @@ def test_explicit(run_cli_command, option_log_level):
     """Test explicitly settings a verbosity"""
     log_level_name = logging.getLevelName(option_log_level)
     result = run_cli_command(cmd, ['--verbosity', log_level_name], raises=True)
-
-    for log_level_name, log_level in LOG_LEVELS.items():
-        if log_level >= option_log_level:
-            assert f'{log_level_name.capitalize()}: verdi' in result.output
-            assert f'{log_level_name.capitalize()}: aiida' in result.output
-        else:
-            assert f'{log_level_name.capitalize()}: verdi' not in result.output
-            assert f'{log_level_name.capitalize()}: aiida' not in result.output
+    verify_log_output(result.output, option_log_level, option_log_level)
 
 
-@pytest.mark.usefixtures('reset_log_level', 'override_logging')
-def test_config_aiida_loglevel(run_cli_command, caplog):
-    """Test the behavior of the ``--verbosity`` option when the ``logging.aiida_loglevel`` config option is set.
+@pytest.mark.usefixtures('reset_log_level')
+def test_config_option_override(run_cli_command, isolated_config):
+    """Test that config log levels are only overridden if the ``--verbosity`` is explicitly passed."""
+    isolated_config.set_option('logging.aiida_loglevel', 'ERROR', scope=None)
+    isolated_config.set_option('logging.verdi_loglevel', 'WARNING', scope=None)
 
-    Even though the ``CMDLINE_LOGGER`` is technically a child of the ``AIIDA_LOGLEVEL`` and so normally the former
-    should not override the latter, that is actually the desired behavior. The option should ensure that it overrides
-    the value of the ``AIIDA_LOGGER`` that may be specified on the profile config.
-    """
-    # First log a ``DEBUG`` message to the ``AIIDA_LOGGER`` and capture it to see the logger is properly configured.
-    message = 'debug test message'
+    # If ``--verbosity`` is not explicitly defined, values from the config options should be used.
+    result = run_cli_command(cmd, raises=True, use_subprocess=False)
+    verify_log_output(result.output, logging.ERROR, logging.WARNING)
 
-    with caplog.at_level(logging.DEBUG):
-        AIIDA_LOGGER.debug(message)
-
-    assert message in caplog.text
-
-    # Now we invoke the command while passing a verbosity level that is higher than is configured for the
-    # ``AIIDA_LOGGER``. The explicit verbosity value should override the value configured on the profile.
-    option_log_level = logging.WARNING
-    option_log_level_name = logging.getLevelName(option_log_level)
-    result = run_cli_command(cmd, ['--verbosity', option_log_level_name], raises=True)
-
-    for log_level_name, log_level in LOG_LEVELS.items():
-        if log_level >= option_log_level:
-            assert f'{log_level_name.capitalize()}: verdi' in result.output
-            assert f'{log_level_name.capitalize()}: aiida' in result.output
-        else:
-            assert f'{log_level_name.capitalize()}: verdi' not in result.output
-            assert f'{log_level_name.capitalize()}: aiida' not in result.output
+    # If ``--verbosity`` is explicitly defined, it override both both config options.
+    result = run_cli_command(cmd, ['--verbosity', 'INFO'], raises=True, use_subprocess=False)
+    verify_log_output(result.output, logging.INFO, logging.INFO)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -613,14 +613,15 @@ def run_cli_command_runner(command, parameters, user_input, initialize_ctx_obj, 
 
 @pytest.fixture
 def reset_log_level():
-    """Reset the `aiida.common.log.CLI_LOG_LEVEL` global and reconfigure the logging.
+    """Reset the ``CLI_LOG_ACTIVE`` and ``CLI_LOG_LEVEL`` globals in ``aiida.common.log`` and reconfigure the logging.
 
-    This fixture should be used by tests that will change the ``CLI_LOG_LEVEL`` global, for example, through the
+    This fixture should be used by tests that will change these globals, for example, through the
     :class:`~aiida.cmdline.params.options.main.VERBOSITY` option in a CLI command invocation.
     """
     from aiida.common import log
     try:
         yield
     finally:
+        log.CLI_ACTIVE = None
         log.CLI_LOG_LEVEL = None
         log.configure_logging(with_orm=True)


### PR DESCRIPTION
Fixes #5923 

The config allows to define the default log level for the logger of the Python API through the `logging.aiida_loglevel` option. The `verdi` CLI provides the `--verbosity` option to control the level of log messages written to console by the command itself, but also by the API code that is called by it. It does so by overriding the `logging.aiida_loglevel` option.

The problem was that it was always doing this, even if the `--verbosity` option was not explicitly specified. The reason is that the option defines `REPORT` as the default. This means the callback is always called and so the `CLI_LOG_LEVEL` global would always be set, causing the `configure_logging` to override the config setting with `REPORT`.

The solution is to remove the default from the option. If the option is not explicitly defined, the callback receives `None` and it doesn't set the `CLI_LOG_LEVEL`. This change brings a new problem though, as now, when `verdi` is called without `--verbosity` the `configure_logging` will not actually configure the handlers of the `aiida` logger to be the `CliHandler`.

To solve this problem, a new global `aiida.common.log.CLI_ACTIVE` is added which is `None` by default. The callback of the verbosity option sets this to `True` to indicate that we are in a `verdi` call. The `configure_logging` will check this global and if set will replace the `console` handler of the `aiida` logger to the `cli` handler.`

Finally, a new config option `logging.verdi_loglevel` is introduced. This is necessary because since the default for `--verbository` has been removed, it means the default from `logging.aiida_loglevel` would be taken. However, since this could be set to something higher than `REPORT`, e.g. `WARNING`, it would mean that most of the verdi commands would not print anything, which would suprise a lot of users.

The logger used by `aiida.cmdline.utils.echo` is changed from `aiida.cmdline` to `verdi`, to decouple it from the `aiida` logger. Its default log level is defined by the `logging.verdi_loglevel`, which is overridden if a more specific level is set with the `--verbosity` option.