### PR TITLE
`verdi code create`: Do not prompt for `--with-mpi`

### DIFF
--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -114,12 +114,17 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
         spec = copy.deepcopy(spec)
 
         is_flag = spec.pop('is_flag', False)
+        default = spec.get('default')
         name_dashed = name.replace('_', '-')
         option_name = f'--{name_dashed}/--no-{name_dashed}' if is_flag else f'--{name_dashed}'
-
         option_short_name = spec.pop('short_name', None)
 
         kwargs = {'cls': spec.pop('cls', InteractiveOption), 'show_default': True, 'is_flag': is_flag, **spec}
+
+        # If the option is a flag with no default, make sure it is not prompted for, as that will force the user to
+        # specify it to be on or off, but cannot let it unspecified.
+        if kwargs['cls'] is InteractiveOption and is_flag and default is None:
+            kwargs['cls'] = functools.partial(InteractiveOption, prompt_fn=lambda ctx: False)
 
         if option_short_name:
             option = click.option(option_short_name, option_name, **kwargs)

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -354,6 +354,23 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
                 'prompt': 'Default `CalcJob` plugin',
                 'help': 'Entry point name of the default plugin (as listed in `verdi plugin list aiida.calculations`).'
             },
+            'use_double_quotes': {
+                'is_flag': True,
+                'default': False,
+                'help': 'Whether the executable and arguments of the code in the submission script should be escaped '
+                'with single or double quotes.',
+                'prompt': 'Escape using double quotes',
+            },
+            'with_mpi': {
+                'is_flag': True,
+                'default': None,
+                'help': (
+                    'Whether the executable should be run as an MPI program. This option can be left unspecified '
+                    'in which case `None` will be set and it is left up to the calculation job plugin or inputs '
+                    'whether to run with MPI.'
+                ),
+                'prompt': 'Run with MPI',
+            },
             'prepend_text': {
                 'cls': TemplateInteractiveOption,
                 'type': click.STRING,
@@ -375,18 +392,5 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
                 'header': 'APPEND_TEXT: if there is any bash commands that should be appended to the executable call '
                 'in all submit scripts for this code, type that between the equal signs below and save the file.',
                 'footer': 'All lines that start with `#=`: will be ignored.'
-            },
-            'use_double_quotes': {
-                'is_flag': True,
-                'default': False,
-                'help': 'Whether the executable and arguments of the code in the submission script should be escaped '
-                'with single or double quotes.',
-                'prompt': 'Escape using double quotes',
-            },
-            'with_mpi': {
-                'is_flag': True,
-                'default': None,
-                'help': 'Whether the executable should be run as an MPI program.',
-                'prompt': 'Run with MPI',
             },
         }

--- a/aiida/restapi/common/identifiers.py
+++ b/aiida/restapi/common/identifiers.py
@@ -189,14 +189,18 @@ class Namespace(MutableMapping):
     # This is a hard-coded mapping to generate the correct full types for process node namespaces of external
     # plugins. The `node_type` in that case is fixed and the `process_type` should start with the entry point group
     # followed by the plugin name and the wildcard.
+    # yapf: disable
     process_full_type_mapping = {
-        'process.calculation.calcjob.': 'process.calculation.calcjob.CalcJobNode.|aiida.calculations:{plugin_name}.%',
+        'process.calculation.calcjob.':
+        'process.calculation.calcjob.CalcJobNode.|aiida.calculations:{plugin_name}.%',
         'process.calculation.calcfunction.':
         'process.calculation.calcfunction.CalcFunctionNode.|aiida.calculations:{plugin_name}.%',
         'process.workflow.workfunction.':
         'process.workflow.workfunction.WorkFunctionNode.|aiida.workflows:{plugin_name}.%',
-        'process.workflow.workchain.': 'process.workflow.workchain.WorkChainNode.|aiida.workflows:{plugin_name}.%',
+        'process.workflow.workchain.':
+        'process.workflow.workchain.WorkChainNode.|aiida.workflows:{plugin_name}.%',
     }
+    # yapf: enable
 
     process_full_type_mapping_unplugged = {
         'process.calculation.calcjob.': 'process.calculation.calcjob.CalcJobNode.|{plugin_name}.%',

--- a/aiida/tools/query/mapping.py
+++ b/aiida/tools/query/mapping.py
@@ -27,6 +27,7 @@ class ProjectionMapper:
     _valid_projections = []
 
     def __init__(self, projection_labels=None, projection_attributes=None, projection_formatters=None):
+        """Construct new instance."""
         if not self._valid_projections:
             raise NotImplementedError('no valid projections were specified by the sub class')
 
@@ -111,17 +112,12 @@ class CalculationProjectionMapper(ProjectionMapper):
         }
 
         default_formatters = {
-            'ctime':
-            lambda value: formatting.format_relative_time(value['ctime']),
-            'mtime':
-            lambda value: formatting.format_relative_time(value['mtime']),
-            'state':
-            lambda value: formatting.
+            'ctime': lambda value: formatting.format_relative_time(value['ctime']),
+            'mtime': lambda value: formatting.format_relative_time(value['mtime']),
+            'state': lambda value: formatting.
             format_state(value[process_state_key], value[process_paused_key], value[exit_status_key]),
-            'process_state':
-            lambda value: formatting.format_process_state(value[process_state_key]),
-            'sealed':
-            lambda value: formatting.format_sealed(value[sealed_key]),
+            'process_state': lambda value: formatting.format_process_state(value[process_state_key]),
+            'sealed': lambda value: formatting.format_sealed(value[sealed_key]),
         }
 
         if projection_labels is not None:

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -122,27 +122,21 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
         ),
         (
             'proxy_jump', {
-                'prompt':
-                'SSH proxy jump',
-                'help':
-                'SSH proxy jump for tunneling through other SSH hosts.'
+                'prompt': 'SSH proxy jump',
+                'help': 'SSH proxy jump for tunneling through other SSH hosts.'
                 ' Use a comma-separated list of hosts of the form [user@]host[:port].'
                 ' If user or port are not specified for a host, the user & port values from the target host are used.'
                 ' This option must be provided explicitly and is not parsed from the SSH config file when left empty.',
-                'non_interactive_default':
-                True
+                'non_interactive_default': True
             }
         ),  # Managed 'manually' in connect
         (
             'proxy_command', {
-                'prompt':
-                'SSH proxy command',
-                'help':
-                'SSH proxy command for tunneling through a proxy server.'
+                'prompt': 'SSH proxy command',
+                'help': 'SSH proxy command for tunneling through a proxy server.'
                 ' For tunneling through another SSH host, consider using the "SSH proxy jump" option instead!'
                 ' Leave empty to parse the proxy command from the SSH config file.',
-                'non_interactive_default':
-                True
+                'non_interactive_default': True
             }
         ),  # Managed 'manually' in connect
         (

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -55,18 +55,13 @@ class Transport(abc.ABC):
     _common_auth_options = [
         (
             'use_login_shell', {
-                'default':
-                True,
-                'switch':
-                True,
-                'prompt':
-                'Use login shell when executing command',
-                'help':
-                ' Not using a login shell can help suppress potential'
+                'default': True,
+                'switch': True,
+                'prompt': 'Use login shell when executing command',
+                'help': ' Not using a login shell can help suppress potential'
                 ' spurious text output that can prevent AiiDA from parsing the output of commands,'
                 ' but may result in some startup files (.profile) not being sourced.',
-                'non_interactive_default':
-                True
+                'non_interactive_default': True
             }
         ),
         (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,7 @@ coalesce_brackets = true
 align_closing_bracket_with_visual_indent = true
 split_arguments_when_comma_terminated = true
 indent_dictionary_value = false
+allow_split_before_dict_value = false
 
 [tool.mypy]
 show_error_codes = true

--- a/tests/calculations/test_templatereplacer.py
+++ b/tests/calculations/test_templatereplacer.py
@@ -22,8 +22,7 @@ def test_base_template(fixture_sandbox, aiida_localhost, generate_calc_job):
 
     entry_point_name = 'core.templatereplacer'
     inputs = {
-        'code':
-        orm.InstalledCode(computer=aiida_localhost, filepath_executable='/bin/bash'),
+        'code': orm.InstalledCode(computer=aiida_localhost, filepath_executable='/bin/bash'),
         'metadata': {
             'options': {
                 'resources': {
@@ -32,8 +31,7 @@ def test_base_template(fixture_sandbox, aiida_localhost, generate_calc_job):
                 }
             }
         },
-        'template':
-        orm.Dict(
+        'template': orm.Dict(
             dict={
                 'input_file_template': 'echo $(({x} + {y}))',
                 'input_file_name': 'input.txt',
@@ -41,8 +39,7 @@ def test_base_template(fixture_sandbox, aiida_localhost, generate_calc_job):
                 'output_file_name': 'output.txt',
             }
         ),
-        'parameters':
-        orm.Dict(dict={
+        'parameters': orm.Dict(dict={
             'x': 1,
             'y': 2
         }),

--- a/tests/calculations/test_transfer.py
+++ b/tests/calculations/test_transfer.py
@@ -161,8 +161,7 @@ def test_validate_transfer_inputs(aiida_localhost, tmp_path):
         'source_nodes': {
             'unused_node': orm.RemoteData(computer=aiida_localhost, remote_path=str(tmp_path)),
         },
-        'instructions':
-        orm.Dict(
+        'instructions': orm.Dict(
             dict={
                 'local_files': [('inexistent_node', None, None)],
                 'remote_files': [('inexistent_node', None, None)],

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -199,10 +199,10 @@ def test_multi_codes_with_mpi(
     from aiida.engine.utils import instantiate_process
 
     inputs = {
-        'code':
-        aiida_local_code_factory('core.arithmetic.add', '/bin/bash'),
-        code_key:
-        aiida_local_code_factory('core.arithmetic.add', '/bin/bash', label=str(uuid.uuid4()), with_mpi=with_mpi_code),
+        'code': aiida_local_code_factory('core.arithmetic.add', '/bin/bash'),
+        code_key: aiida_local_code_factory(
+            'core.arithmetic.add', '/bin/bash', label=str(uuid.uuid4()), with_mpi=with_mpi_code
+        ),
         'metadata': {
             'options': {
                 'resources': {
@@ -237,14 +237,14 @@ def test_multi_codes_with_mpi(
 def test_multi_codes_run_parallel(aiida_local_code_factory, file_regression, parallel_run):
     """test codes_run_mode set in CalcJob"""
     inputs = {
-        'code':
-        aiida_local_code_factory('core.arithmetic.add', '/bin/bash'),
-        'code_info_with_mpi_none':
-        aiida_local_code_factory('core.arithmetic.add', '/bin/bash', label=str(uuid.uuid4())),
-        'code_info_with_mpi_false':
-        aiida_local_code_factory('core.arithmetic.add', '/bin/bash', label=str(uuid.uuid4()), with_mpi=False),
-        'parallel_run':
-        orm.Bool(parallel_run),
+        'code': aiida_local_code_factory('core.arithmetic.add', '/bin/bash'),
+        'code_info_with_mpi_none': aiida_local_code_factory(
+            'core.arithmetic.add', '/bin/bash', label=str(uuid.uuid4())
+        ),
+        'code_info_with_mpi_false': aiida_local_code_factory(
+            'core.arithmetic.add', '/bin/bash', label=str(uuid.uuid4()), with_mpi=False
+        ),
+        'parallel_run': orm.Bool(parallel_run),
         'metadata': {
             'dry_run': True,
             'options': {

--- a/tests/tools/archive/orm/test_links.py
+++ b/tests/tools/archive/orm/test_links.py
@@ -398,26 +398,30 @@ def link_flags_export_helper(name, all_nodes, tmp_path, nodes_to_export, flags, 
         expected_nodes.append(expected_nodes_uuid)
 
     ret = {
-        f'{name}_follow_none':
-        (tmp_path.joinpath(f'{name}_none.aiida'), {
-            calc_flag: False,
-            work_flag: False
-        }, expected_nodes[0]),
-        f'{name}_follow_only_calc':
-        (tmp_path.joinpath(f'{name}_calc.aiida'), {
-            calc_flag: True,
-            work_flag: False
-        }, expected_nodes[1]),
-        f'{name}_follow_only_work':
-        (tmp_path.joinpath(f'{name}_work.aiida'), {
-            calc_flag: False,
-            work_flag: True
-        }, expected_nodes[2]),
-        f'{name}_follow_only_all':
-        (tmp_path.joinpath(f'{name}_all.aiida'), {
-            calc_flag: True,
-            work_flag: True
-        }, expected_nodes[3])
+        f'{name}_follow_none': (
+            tmp_path.joinpath(f'{name}_none.aiida'), {
+                calc_flag: False,
+                work_flag: False
+            }, expected_nodes[0]
+        ),
+        f'{name}_follow_only_calc': (
+            tmp_path.joinpath(f'{name}_calc.aiida'), {
+                calc_flag: True,
+                work_flag: False
+            }, expected_nodes[1]
+        ),
+        f'{name}_follow_only_work': (
+            tmp_path.joinpath(f'{name}_work.aiida'), {
+                calc_flag: False,
+                work_flag: True
+            }, expected_nodes[2]
+        ),
+        f'{name}_follow_only_all': (
+            tmp_path.joinpath(f'{name}_all.aiida'), {
+                calc_flag: True,
+                work_flag: True
+            }, expected_nodes[3]
+        )
     }
 
     prepare_link_flags_export(nodes_to_export, ret)


### PR DESCRIPTION
Fixes #5930 

The `--with-mpi/--no-with-mpi` flag allows to set the `with_mpi`
attribute on the code. This attribute is optional and allows `None` as
a default but since the option is a boolean flag, in interactive mode,
it prompts and forces the user to choose `True` or `False` and it is not
possible to leave it unset, which should be the default behavior.

To solve this, `DynamicEntryPointCommandGroup.create_option` method,
which is used to dynamically generate the CLI options for the various
code subclasses, is updated to remove the prompt for flag options if the
default is `None`. Now, the option will no longer prompt in interactive
mode (and set `None` as the default), but the flag can still be used in
non-interactive mode.