### PR TITLE
Improved customizability and scriptability of `verdi storage mantain`

### DIFF
--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -115,6 +115,11 @@ def storage_info(detailed):
     help='Disable the repacking of the storage when running a `full maintenance`. Useful for improving rsync backup efficiency of huge repos.'
 )
 @click.option(
+    '--yes', '-y', 'skip_prompt'.
+    is_flag=True,
+    help='Skip confirmation prompt.'
+)
+@click.option(
     '--dry-run',
     is_flag=True,
     help=
@@ -122,7 +127,7 @@ def storage_info(detailed):
 )
 @decorators.with_dbenv()
 @click.pass_context
-def storage_maintain(ctx, full, dry_run, no_repack):
+def storage_maintain(ctx, full, no_repack, skip_prompt, dry_run):
     """Performs maintenance tasks on the repository."""
     from aiida.common.exceptions import LockingProfileError
     from aiida.manage.manager import get_manager
@@ -154,8 +159,9 @@ def storage_maintain(ctx, full, dry_run, no_repack):
         )
 
     if not dry_run:
-        if not click.confirm('Are you sure you want continue in this mode?'):
-            return
+        if not skip_prompt:
+            if not click.confirm('Are you sure you want continue in this mode?'):
+                return
 
     try:
         storage.maintain(full=full, dry_run=dry_run, do_repack=not no_repack)

--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -110,6 +110,11 @@ def storage_info(detailed):
     help='Perform all maintenance tasks, including the ones that should not be executed while the profile is in use.'
 )
 @click.option(
+    '--no-repack',
+    is_flag=True,
+    help='Disable the repacking of the storage when running a `full maintenance`. Useful for improving rsync backup efficiency of huge repos.'
+)
+@click.option(
     '--dry-run',
     is_flag=True,
     help=
@@ -117,7 +122,7 @@ def storage_info(detailed):
 )
 @decorators.with_dbenv()
 @click.pass_context
-def storage_maintain(ctx, full, dry_run):
+def storage_maintain(ctx, full, dry_run, no_repack):
     """Performs maintenance tasks on the repository."""
     from aiida.common.exceptions import LockingProfileError
     from aiida.manage.manager import get_manager
@@ -153,7 +158,7 @@ def storage_maintain(ctx, full, dry_run):
             return
 
     try:
-        storage.maintain(full=full, dry_run=dry_run)
+        storage.maintain(full=full, dry_run=dry_run, do_repack=not no_repack)
     except LockingProfileError as exception:
         echo.echo_critical(str(exception))
     echo.echo_success('Requested maintenance procedures finished.')


### PR DESCRIPTION
### Introduced changes

This pull requests, adds 2 option to `verdi storage mantain`:
- `--no-repack`: disables the `do_repack` option when running a full maintenance with the  `DiskObjectStore` backend.
- `--yes` or `-y`: skip the confirmation prompt to use command in scripts (eg periodic maintenance with CRON)

Not using the flags leave the behavior of the command unaltered for back-compatibility

### Reasoning

When performing a storage maintenance operation through the verdi CLI, the only two available options right now is to do either a live or non live operation.

Using the `DiskObjectStore` backend this translates to doing one of the 2:
- `pack_all_loose` only, which store all loose files inside packs, but does not remove the loose files itself.
- `pack_all_loose`, `do_repack`, `clean_storage`, `vacuum`

I think it would be useful to have a more granular control of the live maintain operation.
Especially the `do_repack` option can be undesired, when performing maintenance on a huge repository that is being backed up via rsync. Instead, performing the `clean_storage` periodically is almost mandatory for having efficient backups. Without it we end-up in the same situation as the old storage of having a huge amount of IO nodes to rsync, plus the redundancy of having both the loose and packed version of a file if `verdi storage maintain` is being run periodically.