### PR TITLE
Change default_memory_per_machine_validator to allow a value of 0

### DIFF
--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -267,9 +267,9 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
         if def_memory_per_machine is None:
             return
 
-        if not isinstance(def_memory_per_machine, int) or def_memory_per_machine <= 0:
+        if not isinstance(def_memory_per_machine, int) or def_memory_per_machine < 0:
             raise exceptions.ValidationError(
-                f'Invalid value for def_memory_per_machine, must be a positive int, got: {def_memory_per_machine}'
+                f'Invalid value for def_memory_per_machine, must not be a negative int, got: {def_memory_per_machine}'
             )
 
     def copy(self) -> 'Computer':

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -260,7 +260,7 @@ def test_noninteractive_optional_default_memory_invalid(run_cli_command):
     options_dict['default-memory-per-machine'] = -1
     options = generate_setup_options(options_dict)
     result = run_cli_command(computer_setup, options, raises=True)
-    assert 'Invalid value for def_memory_per_machine, must be a positive int, got: -1' in result.output
+    assert 'Invalid value for def_memory_per_machine, must not be a negative int, got: -1' in result.output
 
 
 def test_noninteractive_wrong_transport_fail(run_cli_command):


### PR DESCRIPTION
The `orm.computer` class has a validator classmethod to check the value set for "default_memory_per_machine" which is ultmately only used in the scheduler batch scripts. Currently the validator will only permit positive integers, which is intuitive, but SLURM allows a value of 0, interpreting this as "use all memory available". When a scheduler has this option, `verdi computer setup` forces the user to use a value, and so in the case where different queues have different amounts of memory per machine, it is desirable to set this default to 0.

Closes #5944 