### PR TITLE
CLI: Change `--yes` to `--force` for `verdi storage maintain`

### DIFF
--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -112,7 +112,7 @@ def storage_info(detailed):
 @click.option(
     '--no-repack', is_flag=True, help='Disable the repacking of the storage when running a `full maintenance`.'
 )
-@click.option('--yes', '-y', 'skip_prompt', is_flag=True, help='Skip confirmation prompt.')
+@options.FORCE()
 @click.option(
     '--dry-run',
     is_flag=True,
@@ -121,7 +121,7 @@ def storage_info(detailed):
 )
 @decorators.with_dbenv()
 @click.pass_context
-def storage_maintain(ctx, full, no_repack, skip_prompt, dry_run):
+def storage_maintain(ctx, full, no_repack, force, dry_run):
     """Performs maintenance tasks on the repository."""
     from aiida.common.exceptions import LockingProfileError
     from aiida.manage.manager import get_manager
@@ -152,10 +152,8 @@ def storage_maintain(ctx, full, no_repack, skip_prompt, dry_run):
             'for a more complete optimization.\n'
         )
 
-    if not dry_run:
-        if not skip_prompt:
-            if not click.confirm('Are you sure you want continue in this mode?'):
-                return
+    if not dry_run and not force and not click.confirm('Are you sure you want continue in this mode?'):
+        return
 
     try:
         if full and no_repack:

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -137,16 +137,16 @@ def tests_storage_maintain_logging(run_cli_command, monkeypatch, caplog):
 
     monkeypatch.setattr(storage, 'maintain', mock_maintain)
 
-    # Not passing user input Y or `--yes` should causing the command to exit without executing `storage.mantain`
+    # Not passing user input Y or `--force` should causing the command to exit without executing `storage.mantain`
     # Checking that no logs are produced in the with caplog context
     with caplog.at_level(logging.INFO):
         _ = run_cli_command(cmd_storage.storage_maintain, use_subprocess=False)
 
     assert len(caplog.records) == 0
 
-    # Test `storage.mantain` with `--yes`
+    # Test `storage.mantain` with `--force`
     with caplog.at_level(logging.INFO):
-        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--yes'], use_subprocess=False)
+        _ = run_cli_command(cmd_storage.storage_maintain, parameters=['--force'], use_subprocess=False)
 
     message_list = caplog.records[0].msg.splitlines()
     assert ' > full: False' in message_list


### PR DESCRIPTION
The `--yes` option was added only recently (not yet released) to the `verdi storage maintain` to allow skipping any prompts. This is renamed to the `--force` option which is used across `verdi` for this purpose, in order to maintain consistency across the interface.