### PR TITLE
Fix bug in `aiida.engine.utils.instantiate_process`

### DIFF
--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -12,6 +12,7 @@
 import asyncio
 import contextlib
 from datetime import datetime
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator, List, Optional, Tuple, Type, Union
 
@@ -55,7 +56,7 @@ def instantiate_process(
         inputs.update(**builder._inputs(prune=True))  # pylint: disable=protected-access
     elif is_process_function(process):
         process_class = process.process_class  # type: ignore[attr-defined]
-    elif issubclass(process, Process):
+    elif inspect.isclass(process) and issubclass(process, Process):
         process_class = process
     else:
         raise ValueError(f'invalid process {type(process)}, needs to be Process or ProcessBuilder')

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -15,7 +15,13 @@ import pytest
 
 from aiida import orm
 from aiida.engine import calcfunction, workfunction
-from aiida.engine.utils import InterruptableFuture, exponential_backoff_retry, interruptable_task, is_process_function
+from aiida.engine.utils import (
+    InterruptableFuture,
+    exponential_backoff_retry,
+    instantiate_process,
+    interruptable_task,
+    is_process_function,
+)
 
 ITERATION = 0
 MAX_ITERATIONS = 3
@@ -64,6 +70,12 @@ class TestExponentialBackoffRetry:
         max_attempts = MAX_ITERATIONS - 1
         with pytest.raises(RuntimeError):
             loop.run_until_complete(exponential_backoff_retry(coro, initial_interval=0.1, max_attempts=max_attempts))
+
+
+def test_instantiate_process_invalid(manager):
+    """Test the :func:`aiida.engine.utils.instantiate_process` function for invalid ``process`` argument."""
+    with pytest.raises(ValueError, match=r'invalid process <class \'bool\'>, needs to be Process or ProcessBuilder'):
+        instantiate_process(manager.get_runner(), True)
 
 
 def test_is_process_function():


### PR DESCRIPTION
If the `process` argument receives an unsupported type that is not a class, the final check `issubclass(process, Process)` would raise:

    TypeError: issubclass() arg 1 must be a class

which is not very useful to the user. This is fixed by first checking that the argument is a class to begin with. At least now when an invalid type is provided, the exception contains the invalid type:

    invalid process <class \'bool\'>, needs to be Process or ProcessBuilder'