### PR TITLE
Hide the "Edit this page" button on the apidoc pages

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -9,4 +9,12 @@
         </p>
   </div>
 </footer>
+<script>
+var editPagePath = document.querySelector("div.tocsection.editthispage a").href;
+var pathSegments = editPagePath.split('/');
+if (pathSegments.includes('apidoc') == true ) {
+    var tocSection = document.querySelector("div.tocsection.editthispage");
+    tocSection.style.display = "none";
+      }
+</script>
 {% endblock %}


### PR DESCRIPTION
Fixes #4947 hide the "Edit this page" button for autogenerated API documentation pages.
This button redirects to a link containing the file on github. This script hides the button if the URL segments contain `apidoc`.