### PR TITLE
Fix logging configuration leading to doubled output

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -101,7 +101,7 @@ def get_logging_config():
             'verdi': {
                 'handlers': ['cli'],
                 'level': lambda: get_config_option('logging.verdi_loglevel'),
-                'propagate': True,
+                'propagate': False,
             },
             'plumpy': {
                 'handlers': ['console'],


### PR DESCRIPTION
The recently added `verdi` logger was incorrectly configured to use `propagate = True`, causing log output from the Python API, for example the `DaemonClient` to be printed twice to the console when invoked through `verdi` commands.