### PR TITLE
Fix the `%verdi` IPython magics utility 

### DIFF
--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -66,14 +66,57 @@ class AiiDALoaderMagics(magic.Magics):
     @magic.needs_local_scope
     @magic.line_magic
     def verdi(self, line='', local_ns=None):  # pylint: disable=no-self-use,unused-argument
-        """Run the AiiDA command line tool, using the currently loaded configuration and profile."""
+        """Run the AiiDA command line tool, using the currently loaded configuration and profile.
+
+        Invoking ``verdi`` normally through the command line follows a different code path, compared to calling it
+        directly from within an active Python interpreter. Some of those code paths we actually need here, and others
+        can actually cause problems:
+
+        * The ``VerdiCommandGroup`` group ensures that the context ``obj`` is set with the loaded ``Config`` and
+          ``Profile``, but this is not done in this manual call, so we have to built it ourselves and pass it in with
+          the ``obj`` keyword.
+        * We cannot call the ``aiida.cmdline.commands.cmd_verdi.verdi`` command directly, as that will invoke the
+          ``aiida.cmdline.parameters.types.profile.ProfileParamType`` parameter used for the ``-p/--profile`` option
+          that is defined on the ``verdi`` command. This will attempt to load the default profile, but here a profile
+          has actually already been loaded. In principle, reloading a profile should not be a problem, but this magic
+          is often used in demo notebooks where a temporary profile was created and loaded, which is not properly added
+          to the config file (since it is temporary) and so loading the profile would fail. The solution is to not call
+          the top-level ``verdi`` command, but the subcommand, which is the first parameter in the command line
+          arguments defined by the ``line`` argument.
+
+        """
+        from click import Context
+
         from aiida.cmdline.commands.cmd_verdi import verdi
         from aiida.common import AttributeDict
         from aiida.manage import get_config, get_profile
+
         config = get_config()
         profile = get_profile()
-        obj = AttributeDict({'config': config, 'profile': profile})
-        return verdi(shlex.split(line), prog_name='%verdi', obj=obj, standalone_mode=False)  # pylint: disable=too-many-function-args,unexpected-keyword-arg
+
+        # The ``line`` should be of the form ``process list -a -p1``, i.e., a ``verdi`` subcommand with some optional
+        # parameters. Validate that the first entry is indeed a subcommand and not the flag to specify the profile which
+        # is not supported in this magic method.
+        cmdline_arguments = shlex.split(line)
+        command_name = cmdline_arguments[0]
+
+        if command_name in ('-p', '--profile'):
+            raise ValueError(
+                'The `-p/--profile` option is not supported for the `%verdi` magic operator. It will use the currently '
+                f'loaded profile `{profile}`'
+            )
+
+        # Construct the subcommand that will be executed, thereby circumventing the profile option of ``verdi`` itself.
+        # If the caller specified a subcommand that doesn't exist, the following will raise an exception.
+        context = Context(verdi)
+        command = verdi.get_command(context, command_name)
+
+        return command(  # pylint: disable=too-many-function-args,unexpected-keyword-arg
+            cmdline_arguments[1:],
+            prog_name='%verdi',
+            obj=AttributeDict({'config': config, 'profile': profile}),
+            standalone_mode=False
+        )
 
     @magic.needs_local_scope
     @magic.line_magic

--- a/docs/source/intro/tutorial.md
+++ b/docs/source/intro/tutorial.md
@@ -43,6 +43,7 @@ This tutorial can be downloaded and run as a Jupyter Notebook: {nb-download}`tut
 :tags: ["hide-cell"]
 
 from aiida import load_profile, engine, orm, plugins
+from aiida.manage.configuration import get_config
 from aiida.storage.sqlite_temp import SqliteTempBackend
 
 %load_ext aiida
@@ -58,6 +59,9 @@ profile = load_profile(
     ),
     allow_switch=True
 )
+config = get_config()
+config.add_profile(profile)
+config.set_default_profile(profile.name)
 profile
 ```
 


### PR DESCRIPTION
Fixes #5822 

The `aiida.tools.ipython.ipython_magics.AiiDALoaderMagics` class
provides the `verdi` method, which allows to invoke `verdi` commands
from a Jupyter notebook, e.g., `%verdi process list`.

This was failing because it would invoke the `verdi` command directly
from the Python API. This would cause the `--profile` parameter to be
evaulated, which would attempt to load the current default profile. If
run from a notebook where the loaded profile was a temporary profile
that had been created on the fly, as is done in the tutorial notebooks
in the documentation, the command would fail. The reason is that the
temporary profile was created and loaded in memory, but not actually
added to the config. The `--profile` parameter, however, would
determine the default profile from the config, which would not be the
loaded temporary profile, and so it would attempt to load a different
profile, which is not allowed, with the default `allow_switch` being set
to `False`.

The solution is to not call the `verdi` command, but the subcommand,
thereby circumventing the `--profile` option. The subcommand name is
retrieved from the parsed command line arguments defined by the `line`
argument, where it should be the first element.

[Docs: Fix the intro/tutorial.md notebook](https://github.com/aiidateam/aiida-core/commit/359bf5f441b6372438cabfe28f10a749873a5a27)

The notebook creates and loads a temporary profile using the
`SqliteTempBackend` backend. This works fine as long as the profile is
only used in the current interpreter and no code is hit that checks the
profile is present in the `Config`. The reason is that although the
profile is loaded, it is created on the fly and not actually added to
the `Config` that is loaded in memory, nor is it written to the
`config.json` file on disk.

As soon as any code is called that will check the existence of the
temporary profile, through the config, it will fail. A good example is
when `%verdi process list` is called. At the end of the command, the
status of the daemon is checked, for which a `DaemonClient` instance is
constructed, which calls `config.get_option('daemon.timeout', profile)`.
This call will validate the provided profile to check that it actually
exists, i.e., is known within the config, which is not the case, and so
a `ProfileConfigurationError` is raised.

The solution is to update the notebook to actually add the created
temporary profile to the config loaded in memory. Note that this could
have the undesirable consequence that if the config state is written to
disk, the temporary profile can be added to `config.json`. This will not
be automatically cleaned up. Since here it concerns a demo notebook that
will just be run on temporary resources anyway, it not being cleaned up
is not a problem.

Ideally there would be a utility for notebooks that creates a temporary
profile and actually adds it to the config, and cleans it up at the end
of the notebook. But it will be difficult to guarantee the cleanup in
all cases.