### PR TITLE
Dependencies: Update requirement `importlib-metadata~=4.13`

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -486,7 +486,7 @@ class CalcJob(Process):
         if entry_point_name is None:
             _, entry_point = get_entry_point_from_class(cls.__module__, cls.__name__)
             if entry_point is not None:
-                entry_point_name = entry_point.name  # type: ignore
+                entry_point_name = entry_point.name
 
         assert entry_point_name is not None
 

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -68,7 +68,7 @@ class GroupMeta(ABCMeta):
             warnings.warn(message)  # pylint: disable=no-member
         else:
             assert entry_point is not None
-            newcls._type_string = cast(str, entry_point.name)  # type: ignore[attr-defined]  # pylint: disable=protected-access
+            newcls._type_string = entry_point.name  # type: ignore[attr-defined]  # pylint: disable=protected-access
 
         return newcls
 

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -102,16 +102,12 @@ class CalcJobNode(CalculationNode):
                 entry_point = get_entry_point_from_string(entry_point_string)
 
                 try:
-                    tools_class = load_entry_point(
-                        'aiida.tools.calculations',
-                        entry_point.name  # type: ignore[attr-defined]
-                    )
+                    tools_class = load_entry_point('aiida.tools.calculations', entry_point.name)
                     self._tools = tools_class(self)
                 except exceptions.EntryPointError as exception:
                     self._tools = CalculationTools(self)
-                    entry_point_name = entry_point.name  # type: ignore[attr-defined]
                     self.logger.warning(
-                        f'could not load the calculation tools entry point {entry_point_name}: {exception}'
+                        f'could not load the calculation tools entry point {entry_point.name}: {exception}'
                     )
 
         return self._tools

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -357,7 +357,7 @@ def get_entry_point_string_from_class(class_module: str, class_name: str) -> Opt
     group, entry_point = get_entry_point_from_class(class_module, class_name)
 
     if group and entry_point:
-        return ENTRY_POINT_STRING_SEPARATOR.join([group, entry_point.name])  # type: ignore[attr-defined]
+        return ENTRY_POINT_STRING_SEPARATOR.join([group, entry_point.name])
     return None
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 - jinja2~=3.0
 - jsonschema~=3.0
 - kiwipy[rmq]~=0.7.7
-- importlib-metadata~=4.3
+- importlib-metadata~=4.13
 - importlib-resources~=5.0
 - numpy~=1.19
 - paramiko>=2.7.2,~=2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "jinja2~=3.0",
     "jsonschema~=3.0",
     "kiwipy[rmq]~=0.7.7",
-    "importlib-metadata~=4.3",
+    "importlib-metadata~=4.13",
     "importlib-resources~=5.0;python_version<'3.9'",
     "numpy~=1.19",
     "paramiko~=2.7,>=2.7.2",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -42,7 +42,7 @@ graphviz==0.19
 greenlet==1.1.2
 idna==3.3
 imagesize==1.3.0
-importlib-metadata==4.8.2
+importlib-metadata==4.13.0
 iniconfig==1.1.1
 ipykernel==6.5.1
 ipython==8.10.0

--- a/requirements/requirements-py-3.8.txt
+++ b/requirements/requirements-py-3.8.txt
@@ -43,7 +43,7 @@ graphviz==0.19
 greenlet==1.1.2
 idna==3.3
 imagesize==1.3.0
-importlib-metadata==4.8.2
+importlib-metadata==4.13.0
 importlib-resources==5.4.0
 iniconfig==1.1.1
 ipykernel==6.5.1

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -43,7 +43,7 @@ graphviz==0.19
 greenlet==1.1.2
 idna==3.3
 imagesize==1.3.0
-importlib-metadata==4.8.2
+importlib-metadata==4.13.0
 iniconfig==1.1.1
 ipykernel==6.5.1
 ipython==8.10.0


### PR DESCRIPTION
Fixes #5109 

This allows us to revert 2a2bf21dc6b49d7783795f14d1de6d1fdcff007b along with some other type ignore statements that are no longer necessary.