### PR TITLE
Dependencies: Bump `graphviz` version to `0.19`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - disk-objectstore~=0.6.0
 - docstring_parser
 - get-annotations~=0.1
-- python-graphviz~=0.13
+- python-graphviz~=0.19
 - ipython<9,>=7
 - jinja2~=3.0
 - jsonschema~=3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "disk-objectstore~=0.6.0",
     "docstring-parser",
     "get-annotations~=0.1;python_version<'3.10'",
-    "graphviz~=0.13",
+    "graphviz~=0.19",
     "ipython>=7,<9",
     "jinja2~=3.0",
     "jsonschema~=3.0",


### PR DESCRIPTION
In the commit 80045ae7308de673a838c152998a6257c9a79134 a feature was added that allows the user to specify the output name of the generated graph with `verdi node graph generate`. This filename is passed to the `outfile` input argument of the `graphviz.render()` method, but this was only added in v0.19 of `graphviz`, see:

https://graphviz.readthedocs.io/en/latest/changelog.html#version-0-19

Here we bump the `graphviz` version to `0.19`.