### PR TITLE
`CalcJob`: Fix bug in `validate_calc_job` if `code` excluded

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -66,8 +66,16 @@ def validate_calc_job(inputs: Any, ctx: PortNamespace) -> Optional[str]:  # pyli
         # checked for consistency.
         return None
 
-    code = inputs.get('code', None)
-    computer_from_code = code.computer
+    try:
+        ctx.get_port('code')
+    except ValueError:
+        # The namespace no longer contains the `code` input, so we should get the computer from the metadata
+        code = None
+        computer_from_code = None
+    else:
+        code = inputs['code']
+        computer_from_code = code.computer
+
     computer_from_metadata = inputs.get('metadata', {}).get('computer', None)
 
     if not computer_from_code and not computer_from_metadata:


### PR DESCRIPTION
Fixes #5968 

If the `CalcJob` spec is exposed into another process namespace while excluding the `code` port, the `validate_calc_job` validator defined on the top-level namespaces would except because it would always attempt to get the `Computer` through the `computer` attribute from the `code` input, even if it could be `None`, in the case that the port was excluded when exposing.

The validator now first checks with `ctx.get_port('code')` whether the namespace still contains the `code` port and otherwise sets it and therefore the associated computer to `None`.