### PR TITLE
`Node`: Validate nested attribute and extra keys

### DIFF
--- a/aiida/orm/implementation/__init__.py
+++ b/aiida/orm/implementation/__init__.py
@@ -48,6 +48,7 @@ __all__ = (
     'EntityType',
     'StorageBackend',
     'clean_value',
+    'validate_attribute_extra_dict_value',
     'validate_attribute_extra_key',
 )
 

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -197,6 +197,7 @@ class TrajectoryData(ArrayData):
         dimension are correct.
         """
         # check dimensions, types
+        super()._validate()
         from aiida.common.exceptions import ValidationError
 
         try:

--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -8,8 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`Data` sub class to represent a dictionary."""
+from __future__ import annotations
+
 import copy
-from typing import Any, Iterator, Tuple, Union
+from typing import Any, Iterator
 
 from aiida.common import exceptions
 
@@ -47,7 +49,7 @@ class Dict(Data):
     Finally, all dictionary mutations will be forbidden once the node is stored.
     """
 
-    def __init__(self, value: Union[None, dict, 'Dict'] = None, **kwargs) -> None:
+    def __init__(self, value: None | dict | Dict = None, **kwargs) -> None:
         """Initialise a ``Dict`` node instance.
 
         Usual rules for attribute names apply, in particular, keys cannot start with an underscore, or a ``ValueError``
@@ -80,7 +82,7 @@ class Dict(Data):
         """Return whether the node contains a key."""
         return key in self.base.attributes
 
-    def set_dict(self, dictionary: Union[dict, 'Dict']) -> None:
+    def set_dict(self, dictionary: dict | Dict) -> None:
         """Replace the current dictionary with another one.
 
         :param dictionary: dictionary to set
@@ -100,7 +102,7 @@ class Dict(Data):
             self.update_dict(dictionary_backup)
             raise
 
-    def update_dict(self, dictionary: Union[dict, 'Dict']) -> None:
+    def update_dict(self, dictionary: dict | Dict) -> None:
         """Update the current dictionary with the keys provided in the dictionary.
 
         .. note:: works exactly as `dict.update()` where new keys are simply added and existing keys are overwritten.
@@ -125,7 +127,7 @@ class Dict(Data):
         for key in self.base.attributes.keys():
             yield key
 
-    def items(self) -> Iterator[Tuple[str, Any]]:
+    def items(self) -> Iterator[tuple[str, Any]]:
         """Iterator of all items stored in the Dict node."""
         for key, value in self.base.attributes.items():
             yield key, value

--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """`Data` sub class to represent a dictionary."""
 import copy
+from typing import Any, Iterator, Tuple, Union
 
 from aiida.common import exceptions
 
@@ -46,7 +47,7 @@ class Dict(Data):
     Finally, all dictionary mutations will be forbidden once the node is stored.
     """
 
-    def __init__(self, value=None, **kwargs):
+    def __init__(self, value: Union[None, dict, 'Dict'] = None, **kwargs) -> None:
         """Initialise a ``Dict`` node instance.
 
         Usual rules for attribute names apply, in particular, keys cannot start with an underscore, or a ``ValueError``
@@ -61,16 +62,16 @@ class Dict(Data):
         if dictionary:
             self.set_dict(dictionary)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> None:
         try:
             return self.base.attributes.get(key)
         except AttributeError as exc:
             raise KeyError from exc
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         self.base.attributes.set(key, value)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Dict):
             return self.get_dict() == other.get_dict()
         return self.get_dict() == other
@@ -79,7 +80,7 @@ class Dict(Data):
         """Return whether the node contains a key."""
         return key in self.base.attributes
 
-    def set_dict(self, dictionary):
+    def set_dict(self, dictionary: Union[dict, 'Dict']) -> None:
         """Replace the current dictionary with another one.
 
         :param dictionary: dictionary to set
@@ -99,7 +100,7 @@ class Dict(Data):
             self.update_dict(dictionary_backup)
             raise
 
-    def update_dict(self, dictionary):
+    def update_dict(self, dictionary: Union[dict, 'Dict']) -> None:
         """Update the current dictionary with the keys provided in the dictionary.
 
         .. note:: works exactly as `dict.update()` where new keys are simply added and existing keys are overwritten.
@@ -109,14 +110,14 @@ class Dict(Data):
         for key, value in dictionary.items():
             self.base.attributes.set(key, value)
 
-    def get_dict(self):
+    def get_dict(self) -> dict:
         """Return a dictionary with the parameters currently set.
 
         :return: dictionary
         """
         return dict(self.base.attributes.all)
 
-    def keys(self):
+    def keys(self) -> Iterator[str]:
         """Iterator of valid keys stored in the Dict object.
 
         :return: iterator over the keys of the current dictionary
@@ -124,7 +125,7 @@ class Dict(Data):
         for key in self.base.attributes.keys():
             yield key
 
-    def items(self):
+    def items(self) -> Iterator[Tuple[str, Any]]:
         """Iterator of all items stored in the Dict node."""
         for key, value in self.base.attributes.items():
             yield key, value

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -239,8 +239,8 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
     def _validate(self) -> None:
         """Validate information stored in Node object.
 
-        For the :py:class:`~aiida.orm.Node` base class, this does a basic check on nested keys in case the value of any
-        attribute or extra is a dictionary.
+        For the :py:class:`~aiida.orm.Node` base class, recursively validates that all keys in the ``attributes`` and
+        ``extras`` dictionaries are valid.
 
         Subclasses can override this method to perform additional checks
         and should usually call ``super()._validate()`` first!

--- a/tests/orm/implementation/test_utils.py
+++ b/tests/orm/implementation/test_utils.py
@@ -20,24 +20,32 @@ from aiida.orm.implementation.utils import FIELD_SEPARATOR, clean_value, validat
 class TestOrmImplementationUtils:
     """Test the utility methods in aiida.orm.implementation.utils"""
 
-    def test_invalid_attribute_extra_key(self):
+    @pytest.mark.parametrize(
+        'invalid_key',
+        (
+            5,
+            f'invalid{FIELD_SEPARATOR}key',  # Top-level keys
+            {
+                'a': {
+                    5: 'b'
+                }
+            },
+            {
+                'a': {
+                    f'invalid{FIELD_SEPARATOR}key': 'b'
+                }
+            }  # Nested keys
+        )
+    )
+    def test_invalid_attribute_extra_key(self, invalid_key):
         """Test supplying an invalid key to the `validate_attribute_extra_key` method."""
-        non_string_key = 5
-        field_separator_key = f'invalid{FIELD_SEPARATOR}key'
 
         with pytest.raises(exceptions.ValidationError):
-            validate_attribute_extra_key(non_string_key)
+            validate_attribute_extra_key(invalid_key)
 
-        with pytest.raises(exceptions.ValidationError):
-            validate_attribute_extra_key(field_separator_key)
-
-    def test_invalid_value(self):
+    @pytest.mark.parametrize('invalid_value', (math.nan, math.inf))
+    def test_invalid_value(self, invalid_value):
         """Test supplying nan and inf values to the `clean_value` method."""
-        nan_value = math.nan
-        inf_value = math.inf
 
         with pytest.raises(exceptions.ValidationError):
-            clean_value(nan_value)
-
-        with pytest.raises(exceptions.ValidationError):
-            clean_value(inf_value)
+            clean_value(invalid_value)

--- a/tests/orm/nodes/data/test_dict.py
+++ b/tests/orm/nodes/data/test_dict.py
@@ -11,7 +11,9 @@
 """Tests for :class:`aiida.orm.nodes.data.dict.Dict` class."""
 import pytest
 
+from aiida.common.exceptions import ValidationError
 from aiida.orm import Dict
+from aiida.orm.implementation.utils import FIELD_SEPARATOR
 
 
 @pytest.fixture
@@ -124,3 +126,11 @@ def test_initialise_with_dict_kwarg(dictionary):
     """Test that the ``Dict`` node can be initialized with the ``dict`` keyword argument for backwards compatibility."""
     node = Dict(dict=dictionary)
     assert sorted(node.keys()) == sorted(dictionary.keys())
+
+
+@pytest.mark.parametrize('invalid_dict', ({'a': {5: 'b'}}, {'a': {f'invalid{FIELD_SEPARATOR}key': 'b'}}))
+def test_validate_nested_keys(invalid_dict):
+    """Test that using invalid nested keys in a ``Dict`` node raises when trying to store the node."""
+
+    with pytest.raises(ValidationError):
+        Dict(invalid_dict).store()


### PR DESCRIPTION
Fixes #3863 

Currently only the top-level keys of the attributes and extras of a node are validated upon instantiation of the node. Nested keys are only (silently) converted to a string when storing the node. This behaviour of silently mutating the keys is dangerous.

Here we add a recursive validation step to the `_validate()` method of the `Node` class, that relies on the already defined `validate_attribute_extra_key` function. The `_validate()` method is only called upon storing the node, and hence this adjustment does not cause any significant performance issues (see PR for benchmarks).

Additionally, typing is added to all methods of the `Dict` class.