### PR TITLE
`ProcessNode`: Add the `exit_code` property

### DIFF
--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -22,7 +22,7 @@ from ..caching import NodeCaching
 from ..node import Node, NodeLinks
 
 if TYPE_CHECKING:
-    from aiida.engine.processes import Process
+    from aiida.engine.processes import ExitCode, Process
     from aiida.engine.processes.builder import ProcessBuilder
 
 __all__ = ('ProcessNode',)
@@ -397,6 +397,24 @@ class ProcessNode(Sealable, Node):
         :rtype: bool
         """
         return self.is_finished and self.exit_status != 0
+
+    @property
+    def exit_code(self) -> Optional['ExitCode']:
+        """Return the exit code of the process.
+
+        It is reconstituted from the ``exit_status`` and ``exit_message`` attributes if both of those are defined.
+
+        :returns: The exit code if defined, or ``None``.
+        """
+        from aiida.engine.processes.exit_code import ExitCode
+
+        exit_status = self.exit_status
+        exit_message = self.exit_message
+
+        if exit_status is None or exit_message is None:
+            return None
+
+        return ExitCode(exit_status, exit_message)
 
     @property
     def exit_status(self) -> Optional[int]:

--- a/tests/orm/nodes/process/test_process.py
+++ b/tests/orm/nodes/process/test_process.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`aiida.orm.nodes.process.process`."""
+from aiida.engine import ExitCode
+from aiida.orm.nodes.process.process import ProcessNode
+
+
+def test_exit_code():
+    """Test the :meth:`aiida.orm.nodes.process.process.ProcessNode.exit_code` property."""
+    node = ProcessNode()
+    assert node.exit_code is None
+
+    node.set_exit_status(418)
+    assert node.exit_code is None
+
+    node.set_exit_message('I am a teapot')
+    assert node.exit_code == ExitCode(418, 'I am a teapot')


### PR DESCRIPTION
Fixes #5972 

This is a convenience property that returns an `ExitCode` from a process node as long as both the `exit_status` and `exit_message` attributes have been defined.