### PR TITLE
`CalcJob`: Add support for nested targets in `remote_symlink_list`

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -275,7 +275,9 @@ def upload_calculation(
                     f'[submission of calculation {node.pk}] copying {dest_rel_path} remotely, '
                     f'directly on the machine {computer.label}'
                 )
+                remote_dirname = pathlib.Path(dest_rel_path).parent
                 try:
+                    transport.makedirs(remote_dirname, ignore_existing=True)
                     transport.symlink(remote_abs_path, dest_rel_path)
                 except (IOError, OSError):
                     logger.warning(


### PR DESCRIPTION
Fixes #4726

It is now possible to specify a target in the `remote_symlink_list` that contains nested directories that do not necessarily exist. The `upload_calculation` will automatically create them before creating the symlink.