### PR TITLE
`BaseRestartWorkChain`: Factor out attachment of outputs

### DIFF
--- a/docs/source/howto/workchains_restart.rst
+++ b/docs/source/howto/workchains_restart.rst
@@ -272,6 +272,17 @@ It is also possible to update the contents of one of the outputs returned by the
 In this case, it is important to go through a ``calcfunction``, as always, as to not lose any provenance.
 
 
+Attaching outputs
+=================
+
+In a normal run, the ``results`` method is the last step in the outline of the ``BaseRestartWorkChain``.
+In this step, the outputs of the last completed calculation job are "attached" to the work chain itself.
+The attaching of the outputs is implemented by the :meth:`~aiida.engine.processes.workchains.restart.BaseRestartWorkChain._attach_outputs` method.
+If the outputs need to be attached at a point in the workflow other then the ``results`` step, this method can be called manually.
+An example would be to call it in a process handler that will abort the work chain.
+In this case the work chain will be stopped immediately and the ``results`` step would no longer be called.
+
+
 Error handling
 ==============
 


### PR DESCRIPTION
When a work chain step returns an exit code, the work chain execution is
aborted. A common use for the handlers of the `BaseRestartWorkChain` is
exactly this, to stop work chain execution when a particular problem or
situation is detected.

The downside is that no other steps can be called by the work chain
implementation, for example, the `results` step to still attach any
(partial) results. Of course an implementation could copy the content of
the `results` method in the handler to do so, but it would have to copy
the contents in each handler that still wanted to attach the outputs,
duplicating the work.

Here, the actual attaching of the outputs is factored out of the
`results` method to the `attach_outputs` method. This method can now
easily be called inside a process handler that wants to attach outputs
before returning an exit code to stop the work chain.