### PR TITLE
Addresses #5984 Doc: Making the negation operator clearer

### DIFF
--- a/docs/source/howto/query.rst
+++ b/docs/source/howto/query.rst
@@ -150,7 +150,7 @@ In case you want all calculation jobs with state ``finished`` or ``excepted``, y
         },
     )
 
-You can negate a filter by adding an exclamation mark in front of the operator.
+You can **negate** a filter by adding an exclamation mark, ``!`` or a ``~``, in front of the operator, that is a ``NOT`` operatror.
 So, to query for all calculation jobs that are not a ``finished`` or ``excepted`` state:
 
 .. code-block:: python

--- a/docs/source/topics/database.rst
+++ b/docs/source/topics/database.rst
@@ -178,6 +178,12 @@ List of all operators:
 | ``contains`` |    lists    | ``'attributes.some_key': {'contains': ['a', 'b']}``   | Filter for lists that should contain certain values.                         |
 +--------------+-------------+-------------------------------------------------------+------------------------------------------------------------------------------+
 
+As previously mentioned in the :ref:`section about filters<how-to:query:filters>` all the operator can be negated (``NOT`` operator) by adding either a ``!`` or ``~`` in front of the operator.
+
+.. note::
+    The negation operator can look different than the one in base SQL, where to indicate a value **not equal to** one would write ``!=`` whilst when using the ``QueryBuilder`` one should instead write ``!==`` or ``~==``.
+
+
 .. _topics:database:advancedquery:tables:relationships:
 
 List of all relationships:


### PR DESCRIPTION
Addresses #5984. Adds a bit more clarity to the negate operator section and adds a reminder where the operators are defined.