### PR TITLE
Dependencies: Add upper limit for `ipython<8.13`

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -160,6 +160,7 @@ py:class html.parser.HTMLParser
 py:class disk_objectstore.container.Container
 
 py:class flask.app.Flask
+py:class flask.json.JSONEncoder
 
 py:class pytest.TempPathFactory
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
 - docstring_parser
 - get-annotations~=0.1
 - python-graphviz~=0.19
-- ipython<9,>=7
+- ipython<8.13,>=7
 - jinja2~=3.0
 - jsonschema~=3.0
 - kiwipy[rmq]~=0.7.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ ssh_kerberos = [
 rest = [
     "flask-cors~=3.0",
     "flask-restful~=0.3.7",
-    "flask~=2.0",
+    "flask~=2.0,<2.3",
     "pyparsing~=2.4",
     "python-memcached~=1.59",
     "seekpath~=1.9,>=1.9.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "docstring-parser",
     "get-annotations~=0.1;python_version<'3.10'",
     "graphviz~=0.19",
-    "ipython>=7,<9",
+    "ipython>=7,<8.13",
     "jinja2~=3.0",
     "jsonschema~=3.0",
     "kiwipy[rmq]~=0.7.7",


### PR DESCRIPTION
The release `ipython==8.13` dropped support for Python 3.8 and so until we drop support as well, we have to introduce this upper limit.