### PR TITLE
`CalcJob`: Assign outputs from node in case of cache hit

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -552,6 +552,11 @@ class CalcJob(Process):
         # been overridden by the engine to `Running` so we cannot check that, but if the `exit_status` is anything other
         # than `None`, it should mean this node was taken from the cache, so the process should not be rerun.
         if self.node.exit_status is not None:
+            # Normally the outputs will be attached to the process by a ``Parser``, if defined in the inputs. But in
+            # this case, the parser will not be called. The outputs will already have been added to the process node
+            # though, so all that needs to be done here is just also assign them to the process instance. This such that
+            # when the process returns its results, it returns the actual outputs and not an empty dictionary.
+            self._outputs = self.node.get_outgoing(link_type=LinkType.CREATE).nested()  # pylint: disable=attribute-defined-outside-init
             return self.node.exit_status
 
         # Launch the upload operation


### PR DESCRIPTION
Fixes #5994 

If a `CalcJob` is launched and a cache hit occurs, the outputs of the cache source are attached automatically to the process node of the `CalcJob` instance in `Node.store`. The process execution itself, shortcuts in `CalcJob.run` to directly return the exit status instead of going to the upload stage.

This shortcut, however, also means that the `Parser` won't be called which normally is responsible for adding the outputs; to the process *node* but also to the *process* itself. By circumventing this, the outputs mapping on the process instance will be empty. This is a problem if the process was run as opposed to submitted. In this case, the `Runner.run` method will return the results by taking it from the `Process.outputs` method, but this will be empty.

Ultimately, this means that when a user *runs* a `CalcJob` that hits the cache, the returned `results` dictionary will always be empty. To fix it, the `CalcJob.run` method is updated to populate the `_outputs` attribute of the process instance with the outputs that are stored on the associated process node. Now the run method will return the correct results dictionary.