### PR TITLE
Bump Python version for RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ formats: []
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
 
 # Need to install the package itself such that the entry points are installed and the API doc can build properly
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,13 @@ version: 2
 # https://github.com/aiidateam/aiida-core/issues/1472
 formats: []
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Need to install the package itself such that the entry points are installed and the API doc can build properly
 python:
-    version: 3.8
     install:
         - method: pip
           path: .

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -132,7 +132,7 @@ def aiida_manager() -> Manager:
 
 @pytest.fixture(scope='session')
 def aiida_instance(
-    tmp_path_factory: pytest.TempPathFactory,
+    tmp_path_factory: pytest.tmpdir.TempPathFactory,
     aiida_manager: Manager,
     aiida_test_profile: str | None,
 ) -> t.Generator[Config, None, None]:
@@ -185,7 +185,7 @@ def aiida_instance(
 
 @pytest.fixture(scope='session')
 def config_psql_dos(
-    tmp_path_factory: pytest.TempPathFactory,
+    tmp_path_factory: pytest.tmpdir.TempPathFactory,
     postgres_cluster: dict[str, str],
 ) -> t.Callable[[dict[str, t.Any] | None], dict[str, t.Any]]:
     """Return a profile configuration for the :class:`~aiida.storage.psql_dos.backend.PsqlDosBackend`."""

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -162,7 +162,7 @@ py:class disk_objectstore.container.Container
 py:class flask.app.Flask
 py:class flask.json.JSONEncoder
 
-py:class pytest.TempPathFactory
+py:class pytest.tmpdir.TempPathFactory
 
 py:class sqlalchemy.orm.decl_api.SqliteModel
 py:class sqlalchemy.orm.decl_api.Base


### PR DESCRIPTION
The readthedocs (RTD) build was failing with the following error:

```
read the docs ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1
```

This was due to a change in the support for `urllib`, see:

https://github.com/urllib3/urllib3/issues/2168

Which requires Python > 3.8. Hence here we update the Python version.