### PR TITLE
Add migration to reset hash for `CalcJobNodes`

### DIFF
--- a/aiida/storage/psql_dos/migrations/utils/integrity.py
+++ b/aiida/storage/psql_dos/migrations/utils/integrity.py
@@ -186,14 +186,12 @@ def write_database_integrity_violation(results, headers, reason_message, action_
         handle.write(tabulate(results, headers))
 
 
-# Currently valid hash key
-_HASH_EXTRA_KEY = '_aiida_hash'
-
-
-def drop_hashes(conn):
+def drop_hashes(conn, hash_extra_key):
     """Drop hashes of nodes.
 
     Print warning only if the DB actually contains nodes.
+
+    :param hash_extra_key: The key in the extras used to store the hash at the time of this migration.
     """
     # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
     # pylint: disable=no-name-in-module,import-error
@@ -204,5 +202,5 @@ def drop_hashes(conn):
     if n_nodes > 0:
         echo.echo_warning('Invalidating the hashes of all nodes. Please run "verdi rehash".', bold=True)
 
-    statement = text(f"UPDATE db_dbnode SET extras = extras #- '{{{_HASH_EXTRA_KEY}}}'::text[];")
+    statement = text(f"UPDATE db_dbnode SET extras = extras #- '{{{hash_extra_key}}}'::text[];")
     conn.execute(statement)

--- a/aiida/storage/psql_dos/migrations/utils/integrity.py
+++ b/aiida/storage/psql_dos/migrations/utils/integrity.py
@@ -9,6 +9,12 @@
 ###########################################################################
 # pylint: disable=invalid-name
 """Methods to validate the database integrity and fix violations."""
+from __future__ import annotations
+
+from aiida.common.log import AIIDA_LOGGER
+
+LOGGER = AIIDA_LOGGER.getChild(__file__)
+
 WARNING_BORDER = '*' * 120
 
 # These are all the entry points from the `aiida.calculations` category as registered with the AiiDA registry
@@ -160,7 +166,6 @@ def write_database_integrity_violation(results, headers, reason_message, action_
 
     from tabulate import tabulate
 
-    from aiida.cmdline.utils import echo
     from aiida.manage import configuration
 
     global_profile = configuration.get_profile()
@@ -171,8 +176,7 @@ def write_database_integrity_violation(results, headers, reason_message, action_
         action_message = 'nothing'
 
     with NamedTemporaryFile(prefix='migration-', suffix='.log', dir='.', delete=False, mode='w+') as handle:
-        echo.echo('')
-        echo.echo_warning(
+        LOGGER.warning(
             '\n{}\nFound one or multiple records that violate the integrity of the database\nViolation reason: {}\n'
             'Performed action: {}\nViolators written to: {}\n{}\n'.format(
                 WARNING_BORDER, reason_message, action_message, handle.name, WARNING_BORDER
@@ -186,21 +190,45 @@ def write_database_integrity_violation(results, headers, reason_message, action_
         handle.write(tabulate(results, headers))
 
 
-def drop_hashes(conn, hash_extra_key):
+def drop_hashes(conn, hash_extra_key: str, entry_point_string: str | None = None) -> None:
     """Drop hashes of nodes.
 
     Print warning only if the DB actually contains nodes.
 
     :param hash_extra_key: The key in the extras used to store the hash at the time of this migration.
+    :param entry_point_string: Optional entry point string of a node type to narrow the subset of nodes to reset. The
+        value should be a complete entry point string, e.g., ``aiida.node:process.calculation.calcjob`` to drop the hash
+        of all ``CalcJobNode`` rows.
     """
     # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
     # pylint: disable=no-name-in-module,import-error
     from sqlalchemy.sql import text
 
-    from aiida.cmdline.utils import echo
-    n_nodes = conn.execute(text("""SELECT count(*) FROM db_dbnode;""")).fetchall()[0][0]
-    if n_nodes > 0:
-        echo.echo_warning('Invalidating the hashes of all nodes. Please run "verdi rehash".', bold=True)
+    from aiida.orm.utils.node import get_type_string_from_class
+    from aiida.plugins import load_entry_point_from_string
 
-    statement = text(f"UPDATE db_dbnode SET extras = extras #- '{{{hash_extra_key}}}'::text[];")
-    conn.execute(statement)
+    if entry_point_string is not None:
+        entry_point = load_entry_point_from_string(entry_point_string)
+        node_type = get_type_string_from_class(entry_point.__module__, entry_point.__name__)
+    else:
+        node_type = None
+
+    if node_type:
+        statement_count = text(f"SELECT count(*) FROM db_dbnode WHERE node_type = '{node_type}';")
+        statement_update = text(
+            f"UPDATE db_dbnode SET extras = extras #- '{{{hash_extra_key}}}'::text[]  WHERE node_type = '{node_type}';"
+        )
+    else:
+        statement_count = text('SELECT count(*) FROM db_dbnode;')
+        statement_update = text(f"UPDATE db_dbnode SET extras = extras #- '{{{hash_extra_key}}}'::text[];")
+
+    node_count = conn.execute(statement_count).fetchall()[0][0]
+
+    if node_count > 0:
+        if entry_point_string:
+            msg = f'Invalidating the hashes of certain nodes. Please run `verdi rehash -p {entry_point_string}`.'
+        else:
+            msg = 'Invalidating the hashes of all nodes. Please run `verdi rehash`.'
+        LOGGER.warning(msg)
+
+    conn.execute(statement_update)

--- a/aiida/storage/psql_dos/migrations/versions/django_0039_reset_hash.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0039_reset_hash.py
@@ -28,9 +28,9 @@ depends_on = None
 
 def upgrade():
     """Migrations for the upgrade."""
-    drop_hashes(op.get_bind())  # pylint: disable=no-member
+    drop_hashes(op.get_bind(), hash_extra_key='_aiida_hash')  # pylint: disable=no-member
 
 
 def downgrade():
     """Migrations for the downgrade."""
-    drop_hashes(op.get_bind())  # pylint: disable=no-member
+    drop_hashes(op.get_bind(), hash_extra_key='_aiida_hash')  # pylint: disable=no-member

--- a/aiida/storage/psql_dos/migrations/versions/e797afa09270_reset_hash.py
+++ b/aiida/storage/psql_dos/migrations/versions/e797afa09270_reset_hash.py
@@ -30,9 +30,9 @@ depends_on = None
 
 def upgrade():
     """drop the hashes when upgrading"""
-    drop_hashes(op.get_bind())  # pylint: disable=no-member
+    drop_hashes(op.get_bind(), hash_extra_key='_aiida_hash')  # pylint: disable=no-member
 
 
 def downgrade():
     """drop the hashes also when downgrading"""
-    drop_hashes(op.get_bind())  # pylint: disable=no-member
+    drop_hashes(op.get_bind(), hash_extra_key='_aiida_hash')  # pylint: disable=no-member

--- a/aiida/storage/psql_dos/migrations/versions/main_0002_recompute_hash_calc_job_node.py
+++ b/aiida/storage/psql_dos/migrations/versions/main_0002_recompute_hash_calc_job_node.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,no-member
+"""Drop the hashes for all ``CalcJobNode`` instances.
+
+The computed hash erroneously included the hash of the file repository. This was present as of v2.0 and so all nodes
+created with versions since then will have incorrect hashes.
+
+Revision ID: main_0002
+Revises: main_0001
+Create Date: 2023-05-05
+
+"""
+from alembic import op
+
+from aiida.storage.psql_dos.migrations.utils.integrity import drop_hashes
+
+revision = 'main_0002'
+down_revision = 'main_0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Migrations for the upgrade."""
+    drop_hashes(
+        op.get_bind(), hash_extra_key='_aiida_hash', entry_point_string='aiida.node:process.calculation.calcjob'
+    )
+
+
+def downgrade():
+    """Migrations for the downgrade."""
+    drop_hashes(
+        op.get_bind(), hash_extra_key='_aiida_hash', entry_point_string='aiida.node:process.calculation.calcjob'
+    )

--- a/aiida/storage/psql_dos/migrator.py
+++ b/aiida/storage/psql_dos/migrator.py
@@ -384,6 +384,7 @@ class PsqlDosMigrator:
         # finally migrate to the main head revision
         MIGRATE_LOGGER.report('Migrating to the head of the main branch')
         self.migrate_up('main@head')
+        self.connection.commit()
 
     def migrate_up(self, version: str) -> None:
         """Migrate the database up to a specific version.

--- a/tests/storage/psql_dos/migrations/main_branch/test_main_0002_recompute_hash_calc_job_node.py
+++ b/tests/storage/psql_dos/migrations/main_branch/test_main_0002_recompute_hash_calc_job_node.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Test ``main_0002_recompute_hash_calc_job_node.py``."""
+from aiida.common import timezone
+from aiida.common.utils import get_new_uuid
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
+
+
+def test_migration(perform_migrations: PsqlDosMigrator):
+    """Test the migration removes the ``_aiida_hash`` extra of all ``CalcJobNodes`` and those nodes only."""
+    perform_migrations.migrate_up('main@main_0001')
+
+    user_model = perform_migrations.get_current_table('db_dbuser')
+    node_model = perform_migrations.get_current_table('db_dbnode')
+
+    with perform_migrations.session() as session:
+        user = user_model(email='test', first_name='test', last_name='test', institution='test')
+        session.add(user)
+        session.commit()
+
+        calcjob = node_model(
+            uuid=get_new_uuid(),
+            user_id=user.id,
+            ctime=timezone.now(),
+            mtime=timezone.now(),
+            label='test',
+            description='',
+            node_type='process.calculation.calcjob.CalcJobNode.',
+            process_type='aiida.calculations:core.arithmetic.add',
+            attributes={'parser_name': 'core.arithmetic.add'},
+            repository_metadata={},
+            extras={
+                '_aiida_hash': 'hash',
+                'other_extra': 'value'
+            }
+        )
+        workflow = node_model(
+            uuid=get_new_uuid(),
+            user_id=user.id,
+            ctime=timezone.now(),
+            mtime=timezone.now(),
+            label='test',
+            description='',
+            node_type='process.workflow.workchain.WorkChainNode.',
+            process_type='aiida.workflows:core.arithmetic.add_multiply',
+            repository_metadata={},
+            extras={
+                '_aiida_hash': 'hash',
+                'other_extra': 'value'
+            }
+        )
+        session.add_all((calcjob, workflow))
+        session.commit()
+
+        calcjob_id = calcjob.id
+        workflow_id = workflow.id
+
+    # Perform the migration that is being tested.
+    perform_migrations.migrate_up('main@main_0002')
+
+    node_model = perform_migrations.get_current_table('db_dbnode')
+
+    # Check that the ``_aiida_hash`` extra was removed, and only that extra, and only for the calcjob, not the workflow.
+    with perform_migrations.session() as session:
+        calcjob = session.query(node_model).filter(node_model.id == calcjob_id).one()
+        assert calcjob.extras == {'other_extra': 'value'}
+
+        workflow = session.query(node_model).filter(node_model.id == workflow_id).one()
+        assert workflow.extras == {'_aiida_hash': 'hash', 'other_extra': 'value'}

--- a/tests/storage/psql_dos/migrations/test_all_schema/test_main_main_0002_.yml
+++ b/tests/storage/psql_dos/migrations/test_all_schema/test_main_main_0002_.yml
@@ -1,0 +1,523 @@
+columns:
+  db_dbauthinfo:
+    aiidauser_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    auth_params:
+      data_type: jsonb
+      default: null
+      is_nullable: false
+    dbcomputer_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    enabled:
+      data_type: boolean
+      default: null
+      is_nullable: false
+    id:
+      data_type: integer
+      default: nextval('db_dbauthinfo_id_seq'::regclass)
+      is_nullable: false
+    metadata:
+      data_type: jsonb
+      default: null
+      is_nullable: false
+  db_dbcomment:
+    content:
+      data_type: text
+      default: null
+      is_nullable: false
+    ctime:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    dbnode_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    id:
+      data_type: integer
+      default: nextval('db_dbcomment_id_seq'::regclass)
+      is_nullable: false
+    mtime:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    user_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    uuid:
+      data_type: uuid
+      default: null
+      is_nullable: false
+  db_dbcomputer:
+    description:
+      data_type: text
+      default: null
+      is_nullable: false
+    hostname:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    id:
+      data_type: integer
+      default: nextval('db_dbcomputer_id_seq'::regclass)
+      is_nullable: false
+    label:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    metadata:
+      data_type: jsonb
+      default: null
+      is_nullable: false
+    scheduler_type:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    transport_type:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    uuid:
+      data_type: uuid
+      default: null
+      is_nullable: false
+  db_dbgroup:
+    description:
+      data_type: text
+      default: null
+      is_nullable: false
+    extras:
+      data_type: jsonb
+      default: null
+      is_nullable: false
+    id:
+      data_type: integer
+      default: nextval('db_dbgroup_id_seq'::regclass)
+      is_nullable: false
+    label:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    time:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    type_string:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    user_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    uuid:
+      data_type: uuid
+      default: null
+      is_nullable: false
+  db_dbgroup_dbnodes:
+    dbgroup_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    dbnode_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    id:
+      data_type: integer
+      default: nextval('db_dbgroup_dbnodes_id_seq'::regclass)
+      is_nullable: false
+  db_dblink:
+    id:
+      data_type: integer
+      default: nextval('db_dblink_id_seq'::regclass)
+      is_nullable: false
+    input_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    label:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    output_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    type:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+  db_dblog:
+    dbnode_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    id:
+      data_type: integer
+      default: nextval('db_dblog_id_seq'::regclass)
+      is_nullable: false
+    levelname:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 50
+    loggername:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    message:
+      data_type: text
+      default: null
+      is_nullable: false
+    metadata:
+      data_type: jsonb
+      default: null
+      is_nullable: false
+    time:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    uuid:
+      data_type: uuid
+      default: null
+      is_nullable: false
+  db_dbnode:
+    attributes:
+      data_type: jsonb
+      default: null
+      is_nullable: true
+    ctime:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    dbcomputer_id:
+      data_type: integer
+      default: null
+      is_nullable: true
+    description:
+      data_type: text
+      default: null
+      is_nullable: false
+    extras:
+      data_type: jsonb
+      default: null
+      is_nullable: true
+    id:
+      data_type: integer
+      default: nextval('db_dbnode_id_seq'::regclass)
+      is_nullable: false
+    label:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    mtime:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    node_type:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 255
+    process_type:
+      data_type: character varying
+      default: null
+      is_nullable: true
+      max_length: 255
+    repository_metadata:
+      data_type: jsonb
+      default: null
+      is_nullable: false
+    user_id:
+      data_type: integer
+      default: null
+      is_nullable: false
+    uuid:
+      data_type: uuid
+      default: null
+      is_nullable: false
+  db_dbsetting:
+    description:
+      data_type: text
+      default: null
+      is_nullable: false
+    id:
+      data_type: integer
+      default: nextval('db_dbsetting_id_seq'::regclass)
+      is_nullable: false
+    key:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 1024
+    time:
+      data_type: timestamp with time zone
+      default: null
+      is_nullable: false
+    val:
+      data_type: jsonb
+      default: null
+      is_nullable: true
+  db_dbuser:
+    email:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 254
+    first_name:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 254
+    id:
+      data_type: integer
+      default: nextval('db_dbuser_id_seq'::regclass)
+      is_nullable: false
+    institution:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 254
+    last_name:
+      data_type: character varying
+      default: null
+      is_nullable: false
+      max_length: 254
+constraints:
+  primary_key:
+    db_dbauthinfo:
+      db_dbauthinfo_pkey:
+      - id
+    db_dbcomment:
+      db_dbcomment_pkey:
+      - id
+    db_dbcomputer:
+      db_dbcomputer_pkey:
+      - id
+    db_dbgroup:
+      db_dbgroup_pkey:
+      - id
+    db_dbgroup_dbnodes:
+      db_dbgroup_dbnodes_pkey:
+      - id
+    db_dblink:
+      db_dblink_pkey:
+      - id
+    db_dblog:
+      db_dblog_pkey:
+      - id
+    db_dbnode:
+      db_dbnode_pkey:
+      - id
+    db_dbsetting:
+      db_dbsetting_pkey:
+      - id
+    db_dbuser:
+      db_dbuser_pkey:
+      - id
+  unique:
+    db_dbauthinfo:
+      uq_db_dbauthinfo_aiidauser_id_dbcomputer_id:
+      - aiidauser_id
+      - dbcomputer_id
+    db_dbcomment:
+      uq_db_dbcomment_uuid:
+      - uuid
+    db_dbcomputer:
+      uq_db_dbcomputer_label:
+      - label
+      uq_db_dbcomputer_uuid:
+      - uuid
+    db_dbgroup:
+      uq_db_dbgroup_label_type_string:
+      - label
+      - type_string
+      uq_db_dbgroup_uuid:
+      - uuid
+    db_dbgroup_dbnodes:
+      uq_db_dbgroup_dbnodes_dbgroup_id_dbnode_id:
+      - dbgroup_id
+      - dbnode_id
+    db_dblog:
+      uq_db_dblog_uuid:
+      - uuid
+    db_dbnode:
+      uq_db_dbnode_uuid:
+      - uuid
+    db_dbsetting:
+      uq_db_dbsetting_key:
+      - key
+    db_dbuser:
+      uq_db_dbuser_email:
+      - email
+foreign_keys:
+  db_dbauthinfo:
+    fk_db_dbauthinfo_aiidauser_id_db_dbuser: FOREIGN KEY (aiidauser_id) REFERENCES
+      db_dbuser(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+    fk_db_dbauthinfo_dbcomputer_id_db_dbcomputer: FOREIGN KEY (dbcomputer_id) REFERENCES
+      db_dbcomputer(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+  db_dbcomment:
+    fk_db_dbcomment_dbnode_id_db_dbnode: FOREIGN KEY (dbnode_id) REFERENCES db_dbnode(id)
+      ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+    fk_db_dbcomment_user_id_db_dbuser: FOREIGN KEY (user_id) REFERENCES db_dbuser(id)
+      ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+  db_dbgroup:
+    fk_db_dbgroup_user_id_db_dbuser: FOREIGN KEY (user_id) REFERENCES db_dbuser(id)
+      ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+  db_dbgroup_dbnodes:
+    fk_db_dbgroup_dbnodes_dbgroup_id_db_dbgroup: FOREIGN KEY (dbgroup_id) REFERENCES
+      db_dbgroup(id) DEFERRABLE INITIALLY DEFERRED
+    fk_db_dbgroup_dbnodes_dbnode_id_db_dbnode: FOREIGN KEY (dbnode_id) REFERENCES
+      db_dbnode(id) DEFERRABLE INITIALLY DEFERRED
+  db_dblink:
+    fk_db_dblink_input_id_db_dbnode: FOREIGN KEY (input_id) REFERENCES db_dbnode(id)
+      DEFERRABLE INITIALLY DEFERRED
+    fk_db_dblink_output_id_db_dbnode: FOREIGN KEY (output_id) REFERENCES db_dbnode(id)
+      ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+  db_dblog:
+    fk_db_dblog_dbnode_id_db_dbnode: FOREIGN KEY (dbnode_id) REFERENCES db_dbnode(id)
+      ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+  db_dbnode:
+    fk_db_dbnode_dbcomputer_id_db_dbcomputer: FOREIGN KEY (dbcomputer_id) REFERENCES
+      db_dbcomputer(id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED
+    fk_db_dbnode_user_id_db_dbuser: FOREIGN KEY (user_id) REFERENCES db_dbuser(id)
+      ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED
+indexes:
+  db_dbauthinfo:
+    db_dbauthinfo_pkey: CREATE UNIQUE INDEX db_dbauthinfo_pkey ON public.db_dbauthinfo
+      USING btree (id)
+    ix_db_dbauthinfo_db_dbauthinfo_aiidauser_id: CREATE INDEX ix_db_dbauthinfo_db_dbauthinfo_aiidauser_id
+      ON public.db_dbauthinfo USING btree (aiidauser_id)
+    ix_db_dbauthinfo_db_dbauthinfo_dbcomputer_id: CREATE INDEX ix_db_dbauthinfo_db_dbauthinfo_dbcomputer_id
+      ON public.db_dbauthinfo USING btree (dbcomputer_id)
+    uq_db_dbauthinfo_aiidauser_id_dbcomputer_id: CREATE UNIQUE INDEX uq_db_dbauthinfo_aiidauser_id_dbcomputer_id
+      ON public.db_dbauthinfo USING btree (aiidauser_id, dbcomputer_id)
+  db_dbcomment:
+    db_dbcomment_pkey: CREATE UNIQUE INDEX db_dbcomment_pkey ON public.db_dbcomment
+      USING btree (id)
+    ix_db_dbcomment_db_dbcomment_dbnode_id: CREATE INDEX ix_db_dbcomment_db_dbcomment_dbnode_id
+      ON public.db_dbcomment USING btree (dbnode_id)
+    ix_db_dbcomment_db_dbcomment_user_id: CREATE INDEX ix_db_dbcomment_db_dbcomment_user_id
+      ON public.db_dbcomment USING btree (user_id)
+    uq_db_dbcomment_uuid: CREATE UNIQUE INDEX uq_db_dbcomment_uuid ON public.db_dbcomment
+      USING btree (uuid)
+  db_dbcomputer:
+    db_dbcomputer_pkey: CREATE UNIQUE INDEX db_dbcomputer_pkey ON public.db_dbcomputer
+      USING btree (id)
+    ix_pat_db_dbcomputer_label: CREATE INDEX ix_pat_db_dbcomputer_label ON public.db_dbcomputer
+      USING btree (label varchar_pattern_ops)
+    uq_db_dbcomputer_label: CREATE UNIQUE INDEX uq_db_dbcomputer_label ON public.db_dbcomputer
+      USING btree (label)
+    uq_db_dbcomputer_uuid: CREATE UNIQUE INDEX uq_db_dbcomputer_uuid ON public.db_dbcomputer
+      USING btree (uuid)
+  db_dbgroup:
+    db_dbgroup_pkey: CREATE UNIQUE INDEX db_dbgroup_pkey ON public.db_dbgroup USING
+      btree (id)
+    ix_db_dbgroup_db_dbgroup_label: CREATE INDEX ix_db_dbgroup_db_dbgroup_label ON
+      public.db_dbgroup USING btree (label)
+    ix_db_dbgroup_db_dbgroup_type_string: CREATE INDEX ix_db_dbgroup_db_dbgroup_type_string
+      ON public.db_dbgroup USING btree (type_string)
+    ix_db_dbgroup_db_dbgroup_user_id: CREATE INDEX ix_db_dbgroup_db_dbgroup_user_id
+      ON public.db_dbgroup USING btree (user_id)
+    ix_pat_db_dbgroup_label: CREATE INDEX ix_pat_db_dbgroup_label ON public.db_dbgroup
+      USING btree (label varchar_pattern_ops)
+    ix_pat_db_dbgroup_type_string: CREATE INDEX ix_pat_db_dbgroup_type_string ON public.db_dbgroup
+      USING btree (type_string varchar_pattern_ops)
+    uq_db_dbgroup_label_type_string: CREATE UNIQUE INDEX uq_db_dbgroup_label_type_string
+      ON public.db_dbgroup USING btree (label, type_string)
+    uq_db_dbgroup_uuid: CREATE UNIQUE INDEX uq_db_dbgroup_uuid ON public.db_dbgroup
+      USING btree (uuid)
+  db_dbgroup_dbnodes:
+    db_dbgroup_dbnodes_pkey: CREATE UNIQUE INDEX db_dbgroup_dbnodes_pkey ON public.db_dbgroup_dbnodes
+      USING btree (id)
+    ix_db_dbgroup_dbnodes_db_dbgroup_dbnodes_dbgroup_id: CREATE INDEX ix_db_dbgroup_dbnodes_db_dbgroup_dbnodes_dbgroup_id
+      ON public.db_dbgroup_dbnodes USING btree (dbgroup_id)
+    ix_db_dbgroup_dbnodes_db_dbgroup_dbnodes_dbnode_id: CREATE INDEX ix_db_dbgroup_dbnodes_db_dbgroup_dbnodes_dbnode_id
+      ON public.db_dbgroup_dbnodes USING btree (dbnode_id)
+    uq_db_dbgroup_dbnodes_dbgroup_id_dbnode_id: CREATE UNIQUE INDEX uq_db_dbgroup_dbnodes_dbgroup_id_dbnode_id
+      ON public.db_dbgroup_dbnodes USING btree (dbgroup_id, dbnode_id)
+  db_dblink:
+    db_dblink_pkey: CREATE UNIQUE INDEX db_dblink_pkey ON public.db_dblink USING btree
+      (id)
+    ix_db_dblink_db_dblink_input_id: CREATE INDEX ix_db_dblink_db_dblink_input_id
+      ON public.db_dblink USING btree (input_id)
+    ix_db_dblink_db_dblink_label: CREATE INDEX ix_db_dblink_db_dblink_label ON public.db_dblink
+      USING btree (label)
+    ix_db_dblink_db_dblink_output_id: CREATE INDEX ix_db_dblink_db_dblink_output_id
+      ON public.db_dblink USING btree (output_id)
+    ix_db_dblink_db_dblink_type: CREATE INDEX ix_db_dblink_db_dblink_type ON public.db_dblink
+      USING btree (type)
+    ix_pat_db_dblink_label: CREATE INDEX ix_pat_db_dblink_label ON public.db_dblink
+      USING btree (label varchar_pattern_ops)
+    ix_pat_db_dblink_type: CREATE INDEX ix_pat_db_dblink_type ON public.db_dblink
+      USING btree (type varchar_pattern_ops)
+  db_dblog:
+    db_dblog_pkey: CREATE UNIQUE INDEX db_dblog_pkey ON public.db_dblog USING btree
+      (id)
+    ix_db_dblog_db_dblog_dbnode_id: CREATE INDEX ix_db_dblog_db_dblog_dbnode_id ON
+      public.db_dblog USING btree (dbnode_id)
+    ix_db_dblog_db_dblog_levelname: CREATE INDEX ix_db_dblog_db_dblog_levelname ON
+      public.db_dblog USING btree (levelname)
+    ix_db_dblog_db_dblog_loggername: CREATE INDEX ix_db_dblog_db_dblog_loggername
+      ON public.db_dblog USING btree (loggername)
+    ix_pat_db_dblog_levelname: CREATE INDEX ix_pat_db_dblog_levelname ON public.db_dblog
+      USING btree (levelname varchar_pattern_ops)
+    ix_pat_db_dblog_loggername: CREATE INDEX ix_pat_db_dblog_loggername ON public.db_dblog
+      USING btree (loggername varchar_pattern_ops)
+    uq_db_dblog_uuid: CREATE UNIQUE INDEX uq_db_dblog_uuid ON public.db_dblog USING
+      btree (uuid)
+  db_dbnode:
+    db_dbnode_pkey: CREATE UNIQUE INDEX db_dbnode_pkey ON public.db_dbnode USING btree
+      (id)
+    ix_db_dbnode_db_dbnode_ctime: CREATE INDEX ix_db_dbnode_db_dbnode_ctime ON public.db_dbnode
+      USING btree (ctime)
+    ix_db_dbnode_db_dbnode_dbcomputer_id: CREATE INDEX ix_db_dbnode_db_dbnode_dbcomputer_id
+      ON public.db_dbnode USING btree (dbcomputer_id)
+    ix_db_dbnode_db_dbnode_label: CREATE INDEX ix_db_dbnode_db_dbnode_label ON public.db_dbnode
+      USING btree (label)
+    ix_db_dbnode_db_dbnode_mtime: CREATE INDEX ix_db_dbnode_db_dbnode_mtime ON public.db_dbnode
+      USING btree (mtime)
+    ix_db_dbnode_db_dbnode_node_type: CREATE INDEX ix_db_dbnode_db_dbnode_node_type
+      ON public.db_dbnode USING btree (node_type)
+    ix_db_dbnode_db_dbnode_process_type: CREATE INDEX ix_db_dbnode_db_dbnode_process_type
+      ON public.db_dbnode USING btree (process_type)
+    ix_db_dbnode_db_dbnode_user_id: CREATE INDEX ix_db_dbnode_db_dbnode_user_id ON
+      public.db_dbnode USING btree (user_id)
+    ix_pat_db_dbnode_label: CREATE INDEX ix_pat_db_dbnode_label ON public.db_dbnode
+      USING btree (label varchar_pattern_ops)
+    ix_pat_db_dbnode_node_type: CREATE INDEX ix_pat_db_dbnode_node_type ON public.db_dbnode
+      USING btree (node_type varchar_pattern_ops)
+    ix_pat_db_dbnode_process_type: CREATE INDEX ix_pat_db_dbnode_process_type ON public.db_dbnode
+      USING btree (process_type varchar_pattern_ops)
+    uq_db_dbnode_uuid: CREATE UNIQUE INDEX uq_db_dbnode_uuid ON public.db_dbnode USING
+      btree (uuid)
+  db_dbsetting:
+    db_dbsetting_pkey: CREATE UNIQUE INDEX db_dbsetting_pkey ON public.db_dbsetting
+      USING btree (id)
+    ix_pat_db_dbsetting_key: CREATE INDEX ix_pat_db_dbsetting_key ON public.db_dbsetting
+      USING btree (key varchar_pattern_ops)
+    uq_db_dbsetting_key: CREATE UNIQUE INDEX uq_db_dbsetting_key ON public.db_dbsetting
+      USING btree (key)
+  db_dbuser:
+    db_dbuser_pkey: CREATE UNIQUE INDEX db_dbuser_pkey ON public.db_dbuser USING btree
+      (id)
+    ix_pat_db_dbuser_email: CREATE INDEX ix_pat_db_dbuser_email ON public.db_dbuser
+      USING btree (email varchar_pattern_ops)
+    uq_db_dbuser_email: CREATE UNIQUE INDEX uq_db_dbuser_email ON public.db_dbuser
+      USING btree (email)


### PR DESCRIPTION
See #5998 where the algorithm for the hash of `CalcJobNodes` was fixed, but therefore changed. This means that existing hashes will be incompatible and should be recomputed. Here a migration is added that drops the hashes for all `CalcJobNodes` and a warning is emitted to suggest the user run `verdi node rehash -e aiida.node:process.calculation.calcjob` to recompute their hashes.

To allow this, the `-e/--entry-point` option of `verdi node rehash` is updated to allow entry points from the `aiida.node` group. The `drop_hashes` utility which is used for the migrations, is improved to make the key of the hash explicitly defined by the migration, and add an argument to scope what type of nodes to drop the hashes for.