### PR TITLE
CLI: interface for manully clean stale PID file

### DIFF
--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -557,6 +557,8 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
         :raises DaemonTimeoutException: If the connection to the daemon timed out.
         :raises DaemonException: If the connection to the daemon failed for any other reason.
         """
+        self._clean_potentially_stale_pid_file()
+        
         command = {'command': 'quit', 'properties': {'waiting': wait}}
         response = self.call_client(command, timeout=timeout)
 

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -424,8 +424,8 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
 
             if self._is_pid_file_stale:
                 raise DaemonStalePidException(
-                    'The daemon could not be reached, seemingly because of a stale PID file. Try starting the daemon '
-                    'to remove it and restore the daemon.'
+                    'The daemon could not be reached, seemingly because of a stale PID file. Either stop or start the '
+                    'daemon to remove it and restore the daemon to a functional state.'
                 ) from exception
 
             if str(exception) == 'Timed out.':

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -558,7 +558,7 @@ class DaemonClient:  # pylint: disable=too-many-public-methods
         :raises DaemonException: If the connection to the daemon failed for any other reason.
         """
         self._clean_potentially_stale_pid_file()
-        
+
         command = {'command': 'quit', 'properties': {'waiting': wait}}
         response = self.call_client(command, timeout=timeout)
 


### PR DESCRIPTION
In https://github.com/aiidateam/aiida-core/commit/8d963c98fbb3b1224cd69f3860f09360287034b3 orphaned PID files can now only be removed by starting the daemon again. In order to provide a way to clean the stale pid file manually. In AiiDAlab docker stack, we run `verdi daemon stop` before database migration. But if the container is shut down ungracefully, the daemon is not properly stopped and leaves a stale PID file which causes the exception when running `verdi daemon stop` next time. 
With the CLI interface in this PR, it allows running the `verdi daemon clean-stale-pid-file` first, to make sure `verdi daemon stop` will not block the starting of the container. 

EDIT: the argument `clean-stale-pid-file` seems nasty, maybe call it `verdi daemon clean`?