### PR TITLE
Expose `get_daemon_client` so it can be imported from `aiida.engine`

### DIFF
--- a/aiida/engine/__init__.py
+++ b/aiida/engine/__init__.py
@@ -61,6 +61,7 @@ __all__ = (
     'assign_',
     'calcfunction',
     'construct_awaitable',
+    'get_daemon_client',
     'get_object_loader',
     'if_',
     'interruptable_task',

--- a/aiida/engine/daemon/__init__.py
+++ b/aiida/engine/daemon/__init__.py
@@ -18,6 +18,7 @@ from .client import *
 
 __all__ = (
     'DaemonClient',
+    'get_daemon_client',
 )
 
 # yapf: enable

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -41,7 +41,7 @@ VERDI_BIN = shutil.which('verdi')
 # Recent versions of virtualenv create the environment variable VIRTUAL_ENV
 VIRTUALENV = os.environ.get('VIRTUAL_ENV', None)
 
-__all__ = ('DaemonClient',)
+__all__ = ('DaemonClient', 'get_daemon_client')
 
 
 class ControllerProtocol(enum.Enum):


### PR DESCRIPTION
This is public API that users should use to easily obtain a `DaemonClient` instance to control the daemon. Currently it has to be imported from `aiida.engine.daemon.client` which is unnecessarily buried deep down.