### PR TITLE
`DynamicEntryPointCommandGroup`: Add support for shared options

### DIFF
--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -29,7 +29,7 @@ def verdi_code():
     """Setup and manage codes."""
 
 
-def create_code(cls, non_interactive, **kwargs):  # pylint: disable=unused-argument
+def create_code(ctx: click.Context, cls, non_interactive: bool, **kwargs):  # pylint: disable=unused-argument
     """Create a new `Code` instance."""
     try:
         instance = cls(**kwargs)

--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -41,12 +41,20 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
 
     """
 
-    def __init__(self, command, entry_point_group: str, entry_point_name_filter=r'.*', **kwargs):
+    def __init__(
+        self,
+        command,
+        entry_point_group: str,
+        entry_point_name_filter: str = r'.*',
+        shared_options: list[click.Option] | None = None,
+        **kwargs
+    ):
         super().__init__(**kwargs)
         self.command = command
         self.entry_point_group = entry_point_group
         self.entry_point_name_filter = entry_point_name_filter
         self.factory = ENTRY_POINT_GROUP_FACTORY_MAPPING[entry_point_group]
+        self.shared_options = shared_options
 
     def list_commands(self, ctx) -> list[str]:
         """Return the sorted list of subcommands for this group.
@@ -95,6 +103,12 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
             options_list.reverse()
 
             for option in options_list:
+                func = option(func)
+
+            shared_options = self.shared_options or []
+            shared_options.reverse()
+
+            for option in shared_options:
                 func = option(func)
 
             return func

--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -68,15 +68,15 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
         :returns: The :class:`click.Command`.
         """
         try:
-            command = self.create_command(cmd_name)
+            command = self.create_command(ctx, cmd_name)
         except exceptions.EntryPointError:
             command = super().get_command(ctx, cmd_name)
         return command
 
-    def create_command(self, entry_point):
+    def create_command(self, ctx, entry_point):
         """Create a subcommand for the given ``entry_point``."""
         cls = self.factory(entry_point)
-        command = functools.partial(self.command, cls)
+        command = functools.partial(self.command, ctx, cls)
         command.__doc__ = cls.__doc__
         return click.command(entry_point)(self.create_options(entry_point)(command))
 


### PR DESCRIPTION
The idea for the `DynamicEntryPointCommandGroup` is to easily create a
command that has subcommands that are created dynamically based on the
entry points that are registered in a certain group. Each entry point
would provide the specific CLI options that it would require. However,
often there will be shared options that are not specific to any entry
point but all of them would require.

Here the `shared_options` argument is added to the constructor of the
`DynamicEntryPointCommandGroup`. It takes a list of `click.Option`
instances and when defined, these options will be added in reverse order
after the options of the specific entry point have been added. This
ensures that the shared options will be available to all dynamically
generated subcommands.