### PR TITLE
`CalcJob`: Remove default of `withmpi` input and make it optional

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -325,7 +325,7 @@ class CalcJob(Process):
         spec.input(
             'metadata.options.withmpi',
             valid_type=bool,
-            default=False,
+            required=False,
             help='Set the calculation to use mpi',
         )
         spec.input(
@@ -946,8 +946,8 @@ class CalcJob(Process):
             if with_mpi_values_set:
                 with_mpi = with_mpi_values_set.pop()
             else:
-                # Fall back to the default of the ``metadata.options.withmpi`` of the ``Calcjob`` class
-                with_mpi = self.node.get_option('withmpi')
+                # Fall back to the default, which is to not use MPI
+                with_mpi = False
 
             if with_mpi:
                 prepend_cmdline_params = code.get_prepend_cmdline_params(mpi_args, extra_mpirun_params)


### PR DESCRIPTION
The `metadata.options.withmpi` specified `False` as the default. This can pose a problem for `CalcJob` implementations that can run with and without MPI.

Since the recent changes in the handling of MPI for `CalcJob` runs, see cdb3eed92b052dea5ca697adffaf3025cbc0ab03, there are now three ways that it is controlled:

 * `metadata.options.withmpi` input
 * `CodeInfo.withmpi` returned by the `CalcJob` implementation
 * `AbstractCode.with_mpi` attribute

The engine will check each of these, and when any of them are explicitly set to conflicting values, an error is raised. The problem is that the `CalcJob` base class, set a default for the `metadata.options.withmpi` input, and set it to `False`.

This forces all `CalcJob` plugins to manually unset it if they can in principle run with or without MPI, as it would except if a `Code` would be passed in the inputs that set `with_mpi` to `True`. The code to do it is non-trivial though:

    options['withmpi'].default = None
    options['withmpi'].required = False
    options['withmpi'].valid_type = (bool, type(None))

This is not user-friendly for users wanting to implement `CalcJob` plugins and it is better to remove the default on the base class.

This change should be fully-backwards compatible since the logic in `CalcJob.presubmit` will check the case where none of the three methods explicitly set a value. In this case, the logic used to fall back on the value of the option set on the node. This branch would actually never be hit, because in this case, the default of `metadata.options.withmpi` would always be set to `False`. This fallback keeps `False` as default, but hardcodes it instead of taking it from the option input.