### PR TITLE
`SinglefileData`: Add the `from_string` classmethod

### DIFF
--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -32,7 +32,7 @@ class SinglefileData(Data):
         """Construct a new instance and set ``content`` as its contents.
 
         :param content: The content as a string.
-        :param filename: Specify filename to use (defaults to name of provided file).
+        :param filename: Specify filename to use (defaults to ``file.txt``).
         """
         return cls(io.StringIO(content), filename, **kwargs)
 

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import os
 import pathlib
 
@@ -25,6 +26,15 @@ class SinglefileData(Data):
     """Data class that can be used to store a single file in its repository."""
 
     DEFAULT_FILENAME = 'file.txt'
+
+    @classmethod
+    def from_string(cls, content: str, filename: str | pathlib.Path | None = None, **kwargs):
+        """Construct a new instance and set ``content`` as its contents.
+
+        :param content: The content as a string.
+        :param filename: Specify filename to use (defaults to name of provided file).
+        """
+        return cls(io.StringIO(content), filename, **kwargs)
 
     def __init__(self, file, filename: str | pathlib.Path | None = None, **kwargs):
         """Construct a new instance and set the contents to that of the file.

--- a/tests/orm/nodes/data/test_singlefile.py
+++ b/tests/orm/nodes/data/test_singlefile.py
@@ -184,3 +184,17 @@ def test_binary_file(check_singlefile_content_with_store):
         filename=basename,
         open_mode='rb',
     )
+
+
+def test_from_string():
+    """Test the :meth:`aiida.orm.nodes.data.singlefile.SinglefileData.from_string` classmethod."""
+    content = 'some\ncontent'
+    node = SinglefileData.from_string(content).store()
+    assert node.get_content() == content
+    assert node.filename == SinglefileData.DEFAULT_FILENAME
+
+    content = 'some\ncontent'
+    filename = 'custom_filename.dat'
+    node = SinglefileData.from_string(content, filename).store()
+    assert node.get_content() == content
+    assert node.filename == filename


### PR DESCRIPTION
Fixes #6021 

This allows the construction of a `SinglefileData` from content that is already in memory as a `str`. Although this was already possible through `SinglefileData(io.StringIO(content))`, the classmethod has advantages:

* No need for separate import of `io`
* Method can be found easily through introspection
* Overall is more intuitive than turning string content into a stream