### PR TITLE
Add `verdi profile setup`

### DIFF
--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -208,7 +208,7 @@ def create_profile(
     """
     from aiida.orm import User
 
-    storage_config = {key: kwargs[key] for key in storage_cls.get_cli_options().keys() if key in kwargs}
+    storage_config = storage_cls.Configuration(**{k: v for k, v in kwargs.items() if v is not None}).dict()
     profile: Profile = config.create_profile(name=name, storage_cls=storage_cls, storage_config=storage_config)
 
     with profile_context(profile.name, allow_switch=True):

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -20,7 +20,7 @@ import contextlib
 import io
 import json
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 import uuid
 
 from pydantic import (  # pylint: disable=no-name-in-module
@@ -32,11 +32,8 @@ from pydantic import (  # pylint: disable=no-name-in-module
     field_validator,
 )
 
-from aiida.common.exceptions import ConfigurationError
-from aiida.common.log import LogLevels
-
 from aiida.common.exceptions import ConfigurationError, EntryPointError, StorageMigrationError
-from aiida.common.log import AIIDA_LOGGER
+from aiida.common.log import AIIDA_LOGGER, LogLevels
 
 from .options import Option, get_option, get_option_names, parse_option
 from .profile import Profile

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -16,9 +16,11 @@ See https://github.com/pydantic/pydantic/issues/2678 for details).
 from __future__ import annotations
 
 import codecs
+import contextlib
+import io
 import json
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import uuid
 
 from pydantic import (  # pylint: disable=no-name-in-module
@@ -33,10 +35,18 @@ from pydantic import (  # pylint: disable=no-name-in-module
 from aiida.common.exceptions import ConfigurationError
 from aiida.common.log import LogLevels
 
+from aiida.common.exceptions import ConfigurationError, EntryPointError, StorageMigrationError
+from aiida.common.log import AIIDA_LOGGER
+
 from .options import Option, get_option, get_option_names, parse_option
 from .profile import Profile
 
 __all__ = ('Config',)
+
+if TYPE_CHECKING:
+    from aiida.orm.implementation.storage_backend import StorageBackend
+
+LOGGER = AIIDA_LOGGER.getChild(__file__)
 
 
 class ConfigVersionSchema(BaseModel, defer_build=True):
@@ -126,7 +136,6 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
         from aiida.manage.caching import _validate_identifier_pattern
         for identifier in value:
             _validate_identifier_pattern(identifier=identifier)
-
         return value
 
 
@@ -445,6 +454,70 @@ class Config:  # pylint: disable=too-many-public-methods
         self.validate_profile(name)
 
         return self._profiles[name]
+
+    def create_profile(self, name: str, storage_cls: Type['StorageBackend'], storage_config: dict[str, str]) -> Profile:
+        """Create a new profile and initialise its storage.
+
+        :param name: The profile name.
+        :param storage_cls: The :class:`aiida.orm.implementation.storage_backend.StorageBackend` implementation to use.
+        :param storage_config: The configuration necessary to initialise and connect to the storage backend.
+        :returns: The created profile.
+        :raises ValueError: If the profile already exists.
+        :raises TypeError: If the ``storage_cls`` is not a subclass of
+            :class:`aiida.orm.implementation.storage_backend.StorageBackend`.
+        :raises EntryPointError: If the ``storage_cls`` does not have an associated entry point.
+        :raises StorageMigrationError: If the storage cannot be initialised.
+        """
+        from aiida.orm.implementation.storage_backend import StorageBackend
+        from aiida.plugins.entry_point import get_entry_point_from_class
+
+        if name in self.profile_names:
+            raise ValueError(f'The profile `{name}` already exists.')
+
+        if not issubclass(storage_cls, StorageBackend):
+            raise TypeError(
+                f'The `storage_cls={storage_cls}` is not subclass of `aiida.orm.implementationStorageBackend`.'
+            )
+
+        _, storage_entry_point = get_entry_point_from_class(storage_cls.__module__, storage_cls.__name__)
+
+        if storage_entry_point is None:
+            raise EntryPointError(f'`{storage_cls}` does not have a registered entry point.')
+
+        profile = Profile(
+            name, {
+                'storage': {
+                    'backend': storage_entry_point.name,
+                    'config': storage_config,
+                },
+                'process_control': {
+                    'backend': 'rabbitmq',
+                    'config': {
+                        'broker_protocol': 'amqp',
+                        'broker_username': 'guest',
+                        'broker_password': 'guest',
+                        'broker_host': '127.0.0.1',
+                        'broker_port': 5672,
+                        'broker_virtual_host': ''
+                    }
+                },
+            }
+        )
+
+        LOGGER.report('Initialising the storage backend.')
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                profile.storage_cls.initialise(profile)
+        except Exception as exception:  # pylint: disable=broad-except
+            raise StorageMigrationError(
+                f'Storage backend initialisation failed, probably because the configuration is incorrect:\n{exception}'
+            )
+        LOGGER.report('Storage initialisation completed.')
+
+        self.add_profile(profile)
+        self.store()
+
+        return profile
 
     def add_profile(self, profile):
         """Add a profile to the configuration.

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -8,7 +8,10 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Generic backend related objects"""
+from __future__ import annotations
+
 import abc
+import collections
 from typing import TYPE_CHECKING, Any, ContextManager, List, Optional, Sequence, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -88,6 +91,16 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         :raises: :class`~aiida.common.exceptions.UnreachableStorage` if the storage cannot be accessed.
         :raises: :class:`~aiida.common.exceptions.StorageMigrationError` if the storage is not initialised.
         """
+
+    @classmethod
+    def get_cli_options(cls) -> collections.OrderedDict:
+        """Return the CLI options that would allow to create an instance of this class."""
+        return collections.OrderedDict(cls._get_cli_options())
+
+    @classmethod
+    @abc.abstractmethod
+    def _get_cli_options(cls) -> dict[str, Any]:
+        """Return the CLI options that would allow to create an instance of this class."""
 
     @abc.abstractmethod
     def __init__(self, profile: 'Profile') -> None:

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import abc
-import collections
 from typing import TYPE_CHECKING, Any, ContextManager, List, Optional, Sequence, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -91,16 +90,6 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         :raises: :class`~aiida.common.exceptions.UnreachableStorage` if the storage cannot be accessed.
         :raises: :class:`~aiida.common.exceptions.StorageMigrationError` if the storage is not initialised.
         """
-
-    @classmethod
-    def get_cli_options(cls) -> collections.OrderedDict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        return collections.OrderedDict(cls._get_cli_options())
-
-    @classmethod
-    @abc.abstractmethod
-    def _get_cli_options(cls) -> dict[str, Any]:
-        """Return the CLI options that would allow to create an instance of this class."""
 
     @abc.abstractmethod
     def __init__(self, profile: 'Profile') -> None:

--- a/aiida/repository/backend/sandbox.py
+++ b/aiida/repository/backend/sandbox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import pathlib
 import shutil
 import typing as t
 import uuid
@@ -65,7 +66,7 @@ class SandboxRepositoryBackend(AbstractRepositoryBackend):
     def sandbox(self):
         """Return the sandbox instance of this repository."""
         if self._sandbox is None:
-            self._sandbox = SandboxFolder(filepath=self._filepath)
+            self._sandbox = SandboxFolder(filepath=pathlib.Path(self._filepath) if self._filepath is not None else None)
 
         return self._sandbox
 

--- a/aiida/storage/psql_dos/backend.py
+++ b/aiida/storage/psql_dos/backend.py
@@ -102,6 +102,56 @@ class PsqlDosBackend(StorageBackend):  # pylint: disable=too-many-public-methods
         finally:
             migrator.close()
 
+    @classmethod
+    def create_config(cls, **kwargs):
+        """Create a configuration dictionary based on the CLI options that can be used to initialize an instance."""
+        return {key: kwargs[key] for key in cls._get_cli_options()}
+
+    @classmethod
+    def _get_cli_options(cls) -> dict:
+        """Return the CLI options that would allow to create an instance of this class."""
+        return {
+            'database_engine': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql engine',
+                'default': 'postgresql_psycopg2',
+                'help': 'The engine to use to connect to the database.',
+            },
+            'database_hostname': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql hostname',
+                'default': 'localhost',
+                'help': 'The hostname of the PostgreSQL server.',
+            },
+            'database_port': {
+                'required': True,
+                'type': int,
+                'prompt': 'Postgresql port',
+                'default': '5432',
+                'help': 'The port of the PostgreSQL server.',
+            },
+            'database_username': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql username',
+                'help': 'The username with which to connect to the PostgreSQL server.',
+            },
+            'database_password': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql password',
+                'help': 'The password with which to connect to the PostgreSQL server.',
+            },
+            'database_name': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql database name',
+                'help': 'The name of the database in the PostgreSQL server.',
+            }
+        }
+
     def __init__(self, profile: Profile) -> None:
         super().__init__(profile)
 

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -19,6 +19,7 @@ import shutil
 from tempfile import mkdtemp
 from typing import Any, BinaryIO, Iterator, Sequence
 
+from pydantic import BaseModel, Field
 from sqlalchemy import column, insert, update
 from sqlalchemy.orm import Session
 
@@ -41,6 +42,15 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
     Whenever it is instantiated, it creates a fresh storage backend,
     and destroys it when it is garbage collected.
     """
+
+    class Configuration(BaseModel):
+
+        filepath: str = Field(
+            title='Temporary directory',
+            description='Temporary directory in which to store data for this backend.',
+            default_factory=mkdtemp
+        )
+
     _read_only = False
 
     @staticmethod
@@ -69,23 +79,6 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
                 'options': options or {},
             }
         )
-
-    @classmethod
-    def create_config(cls, filepath: str | None = None):
-        """Create a configuration dictionary based on the CLI options that can be used to initialize an instance."""
-        return {'filepath': filepath or mkdtemp()}
-
-    @classmethod
-    def _get_cli_options(cls) -> dict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        return {
-            'filepath': {
-                'required': False,
-                'type': str,
-                'prompt': 'Temporary directory',
-                'help': 'Temporary directory in which to store data for this backend.',
-            }
-        }
 
     @classmethod
     def version_head(cls) -> str:

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -90,6 +90,23 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
         )
 
     @classmethod
+    def create_config(cls, filepath: str):
+        """Create a configuration dictionary based on the CLI options that can be used to initialize an instance."""
+        return {'path': filepath}
+
+    @classmethod
+    def _get_cli_options(cls) -> dict:
+        """Return the CLI options that would allow to create an instance of this class."""
+        return {
+            'filepath': {
+                'required': True,
+                'type': str,
+                'prompt': 'Filepath of the archive',
+                'help': 'Filepath of the archive in which to store data for this backend.',
+            }
+        }
+
+    @classmethod
     def version_profile(cls, profile: Profile) -> Optional[str]:
         return read_version(profile.storage_config['path'], search_limit=None)
 
@@ -427,5 +444,5 @@ class FolderBackendRepository(_RoBackendRepository):
     def open(self, key: str) -> Iterator[BinaryIO]:
         if not self._path.joinpath(key).is_file():
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
-        with self._path.joinpath(key).open('rb') as handle:
+        with self._path.joinpath(key).open('rb', encoding='utf-8') as handle:
             yield handle

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -21,6 +21,7 @@ from typing import BinaryIO, Iterable, Iterator, Optional, Sequence, Tuple, cast
 from zipfile import ZipFile, is_zipfile
 
 from archive_path import ZipPath, extract_file_in_zip
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from aiida import __version__
@@ -63,6 +64,14 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
             ...
 
     """
+
+    class Configuration(BaseModel):
+
+        filepath: str = Field(
+            title='Filepath of the archive',
+            description='Filepath of the archive in which to store data for this backend.'
+        )
+
     _read_only = True
 
     @classmethod
@@ -88,23 +97,6 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
                 'options': options or {},
             }
         )
-
-    @classmethod
-    def create_config(cls, filepath: str):
-        """Create a configuration dictionary based on the CLI options that can be used to initialize an instance."""
-        return {'path': filepath}
-
-    @classmethod
-    def _get_cli_options(cls) -> dict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        return {
-            'filepath': {
-                'required': True,
-                'type': str,
-                'prompt': 'Filepath of the archive',
-                'help': 'Filepath of the archive in which to store data for this backend.',
-            }
-        }
 
     @classmethod
     def version_profile(cls, profile: Profile) -> Optional[str]:

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -99,6 +99,9 @@ py:obj aiida.storage.psql_dos.orm.ModelType
 py:obj aiida.storage.psql_dos.orm.SelfType
 py:obj aiida.storage.psql_dos.orm.entities.ModelType
 py:obj aiida.storage.psql_dos.orm.entities.SelfType
+py:class aiida.storage.psql_dos.backend.Configuration
+py:class aiida.storage.sqlite_temp.backend.Configuration
+py:class aiida.storage.sqlite_zip.backend.Configuration
 py:obj aiida.tools.archive.SelfType
 py:obj aiida.tools.archive.EntityType
 py:func QueryBuilder._get_ormclass
@@ -131,6 +134,8 @@ py:class click.types.StringParamType
 py:func click.shell_completion._start_of_option
 py:meth click.Option.get_default
 py:meth fail
+
+py:class pydantic.main.BaseModel
 
 py:class requests.models.Response
 py:class requests.Response

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -356,6 +356,7 @@ Below is a list with all available subcommands.
       delete      Delete one or more profiles.
       list        Display a list of all available profiles.
       setdefault  Set a profile as the default one.
+      setup       Set up a new profile.
       show        Show details for a profile.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,6 +291,7 @@ disable = [
     "use-dict-literal",
     "unnecessary-dunder-call",
 ]
+extension-pkg-whitelist = "pydantic"
 
 [tool.pylint.basic]
 good-names = [

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -131,3 +131,12 @@ def test_delete(run_cli_command, mock_profiles, pg_test_cluster):
     result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
     assert profile_list[2] not in result.output
     assert profile_list[3] not in result.output
+
+
+def test_setup(run_cli_command, isolated_config, tmp_path):
+    """Test the ``verdi profile setup`` command."""
+    profile_name = 'temp-profile'
+    options = ['core.sqlite_temp', '-n', '--filepath', str(tmp_path), '--profile', profile_name]
+    result = run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    assert f'Created new profile `{profile_name}`.' in result.output
+    assert profile_name in isolated_config.profile_names

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -11,6 +11,7 @@
 import json
 import os
 import pathlib
+import uuid
 
 import pytest
 
@@ -18,6 +19,8 @@ from aiida.common import exceptions
 from aiida.manage.configuration import Config, Profile, settings
 from aiida.manage.configuration.migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
 from aiida.manage.configuration.options import get_option
+from aiida.orm.implementation.storage_backend import StorageBackend
+from aiida.storage.sqlite_temp import SqliteTempBackend
 
 
 @pytest.fixture
@@ -418,3 +421,38 @@ def test_delete_profile(config_with_profile, profile_factory):
     # Now reload the config from disk to make sure the changes after deletion were persisted to disk
     config_on_disk = Config.from_file(config.filepath)
     assert profile_name not in config_on_disk.profile_names
+
+
+def test_create_profile_raises(config_with_profile, monkeypatch):
+    """Test the ``create_profile`` method when it raises."""
+    config = config_with_profile
+    profile_name = uuid.uuid4().hex
+
+    def raise_storage_migration_error(*args, **kwargs):
+        raise exceptions.StorageMigrationError()
+
+    monkeypatch.setattr(SqliteTempBackend, 'initialise', raise_storage_migration_error)
+
+    class UnregisteredStorageBackend(StorageBackend):
+        pass
+
+    with pytest.raises(ValueError, match=r'The profile `.*` already exists.'):
+        config.create_profile(config_with_profile.default_profile_name, SqliteTempBackend, {})
+
+    with pytest.raises(TypeError, match=r'The `storage_cls=.*` is not subclass of `.*`.'):
+        config.create_profile(profile_name, object, {})
+
+    with pytest.raises(exceptions.EntryPointError, match=r'.*does not have a registered entry point.'):
+        config.create_profile(profile_name, UnregisteredStorageBackend, {})
+
+    with pytest.raises(exceptions.StorageMigrationError, match='Storage backend initialisation failed.*'):
+        config.create_profile(profile_name, SqliteTempBackend, {})
+
+
+def test_create_profile(config_with_profile):
+    """Test the ``create_profile`` method."""
+    config = config_with_profile
+    profile_name = uuid.uuid4().hex
+
+    config.create_profile(profile_name, SqliteTempBackend, {})
+    assert profile_name in config.profile_names

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -3,8 +3,19 @@
 import pytest
 
 import aiida
-from aiida.manage.configuration import get_profile, profile_context
+from aiida.manage.configuration import Profile, create_profile, get_profile, profile_context
 from aiida.manage.manager import get_manager
+from aiida.storage.sqlite_temp.backend import SqliteTempBackend
+
+
+def test_create_profile(isolated_config, tmp_path):
+    """Test :func:`aiida.manage.configuration.tools.create_profile`."""
+    profile_name = 'testing'
+    profile = create_profile(
+        isolated_config, SqliteTempBackend, name=profile_name, email='test@localhost', filepath=str(tmp_path)
+    )
+    assert isinstance(profile, Profile)
+    assert profile_name in isolated_config.profile_names
 
 
 def test_check_version_release(monkeypatch, capsys, isolated_config):

--- a/tests/storage/sqlite/test_archive.py
+++ b/tests/storage/sqlite/test_archive.py
@@ -12,7 +12,7 @@ def test_basic(tmp_path):
     filename = Path(tmp_path / 'export.aiida')
 
     # generate a temporary backend
-    profile1 = SqliteTempBackend.create_profile(repo_path=str(tmp_path / 'repo1'))
+    profile1 = SqliteTempBackend.create_profile(filepath=str(tmp_path / 'repo1'))
     backend1 = SqliteTempBackend(profile1)
 
     # add simple node
@@ -30,7 +30,7 @@ def test_basic(tmp_path):
     create_archive(None, backend=backend1, filename=filename)
 
     # create a new temporary backend and import
-    profile2 = SqliteTempBackend.create_profile(repo_path=str(tmp_path / 'repo2'))
+    profile2 = SqliteTempBackend.create_profile(filepath=str(tmp_path / 'repo2'))
     backend2 = SqliteTempBackend(profile2)
     import_archive(filename, backend=backend2)
 


### PR DESCRIPTION
The `verdi profile setup` command is based of the `DynamicEntryPointGroup`, which is already used for `verdi code create`, to dynamically create a subcommand for each registered storage entry point. It automatically generates CLI options to allow users to specify configuration parameters necessary to initialize the storage.

Edit: Removing the commit that adds the `SqliteDosStorage` for now, as that is not required for this PR and it needs more work.

~The `SqliteDosStorage` is a variant of the default `PsqlDosStorageBackend` swapping the Postgres database for an Sqlite one. This gets rid of the server requirement as sqlite can run of a file on disk, simplifying the setup significantly. This makes it a perfect storage for use in demos, tutorials and quick temporary work.~

~There was already the `SqliteTempStorage`, but that is a fully in memory storage, which is not persisted across Python interpreters, so it has limited usability. The `SqliteZipStorage` is read-only and so also won't be useful for work requiring storing of new data.~

~The `verdi profile setup` command is added to make it easy to create a new profile. With a single command, a fully functioning profile can be setup ready for use:~
```python
(aiida_310) sph@invader:~/code/aiida/env/dev/aiida-core$ verdi profile setup core.sqlite_dos -n --profile sqlite-dos
Report: Initialising the storage backend.
Report: Storage initialisation completed.
Success: Created new profile `sqlite-dos`.
(aiida_310) sph@invader:~/code/aiida/env/dev/aiida-core$ verdi profile show sqlite-dos
Report: Profile: sqlite-dos
PROFILE_UUID: 949cca3793fb45fe85cd86d0f43629d0
default_user_email: mail@sphuber.net
options: {}
process_control:
  backend: rabbitmq
  config:
    broker_host: 127.0.0.1
    broker_password: guest
    broker_port: 5672
    broker_protocol: amqp
    broker_username: guest
    broker_virtual_host: ''
storage:
  backend: core.sqlite_dos
  config:
    filepath: /tmp/tmpnr_wfwd8

(aiida_310) sph@invader:~/code/aiida/env/dev/aiida-core$ verdi -p sqlite-dos shell
Python 3.10.10 (main, Feb  8 2023, 14:50:01) [GCC 9.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.34.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: node = Int(1).store()

In [2]: node.pk
Out[2]: 1

In [4]:                                                                                                                                                                                        
Do you really want to exit ([y]/n)? 
(aiida_310) sph@invader:~/code/aiida/env/dev/aiida-core$ verdi -p sqlite-dos shell
Python 3.10.10 (main, Feb  8 2023, 14:50:01) [GCC 9.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.34.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: load_node(1).value
Out[1]: 1
```