### PR TITLE
Correct instructions to rehash nodes after migration

### DIFF
--- a/aiida/storage/psql_dos/migrations/utils/integrity.py
+++ b/aiida/storage/psql_dos/migrations/utils/integrity.py
@@ -226,9 +226,9 @@ def drop_hashes(conn, hash_extra_key: str, entry_point_string: str | None = None
 
     if node_count > 0:
         if entry_point_string:
-            msg = f'Invalidating the hashes of certain nodes. Please run `verdi rehash -p {entry_point_string}`.'
+            msg = f'Invalidating the hashes of certain nodes. Please run `verdi node rehash -e {entry_point_string}`.'
         else:
-            msg = 'Invalidating the hashes of all nodes. Please run `verdi rehash`.'
+            msg = 'Invalidating the hashes of all nodes. Please run `verdi node rehash`.'
         LOGGER.warning(msg)
 
     conn.execute(statement_update)


### PR DESCRIPTION
Fixes #6027 

After a migration that can affect the hash of the migrated node, the instructions to rehash the node are provided. However, these instructions are currently incorrect and likely to lead to confusion for the user.

Here the instructions are corrected both when a specific entry point requires rehashing or not.