### PR TITLE
`InteractiveOption`: Fix validation being skipped if `!` provided

### DIFF
--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -89,7 +89,6 @@ def setup(
     config.add_profile(profile)
     config.set_default_profile(profile.name)
     load_profile(profile.name)
-    echo.echo_success(f'created new profile `{profile.name}`.')
 
     # Initialise the storage
     echo.echo_report('initialising the profile storage.')
@@ -114,6 +113,7 @@ def setup(
 
     # store the updated configuration
     config.store()
+    echo.echo_success(f'created new profile `{profile.name}`.')
 
 
 @verdi.command('quicksetup')

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -126,7 +126,7 @@ MPI_PROCS_PER_MACHINE = OverridableOption(
     prompt='Default number of CPUs per machine',
     cls=InteractiveOption,
     prompt_fn=should_call_default_mpiprocs_per_machine,
-    required_fn=False,
+    required=False,
     type=click.INT,
     help='The default number of MPI processes that should be executed per machine (node), if not otherwise specified.'
     'Use 0 to specify no default value.',
@@ -137,7 +137,7 @@ DEFAULT_MEMORY_PER_MACHINE = OverridableOption(
     prompt='Default amount of memory per machine (kB).',
     cls=InteractiveOption,
     prompt_fn=should_call_default_memory_per_machine,
-    required_fn=False,
+    required=False,
     type=click.INT,
     help='The default amount of RAM (kB) that should be allocated per machine (node), if not otherwise specified.'
 )

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -177,7 +177,6 @@ SETUP_PROFILE = options.OverridableOption(
 SETUP_USER_EMAIL = options.USER_EMAIL.clone(
     prompt='Email Address (for sharing data)',
     default=get_config_option('autofill.user.email'),
-    required_fn=lambda x: get_config_option('autofill.user.email') is None,
     required=True,
     cls=options.interactive.InteractiveOption
 )
@@ -185,7 +184,6 @@ SETUP_USER_EMAIL = options.USER_EMAIL.clone(
 SETUP_USER_FIRST_NAME = options.USER_FIRST_NAME.clone(
     prompt='First name',
     default=get_config_option('autofill.user.first_name'),
-    required_fn=lambda x: get_config_option('autofill.user.first_name') is None,
     required=True,
     cls=options.interactive.InteractiveOption
 )
@@ -193,7 +191,6 @@ SETUP_USER_FIRST_NAME = options.USER_FIRST_NAME.clone(
 SETUP_USER_LAST_NAME = options.USER_LAST_NAME.clone(
     prompt='Last name',
     default=get_config_option('autofill.user.last_name'),
-    required_fn=lambda x: get_config_option('autofill.user.last_name') is None,
     required=True,
     cls=options.interactive.InteractiveOption
 )
@@ -201,7 +198,6 @@ SETUP_USER_LAST_NAME = options.USER_LAST_NAME.clone(
 SETUP_USER_INSTITUTION = options.USER_INSTITUTION.clone(
     prompt='Institution',
     default=get_config_option('autofill.user.institution'),
-    required_fn=lambda x: get_config_option('autofill.user.institution') is None,
     required=True,
     cls=options.interactive.InteractiveOption
 )

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -115,7 +115,10 @@ class InteractiveOption(ConditionalOption):
             return self.prompt_for_value(ctx)
 
         if value == self.CHARACTER_IGNORE_DEFAULT and source is click.core.ParameterSource.PROMPT:
-            return None
+            # This means the user does not want to set a specific value for this option, so the ``!`` character is
+            # translated to ``None`` and processed as normal. If the option is required, a validation error will be
+            # raised further down below, forcing the user to specify a valid value.
+            value = None
 
         try:
             return super().process_value(ctx, value)

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -124,7 +124,10 @@ class InteractiveOption(ConditionalOption):
             return super().process_value(ctx, value)
         except click.BadParameter as exception:
             if source is click.core.ParameterSource.PROMPT and self.is_interactive(ctx):
-                click.echo(f'Error: {exception}')
+                if isinstance(exception, click.MissingParameter):
+                    click.echo(f'Error: {self._prompt} has to be specified')
+                else:
+                    click.echo(f'Error: {exception}')
                 return self.prompt_for_value(ctx)
             raise
 

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -285,17 +285,23 @@ USER_INSTITUTION = OverridableOption(
 
 DB_ENGINE = OverridableOption(
     '--db-engine',
+    required=True,
     help='Engine to use to connect to the database.',
     default='postgresql_psycopg2',
     type=click.Choice(['postgresql_psycopg2'])
 )
 
 DB_BACKEND = OverridableOption(
-    '--db-backend', type=click.Choice(['core.psql_dos']), default='core.psql_dos', help='Database backend to use.'
+    '--db-backend',
+    required=True,
+    type=click.Choice(['core.psql_dos']),
+    default='core.psql_dos',
+    help='Database backend to use.'
 )
 
 DB_HOST = OverridableOption(
     '--db-host',
+    required=True,
     type=types.HostnameType(),
     help='Database server host. Leave empty for "peer" authentication.',
     default='localhost'
@@ -303,6 +309,7 @@ DB_HOST = OverridableOption(
 
 DB_PORT = OverridableOption(
     '--db-port',
+    required=True,
     type=click.INT,
     help='Database server port.',
     default=DEFAULT_DBINFO['port'],
@@ -371,7 +378,7 @@ BROKER_VIRTUAL_HOST = OverridableOption(
 )
 
 REPOSITORY_PATH = OverridableOption(
-    '--repository', type=click.Path(file_okay=False), help='Absolute path to the file repository.'
+    '--repository', type=click.Path(file_okay=False), required=True, help='Absolute path to the file repository.'
 )
 
 PROFILE_ONLY_CONFIG = OverridableOption(

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -381,11 +381,11 @@ Below is a list with all available subcommands.
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
       --db-engine [postgresql_psycopg2]
-                                      Engine to use to connect to the database.
-      --db-backend [core.psql_dos]    Database backend to use.
+                                      Engine to use to connect to the database.  [required]
+      --db-backend [core.psql_dos]    Database backend to use.  [required]
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
-                                      authentication.
-      --db-port INTEGER               Database server port.
+                                      authentication.  [required]
+      --db-port INTEGER               Database server port.  [required]
       --db-name NONEMPTYSTRING        Name of the database to create.
       --db-username NONEMPTYSTRING    Name of the database user to create.
       --db-password TEXT              Password of the database user.
@@ -404,7 +404,7 @@ Below is a list with all available subcommands.
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.
-      --repository DIRECTORY          Absolute path to the file repository.
+      --repository DIRECTORY          Absolute path to the file repository.  [required]
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.
       --config FILEORURL              Load option values from configuration file in yaml
@@ -485,11 +485,11 @@ Below is a list with all available subcommands.
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
       --db-engine [postgresql_psycopg2]
-                                      Engine to use to connect to the database.
-      --db-backend [core.psql_dos]    Database backend to use.
+                                      Engine to use to connect to the database.  [required]
+      --db-backend [core.psql_dos]    Database backend to use.  [required]
       --db-host HOSTNAME              Database server host. Leave empty for "peer"
-                                      authentication.
-      --db-port INTEGER               Database server port.
+                                      authentication.  [required]
+      --db-port INTEGER               Database server port.  [required]
       --db-name NONEMPTYSTRING        Name of the database to create.  [required]
       --db-username NONEMPTYSTRING    Name of the database user to create.  [required]
       --db-password TEXT              Password of the database user.  [required]
@@ -504,7 +504,7 @@ Below is a list with all available subcommands.
       --broker-port INTEGER           Port for the message broker.  [required]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.  [required]
-      --repository DIRECTORY          Absolute path to the file repository.
+      --repository DIRECTORY          Absolute path to the file repository.  [required]
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.
       --config FILEORURL              Load option values from configuration file in yaml

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -49,7 +49,7 @@ class TestVerdiSetup:
         self.cli_runner(cmd_setup.setup, ['--help'])
         self.cli_runner(cmd_setup.quicksetup, ['--help'])
 
-    def test_quicksetup(self):
+    def test_quicksetup(self, tmp_path):
         """Test `verdi quicksetup`."""
         profile_name = 'testing'
         user_email = 'some@email.com'
@@ -60,7 +60,8 @@ class TestVerdiSetup:
         options = [
             '--non-interactive', '--profile', profile_name, '--email', user_email, '--first-name', user_first_name,
             '--last-name', user_last_name, '--institution', user_institution, '--db-port', self.pg_test.dsn['port'],
-            '--db-backend', self.storage_backend_name
+            '--db-backend', self.storage_backend_name, '--repository',
+            str(tmp_path)
         ]
 
         self.cli_runner(cmd_setup.quicksetup, options, use_subprocess=False)
@@ -83,7 +84,7 @@ class TestVerdiSetup:
         backend = profile.storage_cls(profile)
         assert backend.get_global_variable('repository|uuid') == backend.get_repository().uuid
 
-    def test_quicksetup_from_config_file(self):
+    def test_quicksetup_from_config_file(self, tmp_path):
         """Test `verdi quicksetup` from configuration file."""
         with tempfile.NamedTemporaryFile('w') as handle:
             handle.write(
@@ -94,12 +95,13 @@ last_name: Talirz
 institution: EPFL
 db_backend: {self.storage_backend_name}
 db_port: {self.pg_test.dsn['port']}
-email: 123@234.de"""
+email: 123@234.de
+repository: {tmp_path}"""
             )
             handle.flush()
             self.cli_runner(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)], use_subprocess=False)
 
-    def test_quicksetup_autofill_on_early_exit(self):
+    def test_quicksetup_autofill_on_early_exit(self, tmp_path):
         """Test `verdi quicksetup` stores user information even if command fails."""
         config = configuration.get_config()
         assert config.get_option('autofill.user.email', scope=None) is None
@@ -117,7 +119,8 @@ email: 123@234.de"""
         options = [
             '--non-interactive', '--profile', 'testing', '--email', user_email, '--first-name', user_first_name,
             '--last-name', user_last_name, '--institution', user_institution, '--db-port',
-            self.pg_test.dsn['port'] + 100
+            self.pg_test.dsn['port'] + 100, '--repository',
+            str(tmp_path)
         ]
 
         self.cli_runner(cmd_setup.quicksetup, options, raises=True, use_subprocess=False)

--- a/tests/cmdline/params/options/test_interactive.py
+++ b/tests/cmdline/params/options/test_interactive.py
@@ -497,7 +497,7 @@ def test_interactive_ignore_default_required_option(run_cli_command):
     """Test that if an option is required, ``!`` is translated to ``None`` and so is not accepted."""
     cmd = create_command(required=True)
     result = run_cli_command(cmd, user_input='!\nvalue\n')
-    expected = 'Opt: !\nError: Missing parameter: opt\nOpt: value\nvalue\n'
+    expected = 'Opt: !\nError: Opt has to be specified\nOpt: value\nvalue\n'
     assert expected in result.output
 
 

--- a/tests/cmdline/params/options/test_interactive.py
+++ b/tests/cmdline/params/options/test_interactive.py
@@ -485,6 +485,22 @@ def test_not_required_interactive_default(run_cli_command):
     assert expected in result.output
 
 
+def test_interactive_ignore_default_not_required_option(run_cli_command):
+    """Test that if an option is not required ``!`` is accepted and is translated to ``None``."""
+    cmd = create_command(required=False)
+    result = run_cli_command(cmd, user_input='!\n')
+    expected = 'Opt: !\nNone\n'
+    assert expected in result.output
+
+
+def test_interactive_ignore_default_required_option(run_cli_command):
+    """Test that if an option is required, ``!`` is translated to ``None`` and so is not accepted."""
+    cmd = create_command(required=True)
+    result = run_cli_command(cmd, user_input='!\nvalue\n')
+    expected = 'Opt: !\nError: Missing parameter: opt\nOpt: value\nvalue\n'
+    assert expected in result.output
+
+
 def test_get_help_message():
     """Test the :meth:`aiida.cmdline.params.options.interactive.InteractiveOption.get_help_message`."""
     option = InteractiveOption('-s', type=click.STRING)


### PR DESCRIPTION
Fixes #6030 

The `InteractiveOption` reserves the exclamation point `!` as a special character in order to "skip" the option and not define it. This is necessary for options that are _not_ required but that do specify a defualt. Without this character, it is impossible to _not_ set the default as, if the user doesn't specify anything specific and simply presses enter, the default is taken, even if the user did not want to specify any specific value.

The problem with the implementation, however, is that when `!` was provided, the option would return `None` as the value, bypassing any validation that might be defined. This would make it possible to bypass the validation of a required option.

The solution is to, when `!` is provided for an interactive option, it is translated to `None` and is then processed as normal, validating it as any other value.