### PR TITLE
Docs: Fix reference target warnings related to `flask_restful`

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -160,6 +160,8 @@ py:class html.parser.HTMLParser
 
 py:class disk_objectstore.container.Container
 
+py:class flask_restful.Api
+py:class flask_restful.Resource
 py:class flask.app.Flask
 py:class Flask
 


### PR DESCRIPTION
The REST API dependency `flask_restful` released `0.3.10` recently which caused the RTD build to start warning about the `Api` and `Resource` classes no longer being findable. The classes are still importable and looking at the changes with `0.3.9` it is not clear that the imports should have changed, so for now these are added to the nitpick ignore list.