### PR TITLE
Do not retry the upload if cp transport is failed because of source folder is not exist

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -110,9 +110,8 @@ def upload_calculation(
         remote_working_directory = computer.get_workdir().format(username=remote_user)
         if not remote_working_directory.strip():
             raise exceptions.ConfigurationError(
-                "[submission of calculation {}] No remote_working_directory configured for computer '{}'".format(
-                    node.pk, computer.label
-                )
+                f'[submission of calculation {node.pk}] No remote_working_directory '
+                f"configured for computer '{computer.label}'"
             )
 
         # If it already exists, no exception is raised
@@ -120,18 +119,17 @@ def upload_calculation(
             transport.chdir(remote_working_directory)
         except IOError:
             logger.debug(
-                '[submission of calculation {}] Unable to chdir in {}, trying to create it'.format(
-                    node.pk, remote_working_directory
-                )
+                f'[submission of calculation {node.pk}] Unable to '
+                f'chdir in {remote_working_directory}, trying to create it'
             )
             try:
                 transport.makedirs(remote_working_directory)
                 transport.chdir(remote_working_directory)
             except EnvironmentError as exc:
                 raise exceptions.ConfigurationError(
-                    '[submission of calculation {}] '
-                    'Unable to create the remote directory {} on '
-                    "computer '{}': {}".format(node.pk, remote_working_directory, computer.label, exc)
+                    f'[submission of calculation {node.pk}] '
+                    f'Unable to create the remote directory {remote_working_directory} on '
+                    f"computer '{computer.label}': {exc}"
                 )
         # Store remotely with sharding (here is where we choose
         # the folder structure of remote jobs; then I store this
@@ -249,37 +247,35 @@ def upload_calculation(
         for (remote_computer_uuid, remote_abs_path, dest_rel_path) in remote_copy_list:
             if remote_computer_uuid == computer.uuid:
                 logger.debug(
-                    '[submission of calculation {}] copying {} remotely, directly on the machine {}'.format(
-                        node.pk, dest_rel_path, computer.label
-                    )
+                    f'[submission of calculation {node.pk}] copying {dest_rel_path} '
+                    f'remotely, directly on the machine {computer.label}'
                 )
                 try:
                     transport.copy(remote_abs_path, dest_rel_path)
                 except (IOError, OSError):
                     logger.warning(
-                        '[submission of calculation {}] Unable to copy remote resource from {} to {}! '
-                        'Stopping.'.format(node.pk, remote_abs_path, dest_rel_path)
+                        f'[submission of calculation {node.pk}] Unable to copy remote '
+                        f'resource from {remote_abs_path} to {dest_rel_path}! Stopping.'
                     )
                     raise
             else:
                 raise NotImplementedError(
-                    '[submission of calculation {}] Remote copy between two different machines is '
-                    'not implemented yet'.format(node.pk)
+                    f'[submission of calculation {node.pk}] Remote copy between two different machines is '
+                    'not implemented yet'
                 )
 
         for (remote_computer_uuid, remote_abs_path, dest_rel_path) in remote_symlink_list:
             if remote_computer_uuid == computer.uuid:
                 logger.debug(
-                    '[submission of calculation {}] copying {} remotely, directly on the machine {}'.format(
-                        node.pk, dest_rel_path, computer.label
-                    )
+                    f'[submission of calculation {node.pk}] copying {dest_rel_path} remotely, '
+                    f'directly on the machine {computer.label}'
                 )
                 try:
                     transport.symlink(remote_abs_path, dest_rel_path)
                 except (IOError, OSError):
                     logger.warning(
-                        '[submission of calculation {}] Unable to create remote symlink from {} to {}! '
-                        'Stopping.'.format(node.pk, remote_abs_path, dest_rel_path)
+                        f'[submission of calculation {node.pk}] Unable to create remote symlink '
+                        f'from {remote_abs_path} to {dest_rel_path}! Stopping.'
                     )
                     raise
             else:
@@ -293,9 +289,8 @@ def upload_calculation(
             with open(filepath, 'w', encoding='utf-8') as handle:  # type: ignore[assignment]
                 for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_copy_list:
                     handle.write(
-                        'would have copied {} to {} in working directory on remote {}'.format(
-                            remote_abs_path, dest_rel_path, computer.label
-                        )
+                        f'would have copied {remote_abs_path} to {dest_rel_path} in working '
+                        f'directory on remote {computer.label}'
                     )
 
         if remote_symlink_list:
@@ -303,9 +298,8 @@ def upload_calculation(
             with open(filepath, 'w', encoding='utf-8') as handle:  # type: ignore[assignment]
                 for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_symlink_list:
                     handle.write(
-                        'would have created symlinks from {} to {} in working directory on remote {}'.format(
-                            remote_abs_path, dest_rel_path, computer.label
-                        )
+                        f'would have created symlinks from {remote_abs_path} to {dest_rel_path} in working'
+                        f'directory on remote {computer.label}'
                     )
 
     # Loop recursively over content of the sandbox folder copying all that are not in `provenance_exclude_list`. Note

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -252,6 +252,11 @@ def upload_calculation(
                 )
                 try:
                     transport.copy(remote_abs_path, dest_rel_path)
+                except FileNotFoundError:
+                    logger.warning(
+                        f'[submission of calculation {node.pk}] Unable to copy remote '
+                        f'resource from {remote_abs_path} to {dest_rel_path}! NOT Stopping but just ignoring!.'
+                    )
                 except (IOError, OSError):
                     logger.warning(
                         f'[submission of calculation {node.pk}] Unable to copy remote '

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -557,7 +557,7 @@ class LocalTransport(Transport):
             raise ValueError('Input remotedestination to copy must be a non empty object')
         if not self.has_magic(remotesource):
             if not os.path.exists(os.path.join(self.curdir, remotesource)):
-                raise OSError('Source not found')
+                raise FileNotFoundError('Source not found')
         if self.normalize(remotesource) == self.normalize(remotedestination):
             raise ValueError('Cannot copy from itself to itself')
 

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -1203,6 +1203,7 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
             raise ValueError('Pathname patterns are not allowed in the destination')
 
         if self.has_magic(remotesource):
+
             to_copy_list = self.glob(remotesource)
 
             if len(to_copy_list) > 1:
@@ -1213,6 +1214,9 @@ class SshTransport(Transport):  # pylint: disable=too-many-public-methods
                 self._exec_cp(cp_exe, cp_flags, file, remotedestination)
 
         else:
+            if not self.path_exists(remotesource):
+                raise FileNotFoundError('Source not found')
+
             self._exec_cp(cp_exe, cp_flags, remotesource, remotedestination)
 
     def _exec_cp(self, cp_exe, cp_flags, src, dst):


### PR DESCRIPTION
This is a change needed to address the caching issue mentioned at https://github.com/aiidateam/aiida-core/issues/5823.
 I want to rerun the parent pw calculation when found in the ph calculation the remote folder is cleaned.

It is not possible in workflow to control the logic according to the transports error at the moment.
This will simply hit the 5 attempts in the exception retry and then will pause the calcjob.

For certain transport errors like the copy from parent_folder to the new calculation, the error can be caught and not raised to avoid 5 exponential attempts. Then the workflow can make the decision to rerun the preliminary calculation base on if the remote folder is empty and if the follow-up calculation is cached. 

I use this change to rewrite the `BandWorkChain` so it can manage to cache cleverly, the example code is at https://github.com/aiidateam/aiida-sssp-workflow/pull/201/commits/260f7a616ace72d1fdfaad2300ccbc3cdfa2810e