### PR TITLE
`DirectScheduler`: Add `?` as `JobState.UNDETERMINED`

### DIFF
--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -55,6 +55,11 @@ _MAP_STATUS_PS = {
     'W': JobState.RUNNING,
     'X': JobState.DONE,
     'Z': JobState.DONE,
+    '?': JobState.UNDETERMINED,
+    # `ps` can sometimes return `?` for the state of a process on macOS. This corresponds to an "unknown" state, see:
+    #
+    # https://apple.stackexchange.com/q/460394/497071
+    #
     # Not sure about these three, I comment them out (they used to be in
     # here, but they don't appear neither on ubuntu nor on Mac)
     #    'F': JobState.DONE,


### PR DESCRIPTION
Fixes #3107

When running a process via `engine.run` on a MacOS `localhost` using the `core.direct` scheduler, warning are often raised regarding an "unrecognised job state `?`'. This is related to the fact that on MacOS the `ps` command is sometimes not able to determine the process state temporarily, and print a `?` in the `STAT` column.

Here we simply add the `?` as one of the possible outputs of the `ps` commmand in the `_MAP_STATUS_PS` dictionary, mapping it to `JobState.UNDETERMINED`.