### PR TITLE
👌 Add configuration for recursion limit in workers

### DIFF
--- a/aiida/engine/daemon/worker.py
+++ b/aiida/engine/daemon/worker.py
@@ -16,7 +16,7 @@ import sys
 from aiida.common.log import configure_logging
 from aiida.engine.daemon.client import get_daemon_client
 from aiida.engine.runners import Runner
-from aiida.manage import get_manager, get_config_option
+from aiida.manage import get_config_option, get_manager
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aiida/engine/daemon/worker.py
+++ b/aiida/engine/daemon/worker.py
@@ -50,8 +50,9 @@ def start_daemon_worker() -> None:
         LOGGER.exception('daemon worker failed to start')
         raise
 
-    if isinstance(limit := get_config_option('daemon.recursion_limit'), int):
-        sys.setrecursionlimit(limit)
+    if isinstance(rlimit := get_config_option('daemon.recursion_limit'), int):
+        LOGGER.info('Setting maximum recursion limit of daemon worker to %s', rlimit)
+        sys.setrecursionlimit(rlimit)
 
     signals = (signal.SIGTERM, signal.SIGINT)
     for s in signals:  # pylint: disable=invalid-name

--- a/aiida/engine/daemon/worker.py
+++ b/aiida/engine/daemon/worker.py
@@ -11,11 +11,12 @@
 import asyncio
 import logging
 import signal
+import sys
 
 from aiida.common.log import configure_logging
 from aiida.engine.daemon.client import get_daemon_client
 from aiida.engine.runners import Runner
-from aiida.manage import get_manager
+from aiida.manage import get_manager, get_config_option
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +49,9 @@ def start_daemon_worker() -> None:
     except Exception:
         LOGGER.exception('daemon worker failed to start')
         raise
+
+    if isinstance(limit := get_config_option('daemon.recursion_limit'), int):
+        sys.setrecursionlimit(limit)
 
     signals = (signal.SIGTERM, signal.SIGINT)
     for s in signals:  # pylint: disable=invalid-name

--- a/aiida/manage/configuration/schema/config-v9.schema.json
+++ b/aiida/manage/configuration/schema/config-v9.schema.json
@@ -30,6 +30,12 @@
           "minimum": 1,
           "description": "Maximum number of concurrent process tasks that each daemon worker can handle"
         },
+        "daemon.recursion_limit": {
+          "type": "integer",
+          "maximum": 100000,
+          "minimum": 1,
+          "description": "Maximum recursion depth for the daemon workers"
+        },
         "db.batch_size": {
           "type": "integer",
           "default": 100000,

--- a/aiida/manage/configuration/schema/config-v9.schema.json
+++ b/aiida/manage/configuration/schema/config-v9.schema.json
@@ -32,6 +32,7 @@
         },
         "daemon.recursion_limit": {
           "type": "integer",
+          "default": 3000,
           "maximum": 100000,
           "minimum": 1,
           "description": "Maximum recursion depth for the daemon workers"


### PR DESCRIPTION
Add `daemon.recursion_limit` config option which, only if specifically set by the user, will change the recursion limit within the worker Python interpreter.

Addresses #4876

As specified, currently no change is made without a user specifically setting the config option, meaning that the default 1000 limit will be used.

It could be an option to set a specific (higher) default for this option.
This has precedent, for example if one opens an IPython terminal session you will find the limit actually set at 3000, since jedi resets the limit: https://github.com/davidhalter/jedi/blob/a28bd24befa4331101d151df10445367de8df16a/jedi/api/__init__.py#L48
The Python 1000 default limit is quite conservative, and given IPython doesn't have an issue with 3000, this should be fine, although setting it too high may lead to stack overflow errors, since Python doesn't handle recursion in a particular efficiently (memory-wise).