### PR TITLE
Process control: Warn instead of except when daemon is not running

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -216,7 +216,6 @@ def process_status(max_depth, processes):
 @options.TIMEOUT()
 @options.WAIT()
 @decorators.with_dbenv()
-@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_kill(processes, timeout, wait):
     """Kill running processes."""
     from aiida.engine.processes import control
@@ -234,7 +233,6 @@ def process_kill(processes, timeout, wait):
 @options.TIMEOUT()
 @options.WAIT()
 @decorators.with_dbenv()
-@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_pause(processes, all_entries, timeout, wait):
     """Pause running processes."""
     from aiida.engine.processes import control
@@ -255,7 +253,6 @@ def process_pause(processes, all_entries, timeout, wait):
 @options.TIMEOUT()
 @options.WAIT()
 @decorators.with_dbenv()
-@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_play(processes, all_entries, timeout, wait):
     """Play (unpause) paused processes."""
     from aiida.engine.processes import control

--- a/aiida/engine/processes/control.py
+++ b/aiida/engine/processes/control.py
@@ -93,7 +93,7 @@ def play_processes(
     :raises ``ProcessTimeoutException``: If the processes do not respond within the timeout.
     """
     if not get_daemon_client().is_daemon_running:
-        raise DaemonException('The daemon is not running.')
+        LOGGER.warning('The daemon is not running, so processes submitted to the daemon are not reachable.')
 
     if processes and all_entries:
         raise ValueError('cannot specify processes when `all_entries = True`.')
@@ -128,7 +128,7 @@ def pause_processes(
     :raises ``ProcessTimeoutException``: If the processes do not respond within the timeout.
     """
     if not get_daemon_client().is_daemon_running:
-        raise DaemonException('The daemon is not running.')
+        LOGGER.warning('The daemon is not running, so processes submitted to the daemon are not reachable.')
 
     if processes and all_entries:
         raise ValueError('cannot specify processes when `all_entries = True`.')
@@ -163,7 +163,7 @@ def kill_processes(
     :raises ``ProcessTimeoutException``: If the processes do not respond within the timeout.
     """
     if not get_daemon_client().is_daemon_running:
-        raise DaemonException('The daemon is not running.')
+        LOGGER.warning('The daemon is not running, so processes submitted to the daemon are not reachable.')
 
     if processes and all_entries:
         raise ValueError('cannot specify processes when `all_entries = True`.')

--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -4,7 +4,6 @@ from plumpy.process_comms import RemoteProcessThreadController
 import pytest
 
 from aiida.engine import ProcessState
-from aiida.engine.daemon.client import DaemonException
 from aiida.engine.launch import submit
 from aiida.engine.processes import control
 from aiida.orm import Int
@@ -24,10 +23,10 @@ def test_processes_all_exclusivity(submit_and_await, action):
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'stopped_daemon_client')
 @pytest.mark.parametrize('action', (control.pause_processes, control.play_processes, control.kill_processes))
-def test_daemon_not_running(action):
-    """Test that control methods raise if the daemon is not running."""
-    with pytest.raises(DaemonException, match='The daemon is not running.'):
-        action(all_entries=True)
+def test_daemon_not_running(action, aiida_caplog):
+    """Test that control methods warns if the daemon is not running."""
+    action(all_entries=True)
+    assert 'The daemon is not running' in aiida_caplog.records[0].message
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')


### PR DESCRIPTION
The `play_processes`, `pause_processes` and `kill_processes` methods of the `engine.processes.control` module would raise if the daemon is not currently running. This instinctively make sense, because in order to be able to interact with a process through an RPC call, which is what these methods do, it has to be "live" with some runner. This normally means a daemon worker, so if the daemon is not running, it is to be expected that the process cannot be reached. However, runners can also be started manually, for example through `verdi daemon worker` or within an interactive shell when a process is "run" instead of submitted.

The `verdi process pause/play/kill` commands actually covered for this case and would also check for the daemon to be running, but instead would log a warning if not the case. Since they call through to the control module, an exception would be logged nevertheless.

The control module now also logs a warning, instead of raise an exception. This allows the CLI command to remove the explicit check for the daemon running with the `only_if_daemon_running` decorator as it can rely on the control module performing the check.