### PR TITLE
DevOps: Do not assume PG cluster started in fixture

### DIFF
--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -95,6 +95,7 @@ def postgres_cluster(
         'database_password': database_password or 'guest',
     }
 
+    cluster = None
     try:
         cluster = PGTest()
 
@@ -107,7 +108,8 @@ def postgres_cluster(
 
         yield postgres_config
     finally:
-        cluster.close()
+        if cluster is not None:
+            cluster.close()
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
When a developer tries to run tests without Posgres installed, in addition to the original exception coming from the `pgtest` library, one would also get a rather unhelpful exception coming from AiiDA fixture which tries to close the non-existent DB connection in the `finally` clause.