### PR TITLE
Fix log messages being logged twice to the daemon log file

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -212,7 +212,7 @@ def configure_logging(with_orm=False, daemon=False, daemon_log_file=None):
 
     # If the ``CLI_ACTIVE`` is set, a ``verdi`` command is being executed, so we replace the ``console`` handler with
     # the ``cli`` one for all loggers.
-    if CLI_ACTIVE is True:
+    if CLI_ACTIVE is True and not daemon:
         for logger in config['loggers'].values():
             handlers = logger['handlers']
             if 'console' in handlers:

--- a/tests/manage/external/test_rmq.py
+++ b/tests/manage/external/test_rmq.py
@@ -112,7 +112,7 @@ def test_duplicate_subscriber_identifier(aiida_local_code_factory, started_daemo
 
     # Verify that the receiving of the duplicate task was logged by the daemon
     daemon_log = pathlib.Path(started_daemon_client.daemon_log_file).read_text(encoding='utf-8')
-    assert f'Error: A subscriber with the process id<{node.pk}> already exists' in daemon_log
+    assert f'A subscriber with the process id<{node.pk}> already exists' in daemon_log
 
 
 @pytest.fixture


### PR DESCRIPTION
In 276a93f3a60546674d0b18220f6415ed33716c89 the logging configuration logic was modified to respect the log level being changed through the `--verbosity` option when invoking `verdi`. The changes added the `cli` handler to all loggers.

This code was also being executed when a daemon worker started up and called `aiida.common.log.configure_logging` causing all logging to end up twice in the daemon log file.