### PR TITLE
Devops: Update Docker base image `aiida-prerequisites==0.7.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-prerequisites:0.6.0
+FROM aiidateam/aiida-prerequisites:0.7.0
 
 USER root
 


### PR DESCRIPTION
This new release comes with Python 3.9 instead of Python 3.8.