### PR TITLE
Using concurrency for CI actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     paths-ignore: ['docs/**']
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   run-and-upload:

--- a/.github/workflows/build_and_test_docker_on_pr.yml
+++ b/.github/workflows/build_and_test_docker_on_pr.yml
@@ -12,6 +12,12 @@ on:
     path_ignore:
       - 'docs/**'
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   build-and-test:

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -7,6 +7,12 @@ on:
     branches-ignore: [gh-pages]
     paths-ignore: ['docs/**']
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   check-requirements:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,12 @@ on:
         - 'tests/storage/psql_dos/migrations/**'
     workflow_dispatch:
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
     tests:

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -7,6 +7,12 @@ on:
         branches-ignore: [gh-pages]
         paths-ignore: ['docs/**']
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
     tests:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -12,6 +12,12 @@ on:
   schedule:
     - cron: '30 02 * * *'  # nightly build
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   validate-dependency-specification:


### PR DESCRIPTION
The [CI concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) is a very useful and resource-saving feature when running CI actions. When the new commits are pushed, the old actions of the same PR will be canceled. I think this is what we expected in most cases.

See the effect in  https://github.com/aiidateam/aiida-core/actions, after the second dummy commit is pushed, the actions of the first one are all canceled.
