### PR TITLE
AiiDA temp profile in `shell` and Jupyter-notebook

### DIFF
--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -21,7 +21,7 @@ from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 @verdi.command('shell')
 @decorators.with_dbenv()
 @click.option('--plain', is_flag=True, help='Use a plain Python shell.')
-@click.option('--light', is_flag=True, help='Use the services-free light option.')
+@click.option('--standalone', is_flag=True, help='Use the services-free standalone option.')
 @click.option(
     '--no-startup',
     is_flag=True,
@@ -33,20 +33,20 @@ from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
     type=click.Choice(AVAILABLE_SHELLS.keys()),
     help='Specify an interactive interpreter interface.'
 )
-def shell(plain, light, no_startup, interface):
+def shell(plain, standalone, no_startup, interface):
     """Start a python shell with preloaded AiiDA environment."""
     try:
         if plain:
             # Don't bother loading IPython, because the user wants plain Python.
             raise ImportError
 
-        if light:
+        if standalone:
             from aiida import get_profile, load_profile, manage
             from aiida.storage.sqlite_temp import SqliteTempBackend
             profile = get_profile()
-            if not profile or profile.name != 'light':
+            if not profile or profile.name != 'standalone':
                 profile = SqliteTempBackend.create_profile(
-                    'light',
+                    'standalone',
                     options={'runner.poll.interval': 1},
                 )
                 load_profile(profile, allow_switch=True)

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -14,12 +14,12 @@ import os
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 
 
 @verdi.command('shell')
-@decorators.with_dbenv()
+# @decorators.with_dbenv()
 @click.option('--plain', is_flag=True, help='Use a plain Python shell.')
 @click.option('--standalone', is_flag=True, help='Use the services-free standalone option.')
 @click.option(

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -36,7 +36,7 @@ Usage
 import json
 import shlex
 
-from IPython import get_ipython, version_info  # type: ignore[attr-defined]
+from IPython import get_ipython, version_info
 from IPython.core import magic
 
 
@@ -136,11 +136,23 @@ class AiiDALoaderMagics(magic.Magics):
         """
         # pylint: disable=unused-argument,attribute-defined-outside-init
         from aiida.cmdline.utils.shell import get_start_namespace
-        from aiida.manage.configuration import load_profile
+        from aiida.manage.configuration import get_config, load_profile
+        from aiida.storage.sqlite_temp import SqliteTempBackend
 
         self.is_warning = False
         lcontent = line.strip()
-        if lcontent:
+        if lcontent == 'standalone':
+            profile = SqliteTempBackend.create_profile(
+                'standalone', options={
+                    'warnings.development_version': False,
+                    'runner.poll.interval': 1
+                }, debug=False
+            )
+            profile = load_profile(profile.name, allow_switch=True)
+            config = get_config()
+            config.add_profile(profile)
+            config.set_default_profile(profile.name)
+        elif lcontent:
             profile = load_profile(lcontent)
         else:
             profile = load_profile()

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -148,10 +148,10 @@ class AiiDALoaderMagics(magic.Magics):
                     'runner.poll.interval': 1
                 }, debug=False
             )
-            profile = load_profile(profile.name, allow_switch=True)
             config = get_config()
             config.add_profile(profile)
             config.set_default_profile(profile.name)
+            profile = load_profile(profile.name, allow_switch=True)
         elif lcontent:
             profile = load_profile(lcontent)
         else:

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -141,9 +141,9 @@ class AiiDALoaderMagics(magic.Magics):
 
         self.is_warning = False
         lcontent = line.strip()
-        if lcontent == 'standalone':
+        if lcontent == 'temp':
             profile = SqliteTempBackend.create_profile(
-                'standalone', options={
+                'temp', options={
                     'warnings.development_version': False,
                     'runner.poll.interval': 1
                 }, debug=False

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -525,6 +525,7 @@ Below is a list with all available subcommands.
 
     Options:
       --plain                         Use a plain Python shell.
+      --light                         Use the services-free light option.
       --no-startup                    When using plain Python, ignore the PYTHONSTARTUP
                                       environment variable and ~/.pythonrc.py script.
       -i, --interface [ipython|bpython]

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -525,7 +525,7 @@ Below is a list with all available subcommands.
 
     Options:
       --plain                         Use a plain Python shell.
-      --light                         Use the services-free light option.
+      --standalone                    Use the services-free standalone option.
       --no-startup                    When using plain Python, ignore the PYTHONSTARTUP
                                       environment variable and ~/.pythonrc.py script.
       -i, --interface [ipython|bpython]

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -525,7 +525,8 @@ Below is a list with all available subcommands.
 
     Options:
       --plain                         Use a plain Python shell.
-      --standalone                    Use the services-free standalone option.
+      --temp                          Setup a temporary profile that uses a in-memory sqlite
+                                      and no rabbitmq.
       --no-startup                    When using plain Python, ignore the PYTHONSTARTUP
                                       environment variable and ~/.pythonrc.py script.
       -i, --interface [ipython|bpython]


### PR DESCRIPTION
PR from AiiDA coding week. 
## Idea
One way to get people started with AiiDA is by offering a services-free option: i.e. just running codes with AiiDA:

1. Without RabbitMQ: i.e. just running in the Python session.
2. Without PostgreSQL: i.e. a temporary database (in memory or persistent sqlite)

## Implementation: AiiDA temp profile
This PR provides the services-free option for using AiiDA. This will create a temporary profile to:
- use the in-memory sqlite
- no RabbitMQ, and process backend set to `null`, a [polling-mechanism](https://github.com/aiidateam/aiida-core/blob/main/aiida/engine/runners.py#L292) is used to check the state of the process.

In the following two places:

- [x] Interactive terminal. Added an option `standalone` to `verdi shell`. 
```console
verdi shell --temp
```

- [x] Jupyter-notebook. Add a `standalone` parameter for the `aiida` command.
```python!
%load_ext aiida
aiida temp
```
- [ ] #TODO add `verdi run --temp`

### To improve
When the user runs the process use `submit`, it outputs `AssertionError: runner does not have a persister`. This may make user confuse. Better to
- disable the submit function in a `temp` profile.