### PR TITLE
✨ NEW: Add `verdi tui`

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        extras: [ '', '[atomic_tools,docs,notebook,rest,tests]' ]
+        extras: [ '', '[atomic_tools,docs,notebook,rest,tests,tui]' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -242,7 +242,7 @@ jobs:
 
     - name: Install aiida-core
       run: |
-        pip install -e .[atomic_tools,docs,notebook,rest,tests]
+        pip install -e .[atomic_tools,docs,notebook,rest,tests,tui]
 
     - run: pip freeze
 

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -9,6 +9,7 @@
 ###########################################################################
 """The main `verdi` click group."""
 import click
+from trogon import tui
 
 from aiida import __version__
 
@@ -17,6 +18,7 @@ from ..params import options, types
 
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
+@tui()
 @click.group(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
 @options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
 @options.VERBOSITY()

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -9,7 +9,6 @@
 ###########################################################################
 """The main `verdi` click group."""
 import click
-from trogon import tui
 
 from aiida import __version__
 
@@ -18,10 +17,19 @@ from ..params import options, types
 
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
-@tui()
 @click.group(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
 @options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
 @options.VERBOSITY()
 @click.version_option(__version__, package_name='aiida_core', message='AiiDA version %(version)s')
 def verdi():
     """The command line interface of AiiDA."""
+
+
+# Apply the ``tui`` interface if the dependency is installed. If the case, this will add the ``verdi tui`` command
+# that allows to explore the interface in a graphical manner in the terminal.
+try:
+    from trogon import tui
+except ImportError:
+    pass
+else:
+    tui()(verdi)

--- a/docs/source/howto/interact.rst
+++ b/docs/source/howto/interact.rst
@@ -22,6 +22,12 @@ AiiDA comes with a command line interface called ``verdi``.
 The :ref:`reference:command-line` section gives an overview of all available commands.
 For more detailed information, refer to the topic section :ref:`topics:cli`.
 
+.. tip::
+
+    The ``verdi`` command line interface can also be explored as a `text-based user interface <https://en.wikipedia.org/wiki/Text-based_user_interface>`_ (TUI).
+    It requires ``aiida-core`` to be installed with the ``tui`` extra (e.g. ``pip install aiida-core[tui]``).
+    The TUI can then be launched with ``verdi tui``.
+
 
 .. _how-to:interact-scripts:
 

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -571,6 +571,21 @@ Below is a list with all available subcommands.
       version    Print the current version of the storage schema.
 
 
+.. _reference:command-line:verdi-tui:
+
+``verdi tui``
+-------------
+
+.. code:: console
+
+    Usage:  [OPTIONS]
+
+      Open Textual TUI.
+
+    Options:
+      --help  Show this message and exit.
+
+
 .. _reference:command-line:verdi-user:
 
 ``verdi user``

--- a/docs/source/topics/cli.rst
+++ b/docs/source/topics/cli.rst
@@ -7,6 +7,12 @@ Command line interface
 The command line interface utility for AiiDA is called ``verdi``.
 This section explains the basic concepts that apply to all ``verdi`` commands.
 
+.. tip::
+
+    The ``verdi`` command line interface can also be explored as a `text-based user interface <https://en.wikipedia.org/wiki/Text-based_user_interface>`_ (TUI).
+    It requires ``aiida-core`` to be installed with the ``tui`` extra (e.g. ``pip install aiida-core[tui]``).
+    The TUI can then be launched with ``verdi tui``.
+
 
 .. _topics:cli:parameters:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "sqlalchemy~=1.4.22",
     "tabulate~=0.8.5",
     "tqdm~=4.45",
-    "trogon",
     "upf_to_json~=0.9.2",
     "wrapt~=1.11"
 ]
@@ -62,6 +61,9 @@ Documentation = "https://aiida.readthedocs.io"
 Source = "https://github.com/aiidateam/aiida-core"
 
 [project.optional-dependencies]
+tui = [
+    "trogon",
+]
 ssh_kerberos = [
     "gssapi~=1.6",
     "pyasn1~=0.4.8"
@@ -440,6 +442,7 @@ module = [
     'sqlalchemy_utils.*',
     'tabulate.*',
     'tqdm.*',
+    'trogon.*',
     'wrapt.*',
     'upf_to_json.*',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "sqlalchemy~=1.4.22",
     "tabulate~=0.8.5",
     "tqdm~=4.45",
+    "trogon",
     "upf_to_json~=0.9.2",
     "wrapt~=1.11"
 ]

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -11,6 +11,7 @@ alabaster==0.7.13
 alembic==1.11.1
 aniso8601==9.0.1
 anyio==3.7.0
+appnope==0.1.3
 archive-path==0.4.2
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
@@ -79,8 +80,9 @@ jupyterlab-widgets==3.0.7
 kiwipy[rmq]==0.7.7
 kiwisolver==1.4.4
 latexcodec==2.0.1
+linkify-it-py==2.0.2
 mako==1.2.4
-markdown-it-py==2.2.0
+markdown-it-py[linkify,plugins]==2.2.0
 markupsafe==2.1.3
 matplotlib==3.7.1
 matplotlib-inline==0.1.6
@@ -160,6 +162,7 @@ qtpy==2.3.1
 requests==2.31.0
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
+rich==13.4.2
 ruamel-yaml==0.17.32
 ruamel-yaml-clib==0.2.7
 scipy==1.10.1
@@ -193,13 +196,16 @@ sympy==1.12
 tabulate==0.8.10
 tenacity==8.2.2
 terminado==0.17.1
+textual==0.29.0
 tinycss2==1.2.1
 tomli==2.0.1
 tornado==6.3.2
 tqdm==4.65.0
 traitlets==5.9.0
+trogon==0.5.0
 typing-extensions==4.6.3
 tzdata==2023.3
+uc-micro-py==1.0.2
 uncertainties==3.1.7
 upf-to-json==0.9.5
 urllib3==2.0.3

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -11,6 +11,7 @@ alabaster==0.7.13
 alembic==1.11.1
 aniso8601==9.0.1
 anyio==3.7.0
+appnope==0.1.3
 archive-path==0.4.2
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
@@ -78,8 +79,9 @@ jupyterlab-widgets==3.0.7
 kiwipy[rmq]==0.7.7
 kiwisolver==1.4.4
 latexcodec==2.0.1
+linkify-it-py==2.0.2
 mako==1.2.4
-markdown-it-py==2.2.0
+markdown-it-py[linkify,plugins]==2.2.0
 markupsafe==2.1.3
 matplotlib==3.7.1
 matplotlib-inline==0.1.6
@@ -159,6 +161,7 @@ qtpy==2.3.1
 requests==2.31.0
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
+rich==13.4.2
 ruamel-yaml==0.17.32
 ruamel-yaml-clib==0.2.7
 scipy==1.10.1
@@ -192,12 +195,15 @@ sympy==1.12
 tabulate==0.8.10
 tenacity==8.2.2
 terminado==0.17.1
+textual==0.29.0
 tinycss2==1.2.1
 tornado==6.3.2
 tqdm==4.65.0
 traitlets==5.9.0
+trogon==0.5.0
 typing-extensions==4.6.3
 tzdata==2023.3
+uc-micro-py==1.0.2
 uncertainties==3.1.7
 upf-to-json==0.9.5
 urllib3==2.0.3

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -11,6 +11,7 @@ alabaster==0.7.13
 alembic==1.11.1
 aniso8601==9.0.1
 anyio==3.7.0
+appnope==0.1.3
 archive-path==0.4.2
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
@@ -81,8 +82,9 @@ jupyterlab-widgets==3.0.7
 kiwipy[rmq]==0.7.7
 kiwisolver==1.4.4
 latexcodec==2.0.1
+linkify-it-py==2.0.2
 mako==1.2.4
-markdown-it-py==2.2.0
+markdown-it-py[linkify,plugins]==2.2.0
 markupsafe==2.1.3
 matplotlib==3.7.1
 matplotlib-inline==0.1.6
@@ -162,6 +164,7 @@ qtpy==2.3.1
 requests==2.31.0
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
+rich==13.4.2
 ruamel-yaml==0.17.32
 ruamel-yaml-clib==0.2.7
 scipy==1.10.1
@@ -195,13 +198,16 @@ sympy==1.12
 tabulate==0.8.10
 tenacity==8.2.2
 terminado==0.17.1
+textual==0.29.0
 tinycss2==1.2.1
 tomli==2.0.1
 tornado==6.3.2
 tqdm==4.65.0
 traitlets==5.9.0
+trogon==0.5.0
 typing-extensions==4.6.3
 tzdata==2023.3
+uc-micro-py==1.0.2
 uncertainties==3.1.7
 upf-to-json==0.9.5
 urllib3==2.0.3


### PR DESCRIPTION
Proof of concept to use https://github.com/Textualize/trogon, a https://github.com/textualize/textual extension, to generate a Textual UI for exploring the `verdi` command-line interface.
It is a simple way for users to see all the available commands in `verdi`, without having to dig through the help of each subcommand.

<img width="823" alt="image" src="https://github.com/aiidateam/aiida-core/assets/2997570/d5be0528-22d1-4658-b915-9b41b16e6e9d">

As you see, its is only 2-lines of code, so no real problem in that respect.

But obviously it adds additional dependencies, which has to be considered (and currently is not on conda: https://github.com/Textualize/trogon/issues/49#issuecomment-1621674908)

---

In the future, I would also suggest that Textual could be used to write improved interfaces for some of the CLI commands, such as exploring the provenance graph and process statuses.
I think its an interesting middle ground between CLIs, which are lightweight but have limited interactivity, and GUIs which generally require technologies outside of Python, REST APIs, etc