### PR TITLE
ADD: using existing DB with `verdi quicksetup`

### DIFF
--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -180,7 +180,7 @@ def quicksetup(
         else:
             db_exists = postgres.db_exists(db_name)
             if db_exists:
-                echo.echo_error('Database name provided already exists, please choose a different name')
+                echo.echo_critical(f'Database name provided {db_name} already exists, please choose a different name')
 
         try:
             db_username, db_name = postgres.create_dbuser_db_safe(

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -14,6 +14,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.params.options.commands import setup as options_setup
 from aiida.cmdline.utils import echo
+from aiida.cmdline.utils.defaults import get_default_database_name
 from aiida.manage.configuration import Profile, load_profile
 
 
@@ -172,6 +173,14 @@ def quicksetup(
 
         if not postgres.is_connected:
             echo.echo_critical('failed to determine the PostgreSQL setup')
+
+        default_dbname = get_default_database_name(profile)
+        if db_name == default_dbname:
+            echo.echo_report(f'Using default database name {db_name} (if it already exists, {db_name}_N)')
+        else:
+            db_exists = postgres.db_exists(db_name)
+            if db_exists:
+                echo.echo_error('Database name provided already exists, please choose a different name')
 
         try:
             db_username, db_name = postgres.create_dbuser_db_safe(

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -206,6 +206,19 @@ SETUP_USER_INSTITUTION = options.USER_INSTITUTION.clone(
     cls=options.interactive.InteractiveOption
 )
 
+QUICKSETUP_CREATE_DATABASE = options.OverridableOption(
+    '--create-db/--reuse-db',
+    'create_new_db',
+    default=True,
+    show_default=True,
+    help=(
+        'Determines if the setup should look for an existing database '
+        '(needs to be provided with the `--db-name` option) or if it '
+        'always creates a new one (using a default or creating names '
+        'on the fly if the provided `--db-name` already exists).'
+    ),
+)
+
 QUICKSETUP_DATABASE_ENGINE = options.DB_ENGINE
 
 QUICKSETUP_DATABASE_BACKEND = options.DB_BACKEND

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -15,6 +15,7 @@ import hashlib
 import click
 
 from aiida.cmdline.params import options, types
+from aiida.cmdline.utils.defaults import get_default_database_name
 from aiida.manage.configuration import Profile, get_config, get_config_option
 from aiida.manage.external.postgres import DEFAULT_DBINFO
 from aiida.manage.external.rmq import BROKER_DEFAULTS
@@ -97,12 +98,8 @@ def get_quicksetup_database_name(ctx, param, value):  # pylint: disable=unused-a
     if value is not None:
         return value
 
-    config = get_config()
-    profile = ctx.params['profile'].name
-    config_hash = hashlib.md5(config.dirpath.encode('utf-8')).hexdigest()
-    database_name = f'{profile}_{getpass.getuser()}_{config_hash}'
-
-    return database_name
+    profile = ctx.params['profile']
+    return get_default_database_name(profile)
 
 
 def get_quicksetup_username(ctx, param, value):  # pylint: disable=unused-argument
@@ -214,9 +211,11 @@ QUICKSETUP_CREATE_DATABASE = options.OverridableOption(
     help=(
         'Determines if the setup should look for an existing database '
         '(needs to be provided with the `--db-name` option) or if it '
-        'always creates a new one (using a default or creating names '
-        'on the fly if the provided `--db-name` already exists).'
-    ),
+        'needs to create a new one (if a `--db-name` is provided, it '
+        'will except if the database exists, otherwise it will create '
+        'names on the fly if the default is used). If an already existing '
+        'database is provided, it needs to be empty (no tables)'
+    )
 )
 
 QUICKSETUP_DATABASE_ENGINE = options.DB_ENGINE

--- a/aiida/cmdline/utils/defaults.py
+++ b/aiida/cmdline/utils/defaults.py
@@ -8,10 +8,12 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Default values and lazy default get methods for command line options."""
+import getpass
+import hashlib
 
 from aiida.cmdline.utils import echo
 from aiida.common import exceptions
-from aiida.manage.configuration import get_config
+from aiida.manage.configuration import Profile, get_config
 
 
 def get_default_profile():  # pylint: disable=unused-argument
@@ -35,3 +37,11 @@ def get_default_profile():  # pylint: disable=unused-argument
         default_profile = None
 
     return default_profile
+
+
+def get_default_database_name(profile: 'Profile'):
+    """Get the default name for the database for a given profile."""
+    profile = profile.name
+    username = getpass.getuser()
+    config_hash = hashlib.md5(get_config().dirpath.encode('utf-8')).hexdigest()
+    return f'{profile}_{username}_{config_hash}'

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -382,9 +382,12 @@ Below is a list with all available subcommands.
       --institution NONEMPTYSTRING    Institution of the user.  [required]
       --create-db / --reuse-db        Determines if the setup should look for an existing
                                       database (needs to be provided with the `--db-name`
-                                      option) or if it always creates a new one (using a
-                                      default or creating names on the fly if the provided
-                                      `--db-name` already exists).  [default: create-db]
+                                      option) or if it needs to create a new one (if a `--db-
+                                      name` is provided, it will except if the database
+                                      exists, otherwise it will create names on the fly if the
+                                      default is used). If an already existing database is
+                                      provided, it needs to be empty (no tables)  [default:
+                                      create-db]
       --db-engine [postgresql_psycopg2]
                                       Engine to use to connect to the database.
       --db-backend [core.psql_dos]    Database backend to use.

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -380,6 +380,11 @@ Below is a list with all available subcommands.
       --first-name NONEMPTYSTRING     First name of the user.  [required]
       --last-name NONEMPTYSTRING      Last name of the user.  [required]
       --institution NONEMPTYSTRING    Institution of the user.  [required]
+      --create-db / --reuse-db        Determines if the setup should look for an existing
+                                      database (needs to be provided with the `--db-name`
+                                      option) or if it always creates a new one (using a
+                                      default or creating names on the fly if the provided
+                                      `--db-name` already exists).  [default: create-db]
       --db-engine [postgresql_psycopg2]
                                       Engine to use to connect to the database.
       --db-backend [core.psql_dos]    Database backend to use.


### PR DESCRIPTION
The command `verdi quicksetup` represents the ideal way for new users to
set up their aiida profile, since AiiDA will directly use all the defaults without
prompting for the non-essential ones (which can then be overridden via the
command options if necessary). This is in contrast with the behavior of
`verdi setup` which prompts for a lot of options that new users may not
understand (even if defaults are provided).

The main limitation preventing it from being fully used this way was that
`verdi quicksetup` would always create new databases. Now an option
`--create-db/--reuse-db` was added to enable this.

### TODOS

- [x] Add docs (explaining, for example, that if the DB is provided, it needs
to be empty or otherwise it will except
- [x] If the database already exists and it was not specified to re-use it,
then it needs to except instead of creating one with `_N`.