### PR TITLE
👌 Improve calcfunction/workfunction typing

### DIFF
--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -167,7 +167,7 @@ class Parser(ABC):
         inputs = {'metadata': {'store_provenance': store_provenance}}
         inputs.update(parser.get_outputs_for_parsing())
 
-        return parse_calcfunction.run_get_node(**inputs)  # type: ignore[attr-defined]
+        return parse_calcfunction.run_get_node(**inputs)
 
     @abstractmethod
     def parse(self, **kwargs) -> Optional[ExitCode]:

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -103,6 +103,15 @@ py:class aiida.storage.sqlite_zip.models.DbGroupNode
 py:class aiida.engine.processes.workchains.context.ToContext
 py:func aiida.orm.implementation.BackendQueryBuilder
 
+### Typing aliases
+py:obj aiida.engine.processes.functions.P
+py:obj aiida.engine.processes.functions.N
+py:obj aiida.engine.processes.functions.R_co
+py:class P
+py:class N
+py:class aiida.engine.processes.functions.N
+py:class aiida.engine.processes.functions.R_co
+
 ### third-party packages
 # Note: These exceptions are needed if
 # * the objects are referenced e.g. as param/return types types in method docstrings (without intersphinx mapping)
@@ -117,7 +126,7 @@ py:class click.types.Path
 py:class click.types.File
 py:class click.types.StringParamType
 py:func click.shell_completion._start_of_option
-py:meth  click.Option.get_default
+py:meth click.Option.get_default
 py:meth fail
 
 py:class requests.models.Response


### PR DESCRIPTION
Utilising [PEP 612](https://peps.python.org/pep-0612), this addition adds beautiful static completions for functions decorated with `@calcfunction` or `@workfunction`

Using the function normally still works as expected:
![image](https://github.com/aiidateam/aiida-core/assets/2997570/3295103f-ff9e-4b79-a759-ce55e6f66ec2)

But now also the additional features of a process function work:
![image](https://github.com/aiidateam/aiida-core/assets/2997570/f5d9b181-c296-4196-b7b2-964849c26314)

----

Unfortunately, PEP 612 was only introduced in Python 3.10, and so I haven't yet added a "fallback" for Python 3.9