### PR TITLE
♻️ Allow for file uploads/downloads to be async

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -529,7 +529,7 @@ class CalcJob(Process):
         super().on_terminated()
 
     @override
-    def run(self) -> Union[plumpy.process_states.Stop, int, plumpy.process_states.Wait]:
+    async def run(self) -> Union[plumpy.process_states.Stop, int, plumpy.process_states.Wait]:
         """Run the calculation job.
 
         This means invoking the `presubmit` and storing the temporary folder in the node's repository. Then we move the
@@ -540,11 +540,11 @@ class CalcJob(Process):
 
         """
         if self.inputs.metadata.dry_run:
-            self._perform_dry_run()
+            await self._perform_dry_run()
             return plumpy.process_states.Stop(None, True)
 
         if 'remote_folder' in self.inputs:
-            exit_code = self._perform_import()
+            exit_code = await self._perform_import()
             return exit_code
 
         # The following conditional is required for the caching to properly work. Even if the source node has a process
@@ -598,7 +598,7 @@ class CalcJob(Process):
         if not self.node.computer:
             self.node.computer = self.inputs.code.computer
 
-    def _perform_dry_run(self):
+    async def _perform_dry_run(self):
         """Perform a dry run.
 
         Instead of performing the normal sequence of steps, just the `presubmit` is called, which will call the method
@@ -615,13 +615,13 @@ class CalcJob(Process):
             with SubmitTestFolder() as folder:
                 calc_info = self.presubmit(folder)
                 transport.chdir(folder.abspath)
-                upload_calculation(self.node, transport, calc_info, folder, inputs=self.inputs, dry_run=True)
+                await upload_calculation(self.node, transport, calc_info, folder, inputs=self.inputs, dry_run=True)
                 self.node.dry_run_info = {  # type: ignore
                     'folder': folder.abspath,
                     'script_filename': self.node.get_option('submit_script_filename')
                 }
 
-    def _perform_import(self):
+    async def _perform_import(self):
         """Perform the import of an already completed calculation.
 
         The inputs contained a `RemoteData` under the key `remote_folder` signalling that this is not supposed to be run
@@ -641,7 +641,7 @@ class CalcJob(Process):
                 with SandboxFolder(filepath_sandbox) as retrieved_temporary_folder:
                     self.presubmit(folder)
                     self.node.set_remote_workdir(self.inputs.remote_folder.get_remote_path())
-                    retrieve_calculation(self.node, transport, retrieved_temporary_folder.abspath)
+                    await retrieve_calculation(self.node, transport, retrieved_temporary_folder.abspath)
                     self.node.set_state(CalcJobState.PARSING)
                     self.node.base.attributes.set(orm.CalcJobNode.IMMIGRATED_KEY, True)
                     return self.parse(retrieved_temporary_folder.abspath)

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -92,7 +92,7 @@ async def task_upload_job(process: 'CalcJob', transport_queue: TransportQueue, c
                 except Exception as exception:  # pylint: disable=broad-except
                     raise PreSubmitException('exception occurred in presubmit call') from exception
                 else:
-                    execmanager.upload_calculation(node, transport, calc_info, folder)
+                    await execmanager.upload_calculation(node, transport, calc_info, folder)
                     skip_submit = calc_info.skip_submit or False
 
             return skip_submit
@@ -310,7 +310,7 @@ async def task_retrieve_job(
 
             if node.get_job_id() is None:
                 logger.warning(f'there is no job id for CalcJobNoe<{node.pk}>: skipping `get_detailed_job_info`')
-                return execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder)
+                return await execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder)
 
             try:
                 detailed_job_info = scheduler.get_detailed_job_info(node.get_job_id())
@@ -320,7 +320,7 @@ async def task_retrieve_job(
             else:
                 node.set_detailed_job_info(detailed_job_info)
 
-            return execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder)
+            return await execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder)
 
     try:
         logger.info(f'scheduled request to retrieve CalcJob<{node.pk}>')

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -552,7 +552,7 @@ class FunctionProcess(Process):
         self.node.store_source_info(self._func)
 
     @override
-    def run(self) -> 'ExitCode' | None:
+    async def run(self) -> 'ExitCode' | None:
         """Run the process."""
         from .exit_code import ExitCode
 

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -295,7 +295,7 @@ class WorkChain(Process, metaclass=Protect):
 
     @override
     @Protect.final
-    def run(self) -> t.Any:
+    async def run(self) -> t.Any:
         self._stepper = self.spec().get_outline().create_stepper(self)  # type: ignore[arg-type]
         return self._do_step()
 

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -449,6 +449,16 @@ class Transport(abc.ABC):
         :param localpath: (str) local_folder_path
         """
 
+    async def get_async(self, remotepath, localpath, *args, **kwargs):
+        """
+        Retrieve a file or folder from remote source to local destination
+        dst must be an absolute path (src not necessarily)
+
+        :param remotepath: (str) remote_folder_path
+        :param localpath: (str) local_folder_path
+        """
+        return self.get(remotepath, localpath, *args, **kwargs)
+
     @abc.abstractmethod
     def getfile(self, remotepath, localpath, *args, **kwargs):
         """
@@ -621,6 +631,17 @@ class Transport(abc.ABC):
         :param str localpath: absolute path to local source
         :param str remotepath: path to remote destination
         """
+
+    async def put_async(self, localpath, remotepath, *args, **kwargs):
+        """
+        Put a file or a directory from local src to remote dst.
+        src must be an absolute path (dst not necessarily))
+        Redirects to putfile and puttree.
+
+        :param str localpath: absolute path to local source
+        :param str remotepath: path to remote destination
+        """
+        return self.put(localpath, remotepath, *args, **kwargs)
 
     @abc.abstractmethod
     def putfile(self, localpath, remotepath, *args, **kwargs):

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - importlib-metadata~=4.13
 - numpy~=1.21
 - paramiko>=2.7.2,~=2.7
-- plumpy~=0.21.6
+- plumpy@ git+https://github.com/aiidateam/plumpy.git@async-run#egg=plumpy
 - pgsu~=0.2.1
 - psutil~=5.6
 - psycopg2-binary~=2.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "importlib-metadata~=4.13",
     "numpy~=1.21",
     "paramiko~=2.7,>=2.7.2",
-    "plumpy~=0.21.6",
+    "plumpy@git+https://github.com/aiidateam/plumpy.git@async-run#egg=plumpy",
     "pgsu~=0.2.1",
     "psutil~=5.6",
     "psycopg2-binary~=2.8",

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -120,7 +120,7 @@ pillow==9.5.0
 platformdirs==3.6.0
 plotly==5.15.0
 pluggy==1.0.0
-plumpy==0.21.8
+plumpy@git+https://github.com/aiidateam/plumpy.git@async-run#egg=plumpy
 prometheus-client==0.17.0
 prompt-toolkit==3.0.38
 psutil==5.9.5

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -119,7 +119,7 @@ pillow==9.5.0
 platformdirs==3.6.0
 plotly==5.15.0
 pluggy==1.0.0
-plumpy==0.21.8
+plumpy@git+https://github.com/aiidateam/plumpy.git@async-run#egg=plumpy
 prometheus-client==0.17.0
 prompt-toolkit==3.0.38
 psutil==5.9.5

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -122,7 +122,7 @@ pillow==9.5.0
 platformdirs==3.6.0
 plotly==5.15.0
 pluggy==1.0.0
-plumpy==0.21.8
+plumpy@git+https://github.com/aiidateam/plumpy.git@async-run#egg=plumpy
 prometheus-client==0.17.0
 prompt-toolkit==3.0.38
 psutil==5.9.5

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -148,7 +148,8 @@ def test_hierarchy_utility(file_hierarchy, tmp_path):
     (['file_a.txt', 'file_u.txt', 'path/file_u.txt', ('path/sub/file_u.txt', '.', 3)], {'file_a.txt': 'file_a'}),
 ))
 # yapf: enable
-def test_retrieve_files_from_list(
+@pytest.mark.asyncio
+async def test_retrieve_files_from_list(
     tmp_path_factory, generate_calculation_node, file_hierarchy, retrieve_list, expected_hierarchy
 ):
     """Test the `retrieve_files_from_list` function."""
@@ -160,7 +161,7 @@ def test_retrieve_files_from_list(
     with LocalTransport() as transport:
         node = generate_calculation_node()
         transport.chdir(source)
-        execmanager.retrieve_files_from_list(node, transport, target, retrieve_list)
+        await execmanager.retrieve_files_from_list(node, transport, target, retrieve_list)
 
     assert serialize_file_hierarchy(target) == expected_hierarchy
 
@@ -178,7 +179,8 @@ def test_retrieve_files_from_list(
     (['sub', 'target'], {'target': {'b': 'file_b'}}),
 ))
 # yapf: enable
-def test_upload_local_copy_list(
+@pytest.mark.asyncio
+async def test_upload_local_copy_list(
     fixture_sandbox, node_and_calc_info, file_hierarchy_simple, tmp_path, local_copy_list, expected_hierarchy
 ):
     """Test the ``local_copy_list`` functionality in ``upload_calculation``."""
@@ -191,7 +193,7 @@ def test_upload_local_copy_list(
     calc_info.local_copy_list = [[folder.uuid] + local_copy_list]
 
     with LocalTransport() as transport:
-        execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
+        await execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
 
     # Check that none of the files were written to the repository of the calculation node, since they were communicated
     # through the ``local_copy_list``.
@@ -202,7 +204,8 @@ def test_upload_local_copy_list(
     assert written_hierarchy == expected_hierarchy
 
 
-def test_upload_local_copy_list_files_folders(fixture_sandbox, node_and_calc_info, file_hierarchy, tmp_path):
+@pytest.mark.asyncio
+async def test_upload_local_copy_list_files_folders(fixture_sandbox, node_and_calc_info, file_hierarchy, tmp_path):
     """Test the ``local_copy_list`` functionality in ``upload_calculation``.
 
     Specifically, verify that files in the ``local_copy_list`` do not end up in the repository of the node.
@@ -226,7 +229,7 @@ def test_upload_local_copy_list_files_folders(fixture_sandbox, node_and_calc_inf
     ]
 
     with LocalTransport() as transport:
-        execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
+        await execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
 
     # Check that none of the files were written to the repository of the calculation node, since they were communicated
     # through the ``local_copy_list``.

--- a/tests/engine/processes/test_caching.py
+++ b/tests/engine/processes/test_caching.py
@@ -16,7 +16,7 @@ class NestedOutputsProcess(Process):
         spec.input('a')
         spec.output_namespace('nested', dynamic=True)
 
-    def run(self):
+    async def run(self):
         self.out('nested', {'a': self.inputs.a + 2})
 
 

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -76,7 +76,7 @@ class ProcessStackTest(Process):
     _node_class = orm.WorkflowNode
 
     @override
-    def run(self):
+    async def run(self):
         pass
 
     @override
@@ -298,7 +298,7 @@ class TestProcess:
                 spec.input_namespace('namespace', valid_type=orm.Int, dynamic=True)
                 spec.output_namespace('namespace', valid_type=orm.Int, dynamic=True)
 
-            def run(self):
+            async def run(self):
                 self.out('namespace', self.inputs.namespace)
 
         results, node = run_get_node(TestProcess1, namespace={'alpha': orm.Int(1), 'beta': orm.Int(2)})
@@ -322,7 +322,7 @@ class TestProcess:
                 spec.output_namespace('integer.namespace', valid_type=orm.Int, dynamic=True)
                 spec.output('required_string', valid_type=orm.Str, required=True)
 
-            def run(self):
+            async def run(self):
                 if self.inputs.add_outputs:
                     self.out('required_string', orm.Str('testing').store())
                     self.out('integer.namespace.two', orm.Int(2).store())

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -39,7 +39,7 @@ class Proc(Process):
         super().define(spec)
         spec.input('a')
 
-    def run(self):
+    async def run(self):
         pass
 
 

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -1775,5 +1775,5 @@ def test_illegal_override_run():
                 super().define(spec)
                 spec.outline(cls.run)
 
-            def run(self):
+            async def run(self):
                 pass

--- a/tests/utils/processes.py
+++ b/tests/utils/processes.py
@@ -26,7 +26,7 @@ class DummyProcess(Process):
         spec.inputs.valid_type = Data
         spec.outputs.valid_type = Data
 
-    def run(self):
+    async def run(self):
         pass
 
 
@@ -42,7 +42,7 @@ class AddProcess(Process):
         spec.input('b', required=True)
         spec.output('result', required=True)
 
-    def run(self):
+    async def run(self):
         summed = self.inputs.a + self.inputs.b
         self.out(summed.store())
 
@@ -57,7 +57,7 @@ class BadOutput(Process):
         super().define(spec)
         spec.outputs.valid_type = Data
 
-    def run(self):
+    async def run(self):
         self.out('bad_output', 5)
 
 
@@ -66,7 +66,7 @@ class ExceptionProcess(Process):
 
     _node_class = WorkflowNode
 
-    def run(self):
+    async def run(self):
         raise RuntimeError('CRASH')
 
 
@@ -75,7 +75,7 @@ class WaitProcess(Process):
 
     _node_class = WorkflowNode
 
-    def run(self):
+    async def run(self):
         return plumpy.Wait(self.next_step)
 
     def next_step(self):
@@ -95,7 +95,7 @@ class InvalidateCaching(Process):
             123, 'GENERIC_EXIT_CODE', message='This process should not be used as cache.', invalidates_cache=True
         )
 
-    def run(self):
+    async def run(self):
         if self.inputs.return_exit_code:
             return self.exit_codes.GENERIC_EXIT_CODE  # pylint: disable=no-member
 
@@ -110,7 +110,7 @@ class IsValidCacheHook(Process):
         super().define(spec)
         spec.input('not_valid_cache', valid_type=Bool, default=lambda: Bool(False))
 
-    def run(self):
+    async def run(self):
         pass
 
     @classmethod


### PR DESCRIPTION
Note, this PR is currently dependent on https://github.com/aiidateam/plumpy/pull/272

---

Currently, a possible bottleneck for workers (running potentially 1000s of processes asynchronously) is the upload/retrieval of calculation input/output data from an external compute resource (e.g. HPC).
This runs in a blocking manner, i.e. all other async tasks have to wait until all the input or outputs are fully uploaded/retrieved.

This could be made asynchronous, either at the "file level" - relinquishing control to the event loop after each file upload/download, or even at the "byte level" - relinquishing control after each "chunk of a file" has been uploaded/downloaded.
(For other transports, like FirecREST there are even other aspects of async to consider.)

This particular PR does not actually implement any async behaviour for uploads/downloads, it merely modifies the engine API to allow for implementations of the `Transport` interface to achieve this.

The PR changes the following functions/methods to async:

- `execmanager.upload_calculation`
- `execmanager.retrieve_calculation`
- `execmanager.retrieve_files_from_list`
- `Calcjob.run`
- `CalcJob._perform_dry_run`
- `CalcJob._perform_import`

However, all of these are not intended for use by the user, hence I would suggest this is backwards compatible.

