### PR TITLE
Avoid entry point lookups in Node/Group metaclasses

### DIFF
--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -20,8 +20,6 @@ from typing import TYPE_CHECKING
 from pgsu import DEFAULT_DSN as DEFAULT_DBINFO  # pylint: disable=no-name-in-module
 from pgsu import PGSU, PostgresConnectionMode
 
-from aiida.cmdline.utils import echo
-
 if TYPE_CHECKING:
     from aiida.manage.configuration import Profile
 
@@ -218,6 +216,8 @@ class Postgres(PGSU):
         :param str dbpass: Password the user should be given.
         :returns: (dbuser, dbname)
         """
+        from aiida.cmdline.utils import echo
+
         if not self.dbuser_exists(dbuser):
             self.create_dbuser(dbuser=dbuser, dbpass=dbpass)
         elif not self.can_user_authenticate(dbuser, dbpass):

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 
 import click
 
-from aiida.cmdline.params.options.interactive import TemplateInteractiveOption
 from aiida.common import exceptions
 from aiida.common.folders import Folder
 from aiida.common.lang import type_check
@@ -331,6 +330,8 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
     @classmethod
     def _get_cli_options(cls) -> dict:
         """Return the CLI options that would allow to create an instance of this class."""
+        from aiida.cmdline.params.options.interactive import TemplateInteractiveOption
+
         return {
             'label': {
                 'short_name': '-L',

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -20,7 +20,6 @@ import pathlib
 
 import click
 
-from aiida.cmdline.params.types import ComputerParamType
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
@@ -179,6 +178,8 @@ class InstalledCode(Code):
     @classmethod
     def _get_cli_options(cls) -> dict:
         """Return the CLI options that would allow to create an instance of this class."""
+        from aiida.cmdline.params.types import ComputerParamType
+
         options = {
             'computer': {
                 'short_name': '-Y',

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -20,7 +20,11 @@ from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
-from aiida.orm.utils.node import AbstractNodeMeta
+from aiida.orm.utils.node import (  # pylint: disable=unused-import
+    AbstractNodeMeta,
+    get_query_type_from_type_string,
+    get_type_string_from_class,
+)
 
 from ..computers import Computer
 from ..entities import Collection as EntityCollection
@@ -149,9 +153,22 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
     _CLS_NODE_LINKS = NodeLinks
     _CLS_NODE_CACHING = NodeCaching
 
-    # added by metaclass
-    _plugin_type_string: ClassVar[str]
-    _query_type_string: ClassVar[str]
+    __plugin_type_string: ClassVar[str]
+    __query_type_string: ClassVar[str]
+
+    @classproperty
+    def _plugin_type_string(cls) -> str:
+        """Return the plugin type string of this node class."""
+        if not hasattr(cls, '__plugin_type_string'):
+            cls.__plugin_type_string = get_type_string_from_class(cls.__module__, cls.__name__)  # type: ignore[misc]
+        return cls.__plugin_type_string
+
+    @classproperty
+    def _query_type_string(cls) -> str:
+        """Return the query type string of this node class."""
+        if not hasattr(cls, '__query_type_string'):
+            cls.__query_type_string = get_query_type_from_type_string(cls._plugin_type_string)  # type: ignore[misc]
+        return cls.__query_type_string
 
     # This will be set by the metaclass call
     _logger: Optional[Logger] = None

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -11,7 +11,6 @@
 import enum
 import pathlib
 
-from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common.utils import ErrorAccumulator
 from aiida.common.warnings import warn_deprecation
 from aiida.orm import InstalledCode, PortableCode
@@ -41,9 +40,13 @@ class CodeBuilder:
         self._err_acc.run(self.validate_installed)
         return self._err_acc.result(raise_error=self.CodeValidationError if raise_error else False)
 
-    @with_dbenv()
     def new(self):
         """Build and return a new code instance (not stored)"""
+        from aiida.manage import get_manager
+
+        # Load the profile backend if not already the case.
+        get_manager().get_profile_storage()
+
         self.validate()
 
         # Will be used at the end to check if all keys are known (those that are not None)

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Manage computer objects with lazy loading of the db env"""
-from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common.exceptions import ValidationError
 from aiida.common.utils import ErrorAccumulator
 
@@ -62,11 +61,13 @@ class ComputerBuilder:  # pylint: disable=too-many-instance-attributes
         """Validate the computer options."""
         return self._err_acc.result(raise_error=self.ComputerValidationError if raise_error else False)
 
-    @with_dbenv()
     def new(self):
         """Build and return a new computer instance (not stored)"""
+        from aiida.manage import get_manager
         from aiida.orm import Computer
 
+        # Load the profile backend if not already the case.
+        get_manager().get_profile_storage()
         self.validate()
 
         # Will be used at the end to check if all keys are known

--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -160,9 +160,4 @@ class AbstractNodeMeta(ABCMeta):
     def __new__(mcs, name, bases, namespace, **kwargs):
         newcls = ABCMeta.__new__(mcs, name, bases, namespace, **kwargs)  # pylint: disable=too-many-function-args
         newcls._logger = logging.getLogger(f"{namespace['__module__']}.{name}")
-
-        # Set the plugin type string and query type string based on the plugin type string
-        newcls._plugin_type_string = get_type_string_from_class(namespace['__module__'], name)  # pylint: disable=protected-access
-        newcls._query_type_string = get_query_type_from_type_string(newcls._plugin_type_string)  # pylint: disable=protected-access
-
         return newcls

--- a/aiida/tools/groups/paths.py
+++ b/aiida/tools/groups/paths.py
@@ -60,7 +60,7 @@ class GroupPath:
     See tests for usage examples.
     """
 
-    def __init__(self, path: str = '', cls: orm.groups.GroupMeta = orm.Group, warn_invalid_child: bool = True) -> None:
+    def __init__(self, path: str = '', cls: orm.groups.Group = orm.Group, warn_invalid_child: bool = True) -> None:
         """Instantiate the class.
 
         :param path: The initial path of the group.
@@ -126,7 +126,7 @@ class GroupPath:
         return self._delimiter
 
     @property
-    def cls(self) -> orm.groups.GroupMeta:
+    def cls(self) -> orm.groups.Group:
         """Return the cls used to query for and instantiate a ``Group`` with."""
         return self._cls
 

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -332,7 +332,7 @@ class TestGroupsSubclasses:
             class SubGroup(orm.Group):
                 pass
 
-        assert SubGroup._type_string is None  # pylint: disable=protected-access
+            assert SubGroup._type_string is None  # pylint: disable=protected-access
 
         # Creating an instance is allowed
         instance = SubGroup(label=uuid.uuid4().hex)


### PR DESCRIPTION
It turns out a big part of why aiida.orm import is so slow are costly entry point lookups
in AbstractNodeMeta and GroupMeta metaclasses.

### Commit 1:  `_plugin_type_string` and `_query_type_string`  

These class attributes require a look up whether the `Node` class has a
registered entry point which can have a non-negligible cost. These
attributes were defined in the `AbstractNodeMeta` class, which is the
metaclass of the `Node` class, which would cause this code to be
executed as soon as the class was imported.

Here, the `AbstractNodeMeta` metaclass is removed. The
`_plugin_type_string` and `_query_type_string` class attributes are
changed to class properties. The actual value is stored in the private
attribute analog which is defined lazily the first time the property is
accessed.

### Commit 2: `__type_string`

This attribute was defined in the GroupMeta metaclass.
Because this was the only purpose of this metaclass,
we can fully remove it and use the same strategy as above.

### Commit 3:  Avoiding `aiida.cmdline` import

There are some further entry point lookups in metaclasses defined in `aiida.cmdline` used for the click interface.
It's not that clear how to get rid of those, but here we at least avoid importing `aiida.cmdline` from `aiida.orm` and `aiida.manage`,
which also speeds up `import aiida`. 

With this last change, there are no entry point lookups during `aiida.orm` import. :tada: 

### Benchmarks

**TODO:** I will add benchmarks shortly...