### PR TITLE
CLI: caching valid control

### DIFF
--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -305,6 +305,7 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force, exit
 
         echo.echo_success(f'{counter} remote folders cleaned on {computer.label}')
 
+
 @verdi_calcjob.command('caching')
 @decorators.with_dbenv()
 @arguments.CALCULATIONS('calcjobs', type=CalculationParamType(sub_classes=('aiida.node:process.calculation.calcjob',)))
@@ -325,13 +326,14 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force, exit
     modified AFTER [-p option] days from now, but BEFORE [-o option] days from now.
     """
     from aiida import orm
+
     #from aiida.orm.utils.remote import get_calcjob_remote_paths
 
     if enable and disable:
-        raise click.UsageError("Cannot enable and disable caching simultaneously.")
+        raise click.UsageError('Cannot enable and disable caching simultaneously.')
 
     if not enable and not disable and not status:
-        raise click.UsageError("Please specify either --enable or --disable or --status.")
+        raise click.UsageError('Please specify either --enable or --disable or --status.')
 
     if calcjobs:
         if (past_days is not None and older_than is not None):
@@ -357,11 +359,11 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force, exit
 
     # get the caching flag
     if enable:
-        action = "enable"
+        action = 'enable'
         caching_flag = True
-    
+
     if disable:
-        action = "disable"
+        action = 'disable'
         caching_flag = False
 
     if not force:

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -258,7 +258,13 @@ class TestVerdiCalculation:
         result = self.cli_runner.invoke(command.calcjob_caching, options)
         assert result.exception is not None
 
-        # Do --enable on a enabled calcjob should fail as the calcjob has been cleaned
+        # With --status flag we should find one calcjob
+        option = ['--status', str(self.result_job.uuid)]
+        result = self.cli_runner.invoke(command.calcjob_caching, option)
+        assert result.exception is None, result.output
+        assert 'true' in result.output
+
+        # Do --enable on a enabled calcjob should raise warning as the calcjob has been set
         options = ['--enable', str(self.result_job.uuid)]
         result = self.cli_runner.invoke(command.calcjob_caching, options)
         assert result.exception is not None, result.output
@@ -268,14 +274,46 @@ class TestVerdiCalculation:
         result = self.cli_runner.invoke(command.calcjob_caching, options)
         assert result.exception is None, result.output
 
-        # Do --disable again should fail as the calcjob has been cleaned
-        options = ['--disable', str(self.result_job.uuid)]
-        result = self.cli_runner.invoke(command.calcjob_caching, options)
-        assert result.exception is not None, result.output
-
         # The flag should have been set
         assert self.result_job.base.extras.get('_aiida_valid_cache') is False
-        
+
+        # With --status flag we should find one calcjob
+        option = ['--status', str(self.result_job.uuid)]
+        result = self.cli_runner.invoke(command.calcjob_caching, option)
+        assert result.exception is None, result.output
+        assert 'false' in result.output
+
+        # TODO
+        ## Check applying both p and o filters
+        #for flag_p in ['-p', '--past-days']:
+        #    for flag_o in ['-o', '--older-than']:
+        #        options = [flag_p, '5', flag_o, '1', '-f']
+        #        result = self.cli_runner.invoke(command.calcjob_caching, options)
+        #        # This should fail - the node was just created in the test
+        #        assert result.exception is not None
+
+        #        options = [flag_p, '5', flag_o, '0', '-f']
+        #        result = self.cli_runner.invoke(command.calcjob_caching, options)
+        #        # This should pass fine
+        #        assert result.exception is None
+        #        self.result_job.outputs.remote_folder.base.extras.delete('cleaned')
+
+        #        options = [flag_p, '0', flag_o, '0', '-f']
+        #        result = self.cli_runner.invoke(command.calcjob_caching, options)
+        #        # This should not pass
+        #        assert result.exception is not None
+
+        ## Should fail because the exit code is not 999 - using the failed job for testing
+        #options = [str(self.calcs[-1].uuid), '-E', '999', '-f']
+        #result = self.cli_runner.invoke(command.calcjob_caching, options)
+        #assert result.exception is not None
+
+        ## Should be fine because the exit code is 100
+        #self.calcs[-1].base.extras.set('_aiida_valid_cache', True)
+        #options = [str(self.calcs[-1].uuid), '-E', '100', '-f']
+        #result = self.cli_runner.invoke(command.calcjob_caching, options)
+        #assert result.exception is None
+
     def test_calcjob_cleanworkdir(self):
         """Test verdi calcjob cleanworkdir"""
 


### PR DESCRIPTION
Similar as `verdi calcjob cleanworkdir` the new command is for turn on/off the caching of calcjob node.