### PR TITLE
Add is_cleaned interface to RemoteData

### DIFF
--- a/aiida/orm/nodes/data/remote/base.py
+++ b/aiida/orm/nodes/data/remote/base.py
@@ -38,10 +38,18 @@ class RemoteData(Data):
         self.base.attributes.set('remote_path', val)
 
     @property
+    def is_cleaned(self):
+        """Return whether the remote folder has been cleaned."""
+        return self.base.extras.get(self.KEY_EXTRA_CLEANED, False)
+
+    @property
     def is_empty(self):
         """
         Check if remote folder is empty
         """
+        if self.is_cleaned:
+            return True
+
         authinfo = self.get_authinfo()
         transport = authinfo.get_transport()
 

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -27,7 +27,8 @@ def remote_data(tmp_path, aiida_localhost):
 def test_clean(remote_data):
     """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
     assert not remote_data.is_empty
+    assert not remote_data.is_cleaned
 
     remote_data._clean()  #  pylint: disable=protected-access
     assert remote_data.is_empty
-    assert remote_data.base.attributes.get(RemoteData.KEY_EXTRA_CLEANED, True)
+    assert remote_data.is_cleaned


### PR DESCRIPTION
Using `is_empty` directly in the workflow may run into problems when the SSH connection is lost. The `is_cleaned` don't need transport which is more lightweight.