### PR TITLE
Docs: Add links to Discourse server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ AiiDA (www.aiida.net) is a workflow manager for computational science with a str
 |    | |
 |-----|----------------------------------------------------------------------------|
 |Latest release| [![PyPI version](https://badge.fury.io/py/aiida-core.svg)](https://badge.fury.io/py/aiida-core) [![conda-forge](https://img.shields.io/conda/vn/conda-forge/aiida-core.svg?style=flat)](https://anaconda.org/conda-forge/aiida-core) [![PyPI pyversions](https://img.shields.io/pypi/pyversions/aiida-core.svg)](https://pypi.python.org/pypi/aiida-core/) |
-|Getting help| [![Docs status](https://readthedocs.org/projects/aiida-core/badge)](http://aiida-core.readthedocs.io/) [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/aiidausers)
+|Getting help| [![Docs status](https://readthedocs.org/projects/aiida-core/badge)](http://aiida-core.readthedocs.io/) [![Discourse status](https://img.shields.io/discourse/status?server=https%3A%2F%2Faiida.discourse.group%2F)](https://aiida.discourse.group/)
 |Build status| [![Build Status](https://github.com/aiidateam/aiida-core/actions/workflows/ci-code.yml/badge.svg)](https://github.com/aiidateam/aiida-core/actions) [![Coverage Status](https://codecov.io/gh/aiidateam/aiida-core/branch/main/graph/badge.svg)](https://codecov.io/gh/aiidateam/aiida-core) [Benchmarks](https://aiidateam.github.io/aiida-core/dev/bench/ubuntu-22.04/psql_dos/) |
 |Activity| [![PyPI-downloads](https://img.shields.io/pypi/dm/aiida-core.svg?style=flat)](https://pypistats.org/packages/aiida-core) [![Commit Activity](https://img.shields.io/github/commit-activity/m/aiidateam/aiida-core.svg)](https://github.com/aiidateam/aiida-core/pulse)
-|Community| [![Affiliated with NumFOCUS](https://img.shields.io/badge/NumFOCUS-affiliated%20project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org/sponsored-projects/affiliated-projects) [![Twitter](https://img.shields.io/twitter/follow/aiidateam.svg?style=social&label=Follow)](https://twitter.com/aiidateam)
+|Community|  [![Affiliated with NumFOCUS](https://img.shields.io/badge/NumFOCUS-affiliated%20project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org/sponsored-projects/affiliated-projects) [![Twitter](https://img.shields.io/twitter/follow/aiidateam.svg?style=social&label=Follow)](https://twitter.com/aiidateam)
 
 
 ## Features
@@ -48,6 +48,7 @@ Please see the [Contributor wiki](https://github.com/aiidateam/aiida-core/wiki) 
 ## Frequently Asked Questions
 
 If you are experiencing problems with your AiiDA installation, please refer to the [FAQ page of the documentation](https://aiida-core.readthedocs.io/en/latest/howto/faq.html).
+For any other questions, discussion and requests for support, please visit the [Discourse server](https://aiida.discourse.group/).
 
 ## How to cite
 

--- a/docs/source/howto/faq.rst
+++ b/docs/source/howto/faq.rst
@@ -4,7 +4,8 @@
 Frequently Asked Questions
 ==========================
 
-If the problem you are facing is not addressed below, you can send an email to the `mailing list <http://www.aiida.net/mailing-list/>`_, or `open an issue on Github <https://github.com/aiidateam/aiida-core/issues/new/choose>`_ if you think it concerns a bug.
+If the problem you are facing is not addressed below, please refer to the `Discourse server <https://aiida.discourse.group/>`_.
+To file a bug report or open a feature request, please `open an issue on Github <https://github.com/aiidateam/aiida-core/issues/new/choose>`_.
 
 
 I have updated the version of AiiDA and now it is no longer working. What should I do?

--- a/docs/source/internals/storage/sqlite_zip.rst
+++ b/docs/source/internals/storage/sqlite_zip.rst
@@ -51,7 +51,7 @@ New archive versions are introduced for several different reasons; this may gene
 .. important::
     For archives of version 0.3 and older it is advisable that you manually try to convince yourself that the migration was completely successful.
     While all migrations are tested, trying to include reasonable edge-cases, the migrations involved from version 0.3 to 0.4 are intricate and the possibility of a missing edge-case test is quite real.
-    It is worth noting that if you ever have an issue, please report it on `GitHub <https://www.github.com/aiidateam/aiida_core/issues/new>`_, join the `AiiDA mailing list <http://www.aiida.net/mailing-list/>`_, or use the `contact form <http://www.aiida.net/contact-new/>`_.
+    It is worth noting that if you ever have an issue, please report it on `GitHub <https://www.github.com/aiidateam/aiida_core/issues/new>`.
 
 .. note::
     If you have migrated an archive file to the newest version, there may be an extra entry in ``metadata.json``.

--- a/docs/source/intro/troubleshooting.rst
+++ b/docs/source/intro/troubleshooting.rst
@@ -19,6 +19,7 @@ If you experience any problems, first check that all services are up and running
 
 In the example output, all service have a green check mark and so should be running as expected.
 If all services are up and running and you are still experiencing problems or if you have trouble with the installation of aiida-core and related services, consider the commonly encountered problems below.
+In case you are still experiencing problems, you can request support by opening a post on the `Discourse server <https://aiida.discourse.group/>`_.
 
 .. _intro:troubleshooting:installation:
 


### PR DESCRIPTION
The Discourse server replaces the mailing list and Slack channel. The README and documentation is updated accordingly.