### PR TITLE
Tests: Fix flaky work chain tests using `recwarn` fixture 

### DIFF
--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -532,7 +532,7 @@ class TestWorkchain:
                 pass
 
         launch.run(TestWorkChain)
-        assert len(recwarn) == 1
+        assert any('The conditional predicate `predicate` returned `true`' in str(r.message) for r in recwarn)
 
     def test_invalid_while_predicate(self, recwarn):
         """Test that workchain raises if the predicate of an ``while_`` condition does not return a boolean."""
@@ -553,7 +553,7 @@ class TestWorkchain:
                 return ExitCode(1)
 
         launch.run(TestWorkChain)
-        assert len(recwarn) == 1
+        assert any('The conditional predicate `predicate` returned `true`' in str(r.message) for r in recwarn)
 
     def test_malformed_outline(self):
         """


### PR DESCRIPTION
The tests were often failing because the `recwarn` fixture contained
two records instead of one. The reason is that elsewhere in the code a
`ResourceWarning` is emitted because an event-loop is not closed when
another one is created. Until this is fixed, the assertion is updated to
not check for the number of warnings emitted, but specifically to check
the expected warning message is present.