### PR TITLE
Deprecation: `aiida.orm.nodes.data.upf` and `verdi data core.upf`

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -25,6 +25,9 @@ def upf():
 
 
 @upf.command('uploadfamily')
+@decorators.deprecated_command(
+    'See https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core'
+)
 @click.argument('folder', type=click.Path(exists=True, file_okay=False, resolve_path=True))
 @click.argument('group_label', type=click.STRING)
 @click.argument('group_description', type=click.STRING)
@@ -49,6 +52,9 @@ def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
 
 
 @upf.command('listfamilies')
+@decorators.deprecated_command(
+    'See https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core'
+)
 @click.option(
     '-d',
     '--with-description',
@@ -94,6 +100,9 @@ def upf_listfamilies(elements, with_description):
 
 
 @upf.command('exportfamily')
+@decorators.deprecated_command(
+    'See https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core'
+)
 @click.argument('folder', type=click.Path(exists=True, file_okay=False, resolve_path=True))
 @arguments.GROUP()
 @decorators.with_dbenv()
@@ -115,6 +124,9 @@ def upf_exportfamily(folder, group):
 
 
 @upf.command('import')
+@decorators.deprecated_command(
+    'See https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core'
+)
 @click.argument('filename', type=click.Path(exists=True, dir_okay=False, resolve_path=True))
 @decorators.with_dbenv()
 def upf_import(filename):
@@ -128,6 +140,9 @@ def upf_import(filename):
 
 
 @upf.command('export')
+@decorators.deprecated_command(
+    'See https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core'
+)
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:core.upf',)))
 @options.EXPORT_FORMAT(
     type=click.Choice(['json']),

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -13,9 +13,17 @@ import re
 
 from upf_to_json import upf_to_json
 
+from aiida.common.warnings import warn_deprecation
+
 from .singlefile import SinglefileData
 
 __all__ = ('UpfData',)
+
+warn_deprecation(
+    'This module is deprecated. See '
+    'https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core.',
+    version=3
+)
 
 REGEX_UPF_VERSION = re.compile(r"""
     \s*<UPF\s+version\s*="


### PR DESCRIPTION
The `UpfData` data plugin and related utilities have been replaced by the versions maintained in the `aiida-pseudo` plugin. The latter has now been significantly adopted by most users and plugin in the ecosystem, so the outdated original version in `aiida-core` can be deprecated and removed.