### PR TITLE
Devops: Replace outdated link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 <!-- Before raising an issue, it is suggested that you first check out the: -->
 
 - [ ] [AiiDA Troubleshooting Documentation](https://aiida.readthedocs.io/projects/aiida-core/en/latest/intro/troubleshooting.html)
-- [ ] [AiiDA Users Forum](https://groups.google.com/forum/#!forum/aiidausers)
+- [ ] [AiiDA Discourse Forum](https://aiida.discourse.group/)
 
 ### Describe the bug
 


### PR DESCRIPTION
It was still pointing to the legacy Google mailing list. The link is updated to point to the Discourse server.