### PR TITLE
`PsqlDosBackend`: Fix `Node.store` excepting when inside a transaction

### DIFF
--- a/aiida/orm/implementation/nodes.py
+++ b/aiida/orm/implementation/nodes.py
@@ -184,13 +184,11 @@ class BackendNode(BackendEntity, BackendEntityExtrasMixin, metaclass=abc.ABCMeta
     def store(  # pylint: disable=arguments-differ
         self: BackendNodeType,
         links: Optional[Sequence['LinkTriple']] = None,
-        with_transaction: bool = True,
         clean: bool = True
     ) -> BackendNodeType:
         """Store the node in the database.
 
         :param links: optional links to add before storing
-        :param with_transaction: if False, do not use a transaction because the caller will already have opened one.
         :param clean: boolean, if True, will clean the attributes and extras before attempting to store
         """
 

--- a/aiida/storage/psql_dos/orm/groups.py
+++ b/aiida/storage/psql_dos/orm/groups.py
@@ -68,8 +68,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], ExtrasMixin, BackendGroup):  
             try:
                 self.model.save()
             except Exception:
-                raise UniquenessError(f'a group of the same type with the label {label} already exists') \
-                    from Exception
+                raise UniquenessError(f'a group of the same type with the label {label} already exists') from Exception
 
     @property
     def description(self):
@@ -103,12 +102,6 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], ExtrasMixin, BackendGroup):  
     @property
     def uuid(self):
         return str(self.model.uuid)
-
-    def __int__(self):
-        if not self.is_stored:
-            return None
-
-        return self._dbnode.id  # pylint: disable=no-member
 
     @property
     def is_stored(self):
@@ -220,7 +213,8 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], ExtrasMixin, BackendGroup):  
                 session.execute(ins.on_conflict_do_nothing(index_elements=['dbnode_id', 'dbgroup_id']))
 
             # Commit everything as up till now we've just flushed
-            session.commit()
+            if not session.in_nested_transaction():
+                session.commit()
 
     def remove_nodes(self, nodes, **kwargs):
         """Remove a node or a set of nodes from the group.
@@ -268,7 +262,8 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], ExtrasMixin, BackendGroup):  
                     statement = table.delete().where(clause)
                     session.execute(statement)
 
-            session.commit()
+            if not session.in_nested_transaction():
+                session.commit()
 
 
 class SqlaGroupCollection(BackendGroupCollection):

--- a/aiida/storage/psql_dos/orm/utils.py
+++ b/aiida/storage/psql_dos/orm/utils.py
@@ -120,6 +120,8 @@ class ModelWrapper:
             self.session.add(self._model)
             if not self._in_transaction():
                 self.session.commit()
+            else:
+                self.session.flush()
         except IntegrityError as exception:
             self.session.rollback()
             raise exceptions.IntegrityError(str(exception))

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -980,7 +980,7 @@ class TestNodeCaching:
         data.store()
 
         clone = data.clone()
-        clone._store_from_cache(data, with_transaction=True)  # pylint: disable=protected-access
+        clone._store_from_cache(data)  # pylint: disable=protected-access
 
         assert clone.is_stored
         assert clone.base.caching.get_cache_source() == data.uuid


### PR DESCRIPTION
Fixes #5802 

Calling `Node.store` with the `PsqlDosBackend` would except whenever inside a transaction, for example, when iterating over a `QueryBuilder` result, which opens a transaction.

The reason is that the node implementation of the `PsqlDosBackend`, the `SqlaNode.store` method calls `commit` on the session. This closes the current transaction, and so when it is then used again, for example in the next iteration of the builder results, an exception is raised by sqlalchemy complaining that the transaction was closed.

The solution is that `SqlaNode.store` should only commit if it is not inside a nested transaction, otherwise it should simply flush the addition of the node to the session such that automatically generated primary keys are populated.

A similar problem was addressed in the `add_nodes` and `remove_nodes` methods of the `SqlaGroup` class. These would also call `commit` at the end, regardless of whether they are called within an open transaction.