### PR TITLE
Follow-up docker build runner macOS-ARM64

### DIFF
--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -32,6 +32,18 @@ jobs:
               with:
                   architecture: ${{ inputs.architecture }}
 
+            # Self-hosted runners share a state (whole VM) between runs
+            # Also, they might have running or stopped containers,
+            # which are not cleaned up by `docker system prun`
+            - name: Reset docker state and cleanup artifacts 🗑️
+              if: ${{ inputs.platform != 'x86_64' }}
+              run: |
+                  docker kill $(docker ps --quiet) || true
+                  docker rm $(docker ps --all --quiet) || true
+                  docker system prune --all --force
+                  rm -rf /tmp/aiida-core/
+              shell: bash
+
             - name: Build image base and base-with-services (output image name aiida-coer §) 🛠
               # The order of the buildx bake files is important, as the second one will overwrite the first one
               run: docker buildx bake -f docker-bake.hcl -f build.json --set *.platform=linux/${{ inputs.architecture }} --load
@@ -44,19 +56,20 @@ jobs:
 
             - name: Save image as a tar for later use 💾
               run: |
-                docker save ${{ env.OWNER }}/aiida-core-base -o /tmp/aiida-core-base-${{ inputs.architecture }}.tar
-                docker save ${{ env.OWNER }}/aiida-core-with-services -o /tmp/aiida-core-with-services-${{ inputs.architecture }}.tar
+                mkdir -p /tmp/aiida-core
+                docker save ${{ env.OWNER }}/aiida-core-base -o /tmp/aiida-core/aiida-core-base-${{ inputs.architecture }}.tar
+                docker save ${{ env.OWNER }}/aiida-core-with-services -o /tmp/aiida-core/aiida-core-with-services-${{ inputs.architecture }}.tar
 
             - name: Upload aiida-core-base image as artifact 💾
               uses: actions/upload-artifact@v3
               with:
                   name: aiida-core-base-${{ inputs.architecture }}
-                  path: /tmp/aiida-core-base-${{ inputs.architecture }}.tar
+                  path: /tmp/aiida-core/aiida-core-base-${{ inputs.architecture }}.tar
                   retention-days: 3
 
             - name: Upload aiida-core-with-services image as artifact 💾
               uses: actions/upload-artifact@v3
               with:
                   name: aiida-core-with-services-${{ inputs.architecture }}
-                  path: /tmp/aiida-core-with-services-${{ inputs.architecture }}.tar
+                  path: /tmp/aiida-core/aiida-core-with-services-${{ inputs.architecture }}.tar
                   retention-days: 3

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -36,12 +36,12 @@ jobs:
               uses: actions/download-artifact@v3
               with:
                   name: ${{ inputs.registry }}-${{ matrix.image }}-amd64-tags
-                  path: /tmp/
+                  path: /tmp/aiida-core
             - name: Download arm64 tags file 📥
               uses: actions/download-artifact@v3
               with:
                   name: ${{ inputs.registry }}-${{ matrix.image }}-arm64-tags
-                  path: /tmp/
+                  path: /tmp/aiida-core
 
             - name: Login to Container Registry 🔑
               uses: docker/login-action@v2
@@ -52,13 +52,13 @@ jobs:
 
             - name: Merge tags for the images of different arch 🔀
               run: |
-                  for arch_tag in $(cat /tmp/${{ matrix.image }}-amd64-tags.txt); do
+                  for arch_tag in $(cat /tmp/aiida-core/${{ matrix.image }}-amd64-tags.txt); do
                     tag=$(echo $arch_tag | sed "s/:amd64-/:/")
                     docker manifest create $tag --amend $arch_tag
                     docker manifest push $tag
                   done
 
-                  for arch_tag in $(cat /tmp/${{ matrix.image }}-arm64-tags.txt); do
+                  for arch_tag in $(cat /tmp/aiida-core/${{ matrix.image }}-arm64-tags.txt); do
                     tag=$(echo $arch_tag | sed "s/:arm64-/:/")
                     docker manifest create $tag --amend $arch_tag
                     docker manifest push $tag

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -85,12 +85,13 @@ jobs:
                       docker push ${arch_tag}
 
                       # write tag to file
-                      echo ${arch_tag} >> /tmp/${{ matrix.image }}-${{ inputs.architecture }}-tags.txt
+                      mkdir -p /tmp/aiida-core
+                      echo ${arch_tag} >> /tmp/aiida-core/${{ matrix.image }}-${{ inputs.architecture }}-tags.txt
                   done
 
             - name: Upload tags file 📤
               uses: actions/upload-artifact@v3
               with:
                   name: ${{ inputs.registry }}-${{ matrix.image }}-${{ inputs.architecture }}-tags
-                  path: /tmp/${{ matrix.image }}-${{ inputs.architecture }}-tags.txt
+                  path: /tmp/aiida-core/${{ matrix.image }}-${{ inputs.architecture }}-tags.txt
                   retention-days: 3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/workflows/docker-build-test-upload.yml
         with:
             architecture: arm64
-            runsOn: buildjet-2vcpu-ubuntu-2204-arm
+            runsOn: ARM64
         if: ${{ !github.event.pull_request.head.repo.fork }}
 
     amd64-push-ghcr:


### PR DESCRIPTION
The buildjet arm64 runner has only three-month trials, after that, we need to pay to use it. The self-hosted runner is deployed on the macOS-arm64 machine located in PSI. 