### PR TITLE
CLI: Fix `repository` being required for `verdi quicksetup`

### DIFF
--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -365,6 +365,7 @@ SETUP_BROKER_VIRTUAL_HOST = QUICKSETUP_BROKER_VIRTUAL_HOST.clone(
 
 SETUP_REPOSITORY_URI = QUICKSETUP_REPOSITORY_URI.clone(
     prompt='Repository directory',
+    required=True,
     callback=None,  # Unset the `callback` to define the default, which is instead done by the `contextual_default`
     contextual_default=get_repository_uri_default,
     cls=options.interactive.InteractiveOption

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -378,7 +378,7 @@ BROKER_VIRTUAL_HOST = OverridableOption(
 )
 
 REPOSITORY_PATH = OverridableOption(
-    '--repository', type=click.Path(file_okay=False), required=True, help='Absolute path to the file repository.'
+    '--repository', type=click.Path(file_okay=False), help='Absolute path to the file repository.'
 )
 
 PROFILE_ONLY_CONFIG = OverridableOption(

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -404,7 +404,7 @@ Below is a list with all available subcommands.
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
                                       leading forward slash.
-      --repository DIRECTORY          Absolute path to the file repository.  [required]
+      --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.
       --config FILEORURL              Load option values from configuration file in yaml


### PR DESCRIPTION
Regression added by c53ea20a497f66bc88f68d0603cf9a32614fc4c2 which made the `--repository` option for `verdi setup` required, as it should be. However, it did so by making the base option required. The problem is that the option for both `verdi setup` as well as `verdi quicksetup` inherit from this, but for `verdi quicksetup` it should not be required as the default will be populated automatically. As an alternative, the option specific for `verdi setup` is now made required.