### PR TITLE
Refactor: Replace `all` with `iterall` where beneficial

### DIFF
--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -371,7 +371,6 @@ def group_list(
         builder.append(orm.Node, filters={'id': {'==': node.pk}}, with_group='group')
 
     builder.order_by({orm.Group: {order_by: order_dir}})
-    result = builder.all()
 
     projection_lambdas = {
         'pk': lambda group: str(group.pk),
@@ -394,7 +393,7 @@ def group_list(
         projection_header.append('Node count')
         projection_fields.append('count')
 
-    for group in result:
+    for group in builder.iterall():
         table.append([projection_lambdas[field](group[0]) for field in projection_fields])
 
     if not all_entries:

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -369,10 +369,10 @@ def rehash(nodes, entry_point, force):
     else:
         builder = QueryBuilder()
         builder.append(classes, tag='node')
-        to_hash = builder.all()
+        to_hash = builder.iterall()
         num_nodes = builder.count()
 
-    if not to_hash:
+    if not num_nodes:
         echo.echo_critical('no matching nodes found')
 
     with click.progressbar(to_hash, label='Rehashing Nodes:') as iter_hash:

--- a/aiida/orm/nodes/caching.py
+++ b/aiida/orm/nodes/caching.py
@@ -138,8 +138,8 @@ class NodeCaching:
         builder.append(self._node.__class__, filters={f'extras.{self._HASH_EXTRA_KEY}': node_hash}, subclassing=False)
 
         return (
-            node for node in builder.all(flat=True) if node.base.caching.is_valid_cache
-        )  # type: ignore[misc,union-attr]
+            node for node, in builder.iterall() if node.base.caching.is_valid_cache  # type: ignore[misc,union-attr]
+        )
 
     @property
     def is_valid_cache(self) -> bool:

--- a/aiida/orm/utils/remote.py
+++ b/aiida/orm/utils/remote.py
@@ -125,7 +125,7 @@ def get_calcjob_remote_paths(  # pylint: disable=too-many-locals
 
     path_mapping = {}
 
-    for remote_data, computer_uuid in query.all():
+    for remote_data, computer_uuid in query.iterall():
         path_mapping.setdefault(computer_uuid, []).append(remote_data)
 
     return path_mapping


### PR DESCRIPTION
Whenever a `QueryBuilder` result is used in a loop and the total result
is not fully stored in memory in some way, it is beneficial to use
`iterall` since that prevents loading everything in memory for no
reason.