### PR TITLE
Docker stack build CI action enabled for any changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,17 +3,17 @@ name: Build, test and push Docker Images
 
 on:
     pull_request:
-        paths:
-            - .docker/**
-            - .github/workflows/docker-*.yml
+        paths-ignore:
+            - "docs/**"
+            - "tests/**"
     push:
         branches:
             - main
         tags:
             - "v*"
-        paths:
-            - .docker/**
-            - .github/workflows/docker-*.yml
+        paths-ignore:
+            - "docs/**"
+            - "tests/**"
     workflow_dispatch:
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency


### PR DESCRIPTION
The docker build CI was only activated when `.docker` or `.github/workflows/docker*.yaml` are changed. It prevent the build check from changes in src code which may potentially break the docker stack build. For example when CLI interface for `quicksetup` is changed or the interface for `computer/code` setup is changed, since the docker stack builds relies on running these commands inside.