### PR TITLE
`PsqlDosBackend`: Fix changes not persisted after `iterall` and `iterdict`

### DIFF
--- a/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -171,9 +171,8 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             # on the session when a yielded row is mutated. This would reset the cursor invalidating it and causing an
             # exception to be raised in the next batch of rows in the iteration.
             # See https://github.com/python/mypy/issues/10109 for the reason of the type warning.
-            in_nested_transaction = session.in_nested_transaction()
-
-            with nullcontext() if in_nested_transaction else session.begin_nested():  # type: ignore[attr-defined]
+            with nullcontext() if session.in_nested_transaction() else self._backend.transaction(
+            ):  # type: ignore[attr-defined]
                 for resultrow in session.execute(stmt):
                     yield [self.to_backend(rowitem) for rowitem in resultrow]
 
@@ -188,9 +187,8 @@ class SqlaQueryBuilder(BackendQueryBuilder):
             # on the session when a yielded row is mutated. This would reset the cursor invalidating it and causing an
             # exception to be raised in the next batch of rows in the iteration.
             # See https://github.com/python/mypy/issues/10109 for the reason of the type warning.
-            in_nested_transaction = session.in_nested_transaction()
-
-            with nullcontext() if in_nested_transaction else session.begin_nested():  # type: ignore[attr-defined]
+            with nullcontext() if session.in_nested_transaction() else self._backend.transaction(
+            ):  # type: ignore[attr-defined]
                 for row in self.get_session().execute(stmt):
                     # build the yield result
                     yield_result: Dict[str, Dict[str, Any]] = {}


### PR DESCRIPTION
Fixes #6133 
Fixes #6009 

The `iterall` and `iterdict` generators of the `QueryBuilder`
implementation for the `PsqlDosBackend` would open a transaction in
order for the `ModelWrapper` to not automatically commit the session
upon any mutation as that would invalidate the cursor. However, it did
not manually commit the session at the end of the iterator, causing any
mutations to be lost when the storage backend was reloaded.

This problem was not just present in the `iterall` and `iterdict`
methods of the `QueryBuilder` but rather the `transaction` method of the
`PsqlDosBackend` never commits the savepoint that is returned by the
`Session.begin_nested` call. Now the `transaction` explicitly commits
the savepoint after the yield and the `QueryBuilder` methods are updated
to simply use the `transaction` method of the storage backend, rather
than going directly to the session.

This change also required a change in the `SqliteZipBackend`, since the
`transaction` is now called during archive creation and import, but the
backend raised a `NotImplementedError`. This is because it used to be a
read-only backend, however, this limitation was recently lifted. The
commit simply forgot to implement the `transaction` method.