### PR TITLE
Verdi: Load config / profile lazily to speed up tab-completion

### DIFF
--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -176,28 +176,28 @@ SETUP_PROFILE = options.OverridableOption(
 
 SETUP_USER_EMAIL = options.USER_EMAIL.clone(
     prompt='Email Address (for sharing data)',
-    default=get_config_option('autofill.user.email'),
+    default=functools.partial(get_config_option, 'autofill.user.email'),
     required=True,
     cls=options.interactive.InteractiveOption
 )
 
 SETUP_USER_FIRST_NAME = options.USER_FIRST_NAME.clone(
     prompt='First name',
-    default=get_config_option('autofill.user.first_name'),
+    default=functools.partial(get_config_option, 'autofill.user.first_name'),
     required=True,
     cls=options.interactive.InteractiveOption
 )
 
 SETUP_USER_LAST_NAME = options.USER_LAST_NAME.clone(
     prompt='Last name',
-    default=get_config_option('autofill.user.last_name'),
+    default=functools.partial(get_config_option, 'autofill.user.last_name'),
     required=True,
     cls=options.interactive.InteractiveOption
 )
 
 SETUP_USER_INSTITUTION = options.USER_INSTITUTION.clone(
     prompt='Institution',
-    default=get_config_option('autofill.user.institution'),
+    default=functools.partial(get_config_option, 'autofill.user.institution'),
     required=True,
     cls=options.interactive.InteractiveOption
 )

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -205,11 +205,12 @@ repository: {tmp_path}"""
         postgres.create_db(db_user, db_name)
 
         profile_name = 'profile-copy'
+        user_email = 'some@email.com'
         profile_uuid = str(uuid.uuid4)
         options = [
             '--non-interactive', '--profile', profile_name, '--profile-uuid', profile_uuid, '--db-backend',
             self.storage_backend_name, '--db-name', db_name, '--db-username', db_user, '--db-password', db_pass,
-            '--db-port', self.pg_test.dsn['port']
+            '--db-port', self.pg_test.dsn['port'], '--email', user_email
         ]
 
         self.cli_runner(cmd_setup.setup, options, use_subprocess=False)


### PR DESCRIPTION
As discussed in https://github.com/aiidateam/aiida-core/issues/6117#issuecomment-1731415983, we want to avoid loading the config file in verdi CLI until it is really needed. This is especially important for speeding up tab-completion.

There are several changes here:

1. Load config lazily in VerdiContext. TODO: I am not super happy about my implementation, better ideas are welcomed! Note that `VerdiContext` has only been introduced recently in #5544, previously the config was loaded lazily as well it seems.
2. Pass expensive defaults that depend on profile as callbacks to click. Passing a function as default is allowed by click and we're already doing that in bunch of places.
3. TODO: It looks like Click evaluates defaults even during tab-completion, since version 8.0. Point 2. above is for now not effective until we override this behavior. We can detect tab-completion via Click context `ctx.resilient_parsing`. EDIT: Postponed for a separate PR.

For point 3 I created an issue on the click repo, let's see what they say https://github.com/pallets/click/issues/2614

Benchmark after implementing points 1. and 2.

## `verdi --version` (main)

```console
Benchmark 1: verdi --version
  Time (mean ± σ):     256.6 ms ±   5.4 ms    [User: 222.2 ms, System: 32.5 ms]
  Range (min … max):   242.3 ms … 262.1 ms    12 runs
```

## `verdi --version` (this PR)

```console
verdi --version
  Time (mean ± σ):     211.8 ms ±   8.9 ms    [User: 178.6 ms, System: 31.3 ms]
  Range (min … max):   183.8 ms … 218.6 ms    13 runs
```