### PR TITLE
DevOps: amendment use aiida-core-base image from ghcr.io

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
             retries: 10
 
     daemon:
-        image: aiidateam/aiida-core-base:edge
+        image: ghcr.io/aiidateam/aiida-core-base:edge
         user: aiida
         entrypoint: tail -f /dev/null
         environment:


### PR DESCRIPTION
Amendment to #6139, for unknown reason, docker pull is failed for docker.io on this repository. Using the docker registry `ghcr.io` works fine. 