### PR TITLE
FIX: Do not evaluate callable defaults during tab-completion

### DIFF
--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -14,6 +14,7 @@
 # yapf: disable
 # pylint: disable=wildcard-import
 
+from .callable import *
 from .config import *
 from .main import *
 from .multivalue import *
@@ -39,6 +40,7 @@ __all__ = (
     'COMPUTER',
     'COMPUTERS',
     'CONFIG_FILE',
+    'CallableDefaultOption',
     'ConfigFileOption',
     'DATA',
     'DATUM',

--- a/aiida/cmdline/params/options/callable.py
+++ b/aiida/cmdline/params/options/callable.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+.. py:module::callable
+    :synopsis: A monkey-patched subclass of click.Option that does not evaluate callable default during tab completion
+"""
+
+import typing as t
+
+import click
+
+__all__ = ('CallableDefaultOption',)
+
+
+class CallableDefaultOption(click.Option):
+    """A monkeypatch for click.Option that does not evaluate default callbacks during tab completion
+
+    This is a temporary solution until a proper fix is implemented in click, see:
+    https://github.com/pallets/click/issues/2614
+    """
+
+    def get_default(self, ctx: click.Context, call: bool = True) -> t.Optional[t.Union[t.Any, t.Callable[[], t.Any]]]:
+        """provides the functionality of :meth:`click.Option.get_default`,
+        but ensures we do not evaluate callable defaults when in tab-completion context."""
+        if ctx.resilient_parsing:
+            return None
+        return super().get_default(ctx=ctx, call=call)

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -158,7 +158,7 @@ class InteractiveOption(ConditionalOption):
         if self._contextual_default is not None:
             default = self._contextual_default(ctx)
         else:
-            default = super().get_default(ctx)
+            default = super().get_default(ctx, call=call)
 
         try:
             default = self.type.deconvert_default(default)

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -111,8 +111,10 @@ def set_log_level(_ctx, _param, value):
     log.CLI_ACTIVE = True
 
     # If the value is ``None``, it means the option was not specified, but we still configure logging for the CLI
+    # However, we skip this when we are in a tab-completion context.
     if value is None:
-        configure_logging()
+        if not _ctx.resilient_parsing:
+            configure_logging()
         return None
 
     try:

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -16,6 +16,7 @@ from aiida.manage.external.rmq import BROKER_DEFAULTS
 
 from .. import types
 from ...utils import defaults, echo  # pylint: disable=no-name-in-module
+from .callable import CallableDefaultOption
 from .config import ConfigFileOption
 from .multivalue import MultipleValueOption
 from .overridable import OverridableOption
@@ -145,6 +146,7 @@ PROFILE = OverridableOption(
     'profile',
     type=types.ProfileParamType(),
     default=defaults.get_default_profile,
+    cls=CallableDefaultOption,
     help='Execute the command for this profile instead of the default profile.'
 )
 

--- a/tests/cmdline/params/options/test_callable.py
+++ b/tests/cmdline/params/options/test_callable.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`aiida.cmdline.params.options.callable` module."""
+from click.shell_completion import ShellComplete
+import pytest
+
+from aiida.cmdline.commands.cmd_verdi import verdi
+
+
+def _get_completions(cli, args, incomplete):
+    comp = ShellComplete(cli, {}, cli.name, '_CLICK_COMPLETE')
+    return comp.get_completions(args, incomplete)
+
+
+@pytest.fixture
+def unload_config():
+    """Temporarily unload the config by setting ``aiida.manage.configuration.CONFIG`` to ``None``."""
+    from aiida.manage import configuration
+
+    config = configuration.CONFIG
+    configuration.CONFIG = None
+    yield
+    configuration.CONFIG = config
+
+
+@pytest.mark.usefixtures('unload_config')
+def test_callable_default_resilient_parsing():
+    """Test that tab-completion of ``verdi`` does not evaluate defaults that load the config, which is expensive."""
+    from aiida.manage import configuration
+
+    assert configuration.CONFIG is None
+    completions = [c.value for c in _get_completions(verdi, [], '')]
+    assert 'help' in completions
+    assert configuration.CONFIG is None


### PR DESCRIPTION
In #6140 we've tried to speed up verdi invocation by lazy loading config / profile. Unfortunately, the configuration is still being loaded during tab-completion.

After fair amount of going through the code in both click and aiida, I now think this is a bug in click, see https://github.com/pallets/click/issues/2614. I've devised a fix that passes the click test suite so it seems that the current behavior is unintented.

I will submit a PR to click, but given the speedup that we stand to gain (~50ms) for such a time-sensitive thing as tab-completion, I think it is worth fixing here for the next aiida-core release, which I suspect will happen before the next click release.

I've verified that with this fix, the profile is indeed not being loaded during tab-completion, by stucking `raise ValueError` in the `aiida.manage.configuration.get_config()` and observing that it raises on main and does not raise here during tab completion.

It would be great to have a regression test for this, but I am not sure how to do it. Here's how click tests it: https://github.com/pallets/click/blob/main/tests/test_shell_completion.py
