### PR TITLE
Repository: Add the `as_path` context manager

### DIFF
--- a/aiida/orm/nodes/data/folder.py
+++ b/aiida/orm/nodes/data/folder.py
@@ -88,6 +88,18 @@ class FolderData(Data):
         with self.base.repository.open(path, mode) as handle:
             yield handle
 
+    @contextlib.contextmanager
+    def as_path(self, path: FilePath | None = None) -> Iterator[pathlib.Path]:
+        """Make the contents of the repository available as a normal filepath on the local file system.
+
+        :param path: optional relative path of the object within the repository.
+        :return: the filepath of the content of the repository or object if ``path`` is specified.
+        :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+        :raises FileNotFoundError: if no object exists for the given path.
+        """
+        with self.base.repository.as_path(path) as filepath:
+            yield filepath
+
     def get_object(self, path: FilePath | None = None) -> File:
         """Return the object at the given path.
 

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -92,6 +92,18 @@ class SinglefileData(Data):
         with self.base.repository.open(path, mode=mode) as handle:
             yield handle
 
+    @contextlib.contextmanager
+    def as_path(self) -> t.Iterator[pathlib.Path]:
+        """Make the contents of the file available as a normal filepath on the local file system.
+
+        :param path: optional relative path of the object within the repository.
+        :return: the filepath of the content of the repository or object if ``path`` is specified.
+        :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+        :raises FileNotFoundError: if no object exists for the given path.
+        """
+        with self.base.repository.as_path(self.filename) as filepath:
+            yield filepath
+
     def get_content(self, mode: str = 'r') -> str | bytes:
         """Return the content of the single file stored for this data node.
 

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -21,6 +21,7 @@ py:class json.encoder.JSONEncoder
 py:class EXPOSED_TYPE
 py:class EVENT_CALLBACK_TYPE
 py:class datetime
+py:meth tempfile.TemporaryDirectory
 
 ### AiiDA
 py:class ReturnType

--- a/tests/orm/nodes/data/test_folder.py
+++ b/tests/orm/nodes/data/test_folder.py
@@ -30,6 +30,7 @@ def test_constructor_tree(tmp_path):
         'list_objects',
         'list_object_names',
         'open',
+        'as_path',
         'get_object',
         'get_object_content',
         'put_object_from_bytes',

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -216,7 +216,7 @@ def test_glob():
 
 
 def test_copy_tree(tmp_path):
-    """Test the ``Repository.copy_tree`` method."""
+    """Test the ``NodeRepository.copy_tree`` method."""
     node = Data()
     node.base.repository.put_object_from_bytes(b'content', 'relative/path')
 
@@ -236,3 +236,26 @@ def test_deprecated_methods(monkeypatch):
     for method in node._deprecated_repo_methods:
         with pytest.warns(AiidaDeprecationWarning):
             getattr(node, method)
+
+
+def test_as_path():
+    """Test the ``NodeRepository.as_path`` method."""
+    node = Data()
+    node.base.repository.put_object_from_bytes(b'content_some_file', 'some_file.txt')
+    node.base.repository.put_object_from_bytes(b'content_relative', 'relative/path.dat')
+
+    with pytest.raises(FileNotFoundError):
+        with node.base.repository.as_path('non_existent'):
+            pass
+
+    with node.base.repository.as_path() as dirpath:
+        assert sorted([p.name for p in dirpath.iterdir()]) == ['relative', 'some_file.txt']
+        assert (dirpath / 'some_file.txt').read_bytes() == b'content_some_file'
+        assert (dirpath / 'relative' / 'path.dat').read_bytes() == b'content_relative'
+
+    with node.base.repository.as_path('relative') as dirpath:
+        assert sorted([p.name for p in dirpath.iterdir()]) == ['path.dat']
+        assert (dirpath / 'path.dat').read_bytes() == b'content_relative'
+
+    with node.base.repository.as_path('relative/path.dat') as filepath:
+        assert filepath.read_bytes() == b'content_relative'

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -252,10 +252,13 @@ def test_as_path():
         assert sorted([p.name for p in dirpath.iterdir()]) == ['relative', 'some_file.txt']
         assert (dirpath / 'some_file.txt').read_bytes() == b'content_some_file'
         assert (dirpath / 'relative' / 'path.dat').read_bytes() == b'content_relative'
+    assert not dirpath.exists()
 
     with node.base.repository.as_path('relative') as dirpath:
         assert sorted([p.name for p in dirpath.iterdir()]) == ['path.dat']
         assert (dirpath / 'path.dat').read_bytes() == b'content_relative'
+    assert not dirpath.exists()
 
     with node.base.repository.as_path('relative/path.dat') as filepath:
         assert filepath.read_bytes() == b'content_relative'
+    assert not filepath.exists()


### PR DESCRIPTION
The node repository interface intentionally does not provide access to
its file objects through filepaths on the file system. This is because,
for efficiency reasons, the content of a repository may not actually be
stored as individual files on a file system, but for example are stored
in an object store.

Therefore, the contents of the repository can only be retrieved as a
file-like object or read as a string or list of bytes into memory.
Certain use-cases require a file to be made available through a filepath.
An example is when it needs to be passed to an API that only accepts a
filepath, such as `numpy.loadfromtxt`.

Currently, the user will have to manually copy the content of the repo's
content to a temporary file on disk, and pass the temporary filepath.
This results in clients having to often resport to the following snippet:

```python
import pathlib
import shutil
import tempfile

with tempfile.TemporaryDirectory() as tmp_path:

    # Copy the entire content to the temporary folder
    dirpath = pathlib.Path(tmp_path)
    node.base.repository.copy_tree(dirpath)

    # Or copy the content of a file. Should use streaming
    # to avoid reading everything into memory
    filepath = (dirpath / 'some_file.txt')
    with filepath.open('rb') as target:
        with node.base.repository.open('rb') as source:
            shutil.copyfileobj(source, target)

    # Now use `filepath` to library call, e.g.
    numpy.loadtxt(filepath)
```

This logic is now provided under the `as_path` context manager. This
will make it easy to access repository content as files on the local
file system. A warning is added to the docs explaining the inefficiency
of the content having to be read and written to a temporary directory
first, encouraging it only to be used when the alternative is not an
option.