### PR TITLE
CLI: Add `cached` and `cached_from` projections to `verdi process list`

### DIFF
--- a/.github/system_tests/test_daemon.py
+++ b/.github/system_tests/test_daemon.py
@@ -37,6 +37,7 @@ from aiida.engine.persistence import ObjectLoader
 from aiida.engine.processes import CalcJob, Process
 from aiida.manage.caching import enable_caching
 from aiida.orm import CalcJobNode, Dict, Int, List, Str, load_code, load_node
+from aiida.orm.nodes.caching import NodeCaching
 from aiida.plugins import CalculationFactory, WorkflowFactory
 from aiida.workflows.arithmetic.add_multiply import add, add_multiply
 from tests.utils.memory import get_instances  # pylint: disable=import-error
@@ -207,14 +208,14 @@ def validate_cached(cached_calcs):
             print_report(calc.pk)
             valid = False
 
-        if '_aiida_cached_from' not in calc.base.extras or calc.base.caching.get_hash(
+        if NodeCaching.CACHED_FROM_KEY not in calc.base.extras or calc.base.caching.get_hash(
         ) != calc.base.extras.get('_aiida_hash'):
             print(f'Cached calculation<{calc.pk}> has invalid hash')
             print_report(calc.pk)
             valid = False
 
         if isinstance(calc, CalcJobNode):
-            original_calc = load_node(calc.base.extras.get('_aiida_cached_from'))
+            original_calc = load_node(calc.base.extras.get(NodeCaching.CACHED_FROM_KEY))
             files_original = original_calc.base.repository.list_object_names()
             files_cached = calc.base.repository.list_object_names()
 

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -95,6 +95,11 @@ def process_list(
     tabulated = tabulate(projected, headers=headers)
     echo.echo(tabulated)
     echo.echo(f'\nTotal results: {len(projected)}\n')
+
+    if 'cached' in project:
+        echo.echo_report('\u267B Processes marked with check-mark were not run but taken from the cache.')
+        echo.echo_report('Add the option `-P pk cached_from` to the command to display cache source.')
+
     print_last_process_state_change()
 
     if not get_daemon_client().is_daemon_running:

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -87,12 +87,12 @@ def print_last_process_state_change(process_type=None):
     timestamp = get_process_state_change_timestamp(process_type)
 
     if timestamp is None:
-        echo_report('last time an entry changed state: never')
+        echo_report('Last time an entry changed state: never')
     else:
         timedelta = timezone.delta(timestamp)
         formatted = format_local_time(timestamp, format_str='at %H:%M:%S on %Y-%m-%d')
         relative = str_timedelta(timedelta, negative_to_zero=True, max_num_fields=1)
-        echo_report(f'last time an entry changed state: {relative} ({formatted})')
+        echo_report(f'Last time an entry changed state: {relative} ({formatted})')
 
 
 def get_node_summary(node):

--- a/aiida/orm/nodes/caching.py
+++ b/aiida/orm/nodes/caching.py
@@ -18,6 +18,7 @@ class NodeCaching:
     # The keys in the extras that are used to store the hash of the node and whether it should be used in caching.
     _HASH_EXTRA_KEY: str = '_aiida_hash'
     _VALID_CACHE_KEY: str = '_aiida_valid_cache'
+    CACHED_FROM_KEY: str = '_aiida_cached_from'
 
     def __init__(self, node: 'Node') -> None:
         """Initialize the caching interface."""
@@ -82,7 +83,7 @@ class NodeCaching:
 
         :return: source node UUID or None
         """
-        return self._node.base.extras.get('_aiida_cached_from', None)
+        return self._node.base.extras.get(self.CACHED_FROM_KEY, None)
 
     @property
     def is_created_from_cache(self) -> bool:

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -539,7 +539,7 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
 
         self._store(clean=False)
         self._add_outputs_from_cache(cache_node)
-        self.base.extras.set('_aiida_cached_from', cache_node.uuid)
+        self.base.extras.set(self.base.caching.CACHED_FROM_KEY, cache_node.uuid)
 
     def _add_outputs_from_cache(self, cache_node: 'Node') -> None:
         """Replicate the output links and nodes from the cached node onto this node."""

--- a/aiida/tools/query/calculation.py
+++ b/aiida/tools/query/calculation.py
@@ -19,11 +19,11 @@ class CalculationQueryBuilder:
     # This tuple serves to mark compound projections that cannot explicitly be projected in the QueryBuilder, but will
     # have to be manually projected from composing its individual projection constituents
     _compound_projections = ('state',)
-    _default_projections = ('pk', 'ctime', 'process_label', 'state', 'process_status')
+    _default_projections = ('pk', 'ctime', 'process_label', 'cached', 'state', 'process_status')
     _valid_projections = (
         'pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'process_status', 'exit_status', 'exit_message',
         'sealed', 'process_label', 'label', 'description', 'node_type', 'paused', 'process_type', 'job_state',
-        'scheduler_state', 'exception'
+        'scheduler_state', 'exception', 'cached', 'cached_from'
     )
 
     def __init__(self, mapper=None):
@@ -125,6 +125,7 @@ class CalculationQueryBuilder:
             for projection in self._valid_projections
             if projection not in self._compound_projections
         ]
+        unique_projections = list(set(projected_attributes))
 
         if filters is None:
             filters = {}
@@ -133,7 +134,7 @@ class CalculationQueryBuilder:
             filters['ctime'] = {'>': timezone.now() - datetime.timedelta(days=past_days)}
 
         builder = orm.QueryBuilder()
-        builder.append(cls=orm.ProcessNode, filters=filters, project=projected_attributes, tag='process')
+        builder.append(cls=orm.ProcessNode, filters=filters, project=unique_projections, tag='process')
 
         if relationships is not None:
             for tag, entity in relationships.items():

--- a/aiida/tools/query/mapping.py
+++ b/aiida/tools/query/mapping.py
@@ -80,6 +80,7 @@ class CalculationProjectionMapper(ProjectionMapper):
     def __init__(self, projections, projection_labels=None, projection_attributes=None, projection_formatters=None):
         # pylint: disable=too-many-locals
         from aiida.orm import ProcessNode
+        from aiida.orm.nodes.caching import NodeCaching
         from aiida.orm.utils.mixins import Sealable
 
         self._valid_projections = projections
@@ -94,8 +95,16 @@ class CalculationProjectionMapper(ProjectionMapper):
         exit_status_key = f'attributes.{ProcessNode.EXIT_STATUS_KEY}'
         exit_message_key = f'attributes.{ProcessNode.EXIT_MESSAGE_KEY}'
         exception_key = f'attributes.{ProcessNode.EXCEPTION_KEY}'
+        cached_from_key = f'extras.{NodeCaching.CACHED_FROM_KEY}'
 
-        default_labels = {'pk': 'PK', 'uuid': 'UUID', 'ctime': 'Created', 'mtime': 'Modified', 'state': 'Process State'}
+        default_labels = {
+            'pk': 'PK',
+            'uuid': 'UUID',
+            'ctime': 'Created',
+            'mtime': 'Modified',
+            'state': 'Process State',
+            'cached': '\u267B'
+        }
 
         default_attributes = {
             'pk': 'id',
@@ -109,15 +118,17 @@ class CalculationProjectionMapper(ProjectionMapper):
             'exit_status': exit_status_key,
             'exit_message': exit_message_key,
             'exception': exception_key,
+            'cached': cached_from_key,
+            'cached_from': cached_from_key,
         }
 
         default_formatters = {
             'ctime': lambda value: formatting.format_relative_time(value['ctime']),
             'mtime': lambda value: formatting.format_relative_time(value['mtime']),
-            'state': lambda value: formatting.
-            format_state(value[process_state_key], value[process_paused_key], value[exit_status_key]),
+            'state': lambda v: formatting.format_state(v[process_state_key], v[process_paused_key], v[exit_status_key]),
             'process_state': lambda value: formatting.format_process_state(value[process_state_key]),
             'sealed': lambda value: formatting.format_sealed(value[sealed_key]),
+            'cached': lambda value: '\u2714' if value[cached_from_key] else '',
         }
 
         if projection_labels is not None:

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -45,7 +45,7 @@ class TestVerdiProcess:
         result = run_cli_command(cmd_process.process_list)
 
         assert 'Total results:' in result.output
-        assert 'last time an entry changed state' in result.output
+        assert 'Last time an entry changed state' in result.output
 
     def test_list(self, run_cli_command):
         """Test the list command."""

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -20,6 +20,7 @@ from aiida.common.lang import override
 from aiida.engine import ExitCode, ExitCodesNamespace, Process, run, run_get_node, run_get_pk
 from aiida.engine.processes.ports import PortNamespace
 from aiida.manage.caching import enable_caching
+from aiida.orm.nodes.caching import NodeCaching
 from aiida.plugins import CalculationFactory
 from tests.utils import processes as test_processes
 
@@ -210,13 +211,13 @@ class TestProcess:
             _, node1 = run_get_node(test_processes.InvalidateCaching, return_exit_code=orm.Bool(False))
             _, node2 = run_get_node(test_processes.InvalidateCaching, return_exit_code=orm.Bool(False))
             assert node1.base.extras.get('_aiida_hash') == node2.base.extras.get('_aiida_hash')
-            assert '_aiida_cached_from' in node2.base.extras
+            assert NodeCaching.CACHED_FROM_KEY in node2.base.extras
 
         with enable_caching():
             _, node3 = run_get_node(test_processes.InvalidateCaching, return_exit_code=orm.Bool(True))
             _, node4 = run_get_node(test_processes.InvalidateCaching, return_exit_code=orm.Bool(True))
             assert node3.base.extras.get('_aiida_hash') == node4.base.extras.get('_aiida_hash')
-            assert '_aiida_cached_from' not in node4.base.extras
+            assert NodeCaching.CACHED_FROM_KEY not in node4.base.extras
 
     def test_valid_cache_hook(self):
         """
@@ -228,13 +229,13 @@ class TestProcess:
             _, node1 = run_get_node(test_processes.IsValidCacheHook)
             _, node2 = run_get_node(test_processes.IsValidCacheHook)
             assert node1.base.extras.get('_aiida_hash') == node2.base.extras.get('_aiida_hash')
-            assert '_aiida_cached_from' in node2.base.extras
+            assert NodeCaching.CACHED_FROM_KEY in node2.base.extras
 
         with enable_caching():
             _, node3 = run_get_node(test_processes.IsValidCacheHook, not_valid_cache=orm.Bool(True))
             _, node4 = run_get_node(test_processes.IsValidCacheHook, not_valid_cache=orm.Bool(True))
             assert node3.base.extras.get('_aiida_hash') == node4.base.extras.get('_aiida_hash')
-            assert '_aiida_cached_from' not in node4.base.extras
+            assert NodeCaching.CACHED_FROM_KEY not in node4.base.extras
 
     def test_process_type_with_entry_point(self):
         """For a process with a registered entry point, the process_type will be its formatted entry point string."""


### PR DESCRIPTION
The `cached` projection will print a checkmark for nodes that were
cached from another node. The `cached_from` projection will show the
UUID of the cache source, if it exists.

The `cached` projection is added to the default projections for `verdi
process list`. The use of caching is becoming more prevalent, but often
users can still be surprised by certain behavior when processes are
taken from cache when they didn't expect it. By showing whether a
process was taken from cache or not by default in the output of `verdi
process list` should provide clarity since this is often the first place
that users check.