### PR TITLE
CLI: Keep list unique in `verdi config set --append`

### DIFF
--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -142,7 +142,7 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
         if not isinstance(current, list):
             echo.echo_critical(f'cannot append/remove to value: {current}')
         if append:
-            value = current + [value]
+            value = list(set(current + [value]))
         else:
             value = [item for item in current if item != value]
 

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -49,10 +49,10 @@ def test_config_append_option(run_cli_command, config_with_profile_factory):
     """Test the `verdi config set --append` command when appending an option value."""
     config = config_with_profile_factory()
     option_name = 'caching.enabled_for'
-    for value in ['x', 'y']:
+    for value in ['x', 'y', 'x', 'y']:
         options = ['config', 'set', '--append', option_name, value]
         run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
-    assert config.get_option(option_name, scope=get_profile().name) == ['x', 'y']
+    assert sorted(config.get_option(option_name, scope=get_profile().name)) == ['x', 'y']
 
 
 def test_config_remove_option(run_cli_command, config_with_profile_factory):
@@ -60,7 +60,7 @@ def test_config_remove_option(run_cli_command, config_with_profile_factory):
     config = config_with_profile_factory()
 
     option_name = 'caching.disabled_for'
-    config.set_option(option_name, ['x', 'y'], scope=get_profile().name)
+    config.set_option(option_name, ['x', 'x', 'y', 'x'], scope=get_profile().name)
 
     options = ['config', 'set', '--remove', option_name, 'x']
     run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)


### PR DESCRIPTION
Fixes #6160 

When calling the command multiple times for the same value, it would be added multiple times to the list, even though in all cases a unique list would be expected.