### PR TITLE
Docker: Pass environment variable to aiida-prepare script

### DIFF
--- a/.docker/aiida-core-base/s6-assets/s6-rc.d/aiida-prepare/up
+++ b/.docker/aiida-core-base/s6-assets/s6-rc.d/aiida-prepare/up
@@ -1,4 +1,6 @@
 #!/command/execlineb -S0
 
+with-contenv
+
 foreground { s6-echo "Calling /etc/init/aiida-prepare" }
 /etc/init/aiida-prepare.sh

--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -31,6 +31,7 @@ def test_verdi_status(aiida_exec, container_user, timeout):
     # check that we have suppressed the warnings
     assert 'Warning' not in output
 
+
 def test_computer_setup_success(aiida_exec, container_user, timeout):
     time.sleep(timeout)
     output = aiida_exec('verdi computer show localhost', user=container_user).decode().strip()

--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -36,5 +36,5 @@ def test_computer_setup_success(aiida_exec, container_user, timeout):
     time.sleep(timeout)
     output = aiida_exec('verdi computer test localhost', user=container_user).decode().strip()
 
-    assert "Success" in output
-    assert "Failed" not in output
+    assert 'Success' in output
+    assert 'Failed' not in output

--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -30,3 +30,8 @@ def test_verdi_status(aiida_exec, container_user, timeout):
 
     # check that we have suppressed the warnings
     assert 'Warning' not in output
+
+def test_computer_setup_success(aiida_exec, container_user, timeout):
+    time.sleep(timeout)
+    output = aiida_exec('verdi computer show localhost', user=container_user).decode().strip()
+    assert f'/home/{container_user}/aiida_run' in output

--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -34,5 +34,7 @@ def test_verdi_status(aiida_exec, container_user, timeout):
 
 def test_computer_setup_success(aiida_exec, container_user, timeout):
     time.sleep(timeout)
-    output = aiida_exec('verdi computer show localhost', user=container_user).decode().strip()
-    assert f'/home/{container_user}/aiida_run' in output
+    output = aiida_exec('verdi computer test localhost', user=container_user).decode().strip()
+
+    assert "Success" in output
+    assert "Failed" not in output


### PR DESCRIPTION
If the environment variable does not pass to the service script by `with-contenv`, the work dir of `localhost` will set with `/home//aiida_run` and the calculation will fail with permission denied.