### PR TITLE
Dependencies: Restore `sphinx-sqlalchemy`

### DIFF
--- a/docs/source/internals/storage/psql_dos.rst
+++ b/docs/source/internals/storage/psql_dos.rst
@@ -36,17 +36,17 @@ This is a 32-position hexadecimal sequence that is stored as a string with some 
   - ``→`` indicate foreign keys
   - ``?`` indicate value types that are nullable.
 
-..
-    .. sqla-model:: ~aiida.storage.psql_dos.models.user.DbUser
-    .. sqla-model:: ~aiida.storage.psql_dos.models.node.DbNode
-    .. sqla-model:: ~aiida.storage.psql_dos.models.node.DbLink
-    .. sqla-model:: ~aiida.storage.psql_dos.models.group.DbGroup
-    .. sqla-model:: ~aiida.storage.psql_dos.models.group.DbGroupNode
-    .. sqla-model:: ~aiida.storage.psql_dos.models.computer.DbComputer
-    .. sqla-model:: ~aiida.storage.psql_dos.models.authinfo.DbAuthInfo
-    .. sqla-model:: ~aiida.storage.psql_dos.models.comment.DbComment
-    .. sqla-model:: ~aiida.storage.psql_dos.models.log.DbLog
-    .. sqla-model:: ~aiida.storage.psql_dos.models.settings.DbSetting
+
+    sqla-model:: ~aiida.storage.psql_dos.models.user.DbUser
+    sqla-model:: ~aiida.storage.psql_dos.models.node.DbNode
+    sqla-model:: ~aiida.storage.psql_dos.models.node.DbLink
+    sqla-model:: ~aiida.storage.psql_dos.models.group.DbGroup
+    sqla-model:: ~aiida.storage.psql_dos.models.group.DbGroupNode
+    sqla-model:: ~aiida.storage.psql_dos.models.computer.DbComputer
+    sqla-model:: ~aiida.storage.psql_dos.models.authinfo.DbAuthInfo
+    sqla-model:: ~aiida.storage.psql_dos.models.comment.DbComment
+    sqla-model:: ~aiida.storage.psql_dos.models.log.DbLog
+    sqla-model:: ~aiida.storage.psql_dos.models.settings.DbSetting
 
 The many-to-one relationship
 ----------------------------

--- a/docs/source/internals/storage/sqlite_zip.rst
+++ b/docs/source/internals/storage/sqlite_zip.rst
@@ -83,15 +83,15 @@ The only differences are in the handling of certain data types by SQLite versus 
 
 Also, `varchar_pattern_ops` indexes are not possible in SQLite.
 
-..
-    Tables
-    ......
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbUser
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbNode
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbLink
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbGroup
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbGroupNodes
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbComputer
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbAuthInfo
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbComment
-    .. sqla-model:: ~aiida.storage.sqlite_zip.models.DbLog
+
+Tables
+......
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbUser
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbNode
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbLink
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbGroup
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbGroupNodes
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbComputer
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbAuthInfo
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbComment
+sqla-model:: ~aiida.storage.sqlite_zip.models.DbLog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ docs = [
     "sphinx-design~=0.0.13",
     "sphinx-notfound-page~=0.5",
     "sphinxext-rediraffe~=0.2.4",
-  #  "sphinx-sqlalchemy~=0.1.1",
+    "sphinx-sqlalchemy~=0.2.0",
     "sphinx-intl~=2.1.0",
     "myst-nb~=0.17.0",
 ]

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -178,6 +178,7 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.0.13
 sphinx-intl==2.1.0
 sphinx-notfound-page==0.8.3
+sphinx-sqlalchemy==0.2.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-details-directive==0.1.0
 sphinxcontrib-devhelp==1.0.2

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -177,6 +177,7 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.0.13
 sphinx-intl==2.1.0
 sphinx-notfound-page==0.8.3
+sphinx-sqlalchemy==0.2.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-details-directive==0.1.0
 sphinxcontrib-devhelp==1.0.2

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -180,6 +180,7 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.0.13
 sphinx-intl==2.1.0
 sphinx-notfound-page==0.8.3
+sphinx-sqlalchemy==0.2.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-details-directive==0.1.0
 sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
This dependency was temporarily removed since it didn't yet support sqlalchemy v2, but that has now been released with `v0.2.0`.