### PR TITLE
Add rsync/graphviz executables and jedi for autocompeletion

### DIFF
--- a/.docker/aiida-core-base/Dockerfile
+++ b/.docker/aiida-core-base/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update --yes && \
     # development tools
     git \
     openssh-client \
+    rsync \
+    graphviz \
     vim \
     # the gcc compiler need to build some python packages e.g. psutil and pymatgen
     build-essential \

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
 - get-annotations~=0.1
 - python-graphviz~=0.19
 - ipython>=7
+- jedi<0.19
 - jinja2~=3.0
 - kiwipy[rmq]~=0.7.7
 - importlib-metadata~=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "get-annotations~=0.1;python_version<'3.10'",
     "graphviz~=0.19",
     "ipython>=7",
+    "jedi<0.19",
     "jinja2~=3.0",
     "kiwipy[rmq]~=0.7.7",
     "importlib-metadata~=6.0",

--- a/requirements/requirements-py-3.12.txt
+++ b/requirements/requirements-py-3.12.txt
@@ -62,7 +62,7 @@ ipython==8.16.1
 ipython-genutils==0.2.0
 ipywidgets==8.1.1
 itsdangerous==2.1.2
-jedi==0.19.1
+jedi==0.18.2
 jinja2==3.1.2
 joblib==1.3.2
 jsonschema[format-nongpl]==3.2.0


### PR DESCRIPTION
- `rsync` is needed for the new backup mechenism.
- `graphviz` is needed for plot the provenance graph.
- `jedi` was not a dependency which will make the IPython (`verdi shell`) autocompletion not work for `node.inputs.<tab>`. 