### PR TITLE
Add the `report` method to `logging.LoggerAdapter`

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -41,6 +41,7 @@ class AiidaLoggerType(logging.Logger):
 
 setattr(logging, 'REPORT', LOG_LEVEL_REPORT)
 setattr(logging.Logger, 'report', report)
+setattr(logging.LoggerAdapter, 'report', report)
 
 # Convenience dictionary of available log level names and their log level integer
 LOG_LEVELS = {

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -48,6 +48,15 @@ class BrokenArithmeticAddParser(Parser):
         self.out('invalid_output', orm.Str('0'))
 
 
+class ReportArithmeticAddParser(Parser):
+    """Parser for an ``ArithmeticAddCalculation`` job that just logs a message at the ``REPORT`` level."""
+
+    def parse(self, **kwargs):
+        """Log a message at the ``REPORT`` level."""
+        self.logger.report('test the report method.')
+        self.out('sum', orm.Int(3))
+
+
 class TestParser:
     """Test backend entities and their collections"""
 
@@ -125,7 +134,7 @@ class TestParser:
         retrieved.store()
         retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
 
-        for cls in [ArithmeticAddParser, SimpleArithmeticAddParser]:
+        for cls in [ArithmeticAddParser, SimpleArithmeticAddParser, ReportArithmeticAddParser]:
             result, calcfunction = cls.parse_from_node(node)
 
             assert isinstance(result['sum'], orm.Int)


### PR DESCRIPTION
AiiDA defines the `REPORT` log level and adds the `report` method to the `logging.Logger` class so a log message can easily be emitted at that level. However, the logger of `Process` instances is a `LoggerAdapter` which does not inherit from `Logger` so the method also needs to be added there independently.