### PR TITLE
ORM: Switch to `pydantic` for code schema definition

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -138,6 +138,7 @@ py:meth click.Option.get_default
 py:meth fail
 
 py:class ComputedFieldInfo
+py:class pydantic.fields.Field
 py:class pydantic.main.BaseModel
 
 py:class requests.models.Response

--- a/src/aiida/cmdline/commands/cmd_code.py
+++ b/src/aiida/cmdline/commands/cmd_code.py
@@ -221,7 +221,7 @@ def show(code):
     table.append(['PK', code.pk])
     table.append(['UUID', code.uuid])
     table.append(['Type', code.entry_point.name])
-    for key in code.get_cli_options().keys():
+    for key in code.Model.model_fields.keys():
         try:
             table.append([key.capitalize().replace('_', ' '), getattr(code, key)])
         except AttributeError:
@@ -242,7 +242,7 @@ def export(code, output_file):
 
     code_data = {}
 
-    for key in code.get_cli_options().keys():
+    for key in code.Model.model_fields.keys():
         if key == 'computer':
             value = getattr(code, key).label
         else:

--- a/src/aiida/common/pydantic.py
+++ b/src/aiida/common/pydantic.py
@@ -1,0 +1,46 @@
+"""Utilities related to ``pydantic``."""
+from __future__ import annotations
+
+import typing as t
+
+from pydantic import Field
+
+
+def MetadataField(  # noqa: N802
+    default: t.Any | None = None,
+    *,
+    priority: int = 0,
+    short_name: str | None = None,
+    option_cls: t.Any | None = None,
+    **kwargs,
+):
+    """Return a :class:`pydantic.fields.Field` instance with additional metadata.
+
+    .. code-block:: python
+
+        class Model(BaseModel):
+
+            attribute: MetadataField('default', priority=1000, short_name='-A')
+
+    This is a utility function that constructs a ``Field`` instance with an easy interface to add additional metadata.
+    It is possible to add metadata using ``Annotated``::
+
+        class Model(BaseModel):
+
+            attribute: Annotated[str, {'metadata': 'value'}] = Field(...)
+
+    However, when requiring multiple metadata, this notation can make the model difficult to read. Since this utility
+    is only used to automatically build command line interfaces from the model definition, it is possible to restrict
+    which metadata are accepted.
+
+    :param priority: Used to order the list of all fields in the model. Ordering is done from small to large priority.
+    :param short_name: Optional short name to use for an option on a command line interface.
+    :param option_cls: The :class:`click.Option` class to use to construct the option.
+    """
+    field_info = Field(default, **kwargs)
+
+    for key, value in (('priority', priority), ('short_name', short_name), ('option_cls', option_cls)):
+        if value is not None:
+            field_info.metadata.append({key: value})
+
+    return field_info

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -219,7 +219,7 @@ def create_profile(
     from aiida.manage import get_manager
     from aiida.orm import User
 
-    storage_config = storage_cls.Configuration(**{k: v for k, v in kwargs.items() if v is not None}).model_dump()
+    storage_config = storage_cls.Model(**{k: v for k, v in kwargs.items() if v is not None}).model_dump()
     profile: Profile = config.create_profile(name=name, storage_cls=storage_cls, storage_config=storage_config)
 
     with profile_context(profile.name, allow_switch=True):

--- a/src/aiida/orm/nodes/data/code/abstract.py
+++ b/src/aiida/orm/nodes/data/code/abstract.py
@@ -10,19 +10,23 @@
 from __future__ import annotations
 
 import abc
-import collections
+import functools
 import pathlib
-from typing import TYPE_CHECKING
+import typing as t
 
+from pydantic import BaseModel, field_validator
+
+from aiida.cmdline.params.options.interactive import TemplateInteractiveOption
 from aiida.common import exceptions
 from aiida.common.folders import Folder
 from aiida.common.lang import type_check
+from aiida.common.pydantic import MetadataField
 from aiida.orm import Computer
 from aiida.plugins import CalculationFactory
 
 from ..data import Data
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from aiida.engine import ProcessBuilder
 
 __all__ = ('AbstractCode',)
@@ -39,6 +43,80 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
     _KEY_ATTRIBUTE_WITH_MPI: str = 'with_mpi'
     _KEY_ATTRIBUTE_WRAP_CMDLINE_PARAMS: str = 'wrap_cmdline_params'
     _KEY_EXTRA_IS_HIDDEN: str = 'hidden'  # Should become ``is_hidden`` once ``Code`` is dropped
+
+    class Model(BaseModel):
+        """Model describing required information to create an instance."""
+
+        label: str = MetadataField(
+            ...,
+            title='Label',
+            description='A unique label to identify the code by.',
+            short_name='-L',
+        )
+        description: str = MetadataField(
+            '',
+            title='Description',
+            description='Human-readable description, ideally including version and compilation environment.',
+            short_name='-D',
+        )
+        default_calc_job_plugin: t.Optional[str] = MetadataField(
+            None,
+            title='Default `CalcJob` plugin',
+            description='Entry point name of the default plugin (as listed in `verdi plugin list aiida.calculations`).',
+            short_name='-P',
+        )
+        use_double_quotes: bool = MetadataField(
+            False,
+            title='Escape using double quotes',
+            description='Whether the executable and arguments of the code in the submission script should be escaped '
+            'with single or double quotes.',
+        )
+        with_mpi: t.Optional[bool] = MetadataField(
+            None,
+            title='Run with MPI',
+            description='Whether the executable should be run as an MPI program. This option can be left unspecified '
+            'in which case `None` will be set and it is left up to the calculation job plugin or inputs '
+            'whether to run with MPI.',
+        )
+        prepend_text: str = MetadataField(
+            '',
+            title='Prepend script',
+            description='Bash commands that should be prepended to the run line in all submit scripts for this code.',
+            option_cls=functools.partial(
+                TemplateInteractiveOption,
+                extension='.bash',
+                header='PREPEND_TEXT: if there is any bash commands that should be prepended to the executable call '
+                'in all submit scripts for this code, type that between the equal signs below and save the file.',
+                footer='All lines that start with `#=`: will be ignored.',
+            ),
+        )
+        append_text: str = MetadataField(
+            '',
+            title='Append script',
+            description='Bash commands that should be appended to the run line in all submit scripts for this code.',
+            option_cls=functools.partial(
+                TemplateInteractiveOption,
+                extension='.bash',
+                header='APPEND_TEXT: if there is any bash commands that should be appended to the executable call '
+                'in all submit scripts for this code, type that between the equal signs below and save the file.',
+                footer='All lines that start with `#=`: will be ignored.',
+            ),
+        )
+
+        @field_validator('label')
+        @classmethod
+        def validate_label_uniqueness(cls, value: str) -> str:
+            """Validate that the label does not already exist."""
+            from aiida.orm import load_code
+
+            try:
+                load_code(value)
+            except exceptions.NotExistent:
+                return value
+            except exceptions.MultipleObjectsError as exception:
+                raise ValueError(f'Multiple codes with the label `{value}` already exist.') from exception
+            else:
+                raise ValueError(f'A code with the label `{value}` already exists.')
 
     def __init__(
         self,
@@ -302,95 +380,3 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         builder.code = self
 
         return builder
-
-    @staticmethod
-    def cli_validate_label_uniqueness(_, __, value):
-        """Validate the uniqueness of the label of the code."""
-        import click
-
-        from aiida.orm import load_code
-
-        try:
-            load_code(value)
-        except exceptions.NotExistent:
-            pass
-        except exceptions.MultipleObjectsError:
-            raise click.BadParameter(f'Multiple codes with the label `{value}` already exist.')
-        else:
-            raise click.BadParameter(f'A code with the label `{value}` already exists.')
-
-        return value
-
-    @classmethod
-    def get_cli_options(cls) -> collections.OrderedDict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        return collections.OrderedDict(cls._get_cli_options())
-
-    @classmethod
-    def _get_cli_options(cls) -> dict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        import click
-
-        from aiida.cmdline.params.options.interactive import TemplateInteractiveOption
-
-        return {
-            'label': {
-                'short_name': '-L',
-                'required': True,
-                'type': click.STRING,
-                'prompt': 'Label',
-                'help': 'A unique label to identify the code by.',
-                'callback': cls.cli_validate_label_uniqueness,
-            },
-            'description': {
-                'short_name': '-D',
-                'type': click.STRING,
-                'prompt': 'Description',
-                'help': 'Human-readable description, ideally including version and compilation environment.',
-            },
-            'default_calc_job_plugin': {
-                'short_name': '-P',
-                'type': click.STRING,
-                'prompt': 'Default `CalcJob` plugin',
-                'help': 'Entry point name of the default plugin (as listed in `verdi plugin list aiida.calculations`).',
-            },
-            'use_double_quotes': {
-                'is_flag': True,
-                'default': False,
-                'help': 'Whether the executable and arguments of the code in the submission script should be escaped '
-                'with single or double quotes.',
-                'prompt': 'Escape using double quotes',
-            },
-            'with_mpi': {
-                'is_flag': True,
-                'default': None,
-                'help': (
-                    'Whether the executable should be run as an MPI program. This option can be left unspecified '
-                    'in which case `None` will be set and it is left up to the calculation job plugin or inputs '
-                    'whether to run with MPI.'
-                ),
-                'prompt': 'Run with MPI',
-            },
-            'prepend_text': {
-                'cls': TemplateInteractiveOption,
-                'type': click.STRING,
-                'default': '',
-                'prompt': 'Prepend script',
-                'help': 'Bash commands that should be prepended to the run line in all submit scripts for this code.',
-                'extension': '.bash',
-                'header': 'PREPEND_TEXT: if there is any bash commands that should be prepended to the executable call '
-                'in all submit scripts for this code, type that between the equal signs below and save the file.',
-                'footer': 'All lines that start with `#=`: will be ignored.',
-            },
-            'append_text': {
-                'cls': TemplateInteractiveOption,
-                'type': click.STRING,
-                'default': '',
-                'prompt': 'Append script',
-                'help': 'Bash commands that should be appended to the run line in all submit scripts for this code.',
-                'extension': '.bash',
-                'header': 'APPEND_TEXT: if there is any bash commands that should be appended to the executable call '
-                'in all submit scripts for this code, type that between the equal signs below and save the file.',
-                'footer': 'All lines that start with `#=`: will be ignored.',
-            },
-        }

--- a/src/aiida/orm/nodes/data/code/installed.py
+++ b/src/aiida/orm/nodes/data/code/installed.py
@@ -17,12 +17,16 @@ from __future__ import annotations
 
 import pathlib
 
+from pydantic import field_validator, model_validator
+
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
+from aiida.common.pydantic import MetadataField
 from aiida.orm import Computer
 from aiida.orm.entities import from_backend_entity
 
+from .abstract import AbstractCode
 from .legacy import Code
 
 __all__ = ('InstalledCode',)
@@ -32,6 +36,57 @@ class InstalledCode(Code):
     """Data plugin representing an executable code on a remote computer."""
 
     _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE: str = 'filepath_executable'
+
+    class Model(AbstractCode.Model):
+        """Model describing required information to create an instance."""
+
+        computer: str = MetadataField(
+            ...,
+            title='Computer',
+            description='The remote computer on which the executable resides.',
+            short_name='-Y',
+            priority=2,
+        )
+        filepath_executable: str = MetadataField(
+            ...,
+            title='Filepath executable',
+            description='Filepath of the executable on the remote computer.',
+            short_name='-X',
+            priority=1,
+        )
+
+        @field_validator('label')
+        @classmethod
+        def validate_label_uniqueness(cls, value: str) -> str:
+            """Override the validator for the ``label`` of the base class since uniqueness is defined on full label."""
+            return value
+
+        @field_validator('computer')
+        @classmethod
+        def validate_computer(cls, value: str) -> Computer:
+            """Override the validator for the ``label`` of the base class since uniqueness is defined on full label."""
+            from aiida.orm import load_computer
+
+            try:
+                return load_computer(value)
+            except exceptions.NotExistent as exception:
+                raise ValueError(exception) from exception
+
+        @model_validator(mode='after')  # type: ignore[misc]
+        def validate_full_label_uniqueness(self) -> AbstractCode.Model:
+            """Validate that the full label does not already exist."""
+            from aiida.orm import load_code
+
+            full_label = f'{self.label}@{self.computer.label}'  # type: ignore[attr-defined]
+
+            try:
+                load_code(full_label)
+            except exceptions.NotExistent:
+                return self
+            except exceptions.MultipleObjectsError as exception:
+                raise ValueError(f'Multiple codes with the label `{full_label}` already exist.') from exception
+            else:
+                raise ValueError(f'A code with the label `{full_label}` already exists.')
 
     def __init__(self, computer: Computer, filepath_executable: str, **kwargs):
         """Construct a new instance.
@@ -148,55 +203,3 @@ class InstalledCode(Code):
         """
         type_check(value, str)
         self.base.attributes.set(self._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE, value)
-
-    @staticmethod
-    def cli_validate_label_uniqueness(ctx, _, value):
-        """Validate the uniqueness of the label of the code."""
-        import click
-
-        from aiida.orm import load_code
-
-        computer = ctx.params.get('computer', None)
-
-        if computer is None:
-            return value
-
-        full_label = f'{value}@{computer.label}'
-
-        try:
-            load_code(full_label)
-        except exceptions.NotExistent:
-            pass
-        except exceptions.MultipleObjectsError:
-            raise click.BadParameter(f'Multiple codes with the label `{full_label}` already exist.')
-        else:
-            raise click.BadParameter(f'A code with the label `{full_label}` already exists.')
-
-        return value
-
-    @classmethod
-    def _get_cli_options(cls) -> dict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        import click
-
-        from aiida.cmdline.params.types import ComputerParamType
-
-        options = {
-            'computer': {
-                'short_name': '-Y',
-                'required': True,
-                'prompt': 'Computer',
-                'help': 'The remote computer on which the executable resides.',
-                'type': ComputerParamType(),
-            },
-            'filepath_executable': {
-                'short_name': '-X',
-                'required': True,
-                'type': click.Path(exists=False),
-                'prompt': 'Absolute filepath executable',
-                'help': 'Absolute filepath of the executable on the remote computer.',
-            },
-        }
-        options.update(**super()._get_cli_options())
-
-        return options

--- a/src/aiida/orm/nodes/data/code/portable.py
+++ b/src/aiida/orm/nodes/data/code/portable.py
@@ -20,11 +20,15 @@ from __future__ import annotations
 
 import pathlib
 
+from pydantic import field_validator
+
 from aiida.common import exceptions
 from aiida.common.folders import Folder
 from aiida.common.lang import type_check
+from aiida.common.pydantic import MetadataField
 from aiida.orm import Computer
 
+from .abstract import AbstractCode
 from .legacy import Code
 
 __all__ = ('PortableCode',)
@@ -34,6 +38,35 @@ class PortableCode(Code):
     """Data plugin representing an executable code stored in AiiDA's storage."""
 
     _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE: str = 'filepath_executable'
+
+    class Model(AbstractCode.Model):
+        """Model describing required information to create an instance."""
+
+        filepath_files: str = MetadataField(
+            ...,
+            title='Code directory',
+            description='Filepath to directory containing code files.',
+            short_name='-F',
+            priority=2,
+        )
+        filepath_executable: str = MetadataField(
+            ...,
+            title='Filepath executable',
+            description='Relative filepath of executable with directory of code files.',
+            short_name='-X',
+            priority=1,
+        )
+
+        @field_validator('filepath_files')
+        @classmethod
+        def validate_filepath_files(cls, value: str) -> pathlib.Path:
+            """Validate that ``filepath_files`` is an existing directory."""
+            filepath = pathlib.Path(value)
+            if not filepath.exists():
+                raise ValueError(f'The filepath `{value}` does not exist.')
+            if not filepath.is_dir():
+                raise ValueError(f'The filepath `{value}` is not a directory.')
+            return filepath
 
     def __init__(self, filepath_executable: str, filepath_files: pathlib.Path, **kwargs):
         """Construct a new instance.
@@ -141,28 +174,3 @@ class PortableCode(Code):
             raise ValueError('The `filepath_executable` should not be absolute.')
 
         self.base.attributes.set(self._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE, value)
-
-    @classmethod
-    def _get_cli_options(cls) -> dict:
-        """Return the CLI options that would allow to create an instance of this class."""
-        import click
-
-        options = {
-            'filepath_executable': {
-                'short_name': '-X',
-                'required': True,
-                'type': click.STRING,
-                'prompt': 'Relative filepath executable',
-                'help': 'Relative filepath of executable with directory of code files.',
-            },
-            'filepath_files': {
-                'short_name': '-F',
-                'required': True,
-                'type': click.Path(exists=True, file_okay=False, dir_okay=True, path_type=pathlib.Path),
-                'prompt': 'Code directory',
-                'help': 'Filepath to directory containing code files.',
-            },
-        }
-        options.update(**super()._get_cli_options())
-
-        return options

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -71,7 +71,7 @@ class PsqlDosBackend(StorageBackend):
     The `django` backend was removed, to consolidate access to this storage.
     """
 
-    class Configuration(BaseModel):
+    class Model(BaseModel):
         """Model describing required information to configure an instance of the storage."""
 
         database_engine: str = Field(

--- a/src/aiida/storage/sqlite_dos/backend.py
+++ b/src/aiida/storage/sqlite_dos/backend.py
@@ -95,7 +95,7 @@ class SqliteDosStorage(PsqlDosBackend):
 
     migrator = SqliteDosMigrator
 
-    class Configuration(BaseModel):
+    class Model(BaseModel):
         """Model describing required information to configure an instance of the storage."""
 
         filepath: str = Field(

--- a/src/aiida/storage/sqlite_temp/backend.py
+++ b/src/aiida/storage/sqlite_temp/backend.py
@@ -42,7 +42,7 @@ class SqliteTempBackend(StorageBackend):
     and destroys it when it is garbage collected.
     """
 
-    class Configuration(BaseModel):
+    class Model(BaseModel):
         filepath: str = Field(
             title='Temporary directory',
             description='Temporary directory in which to store data for this backend.',

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -67,7 +67,7 @@ class SqliteZipBackend(StorageBackend):
     read_only = True
     """This plugin is read only and data cannot be created or mutated."""
 
-    class Configuration(BaseModel):
+    class Model(BaseModel):
         """Model describing required information to configure an instance of the storage."""
 
         filepath: str = Field(title='Filepath of the archive', description='Filepath of the archive.')

--- a/tests/cmdline/groups/test_dynamic.py
+++ b/tests/cmdline/groups/test_dynamic.py
@@ -9,7 +9,7 @@ from pydantic_core import PydanticUndefined
 class CustomClass:
     """Test plugin class."""
 
-    class Configuration(BaseModel):
+    class Model(BaseModel):
         """Model configuration."""
 
         optional_type: t.Union[int, float] = Field(title='Optional type')
@@ -27,6 +27,6 @@ def test_list_options(entry_points):
 
     for option_decorators in group.list_options('custom'):
         option = option_decorators(lambda x: True).__click_params__[0]
-        field = CustomClass.Configuration.model_fields[option.name]
+        field = CustomClass.Model.model_fields[option.name]
         assert option.default == field.default_factory if field.default is PydanticUndefined else field.default
         assert option.type == t.get_args(field.annotation) or field.annotation

--- a/tests/storage/sqlite_dos/test_backend.py
+++ b/tests/storage/sqlite_dos/test_backend.py
@@ -6,8 +6,8 @@ from aiida.storage.sqlite_dos.backend import SqliteDosStorage
 
 
 @pytest.mark.usefixtures('chdir_tmp_path')
-def test_configuration():
-    """Test :class:`aiida.storage.sqlite_dos.backend.SqliteDosStorage.Configuration`."""
+def test_model():
+    """Test :class:`aiida.storage.sqlite_dos.backend.SqliteDosStorage.Model`."""
     filepath = pathlib.Path.cwd() / 'archive.aiida'
-    configuration = SqliteDosStorage.Configuration(filepath=filepath.name)
-    assert pathlib.Path(configuration.filepath).is_absolute()
+    model = SqliteDosStorage.Model(filepath=filepath.name)
+    assert pathlib.Path(model.filepath).is_absolute()

--- a/tests/storage/sqlite_zip/test_backend.py
+++ b/tests/storage/sqlite_zip/test_backend.py
@@ -51,13 +51,13 @@ def test_initialise_reset_false(tmp_path, aiida_caplog):
 
 
 @pytest.mark.usefixtures('chdir_tmp_path')
-def test_configuration():
-    """Test :class:`aiida.storage.sqlite_zip.backend.SqliteZipBackend.Configuration`."""
+def test_model():
+    """Test :class:`aiida.storage.sqlite_zip.backend.SqliteZipBackend.Model`."""
     with pytest.raises(ValidationError, match=r'.*The archive `non-existent` does not exist.*'):
-        SqliteZipBackend.Configuration(filepath='non-existent')
+        SqliteZipBackend.Model(filepath='non-existent')
 
     filepath = pathlib.Path.cwd() / 'archive.aiida'
     filepath.touch()
 
-    configuration = SqliteZipBackend.Configuration(filepath=filepath.name)
-    assert pathlib.Path(configuration.filepath).is_absolute()
+    model = SqliteZipBackend.Model(filepath=filepath.name)
+    assert pathlib.Path(model.filepath).is_absolute()


### PR DESCRIPTION
The `verdi code create` command dynamically generates a subcommand for each registered entry point that is a subclass of the `AbstractCode` data plugin base class. The options for each subcommand are generated automatically for each plugin using the `DynamicEntryPointCommandGroup`.

When first developed, this `click.Group` subclass would rely on the plugin defining the `get_cli_options` method to return a dictionary with a spec for each of the options. This specification used an ad-hoc custom schema making it not very useful for any other applications.

Recently, the class added support for using `pydantic` models to define the specification instead. This was already used for plugins of storage backends. Here, the `AbstractCode` and its subclasses are also migrated to use `pydantic` instead to define their model.

Most of the data that is required to create `click` options from the pydantic model can be communicated using the default properties of pydantic's `Field` class. However, there was the need for a few additional metadata properties:

* `priority`: To control the order in which options are prompted for. This used to be controlled by the `_get_cli_options` of each plugin. It could define the options in the order required and could also determine whether they came before or after the options that could potentially be inherited from a base class. The way the pydantic models work, the fields of a subclass will always come _after_ those of the base class and there is no way to control this.

* `short_name`: The short form of the option name. The option name is derived from the `title` attribute of the `Field`. In addition to a full name, options often want to provide a short form option. Since there is no algorithmic method of deducing this from the title, a dedicated metadata keyword is added.

* `option_cls`: To customize the class to be used to create the option. This can be used by options that should use a different subclass of the `click.Option` base class.

The `aiida.common.pydantic.MetadataField` utility function is added which provides a transparent way to define these metadata arguments when declaring a field in the model. The alternative is to use `Annotated` but this quickly makes the model difficult to read if multiple metadata are provided.

The changes introduce _almost_ no difference in behavior of the `verdi code create` command. There is one exception and that is that the callbacks of the options are now replaced by the validators of the models. The downside is that the validators are only called once all options are specified, whereas the callbacks would be called immediately once the respective option was defined. This is not really a problem except for the `label` of the `InstalledCode`. The callback would be called immediately and so if an invalid label was provided during an interactive session, the user would be immediately prompted to provide a new label. It is not clear how this behavior can be reproduced using the pydantic validators.