### PR TITLE
ORM: Filter inconsequential warnings from `sqlalchemy`

### DIFF
--- a/aiida/storage/psql_dos/orm/__init__.py
+++ b/aiida/storage/psql_dos/orm/__init__.py
@@ -8,3 +8,60 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Implementation of ORM backend entities."""
+import typing as t
+from typing import Any, Optional
+
+from sqlalchemy.orm import unitofwork
+from sqlalchemy.orm.interfaces import MapperProperty
+from sqlalchemy.orm.state import InstanceState
+
+
+def register_object(
+    self,
+    state: InstanceState[Any],
+    isdelete: bool = False,
+    listonly: bool = False,
+    cancel_delete: bool = False,
+    operation: Optional[str] = None,
+    prop: Optional[MapperProperty] = None,
+) -> bool:
+    """Monkeypatch :meth:`sqlalchemy.orm.unitofwork.UOWTransaction.register_object` to remove warning."""
+    # pylint: disable=protected-access,unused-argument
+    if not self.session._contains_state(state):
+        # The original implementation raises a warning here if ``not state.deleted and operation is not None`` which is
+        # intentionally removed.
+        return False
+
+    if state not in self.states:
+        mapper = state.manager.mapper
+
+        if mapper not in self.mappers:
+            self._per_mapper_flush_actions(mapper)
+
+        self.mappers[mapper].add(state)
+        self.states[state] = (isdelete, listonly)
+    else:
+        if not listonly and (isdelete or cancel_delete):
+            self.states[state] = (isdelete, False)
+    return True
+
+
+# The :meth:`sqlalchemy.orm.unitofwork.UOWTransaction.register_object` method emits a warning whenever an object is
+# registered that is not part of the session. This can happen when the session is committed or flushed and an object
+# inside the session contains a reference to another object, for example through a relationship, is not explicitly part
+# of the session. If that referenced object is not already stored and persisted, it might get lost. On the other hand,
+# if the object was already persisted before, there is no risk.
+#
+# This situation occurs a lot in AiiDA's code base. Prime example is when a new process is created. Typically the input
+# nodes are either already stored, or stored first. As soon as they get stored, the session is committed and the session
+# is reset by expiring all objects. Now, the input links are created from the input nodes to the process node, and at
+# the end the process node is stored to commit and persist it with the links. It is at this point that Sqlalchemy
+# realises that the input nodes are not explicitly part of the session.
+#
+# One direct solution would be to add the input nodes again to the session before committing the process node and the
+# links. However, this code is part of the backend independent :mod:`aiida.orm` module and this is a backend-specific
+# problem. This is also just one example and there are most likely other places in the code where the problem arises.
+# Therefore, as an ugly hack, the :meth:`sqlalchemy.orm.unitofwork.UOWTransaction.register_object` is monkey patched to
+# remove the warning. This will be sensitive to future changes in sqlalchemy though as this is probably not intended to
+# be public API.
+setattr(unitofwork.UOWTransaction, 'register_object', register_object)

--- a/aiida/storage/psql_dos/orm/__init__.py
+++ b/aiida/storage/psql_dos/orm/__init__.py
@@ -8,43 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Implementation of ORM backend entities."""
-import typing as t
-from typing import Any, Optional
+import warnings
 
-from sqlalchemy.orm import unitofwork
-from sqlalchemy.orm.interfaces import MapperProperty
-from sqlalchemy.orm.state import InstanceState
-
-
-def register_object(
-    self,
-    state: InstanceState[Any],
-    isdelete: bool = False,
-    listonly: bool = False,
-    cancel_delete: bool = False,
-    operation: Optional[str] = None,
-    prop: Optional[MapperProperty] = None,
-) -> bool:
-    """Monkeypatch :meth:`sqlalchemy.orm.unitofwork.UOWTransaction.register_object` to remove warning."""
-    # pylint: disable=protected-access,unused-argument
-    if not self.session._contains_state(state):
-        # The original implementation raises a warning here if ``not state.deleted and operation is not None`` which is
-        # intentionally removed.
-        return False
-
-    if state not in self.states:
-        mapper = state.manager.mapper
-
-        if mapper not in self.mappers:
-            self._per_mapper_flush_actions(mapper)
-
-        self.mappers[mapper].add(state)
-        self.states[state] = (isdelete, listonly)
-    else:
-        if not listonly and (isdelete or cancel_delete):
-            self.states[state] = (isdelete, False)
-    return True
-
+from sqlalchemy.exc import SAWarning
 
 # The :meth:`sqlalchemy.orm.unitofwork.UOWTransaction.register_object` method emits a warning whenever an object is
 # registered that is not part of the session. This can happen when the session is committed or flushed and an object
@@ -61,7 +27,7 @@ def register_object(
 # One direct solution would be to add the input nodes again to the session before committing the process node and the
 # links. However, this code is part of the backend independent :mod:`aiida.orm` module and this is a backend-specific
 # problem. This is also just one example and there are most likely other places in the code where the problem arises.
-# Therefore, as an ugly hack, the :meth:`sqlalchemy.orm.unitofwork.UOWTransaction.register_object` is monkey patched to
-# remove the warning. This will be sensitive to future changes in sqlalchemy though as this is probably not intended to
-# be public API.
-setattr(unitofwork.UOWTransaction, 'register_object', register_object)
+# Therefore, as a work around, the specific warning is ignored through a warrning filter.
+warnings.filterwarnings(
+    'ignore', category=SAWarning, message='Object of type .* not in session, .* operation along .* will not proceed'
+)

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -205,6 +205,7 @@ py:class sqlalchemy.orm.decl_api.SqliteModel
 py:class sqlalchemy.orm.decl_api.Base
 py:class sqlalchemy.sql.compiler.TypeCompiler
 py:class sqlalchemy.sql.elements.BooleanClauseList
+py:meth sqlalchemy.orm.unitofwork.UOWTransaction.register_object
 
 py:class sphinx.ext.autodoc.ClassDocumenter
 py:class sphinx.util.docutils.SphinxDirective

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -344,6 +344,7 @@ filterwarnings = [
     "ignore::DeprecationWarning:pymatgen:",
     "ignore::DeprecationWarning:jsonbackend:",
     "ignore::DeprecationWarning:pkg_resources:",
+    "ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning",
     "ignore::pytest.PytestCollectionWarning",
     "default::ResourceWarning",
 ]


### PR DESCRIPTION
Fixes #6183  (well, works around it really 😅)

Recently, the code was updated to be compatible with `sqlalchmey~=2.0` which caused a lot of warnings to be emitted. As of `sqlalchemy==2.0.19` the `sqlalchemy.orm.unitofwork.UOWTransaction.register_object` method emits a warning whenever an object is registered that is not part of the session. See for details:

https://docs.sqlalchemy.org/en/20/changelog/changelog_20.html#change-53740fe9731bbe0f3bb71e3453df07d3

This can happen when the session is committed or flushed and an object inside the session contains a reference to another object, for example through a relationship, is not explicitly part of the session. If that referenced object is not already stored and persisted, it might get lost. On the other hand, if the object was already persisted before, there is no risk.

This situation occurs a lot in AiiDA's code base. Prime example is when a new process is created. Typically the input nodes are either already stored, or stored first. As soon as they get stored, the session is committed and the session is reset by expiring all objects. Now, the input links are created from the input nodes to the process node, and at the end the process node is stored to commit and persist it with the links. It is at this point that Sqlalchemy realises that the input nodes are not explicitly part of the session.

One direct solution would be to add the input nodes again to the session before committing the process node and the links. However, this code is part of the backend independent :mod:`aiida.orm` module and this is a backend-specific problem. This is also just one example and there are most likely other places in the code where the problem arises. Therefore, as an ugly hack, `sqlalchemy.orm.unitofwork.UOWTransaction.register_object` is monkey patched to remove the warning. This will be sensitive to future changes in sqlalchemy though as this is probably not intended to be public API.