### PR TITLE
Add link serialize

### DIFF
--- a/aiida/orm/utils/serialize.py
+++ b/aiida/orm/utils/serialize.py
@@ -91,9 +91,9 @@ def node_constructor(loader: yaml.Loader, node: yaml.Node) -> orm.Node:
 def represent_node_links_manager(dumper: yaml.Dumper, node_links_manager: NodeLinksManager) -> yaml.MappingNode:
     """Represent a link in yaml."""
     data = {
-        'incoming': node_links_manager._incoming,
-        'link_type': node_links_manager._link_type.value,
-        'node': node_links_manager._node.uuid,
+        'incoming': node_links_manager._incoming,  # pylint: disable=protected-access
+        'link_type': node_links_manager._link_type.value,  # pylint: disable=protected-access
+        'node': node_links_manager._node.uuid,  # pylint: disable=protected-access
     }
     return dumper.represent_mapping(_NODE_LINKS_MANAGER_TAG, data)
 

--- a/tests/orm/utils/test_serialize.py
+++ b/tests/orm/utils/test_serialize.py
@@ -188,6 +188,6 @@ def test_serialize_node_links_manager():
     node_links_manager = NodeLinksManager(node=node, link_type=LinkType.CREATE, incoming=False)
     deserialized = serialize.deserialize_unsafe(serialize.serialize(node_links_manager))
     assert isinstance(deserialized, NodeLinksManager)
-    assert deserialized._node.uuid == node.uuid
-    assert deserialized._link_type == LinkType.CREATE
-    assert deserialized._incoming is False
+    assert deserialized._node.uuid == node.uuid  # pylint: disable=protected-access
+    assert deserialized._link_type == LinkType.CREATE  # pylint: disable=protected-access
+    assert deserialized._incoming is False  # pylint: disable=protected-access

--- a/tests/orm/utils/test_serialize.py
+++ b/tests/orm/utils/test_serialize.py
@@ -181,10 +181,13 @@ def test_dataclass():
     assert deserialized == obj
 
 
-def test_serialize_link():
-    """Test you can serialize and deserialize a link"""
+def test_serialize_node_links_manager():
+    """Test you can serialize and deserialize a NodeLinksManager"""
     from aiida.orm.utils.managers import NodeLinksManager
     node = orm.Data().store()
-    link = NodeLinksManager(node=node, link_type=LinkType.CREATE, incoming=False)
-    deserialized = serialize.deserialize_unsafe(serialize.serialize(link))
-    assert node.uuid == deserialized._node.uuid
+    node_links_manager = NodeLinksManager(node=node, link_type=LinkType.CREATE, incoming=False)
+    deserialized = serialize.deserialize_unsafe(serialize.serialize(node_links_manager))
+    assert isinstance(deserialized, NodeLinksManager)
+    assert deserialized._node.uuid == node.uuid
+    assert deserialized._link_type == LinkType.CREATE
+    assert deserialized._incoming is False

--- a/tests/orm/utils/test_serialize.py
+++ b/tests/orm/utils/test_serialize.py
@@ -179,3 +179,12 @@ def test_dataclass():
 
     deserialized = serialize.deserialize_unsafe(serialized)
     assert deserialized == obj
+
+
+def test_serialize_link():
+    """Test you can serialize and deserialize a link"""
+    from aiida.orm.utils.managers import NodeLinksManager
+    node = orm.Data().store()
+    link = NodeLinksManager(node=node, link_type=LinkType.CREATE, incoming=False)
+    deserialized = serialize.deserialize_unsafe(serialize.serialize(link))
+    assert node.uuid == deserialized._node.uuid


### PR DESCRIPTION
Currently, the AiiDA serializer manages to serialize a link (using `!!python/object` tag), but deserializing it leads to infinite recursion. The problem is that the `__init__` of the `NodeLinksManager` is not called by yaml, see this issue: https://github.com/yaml/pyyaml/issues/216.

This PR defines the yaml constructor and represent for the link.