### PR TITLE
Process functions: Fix bug with variable arguments

### DIFF
--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -462,7 +462,7 @@ class FunctionProcess(Process):
             spec.inputs.help = namespace_help_string
 
             # If the function supports varargs or kwargs then allow dynamic inputs, otherwise disallow
-            spec.inputs.dynamic = var_positional or var_keyword
+            spec.inputs.dynamic = var_positional is not None or var_keyword is not None
 
             # Function processes must have a dynamic output namespace since we do not know beforehand what outputs
             # will be returned and the valid types for the value should be `Data` nodes as well as a dictionary because

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -87,6 +87,15 @@ def function_kwargs(**kwargs):
 
 
 @workfunction
+def function_varargs_kwargs(*args, **kwargs):
+    """Return the positional and keyword arguments as is in a single dictionary."""
+    results = dict(kwargs)
+    for index, arg in enumerate(args):
+        results[f'arg_{index}'] = arg
+    return results
+
+
+@workfunction
 def function_args_and_kwargs(data_a, **kwargs):
     result = {'data_a': data_a}
     result.update(kwargs)
@@ -355,6 +364,16 @@ def test_function_args_and_kwargs_default():
     result = function_args_and_default(*args_input_explicit)
     assert isinstance(result, dict)
     assert result == {'data_a': args_input_explicit[0], 'data_b': args_input_explicit[1]}
+
+
+def test_function_varargs_and_kwargs():
+    """Test function that accepts both positional and keyword arguments."""
+    results = function_varargs_kwargs(*(orm.Str('a'), orm.Str('b')), kwarg_c=orm.Str('c'), kwarg_d=orm.Str('d'))
+    assert sorted(results.keys()) == ['arg_0', 'arg_1', 'kwarg_c', 'kwarg_d']
+    assert results['arg_0'] == orm.Str('a')
+    assert results['arg_1'] == orm.Str('b')
+    assert results['kwarg_c'] == orm.Str('c')
+    assert results['kwarg_d'] == orm.Str('d')
 
 
 def test_function_args_passing_kwargs():

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -45,8 +45,13 @@ def function_return_input(data):
 
 
 @calcfunction
-def function_variadic_arguments(int_a, int_b, *args):
-    return int_a + int_b + orm.Int(sum(args))
+def function_variadic_arguments(str_a, str_b, *args):
+    return orm.Str(' '.join([e.value for e in (str_a, str_b, *args)]))
+
+
+@calcfunction
+def function_variadic_arguments_and_keywords(*args, str_a, str_b):
+    return orm.Str(' '.join([e.value for e in (*args, str_a, str_b)]))
 
 
 @calcfunction
@@ -223,17 +228,17 @@ def test_get_function_source_code():
 
 def test_function_varargs():
     """Test a function with variadic arguments."""
-    result, node = function_variadic_arguments.run_get_node(orm.Int(1), orm.Int(2), *(orm.Int(3), orm.Int(4)))
-    assert isinstance(result, orm.Int)
-    assert result.value == 10
+    result, node = function_variadic_arguments.run_get_node(orm.Str('a'), orm.Str('b'), *(orm.Str('c'), orm.Str('d')))
+    assert isinstance(result, orm.Str)
+    assert result.value == 'a b c d'
 
     inputs = node.get_incoming().nested()
-    assert inputs['int_a'].value == 1
-    assert inputs['int_b'].value == 2
-    assert inputs['args_0'].value == 3
-    assert inputs['args_1'].value == 4
-    assert node.inputs.args_0.value == 3
-    assert node.inputs.args_1.value == 4
+    assert inputs['str_a'].value == 'a'
+    assert inputs['str_b'].value == 'b'
+    assert inputs['args_0'].value == 'c'
+    assert inputs['args_1'].value == 'd'
+    assert node.inputs.args_0.value == 'c'
+    assert node.inputs.args_1.value == 'd'
 
 
 def test_function_varargs_label_overlap():
@@ -243,6 +248,14 @@ def test_function_varargs_label_overlap():
     """
     with pytest.raises(RuntimeError, match=r'variadic argument with index `.*` would get the label `.*` but this'):
         function_variadic_arguments_label_overlap.run_get_node(orm.Int(1), *(orm.Int(2), orm.Int(3)))
+
+
+def test_function_variadic_arguments_and_keywords():
+    """Test passing variable positional arguments before keyword arguments."""
+    result = function_variadic_arguments_and_keywords(
+        *(orm.Str('a'), orm.Str('b')), str_a=orm.Str('c'), str_b=orm.Str('d')
+    )
+    assert result.value == 'a b c d'
 
 
 def test_function_args():


### PR DESCRIPTION
The process function implementation contained a bug where a function that specified variable positional arguments followed by keyword arguments would not be accepted. For example:

    def function(*args, arg_a, arg_b):
        pass

    function(*(1, 2), 3, 4)

is a perfectly valid function definition and call but it would not work when decorated into a process function.

Part of the problem was that the class argument `_varargs` of the dynamically constructed `FunctionProcess` was used for the name of variable positional as well as keyword arguments. If both were defined, the former would be overridden by the latter. This is now split in `_var_positional` and `_var_keyword` respectively.

The conversion of the original positional and keyword arguments passed to the function into the process input dictionary is simplified. As well as for the reverse process where the process inputs are converted back in to positional and keyword arguments before passing them to the wrapped function.