### PR TITLE
Engine: Make process inputs in launchers positional

### DIFF
--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -18,8 +18,6 @@ import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator, List, Optional, Tuple, Type, Union
 
-from aiida.common.warnings import warn_deprecation
-
 if TYPE_CHECKING:
     from .processes import Process, ProcessBuilder
     from .runners import Runner
@@ -30,25 +28,12 @@ LOGGER = logging.getLogger(__name__)
 PROCESS_STATE_CHANGE_KEY = 'process|state_change|{}'
 PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed state'
 
-LAUNCHER_SIGNATURE_DEPRECATION = """
-Passing inputs as keyword arguments is deprecated. Please pass as the second positional argument:
-
-    inputs = {...}
-    submit(process, inputs)
-
-or as a keyword argument instead:
-
-    inputs = {...}
-    submit(process, inputs=inputs)
-"""
-
 
 def prepare_inputs(inputs: dict[str, Any] | None = None, **kwargs: Any) -> dict[str, Any]:
     """Prepare inputs for launch of a process.
 
-    This is a temporary utility function while the launch functions accept inputs to the process both through keyword
+    This is a utility function to pre-process inputs for the process that can be specified both through keyword
     arguments as well as through the explicit ``inputs`` argument. When both are specified, a ``ValueError`` is raised.
-    If keywords are used, a deprecation warning is issued.
 
     :param inputs: Inputs dictionary.
     :param kwargs: Inputs defined as keyword arguments.
@@ -59,7 +44,6 @@ def prepare_inputs(inputs: dict[str, Any] | None = None, **kwargs: Any) -> dict[
         raise ValueError('Cannot specify both `inputs` and `kwargs`.')
 
     if kwargs:
-        warn_deprecation(LAUNCHER_SIGNATURE_DEPRECATION, version=3)
         inputs = kwargs
 
     return inputs or {}

--- a/docs/source/topics/processes/include/snippets/launch/launch_submit_dictionary.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_submit_dictionary.py
@@ -7,4 +7,4 @@ inputs = {
     'x': orm.Int(1),
     'y': orm.Int(2)
 }
-node = submit(ArithmeticAddCalculation, **inputs)
+node = submit(ArithmeticAddCalculation, inputs)

--- a/docs/source/topics/processes/usage.rst
+++ b/docs/source/topics/processes/usage.rst
@@ -334,10 +334,19 @@ As the name suggest, the first three will 'run' the process and the latter will 
 Running means that the process will be executed in the same interpreter in which it is launched, blocking the interpreter, until the process is terminated.
 Submitting to the daemon, in contrast, means that the process will be sent to the daemon for execution, and the interpreter is released straight away.
 
-All functions have the exact same interface ``launch(process, **inputs)`` where:
+All functions have the exact same interface ``launch(process, inputs)`` where:
 
 * ``process`` is the process class or process function to launch
-* ``inputs`` are the inputs as keyword arguments to pass to the process.
+* ``inputs`` the inputs dictionary to pass to the process.
+
+.. versionchanged:: 2.5
+
+    Before AiiDA v2.5, the inputs could only be passed as keyword arguments.
+    This behavior is still supported, e.g., one can launch a process as ``launch(process, **inputs)`` or ``launch(process, input_a=value_a, input_b=value_b)``.
+    However, the recommended approach is now to use an input dictionary passed as the second positional argument.
+    The reason is that certain launchers define arguments themselves which can overlap with inputs of the process.
+    For example, the ``submit`` method defines the ``wait`` keyword.
+    If the process being launched *also* defines an input named ``wait``, the launcher method cannot tell them apart.
 
 What inputs can be passed depends on the exact process class that is to be launched.
 For example, when we want to run an instance of the :py:class:`~aiida.calculations.arithmetic.add.ArithmeticAddCalculation` process, which takes two :py:class:`~aiida.orm.nodes.data.int.Int` nodes as inputs under the name ``x`` and ``y`` [#f1]_, we would do the following:
@@ -350,7 +359,8 @@ The function will submit the calculation to the daemon and immediately return co
 .. warning::
     For a process to be submittable, the class or function needs to be importable in the daemon environment by a) giving it an :ref:`associated entry point<how-to:plugin-codes:entry-points>` or b) :ref:`including its module path<how-to:faq:process-not-importable-daemon>` in the ``PYTHONPATH`` that the daemon workers will have.
 
-.. tip::
+.. versionadded:: 2.5
+
     Use ``wait=True`` when calling ``submit`` to wait for the process to complete before returning the node.
     This can be useful for tutorials and demos in interactive notebooks where the user should not continue before the process is done.
     One could of course also use ``run`` (see below), but then the process would be lost if the interpreter gets accidentally shut down.

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -82,9 +82,7 @@ def test_submit(runner):
         runner.submit(Proc, inputs, **inputs)
 
     runner.submit(Proc, inputs)
-
-    with pytest.warns(match='Passing inputs as keyword arguments is deprecated'):
-        runner.submit(Proc, **inputs)
+    runner.submit(Proc, **inputs)
 
 
 def test_run_return_value_cached(aiida_local_code_factory):

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -74,14 +74,17 @@ def test_call_on_process_finish(runner):
     assert future.result()
 
 
-def test_submit_args(runner):
-    """Test that a useful exception is raised when the inputs are passed as a dictionary instead of expanded kwargs.
+def test_submit(runner):
+    """Test that inputs can be specified either as a positional dictionary or through keyword arguments."""
+    inputs = {'a': Str('input')}
 
-    Regression test for #3609. Before, it would throw the validation exception of the first port to be validated. If
-    a user accidentally forgot to expand the inputs with `**` it would be a misleading error.
-    """
-    with pytest.raises(TypeError, match=r'takes 2 positional arguments but 3 were given'):
-        runner.submit(Proc, {'a': Str('input')})
+    with pytest.raises(ValueError, match='Cannot specify both `inputs` and `kwargs`.'):
+        runner.submit(Proc, inputs, **inputs)
+
+    runner.submit(Proc, inputs)
+
+    with pytest.warns(match='Passing inputs as keyword arguments is deprecated'):
+        runner.submit(Proc, **inputs)
 
 
 def test_run_return_value_cached(aiida_local_code_factory):


### PR DESCRIPTION
So far the launcher functions, `run` and `submit`, had a signature where the process class was the only positional argument and the inputs for the process were defined through keyword arguments.

Recently, however, some fixed arguments were added to `submit`, namely `wait` and `wait_interval`. A potential problem was missed in this change as these new keywords now "shadow" a similarly named input port for a process. If a `Process` defines an input port named `wait` or `wait_interval`, when passed through the keyword arguments, it will now be mistaken as the fixed argument for the `submit` function and won't be passed to the process inputs.

The new functionality by `wait` and `wait_interval` is desirable and in the future additional arguments may need to be added. Therefore, rather than undoing the change, another solution is implemented. The `inputs` positional argument is added and the `wait` and `wait_interval` arguments are made keyword only. The process inputs should now be defined as a dictionary for the `inputs` argument and no longer through `**kwargs`. If `**kwargs` are still defined, a deprecation warning is emitted and they are assigned to `inputs`.

With this approach, backwards-compatibility is maintained and users will be able to transition to passing inputs as a dictionary instead of keywords. In addition, if a user actually gets hit by `wait` shadowing the input port of a `Process`, they can now switch to specifying the inputs through `inputs` and their input won't be blocked.