### PR TITLE
Make `warn_deprecation` respect the `warnings.showdeprecations` option

### DIFF
--- a/aiida/common/warnings.py
+++ b/aiida/common/warnings.py
@@ -37,14 +37,21 @@ class AiidaTestWarning(Warning):
 
 
 def warn_deprecation(message: str, version: int, stacklevel=2) -> None:
-    """Warns about a deprecation for a future aiida-core version.
+    """Warn about a deprecation for a future aiida-core version.
 
-    Warnings are activated if the `AIIDA_WARN_v{major}` environment variable is set to `True`.
+    Warnings are emitted if the ``warnings.showdeprecations`` config option is set to ``True``. Its value can be
+    overwritten with the ``AIIDA_WARN_v{version}`` environment variable. The exact value for the environment variable is
+    irrelevant. Any value will mean the variable is enabled and warnings will be emitted.
 
     :param message: the message to be printed
     :param version: the major version number of the future version
     :param stacklevel: the stack level at which the warning is issued
     """
-    if os.environ.get(f'AIIDA_WARN_v{version}'):
+    from aiida.manage.configuration import get_config_option
+
+    from_config = get_config_option('warnings.showdeprecations')
+    from_environment = os.environ.get(f'AIIDA_WARN_v{version}')
+
+    if from_config or from_environment:
         message = f'{message} (this will be removed in v{version})'
         warnings.warn(message, AiidaDeprecationWarning, stacklevel=stacklevel)

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -340,6 +340,9 @@ def load_documentation_profile():
                     'broker_virtual_host': '',
                 }
             },
+            'options': {
+                'warnings.showdeprecations': False
+            }
         }
         config = {'default_profile': profile_name, 'profiles': {profile_name: profile_config}}
         CONFIG = Config(handle.name, config)

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -51,7 +51,7 @@ import os
 from typing import TYPE_CHECKING, Any, Optional
 import warnings
 
-from aiida.common.warnings import AiidaDeprecationWarning, warn_deprecation
+from aiida.common.warnings import AiidaDeprecationWarning
 
 if TYPE_CHECKING:
     from aiida.manage.configuration import Config, Profile  # pylint: disable=import-self
@@ -117,11 +117,13 @@ def _merge_deprecated_cache_yaml(config, filepath):
     while not cache_path_backup or os.path.isfile(cache_path_backup):
         cache_path_backup = f"{cache_path}.{timezone.now().strftime('%Y%m%d-%H%M%S.%f')}"
 
-    warn_deprecation(
+    warnings.warn(
         'cache_config.yml use is deprecated and support will be removed in `v3.0`. Merging into config.json and '
         f'moving to: {cache_path_backup}',
-        version=3
+        AiidaDeprecationWarning,
+        stacklevel=2
     )
+
     with open(cache_path, 'r', encoding='utf8') as handle:
         cache_config = yaml.safe_load(handle)
     for profile_name, data in cache_config.items():

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -20,13 +20,6 @@ from .abstract import AbstractCode
 
 __all__ = ('Code',)
 
-warn_deprecation(
-    'The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode`'
-    ' or `aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respectively. If you are '
-    'using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
-    version=3
-)
-
 
 class Code(AbstractCode):
     """
@@ -49,6 +42,14 @@ class Code(AbstractCode):
 
     def __init__(self, remote_computer_exec=None, local_executable=None, input_plugin_name=None, files=None, **kwargs):
         super().__init__(**kwargs)
+
+        warn_deprecation(
+            'The `Code` class is deprecated. To create an instance, use the '
+            '`aiida.orm.nodes.data.code.installed.InstalledCode` or `aiida.orm.nodes.data.code.portable.PortableCode` '
+            'for a "remote" or "local" code, respectively. If you are using this class to compare type, e.g. in '
+            '`isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
+            version=3
+        )
 
         if remote_computer_exec and local_executable:
             raise ValueError('cannot set `remote_computer_exec` and `local_executable` at the same time')

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -19,11 +19,14 @@ from .singlefile import SinglefileData
 
 __all__ = ('UpfData',)
 
-warn_deprecation(
-    'This module is deprecated. See '
-    'https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core.',
-    version=3
-)
+
+def emit_deprecation():
+    warn_deprecation(
+        'The `aiida.orm.nodes.data.upf` module is deprecated. For details how to replace it, please see '
+        'https://aiida-pseudo.readthedocs.io/en/latest/howto.html#migrate-from-legacy-upfdata-from-aiida-core.',
+        version=3
+    )
+
 
 REGEX_UPF_VERSION = re.compile(r"""
     \s*<UPF\s+version\s*="
@@ -56,6 +59,8 @@ def get_pseudos_from_structure(structure, family_name):
     :raise aiida.common.NotExistent: if no UPF for an element in the group is found in the group.
     """
     from aiida.common.exceptions import MultipleObjectsError, NotExistent
+
+    emit_deprecation()
 
     pseudo_list = {}
     family_pseudos = {}
@@ -95,6 +100,8 @@ def upload_upf_family(folder, group_label, group_description, stop_if_existing=T
     from aiida.common import AIIDA_LOGGER
     from aiida.common.exceptions import UniquenessError
     from aiida.common.files import md5_file
+
+    emit_deprecation()
 
     if not os.path.isdir(folder):
         raise ValueError('folder must be a directory')
@@ -204,6 +211,8 @@ def parse_upf(fname, check_filename=True, encoding='utf-8'):
     from aiida.common.exceptions import ParsingError
     from aiida.orm.nodes.data.structure import _valid_symbols
 
+    emit_deprecation()
+
     parsed_data = {}
 
     try:
@@ -278,6 +287,8 @@ class UpfData(SinglefileData):
 
         from aiida.common.files import md5_file
 
+        emit_deprecation()
+
         if not os.path.isabs(filepath):
             raise ValueError('filepath must be an absolute path')
 
@@ -300,6 +311,10 @@ class UpfData(SinglefileData):
             )
 
         return (pseudos[0], False)
+
+    def __init__(self, *args, **kwargs):
+        emit_deprecation()
+        super().__init__(*args, **kwargs)
 
     def store(self, *args, **kwargs):  # pylint: disable=signature-differs
         """Store the node, reparsing the file so that the md5 and the element are correctly reset."""

--- a/docs/source/howto/installation.rst
+++ b/docs/source/howto/installation.rst
@@ -256,6 +256,39 @@ Similarly to unset a value:
 .. seealso:: :ref:`How-to configure caching <how-to:run-codes:caching>`
 
 
+.. _how-to:installation:configure:warnings:
+
+Controlling warnings
+--------------------
+
+AiiDA may emit warnings for a variety of reasons, for example, warnings when a deprecated part of the code is used.
+These warnings are on by default as they provide the user with important information.
+The warnings can be turned off using the ``warnings.showdeprecations`` config option, for example:
+
+.. code-block:: console
+
+    verdi config set warnings.showdeprecations false
+
+.. tip::
+
+    The command above changes the option for the current profile.
+    However, certain warnings are emitted before a profile can be loaded, for example, when certain modules are imported.
+    To also silence these warnings, apply the option globally:
+
+        .. code-block:: console
+
+            verdi config set warnings.showdeprecations false --global
+
+In addition to the config option, AiiDA also provides the dedicated environment variable ``AIIDA_WARN_v{version}`` for deprecation warnings.
+Here ``{version}`` is the version number in which the deprecated code will be removed, e.g., ``AIIDA_WARN_v3``.
+This environment variable can be used to enable deprecation warnings even if ``warnings.showdeprecations`` is turned off.
+This can be useful to temporarily enable deprecation warnings for a single command, e.g.:
+
+.. code-block:: console
+
+    AIIDA_WARN_v3=1 verdi run script.py
+
+
 .. _how-to:installation:configure:instance-isolation:
 
 Isolating multiple instances


### PR DESCRIPTION
Fixes #6210 

In v2.0 the `aiida.commmon.warnings.warn_deprecation` utility was added, which was to be used to emit all deprecation warnings. By default it was disabled as a lot of deprecations were to be added and they were thought to be overwhelming users. The `AIIDA_WARN_v3` environment variable was added to allow users to enable the warnings.

There are two problems with this change:

* The existing `warnings.showdeprecations` config option was completely ignored, even though that existed before as a manner to control the behavior of warnings being emitted.
* Most users won't be aware of the `AIIDA_WARN_v3` environment variable and so are not likely to ever seeing the deprecation warnings. This completely defeats the purpose of the warnings.

The `warn_deprecation` function is changed to also respect the value of the `warnings.showdeprecations` option. Since that is enabled by default deprecation warnings will now be shown by default, allowing users to update their code. A section is added to the documentation to instruct how to disable the warnings if they are too noisy or not wanted. The `AIIDA_WARN_v3` variable is kept as it allows to enable warnings temporarily for isolated commands, even if disabled by default.