### PR TITLE
Pinning mamba version to 1.5.2

### DIFF
--- a/.docker/aiida-core-base/Dockerfile
+++ b/.docker/aiida-core-base/Dockerfile
@@ -104,6 +104,9 @@ USER ${SYSTEM_UID}
 # Pin python version here
 ARG PYTHON_VERSION
 
+# Pin mamba version here
+ARG MAMBA_VERSION
+
 # Download and install Micromamba, and initialize Conda prefix.
 #   <https://github.com/mamba-org/mamba#micromamba>
 #   Similar projects using Micromamba:
@@ -134,7 +137,7 @@ RUN set -x && \
         --prefix="${CONDA_DIR}" \
         --yes \
         "${PYTHON_SPECIFIER}" \
-        'mamba' && \
+        "mamba=${MAMBA_VERSION}" && \
     rm micromamba && \
     # Pin major.minor version of python
     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -51,6 +51,7 @@ target "aiida-core-base" {
   platforms = "${PLATFORMS}"
   args = {
     "PYTHON_VERSION" = "${PYTHON_VERSION}"
+    "MAMBA_VERSION" = "1.5.2"
   }
 }
 target "aiida-core-with-services" {


### PR DESCRIPTION
The mamba version `1.5.3` and `1.5.4` has issue that will fail the docker build, as reported in https://github.com/mamba-org/mamba/issues/3044. Pining the version to `1.5.2`.