### PR TITLE
CLI: Fix `DynamicEntryPointCommandGroup` for default values

### DIFF
--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -142,9 +142,15 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
 
             for key, field_info in cls.Configuration.model_fields.items():
                 default = field_info.default_factory if field_info.default is PydanticUndefined else field_info.default
+
+                # The ``field_info.annotation`` property returns the annotation of the field. This can be a plain type
+                # or a type from ``typing``, e.g., ``Union[int, float]`` or ``Optional[str]``. In these cases, the type
+                # that needs to be passed to ``click`` is the arguments of the type, which can be obtained using the
+                # ``typing.get_args()`` method. If it is not a compound type, this returns an empty tuplem so in that
+                # case, the type is simply the ``field_info.annotation``.
                 options_spec[key] = {
                     'required': field_info.is_required(),
-                    'type': field_info.annotation,
+                    'type': t.get_args(field_info.annotation) or field_info.annotation,
                     'prompt': field_info.title,
                     'default': default,
                     'help': field_info.description,

--- a/tests/cmdline/groups/test_dynamic.py
+++ b/tests/cmdline/groups/test_dynamic.py
@@ -31,3 +31,4 @@ def test_list_options(entry_points):
         option = option_decorators(lambda x: True).__click_params__[0]
         field = CustomClass.Configuration.model_fields[option.name]
         assert option.default == field.default_factory if field.default is PydanticUndefined else field.default
+        assert option.type == t.get_args(field.annotation) or field.annotation

--- a/tests/cmdline/groups/test_dynamic.py
+++ b/tests/cmdline/groups/test_dynamic.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`aiida.cmdline.groups.dynamic`."""
+import typing as t
+
+from pydantic import BaseModel, Field
+from pydantic_core import PydanticUndefined
+
+from aiida.cmdline.groups.dynamic import DynamicEntryPointCommandGroup
+
+
+class CustomClass:
+    """Test plugin class."""
+
+    class Configuration(BaseModel):
+        """Model configuration."""
+
+        optional_type: t.Union[int, float] = Field(title='Optional type')
+        union_type: t.Union[int, float] = Field(title='Union type')
+        without_default: str = Field(title='Without default')
+        with_default: str = Field(title='With default', default='default')
+        with_default_factory: str = Field(title='With default factory', default_factory=lambda: True)
+
+
+def test_list_options(entry_points):
+    """Test :meth:`aiida.cmdline.groups.dynamic.DyanmicEntryPointCommandGroup.list_options`."""
+    entry_points.add(CustomClass, 'aiida.custom:custom')
+
+    group = DynamicEntryPointCommandGroup(lambda *args, **kwargs: True, entry_point_group='aiida.custom')
+
+    for option_decorators in group.list_options('custom'):
+        option = option_decorators(lambda x: True).__click_params__[0]
+        field = CustomClass.Configuration.model_fields[option.name]
+        assert option.default == field.default_factory if field.default is PydanticUndefined else field.default


### PR DESCRIPTION
Options generated for model fields that do not define a default would get the `PydanticUndefined` value as default, because this is the value that pydantic's `FieldInfo.default` returns when no explicit default was set. This is to be able to distinguish it from `None` as a default value.

The `default_factory` attribute was also not respected. The problem is fixed by explicitly checking for `PydanticUndefined` as the value of the `FieldInfo.default` property. If that is the case, the value is set to `FieldInfo.default_factory` which returns `None` if not set. The `Option.default` attribute of `click` takes a callable, so if the `default_factory` is defined, this should work.