### PR TITLE
`CalcJob`: Fix MPI behavior if `withmpi` option default is True

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -946,8 +946,14 @@ class CalcJob(Process):
             if with_mpi_values_set:
                 with_mpi = with_mpi_values_set.pop()
             else:
-                # Fall back to the default, which is to not use MPI
-                with_mpi = False
+                # Fall back to the default, which is the default of the option in the process input specification with
+                # ``False`` as final fallback if the default is not even specified
+                try:
+                    with_mpi = self.spec().inputs['metadata']['options']['withmpi'].default  # type: ignore[index]
+                except RuntimeError:
+                    # ``plumpy.InputPort.default`` raises a ``RuntimeError`` if no default has been set. This is bad
+                    # design and should be changed, but we have to deal with it like this for now.
+                    with_mpi = False
 
             if with_mpi:
                 prepend_cmdline_params = code.get_prepend_cmdline_params(mpi_args, extra_mpirun_params)


### PR DESCRIPTION
The documentation states that if neither:

* the `Code` input (through the `withmpi` attribute)
* the `CalcJob` implementation (through `CodeInfo.withpi')
* nor the `metadata.options.withmpi` input

explicitly defines a boolean value, then the implementation falls back on the _default_ of the `metadata.options.withmpi` input port. However, the code was actually ignoring this and always falling back to `False`. This is now corrected, with `False` still as ultimate fallback value in case a default for `metadata.options.withmpi` is not defined at all.