### PR TITLE
`SqliteDosStorage`: Change default for `filepath` to be in config folder

### DIFF
--- a/aiida/storage/sqlite_dos/backend.py
+++ b/aiida/storage/sqlite_dos/backend.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 from functools import cached_property
 from pathlib import Path
-from tempfile import mkdtemp
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from disk_objectstore import Container
 from pydantic import BaseModel, Field
@@ -21,6 +21,7 @@ from sqlalchemy import insert
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from aiida.manage import Profile
+from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
 from aiida.orm.implementation import BackendEntity
 from aiida.storage.psql_dos.models.settings import DbSetting
 from aiida.storage.sqlite_zip import models, orm
@@ -97,7 +98,7 @@ class SqliteDosStorage(PsqlDosBackend):
         filepath: str = Field(
             title='Directory of the backend',
             description='Filepath of the directory in which to store data for this backend.',
-            default_factory=mkdtemp
+            default_factory=lambda: AIIDA_CONFIG_FOLDER / 'repository' / f'sqlite_dos_{uuid4().hex}'
         )
 
     @classmethod

--- a/tests/storage/sqlite_dos/__init__.py
+++ b/tests/storage/sqlite_dos/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`aiida.storage.sqlite_dos`."""

--- a/tests/storage/sqlite_dos/test_backend.py
+++ b/tests/storage/sqlite_dos/test_backend.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`aiida.storage.sqlite_dos.backend`."""
+import pathlib
+
+import pytest
+
+from aiida.storage.sqlite_dos.backend import SqliteDosStorage
+
+
+@pytest.mark.usefixtures('chdir_tmp_path')
+def test_configuration():
+    """Test :class:`aiida.storage.sqlite_dos.backend.SqliteDosStorage.Configuration`."""
+    filepath = pathlib.Path.cwd() / 'archive.aiida'
+    configuration = SqliteDosStorage.Configuration(filepath=filepath.name)
+    assert pathlib.Path(configuration.filepath).is_absolute()

--- a/tests/storage/sqlite_zip/__init__.py
+++ b/tests/storage/sqlite_zip/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`aiida.storage.sqlite_zip`."""


### PR DESCRIPTION
The point of the `core.sqlite_dos` storage plugin is to provide a
permanent storage that is easy to setup. However, the default value for
the `filepath` was created in the systems temporary directory, causing
the storage being permanent to not be respected as it was likely to get
cleaned unexpectedly.

Instead, the default is now placed inside the `repository` directory of
the config folder. This is also the location of the default for the
`verdi quicksetup` and `verdi setup` commands. The one difference is that
for the former, the actual folder is based on the chosen profile name,
however, this approach is not possible as the profile name is not
available when the default is created using the `Configuration` model.
Instead, the name takes a random UUID prefixed with `sqlite_dos_` to
indicate what the storage plugin is.