### PR TITLE
CLI: Add `--set-as-default` option to `verdi profile setup`

### DIFF
--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -24,7 +24,14 @@ def verdi_profile():
     """Inspect and manage the configured profiles."""
 
 
-def command_create_profile(ctx: click.Context, storage_cls, non_interactive: bool, profile: Profile, **kwargs):  # pylint: disable=unused-argument
+def command_create_profile(
+    ctx: click.Context,
+    storage_cls,
+    non_interactive: bool,
+    profile: Profile,
+    set_as_default: bool = True,
+    **kwargs
+):  # pylint: disable=unused-argument
     """Create a new profile, initialise its storage and create a default user.
 
     :param ctx: The context of the CLI command.
@@ -32,6 +39,7 @@ def command_create_profile(ctx: click.Context, storage_cls, non_interactive: boo
     :param non_interactive: Whether the command was invoked interactively or not.
     :param profile: The profile instance. This is an empty ``Profile`` instance created by the command line argument
         which currently only contains the selected profile name for the profile that is to be created.
+    :param set_as_default: Whether to set the created profile as the new default.
     :param kwargs: Arguments to initialise instance of the selected storage implementation.
     """
     try:
@@ -41,6 +49,9 @@ def command_create_profile(ctx: click.Context, storage_cls, non_interactive: boo
 
     echo.echo_success(f'Created new profile `{profile.name}`.')
 
+    if set_as_default:
+        ctx.invoke(profile_setdefault, profile=profile)
+
 
 @verdi_profile.group(
     'setup',
@@ -49,6 +60,7 @@ def command_create_profile(ctx: click.Context, storage_cls, non_interactive: boo
     entry_point_group='aiida.storage',
     shared_options=[
         setup.SETUP_PROFILE(),
+        setup.SETUP_PROFILE_SET_AS_DEFAULT(),
         setup.SETUP_USER_EMAIL(),
         setup.SETUP_USER_FIRST_NAME(),
         setup.SETUP_USER_LAST_NAME(),

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -177,6 +177,15 @@ SETUP_PROFILE = options.OverridableOption(
     cls=options.interactive.InteractiveOption
 )
 
+SETUP_PROFILE_SET_AS_DEFAULT = options.OverridableOption(
+    '--set-as-default/--no-set-as-default',
+    prompt='Set as default?',
+    help='Whether to set the profile as the default.',
+    is_flag=True,
+    default=True,
+    cls=options.interactive.InteractiveOption
+)
+
 SETUP_USER_EMAIL = options.USER_EMAIL.clone(
     prompt='Email Address (for sharing data)',
     default=functools.partial(get_config_option, 'autofill.user.email'),

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -137,10 +137,28 @@ def test_delete(run_cli_command, mock_profiles, pg_test_cluster):
 def test_setup(run_cli_command, isolated_config, tmp_path, entry_point):
     """Test the ``verdi profile setup`` command.
 
-    Note that the options for user name and institution are not given in purpose
+    Note that the options for user name and institution are not given on purpose as these should not be required.
     """
     profile_name = 'temp-profile'
     options = [entry_point, '-n', '--filepath', str(tmp_path), '--profile', profile_name, '--email', 'email@host']
     result = run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
     assert f'Created new profile `{profile_name}`.' in result.output
     assert profile_name in isolated_config.profile_names
+    assert isolated_config.default_profile_name == profile_name
+
+
+@pytest.mark.parametrize('set_as_default', (True, False))
+def test_setup_set_as_default(run_cli_command, isolated_config, tmp_path, set_as_default):
+    """Test the ``--set-as-default`` flag of the ``verdi profile setup`` command."""
+    profile_name = 'temp-profile'
+    flag = '--set-as-default' if set_as_default else '--no-set-as-default'
+    options = [
+        'core.sqlite_dos', '-n', '--filepath',
+        str(tmp_path), '--profile', profile_name, '--email', 'email@host', flag
+    ]
+    result = run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    assert f'Created new profile `{profile_name}`.' in result.output
+    if set_as_default:
+        assert isolated_config.default_profile_name == profile_name
+    else:
+        assert isolated_config.default_profile_name != profile_name


### PR DESCRIPTION
In most cases when a new profile is created, a user will expect it to be the new default. Currently this was not the case for `verdi profile setup` even if it was the first profile to be created.

The `--set-as-default/--no-set-as-default` flag is added which when enabled will set the new profile as the default.