### PR TITLE
Fix `aiida.manage.configuration.create_profile` for `core.sqlite_zip`

### DIFF
--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -42,6 +42,9 @@ def command_create_profile(
     :param set_as_default: Whether to set the created profile as the new default.
     :param kwargs: Arguments to initialise instance of the selected storage implementation.
     """
+    if not storage_cls.read_only and kwargs.get('email', None) is None:
+        raise click.BadParameter('The option is required for storages that are not read-only.', param_hint='--email')
+
     try:
         profile = create_profile(ctx.obj.config, storage_cls, name=profile.name, **kwargs)
     except (ValueError, TypeError, exceptions.EntryPointError, exceptions.StorageMigrationError) as exception:
@@ -61,7 +64,7 @@ def command_create_profile(
     shared_options=[
         setup.SETUP_PROFILE(),
         setup.SETUP_PROFILE_SET_AS_DEFAULT(),
-        setup.SETUP_USER_EMAIL(),
+        setup.SETUP_USER_EMAIL(required=False),
         setup.SETUP_USER_FIRST_NAME(),
         setup.SETUP_USER_LAST_NAME(),
         setup.SETUP_USER_INSTITUTION(),

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -52,6 +52,8 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
     created only for the latest schema version.
     """
 
+    read_only = False
+
     @classmethod
     @abc.abstractmethod
     def version_head(cls) -> str:

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -51,8 +51,6 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
             default_factory=mkdtemp
         )
 
-    _read_only = False
-
     cli_exposed = False
     """Ensure this plugin is not exposed in ``verdi profile setup``."""
 

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -71,10 +71,7 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
     class Configuration(BaseModel):
         """Model describing required information to configure an instance of the storage."""
 
-        filepath: str = Field(
-            title='Filepath of the archive',
-            description='Filepath of the archive in which to store data for this backend.'
-        )
+        filepath: str = Field(title='Filepath of the archive', description='Filepath of the archive.')
 
         @field_validator('filepath')
         @classmethod
@@ -89,15 +86,15 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
         return get_schema_version_head()
 
     @staticmethod
-    def create_profile(path: str | Path, options: dict | None = None) -> Profile:
+    def create_profile(filepath: str | Path, options: dict | None = None) -> Profile:
         """Create a new profile instance for this backend, from the path to the zip file."""
-        profile_name = Path(path).name
+        profile_name = Path(filepath).name
         return Profile(
             profile_name, {
                 'storage': {
                     'backend': 'core.sqlite_zip',
                     'config': {
-                        'path': str(path)
+                        'filepath': str(filepath)
                     }
                 },
                 'process_control': {
@@ -110,7 +107,7 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
 
     @classmethod
     def version_profile(cls, profile: Profile) -> Optional[str]:
-        return read_version(profile.storage_config['path'], search_limit=None)
+        return read_version(profile.storage_config['filepath'], search_limit=None)
 
     @classmethod
     def initialise(cls, profile: 'Profile', reset: bool = False) -> bool:
@@ -121,7 +118,7 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
             tests having run.
         :returns: ``True`` if the storage was initialised by the function call, ``False`` if it was already initialised.
         """
-        filepath_archive = Path(profile.storage_config['path'])
+        filepath_archive = Path(profile.storage_config['filepath'])
 
         if filepath_archive.exists() and not reset:
             # The archive exists but ``reset == False``, so we try to migrate to the latest schema version. If the
@@ -173,7 +170,7 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
 
     def __init__(self, profile: Profile):
         super().__init__(profile)
-        self._path = Path(profile.storage_config['path'])
+        self._path = Path(profile.storage_config['filepath'])
         validate_storage(self._path)
         # lazy open the archive zipfile and extract the database file
         self._db_file: Optional[Path] = None

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -65,6 +65,9 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
 
     """
 
+    read_only = True
+    """This plugin is read only and data cannot be created or mutated."""
+
     class Configuration(BaseModel):
         """Model describing required information to configure an instance of the storage."""
 
@@ -80,8 +83,6 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
             filepath = Path(value)
             assert filepath.is_file(), f'The archive `{value}` does not exist.'
             return str(filepath.resolve().absolute())
-
-    _read_only = True
 
     @classmethod
     def version_head(cls) -> str:

--- a/aiida/storage/sqlite_zip/orm.py
+++ b/aiida/storage/sqlite_zip/orm.py
@@ -68,7 +68,7 @@ class SqliteEntityOverride:
 
     def store(self, *args, **kwargs):
         backend = self._model._backend  # pylint: disable=protected-access
-        if getattr(backend, '_read_only', False):
+        if backend.read_only:
             raise ReadOnlyError(f'Cannot store entity in read-only backend: {backend}')
         return super().store(*args, **kwargs)  # type: ignore # pylint: disable=no-member
 

--- a/docs/source/topics/storage.rst
+++ b/docs/source/topics/storage.rst
@@ -159,8 +159,8 @@ An example of an automated generated directory is ``.aiida/repository/sqlite_dos
 ``core.sqlite_zip``
 ===================
 
-The `core.sqlite_zip` is a storage plugin that is used to create export archives.
-It functions more or less identical to the `core.sqlite_dos` plugin, as it uses an SQLite database and a disk-objectstore container, except everything is bundled up in a `zip archive <https://en.wikipedia.org/wiki/ZIP_(file_format)>`_.
+The ``core.sqlite_zip`` is a storage plugin that is used to create export archives.
+It functions more or less identical to the ``core.sqlite_dos`` plugin, as it uses an SQLite database and a disk-objectstore container, except everything is bundled up in a `zip archive <https://en.wikipedia.org/wiki/ZIP_(file_format)>`_.
 
 The storage plugin is not suited for normal use, because once the archive is created, it becomes read-only.
 However, since otherwise it functions like normal storage plugins, a profile can be created with it that make it easy to explore its contents:

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -14,6 +14,7 @@ import pytest
 
 from aiida.cmdline.commands import cmd_profile, cmd_verdi
 from aiida.manage import configuration
+from aiida.tools.archive.create import create_archive
 
 
 @pytest.fixture(scope='module')
@@ -133,12 +134,16 @@ def test_delete(run_cli_command, mock_profiles, pg_test_cluster):
     assert profile_list[3] not in result.output
 
 
-@pytest.mark.parametrize('entry_point', ('core.sqlite_temp', 'core.sqlite_dos'))
+@pytest.mark.parametrize('entry_point', ('core.sqlite_temp', 'core.sqlite_dos', 'core.sqlite_zip'))
 def test_setup(run_cli_command, isolated_config, tmp_path, entry_point):
     """Test the ``verdi profile setup`` command.
 
     Note that the options for user name and institution are not given on purpose as these should not be required.
     """
+    if entry_point == 'core.sqlite_zip':
+        tmp_path = tmp_path / 'archive.aiida'
+        create_archive([], filename=tmp_path)
+
     profile_name = 'temp-profile'
     options = [entry_point, '-n', '--filepath', str(tmp_path), '--profile', profile_name, '--email', 'email@host']
     result = run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)


### PR DESCRIPTION
The `create_profile` method was failing in combination with the
`SqliteZipStorage` for two reasons:

* The `SqliteZipStorage` implementation would expect the location of the
  storage on disk under the key `path`, but the configuration defines it
  as `filepath`. The class now consistently accepts `filepath`, to keep
  it in lines with the `SqliteDosStorage`.
* The `create_profile` method would except when it tried to create a
  default user, because the storage is read-only. It now checks the
  `read_only` attribute of the storage plugin to decide whether a
  default user should be created.