### PR TITLE
`DynamicEntryPointCommandGroup`: Allow entry points to be excluded

### DIFF
--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -68,7 +68,8 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
         commands = super().list_commands(ctx)
         commands.extend([
             entry_point for entry_point in get_entry_point_names(self.entry_point_group)
-            if re.match(self.entry_point_name_filter, entry_point)
+            if re.match(self.entry_point_name_filter, entry_point) and
+            getattr(self.factory(entry_point), 'cli_exposed', True)
         ])
         return sorted(commands)
 

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -53,6 +53,9 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
 
     _read_only = False
 
+    cli_exposed = False
+    """Ensure this plugin is not exposed in ``verdi profile setup``."""
+
     @staticmethod
     def create_profile(
         name: str = 'temp',


### PR DESCRIPTION
The `DynamicEntryPointCommandGroup` now checks plugin classes for the `cli_exposed` class attribute, and when set to `False`, no dynamic command is generated for the entry point, even if it matches the entry point filter regex.

This is used for the `core.sqlite_temp` storage plugin, since this is a storage that is automatically cleaned up after it is garbage collected, for example when the Python interpreter shuts down. It therefore does not make sense to allow a profile to be created using this storage plugin through `verdi profile setup`.