### PR TITLE
`verdi profile delete`: Make it storage plugin agnostic

### DIFF
--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -247,6 +247,10 @@ class StorageBackend(abc.ABC):  # pylint: disable=too-many-public-methods
         :raises: ``IntegrityError`` if the keys in a row are not a subset of the columns in the table
         """
 
+    def delete(self) -> None:
+        """Delete the storage and all the data."""
+        raise NotImplementedError()
+
     @abc.abstractmethod
     def delete_nodes_and_connections(self, pks_to_delete: Sequence[int]):
         """Delete all nodes corresponding to pks in the input and any links to/from them.

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -284,6 +284,10 @@ class SqliteTempBackend(StorageBackend):  # pylint: disable=too-many-public-meth
         with (nullcontext() if self.in_transaction else self.transaction()):
             session.execute(update(mapper), rows)
 
+    def delete(self) -> None:
+        """Delete the storage and all the data."""
+        self._repo.erase()
+
     def delete_nodes_and_connections(self, pks_to_delete: Sequence[int]):
         raise NotImplementedError
 

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -293,6 +293,13 @@ class SqliteZipBackend(StorageBackend):  # pylint: disable=too-many-public-metho
     def bulk_update(self, entity_type: EntityTypes, rows: list[dict]) -> None:
         raise ReadOnlyError()
 
+    def delete(self) -> None:
+        """Delete the storage and all the data."""
+        filepath = Path(self.profile.storage_config['filepath'])
+        if filepath.exists():
+            filepath.unlink()
+            LOGGER.report(f'Deleted archive at `{filepath}`.')
+
     def delete_nodes_and_connections(self, pks_to_delete: Sequence[int]):
         raise ReadOnlyError()
 

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -427,7 +427,7 @@ def test_delete_profile(config_with_profile, profile_factory):
     # Write the contents to disk so that the to-be-deleted profile is in the config file on disk
     config.store()
 
-    config.delete_profile(profile_name)
+    config.delete_profile(profile_name, delete_storage=False)
     assert profile_name not in config.profile_names
 
     # Now reload the config from disk to make sure the changes after deletion were persisted to disk


### PR DESCRIPTION
Fixes #5515

The `verdi profile delete` implementation was hardcoded to work only for
the `core.psql_dos` storage plugin. However, it is possible for profiles
to use different storage plugins, causing the command to except.

The command now forwards to `Config.delete_profile`. This method gets
the storage plugin defined for the profile and constructs an instance of
it for the given profile. It then calls `delete` on the storage instance
if the `delete_storage` argument is set to `True`.

The new `delete` method is defined on the `StorageBackend` abstract base
class. It is intentionally not made abstract, but rather explicitly
raises `NotImplementedError`. Otherwise existing storage plugins outside
of `aiida-core` would no longer be instantiable before they implement
the method.

The various options of `verdi profile delete` to control what parts of
the storage are deleted, are simplified to just a single switch that
controls whether the storage is deleted or not.

The command now also properly detects if the delete profile was the
default, in which case another profile is marked as the new default if
any profiles remain at all.