### PR TITLE
Engine: Fix log report when `submit=wait`

### DIFF
--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -125,8 +125,11 @@ def submit(process: TYPE_SUBMIT_PROCESS, wait: bool = False, wait_interval: int 
         return node
 
     while not node.is_terminated:
+        LOGGER.report(
+            f'Process<{node.pk}> has not yet terminated, current state is `{node.process_state}`. '
+            f'Waiting for {wait_interval} seconds.'
+        )
         time.sleep(wait_interval)
-        LOGGER.report(f'Process<{node.pk}> has not yet terminated, current state is `{node.process_state}`.')
 
     return node
 


### PR DESCRIPTION
Fixes #6209 

It was placed after the sleep, causing it to erroneously print the process hasn't terminated yet even when it did during the first wait interval. It is now placed before the sleep and it includes the number of seconds it is going to wait.