### PR TITLE
Docs: Fix instructions for inspecting archive files

### DIFF
--- a/docs/source/howto/archive_profile.md
+++ b/docs/source/howto/archive_profile.md
@@ -16,7 +16,7 @@ kernelspec:
 # How to inspect an archive
 
 ```{note}
-This tutorial can be downloaded and run as a Jupyter Notebook: {nb-download}`archive_profile.ipynb` {octicon}`download`, together with the archive {download}`include/process.aiida`.
+This tutorial can be downloaded and run as a Jupyter Notebook: {nb-download}`archive_profile.ipynb` {octicon}`download`, together with the archive {download}`process.aiida`.
 ```
 
 The AiiDA archive is a file format for long term storage of data from a particular profile.
@@ -25,7 +25,7 @@ See {ref}`how-to:share:archives` for information on how to create and migrate an
 The easiest way to inspect the contents of an archive is to create a profile that "mounts" the archive as its data storage:
 
 ```{code-cell} ipython3
-!verdi profile setup core.sqlite_zip -n --profile archive --filepath include/process.aiida
+!verdi profile setup core.sqlite_zip -n --profile archive --filepath process.aiida
 ```
 
 You can now inspect the contents of the `process.aiida` archive by using the `archive` profile in the same way you would a standard AiiDA profile.

--- a/docs/source/howto/visualising_graphs.md
+++ b/docs/source/howto/visualising_graphs.md
@@ -72,7 +72,7 @@ as outlined in the [graphviz attributes table](https://www.graphviz.org/doc/info
 graph = Graph(node_id_type="uuid",
               global_node_style={"penwidth": 1},
               global_edge_style={"color": "blue"},
-              graph_attr={"size": "8!,8!", "rankdir": "LR"})
+              graph_attr={"rankdir": "LR"})
 graph.add_incoming(calc1_uuid)
 graph.add_outgoing(calc1_uuid)
 graph.graphviz
@@ -86,7 +86,7 @@ def link_style(link_pair, **kwargs):
 
 graph = Graph(node_style_fn=pstate_node_styles,
               link_style_fn=link_style,
-              graph_attr={"size": "8!,8!", "rankdir": "LR"})
+              graph_attr={"rankdir": "LR"})
 graph.add_incoming(calc1_uuid)
 graph.add_outgoing(calc1_uuid)
 graph.graphviz
@@ -95,7 +95,7 @@ graph.graphviz
 Edges can be annotated by one or both of their edge label and link type.
 
 ```{code-cell} ipython3
-graph = Graph(graph_attr={"size": "8!,8!", "rankdir": "LR"})
+graph = Graph(graph_attr={"rankdir": "LR"})
 graph.add_incoming(calc1_uuid,
                    annotate_links="both")
 graph.add_outgoing(calc1_uuid,
@@ -106,7 +106,7 @@ graph.graphviz
 The {py:meth}`~aiida.tools.visualization.graph.Graph.recurse_descendants` and {py:meth}`~aiida.tools.visualization.graph.Graph.recurse_ancestors` methods can be used to construct a full provenance graph.
 
 ```{code-cell} ipython3
-graph = Graph(graph_attr={"size": "8!,8!", "rankdir": "LR"})
+graph = Graph(graph_attr={"rankdir": "LR"})
 graph.recurse_descendants(
     dict1_uuid,
     origin_style=None,
@@ -119,7 +119,7 @@ graph.graphviz
 The link types can also be filtered, to view only the 'data' or 'logical' provenance.
 
 ```{code-cell} ipython3
-graph = Graph(graph_attr={"size": "8,8!", "rankdir": "LR"})
+graph = Graph(graph_attr={"rankdir": "LR"})
 graph.recurse_descendants(
     dict1_uuid,
     origin_style=None,
@@ -131,7 +131,7 @@ graph.graphviz
 ```
 
 ```{code-cell} ipython3
-graph = Graph(graph_attr={"size": "8,8!", "rankdir": "LR"})
+graph = Graph(graph_attr={"rankdir": "LR"})
 graph.recurse_descendants(
     dict1_uuid,
     origin_style=None,
@@ -147,7 +147,7 @@ then the `highlight_classes` option can be used
 to only color specified nodes:
 
 ```{code-cell} ipython3
-graph = Graph(graph_attr={"size": "20,20", "rankdir": "LR"})
+graph = Graph(graph_attr={"rankdir": "LR"})
 graph.recurse_descendants(
     dict1_uuid,
     highlight_classes=['Dict']


### PR DESCRIPTION
Fixes #6219 

The instructions were incorrect and caused exceptions:

* The `profile_context ` would except if another profile would already be loaded, unless `allow_switch=True` is passed explicitly.
* The profile will use a relative path for the archive in the profile config. This will cause an exception when the path cannot be found.
* No default user would be set for the profile, causing an exception when a new ORM entity would be instantiated.

The instructions are fixed by suggesting to use the new CLI command `verdi profile setup` to create a profile using the `core.sqlite_zip` storage. This allows the profile to be used like any other profile, simplifying the instructions, and fixing the problems above.