### PR TITLE
Bump artifact action to v4

### DIFF
--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -16,7 +16,7 @@ runs:
     using: composite
     steps:
         - name: Download built image 📥
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
               name: ${{ inputs.image }}-${{ inputs.architecture }}
               path: /tmp/

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -61,14 +61,14 @@ jobs:
                 docker save ${{ env.OWNER }}/aiida-core-with-services -o /tmp/aiida-core/aiida-core-with-services-${{ inputs.architecture }}.tar
 
             - name: Upload aiida-core-base image as artifact 💾
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: aiida-core-base-${{ inputs.architecture }}
                   path: /tmp/aiida-core/aiida-core-base-${{ inputs.architecture }}.tar
                   retention-days: 3
 
             - name: Upload aiida-core-with-services image as artifact 💾
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: aiida-core-with-services-${{ inputs.architecture }}
                   path: /tmp/aiida-core/aiida-core-with-services-${{ inputs.architecture }}.tar

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -33,12 +33,12 @@ jobs:
                   architecture: amd64
 
             - name: Download amd64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ matrix.image }}-amd64-tags
                   path: /tmp/aiida-core
             - name: Download arm64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ matrix.image }}-arm64-tags
                   path: /tmp/aiida-core

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -90,7 +90,7 @@ jobs:
                   done
 
             - name: Upload tags file 📤
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ matrix.image }}-${{ inputs.architecture }}-tags
                   path: /tmp/aiida-core/${{ matrix.image }}-${{ inputs.architecture }}-tags.txt


### PR DESCRIPTION
The changes should significantly speed up artifact upload, see https://github.com/actions/upload-artifact#v4---whats-new