### PR TITLE
`DynamicEntryPointCommandGroup`: Temporarily silence deprecation warning

### DIFF
--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -130,12 +130,14 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
         cls = self.factory(entry_point)
 
         if not hasattr(cls, 'Configuration'):
-            from aiida.common.warnings import warn_deprecation
-            warn_deprecation(
-                'Relying on `_get_cli_options` is deprecated. The options should be defined through a '
-                '`pydantic.BaseModel` that should be assigned to the `Config` class attribute.',
-                version=3
-            )
+            # This should be enabled once the ``Code`` classes are migrated to using pydantic to define their model.
+            # See https://github.com/aiidateam/aiida-core/pull/6190
+            # from aiida.common.warnings import warn_deprecation
+            # warn_deprecation(
+            #     'Relying on `_get_cli_options` is deprecated. The options should be defined through a '
+            #     '`pydantic.BaseModel` that should be assigned to the `Config` class attribute.',
+            #     version=3
+            # )
             options_spec = self.factory(entry_point).get_cli_options()  # type: ignore[union-attr]
         else:
 


### PR DESCRIPTION
The `AbstractCode` and its subclasses have not yet migrated to using `pydantic` instead of `_get_cli_options()` and therefore running the `verdi code create` command would emit the deprecation warning. The warning is temporarily silenced until the code has also been migrated.