### PR TITLE
Pre-commit: Update a number of pre-commit hooks 

### DIFF
--- a/.docker/tests/conftest.py
+++ b/.docker/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import time
 from pathlib import Path

--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 
 import pytest

--- a/.github/system_tests/test_containerized_code.py
+++ b/.github/system_tests/test_containerized_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.github/system_tests/test_daemon.py
+++ b/.github/system_tests/test_daemon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.github/system_tests/workchains.py
+++ b/.github/system_tests/workchains.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.github/workflows/check_release_tag.py
+++ b/.github/workflows/check_release_tag.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Check that the GitHub release tag matches the package version."""
 import argparse
 import ast

--- a/.molecule/default/files/polish/__init__.py
+++ b/.molecule/default/files/polish/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.molecule/default/files/polish/lib/__init__.py
+++ b/.molecule/default/files/polish/lib/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.molecule/default/files/polish/lib/expression.py
+++ b/.molecule/default/files/polish/lib/expression.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.molecule/default/files/polish/lib/workchain.py
+++ b/.molecule/default/files/polish/lib/workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
+  - id: check-merge-conflict
+  - id: check-yaml
   - id: double-quote-string-fixer
   - id: end-of-file-fixer
     exclude: &exclude_pre_commit_hooks >
@@ -15,10 +17,11 @@ repos:
         CHANGELOG.md|
       )$
   - id: fix-encoding-pragma
+    args: [--remove]
   - id: mixed-line-ending
+    args: [--fix=lf]
   - id: trailing-whitespace
     exclude: *exclude_pre_commit_hooks
-  - id: check-yaml
 
 - repo: https://github.com/ikamensh/flynt/
   rev: 1.0.1
@@ -204,8 +207,8 @@ repos:
     pass_filenames: false
     files: >-
       (?x)^(
-          pyproject.toml|
-          utils/dependency_management.py
+        pyproject.toml|
+        utils/dependency_management.py
       )$
 
   - id: dependencies

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/__main__.py
+++ b/aiida/__main__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/calculations/__init__.py
+++ b/aiida/calculations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/calculations/arithmetic/__init__.py
+++ b/aiida/calculations/arithmetic/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/calculations/arithmetic/add.py
+++ b/aiida/calculations/arithmetic/add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/calculations/diff_tutorial/calculations.py
+++ b/aiida/calculations/diff_tutorial/calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Calculations provided by aiida_diff tutorial plugin.
 
 Register calculations via the "aiida.calculations" entry point in the pyproject.toml file.

--- a/aiida/calculations/importers/arithmetic/add.py
+++ b/aiida/calculations/importers/arithmetic/add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Importer for the :class:`aiida.calculations.arithmetic.add.ArithmeticAddCalculation` plugin."""
 from pathlib import Path
 from re import match

--- a/aiida/calculations/monitors/base.py
+++ b/aiida/calculations/monitors/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Monitors for the :class:`aiida.calculations.arithmetic.add.ArithmeticAddCalculation` plugin."""
 from __future__ import annotations
 

--- a/aiida/calculations/templatereplacer.py
+++ b/aiida/calculations/templatereplacer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/calculations/transfer.py
+++ b/aiida/calculations/transfer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/__init__.py
+++ b/aiida/cmdline/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_archive.py
+++ b/aiida/cmdline/commands/cmd_archive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/__init__.py
+++ b/aiida/cmdline/commands/cmd_data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_array.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_array.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_dict.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_list.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_help.py
+++ b/aiida/cmdline/commands/cmd_help.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_plugin.py
+++ b/aiida/cmdline/commands/cmd_plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_rabbitmq.py
+++ b/aiida/cmdline/commands/cmd_rabbitmq.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_storage.py
+++ b/aiida/cmdline/commands/cmd_storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/groups/__init__.py
+++ b/aiida/cmdline/groups/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module with custom implementations of :class:`click.Group`."""
 
 # AUTO-GENERATED

--- a/aiida/cmdline/groups/dynamic.py
+++ b/aiida/cmdline/groups/dynamic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Subclass of :class:`click.Group` that loads subcommands dynamically from entry points."""
 from __future__ import annotations
 

--- a/aiida/cmdline/groups/verdi.py
+++ b/aiida/cmdline/groups/verdi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Subclass of :class:`click.Group` for the ``verdi`` CLI."""
 from __future__ import annotations
 

--- a/aiida/cmdline/params/__init__.py
+++ b/aiida/cmdline/params/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/arguments/__init__.py
+++ b/aiida/cmdline/params/arguments/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/arguments/main.py
+++ b/aiida/cmdline/params/arguments/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/arguments/overridable.py
+++ b/aiida/cmdline/params/arguments/overridable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/callable.py
+++ b/aiida/cmdline/params/options/callable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/commands/__init__.py
+++ b/aiida/cmdline/params/options/commands/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/conditional.py
+++ b/aiida/cmdline/params/options/conditional.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/config.py
+++ b/aiida/cmdline/params/options/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/main.py
+++ b/aiida/cmdline/params/options/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/multivalue.py
+++ b/aiida/cmdline/params/options/multivalue.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/options/overridable.py
+++ b/aiida/cmdline/params/options/overridable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/calculation.py
+++ b/aiida/cmdline/params/types/calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/choice.py
+++ b/aiida/cmdline/params/types/choice.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/code.py
+++ b/aiida/cmdline/params/types/code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/computer.py
+++ b/aiida/cmdline/params/types/computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/config.py
+++ b/aiida/cmdline/params/types/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/data.py
+++ b/aiida/cmdline/params/types/data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/group.py
+++ b/aiida/cmdline/params/types/group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/identifier.py
+++ b/aiida/cmdline/params/types/identifier.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/multiple.py
+++ b/aiida/cmdline/params/types/multiple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/node.py
+++ b/aiida/cmdline/params/types/node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/plugin.py
+++ b/aiida/cmdline/params/types/plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/process.py
+++ b/aiida/cmdline/params/types/process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/profile.py
+++ b/aiida/cmdline/params/types/profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/strings.py
+++ b/aiida/cmdline/params/types/strings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/user.py
+++ b/aiida/cmdline/params/types/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/params/types/workflow.py
+++ b/aiida/cmdline/params/types/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/__init__.py
+++ b/aiida/cmdline/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/ascii_vis.py
+++ b/aiida/cmdline/utils/ascii_vis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/defaults.py
+++ b/aiida/cmdline/utils/defaults.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/log.py
+++ b/aiida/cmdline/utils/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utilities for logging in the command line interface context."""
 import logging
 

--- a/aiida/cmdline/utils/multi_line_input.py
+++ b/aiida/cmdline/utils/multi_line_input.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/query/__init__.py
+++ b/aiida/cmdline/utils/query/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/query/formatting.py
+++ b/aiida/cmdline/utils/query/formatting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/query/mapping.py
+++ b/aiida/cmdline/utils/query/mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/repository.py
+++ b/aiida/cmdline/utils/repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/shell.py
+++ b/aiida/cmdline/utils/shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/cmdline/utils/templates.py
+++ b/aiida/cmdline/utils/templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/__init__.py
+++ b/aiida/common/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/constants.py
+++ b/aiida/common/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/files.py
+++ b/aiida/common/files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/json.py
+++ b/aiida/common/json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/lang.py
+++ b/aiida/common/lang.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/links.py
+++ b/aiida/common/links.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/progress_reporter.py
+++ b/aiida/common/progress_reporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/timezone.py
+++ b/aiida/common/timezone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/common/warnings.py
+++ b/aiida/common/warnings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/__init__.py
+++ b/aiida/engine/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/daemon/__init__.py
+++ b/aiida/engine/daemon/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/daemon/worker.py
+++ b/aiida/engine/daemon/worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/exceptions.py
+++ b/aiida/engine/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/persistence.py
+++ b/aiida/engine/persistence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/__init__.py
+++ b/aiida/engine/processes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/calcjobs/__init__.py
+++ b/aiida/engine/processes/calcjobs/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/calcjobs/importer.py
+++ b/aiida/engine/processes/calcjobs/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Abstract utility class that helps to import calculation jobs completed outside of AiiDA."""
 from abc import ABC, abstractmethod
 from typing import Dict, Union

--- a/aiida/engine/processes/calcjobs/manager.py
+++ b/aiida/engine/processes/calcjobs/manager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/calcjobs/monitors.py
+++ b/aiida/engine/processes/calcjobs/monitors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utilities to define monitor functions for ``CalcJobs``."""
 from __future__ import annotations
 

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/control.py
+++ b/aiida/engine/processes/control.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Functions to control and interact with running processes."""
 from __future__ import annotations
 

--- a/aiida/engine/processes/exit_code.py
+++ b/aiida/engine/processes/exit_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/futures.py
+++ b/aiida/engine/processes/futures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/process_spec.py
+++ b/aiida/engine/processes/process_spec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/utils.py
+++ b/aiida/engine/processes/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module with utilities."""
 from collections.abc import Mapping
 

--- a/aiida/engine/processes/workchains/__init__.py
+++ b/aiida/engine/processes/workchains/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/workchains/awaitable.py
+++ b/aiida/engine/processes/workchains/awaitable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/workchains/context.py
+++ b/aiida/engine/processes/workchains/context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/workchains/restart.py
+++ b/aiida/engine/processes/workchains/restart.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/workchains/utils.py
+++ b/aiida/engine/processes/workchains/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/transports.py
+++ b/aiida/engine/transports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/__init__.py
+++ b/aiida/manage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/caching.py
+++ b/aiida/manage/caching.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/migrations/__init__.py
+++ b/aiida/manage/configuration/migrations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/migrations/migrations.py
+++ b/aiida/manage/configuration/migrations/migrations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/options.py
+++ b/aiida/manage/configuration/options.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/profile.py
+++ b/aiida/manage/configuration/profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/schema/__init__.py
+++ b/aiida/manage/configuration/schema/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/configuration/settings.py
+++ b/aiida/manage/configuration/settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/external/__init__.py
+++ b/aiida/manage/external/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/external/rmq/__init__.py
+++ b/aiida/manage/external/rmq/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/external/rmq/client.py
+++ b/aiida/manage/external/rmq/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Client for RabbitMQ Management HTTP API."""
 from __future__ import annotations
 

--- a/aiida/manage/external/rmq/defaults.py
+++ b/aiida/manage/external/rmq/defaults.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Defaults related to RabbitMQ."""
 from aiida.common.extendeddicts import AttributeDict
 

--- a/aiida/manage/external/rmq/launcher.py
+++ b/aiida/manage/external/rmq/launcher.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """A sub class of ``plumpy.ProcessLauncher`` to launch a ``Process``."""
 import asyncio
 import logging

--- a/aiida/manage/external/rmq/utils.py
+++ b/aiida/manage/external/rmq/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utilites for RabbitMQ."""
 
 from . import defaults

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/profile_access.py
+++ b/aiida/manage/profile_access.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/tests/__init__.py
+++ b/aiida/manage/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/manage/tests/pytest_fixtures.py
+++ b/aiida/manage/tests/pytest_fixtures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/__init__.py
+++ b/aiida/orm/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/autogroup.py
+++ b/aiida/orm/autogroup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/comments.py
+++ b/aiida/orm/comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/convert.py
+++ b/aiida/orm/convert.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/extras.py
+++ b/aiida/orm/extras.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/__init__.py
+++ b/aiida/orm/implementation/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/comments.py
+++ b/aiida/orm/implementation/comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/computers.py
+++ b/aiida/orm/implementation/computers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/entities.py
+++ b/aiida/orm/implementation/entities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/logs.py
+++ b/aiida/orm/implementation/logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/nodes.py
+++ b/aiida/orm/implementation/nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/querybuilder.py
+++ b/aiida/orm/implementation/querybuilder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/storage_backend.py
+++ b/aiida/orm/implementation/storage_backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/users.py
+++ b/aiida/orm/implementation/users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/implementation/utils.py
+++ b/aiida/orm/implementation/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/__init__.py
+++ b/aiida/orm/nodes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/attributes.py
+++ b/aiida/orm/nodes/attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/caching.py
+++ b/aiida/orm/nodes/caching.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Interface to control caching of a node instance."""
 from __future__ import annotations
 

--- a/aiida/orm/nodes/comments.py
+++ b/aiida/orm/nodes/comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Interface for comments of a node instance."""
 from __future__ import annotations
 

--- a/aiida/orm/nodes/data/__init__.py
+++ b/aiida/orm/nodes/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/__init__.py
+++ b/aiida/orm/nodes/data/array/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/array.py
+++ b/aiida/orm/nodes/data/array/array.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/kpoints.py
+++ b/aiida/orm/nodes/data/array/kpoints.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/projection.py
+++ b/aiida/orm/nodes/data/array/projection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/array/xy.py
+++ b/aiida/orm/nodes/data/array/xy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/base.py
+++ b/aiida/orm/nodes/data/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/bool.py
+++ b/aiida/orm/nodes/data/bool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/code/__init__.py
+++ b/aiida/orm/nodes/data/code/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugins that represent an executable code."""
 
 # AUTO-GENERATED

--- a/aiida/orm/nodes/data/code/abstract.py
+++ b/aiida/orm/nodes/data/code/abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/code/containerized.py
+++ b/aiida/orm/nodes/data/code/containerized.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/code/installed.py
+++ b/aiida/orm/nodes/data/code/installed.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/code/legacy.py
+++ b/aiida/orm/nodes/data/code/legacy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/code/portable.py
+++ b/aiida/orm/nodes/data/code/portable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/enum.py
+++ b/aiida/orm/nodes/data/enum.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugin that allows to easily wrap an :class:`enum.Enum` member.
 
 Nomenclature is taken from Python documentation: https://docs.python.org/3/library/enum.html

--- a/aiida/orm/nodes/data/float.py
+++ b/aiida/orm/nodes/data/float.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/folder.py
+++ b/aiida/orm/nodes/data/folder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/int.py
+++ b/aiida/orm/nodes/data/int.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/jsonable.py
+++ b/aiida/orm/nodes/data/jsonable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugin that allows to easily wrap objects that are JSON-able."""
 import importlib
 import json

--- a/aiida/orm/nodes/data/list.py
+++ b/aiida/orm/nodes/data/list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/numeric.py
+++ b/aiida/orm/nodes/data/numeric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/orbital.py
+++ b/aiida/orm/nodes/data/orbital.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/remote/__init__.py
+++ b/aiida/orm/nodes/data/remote/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module with data plugins that represent remote resources and so effectively are symbolic links."""
 
 # AUTO-GENERATED

--- a/aiida/orm/nodes/data/remote/base.py
+++ b/aiida/orm/nodes/data/remote/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/remote/stash/__init__.py
+++ b/aiida/orm/nodes/data/remote/stash/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module with data plugins that represent files of completed calculations jobs that have been stashed."""
 
 # AUTO-GENERATED

--- a/aiida/orm/nodes/data/remote/stash/base.py
+++ b/aiida/orm/nodes/data/remote/stash/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugin that models an archived folder on a remote computer."""
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check

--- a/aiida/orm/nodes/data/remote/stash/folder.py
+++ b/aiida/orm/nodes/data/remote/stash/folder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugin that models a stashed folder on a remote computer."""
 import typing
 

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/str.py
+++ b/aiida/orm/nodes/data/str.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/links.py
+++ b/aiida/orm/nodes/links.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Interface for links of a node instance."""
 from __future__ import annotations
 

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/__init__.py
+++ b/aiida/orm/nodes/process/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/calculation/__init__.py
+++ b/aiida/orm/nodes/process/calculation/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/calculation/calcfunction.py
+++ b/aiida/orm/nodes/process/calculation/calcfunction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/calculation/calculation.py
+++ b/aiida/orm/nodes/process/calculation/calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/workflow/__init__.py
+++ b/aiida/orm/nodes/process/workflow/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/workflow/workchain.py
+++ b/aiida/orm/nodes/process/workflow/workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/workflow/workflow.py
+++ b/aiida/orm/nodes/process/workflow/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/process/workflow/workfunction.py
+++ b/aiida/orm/nodes/process/workflow/workfunction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/nodes/repository.py
+++ b/aiida/orm/nodes/repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Interface to the file repository of a node instance."""
 from __future__ import annotations
 

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/users.py
+++ b/aiida/orm/users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/__init__.py
+++ b/aiida/orm/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/builders/__init__.py
+++ b/aiida/orm/utils/builders/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/builders/code.py
+++ b/aiida/orm/utils/builders/code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/builders/computer.py
+++ b/aiida/orm/utils/builders/computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/calcjob.py
+++ b/aiida/orm/utils/calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/log.py
+++ b/aiida/orm/utils/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/managers.py
+++ b/aiida/orm/utils/managers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/remote.py
+++ b/aiida/orm/utils/remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/orm/utils/serialize.py
+++ b/aiida/orm/utils/serialize.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/__init__.py
+++ b/aiida/parsers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/plugins/__init__.py
+++ b/aiida/parsers/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/plugins/arithmetic/__init__.py
+++ b/aiida/parsers/plugins/arithmetic/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/plugins/arithmetic/add.py
+++ b/aiida/parsers/plugins/arithmetic/add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/plugins/diff_tutorial/parsers.py
+++ b/aiida/parsers/plugins/diff_tutorial/parsers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Parsers for DiffCalculation of plugin tutorial.
 
 Register parsers via the "aiida.parsers" entry point in the pyproject.toml file.

--- a/aiida/parsers/plugins/templatereplacer/__init__.py
+++ b/aiida/parsers/plugins/templatereplacer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/parsers/plugins/templatereplacer/parser.py
+++ b/aiida/parsers/plugins/templatereplacer/parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/plugins/__init__.py
+++ b/aiida/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/plugins/factories.py
+++ b/aiida/plugins/factories.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/repository/__init__.py
+++ b/aiida/repository/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/repository/backend/__init__.py
+++ b/aiida/repository/backend/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for file repository backend implementations."""
 
 # AUTO-GENERATED

--- a/aiida/repository/backend/abstract.py
+++ b/aiida/repository/backend/abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Class that defines the abstract interface for an object repository.
 
 The scope of this class is intentionally very narrow. Any backend implementation should merely provide the methods to

--- a/aiida/repository/backend/disk_object_store.py
+++ b/aiida/repository/backend/disk_object_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of the ``AbstractRepositoryBackend`` using the ``disk-objectstore`` as the backend."""
 import contextlib
 import dataclasses

--- a/aiida/repository/backend/sandbox.py
+++ b/aiida/repository/backend/sandbox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of the ``AbstractRepositoryBackend`` using a sandbox folder on disk as the backend."""
 from __future__ import annotations
 

--- a/aiida/repository/common.py
+++ b/aiida/repository/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/repository/repository.py
+++ b/aiida/repository/repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for the implementation of a file repository."""
 import contextlib
 import pathlib

--- a/aiida/restapi/__init__.py
+++ b/aiida/restapi/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/common/__init__.py
+++ b/aiida/restapi/common/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/common/config.py
+++ b/aiida/restapi/common/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/common/exceptions.py
+++ b/aiida/restapi/common/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/common/identifiers.py
+++ b/aiida/restapi/common/identifiers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/common/utils.py
+++ b/aiida/restapi/common/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/__init__.py
+++ b/aiida/restapi/translator/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/computer.py
+++ b/aiida/restapi/translator/computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/group.py
+++ b/aiida/restapi/translator/group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/__init__.py
+++ b/aiida/restapi/translator/nodes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/__init__.py
+++ b/aiida/restapi/translator/nodes/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/array/__init__.py
+++ b/aiida/restapi/translator/nodes/data/array/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/array/bands.py
+++ b/aiida/restapi/translator/nodes/data/array/bands.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/cif.py
+++ b/aiida/restapi/translator/nodes/data/cif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/code.py
+++ b/aiida/restapi/translator/nodes/data/code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/kpoints.py
+++ b/aiida/restapi/translator/nodes/data/kpoints.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/structure.py
+++ b/aiida/restapi/translator/nodes/data/structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/data/upf.py
+++ b/aiida/restapi/translator/nodes/data/upf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/__init__.py
+++ b/aiida/restapi/translator/nodes/process/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/calculation/__init__.py
+++ b/aiida/restapi/translator/nodes/process/calculation/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/calculation/calcfunction.py
+++ b/aiida/restapi/translator/nodes/process/calculation/calcfunction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/calculation/calcjob.py
+++ b/aiida/restapi/translator/nodes/process/calculation/calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/process.py
+++ b/aiida/restapi/translator/nodes/process/process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/workflow/__init__.py
+++ b/aiida/restapi/translator/nodes/process/workflow/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/workflow/workchain.py
+++ b/aiida/restapi/translator/nodes/process/workflow/workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/nodes/process/workflow/workfunction.py
+++ b/aiida/restapi/translator/nodes/process/workflow/workfunction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/restapi/translator/user.py
+++ b/aiida/restapi/translator/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/__init__.py
+++ b/aiida/schedulers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/__init__.py
+++ b/aiida/schedulers/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/pbspro.py
+++ b/aiida/schedulers/plugins/pbspro.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/sge.py
+++ b/aiida/schedulers/plugins/sge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/plugins/torque.py
+++ b/aiida/schedulers/plugins/torque.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/sphinxext/__init__.py
+++ b/aiida/sphinxext/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/sphinxext/calcjob.py
+++ b/aiida/sphinxext/calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/sphinxext/process.py
+++ b/aiida/sphinxext/process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/sphinxext/workchain.py
+++ b/aiida/sphinxext/workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/__init__.py
+++ b/aiida/storage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/log.py
+++ b/aiida/storage/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/__init__.py
+++ b/aiida/storage/psql_dos/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/alembic_cli.py
+++ b/aiida/storage/psql_dos/alembic_cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/backend.py
+++ b/aiida/storage/psql_dos/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/__init__.py
+++ b/aiida/storage/psql_dos/migrations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/env.py
+++ b/aiida/storage/psql_dos/migrations/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/__init__.py
+++ b/aiida/storage/psql_dos/migrations/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/calc_state.py
+++ b/aiida/storage/psql_dos/migrations/utils/calc_state.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/create_dbattribute.py
+++ b/aiida/storage/psql_dos/migrations/utils/create_dbattribute.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/dblog_update.py
+++ b/aiida/storage/psql_dos/migrations/utils/dblog_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/duplicate_uuids.py
+++ b/aiida/storage/psql_dos/migrations/utils/duplicate_uuids.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/integrity.py
+++ b/aiida/storage/psql_dos/migrations/utils/integrity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py
+++ b/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/migrate_repository.py
+++ b/aiida/storage/psql_dos/migrations/utils/migrate_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/parity.py
+++ b/aiida/storage/psql_dos/migrations/utils/parity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/provenance_redesign.py
+++ b/aiida/storage/psql_dos/migrations/utils/provenance_redesign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/reflect.py
+++ b/aiida/storage/psql_dos/migrations/utils/reflect.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/utils/utils.py
+++ b/aiida/storage/psql_dos/migrations/utils/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/041a79fc615f_dblog_cleaning.py
+++ b/aiida/storage/psql_dos/migrations/versions/041a79fc615f_dblog_cleaning.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/07fac78e6209_drop_computer_transport_params.py
+++ b/aiida/storage/psql_dos/migrations/versions/07fac78e6209_drop_computer_transport_params.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
+++ b/aiida/storage/psql_dos/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/0edcdd5a30f0_dbgroup_extras.py
+++ b/aiida/storage/psql_dos/migrations/versions/0edcdd5a30f0_dbgroup_extras.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/118349c10896_default_link_label.py
+++ b/aiida/storage/psql_dos/migrations/versions/118349c10896_default_link_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
+++ b/aiida/storage/psql_dos/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
+++ b/aiida/storage/psql_dos/migrations/versions/140c971ae0a3_migrate_builtin_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/162b99bca4a2_drop_dbcalcstate.py
+++ b/aiida/storage/psql_dos/migrations/versions/162b99bca4a2_drop_dbcalcstate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/1830c8430131_drop_node_columns_nodeversion_public.py
+++ b/aiida/storage/psql_dos/migrations/versions/1830c8430131_drop_node_columns_nodeversion_public.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
+++ b/aiida/storage/psql_dos/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/1de112340b16_django_parity_1.py
+++ b/aiida/storage/psql_dos/migrations/versions/1de112340b16_django_parity_1.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/1de112340b17_django_parity_2.py
+++ b/aiida/storage/psql_dos/migrations/versions/1de112340b17_django_parity_2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/1de112340b18_django_parity_3.py
+++ b/aiida/storage/psql_dos/migrations/versions/1de112340b18_django_parity_3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/1feaea71bd5a_migrate_repository.py
+++ b/aiida/storage/psql_dos/migrations/versions/1feaea71bd5a_migrate_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/239cea6d2452_provenance_redesign.py
+++ b/aiida/storage/psql_dos/migrations/versions/239cea6d2452_provenance_redesign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/26d561acd560_data_migration_legacy_job_calculations.py
+++ b/aiida/storage/psql_dos/migrations/versions/26d561acd560_data_migration_legacy_job_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/34a831f4286d_entry_point_core_prefix.py
+++ b/aiida/storage/psql_dos/migrations/versions/34a831f4286d_entry_point_core_prefix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/35d4ee9a1b0e_code_hidden_attr_to_extra.py
+++ b/aiida/storage/psql_dos/migrations/versions/35d4ee9a1b0e_code_hidden_attr_to_extra.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/375c2db70663_dblog_uuid_uniqueness_constraint.py
+++ b/aiida/storage/psql_dos/migrations/versions/375c2db70663_dblog_uuid_uniqueness_constraint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/storage/psql_dos/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/3d6190594e19_remove_dbcomputer_enabled.py
+++ b/aiida/storage/psql_dos/migrations/versions/3d6190594e19_remove_dbcomputer_enabled.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/535039300e4a_computer_name_to_label.py
+++ b/aiida/storage/psql_dos/migrations/versions/535039300e4a_computer_name_to_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Rename `db_dbcomputer.name` to `db_dbcomputer.label`
 
 Revision ID: 535039300e4a

--- a/aiida/storage/psql_dos/migrations/versions/59edaf8a8b79_adding_indexes_and_constraints_to_the_.py
+++ b/aiida/storage/psql_dos/migrations/versions/59edaf8a8b79_adding_indexes_and_constraints_to_the_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/5a49629f0d45_dblink_indices.py
+++ b/aiida/storage/psql_dos/migrations/versions/5a49629f0d45_dblink_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/5d4d844852b6_invalidating_node_hash.py
+++ b/aiida/storage/psql_dos/migrations/versions/5d4d844852b6_invalidating_node_hash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/5ddd24e52864_dbnode_type_to_dbnode_node_type.py
+++ b/aiida/storage/psql_dos/migrations/versions/5ddd24e52864_dbnode_type_to_dbnode_node_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/61fc0913fae9_remove_node_prefix.py
+++ b/aiida/storage/psql_dos/migrations/versions/61fc0913fae9_remove_node_prefix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
+++ b/aiida/storage/psql_dos/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/6a5c2ea1439d_move_data_within_node_module.py
+++ b/aiida/storage/psql_dos/migrations/versions/6a5c2ea1439d_move_data_within_node_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/6c629c886f84_process_type.py
+++ b/aiida/storage/psql_dos/migrations/versions/6c629c886f84_process_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/70c7d732f1b2_delete_dbpath.py
+++ b/aiida/storage/psql_dos/migrations/versions/70c7d732f1b2_delete_dbpath.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/7536a82b2cc4_add_node_repository_metadata.py
+++ b/aiida/storage/psql_dos/migrations/versions/7536a82b2cc4_add_node_repository_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/7a6587e16f4c_unique_constraints_for_the_db_dbgroup_.py
+++ b/aiida/storage/psql_dos/migrations/versions/7a6587e16f4c_unique_constraints_for_the_db_dbgroup_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/7b38a9e783e7_seal_unsealed_processes.py
+++ b/aiida/storage/psql_dos/migrations/versions/7b38a9e783e7_seal_unsealed_processes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
+++ b/aiida/storage/psql_dos/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/89176227b25_add_indexes_to_dbworkflowdata_table.py
+++ b/aiida/storage/psql_dos/migrations/versions/89176227b25_add_indexes_to_dbworkflowdata_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/91b573400be5_prepare_schema_reset.py
+++ b/aiida/storage/psql_dos/migrations/versions/91b573400be5_prepare_schema_reset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/__init__.py
+++ b/aiida/storage/psql_dos/migrations/versions/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/a514d673c163_drop_dblock.py
+++ b/aiida/storage/psql_dos/migrations/versions/a514d673c163_drop_dblock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/a603da2cc809_code_sub_class_of_data.py
+++ b/aiida/storage/psql_dos/migrations/versions/a603da2cc809_code_sub_class_of_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/a6048f0ffca8_update_linktypes.py
+++ b/aiida/storage/psql_dos/migrations/versions/a6048f0ffca8_update_linktypes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/b8b23ddefad4_dbgroup_name_to_label_type_to_type_string.py
+++ b/aiida/storage/psql_dos/migrations/versions/b8b23ddefad4_dbgroup_name_to_label_type_to_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/bf591f31dd12_dbgroup_type_string.py
+++ b/aiida/storage/psql_dos/migrations/versions/bf591f31dd12_dbgroup_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
+++ b/aiida/storage/psql_dos/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/d254fdfed416_rename_parameter_data_to_dict.py
+++ b/aiida/storage/psql_dos/migrations/versions/d254fdfed416_rename_parameter_data_to_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/de2eaf6978b4_simplify_user_model.py
+++ b/aiida/storage/psql_dos/migrations/versions/de2eaf6978b4_simplify_user_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0001_initial.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0001_initial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0002_db_state_change.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0002_db_state_change.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0003_add_link_type.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0003_add_link_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0004_add_daemon_and_uuid_indices.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0004_add_daemon_and_uuid_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0005_add_cmtime_indices.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0005_add_cmtime_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0006_delete_dbpath.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0006_delete_dbpath.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0007_update_linktypes.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0007_update_linktypes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0008_code_hidden_to_extra.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0008_code_hidden_to_extra.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0009_base_data_plugin_type_string.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0009_base_data_plugin_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0010_process_type.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0010_process_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0011_delete_kombu_tables.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0011_delete_kombu_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0012_drop_dblock.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0012_drop_dblock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0013_django_1_8.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0013_django_1_8.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0014_add_node_uuid_unique_constraint.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0014_add_node_uuid_unique_constraint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0015_invalidating_node_hash.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0015_invalidating_node_hash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0016_code_sub_class_of_data.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0016_code_sub_class_of_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0017_drop_dbcalcstate.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0017_drop_dbcalcstate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0018_django_1_11.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0018_django_1_11.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0019_migrate_builtin_calculations.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0019_migrate_builtin_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0020_provenance_redesign.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0020_provenance_redesign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0021_dbgroup_name_to_label_type_to_type_string.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0021_dbgroup_name_to_label_type_to_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0022_dbgroup_type_string_change_content.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0022_dbgroup_type_string_change_content.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0023_calc_job_option_attribute_keys.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0023_calc_job_option_attribute_keys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0024a_dblog_update.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0024a_dblog_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0024b_dblog_update.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0024b_dblog_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0025_move_data_within_node_module.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0025_move_data_within_node_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0026_trajectory_symbols_to_attribute.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0026_trajectory_symbols_to_attribute.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0027_delete_trajectory_symbols_array.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0027_delete_trajectory_symbols_array.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0028_remove_node_prefix.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0028_remove_node_prefix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0029_rename_parameter_data_to_dict.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0029_rename_parameter_data_to_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0030_dbnode_type_to_dbnode_node_type.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0030_dbnode_type_to_dbnode_node_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0031_remove_dbcomputer_enabled.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0031_remove_dbcomputer_enabled.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0032_remove_legacy_workflows.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0032_remove_legacy_workflows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0033_replace_text_field_with_json_field.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0033_replace_text_field_with_json_field.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0034_drop_node_columns_nodeversion_public.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0034_drop_node_columns_nodeversion_public.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0035_simplify_user_model.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0035_simplify_user_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0036_drop_computer_transport_params.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0036_drop_computer_transport_params.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0037_attributes_extras_settings_json.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0037_attributes_extras_settings_json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0038_data_migration_legacy_job_calculations.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0038_data_migration_legacy_job_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0039_reset_hash.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0039_reset_hash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0040_data_migration_legacy_process_attributes.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0040_data_migration_legacy_process_attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0041_seal_unsealed_processes.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0041_seal_unsealed_processes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0042_prepare_schema_reset.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0042_prepare_schema_reset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0043_default_link_label.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0043_default_link_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0044_dbgroup_type_string.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0044_dbgroup_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0045_dbgroup_extras.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0045_dbgroup_extras.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0046_add_node_repository_metadata.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0046_add_node_repository_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0047_migrate_repository.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0047_migrate_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0048_computer_name_to_label.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0048_computer_name_to_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0049_entry_point_core_prefix.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0049_entry_point_core_prefix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/django_0050_sqlalchemy_parity.py
+++ b/aiida/storage/psql_dos/migrations/versions/django_0050_sqlalchemy_parity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/e15ef2630a1b_initial_schema.py
+++ b/aiida/storage/psql_dos/migrations/versions/e15ef2630a1b_initial_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/e72ad251bcdb_dbgroup_class_change_type_string_values.py
+++ b/aiida/storage/psql_dos/migrations/versions/e72ad251bcdb_dbgroup_class_change_type_string_values.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/e734dd5e50d7_data_migration_legacy_process_attributes.py
+++ b/aiida/storage/psql_dos/migrations/versions/e734dd5e50d7_data_migration_legacy_process_attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/e797afa09270_reset_hash.py
+++ b/aiida/storage/psql_dos/migrations/versions/e797afa09270_reset_hash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/ea2f50e7f615_dblog_create_uuid_column.py
+++ b/aiida/storage/psql_dos/migrations/versions/ea2f50e7f615_dblog_create_uuid_column.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/f9a69de76a9a_delete_kombu_tables.py
+++ b/aiida/storage/psql_dos/migrations/versions/f9a69de76a9a_delete_kombu_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/main_0001_initial.py
+++ b/aiida/storage/psql_dos/migrations/versions/main_0001_initial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrations/versions/main_0002_recompute_hash_calc_job_node.py
+++ b/aiida/storage/psql_dos/migrations/versions/main_0002_recompute_hash_calc_job_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/migrator.py
+++ b/aiida/storage/psql_dos/migrator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/__init__.py
+++ b/aiida/storage/psql_dos/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/authinfo.py
+++ b/aiida/storage/psql_dos/models/authinfo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/base.py
+++ b/aiida/storage/psql_dos/models/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/comment.py
+++ b/aiida/storage/psql_dos/models/comment.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/computer.py
+++ b/aiida/storage/psql_dos/models/computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/group.py
+++ b/aiida/storage/psql_dos/models/group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/log.py
+++ b/aiida/storage/psql_dos/models/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/node.py
+++ b/aiida/storage/psql_dos/models/node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/settings.py
+++ b/aiida/storage/psql_dos/models/settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/models/user.py
+++ b/aiida/storage/psql_dos/models/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/__init__.py
+++ b/aiida/storage/psql_dos/orm/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/authinfos.py
+++ b/aiida/storage/psql_dos/orm/authinfos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/comments.py
+++ b/aiida/storage/psql_dos/orm/comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/computers.py
+++ b/aiida/storage/psql_dos/orm/computers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/convert.py
+++ b/aiida/storage/psql_dos/orm/convert.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/entities.py
+++ b/aiida/storage/psql_dos/orm/entities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/extras_mixin.py
+++ b/aiida/storage/psql_dos/orm/extras_mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/groups.py
+++ b/aiida/storage/psql_dos/orm/groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/logs.py
+++ b/aiida/storage/psql_dos/orm/logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/nodes.py
+++ b/aiida/storage/psql_dos/orm/nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/querybuilder/__init__.py
+++ b/aiida/storage/psql_dos/orm/querybuilder/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/querybuilder/joiner.py
+++ b/aiida/storage/psql_dos/orm/querybuilder/joiner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/users.py
+++ b/aiida/storage/psql_dos/orm/users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/orm/utils.py
+++ b/aiida/storage/psql_dos/orm/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/psql_dos/utils.py
+++ b/aiida/storage/psql_dos/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_dos/__init__.py
+++ b/aiida/storage/sqlite_dos/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Storage implementation using Sqlite database and disk-objectstore container."""
 
 # AUTO-GENERATED

--- a/aiida/storage/sqlite_dos/backend.py
+++ b/aiida/storage/sqlite_dos/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_temp/__init__.py
+++ b/aiida/storage/sqlite_temp/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_temp/backend.py
+++ b/aiida/storage/sqlite_temp/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/__init__.py
+++ b/aiida/storage/sqlite_zip/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/backend.py
+++ b/aiida/storage/sqlite_zip/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/__init__.py
+++ b/aiida/storage/sqlite_zip/migrations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/env.py
+++ b/aiida/storage/sqlite_zip/migrations/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/__init__.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v04_to_v05.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v04_to_v05.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v05_to_v06.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v05_to_v06.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v06_to_v07.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v06_to_v07.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v07_to_v08.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v07_to_v08.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v08_to_v09.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v08_to_v09.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v09_to_v10.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v09_to_v10.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v10_to_v11.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v10_to_v11.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v11_to_v12.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v11_to_v12.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy/v12_to_v13.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy/v12_to_v13.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/utils.py
+++ b/aiida/storage/sqlite_zip/migrations/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/v1_db_schema.py
+++ b/aiida/storage/sqlite_zip/migrations/v1_db_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/versions/__init__.py
+++ b/aiida/storage/sqlite_zip/migrations/versions/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/versions/main_0000_initial.py
+++ b/aiida/storage/sqlite_zip/migrations/versions/main_0000_initial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/versions/main_0000a_replace_nulls.py
+++ b/aiida/storage/sqlite_zip/migrations/versions/main_0000a_replace_nulls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/versions/main_0000b_non_nullable.py
+++ b/aiida/storage/sqlite_zip/migrations/versions/main_0000b_non_nullable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrations/versions/main_0001.py
+++ b/aiida/storage/sqlite_zip/migrations/versions/main_0001.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/migrator.py
+++ b/aiida/storage/sqlite_zip/migrator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/models.py
+++ b/aiida/storage/sqlite_zip/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/orm.py
+++ b/aiida/storage/sqlite_zip/orm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/storage/sqlite_zip/utils.py
+++ b/aiida/storage/sqlite_zip/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/__init__.py
+++ b/aiida/tools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/__init__.py
+++ b/aiida/tools/archive/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/abstract.py
+++ b/aiida/tools/archive/abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/common.py
+++ b/aiida/tools/archive/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/create.py
+++ b/aiida/tools/archive/create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/exceptions.py
+++ b/aiida/tools/archive/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/implementations/__init__.py
+++ b/aiida/tools/archive/implementations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/implementations/sqlite_zip/__init__.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/implementations/sqlite_zip/main.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/implementations/sqlite_zip/reader.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/reader.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/implementations/sqlite_zip/writer.py
+++ b/aiida/tools/archive/implementations/sqlite_zip/writer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/archive/imports.py
+++ b/aiida/tools/archive/imports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/calculations/__init__.py
+++ b/aiida/tools/calculations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/calculations/base.py
+++ b/aiida/tools/calculations/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/__init__.py
+++ b/aiida/tools/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/array/__init__.py
+++ b/aiida/tools/data/array/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/array/kpoints/__init__.py
+++ b/aiida/tools/data/array/kpoints/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/array/kpoints/legacy.py
+++ b/aiida/tools/data/array/kpoints/legacy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/array/kpoints/main.py
+++ b/aiida/tools/data/array/kpoints/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/array/kpoints/seekpath.py
+++ b/aiida/tools/data/array/kpoints/seekpath.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/array/trajectory.py
+++ b/aiida/tools/data/array/trajectory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/orbital/__init__.py
+++ b/aiida/tools/data/orbital/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/orbital/orbital.py
+++ b/aiida/tools/data/orbital/orbital.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/orbital/realhydrogen.py
+++ b/aiida/tools/data/orbital/realhydrogen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/data/structure.py
+++ b/aiida/tools/data/structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbexporters/__init__.py
+++ b/aiida/tools/dbexporters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/__init__.py
+++ b/aiida/tools/dbimporters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/__init__.py
+++ b/aiida/tools/dbimporters/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/cod.py
+++ b/aiida/tools/dbimporters/plugins/cod.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/icsd.py
+++ b/aiida/tools/dbimporters/plugins/icsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/materialsproject.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/mpds.py
+++ b/aiida/tools/dbimporters/plugins/mpds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/mpod.py
+++ b/aiida/tools/dbimporters/plugins/mpod.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/nninc.py
+++ b/aiida/tools/dbimporters/plugins/nninc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/oqmd.py
+++ b/aiida/tools/dbimporters/plugins/oqmd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/pcod.py
+++ b/aiida/tools/dbimporters/plugins/pcod.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/dbimporters/plugins/tcod.py
+++ b/aiida/tools/dbimporters/plugins/tcod.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/graph/__init__.py
+++ b/aiida/tools/graph/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/graph/age_entities.py
+++ b/aiida/tools/graph/age_entities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/graph/age_rules.py
+++ b/aiida/tools/graph/age_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/graph/deletions.py
+++ b/aiida/tools/graph/deletions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/graph/graph_traversers.py
+++ b/aiida/tools/graph/graph_traversers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/groups/__init__.py
+++ b/aiida/tools/groups/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/groups/paths.py
+++ b/aiida/tools/groups/paths.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/ipython/__init__.py
+++ b/aiida/tools/ipython/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/ipython/aiida_magic_register.py
+++ b/aiida/tools/ipython/aiida_magic_register.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/query/calculation.py
+++ b/aiida/tools/query/calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/query/formatting.py
+++ b/aiida/tools/query/formatting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/query/mapping.py
+++ b/aiida/tools/query/mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/visualization/__init__.py
+++ b/aiida/tools/visualization/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/tools/visualization/graph.py
+++ b/aiida/tools/visualization/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/__init__.py
+++ b/aiida/transports/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/plugins/__init__.py
+++ b/aiida/transports/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/plugins/ssh.py
+++ b/aiida/transports/plugins/ssh.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/transports/util.py
+++ b/aiida/transports/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/workflows/__init__.py
+++ b/aiida/workflows/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/workflows/arithmetic/__init__.py
+++ b/aiida/workflows/arithmetic/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/workflows/arithmetic/add_multiply.py
+++ b/aiida/workflows/arithmetic/add_multiply.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/aiida/workflows/arithmetic/multiply_add.py
+++ b/aiida/workflows/arithmetic/multiply_add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/docs/source/howto/include/scripts/performance_benchmark_base.py
+++ b/docs/source/howto/include/scripts/performance_benchmark_base.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Script to benchmark the performance of the AiiDA workflow engine on a given installation."""
 import click
 

--- a/docs/source/howto/include/snippets/extend_workflows.py
+++ b/docs/source/howto/include/snippets/extend_workflows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/docs/source/howto/include/snippets/myprofile-rest.wsgi
+++ b/docs/source/howto/include/snippets/myprofile-rest.wsgi
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # wsgi script for AiiDA profile 'myprofile'
 from aiida.manage.configuration import load_profile
 from aiida.restapi.run_api import configure_api

--- a/docs/source/howto/include/snippets/plugins/launch.py
+++ b/docs/source/howto/include/snippets/plugins/launch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Launch a calculation using the 'diff-tutorial' plugin"""
 from pathlib import Path
 

--- a/docs/source/internals/includes/snippets/api.py
+++ b/docs/source/internals/includes/snippets/api.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import click
 from flask_restful import Resource
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_load_node.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_load_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int, load_node
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_store.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_calcfunction_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_data_types.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_data_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_decorator.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_decorator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_metadata.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction, run
 from aiida.orm import Int
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_no_provenance.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_no_provenance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction, run
 from aiida.orm import Int
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction, run, run_get_node, run_get_pk
 from aiida.orm import Int
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run_attribute.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_calcfunction_run_attribute.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_plain_python.py
+++ b/docs/source/topics/calculations/include/snippets/calcfunctions/add_multiply_plain_python.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 def add(x, y):
     return x + y
 

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_parser.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.orm import Int
 from aiida.parsers.parser import Parser
 

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_run.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import run
 from aiida.orm import Int, load_code
 from aiida.plugins import CalculationFactory

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_inputs.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_inputs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import engine, orm
 
 

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_outputs.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_outputs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import engine, orm
 
 

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_prepare_for_submission.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_spec_prepare_for_submission.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
 from aiida.orm import Int

--- a/docs/source/topics/include/scheduler_template.py
+++ b/docs/source/topics/include/scheduler_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Template for a scheduler plugin."""
 import logging
 

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_exception.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_exception.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_exit_code.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_exit_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import ExitCode, calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_multiple_outputs.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_multiple_outputs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/calcfunction_nested_outputs.py
+++ b/docs/source/topics/processes/include/snippets/functions/calcfunction_nested_outputs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/parse_docstring.py
+++ b/docs/source/topics/processes/include/snippets/functions/parse_docstring.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 
 

--- a/docs/source/topics/processes/include/snippets/functions/parse_docstring_expose.py
+++ b/docs/source/topics/processes/include/snippets/functions/parse_docstring_expose.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain, calcfunction
 
 

--- a/docs/source/topics/processes/include/snippets/functions/parse_docstring_expose_ipython.py
+++ b/docs/source/topics/processes/include/snippets/functions/parse_docstring_expose_ipython.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 In [1]: builder = Wrapper.get_builder()
 
 In [2]: builder.x?

--- a/docs/source/topics/processes/include/snippets/functions/process_function_attributes.py
+++ b/docs/source/topics/processes/include/snippets/functions/process_function_attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_args.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_args.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_default.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_default.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_kwargs.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_calcfunction_kwargs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/functions/signature_plain_python_args_kwargs.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_plain_python_args_kwargs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 def add(*args, **kwargs):

--- a/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_default.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_default.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 def add_multiply(x, y, z=1):

--- a/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_illegal.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_illegal.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 def add_multiply(x, y=1, z):
     return (x + y) * z

--- a/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_keyword.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_keyword.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 def add_multiply(x, y, z=1):

--- a/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_positional.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_plain_python_call_positional.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 def add_multiply(x, y, z=1):

--- a/docs/source/topics/processes/include/snippets/functions/signature_plain_python_definition.py
+++ b/docs/source/topics/processes/include/snippets/functions/signature_plain_python_definition.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 def add_multiply(x, y, z=1):

--- a/docs/source/topics/processes/include/snippets/functions/typing_call_raise.py
+++ b/docs/source/topics/processes/include/snippets/functions/typing_call_raise.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Float, Int
 

--- a/docs/source/topics/processes/include/snippets/functions/typing_none.py
+++ b/docs/source/topics/processes/include/snippets/functions/typing_none.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import typing
 
 from aiida.engine import calcfunction

--- a/docs/source/topics/processes/include/snippets/functions/typing_pep_563.py
+++ b/docs/source/topics/processes/include/snippets/functions/typing_pep_563.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 from aiida.engine import calcfunction

--- a/docs/source/topics/processes/include/snippets/functions/typing_pep_604.py
+++ b/docs/source/topics/processes/include/snippets/functions/typing_pep_604.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 from aiida.engine import calcfunction

--- a/docs/source/topics/processes/include/snippets/functions/typing_union.py
+++ b/docs/source/topics/processes/include/snippets/functions/typing_union.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import typing as t
 
 from aiida.engine import calcfunction

--- a/docs/source/topics/processes/include/snippets/launch/launch_builder.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import orm, plugins
 from aiida.engine import submit
 

--- a/docs/source/topics/processes/include/snippets/launch/launch_process_function.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_process_function.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/processes/include/snippets/launch/launch_run.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import orm, plugins
 from aiida.engine import run
 

--- a/docs/source/topics/processes/include/snippets/launch/launch_run_alternative.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_run_alternative.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import orm, plugins
 from aiida.engine import run_get_node, run_get_pk
 

--- a/docs/source/topics/processes/include/snippets/launch/launch_run_shortcut.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_run_shortcut.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import orm, plugins
 from aiida.engine import run
 

--- a/docs/source/topics/processes/include/snippets/launch/launch_submit.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_submit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import orm, plugins
 from aiida.engine import submit
 

--- a/docs/source/topics/processes/include/snippets/launch/launch_submit_dictionary.py
+++ b/docs/source/topics/processes/include/snippets/launch/launch_submit_dictionary.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida import orm, plugins
 from aiida.engine import submit
 

--- a/docs/source/topics/processes/include/snippets/serialize/run_workchain_serialize.py
+++ b/docs/source/topics/processes/include/snippets/serialize/run_workchain_serialize.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 from serialize_workchain import SerializeWorkChain
 
 from aiida.engine import run

--- a/docs/source/topics/processes/include/snippets/serialize/workchain_serialize.py
+++ b/docs/source/topics/processes/include/snippets/serialize/workchain_serialize.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain
 from aiida.orm import to_aiida_type
 

--- a/docs/source/topics/transport_template.py
+++ b/docs/source/topics/transport_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.transports import Transport
 
 

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/child.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/child.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain
 from aiida.orm import Bool, Float, Int
 

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/complex_parent.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/complex_parent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from child import ChildWorkChain
 
 from aiida.engine import ToContext, WorkChain

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/run_complex.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/run_complex.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 
 from complex_parent import ComplexParentWorkChain
 

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/run_simple.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/run_simple.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 
 from simple_parent import SimpleParentWorkChain
 

--- a/docs/source/topics/workflows/include/snippets/expose_inputs/simple_parent.py
+++ b/docs/source/topics/workflows/include/snippets/expose_inputs/simple_parent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from child import ChildWorkChain
 
 from aiida.engine import ToContext, WorkChain

--- a/docs/source/topics/workflows/include/snippets/workchains/add_multiply_workchain_external_computation.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/add_multiply_workchain_external_computation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain, calcfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/add_multiply_workchain_outline_computation.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/add_multiply_workchain_outline_computation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_builder.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import submit
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_expand.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_expand.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import run
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_get_node_pk.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_get_node_pk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import run_get_node, run_get_pk
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_keyword.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_keyword.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import run
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import submit
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_append.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_append.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain, append_
 
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_complete.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_complete.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import ToContext, WorkChain
 
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_internal.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_internal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_parallel.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_parallel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain
 
 

--- a/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_parallel_nested.py
+++ b/docs/source/topics/workflows/include/snippets/workchains/run_workchain_submit_parallel_nested.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import WorkChain
 
 

--- a/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_orchestrate.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_orchestrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction, workfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_select.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/add_multiply_workfunction_select.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import workfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_halfway.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_halfway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import calcfunction, workfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_internal.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_add_multiply_internal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import workfunction
 from aiida.orm import Int
 

--- a/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_store.py
+++ b/docs/source/topics/workflows/include/snippets/workfunctions/workfunction_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from aiida.engine import workfunction
 from aiida.orm import Int
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/benchmark/test_archive.py
+++ b/tests/benchmark/test_archive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/benchmark/test_engine.py
+++ b/tests/benchmark/test_engine.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/benchmark/test_nodes.py
+++ b/tests/benchmark/test_nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/calculations/__init__.py
+++ b/tests/calculations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/calculations/arithmetic/__init__.py
+++ b/tests/calculations/arithmetic/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/calculations/arithmetic/test_add.py
+++ b/tests/calculations/arithmetic/test_add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/calculations/importers/arithmetic/test_add.py
+++ b/tests/calculations/importers/arithmetic/test_add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.calculations.importers.arithmetic.add` module."""
 from aiida.calculations.importers.arithmetic.add import ArithmeticAddCalculationImporter
 from aiida.orm import Int, RemoteData

--- a/tests/calculations/test_templatereplacer.py
+++ b/tests/calculations/test_templatereplacer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/calculations/test_transfer.py
+++ b/tests/calculations/test_transfer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/__init__.py
+++ b/tests/cmdline/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/__init__.py
+++ b/tests/cmdline/commands/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_devel.py
+++ b/tests/cmdline/commands/test_devel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_group_ls.py
+++ b/tests/cmdline/commands/test_group_ls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_help.py
+++ b/tests/cmdline/commands/test_help.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_plugin.py
+++ b/tests/cmdline/commands/test_plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_restapi.py
+++ b/tests/cmdline/commands/test_restapi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/groups/test_dynamic.py
+++ b/tests/cmdline/groups/test_dynamic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.cmdline.groups.dynamic`."""
 import typing as t
 

--- a/tests/cmdline/params/__init__.py
+++ b/tests/cmdline/params/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/options/__init__.py
+++ b/tests/cmdline/params/options/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/options/test_callable.py
+++ b/tests/cmdline/params/options/test_callable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/options/test_conditional.py
+++ b/tests/cmdline/params/options/test_conditional.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/options/test_config.py
+++ b/tests/cmdline/params/options/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/options/test_interactive.py
+++ b/tests/cmdline/params/options/test_interactive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/options/test_verbosity.py
+++ b/tests/cmdline/params/options/test_verbosity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/__init__.py
+++ b/tests/cmdline/params/types/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_calculation.py
+++ b/tests/cmdline/params/types/test_calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_code.py
+++ b/tests/cmdline/params/types/test_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_computer.py
+++ b/tests/cmdline/params/types/test_computer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_data.py
+++ b/tests/cmdline/params/types/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_group.py
+++ b/tests/cmdline/params/types/test_group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_identifier.py
+++ b/tests/cmdline/params/types/test_identifier.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_node.py
+++ b/tests/cmdline/params/types/test_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_path.py
+++ b/tests/cmdline/params/types/test_path.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/params/types/test_plugin.py
+++ b/tests/cmdline/params/types/test_plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/utils/__init__.py
+++ b/tests/cmdline/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/utils/test_common.py
+++ b/tests/cmdline/utils/test_common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/utils/test_decorators.py
+++ b/tests/cmdline/utils/test_decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/utils/test_log.py
+++ b/tests/cmdline/utils/test_log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/utils/test_multiline.py
+++ b/tests/cmdline/utils/test_multiline.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/cmdline/utils/test_repository.py
+++ b/tests/cmdline/utils/test_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_escaping.py
+++ b/tests/common/test_escaping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_extendeddicts.py
+++ b/tests/common/test_extendeddicts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_folders.py
+++ b/tests/common/test_folders.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_links.py
+++ b/tests/common/test_links.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_timezone.py
+++ b/tests/common/test_timezone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/__init__.py
+++ b/tests/engine/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/calcfunctions.py
+++ b/tests/engine/calcfunctions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Definition of a calculation function used in ``test_calcfunctions.py``."""
 from aiida.engine import calcfunction
 from aiida.orm import Int

--- a/tests/engine/daemon/__init__.py
+++ b/tests/engine/daemon/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/daemon/test_worker.py
+++ b/tests/engine/daemon/test_worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/__init__.py
+++ b/tests/engine/processes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/calcjobs/test_monitors.py
+++ b/tests/engine/processes/calcjobs/test_monitors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.engine.processes.calcjobs.monitors` module."""
 import time
 

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/test_caching.py
+++ b/tests/engine/processes/test_caching.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test the caching functionality for a :class:`aiida.engine.processes.process.Process`."""
 from aiida.engine import Process, run
 from aiida.manage import enable_caching

--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.engine.processes.control` module."""
 import pytest
 from plumpy.process_comms import RemoteProcessThreadController

--- a/tests/engine/processes/test_exit_code.py
+++ b/tests/engine/processes/test_exit_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/workchains/__init__.py
+++ b/tests/engine/processes/workchains/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/processes/workchains/test_utils.py
+++ b/tests/engine/processes/workchains/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_class_loader.py
+++ b/tests/engine/test_class_loader.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_futures.py
+++ b/tests/engine/test_futures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_manager.py
+++ b/tests/engine/test_manager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_memory_leaks.py
+++ b/tests/engine/test_memory_leaks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_persistence.py
+++ b/tests/engine/test_persistence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_ports.py
+++ b/tests/engine/test_ports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_process_spec.py
+++ b/tests/engine/test_process_spec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_rmq.py
+++ b/tests/engine/test_rmq.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_run.py
+++ b/tests/engine/test_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_transport.py
+++ b/tests/engine/test_transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/engine/test_workfunctions.py
+++ b/tests/engine/test_workfunctions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/__init__.py
+++ b/tests/manage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/configuration/__init__.py
+++ b/tests/manage/configuration/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/configuration/migrations/__init__.py
+++ b/tests/manage/configuration/migrations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.manage.configuration` module."""
 import pytest
 

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/configuration/test_profile.py
+++ b/tests/manage/configuration/test_profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/external/__init__.py
+++ b/tests/manage/external/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/external/test_postgres.py
+++ b/tests/manage/external/test_postgres.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/external/test_rmq.py
+++ b/tests/manage/external/test_rmq.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/test_caching_config.py
+++ b/tests/manage/test_caching_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/test_manager.py
+++ b/tests/manage/test_manager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.manage.manager` module."""
 import pytest
 from packaging.version import parse

--- a/tests/manage/test_profile_access.py
+++ b/tests/manage/test_profile_access.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/manage/tests/test_pytest_fixtures.py
+++ b/tests/manage/tests/test_pytest_fixtures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.manage.tests.pytest_fixtures` module."""
 import uuid
 

--- a/tests/orm/__init__.py
+++ b/tests/orm/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/data/code/test_abstract.py
+++ b/tests/orm/data/code/test_abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/data/code/test_containerized.py
+++ b/tests/orm/data/code/test_containerized.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/data/code/test_installed.py
+++ b/tests/orm/data/code/test_installed.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/data/code/test_portable.py
+++ b/tests/orm/data/code/test_portable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/data/test_code.py
+++ b/tests/orm/data/test_code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/data/test_enum.py
+++ b/tests/orm/data/test_enum.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :class:`aiida.orm.nodes.data.enum.Enum` data plugin."""
 import enum
 

--- a/tests/orm/implementation/__init__.py
+++ b/tests/orm/implementation/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/implementation/test_comments.py
+++ b/tests/orm/implementation/test_comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/implementation/test_groups.py
+++ b/tests/orm/implementation/test_groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/implementation/test_logs.py
+++ b/tests/orm/implementation/test_logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/implementation/test_nodes.py
+++ b/tests/orm/implementation/test_nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/implementation/test_utils.py
+++ b/tests/orm/implementation/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/__init__.py
+++ b/tests/orm/nodes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/__init__.py
+++ b/tests/orm/nodes/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_array.py
+++ b/tests/orm/nodes/data/test_array.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_array_bands.py
+++ b/tests/orm/nodes/data/test_array_bands.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_base.py
+++ b/tests/orm/nodes/data/test_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_cif.py
+++ b/tests/orm/nodes/data/test_cif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_data.py
+++ b/tests/orm/nodes/data/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_dict.py
+++ b/tests/orm/nodes/data/test_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_folder.py
+++ b/tests/orm/nodes/data/test_folder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_jsonable.py
+++ b/tests/orm/nodes/data/test_jsonable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :class:`aiida.orm.nodes.data.jsonable.JsonableData` data type."""
 import datetime
 import math

--- a/tests/orm/nodes/data/test_kpoints.py
+++ b/tests/orm/nodes/data/test_kpoints.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_list.py
+++ b/tests/orm/nodes/data/test_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_orbital.py
+++ b/tests/orm/nodes/data/test_orbital.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_remote_stash.py
+++ b/tests/orm/nodes/data/test_remote_stash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_singlefile.py
+++ b/tests/orm/nodes/data/test_singlefile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_structure.py
+++ b/tests/orm/nodes/data/test_structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_to_aiida_type.py
+++ b/tests/orm/nodes/data/test_to_aiida_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_trajectory.py
+++ b/tests/orm/nodes/data/test_trajectory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the `TrajectoryData` class."""
 import numpy as np
 import pytest

--- a/tests/orm/nodes/data/test_upf.py
+++ b/tests/orm/nodes/data/test_upf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/data/test_xy.py
+++ b/tests/orm/nodes/data/test_xy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/process/test_process.py
+++ b/tests/orm/nodes/process/test_process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.orm.nodes.process.process`."""
 import pytest
 

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.orm.nodes.repository` module."""
 import pathlib
 

--- a/tests/orm/test_authinfos.py
+++ b/tests/orm/test_authinfos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_autogroups.py
+++ b/tests/orm/test_autogroups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_comments.py
+++ b/tests/orm/test_comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_entities.py
+++ b/tests/orm/test_entities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_groups.py
+++ b/tests/orm/test_groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_logs.py
+++ b/tests/orm/test_logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_mixins.py
+++ b/tests/orm/test_mixins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/test_users.py
+++ b/tests/orm/test_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/utils/__init__.py
+++ b/tests/orm/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/utils/test_calcjob.py
+++ b/tests/orm/utils/test_calcjob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/utils/test_loaders.py
+++ b/tests/orm/utils/test_loaders.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/utils/test_managers.py
+++ b/tests/orm/utils/test_managers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/utils/test_node.py
+++ b/tests/orm/utils/test_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/orm/utils/test_serialize.py
+++ b/tests/orm/utils/test_serialize.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/parsers/__init__.py
+++ b/tests/parsers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/plugins/test_entry_point.py
+++ b/tests/plugins/test_entry_point.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/plugins/test_factories.py
+++ b/tests/plugins/test_factories.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/plugins/test_utils.py
+++ b/tests/plugins/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/repository/backend/test_abstract.py
+++ b/tests/repository/backend/test_abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.repository.backend.abstract` module."""
 import io
 import tempfile

--- a/tests/repository/backend/test_disk_object_store.py
+++ b/tests/repository/backend/test_disk_object_store.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.repository.backend.disk_object_store` module."""
 import io
 import pathlib

--- a/tests/repository/backend/test_sandbox.py
+++ b/tests/repository/backend/test_sandbox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.repository.backend.sandbox` module."""
 import io
 import pathlib

--- a/tests/repository/conftest.py
+++ b/tests/repository/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test fixtures for the :mod:`aiida.repository` module."""
 import os
 import pathlib

--- a/tests/repository/test_common.py
+++ b/tests/repository/test_common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.repository.common` module."""
 import pytest
 

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida.repository.repository` module."""
 import contextlib
 import io

--- a/tests/restapi/__init__.py
+++ b/tests/restapi/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/test_config.py
+++ b/tests/restapi/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/test_identifiers.py
+++ b/tests/restapi/test_identifiers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/test_statistics.py
+++ b/tests/restapi/test_statistics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/test_threaded_restapi.py
+++ b/tests/restapi/test_threaded_restapi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/restapi/test_translator.py
+++ b/tests/restapi/test_translator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/__init__.py
+++ b/tests/schedulers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_all.py
+++ b/tests/schedulers/test_all.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_datastructures.py
+++ b/tests/schedulers/test_datastructures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_direct.py
+++ b/tests/schedulers/test_direct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_lsf.py
+++ b/tests/schedulers/test_lsf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_pbspro.py
+++ b/tests/schedulers/test_pbspro.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_sge.py
+++ b/tests/schedulers/test_sge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_slurm.py
+++ b/tests/schedulers/test_slurm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/schedulers/test_torque.py
+++ b/tests/schedulers/test_torque.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/sphinxext/conftest.py
+++ b/tests/sphinxext/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/sphinxext/sources/workchain/conf.py
+++ b/tests/sphinxext/sources/workchain/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/sphinxext/sources/workchain_broken/conf.py
+++ b/tests/sphinxext/sources/workchain_broken/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/sphinxext/test_workchain.py
+++ b/tests/sphinxext/test_workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/sphinxext/workchains/broken_demo_workchain.py
+++ b/tests/sphinxext/workchains/broken_demo_workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/sphinxext/workchains/demo_workchain.py
+++ b/tests/sphinxext/workchains/demo_workchain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/static/__init__.py
+++ b/tests/static/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/__init__.py
+++ b/tests/storage/psql_dos/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/conftest.py
+++ b/tests/storage/psql_dos/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/conftest.py
+++ b/tests/storage/psql_dos/migrations/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0024_dblog_update.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0024_dblog_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0028_0029_node_type.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0028_0029_node_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0032_remove_legacy_workflows.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0032_remove_legacy_workflows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0033_replace_text_field_with_json_field.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0033_replace_text_field_with_json_field.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0037_attributes_extras_settings_json.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0037_attributes_extras_settings_json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0038_data_migration_legacy_job_calculations.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0038_data_migration_legacy_job_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0039_reset_hash.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0039_reset_hash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0040_data_migration_legacy_process_attributes.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0040_data_migration_legacy_process_attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0041_seal_unsealed_processes.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0041_seal_unsealed_processes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0043_default_link_label.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0043_default_link_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0044_dbgroup_type_string.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0044_dbgroup_type_string.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0045_dbgroup_extras.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0045_dbgroup_extras.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0046_add_node_repository_metadata.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0046_add_node_repository_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0047_migrate_repository.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0047_migrate_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0048_computer_name_to_label.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0048_computer_name_to_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0049_entry_point_core_prefix.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0049_entry_point_core_prefix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_0050_schema_parity.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0050_schema_parity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_legacy.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_legacy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/django_branch/test_migrate_to_head.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_migrate_to_head.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/main_branch/test_main_0002_recompute_hash_calc_job_node.py
+++ b/tests/storage/psql_dos/migrations/main_branch/test_main_0002_recompute_hash_calc_job_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_10_group_update.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_10_group_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_11_v2_repository.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_11_v2_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_12_sqla_django_parity.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_12_sqla_django_parity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_1_provenance_redesign.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_1_provenance_redesign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_2_group_renaming.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_2_group_renaming.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_3_calc_attributes_keys.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_3_calc_attributes_keys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_4_dblog_update.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_4_dblog_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_5_data_move_with_node.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_5_data_move_with_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_7_node_prefix_removal.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_7_node_prefix_removal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_8_parameter_data_to_dict.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_8_parameter_data_to_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_9_legacy_process.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_9_legacy_process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_migrate_to_head.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_migrate_to_head.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/migrations/test_all_schema.py
+++ b/tests/storage/psql_dos/migrations/test_all_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/test_alembic_cli.py
+++ b/tests/storage/psql_dos/test_alembic_cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/test_nodes.py
+++ b/tests/storage/psql_dos/test_nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/test_query.py
+++ b/tests/storage/psql_dos/test_query.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/test_schema.py
+++ b/tests/storage/psql_dos/test_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/psql_dos/test_session.py
+++ b/tests/storage/psql_dos/test_session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/sqlite/__init__.py
+++ b/tests/storage/sqlite/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/sqlite/test_archive.py
+++ b/tests/storage/sqlite/test_archive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test export and import of AiiDA archives to/from a temporary profile."""
 from pathlib import Path
 

--- a/tests/storage/sqlite/test_orm.py
+++ b/tests/storage/sqlite/test_orm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/storage/sqlite_dos/__init__.py
+++ b/tests/storage/sqlite_dos/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.storage.sqlite_dos`."""

--- a/tests/storage/sqlite_dos/test_backend.py
+++ b/tests/storage/sqlite_dos/test_backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.storage.sqlite_dos.backend`."""
 import pathlib
 

--- a/tests/storage/sqlite_zip/__init__.py
+++ b/tests/storage/sqlite_zip/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.storage.sqlite_zip`."""

--- a/tests/storage/sqlite_zip/test_backend.py
+++ b/tests/storage/sqlite_zip/test_backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.storage.sqlite_zip.backend`."""
 import pathlib
 

--- a/tests/test_calculation_node.py
+++ b/tests/test_calculation_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for fixtures in the ``conftest.py``."""
 import pytest
 from importlib_metadata import EntryPoint

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/test_dbimporters.py
+++ b/tests/test_dbimporters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/conftest.py
+++ b/tests/tools/archive/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/conftest.py
+++ b/tests/tools/archive/migration/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_legacy_funcs.py
+++ b/tests/tools/archive/migration/test_legacy_funcs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_legacy_migrations.py
+++ b/tests/tools/archive/migration/test_legacy_migrations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_legacy_to_main.py
+++ b/tests/tools/archive/migration/test_legacy_to_main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_prov_redesign.py
+++ b/tests/tools/archive/migration/test_prov_redesign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_v012_to_v013.py
+++ b/tests/tools/archive/migration/test_v012_to_v013.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_v04_to_v05.py
+++ b/tests/tools/archive/migration/test_v04_to_v05.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_v05_to_v06.py
+++ b/tests/tools/archive/migration/test_v05_to_v06.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_v06_to_v07.py
+++ b/tests/tools/archive/migration/test_v06_to_v07.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_v07_to_v08.py
+++ b/tests/tools/archive/migration/test_v07_to_v08.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/migration/test_v08_to_v09.py
+++ b/tests/tools/archive/migration/test_v08_to_v09.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/__init__.py
+++ b/tests/tools/archive/orm/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_attributes.py
+++ b/tests/tools/archive/orm/test_attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_authinfo.py
+++ b/tests/tools/archive/orm/test_authinfo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_calculations.py
+++ b/tests/tools/archive/orm/test_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_codes.py
+++ b/tests/tools/archive/orm/test_codes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_comments.py
+++ b/tests/tools/archive/orm/test_comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_computers.py
+++ b/tests/tools/archive/orm/test_computers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_extras.py
+++ b/tests/tools/archive/orm/test_extras.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_groups.py
+++ b/tests/tools/archive/orm/test_groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_links.py
+++ b/tests/tools/archive/orm/test_links.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_logs.py
+++ b/tests/tools/archive/orm/test_logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/orm/test_users.py
+++ b/tests/tools/archive/orm/test_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_abstract.py
+++ b/tests/tools/archive/test_abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_backend.py
+++ b/tests/tools/archive/test_backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_complex.py
+++ b/tests/tools/archive/test_complex.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_repository.py
+++ b/tests/tools/archive/test_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_schema.py
+++ b/tests/tools/archive/test_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_simple.py
+++ b/tests/tools/archive/test_simple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_specific_import.py
+++ b/tests/tools/archive/test_specific_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/test_utils.py
+++ b/tests/tools/archive/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/archive/utils.py
+++ b/tests/tools/archive/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/data/__init__.py
+++ b/tests/tools/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/data/orbital/__init__.py
+++ b/tests/tools/data/orbital/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/data/orbital/test_orbitals.py
+++ b/tests/tools/data/orbital/test_orbitals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/dbimporters/__init__.py
+++ b/tests/tools/dbimporters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/dbimporters/test_icsd.py
+++ b/tests/tools/dbimporters/test_icsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/dbimporters/test_materialsproject.py
+++ b/tests/tools/dbimporters/test_materialsproject.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/graph/__init__.py
+++ b/tests/tools/graph/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/graph/test_age.py
+++ b/tests/tools/graph/test_age.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/graph/test_graph_traversers.py
+++ b/tests/tools/graph/test_graph_traversers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/groups/__init__.py
+++ b/tests/tools/groups/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/groups/test_paths.py
+++ b/tests/tools/groups/test_paths.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/ipython/test_ipython_magics.py
+++ b/tests/tools/ipython/test_ipython_magics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida.tools.ipython.ipython_magics`."""
 import textwrap
 

--- a/tests/tools/visualization/__init__.py
+++ b/tests/tools/visualization/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/transports/__init__.py
+++ b/tests/transports/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/transports/test_local.py
+++ b/tests/transports/test_local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/transports/test_ssh.py
+++ b/tests/transports/test_ssh.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/utils/archives.py
+++ b/tests/utils/archives.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/utils/memory.py
+++ b/tests/utils/memory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/utils/processes.py
+++ b/tests/utils/processes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/workflows/__init__.py
+++ b/tests/workflows/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/workflows/arithmetic/__init__.py
+++ b/tests/workflows/arithmetic/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/tests/workflows/arithmetic/test_add_multiply.py
+++ b/tests/workflows/arithmetic/test_add_multiply.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/utils/make_all.py
+++ b/utils/make_all.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Pre-commit hook to add ``__all__`` imports to ``__init__`` files."""
 import ast
 import sys

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #


### PR DESCRIPTION
* Add the `check-merge-conflict` hook
* Explicitly define target line ending for `mixed-line-ending`
* Change `fix-encoding-pragma` to actually remove the pragma
  This was mostly useful when Python 2 was still in use but now that
  Python 3 is the only version supported, this encoding pragma is no
  longer necessary.