### PR TITLE
Dependencies: Pin `mypy` to minor version `mypy~=1.7.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ notebook = [
   'notebook~=6.1,>=6.1.5'
 ]
 pre-commit = [
-  'mypy~=1.7',
+  'mypy~=1.7.1',
   'packaging~=23.0',
   'pre-commit~=2.2',
   'sqlalchemy[mypy]~=2.0',


### PR DESCRIPTION
Later minor versions can ship with new features that can cause the pre-commit to fail all of a sudden.