### PR TITLE
CLI: Add the `verdi node list` command

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -289,6 +289,7 @@ Below is a list with all available subcommands.
       extras       Show the extras of one or more nodes.
       graph        Create visual representations of the provenance graph.
       label        View or set the label of one or more nodes.
+      list         Query all nodes with optional filtering and ordering.
       rehash       Recompute the hash for nodes in the database.
       repo         Inspect the content of a node repository folder.
       show         Show generic information on one or more nodes.

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import abc
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Generic, List, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, List, Optional, Type, TypeVar, Union, cast
 
 from plumpy.base.utils import call_with_super_check, super_check
 
@@ -99,15 +99,19 @@ class Collection(abc.ABC, Generic[EntityType]):
         self,
         filters: Optional['FilterType'] = None,
         order_by: Optional['OrderByType'] = None,
+        project: Optional[Union[list[str], str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        subclassing: bool = True,
     ) -> 'QueryBuilder':
         """Get a query builder for the objects of this collection.
 
         :param filters: the keyword value pair filters to match
         :param order_by: a list of (key, direction) pairs specifying the sort order
+        :param project: Optional projections.
         :param limit: the maximum number of results to return
         :param offset: number of initial results to be skipped
+        :param subclassing: whether to match subclasses of the type as well.
         """
         from . import querybuilder
 
@@ -115,7 +119,7 @@ class Collection(abc.ABC, Generic[EntityType]):
         order_by = {self.entity_type: order_by} if order_by else {}
 
         query = querybuilder.QueryBuilder(backend=self._backend, limit=limit, offset=offset)
-        query.append(self.entity_type, project='*', filters=filters)
+        query.append(self.entity_type, project=project, filters=filters, subclassing=subclassing)
         query.order_by([order_by])
         return query
 

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -46,6 +46,7 @@ class TestVerdiProcess:
         assert 'Total results:' in result.output
         assert 'Last time an entry changed state' in result.output
 
+    @pytest.mark.usefixtures('aiida_profile_clean')
     def test_list(self, run_cli_command):
         """Test the list command."""
         calcs = []


### PR DESCRIPTION
This is a generic purpose command that makes it easy to query for nodes. It allows to filter on node types and order/limit the results.