### PR TITLE
`SlurmScheduler`: Make detailed job info fields dynamic

### DIFF
--- a/tests/schedulers/test_slurm.py
+++ b/tests/schedulers/test_slurm.py
@@ -415,8 +415,7 @@ def test_parse_out_of_memory():
     detailed_job_info = {
         'retval': 0,
         'stderr': '',
-        'stdout': """||||||||||||||||||||||||||||||||||||||||||||||||||
-        |||||||||||||||||||||||||||||||||||||||||OUT_OF_MEMORY|||||||||""",
+        'stdout': 'Account|State|\nroot|OUT_OF_MEMORY|\n',
     }
 
     exit_code = scheduler.parse_output(detailed_job_info, stdout, stderr)
@@ -429,8 +428,7 @@ def test_parse_node_failure():
     detailed_job_info = {
         'retval': 0,
         'stderr': '',
-        'stdout': """||||||||||||||||||||||||||||||||||||||||||||||||||
-        |||||||||||||||||||||||||||||||||||||||||NODE_FAIL|||||||||""",
+        'stdout': 'Account|State|\nroot|NODE_FAIL|\n',
     }
 
     exit_code = scheduler.parse_output(detailed_job_info, '', '')
@@ -444,7 +442,10 @@ def test_parse_node_failure():
         ({'stderr': ''}, ValueError),  # Key `stdout` missing
         ({'stdout': None}, TypeError),  # `stdout` is not a string
         ({'stdout': ''}, ValueError),  # `stdout` does not contain at least two lines
-        ({'stdout': 'Header\nValue'}, ValueError),  # `stdout` second line contains too few elements separated by pipe
+        (
+            {'stdout': 'Account|State|\nValue|'},
+            ValueError,
+        ),  # `stdout` second line contains too few elements separated by pipe
     ],
 )
 def test_parse_output_invalid(detailed_job_info, expected):
@@ -457,10 +458,8 @@ def test_parse_output_invalid(detailed_job_info, expected):
 
 def test_parse_output_valid():
     """Test `SlurmScheduler.parse_output` for valid arguments."""
-    number_of_fields = len(SlurmScheduler._detailed_job_info_fields)
-    detailed_job_info = {'stdout': f"Header\n{'|' * number_of_fields}"}
+    detailed_job_info = {'stdout': 'State|Account|\n||\n'}
     scheduler = SlurmScheduler()
-
     assert scheduler.parse_output(detailed_job_info, '', '') is None
 
 


### PR DESCRIPTION
Fixes #6269 

The `SlurmScheduler` plugin uses SLURM's `sacct` command to retrieve detailed information for a given job. The command allows to specify which fields should be projected using the `--format` option. The fields to use were hardcoded by the plugin.

This approach made the plugin susceptible to breaking if the supported fields would change. This happened for example for SLURM v23.02, where the `Reserved` field was renamed to `Planned`, see this change log:

https://github.com/SchedMD/slurm/blob/863ead570d450e25022f04cc5c9cfb379aa8ae4d/RELEASE_NOTES#L181C1-L182C40

This caused the `sacct` command to return an error and the detailed job info would not be retrieved.

To make the plugin more robust with respect to these kinds of changes, the fields are no longer hardcoded, but they are determined dynamically by calling `sacct --helpformat` in a sub shell. This prints a table of the supported fields by the SLURM version that is interacted with. Using `tr`, this table is transformed into a single comma-delimited list, which is the format expected by `--format`.