### PR TITLE
Lazy pydantic import

### DIFF
--- a/src/aiida/cmdline/commands/cmd_config.py
+++ b/src/aiida/cmdline/commands/cmd_config.py
@@ -38,7 +38,8 @@ def verdi_config_list(ctx, prefix, description: bool):
     """
     from tabulate import tabulate
 
-    from aiida.manage.configuration import Config, Profile
+    from aiida.manage.configuration import Profile
+    from aiida.manage.configuration.config import Config
 
     config: Config = ctx.obj.config
     profile: Profile | None = ctx.obj.get('profile', None)
@@ -79,7 +80,8 @@ def verdi_config_list(ctx, prefix, description: bool):
 @click.pass_context
 def verdi_config_show(ctx, option):
     """Show details of an AiiDA option for the current profile."""
-    from aiida.manage.configuration import Config, Profile
+    from aiida.manage.configuration import Profile
+    from aiida.manage.configuration.config import Config
 
     config: Config = ctx.obj.config
     profile: Profile | None = ctx.obj.profile
@@ -125,7 +127,10 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
     import typing
 
     from aiida.common.exceptions import ConfigurationError
-    from aiida.manage.configuration import Config, Profile
+
+    if typing.TYPE_CHECKING:
+        from aiida.manage.configuration import Profile
+        from aiida.manage.configuration.config import Config
 
     if append and remove:
         echo.echo_critical('Cannot flag both append and remove')
@@ -170,7 +175,8 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
 @click.pass_context
 def verdi_config_unset(ctx, option, globally):
     """Unset an AiiDA option."""
-    from aiida.manage.configuration import Config, Profile
+    from aiida.manage.configuration import Profile
+    from aiida.manage.configuration.config import Config
 
     config: Config = ctx.obj.config
     profile: Profile | None = ctx.obj.profile

--- a/src/aiida/manage/__init__.py
+++ b/src/aiida/manage/__init__.py
@@ -30,7 +30,6 @@ from .manager import *
 __all__ = (
     'BROKER_DEFAULTS',
     'CURRENT_CONFIG_VERSION',
-    'Config',
     'MIGRATIONS',
     'ManagementApiConnectionError',
     'OLDEST_COMPATIBLE_CONFIG_VERSION',

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -13,14 +13,12 @@
 
 # fmt: off
 
-from .config import *
 from .migrations import *
 from .options import *
 from .profile import *
 
 __all__ = (
     'CURRENT_CONFIG_VERSION',
-    'Config',
     'MIGRATIONS',
     'OLDEST_COMPATIBLE_CONFIG_VERSION',
     'Option',
@@ -197,7 +195,7 @@ def profile_context(profile: Optional[str] = None, allow_switch=False) -> 'Profi
 
 
 def create_profile(
-    config: Config,
+    config: 'Config',
     storage_cls,
     *,
     name: str,

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -56,7 +56,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from aiida.common.warnings import AiidaDeprecationWarning
 
 if TYPE_CHECKING:
-    from aiida.manage.configuration import Config, Profile
+    from .config import Config
 
 # global variables for aiida
 CONFIG: Optional['Config'] = None

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -37,8 +37,6 @@ from aiida.common.log import AIIDA_LOGGER, LogLevels
 from .options import Option, get_option, get_option_names, parse_option
 from .profile import Profile
 
-__all__ = ('Config',)
-
 if TYPE_CHECKING:
     from aiida.orm.implementation.storage_backend import StorageBackend
 

--- a/src/aiida/manage/tests/pytest_fixtures.py
+++ b/src/aiida/manage/tests/pytest_fixtures.py
@@ -42,9 +42,12 @@ from aiida.common.log import AIIDA_LOGGER
 from aiida.common.warnings import warn_deprecation
 from aiida.engine import Process, ProcessBuilder, submit
 from aiida.engine.daemon.client import DaemonClient, DaemonNotRunningException, DaemonTimeoutException
-from aiida.manage import Config, Profile, get_manager, get_profile
+from aiida.manage import Profile, get_manager, get_profile
 from aiida.manage.manager import Manager
 from aiida.orm import Computer, ProcessNode, User
+
+if t.TYPE_CHECKING:
+    from aiida.manage.configuration.config import Config
 
 
 def recursive_merge(left: dict[t.Any, t.Any], right: dict[t.Any, t.Any]) -> None:

--- a/tests/cmdline/params/options/test_callable.py
+++ b/tests/cmdline/params/options/test_callable.py
@@ -37,3 +37,30 @@ def test_callable_default_resilient_parsing():
     completions = [c.value for c in _get_completions(verdi, [], '')]
     assert 'help' in completions
     assert configuration.CONFIG is None
+
+
+@pytest.mark.usefixtures('unload_config')
+def test_undesired_imports_during_tab_completion():
+    """Check that verdi does not import certain python modules
+    that would make tab-completion slow.
+
+    NOTE: This is analogous to `verdi devel check-undesired-imports`
+    """
+    import sys
+
+    for modulename in [
+        'asyncio',
+        'requests',
+        'plumpy',
+        'disk_objectstore',
+        'paramiko',
+        'seekpath',
+        'CifFile',
+        'ase',
+        'pymatgen',
+        'spglib',
+        'pydantic',
+        'pymysql',
+        'yaml',
+    ]:
+        assert modulename not in sys.modules, f'Detected loaded module {modulename} during tab-completion'

--- a/tests/cmdline/params/options/test_callable.py
+++ b/tests/cmdline/params/options/test_callable.py
@@ -34,10 +34,9 @@ def unload_config():
 
 @pytest.fixture
 def unimport_slow_imports():
-    """Pretend that pydantic has not been imported yet."""
-
-    for modulename in SLOW_IMPORTS:
-        del sys.modules['pydantic']
+    """Remove modules in ``SLOW_IMPORTS`` from ``sys.modules``."""
+    for module in SLOW_IMPORTS:
+        del sys.modules[module]
 
 
 @pytest.mark.usefixtures('unload_config')
@@ -54,15 +53,14 @@ def test_callable_default_resilient_parsing():
 @pytest.mark.usefixtures('unload_config')
 @pytest.mark.usefixtures('unimport_slow_imports')
 def test_slow_imports_during_tab_completion():
-    """Check that verdi does not import certain python modules
-    that would make tab-completion slow.
+    """Check that verdi does not import certain python modules that would make tab-completion slow.
 
     NOTE: This is analogous to `verdi devel check-undesired-imports`
     """
 
     # Let's double check that the undesired imports are not already loaded
     for modulename in SLOW_IMPORTS:
-        assert modulename not in sys.modules, f'Detected loaded module {modulename}'
+        assert modulename not in sys.modules, f'Module `{modulename}` was not properly unloaded'
 
     completions = [c.value for c in _get_completions(verdi, [], '')]
     assert 'help' in completions

--- a/tests/cmdline/params/options/test_callable.py
+++ b/tests/cmdline/params/options/test_callable.py
@@ -39,6 +39,7 @@ def test_callable_default_resilient_parsing():
     assert configuration.CONFIG is None
 
 
+# TODO: I think we'll need to monkeypatch `sys.modules` (is that even possible?)
 @pytest.mark.usefixtures('unload_config')
 def test_undesired_imports_during_tab_completion():
     """Check that verdi does not import certain python modules
@@ -49,18 +50,6 @@ def test_undesired_imports_during_tab_completion():
     import sys
 
     for modulename in [
-        'asyncio',
-        'requests',
-        'plumpy',
-        'disk_objectstore',
-        'paramiko',
-        'seekpath',
-        'CifFile',
-        'ase',
-        'pymatgen',
-        'spglib',
         'pydantic',
-        'pymysql',
-        'yaml',
     ]:
         assert modulename not in sys.modules, f'Detected loaded module {modulename} during tab-completion'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,10 @@ import warnings
 import click
 import pytest
 from aiida import get_profile
-from aiida.manage.configuration import Config, Profile, get_config, load_profile
+from aiida.manage.configuration import Profile, get_config, load_profile
+
+if t.TYPE_CHECKING:
+    from aiida.manage.configuration.config import Config
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures', 'sphinx.testing.fixtures']
 
@@ -173,9 +176,10 @@ def isolated_config(monkeypatch):
     changing it in tests maybe necessary if a command is invoked that will be reading the config from disk in another
     Python process and so doesn't have access to the loaded config in memory in the process that is running the test.
     """
+    import aiida.manage.configuration.config as _config
     from aiida.manage import configuration
 
-    monkeypatch.setattr(configuration.Config, '_backup', lambda *args, **kwargs: None)
+    monkeypatch.setattr(_config.Config, '_backup', lambda *args, **kwargs: None)
 
     current_config = configuration.CONFIG
     configuration.CONFIG = copy.deepcopy(current_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,10 +176,10 @@ def isolated_config(monkeypatch):
     changing it in tests maybe necessary if a command is invoked that will be reading the config from disk in another
     Python process and so doesn't have access to the loaded config in memory in the process that is running the test.
     """
-    import aiida.manage.configuration.config as _config
+    from aiida.manage.configuration.config import Config
     from aiida.manage import configuration
 
-    monkeypatch.setattr(_config.Config, '_backup', lambda *args, **kwargs: None)
+    monkeypatch.setattr(Config, '_backup', lambda *args, **kwargs: None)
 
     current_config = configuration.CONFIG
     configuration.CONFIG = copy.deepcopy(current_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,8 +176,8 @@ def isolated_config(monkeypatch):
     changing it in tests maybe necessary if a command is invoked that will be reading the config from disk in another
     Python process and so doesn't have access to the loaded config in memory in the process that is running the test.
     """
-    from aiida.manage.configuration.config import Config
     from aiida.manage import configuration
+    from aiida.manage.configuration.config import Config
 
     monkeypatch.setattr(Config, '_backup', lambda *args, **kwargs: None)
 

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -14,7 +14,8 @@ import uuid
 
 import pytest
 from aiida.common import exceptions
-from aiida.manage.configuration import Config, Profile, settings
+from aiida.manage.configuration import Profile, settings
+from aiida.manage.configuration.config import Config
 from aiida.manage.configuration.migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
 from aiida.manage.configuration.options import get_option
 from aiida.orm.implementation.storage_backend import StorageBackend


### PR DESCRIPTION
`pydantic` adds a lot of time to aiida startup, which is especially detrimental to tab completion.
Here I test the approach of deferring import of `aiida.manage.configuration.config` until really needed, which in turn defers pydantic.

Upcoming usage of pydantic from #6255 seems to be centered in `aiida.orm` which is not imported by default in `verdi` so this PR still seems worth it.

This is in principle a breaking change since we no longer export `Config` in `aiida.manage.configuration` module. But I guess it is not meant to be manipulated directly by users anyway.