### PR TITLE
CLI: Fix the `ctx.obj.profile` attribute not being initialized

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -603,13 +603,15 @@ def run_cli_command_subprocess(command, parameters, user_input, profile_name, su
 def run_cli_command_runner(command, parameters, user_input, initialize_ctx_obj, kwargs):
     """Run CLI command through ``click.testing.CliRunner``."""
     from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup
-    from aiida.common import AttributeDict
+    from aiida.cmdline.groups.verdi import LazyVerdiObjAttributeDict
     from click.testing import CliRunner
 
     if initialize_ctx_obj:
         config = get_config()
         profile = get_profile()
-        obj = AttributeDict({'config': config, 'profile': profile})
+        obj = LazyVerdiObjAttributeDict(None, {'config': config})
+        if profile is not None:
+            obj.profile = profile
     else:
         obj = None
 


### PR DESCRIPTION
Fixes #6273 

The `verdi` CLI uses a custom context class `VerdiContext`, which in turn provides a custom implementation for the `obj` property. This dictionary is primarily designed to lazily load the config and assigning it to the `config` attribute.

Besides the `config`, the `ctx.obj` can also be used to retrieve the active profile for a `verdi` command. However, this is not initialized by the context itself, but is left to the `ProfileParamType`. This means though that `ctx.obj.profile` can raise an `AttributeError` if no profile is set, for example when a config defines no profiles whatsoever.

This behavior was causing `verdi config set --global` to fail for configs without profiles, because it calls `ctx.obj.profile` which would raise an `AttributeError`. Although this was being tested for in `tests/cmdline/commands/test_config.py:test_config_set_option_no_profile` the bug was missed because the `run_cli_command` fixture would manually customize the `ctx.obj` instance to always define the `profile` attribute, even if it was `None`.

The `LazyConfigAttributeDict` is updated to not just initialize the `config` key, but also initialize `profile`, which is set to `None` if it doesn't already exist. Since it now handles multiple special keys, it is renamed to `LazyVerdiObjAttributeDict`. The `run_cli_command_runner` function, called by the `run_cli_command` fixture is updated to also use the `LazyVerdiObjAttributeDict` class, instead of the plain `AttributeDict`, and makes sure to only define the `profile` attribute if it is defined. This ensures that the pathway through the test runner is similar to an actual invocation of `verdi`.