### PR TITLE
Engine: Add positional inputs for `Process.submit`

### DIFF
--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -99,8 +99,7 @@ def submit(
     :param wait: when set to ``True``, the submission will be blocking and wait for the process to complete at which
         point the function returns the calculation node.
     :param wait_interval: the number of seconds to wait between checking the state of the process when ``wait=True``.
-    :param kwargs: inputs to be passed to the process. This is deprecated and the inputs should instead be passed as a
-        dictionary to the ``inputs`` argument.
+    :param kwargs: inputs to be passed to the process. This is an alternative to the positional ``inputs`` argument.
     :return: the calculation node of the process
     """
     inputs = prepare_inputs(inputs, **kwargs)

--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -7,6 +7,8 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """The AiiDA process class"""
+from __future__ import annotations
+
 import asyncio
 import collections
 import copy
@@ -517,14 +519,14 @@ class Process(plumpy.processes.Process):
         super().set_status(status)
         self.node.set_process_status(status)
 
-    def submit(self, process: Type['Process'], **kwargs) -> orm.ProcessNode:
+    def submit(self, process: Type['Process'], inputs: dict[str, Any] | None = None, **kwargs) -> orm.ProcessNode:
         """Submit process for execution.
 
-        :param process: process
-        :return: the calculation node of the process
-
+        :param process: The process class.
+        :param inputs: The dictionary of process inputs.
+        :return: The process node.
         """
-        return self.runner.submit(process, **kwargs)
+        return self.runner.submit(process, inputs, **kwargs)
 
     @property
     def runner(self) -> 'Runner':


### PR DESCRIPTION
The signatures of the `run` and `submit` launch functions were updated in v2.5 to support passing the process inputs as a positional dictionary instead of through keyword arguments, however, `Process.submit` was accidentally left out.