### PR TITLE
CLI: Add the `-M/--most-recent-node` option to `verdi process` commands

### DIFF
--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -69,6 +69,7 @@ __all__ = (
     'INPUT_PLUGIN',
     'LABEL',
     'LIMIT',
+    'MOST_RECENT_NODE',
     'NODE',
     'NODES',
     'NON_INTERACTIVE',
@@ -590,6 +591,13 @@ OLDER_THAN = OverridableOption(
     type=click.INT,
     metavar='OLDER_THAN',
     help='Only include entries created before OLDER_THAN days ago.',
+)
+
+MOST_RECENT_NODE = OverridableOption(
+    '-M',
+    '--most-recent-node',
+    is_flag=True,
+    help='Select the most recently created node.',
 )
 
 ALL = OverridableOption(


### PR DESCRIPTION
The `-M/--most-recent-node` option is added to the `status`, `show` and
`report` subcommands of `verdi process`. When specified, these commands
don't need specific process node identifiers but the most recent will
automatically be selected. This is a useful feature when users are
actively running processes one by one during testing and they usually
want to look at the last created process node.