### PR TITLE
ORM: Fix `ProcessNode.get_builder_restart`

### DIFF
--- a/tests/orm/nodes/process/test_process.py
+++ b/tests/orm/nodes/process/test_process.py
@@ -1,9 +1,13 @@
 """Tests for :mod:`aiida.orm.nodes.process.process`."""
 import pytest
-from aiida.engine import ExitCode, ProcessState
+from aiida.engine import ExitCode, ProcessState, launch
+from aiida.orm import Int
 from aiida.orm.nodes.caching import NodeCaching
 from aiida.orm.nodes.process.process import ProcessNode
 from aiida.orm.nodes.process.workflow import WorkflowNode
+from aiida.plugins import CalculationFactory
+
+ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')
 
 
 def test_exit_code():
@@ -69,3 +73,15 @@ def test_is_valid_cache(process_nodes):
     """Test the :meth:`aiida.orm.nodes.process.process.ProcessNode.is_valid_cache` property."""
     for node, is_valid_cache in process_nodes:
         assert node.base.caching.is_valid_cache == is_valid_cache, node
+
+
+def test_get_builder_restart(aiida_local_code_factory):
+    """Test :meth:`aiida.orm.nodes.process.process.ProcessNode.get_builder_restart`."""
+    inputs = {
+        'code': aiida_local_code_factory('core.arithmetic.add', '/bin/bash'),
+        'x': Int(1),
+        'y': Int(1),
+        'metadata': {'options': {'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}}},
+    }
+    _, node = launch.run_get_node(ArithmeticAddCalculation, inputs)
+    assert node.get_builder_restart()._inputs(prune=True) == inputs


### PR DESCRIPTION
Fixes #5977

The `get_builder_restart` would fail if the process input specification contained the inputs of a `CalcJob`. The method would first assign the regular inputs to the builder followed by the metadata. However, each time the builder is updated, the validation is triggered. The normal inputs do not contain the required metadata, such as the `resources` option, causing the validation to fail.

The solution is to update the builder with the complete set of inputs in one go, merging the normal inputs with the metadata inputs prior to that.