### PR TITLE
`CalcJob`: Allow to define order of copying of input files

### DIFF
--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -18,12 +18,12 @@ import pathlib
 import shutil
 from collections.abc import Mapping
 from logging import LoggerAdapter
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 from typing import Mapping as MappingType
 
 from aiida.common import AIIDA_LOGGER, exceptions
-from aiida.common.datastructures import CalcInfo
+from aiida.common.datastructures import CalcInfo, FileCopyOperation
 from aiida.common.folders import SandboxFolder
 from aiida.common.links import LinkType
 from aiida.engine.processes.exit_code import ExitCode
@@ -201,96 +201,30 @@ def upload_calculation(
     remote_symlink_list = calc_info.remote_symlink_list or []
     provenance_exclude_list = calc_info.provenance_exclude_list or []
 
-    for uuid, filename, target in local_copy_list:
-        logger.debug(f'[submission of calculation {node.uuid}] copying local file/folder to {target}')
+    file_copy_operation_order = calc_info.file_copy_operation_order or [
+        FileCopyOperation.SANDBOX,
+        FileCopyOperation.LOCAL,
+        FileCopyOperation.REMOTE,
+    ]
 
-        try:
-            data_node = load_node(uuid=uuid)
-        except exceptions.NotExistent:
-            data_node = _find_data_node(inputs, uuid) if inputs else None
-
-        if data_node is None:
-            logger.warning(f'failed to load Node<{uuid}> specified in the `local_copy_list`')
+    for file_copy_operation in file_copy_operation_order:
+        if file_copy_operation is FileCopyOperation.LOCAL:
+            _copy_local_files(logger, node, transport, inputs, local_copy_list)
+        elif file_copy_operation is FileCopyOperation.REMOTE:
+            if not dry_run:
+                _copy_remote_files(logger, node, computer, transport, remote_copy_list, remote_symlink_list)
+        elif file_copy_operation is FileCopyOperation.SANDBOX:
+            if not dry_run:
+                _copy_sandbox_files(logger, node, transport, folder)
         else:
-            # If no explicit source filename is defined, we assume the top-level directory
-            filename_source = filename or '.'
-            filename_target = target or ''
-
-            # Make the target filepath absolute and create any intermediate directories if they don't yet exist
-            filepath_target = pathlib.Path(folder.abspath) / filename_target
-            filepath_target.parent.mkdir(parents=True, exist_ok=True)
-
-            if data_node.base.repository.get_object(filename_source).file_type == FileType.DIRECTORY:
-                # If the source object is a directory, we copy its entire contents
-                data_node.base.repository.copy_tree(filepath_target, filename_source)
-                sources = data_node.base.repository.list_object_names(filename_source)
-                if filename_target:
-                    sources = [str(pathlib.Path(filename_target) / subpath) for subpath in sources]
-                provenance_exclude_list.extend(sources)
-            else:
-                # Otherwise, simply copy the file
-                with folder.open(target, 'wb') as handle:
-                    with data_node.base.repository.open(filename, 'rb') as source:
-                        shutil.copyfileobj(source, handle)
-
-                provenance_exclude_list.append(target)
+            raise RuntimeError(f'file copy operation {file_copy_operation} is not yet implemented.')
 
     # In a dry_run, the working directory is the raw input folder, which will already contain these resources
-    if not dry_run:
-        for filename in folder.get_content_list():
-            logger.debug(f'[submission of calculation {node.pk}] copying file/folder {filename}...')
-            transport.put(folder.get_abs_path(filename), filename)
-
-        for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_copy_list:
-            if remote_computer_uuid == computer.uuid:
-                logger.debug(
-                    f'[submission of calculation {node.pk}] copying {dest_rel_path} '
-                    f'remotely, directly on the machine {computer.label}'
-                )
-                try:
-                    transport.copy(remote_abs_path, dest_rel_path)
-                except FileNotFoundError:
-                    logger.warning(
-                        f'[submission of calculation {node.pk}] Unable to copy remote '
-                        f'resource from {remote_abs_path} to {dest_rel_path}! NOT Stopping but just ignoring!.'
-                    )
-                except (IOError, OSError):
-                    logger.warning(
-                        f'[submission of calculation {node.pk}] Unable to copy remote '
-                        f'resource from {remote_abs_path} to {dest_rel_path}! Stopping.'
-                    )
-                    raise
-            else:
-                raise NotImplementedError(
-                    f'[submission of calculation {node.pk}] Remote copy between two different machines is '
-                    'not implemented yet'
-                )
-
-        for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_symlink_list:
-            if remote_computer_uuid == computer.uuid:
-                logger.debug(
-                    f'[submission of calculation {node.pk}] copying {dest_rel_path} remotely, '
-                    f'directly on the machine {computer.label}'
-                )
-                remote_dirname = pathlib.Path(dest_rel_path).parent
-                try:
-                    transport.makedirs(remote_dirname, ignore_existing=True)
-                    transport.symlink(remote_abs_path, dest_rel_path)
-                except (IOError, OSError):
-                    logger.warning(
-                        f'[submission of calculation {node.pk}] Unable to create remote symlink '
-                        f'from {remote_abs_path} to {dest_rel_path}! Stopping.'
-                    )
-                    raise
-            else:
-                raise IOError(
-                    f'It is not possible to create a symlink between two different machines for calculation {node.pk}'
-                )
-    else:
+    if dry_run:
         if remote_copy_list:
             filepath = os.path.join(workdir, '_aiida_remote_copy_list.txt')
             with open(filepath, 'w', encoding='utf-8') as handle:  # type: ignore[assignment]
-                for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_copy_list:
+                for _, remote_abs_path, dest_rel_path in remote_copy_list:
                     handle.write(
                         f'would have copied {remote_abs_path} to {dest_rel_path} in working '
                         f'directory on remote {computer.label}'
@@ -299,7 +233,7 @@ def upload_calculation(
         if remote_symlink_list:
             filepath = os.path.join(workdir, '_aiida_remote_symlink_list.txt')
             with open(filepath, 'w', encoding='utf-8') as handle:  # type: ignore[assignment]
-                for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_symlink_list:
+                for _, remote_abs_path, dest_rel_path in remote_symlink_list:
                     handle.write(
                         f'would have created symlinks from {remote_abs_path} to {dest_rel_path} in working'
                         f'directory on remote {computer.label}'
@@ -344,6 +278,103 @@ def upload_calculation(
         return RemoteData(computer=computer, remote_path=workdir)
 
     return None
+
+
+def _copy_remote_files(logger, node, computer, transport, remote_copy_list, remote_symlink_list):
+    """Perform the copy instructions of the ``remote_copy_list`` and ``remote_symlink_list``."""
+    for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_copy_list:
+        if remote_computer_uuid == computer.uuid:
+            logger.debug(
+                f'[submission of calculation {node.pk}] copying {dest_rel_path} '
+                f'remotely, directly on the machine {computer.label}'
+            )
+            try:
+                transport.copy(remote_abs_path, dest_rel_path)
+            except FileNotFoundError:
+                logger.warning(
+                    f'[submission of calculation {node.pk}] Unable to copy remote '
+                    f'resource from {remote_abs_path} to {dest_rel_path}! NOT Stopping but just ignoring!.'
+                )
+            except (IOError, OSError):
+                logger.warning(
+                    f'[submission of calculation {node.pk}] Unable to copy remote '
+                    f'resource from {remote_abs_path} to {dest_rel_path}! Stopping.'
+                )
+                raise
+        else:
+            raise NotImplementedError(
+                f'[submission of calculation {node.pk}] Remote copy between two different machines is '
+                'not implemented yet'
+            )
+
+    for remote_computer_uuid, remote_abs_path, dest_rel_path in remote_symlink_list:
+        if remote_computer_uuid == computer.uuid:
+            logger.debug(
+                f'[submission of calculation {node.pk}] copying {dest_rel_path} remotely, '
+                f'directly on the machine {computer.label}'
+            )
+            remote_dirname = pathlib.Path(dest_rel_path).parent
+            try:
+                transport.makedirs(remote_dirname, ignore_existing=True)
+                transport.symlink(remote_abs_path, dest_rel_path)
+            except (IOError, OSError):
+                logger.warning(
+                    f'[submission of calculation {node.pk}] Unable to create remote symlink '
+                    f'from {remote_abs_path} to {dest_rel_path}! Stopping.'
+                )
+                raise
+        else:
+            raise IOError(
+                f'It is not possible to create a symlink between two different machines for calculation {node.pk}'
+            )
+
+
+def _copy_local_files(logger, node, transport, inputs, local_copy_list):
+    """Perform the copy instrctions of the ``local_copy_list``."""
+    with TemporaryDirectory() as tmpdir:
+        dirpath = pathlib.Path(tmpdir)
+
+        # The transport class can only copy files directly from the file system, so the files in the source node's repo
+        # have to first be copied to a temporary directory on disk.
+        for uuid, filename, target in local_copy_list:
+            logger.debug(f'[submission of calculation {node.uuid}] copying local file/folder to {target}')
+
+            try:
+                data_node = load_node(uuid=uuid)
+            except exceptions.NotExistent:
+                data_node = _find_data_node(inputs, uuid) if inputs else None
+
+            if data_node is None:
+                logger.warning(f'failed to load Node<{uuid}> specified in the `local_copy_list`')
+                continue
+
+            # If no explicit source filename is defined, we assume the top-level directory
+            filename_source = filename or '.'
+            filename_target = target or ''
+
+            # Make the target filepath absolute and create any intermediate directories if they don't yet exist
+            filepath_target = (dirpath / filename_target).resolve().absolute()
+            filepath_target.parent.mkdir(parents=True, exist_ok=True)
+
+            if data_node.base.repository.get_object(filename_source).file_type == FileType.DIRECTORY:
+                # If the source object is a directory, we copy its entire contents
+                data_node.base.repository.copy_tree(filepath_target, filename_source)
+            else:
+                # Otherwise, simply copy the file
+                with filepath_target.open('wb') as handle:
+                    with data_node.base.repository.open(filename_source, 'rb') as source:
+                        shutil.copyfileobj(source, handle)
+
+        # Now copy the contents of the temporary folder to the remote working directory using the transport
+        for filepath in dirpath.iterdir():
+            transport.put(str(filepath), filepath.name)
+
+
+def _copy_sandbox_files(logger, node, transport, folder):
+    """Copy the contents of the sandbox folder to the working directory."""
+    for filename in folder.get_content_list():
+        logger.debug(f'[submission of calculation {node.pk}] copying file/folder {filename}...')
+        transport.put(folder.get_abs_path(filename), filename)
 
 
 def submit_calculation(calculation: CalcJobNode, transport: Transport) -> str | ExitCode:

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -21,7 +21,7 @@ import plumpy.process_states
 
 from aiida import orm
 from aiida.common import AttributeDict, exceptions
-from aiida.common.datastructures import CalcInfo
+from aiida.common.datastructures import CalcInfo, FileCopyOperation
 from aiida.common.folders import Folder
 from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
@@ -974,6 +974,22 @@ class CalcJob(Process):
             codes_run_mode = calc_info.codes_run_mode
 
         job_tmpl.codes_run_mode = codes_run_mode
+
+        if calc_info.file_copy_operation_order is not None:
+            if not isinstance(calc_info.file_copy_operation_order, list) or any(  # type: ignore[redundant-expr]
+                not isinstance(e, FileCopyOperation) for e in calc_info.file_copy_operation_order
+            ):
+                raise PluginInternalError(
+                    'calc_info.file_copy_operation_order is not a list of `FileCopyOperation` enums.'
+                )
+        else:
+            # Set the default
+            calc_info.file_copy_operation_order = [
+                FileCopyOperation.SANDBOX,
+                FileCopyOperation.LOCAL,
+                FileCopyOperation.REMOTE,
+            ]
+
         ########################################################################
 
         custom_sched_commands = self.node.get_option('custom_scheduler_commands')


### PR DESCRIPTION
Fixes #6012 

There are three different sources of files that are copied to the working directory on the remote computer where a calculation job is executed:

* Sandbox: files written to a temporary sandbox folder on the local file system written by the `CalcJob` plugin, first in the `prepare_for_submission` method, followed by the `presubmit` of the base class.
* Local: files written to the temporary sandbox folder by the engine based on the `local_copy_list` defined by the plugin in the `prepare_for_submission` method.
* Remote: files written directly to the remote working directory by the engine base on the `remote_copy_list` defined by the plugin in the `prepare_for_submission` method.

Historically, these operations were performed in the order of local, sandbox and remote. For certain use cases, however, this was deemed non-ideal, for example because files from the remote would override files written by the plugin itself in the sandbox. This enum can be assigned to the `CalcInfo` instance returned by the calculation job plugin `prepare_for_submission` implementation to change the order.

Here, a new attribute `file_copy_order` is added to the `CalcInfo` datastructure. It takes an instance of the `FileCopyOrder` enum. The value of the enum determines the order in which the type of files as listed above are copied to the working directory. The default is kept to the historical order of `LOCAL_SANDBOX_REMOTE`, but one more option is added `REMOTE_LOCAL_SANDBOX` for now.

To simplify the implementation, the code to copy these three types of files are factored out of the `upload_calculation` function to the functions `_copy_remote_files`, `_copy_remote_files` and `_copy_sandbox_files` functions, respectively.