### PR TITLE
CLI: Let `-v/--verbosity` only affect `aiida` and `verdi` loggers

### DIFF
--- a/docs/source/intro/troubleshooting.rst
+++ b/docs/source/intro/troubleshooting.rst
@@ -440,13 +440,13 @@ If you are experiencing a problem, you can increase the default minimum logging 
 
 .. code-block:: console
 
-    $ verdi config logging.aiida_loglevel DEBUG
+    $ verdi config set logging.aiida_loglevel DEBUG
 
 You might also be interested in reviewing the circus log messages (the ``circus`` library is the daemonizer that manages the daemon runners),
 
 .. code-block:: console
 
-    $ verdi config logging.circus_loglevel DEBUG
+    $ verdi config set logging.circus_loglevel DEBUG
 
 however those messages are usually only relevant to debug AiiDA internals.
 
@@ -470,10 +470,12 @@ When the problem is solved, we suggest to reset the default logging level, with:
 
 to avoid too much noise in the logfiles.
 
+.. tip::
+
+    It is also possible to temporarily change the log level for ``verdi`` commands using the ``--v/--verbosity`` options (see :ref:`this section <topics:cli:verbosity>` for more details).
+
 The config options set for the current profile can be viewed using
 
 .. code-block:: console
 
-    $ verdi profile show
-
-in the ``options`` row.
+    $ verdi config list

--- a/docs/source/topics/cli.rst
+++ b/docs/source/topics/cli.rst
@@ -114,7 +114,7 @@ Verbosity
 =========
 All ``verdi`` commands have the ``-v/--verbosity`` option, which allows to control the verbosity of the output that is printed by the command.
 The option takes a value that is known as the log level and all messages that are emitted with an inferior log level will be suppressed.
-The valid values in order of increasing log level are: `NOTSET`, `DEBUG`, `INFO`, `REPORT`, `WARNING`, `ERROR` and `CRITICAL`.
+The valid values in order of increasing log level are: ``NOTSET``, ``DEBUG``, ``INFO``, ``REPORT``, ``WARNING``, ``ERROR`` and ``CRITICAL``.
 For example, if the log level is set to ``ERROR``, only messages with the ``ERROR`` and ``CRITICAL`` level will be shown.
 The choice for these log level values comes directly from `Python's built-in logging module <https://docs.python.org/3/library/logging.html>`_.
 The ``REPORT`` level is a log level that is defined and added by AiiDA that sits between the ``INFO`` and ``WARNING`` level, and is the default log level.
@@ -133,7 +133,11 @@ is identical to
     verdi --verbosity debug process list
 
 When the option is specified multiple times, only the last value will be considered.
-If the `--verbosity` option is specified, it overrides the log level of all the loggers configured by AiiDA, e.g. `logging.aiida_loglevel`.
+
+.. note::
+
+    The ``--verbosity`` option only overrides the log level of the ``aiida`` and ``verdi`` loggers.
+    To control the log level of other loggers, please use ``verdi config set`` (see :ref:`this section <intro:increase-logging-verbosity>`).
 
 
 .. _topics:cli:identifiers:

--- a/src/aiida/common/log.py
+++ b/src/aiida/common/log.py
@@ -215,10 +215,13 @@ def configure_logging(with_orm=False, daemon=False, daemon_log_file=None):
             handlers.append('cli')
 
     # If ``CLI_LOG_LEVEL`` is set, a ``verdi`` command is being executed with the ``--verbosity`` option. In this case
-    # we override the log levels of all loggers with the specified log level.
+    # we override the log levels of the ``aiida`` and ``verdi`` loggers with the specified log level. The other loggers
+    # are left untouched as they can become very noisy for lower log levels and drown out the useful information. Users
+    # can still configure those manually beforehand through the config options.
     if CLI_LOG_LEVEL is not None:
-        for logger in config['loggers'].values():
-            logger['level'] = CLI_LOG_LEVEL
+        for name, logger in config['loggers'].items():
+            if name in ['aiida', 'verdi']:
+                logger['level'] = CLI_LOG_LEVEL
 
     # Add the `DbLogHandler` if `with_orm` is `True`
     if with_orm:


### PR DESCRIPTION
In 42c5ab101c77a7e278bddb87d0055b907db42dc3, the logging of the CLI was reworked, specifically the functionality of the `-v/--verbosity`. The decision was made to have the log level, specified through this option, be applied to all loggers. While this makes sense, this had some unintended consequences.

The `verdi` commands and the Python API themselves often use `INFO` log messages to provide additional useful information. But when enabled using `-v INFO`, they would be drowned out by info messages of other loggers, most notably by the `sqlalchemy` logger. Since we cannot control the level at which these messages of third-party packages are emitted, we are forced to not update the loglevel for these loggers.

The downside is that now the loggers are no longer all controlled at once through a single option. But it is doubtful that anyone was relying on this anyway, since the most relevant information comes from the `aiida` logger. And it is still possible to change the log level of external loggers through the configuration options.