### PR TITLE
Add python 3.12 tox environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -414,22 +414,23 @@ deps =
     py39: -rrequirements/requirements-py-3.9.txt
     py310: -rrequirements/requirements-py-3.10.txt
     py311: -rrequirements/requirements-py-3.11.txt
+    py312: -rrequirements/requirements-py-3.12.txt
 
-[testenv:py{39,310,311}]
+[testenv:py{39,310,311,312}]
 passenv =
     PYTHONASYNCIODEBUG
 setenv =
     AIIDA_WARN_v3 =
 commands = pytest {posargs}
 
-[testenv:py{39,310,311}-verdi]
+[testenv:py{39,310,311,312}-verdi]
 passenv =
     AIIDA_TEST_BACKEND
 setenv =
     AIIDA_PATH = {toxinidir}/.tox/.aiida
 commands = verdi {posargs}
 
-[testenv:py{39,310,311}-docs-{clean,update}]
+[testenv:py{39,310,311,312}-docs-{clean,update}]
 description =
     clean: Build the documentation (remove any existing build)
     update: Build the documentation (modify any existing build)
@@ -442,13 +443,14 @@ commands =
     clean: make clean
     make debug
 
-[testenv:py{39,310,311}-docs-live]
+[testenv:py{39,310,311,312}-docs-live]
 # tip: remove apidocs before using this feature (`cd docs; make clean`)
 description = Build the documentation and launch browser (with live updates)
 deps =
     py39: -rrequirements/requirements-py-3.9.txt
     py310: -rrequirements/requirements-py-3.10.txt
     py311: -rrequirements/requirements-py-3.11.txt
+    py312: -rrequirements/requirements-py-3.12.txt
     sphinx-autobuild
 setenv =
     RUN_APIDOC = False
@@ -458,7 +460,7 @@ commands =
         --port 0 --open-browser \
         -n -b {posargs:html} docs/source/ docs/build/{posargs:html}
 
-[testenv:py{39,310,311}-pre-commit]
+[testenv:py{39,310,311,312}-pre-commit]
 description = Run the pre-commit checks
 extras = pre-commit
 commands = pre-commit run {posargs}


### PR DESCRIPTION
#6161 added support for python 3.12 but did not add a py312 tox environment. This PR remedies that.