### PR TITLE
Add docker image for aiida-core development

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,21 +1,30 @@
-# AiiDA docker stacks
+# AiiDA Docker stacks
 
 ### Build images locally
 
-To build the images, run `docker buildx bake -f build.json -f docker-bake.hcl --load` (tested with *docker buildx* version v0.8.2).
+To build the images, run the following command: (tested with _docker buildx_ version v0.8.2)
+
+```bash
+docker buildx bake -f docker-bake.hcl -f build.json --load
+```
 
 The build system will attempt to detect the local architecture and automatically build images for it (tested with amd64 and arm64).
-You can also specify a custom platform with the `--platform`, example: `docker buildx bake -f build.json -f docker-bake.hcl --set *.platform=linux/amd64 --load`.
 
-### Test the build images locally
+You can also specify a custom platform with `--platform`, for example:
 
-Run
+```bash
+docker buildx bake -f docker-bake.hcl -f build.json --set *.platform=linux/amd64 --load
+```
+
+### Test built images locally
+
+To test the images, run
 
 ```bash
 TAG=newly-baked python -m pytest -s tests
 ```
 
-### Trigger a build on ghcr.io and dockerhub
+### Trigger a build on ghcr.io and Dockerhub
 
-Only the PR open to the organization repository will trigger a build on ghcr.io.
-Push to dockerhub is triggered when making a release on github.
+- Only an open PR to the organization's repository will trigger a build on ghcr.io.
+- A push to dockerhub is triggered when making a release on github.

--- a/.docker/aiida-core-dev/Dockerfile
+++ b/.docker/aiida-core-dev/Dockerfile
@@ -3,7 +3,7 @@ FROM aiida-core-with-services
 
 LABEL maintainer="AiiDA Team <developers@aiida.net>"
 
-COPY aiida-clone-and-install.sh /etc/init/run-before-daemon-start/
+COPY aiida-clone-and-install.sh /etc/init/run-before-daemon-start/10-aiida-clone-and-install.sh
 
 USER ${SYSTEM_UID}
 WORKDIR "/home/${SYSTEM_USER}"

--- a/.docker/aiida-core-dev/Dockerfile
+++ b/.docker/aiida-core-dev/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM aiida-core-with-services
+
+LABEL maintainer="AiiDA Team <developers@aiida.net>"
+
+COPY aiida-clone-and-install.sh /etc/init/run-before-daemon-start/
+
+USER ${SYSTEM_UID}
+WORKDIR "/home/${SYSTEM_USER}"

--- a/.docker/aiida-core-dev/aiida-clone-and-install.sh
+++ b/.docker/aiida-core-dev/aiida-clone-and-install.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 cd ~ || exit
-git clone https://github.com/aiidateam/aiida-core.git
+git clone https://github.com/aiidateam/aiida-core.git --origin upstream
 cd aiida-core || exit
-git remote rename origin upstream
 pip install --user -e ."[pre-commit,atomic_tools,docs,rest,tests,tui]"
 pip install tox
 cd || exit

--- a/.docker/aiida-core-dev/aiida-clone-and-install.sh
+++ b/.docker/aiida-core-dev/aiida-clone-and-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cd ~ || exit
-git clone https://github.com/aiidateam/aiida-core.git --origin upstream
-cd aiida-core || exit
-pip install --user -e ."[pre-commit,atomic_tools,docs,rest,tests,tui]" tox
-cd || exit
+REPO_PATH=/home/aiida/aiida-core
+
+git clone https://github.com/aiidateam/aiida-core.git --origin upstream $REPO_PATH
+
+pip install --user -e "$REPO_PATH/[pre-commit,atomic_tools,docs,rest,tests,tui]" tox

--- a/.docker/aiida-core-dev/aiida-clone-and-install.sh
+++ b/.docker/aiida-core-dev/aiida-clone-and-install.sh
@@ -3,6 +3,5 @@
 cd ~ || exit
 git clone https://github.com/aiidateam/aiida-core.git --origin upstream
 cd aiida-core || exit
-pip install --user -e ."[pre-commit,atomic_tools,docs,rest,tests,tui]"
-pip install tox
+pip install --user -e ."[pre-commit,atomic_tools,docs,rest,tests,tui]" tox
 cd || exit

--- a/.docker/aiida-core-dev/aiida-clone-and-install.sh
+++ b/.docker/aiida-core-dev/aiida-clone-and-install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd ~ || exit
+git clone https://github.com/aiidateam/aiida-core.git
+cd aiida-core || exit
+git remote rename origin upstream
+pip install --user -e ."[pre-commit,atomic_tools,docs,rest,tests,tui]"
+pip install tox
+cd || exit

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "PLATFORMS" {
 }
 
 variable "TARGETS" {
-  default = ["aiida-core-base", "aiida-core-with-services"]
+  default = ["aiida-core-base", "aiida-core-with-services", "aiida-core-dev"]
 }
 
 function "tags" {
@@ -40,6 +40,9 @@ target "aiida-core-base-meta" {
 }
 target "aiida-core-with-services-meta" {
   tags = tags("aiida-core-with-services")
+}
+target "aiida-core-dev-meta" {
+  tags = tags("aiida-core-dev")
 }
 
 target "aiida-core-base" {
@@ -65,4 +68,12 @@ target "aiida-core-with-services" {
     "PGSQL_VERSION" = "${PGSQL_VERSION}"
     "RMQ_VERSION" = "${RMQ_VERSION}"
   }
+}
+target "aiida-core-dev" {
+  inherits = ["aiida-core-dev-meta"]
+  context = "aiida-core-dev"
+  contexts = {
+    aiida-core-with-services = "target:aiida-core-with-services"
+  }
+  platforms = "${PLATFORMS}"
 }

--- a/.docker/docker-compose.aiida-core-dev.yml
+++ b/.docker/docker-compose.aiida-core-dev.yml
@@ -7,8 +7,3 @@ services:
     environment:
       TZ: Europe/Zurich
       SETUP_DEFAULT_AIIDA_PROFILE: 'true'
-        #volumes:
-        #    - aiida-home-folder:/home/aiida
-
-volumes:
-  aiida-home-folder:

--- a/.docker/docker-compose.aiida-core-dev.yml
+++ b/.docker/docker-compose.aiida-core-dev.yml
@@ -1,0 +1,14 @@
+version: '3.4'
+
+services:
+
+  aiida:
+    image: ${REGISTRY:-}${BASE_IMAGE:-aiidateam/aiida-core-dev}:${TAG:-latest}
+    environment:
+      TZ: Europe/Zurich
+      SETUP_DEFAULT_AIIDA_PROFILE: 'true'
+        #volumes:
+        #    - aiida-home-folder:/home/aiida
+
+volumes:
+  aiida-home-folder:

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -43,7 +43,7 @@ jobs:
         rm -rf /tmp/aiida-core/
       shell: bash
 
-    - name: Build images aiida-core-base and aiida-core-with-services
+    - name: Build aiida-core images
       # The order of the buildx bake files is important, as the second one will overwrite the first one
       run: docker buildx bake -f docker-bake.hcl -f build.json --set *.platform=linux/${{ inputs.architecture }} --load
       env:
@@ -53,11 +53,12 @@ jobs:
     - name: Run tests ✅
       run: TAG=newly-baked python -m pytest -s tests
 
-    - name: Save image as a tar for later use 💾
+    - name: Save images as tar for later use 💾
       run: |
         mkdir -p /tmp/aiida-core
         docker save ${{ env.OWNER }}/aiida-core-base -o /tmp/aiida-core/aiida-core-base-${{ inputs.architecture }}.tar
         docker save ${{ env.OWNER }}/aiida-core-with-services -o /tmp/aiida-core/aiida-core-with-services-${{ inputs.architecture }}.tar
+        docker save ${{ env.OWNER }}/aiida-core-dev -o /tmp/aiida-core/aiida-core-dev-${{ inputs.architecture }}.tar
 
     - name: Upload aiida-core-base image as artifact 💾
       uses: actions/upload-artifact@v4
@@ -71,4 +72,11 @@ jobs:
       with:
         name: aiida-core-with-services-${{ inputs.architecture }}
         path: /tmp/aiida-core/aiida-core-with-services-${{ inputs.architecture }}.tar
+        retention-days: 3
+
+    - name: Upload aiida-core-dev image as artifact 💾
+      uses: actions/upload-artifact@v4
+      with:
+        name: aiida-core-dev-${{ inputs.architecture }}
+        path: /tmp/aiida-core/aiida-core-dev-${{ inputs.architecture }}.tar
         retention-days: 3


### PR DESCRIPTION
This PR intends to introduce a development-centric `aiida-core` Docker image based on the `aiida-core-with-services` image. The following recipe is added via a pre-daemon-start script:

- clone the aiida-core repo to the user's home
- rename the official remote to `upstream` (reserving `origin` to the developer's repo)
- editably install the repo with `pip install --user -e ."[pre-commit,atomic_tools,docs,rest,tests,tui]"`
- install `tox` for local testing

Documentation to follow shortly.