### PR TITLE
CLI: Fix logging not showing in `verdi daemon worker`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -260,4 +260,4 @@ def worker():
     """Run a single daemon worker in the current interpreter."""
     from aiida.engine.daemon.worker import start_daemon_worker
 
-    start_daemon_worker()
+    start_daemon_worker(foreground=True)

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -36,10 +36,14 @@ async def shutdown_worker(runner: Runner) -> None:
     LOGGER.info('Daemon worker stopped')
 
 
-def start_daemon_worker() -> None:
-    """Start a daemon worker for the currently configured profile."""
+def start_daemon_worker(foreground: bool = False) -> None:
+    """Start a daemon worker for the currently configured profile.
+
+    :param foreground: If true, the logging will be configured to write to stdout, otherwise it will be configured to
+        write to the daemon log file.
+    """
     daemon_client = get_daemon_client()
-    configure_logging(daemon=True, daemon_log_file=daemon_client.daemon_log_file)
+    configure_logging(daemon=not foreground, daemon_log_file=daemon_client.daemon_log_file)
 
     try:
         manager = get_manager()


### PR DESCRIPTION
The `verdi daemon worker` will launch a single daemon worker in the foreground which is useful for debugging. However, in this case, the logging was not configured to write to stdout which renders the command essentially moot.

The `aiida.engine.daemon.worker.start_worker` function now takes the argument `foreground` which is `False` by default, but when set to `True`, the logging is configured to write to stdout instead of the daemon log file.