### PR TITLE
database password cannot contain @ ? .. issue fixed

### DIFF
--- a/src/aiida/storage/psql_dos/utils.py
+++ b/src/aiida/storage/psql_dos/utils.py
@@ -32,16 +32,18 @@ def create_sqlalchemy_engine(config: PsqlConfig):
         more info.
     """
     from sqlalchemy import create_engine
+    from urllib.parse import quote_plus
 
     # The hostname may be `None`, which is a valid value in the case of peer authentication for example. In this case
     # it should be converted to an empty string, because otherwise the `None` will be converted to string literal "None"
     hostname = config['database_hostname'] or ''
     separator = ':' if config['database_port'] else ''
+    password = quote_plus(config['database_password'])
 
     engine_url = 'postgresql://{user}:{password}@{hostname}{separator}{port}/{name}'.format(
         separator=separator,
         user=config['database_username'],
-        password=config['database_password'],
+        password=password,
         hostname=hostname,
         port=config['database_port'],
         name=config['database_name'],

--- a/src/aiida/storage/psql_dos/utils.py
+++ b/src/aiida/storage/psql_dos/utils.py
@@ -31,8 +31,9 @@ def create_sqlalchemy_engine(config: PsqlConfig):
         See https://docs.sqlalchemy.org/en/13/core/engines.html?highlight=create_engine#sqlalchemy.create_engine for
         more info.
     """
-    from sqlalchemy import create_engine
     from urllib.parse import quote_plus
+
+    from sqlalchemy import create_engine
 
     # The hostname may be `None`, which is a valid value in the case of peer authentication for example. In this case
     # it should be converted to an empty string, because otherwise the `None` will be converted to string literal "None"

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -207,7 +207,7 @@ repository: {tmp_path}"""
         postgres.determine_setup()
         db_name = 'aiida_test_setup'
         db_user = 'aiida_test_setup'
-        db_pass = 'aiida_test_setup'
+        db_pass = '@aiida_test_setup'
         postgres.create_dbuser(db_user, db_pass)
         postgres.create_db(db_user, db_name)
 


### PR DESCRIPTION
closes #6122

By incorporating this solution, passwords starting with "@" are handled seamlessly, maintaining the functionality of the code without any unexpected errors.