### PR TITLE
BaseRestartWorkChain: fix handlers overrides

### DIFF
--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -398,8 +398,8 @@ class BaseRestartWorkChain(WorkChain):
             if isinstance(overrides, bool):
                 enabled = overrides
             else:
-                enabled = overrides.pop('enabled', None)
-                priority = overrides.pop('priority', None)
+                enabled = overrides.get('enabled')
+                priority = overrides.get('priority')
 
             if enabled is False or (enabled is None and not handler.enabled):  # type: ignore[attr-defined]
                 continue

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -72,7 +72,8 @@ def test_get_process_handlers_by_priority(generate_work_chain, inputs, prioritie
         warnings.simplefilter('ignore')
         process = generate_work_chain(SomeWorkChain, inputs)
     process.setup()
-    assert sorted([priority for priority, handler in process.get_process_handlers_by_priority()]) == priorities
+    handlers = process.get_process_handlers_by_priority()
+    assert sorted([priority for priority, _ in handlers]) == priorities
 
     # Verify the actual handlers on the class haven't been modified
     assert getattr(SomeWorkChain, 'handler_a').priority == 200
@@ -81,6 +82,14 @@ def test_get_process_handlers_by_priority(generate_work_chain, inputs, prioritie
     assert getattr(SomeWorkChain, 'handler_a').enabled
     assert getattr(SomeWorkChain, 'handler_b').enabled
     assert not getattr(SomeWorkChain, 'handler_c').enabled
+
+    # Validate that a second invocation return the exact same results. This is a regression test for
+    # https://github.com/aiidateam/aiida-core/issues/6307. Note that the handlers are compared by name, because the
+    # bound methods will be separate clones and the ``__eq__`` operation will return ``False`` even though it represents
+    # the same handler function.
+    assert [(p, h.__name__) for p, h in process.get_process_handlers_by_priority()] == [
+        (p, h.__name__) for p, h in handlers
+    ]
 
 
 @pytest.mark.requires_rmq


### PR DESCRIPTION
fixes #6307 

It turns out that the issue was in the `get_process_handlers_by_priority` method. When running `enabled = overrides.pop('enabled', None)` the original dictionary would be overridden by the `pop` method, and for the next iteration, it would remain empty.

I tested the updated version of the work chain, and the issue was fixed for me locally.