### PR TITLE
Docker/aiida core dev checkout

### DIFF
--- a/.docker/aiida-core-dev/Dockerfile
+++ b/.docker/aiida-core-dev/Dockerfile
@@ -4,9 +4,7 @@ FROM aiida-core-with-services
 LABEL maintainer="AiiDA Team <developers@aiida.net>"
 
 COPY aiida-clone-and-install.sh /etc/init/run-before-daemon-start/10-aiida-clone-and-install.sh
-COPY --from=src . /opt/aiida-core
+COPY --chown=${SYSTEM_UID}:${SYSTEM_GID} --from=src . /home/${SYSTEM_USER}/aiida-core
 
 USER ${SYSTEM_UID}
 WORKDIR "/home/${SYSTEM_USER}"
-
-

--- a/.docker/aiida-core-dev/Dockerfile
+++ b/.docker/aiida-core-dev/Dockerfile
@@ -4,6 +4,9 @@ FROM aiida-core-with-services
 LABEL maintainer="AiiDA Team <developers@aiida.net>"
 
 COPY aiida-clone-and-install.sh /etc/init/run-before-daemon-start/10-aiida-clone-and-install.sh
+COPY --from=src . /opt/aiida-core
 
 USER ${SYSTEM_UID}
 WORKDIR "/home/${SYSTEM_USER}"
+
+

--- a/.docker/aiida-core-dev/aiida-clone-and-install.sh
+++ b/.docker/aiida-core-dev/aiida-clone-and-install.sh
@@ -2,6 +2,11 @@
 
 REPO_PATH=/home/aiida/aiida-core
 
-cp -R /opt/aiida-core $REPO_PATH
+# If the repo is not already existent, clone it
+# This is only necessary if the image is run through k8s with persistent volume, as the volume will be empty
+# For the docker, the container folder (i.e. `$HOME`) that mounted to the volume will be copied to the volume.
+if [ ! -d "$REPO_PATH" ]; then
+    git clone https://github.com/aiidateam/aiida-core.git --origin upstream $REPO_PATH
+fi
 
 pip install --user -e "$REPO_PATH/[pre-commit,atomic_tools,docs,rest,tests,tui]" tox

--- a/.docker/aiida-core-dev/aiida-clone-and-install.sh
+++ b/.docker/aiida-core-dev/aiida-clone-and-install.sh
@@ -2,6 +2,6 @@
 
 REPO_PATH=/home/aiida/aiida-core
 
-git clone https://github.com/aiidateam/aiida-core.git --origin upstream $REPO_PATH
+cp -R /opt/aiida-core $REPO_PATH
 
 pip install --user -e "$REPO_PATH/[pre-commit,atomic_tools,docs,rest,tests,tui]" tox

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -73,6 +73,7 @@ target "aiida-core-dev" {
   inherits = ["aiida-core-dev-meta"]
   context = "aiida-core-dev"
   contexts = {
+    src = ".."
     aiida-core-with-services = "target:aiida-core-with-services"
   }
   platforms = "${PLATFORMS}"


### PR DESCRIPTION
Solve the issue mentioned in #6303

The first commit is I first copy the source to the container (to `/opt/aiida-core`) and when the container start at run-time copy the it to the `/home/aiida/aiida-core`.
The second commit is another solution that directly copy the src to `/home/aiida/aiida-core`. This will work for docker but not for other OCI such as the k8s container engine (`containerd`). 