### PR TITLE
CLI: Add the `verdi init` command

### DIFF
--- a/docs/source/howto/installation.rst
+++ b/docs/source/howto/installation.rst
@@ -304,10 +304,11 @@ It contains the configuration file, which holds all the profile information, dae
 
 The location of the configuration directory is determined as follows:
 
-1. First, the ``AIIDA_PATH`` environment variables is checked, which can be a colon-separated list of directories.
+1. First, the current working directory is checked for an existing configuration directory moving up the file hierarchy until the first is encountered or the root directory is hit.
+The home directory is ignored, because it is likely that this will always exist and would always overshadow the ``AIIDA_PATH`` variable.
+2. Second, the ``AIIDA_PATH`` environment variable is checked, which can be a colon-separated list of directories.
 The first directory that points to an existing configuration directory is selected.
-If no existing directories are found, the last directory defined in the variable is used and the configuration directory is created there if it did not already exist.
-2. If the ``AIIDA_PATH`` is not defined, the current working directory is checked, going up the hierarchy until the first existing configuration directory is encountered.
+If none of the specified directories contains a configuration directory, the last considered directory is taken.
 3. If no existing configuration directory is found yet, the ``.aiida`` directory in the user's home folder is used, and is created automatically if it does not already exist.
 
 Examples
@@ -329,17 +330,19 @@ Consider the following directory structure::
 
 The following table shows the configuration directory that is selected given a certain ``AIIDA_PATH`` variable and the current working directory:
 
-+--------------------------------------------------------------+----------------------------------+
-| Variables                                                    | Configuration directory          |
-+==============================================================+==================================+
-| ``AIIDA_PATH = '~/project_b/'``                              | ``~/project_b/.aiida``           |
-| ``AIIDA_PATH = '~/project_b/.aiida'``                        | ``~/project_b/.aiida``           |
-| ``AIIDA_PATH = '~/project_a/.aiida:~/project_b/.aiida'``     | ``~/project_a/.aiida``           |
-| ``AIIDA_PATH = '~/project_a/subfolder:~/project_a/.aiida:'`` | ``~/project_a/subfolder/.aiida`` |
-| ``CWD = '~/project_a/subfolder``                             | ``~/project_a/subfolder/.aiida`` |
-| ``CWD = '~/project_b/subfolder``                             | ``~/project_b/.aiida``           |
-| ``CWD = '~/project_c/subfolder``                             | ``~/.aiida``                     |
-+--------------------------------------------------------------+----------------------------------+
++---------------------------------------------------------------------+-----------------------------------+
+| Variables                                                           | Configuration directory           |
++=====================================================================+===================================+
+| ``AIIDA_PATH = '~/project_b/'``                                     | ``~/project_b/.aiida``            |
+| ``AIIDA_PATH = '~/project_b/.aiida'``                               | ``~/project_b/.aiida``            |
+| ``AIIDA_PATH = '~/project_a/.aiida:~/project_b/.aiida'``            | ``~/project_a/.aiida``            |
+| ``AIIDA_PATH = '~/project_a/subfolder:~/project_a/.aiida:'``        | ``~/project_a/subfolder/.aiida``  |
+| ``CWD = '~/project_a/subfolder``                                    | ``~/project_a/subfolder/.aiida``  |
+| ``CWD = '~/project_b/subfolder``                                    | ``~/project_b/.aiida``            |
+| ``CWD = '~/project_c/subfolder``                                    | ``~/.aiida``                      |
+| ``CWD = '~/project_b/subfolder`` & ``AIIDA_PATH = '~/project_a/'``  | ``~/project_b/.aiida``            |
+| ``CWD = '~/project_c/subfolder`` & ``AIIDA_PATH = '~/project_a/'``  | ``~/project_a/.aiida``            |
++---------------------------------------------------------------------+-----------------------------------+
 
 .. tip::
 

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -267,6 +267,35 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
 
+.. _reference:command-line:verdi-init:
+
+``verdi init``
+--------------
+
+.. code:: console
+
+    Usage:  [OPTIONS] [DIRECTORY]
+
+      Initialize a new AiiDA instance.
+
+      The instance is initialized in DIRECTORY, which defaults to the current working
+      directory. A profile is automatically created using the `core.sqlite_dos` storage
+      backend and the localhost is configured as a computer.
+
+      By default, a user is created in the database that is automatically attached to all the
+      nodes that will be created in the future. The user details are specified by default but
+      can be customized using a number of options that this command exposes.
+
+    Options:
+      --from-archive FILE  Mount the archive as a read-only profile instead of creating an
+                           empty profile.
+      --email TEXT         The email of the user.  [default: aiida@localhost]
+      --first-name TEXT    The first name of the user.  [default: John]
+      --last-name TEXT     The last name of the user.  [default: Doe]
+      --institution TEXT   The institution of the user.  [default: Unknown]
+      --help               Show this message and exit.
+
+
 .. _reference:command-line:verdi-node:
 
 ``verdi node``

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -274,13 +274,13 @@ Below is a list with all available subcommands.
 
 .. code:: console
 
-    Usage:  [OPTIONS] [DIRECTORY]
+    Usage:  [OPTIONS]
 
       Initialize a new AiiDA instance.
 
-      The instance is initialized in DIRECTORY, which defaults to the current working
-      directory. A profile is automatically created using the `core.sqlite_dos` storage
-      backend and the localhost is configured as a computer.
+      Create a new AiiDA instance in the current working directory. A profile is automatically
+      created using the `core.sqlite_dos` storage backend and the localhost is configured as a
+      computer.
 
       By default, a user is created in the database that is automatically attached to all the
       nodes that will be created in the future. The user details are specified by default but

--- a/src/aiida/cmdline/commands/__init__.py
+++ b/src/aiida/cmdline/commands/__init__.py
@@ -24,6 +24,7 @@ from aiida.cmdline.commands import (
     cmd_devel,
     cmd_group,
     cmd_help,
+    cmd_init,
     cmd_node,
     cmd_plugin,
     cmd_process,

--- a/src/aiida/cmdline/commands/cmd_init.py
+++ b/src/aiida/cmdline/commands/cmd_init.py
@@ -1,0 +1,136 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""``verdi init`` command."""
+
+import pathlib
+
+import click
+
+from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.utils import echo
+from aiida.manage.configuration import get_config_option
+
+
+@verdi.command('init')
+@click.argument(
+    'directory', type=click.Path(exists=False, path_type=pathlib.Path, resolve_path=True), default=pathlib.Path.cwd()
+)
+@click.option(
+    '--from-archive',
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=pathlib.Path),
+    help='Mount the archive as a read-only profile instead of creating an empty profile.',
+)
+@click.option(
+    '--email',
+    default=get_config_option('autofill.user.email') or 'aiida@localhost',
+    show_default=True,
+    help='The email of the user.',
+)
+@click.option(
+    '--first-name',
+    default=get_config_option('autofill.user.first_name') or 'John',
+    show_default=True,
+    help='The first name of the user.',
+)
+@click.option(
+    '--last-name',
+    default=get_config_option('autofill.user.last_name') or 'Doe',
+    show_default=True,
+    help='The last name of the user.',
+)
+@click.option(
+    '--institution',
+    default=get_config_option('autofill.user.institution') or 'Unknown',
+    show_default=True,
+    help='The institution of the user.',
+)
+def verdi_init(directory, from_archive, email, first_name, last_name, institution):
+    """Initialize a new AiiDA instance.
+
+    The instance is initialized in DIRECTORY, which defaults to the current working directory. A profile is
+    automatically created using the `core.sqlite_dos` storage backend and the localhost is configured as a computer.
+
+    By default, a user is created in the database that is automatically attached to all the nodes that will be created
+    in the future. The user details are specified by default but can be customized using a number of options that this
+    command exposes.
+    """
+    import tempfile
+    import warnings
+
+    from aiida.common import exceptions
+    from aiida.manage import get_manager
+    from aiida.manage.configuration import create_profile, get_config, load_profile, reset_config, settings
+    from aiida.orm import Computer
+
+    # Unload the profile that was loaded by default and reset the configuration.
+    get_manager().unload_profile()
+    reset_config()
+
+    dirpath_config = directory / settings.DEFAULT_CONFIG_DIR_NAME
+
+    if dirpath_config.is_dir():
+        echo.echo_critical(f'A configuration directory already exists in `{directory}`.')
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        settings.set_configuration_directory(dirpath_config)
+
+    echo.echo_success(f'Initialized new AiiDA instance in `{dirpath_config}`.')
+
+    # Now load the config causing the configuration file to be created.
+    config = get_config(create=True)
+    dirpath_loaded = pathlib.Path(config.filepath).parent
+    assert dirpath_loaded == dirpath_config, f'Filepath of loaded config `{dirpath_loaded}` != `{dirpath_config}`.'
+
+    if from_archive:
+        storage_backend = 'core.sqlite_zip'
+        storage_config = {
+            'filepath': str(from_archive),
+        }
+    else:
+        storage_backend = 'core.sqlite_dos'
+        storage_config = {}
+
+    try:
+        profile = create_profile(
+            config,
+            name='init',
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            institution=institution,
+            storage_backend=storage_backend,
+            storage_config=storage_config,
+        )
+    except (ValueError, TypeError, exceptions.EntryPointError, exceptions.StorageMigrationError) as exception:
+        echo.echo_critical(str(exception))
+
+    echo.echo_success(f'Created new profile `{profile.name}`.')
+
+    config.set_option('runner.poll.interval', 1, scope=profile.name)
+    config.set_default_profile(profile.name, overwrite=True)
+    config.store()
+
+    if not from_archive:
+        echo.echo_info(f'Loaded newly created profile `{profile.name}`.')
+        load_profile(profile.name, allow_switch=True)
+
+        computer = Computer(
+            label='localhost',
+            hostname='localhost',
+            description='Localhost automatically created by `verdi blitz`',
+            transport_type='core.local',
+            scheduler_type='core.direct',
+            workdir=str(pathlib.Path(tempfile.gettempdir()) / 'aiida_scratch'),
+        ).store()
+        computer.configure(safe_interval=0)
+        computer.set_minimum_job_poll_interval(1)
+        computer.set_default_mpiprocs_per_machine(1)
+
+        echo.echo_success('Configured the localhost as a computer.')

--- a/src/aiida/cmdline/commands/cmd_init.py
+++ b/src/aiida/cmdline/commands/cmd_init.py
@@ -18,9 +18,6 @@ from aiida.manage.configuration import get_config_option
 
 
 @verdi.command('init')
-@click.argument(
-    'directory', type=click.Path(exists=False, path_type=pathlib.Path, resolve_path=True), default=pathlib.Path.cwd()
-)
 @click.option(
     '--from-archive',
     type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=pathlib.Path),
@@ -50,11 +47,11 @@ from aiida.manage.configuration import get_config_option
     show_default=True,
     help='The institution of the user.',
 )
-def verdi_init(directory, from_archive, email, first_name, last_name, institution):
+def verdi_init(from_archive, email, first_name, last_name, institution):
     """Initialize a new AiiDA instance.
 
-    The instance is initialized in DIRECTORY, which defaults to the current working directory. A profile is
-    automatically created using the `core.sqlite_dos` storage backend and the localhost is configured as a computer.
+    Create a new AiiDA instance in the current working directory. A profile is automatically created using the
+    `core.sqlite_dos` storage backend and the localhost is configured as a computer.
 
     By default, a user is created in the database that is automatically attached to all the nodes that will be created
     in the future. The user details are specified by default but can be customized using a number of options that this
@@ -72,10 +69,15 @@ def verdi_init(directory, from_archive, email, first_name, last_name, institutio
     get_manager().unload_profile()
     reset_config()
 
-    dirpath_config = directory / settings.DEFAULT_CONFIG_DIR_NAME
+    dirpath_config = settings.get_configuration_directory_from_envvar()
+
+    if dirpath_config is not None:
+        echo.echo_warning(f'The `AIIDA_PATH` environment variable is set; config directory set to `{dirpath_config}`.')
+    else:
+        dirpath_config = pathlib.Path.cwd() / settings.DEFAULT_CONFIG_DIR_NAME
 
     if dirpath_config.is_dir():
-        echo.echo_critical(f'A configuration directory already exists in `{directory}`.')
+        echo.echo_critical(f'The configuration directory `{dirpath_config}` already exists.')
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -234,7 +234,7 @@ def create_default_user(
         if user:
             manager.set_default_user_email(profile, user.email)
 
-    return
+    return user
 
 
 def create_profile(

--- a/src/aiida/storage/sqlite_dos/backend.py
+++ b/src/aiida/storage/sqlite_dos/backend.py
@@ -102,7 +102,7 @@ class SqliteDosStorage(PsqlDosBackend):
         filepath: str = Field(
             title='Directory of the backend',
             description='Filepath of the directory in which to store data for this backend.',
-            default_factory=lambda: AIIDA_CONFIG_FOLDER / 'repository' / f'sqlite_dos_{uuid4().hex}',
+            default_factory=lambda: str(AIIDA_CONFIG_FOLDER / 'repository' / f'sqlite_dos_{uuid4().hex}'),
         )
 
         @field_validator('filepath')

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -297,7 +297,7 @@ class SqliteZipBackend(StorageBackend):
         raise ReadOnlyError()
 
     def get_global_variable(self, key: str):
-        raise NotImplementedError
+        return None
 
     def set_global_variable(self, key: str, value, description: Optional[str] = None, overwrite=True) -> None:
         raise ReadOnlyError()

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -147,24 +147,13 @@ def test_environment_variable_set_multiple_path(tmp_path):
 
 @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
 @pytest.mark.usefixtures('cache_aiida_path_variable')
-@pytest.mark.parametrize('environment_variable', (True, False))
-def test_cwd(environment_variable, chdir_tmp_path):
-    """Test that the current working directory is checked as long as ``AIIDA_PATH`` environment variable is not set."""
-    if environment_variable:
-        dirpath_env = chdir_tmp_path / 'env' / settings.DEFAULT_CONFIG_DIR_NAME
-        dirpath_env.mkdir(parents=True)
-        os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(dirpath_env.absolute())
-    else:
-        os.environ.pop(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
-
+def test_cwd(chdir_tmp_path):
+    """Test that the current working directory is checked."""
     dirpath_cwd = chdir_tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
     dirpath_cwd.mkdir()
 
     settings.set_configuration_directory()
-    if environment_variable:
-        assert settings.AIIDA_CONFIG_FOLDER == dirpath_env
-    else:
-        assert settings.AIIDA_CONFIG_FOLDER == dirpath_cwd
+    assert settings.AIIDA_CONFIG_FOLDER == dirpath_cwd
 
 
 @pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')

--- a/tests/manage/configuration/test_settings.py
+++ b/tests/manage/configuration/test_settings.py
@@ -1,0 +1,69 @@
+"""Tests for :mod:`aiida.manage.configuration.settings`."""
+
+import os
+
+import pytest
+from aiida.manage.configuration import settings
+
+
+@pytest.fixture
+def cache_aiida_path_variable():
+    """Fixture that will store the ``AIIDA_PATH`` environment variable and restore it after the yield."""
+    aiida_path_original = os.environ.pop(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
+
+    yield
+    if aiida_path_original is not None:
+        os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = aiida_path_original
+    else:
+        try:
+            del os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE]
+        except KeyError:
+            pass
+
+    # Make sure to reset the global variables set by the following call that are dependent on the environment variable
+    # ``DEFAULT_AIIDA_PATH_VARIABLE``. It may have been changed by a test using this fixture.
+    settings.set_configuration_directory()
+
+
+@pytest.mark.usefixtures('cache_aiida_path_variable', 'chdir_tmp_path')
+def test_get_configuration_directory_default():
+    """Test :meth:`aiida.manage.configuration.settings.get_configuration_directory`."""
+    assert settings.get_configuration_directory() == settings.get_configuration_directory_default()
+
+
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_get_configuration_directory_cwd(chdir_tmp_path):
+    """Test :meth:`aiida.manage.configuration.settings.get_configuration_directory`."""
+    dirpath_config = chdir_tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
+    dirpath_config.mkdir()
+    assert settings.get_configuration_directory() == dirpath_config
+
+
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_get_configuration_directory_cwd_parent(chdir_tmp_path):
+    """Test :meth:`aiida.manage.configuration.settings.get_configuration_directory`."""
+    dirpath_config = chdir_tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
+    dirpath_config.mkdir()
+    dirpath_child = chdir_tmp_path / 'some' / 'sub' / 'directory'
+    dirpath_child.mkdir(parents=True)
+    os.chdir(dirpath_child)
+    assert settings.get_configuration_directory() == dirpath_config
+
+
+@pytest.mark.usefixtures('cache_aiida_path_variable')
+def test_get_configuration_directory_path_variable(chdir_tmp_path):
+    """Test :meth:`aiida.manage.configuration.settings.get_configuration_directory`."""
+    dirpath_config = chdir_tmp_path / 'some_dir' / settings.DEFAULT_CONFIG_DIR_NAME
+    dirpath_config.mkdir(parents=True)
+
+    # Without the path variable specified, it should default to the default directory
+    assert settings.get_configuration_directory() == settings.get_configuration_directory_default()
+
+    # With the path variable set, that should now be the targeted directory
+    os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(dirpath_config.absolute())
+    assert settings.get_configuration_directory() == dirpath_config
+
+    # If a config directory is now created in the cwd, it should ignore the path variable
+    dirpath_config_cwd = chdir_tmp_path / settings.DEFAULT_CONFIG_DIR_NAME
+    dirpath_config_cwd.mkdir()
+    assert settings.get_configuration_directory() == dirpath_config_cwd


### PR DESCRIPTION
This is an alternative solution to #6305 
The `verdi init` command is slightly different in that it doesn't just create a new profile, but it creates the profile in a new AiiDA instance, i.e., a new `.aiida` folder is created (in the current working directory by default). This makes the behavior similar to `git init` that initializes a new repo. Once the user is done, the instance folder can simply be removed and there will be no trace left. By default the command will create a profile with the `core.sqlite_dos` which won't require any services, but alternatively a profile with `core.sqlite_zip` can be created instead from an existing archive. This version will be read-only, but will allow a user to easily start browsing an archive with a single command `verdi init --from-archive some_archive.aiida`.