### PR TITLE
Deprecating --reset flag in `verdi daemon restart`

### DIFF
--- a/docs/source/howto/faq.rst
+++ b/docs/source/howto/faq.rst
@@ -85,7 +85,7 @@ For example, go to the directory that contains the file where you defined the pr
 
     $ echo "export PYTHONPATH=\$PYTHONPATH:$PWD" >> $HOME/.bashrc
     $ source $HOME/.bashrc
-    $ verdi daemon restart --reset
+    $ verdi daemon restart
 
 .. _how-to:faq:caching-not-enabled:
 

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -453,7 +453,7 @@ Finally instead of running your calculation in the current shell, you can submit
 
 .. code-block:: console
 
-    $ verdi daemon restart --reset
+    $ verdi daemon restart
 
 * Update your launch script to use:
 

--- a/docs/source/howto/plugins_install.rst
+++ b/docs/source/howto/plugins_install.rst
@@ -27,11 +27,11 @@ For example, if the code is available through a Git repository:
 
 .. warning::
 
-    If your daemon was running when installing or updating a plugin package, make sure to restart it with the ``--reset`` flag for changes to take effect:
+    If you installed or updated a plugin package while your daemon was running, be sure to restart it so that the changes take effect:
 
     .. code-block:: console
 
-        $ verdi daemon restart --reset
+        $ verdi daemon restart
 
 To verify which plugins are currently installed, use the command:
 

--- a/docs/source/howto/workchains_restart.rst
+++ b/docs/source/howto/workchains_restart.rst
@@ -185,7 +185,7 @@ As you can see the work chain launched a single instance of the ``ArithmeticAddC
 
     .. code-block:: bash
 
-        $ verdi daemon restart --reset
+        $ verdi daemon restart
 
     Indeed, when updating an existing work chain file or adding a new one, it is **necessary** to restart the daemon **every time** after all changes have taken place.
 
@@ -249,7 +249,7 @@ When submitting or running the work chain using namespaced inputs (``add`` in th
 
     .. code-block:: bash
 
-        $ verdi daemon restart --reset
+        $ verdi daemon restart
 
 
 Customizing outputs

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -18,7 +18,6 @@ import click
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators, echo
-from aiida.common.warnings import warn_deprecation
 
 
 def validate_daemon_workers(ctx, param, value):
@@ -225,7 +224,8 @@ def restart(ctx, reset, no_wait, timeout):
     """
     if reset:
         echo.echo_deprecated(
-            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.')
+            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.'
+        )
     if no_wait:
         echo.echo_deprecated('The `--no-wait` flag is deprecated and no longer has any effect.')
     if timeout is not None:

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -224,13 +224,12 @@ def restart(ctx, reset, no_wait, timeout):
     Returns exit code 0 if the result is OK, non-zero if there was an error.
     """
     if reset:
-        warn_deprecation(
-            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', version=3
-        )
+        echo.echo_deprecated(
+            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.')
     if no_wait:
-        warn_deprecation('The `--no-wait` flag is deprecated and no longer has any effect.', version=3)
+        echo.echo_deprecated('The `--no-wait` flag is deprecated and no longer has any effect.')
     if timeout is not None:
-        warn_deprecation('The `--timeout` option is deprecated and no longer has any effect.', version=3)
+        echo.echo_deprecated('The `--timeout` option is deprecated and no longer has any effect.')
 
     # These two lines can be simplified to `ctx.invoke(start)` once issue #950 in `click` is resolved.
     # Due to that bug, the `callback` of the `number` argument the `start` command is not being called, which is

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -218,14 +218,14 @@ def stop(ctx, no_wait, all_profiles, timeout):
 def restart(ctx, reset, no_wait, timeout):
     """Restart the daemon.
 
-    By default the full daemon will be stopped and restarted with the default
+    The daemon is stopped before being restarted with the default
     number of workers that is started when calling `verdi daemon start` manually.
 
     Returns exit code 0 if the result is OK, non-zero if there was an error.
     """
     if reset:
         warn_deprecation(
-            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', nl=False
+            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', version=3
         )
 
     ctx.invoke(stop, no_wait=no_wait)

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -225,13 +225,12 @@ def restart(ctx, reset, no_wait, timeout):
     """
     if reset:
         warn_deprecation(
-            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', version=3)
+            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', version=3
+        )
     if no_wait:
-        warn_deprecation(
-            'The `--no-wait` flag is deprecated and no longer has any effect.', version=3)
+        warn_deprecation('The `--no-wait` flag is deprecated and no longer has any effect.', version=3)
     if timeout is not None:
-        warn_deprecation(
-            'The `--timeout` option is deprecated and no longer has any effect.', version=3)
+        warn_deprecation('The `--timeout` option is deprecated and no longer has any effect.', version=3)
 
     # These two lines can be simplified to `ctx.invoke(start)` once issue #950 in `click` is resolved.
     # Due to that bug, the `callback` of the `number` argument the `start` command is not being called, which is

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -224,9 +224,11 @@ def restart(ctx, reset, no_wait, timeout):
     Returns exit code 0 if the result is OK, non-zero if there was an error.
     """
     if reset:
-        warn_deprecation('`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', nl=False)
+        warn_deprecation(
+            '`--reset` flag is deprecated. Now, `verdi daemon restart` by default restarts the full daemon.', nl=False
+        )
 
-    ctx.invoke(stop, no_wait = no_wait)
+    ctx.invoke(stop, no_wait=no_wait)
     ctx.invoke(start)
 
 

--- a/src/aiida/cmdline/commands/cmd_rabbitmq.py
+++ b/src/aiida/cmdline/commands/cmd_rabbitmq.py
@@ -255,7 +255,7 @@ def cmd_tasks_revive(processes, force):
 
     \b
         1. Does ``verdi status`` indicate that both daemon and RabbitMQ are running properly?
-           If not, restart the daemon with ``verdi daemon restart --reset`` and restart RabbitMQ.
+           If not, restart the daemon with ``verdi daemon restart`` and restart RabbitMQ.
         2. Try ``verdi process play <PID>``.
            If you receive a message that the process is no longer reachable,
            use ``verdi devel rabbitmq tasks revive <PID>``.

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -73,7 +73,7 @@ def revive_processes(processes: list[ProcessNode], *, wait: bool = False) -> Non
     Warning: Use only as a last resort after you've gone through the checklist below.
 
         1. Does ``verdi status`` indicate that both daemon and RabbitMQ are running properly?
-           If not, restart the daemon with ``verdi daemon restart --reset`` and restart RabbitMQ.
+           If not, restart the daemon with ``verdi daemon restart`` and restart RabbitMQ.
         2. Try to play the process through ``play_processes``.
            If a ``ProcessTimeoutException`` is raised use this method to attempt to revive it.
 


### PR DESCRIPTION
Fixes #4948

now with `verdi daemon restart` the full daemon is restarted, it's not possible anymore to restart only workers.

@sphuber since I'm ignorant of how AiiDA behaves when a running daemon stops, I don't really know if `--no-wait` is safe for this command,  I appreciate your comments.
