### PR TITLE
Config: Set existing user as default for read-only storages

### DIFF
--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -226,11 +226,17 @@ def create_profile(
         manager = get_manager()
         storage = manager.get_profile_storage()
 
-        if not storage.read_only:
+        if storage.read_only:
+            # Check if the storage contains any users, and just set a random one as default user.
+            user = User.collection.query().first(flat=True)
+        else:
+            # Otherwise create a user and store it
             user = User(email=email, first_name=first_name, last_name=last_name, institution=institution).store()
-            # We can safely use ``Config.set_default_user_email`` here instead of ``Manager.set_default_user_email``
-            # since the storage backend of this new profile is not loaded yet.
-            config.set_default_user_email(profile, user.email)
+
+        # The user can be ``None`` if the storage is read-only and doesn't contain any users. This shouldn't happen in
+        # real situations, but this safe guard is added to be safe.
+        if user:
+            manager.set_default_user_email(profile, user.email)
 
     return profile
 


### PR DESCRIPTION
Fixes #6165

The `create_profile` command would only set a default user for storage backends that are not read-only. The reason is that the default user is first created and so needs to be stored, which is not possible by definition for read-only storages. This would lead to problems elsewhere, however, as a lot of the API assumes that a default user is set. This would make read-only storage backends, such as `core.sqlite_zip` effectively useless.

Since `core.sqlite_zip` profiles mount an export archive, which by definition should always include at least a single user, instead of creating a new one, the default user can be one of the users already part of the storage. Note that for certain edge-cases, such as in testing where the archive doesn't contain anything, it is possible that no user is present, but this should not happen in real use-cases.