### PR TITLE
Caching: Include the node's class in objects to hash

### DIFF
--- a/src/aiida/orm/nodes/caching.py
+++ b/src/aiida/orm/nodes/caching.py
@@ -60,6 +60,7 @@ class NodeCaching:
         except (ImportError, AttributeError) as exc:
             raise exceptions.HashingError("The node's package version could not be determined") from exc
         objects = [
+            str(self._node.__class__),
             version,
             {
                 key: val

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -1009,6 +1009,14 @@ class TestNodeCaching:
         assert hash(node_a) != hash(node_0)
         assert hash(node_b) != hash(node_0)
 
+    def test_subclasses_are_distinguished(self):
+        """Test that subclasses get different hashes even if they contain the same attributes."""
+        node_int = Int(5).store()
+        node_data = Data()
+        node_data.base.attributes.set_many(node_int.base.attributes.all)
+        node_data.store()
+        assert node_int.base.caching.get_hash() != node_data.base.caching.get_hash()
+
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_iter_repo_keys():


### PR DESCRIPTION
Fixes #6320 

The current implementation did not include the class of the node in the list of objects to include in the hash calculation. This made it possible for two nodes of different types but with the same attributes to have the same hash, as long as one type was a subclass of the other.

Arguably when two nodes have a different type, even if subclasses, their hashes should never be the same. Therefore, the node's class is added to the list returned by `NodeCaching._get_objects_to_hash()`.