### PR TITLE
Caching: `NodeCaching._get_objects_to_hash` return type to `dict`

### DIFF
--- a/docs/source/internals/engine.rst
+++ b/docs/source/internals/engine.rst
@@ -30,7 +30,7 @@ On the level of the :class:`Process <aiida.engine.processes.process.Process>` an
 * The :meth:`ProcessNodeCaching.is_valid_cache <aiida.orm.nodes.process.process.ProcessNodeCaching.is_valid_cache>` calls :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>`, passing the node itself.
   This can be used in :class:`~aiida.engine.processes.process.Process` subclasses (e.g. in calculation plugins) to implement custom ways of invalidating the cache.
 * The :meth:`ProcessNodeCaching._hash_ignored_inputs <aiida.orm.nodes.process.process.ProcessNodeCaching._hash_ignored_inputs>` attribute lists the inputs that should be ignored when creating the hash.
-  This is checked by the :meth:`ProcessNodeCaching._get_objects_to_hash <aiida.orm.nodes.process.process.ProcessNodeCaching._get_objects_to_hash>` method.
+  This is checked by the :meth:`ProcessNodeCaching.get_objects_to_hash <aiida.orm.nodes.process.process.ProcessNodeCaching.get_objects_to_hash>` method.
 * The :meth:`Process.is_valid_cache <aiida.engine.processes.process.Process.is_valid_cache>` is where the :meth:`exit_codes <aiida.engine.processes.process_spec.ProcessSpec.exit_code>` that have been marked by ``invalidates_cache`` are checked.
 
 

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -40,16 +40,16 @@ In order to figure out why a calculation is *not* being reused, the :meth:`~aiid
 
     In [7]: node.base.caching._get_objects_to_hash()
     Out[7]:
-    [
-        '1.0.0',
-        {
+    {
+        'class': "<class 'aiida.orm.nodes.process.calculation.calcjob.CalcJobNode'>",
+        'version': '2.6.0',
+        'attributes': {
             'resources': {'num_machines': 2, 'default_mpiprocs_per_machine': 28},
             'parser_name': 'cp2k',
             'linkname_retrieved': 'retrieved'
         },
-        <aiida.common.folders.Folder at 0x1171b9a20>,
-        '6850dc88-0949-482e-bba6-8b11205aec11',
-        {
+        'computer_uuid': '85faf55e-8597-4649-90e0-55881271c33c',
+        'links': {
             'code': 'f6bd65b9ca3a5f0cf7d299d9cfc3f403d32e361aa9bb8aaa5822472790eae432',
             'parameters': '2c20fdc49672c3505cebabacfb9b1258e71e7baae5940a80d25837bee0032b59',
             'structure': 'c0f1c1d1bbcfc7746dcf7d0d675904c62a5b1759d37db77b564948fa5a788769',

--- a/docs/source/topics/provenance/caching.rst
+++ b/docs/source/topics/provenance/caching.rst
@@ -29,7 +29,7 @@ The hash of a :class:`~aiida.orm.ProcessNode` includes, on top of this, the hash
 Once a node is stored in the database, its hash is stored in the ``_aiida_hash`` extra, and this extra is used to find matching nodes.
 If a node of the same class with the same hash already exists in the database, this is considered a cache match.
 You can use the :meth:`~aiida.orm.nodes.caching.NodeCaching.get_hash` method to check the hash of any node.
-In order to figure out why a calculation is *not* being reused, the :meth:`~aiida.orm.nodes.caching.NodeCaching._get_objects_to_hash` method may be useful:
+In order to figure out why a calculation is *not* being reused, the :meth:`~aiida.orm.nodes.caching.NodeCaching.get_objects_to_hash` method may be useful:
 
 .. code-block:: ipython
 
@@ -38,7 +38,7 @@ In order to figure out why a calculation is *not* being reused, the :meth:`~aiid
     In [6]: node.base.caching.get_hash()
     Out[6]: '62eca804967c9428bdbc11c692b7b27a59bde258d9971668e19ccf13a5685eb8'
 
-    In [7]: node.base.caching._get_objects_to_hash()
+    In [7]: node.base.caching.get_objects_to_hash()
     Out[7]:
     {
         'class': "<class 'aiida.orm.nodes.process.calculation.calcjob.CalcJobNode'>",
@@ -71,7 +71,7 @@ The hashing of *Data nodes* can be customized both when implementing a new data 
 In the :py:class:`~aiida.orm.Node` subclass:
 
 * Use the ``_hash_ignored_attributes`` to exclude a list of node attributes ``['attr1', 'attr2']`` from computing the hash.
-* Include extra information in computing the hash by overriding the :meth:`~aiida.orm.nodes.caching.NodeCaching._get_objects_to_hash` method.
+* Include extra information in computing the hash by overriding the :meth:`~aiida.orm.nodes.caching.NodeCaching.get_objects_to_hash` method.
   Use the ``super()`` method, and then append to the list of objects to hash.
 
 You can also modify hashing behavior during runtime by passing a keyword argument to :meth:`~aiida.orm.nodes.caching.NodeCaching.get_hash`, which are forwarded to :meth:`~aiida.common.hashing.make_hash`.

--- a/src/aiida/orm/nodes/caching.py
+++ b/src/aiida/orm/nodes/caching.py
@@ -7,6 +7,7 @@ import typing as t
 from aiida.common import exceptions
 from aiida.common.hashing import make_hash
 from aiida.common.lang import type_check
+from aiida.common.warnings import warn_deprecation
 
 from ..querybuilder import QueryBuilder
 
@@ -44,7 +45,7 @@ class NodeCaching:
         :param ignore_errors: return ``None`` on ``aiida.common.exceptions.HashingError`` (logging the exception)
         """
         try:
-            return make_hash(self._get_objects_to_hash(), **kwargs)
+            return make_hash(self.get_objects_to_hash(), **kwargs)
         except exceptions.HashingError:
             if not ignore_errors:
                 raise
@@ -53,6 +54,12 @@ class NodeCaching:
             return None
 
     def _get_objects_to_hash(self) -> list[t.Any]:
+        warn_deprecation(
+            '`NodeCaching._get_objects_to_hash` is deprecated, use `NodeCaching.get_objects_to_hash` instead', version=3
+        )
+        return self.get_objects_to_hash()
+
+    def get_objects_to_hash(self) -> list[t.Any]:
         """Return a list of objects which should be included in the hash."""
         top_level_module = self._node.__module__.split('.', 1)[0]
 

--- a/src/aiida/orm/nodes/caching.py
+++ b/src/aiida/orm/nodes/caching.py
@@ -55,22 +55,23 @@ class NodeCaching:
     def _get_objects_to_hash(self) -> list[t.Any]:
         """Return a list of objects which should be included in the hash."""
         top_level_module = self._node.__module__.split('.', 1)[0]
+
         try:
             version = importlib.import_module(top_level_module).__version__
         except (ImportError, AttributeError) as exc:
             raise exceptions.HashingError("The node's package version could not be determined") from exc
-        objects = [
-            str(self._node.__class__),
-            version,
-            {
+
+        return {
+            'class': str(self._node.__class__),
+            'version': version,
+            'attributes': {
                 key: val
                 for key, val in self._node.base.attributes.items()
                 if key not in self._node._hash_ignored_attributes and key not in self._node._updatable_attributes
             },
-            self._node.base.repository.hash(),
-            self._node.computer.uuid if self._node.computer is not None else None,
-        ]
-        return objects
+            'repository_hash': self._node.base.repository.hash(),
+            'computer_uuid': self._node.computer.uuid if self._node.computer is not None else None,
+        }
 
     def rehash(self) -> None:
         """Regenerate the stored hash of the Node."""

--- a/src/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/src/aiida/orm/nodes/process/calculation/calcjob.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, Sequence, T
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcJobState
 from aiida.common.lang import classproperty
-from aiida.common.links import LinkType
-from aiida.orm.fields import add_field
 
 from ..process import ProcessNodeCaching
 from .calculation import CalculationNode
@@ -43,22 +41,8 @@ class CalcJobNodeCaching(ProcessNodeCaching):
         anyway in the computation of the hash would mean that the hash of the node would change as soon as the process
         has started and the input files have been written to the repository.
         """
-        from importlib import import_module
-
-        objects = [
-            import_module(self._node.__module__.split('.', 1)[0]).__version__,
-            {
-                key: val
-                for key, val in self._node.base.attributes.items()
-                if key not in self._node._hash_ignored_attributes and key not in self._node._updatable_attributes
-            },
-            self._node.computer.uuid if self._node.computer is not None else None,
-            {
-                entry.link_label: entry.node.base.caching.get_hash()
-                for entry in self._node.base.links.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
-                if entry.link_label not in self._hash_ignored_inputs
-            },
-        ]
+        objects = super()._get_objects_to_hash()
+        objects.pop('repository_hash', None)
         return objects
 
 

--- a/src/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/src/aiida/orm/nodes/process/calculation/calcjob.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, Sequence, T
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcJobState
 from aiida.common.lang import classproperty
+from aiida.orm.fields import add_field
 
 from ..process import ProcessNodeCaching
 from .calculation import CalculationNode
@@ -32,7 +33,7 @@ __all__ = ('CalcJobNode',)
 class CalcJobNodeCaching(ProcessNodeCaching):
     """Interface to control caching of a node instance."""
 
-    def _get_objects_to_hash(self) -> List[Any]:
+    def get_objects_to_hash(self) -> List[Any]:
         """Return a list of objects which should be included in the hash.
 
         This method is purposefully overridden from the base `Node` class, because we do not want to include the
@@ -41,7 +42,7 @@ class CalcJobNodeCaching(ProcessNodeCaching):
         anyway in the computation of the hash would mean that the hash of the node would change as soon as the process
         has started and the input files have been written to the repository.
         """
-        objects = super()._get_objects_to_hash()
+        objects = super().get_objects_to_hash()
         objects.pop('repository_hash', None)
         return objects
 

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -83,11 +83,15 @@ class ProcessNodeCaching(NodeCaching):
     def _get_objects_to_hash(self) -> List[Any]:
         """Return a list of objects which should be included in the hash."""
         res = super()._get_objects_to_hash()
-        res.append(
+        res.update(
             {
-                entry.link_label: entry.node.base.caching.get_hash()
-                for entry in self._node.base.links.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
-                if entry.link_label not in self._hash_ignored_inputs
+                'inputs': {
+                    entry.link_label: entry.node.base.caching.get_hash()
+                    for entry in self._node.base.links.get_incoming(
+                        link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)
+                    )
+                    if entry.link_label not in self._hash_ignored_inputs
+                }
             }
         )
         return res

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -80,9 +80,9 @@ class ProcessNodeCaching(NodeCaching):
         """
         super(ProcessNodeCaching, self.__class__).is_valid_cache.fset(self, valid)
 
-    def _get_objects_to_hash(self) -> List[Any]:
+    def get_objects_to_hash(self) -> List[Any]:
         """Return a list of objects which should be included in the hash."""
-        res = super()._get_objects_to_hash()
+        res = super().get_objects_to_hash()
         res.update(
             {
                 'inputs': {


### PR DESCRIPTION
When debugging the caching functionality, it is often useful to look at the objects that are used to compute the hash, which is returned by the `NodeCaching._get_objects_to_hash`. It returning a list, makes it difficult to identify what each object represents. By changing the return type to a dictionary, the key for each object allows to give a useful hint as to what it represents, making debugging easier.