### PR TITLE
Fix: `quicksetup` when sqlite-profiles present

### DIFF
--- a/src/aiida/cmdline/params/options/commands/setup.py
+++ b/src/aiida/cmdline/params/options/commands/setup.py
@@ -145,9 +145,11 @@ def get_quicksetup_password(ctx, param, value):
     config = get_config()
 
     for available_profile in config.profiles:
-        if available_profile.storage_config['database_username'] == username:
-            value = available_profile.storage_config['database_password']
-            break
+        if available_profile.storage_backend == 'core.psql_dos':
+            storage_config = available_profile.storage_config
+            if storage_config['database_username'] == username:
+                value = storage_config['database_password']
+                break
     else:
         value = get_random_string(16)
 


### PR DESCRIPTION
Fixes #6319.

Added explicit check for `core.psql_dos` in `get_quicksetup_password` of `verdi quicksetup`, which fixes the `ValueError` that otherwise occurs if profiles with `core.sqlite_zip` or `core.sqlite_dos` are contained in the AiiDA config.