### PR TITLE
Caching: Add `CACHE_VERSION` attribute to `CalcJob` and `Parser`

### DIFF
--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -711,19 +711,11 @@ class Process(plumpy.processes.Process):
         self._setup_version_info()
         self._setup_inputs()
 
-    def _setup_version_info(self) -> None:
+    def _setup_version_info(self) -> dict[str, Any]:
         """Store relevant plugin version information."""
-        from aiida.plugins.entry_point import format_entry_point_string
-
         version_info = self.runner.plugin_version_provider.get_version_info(self.__class__)
-
-        for key, monitor in self.inputs.get('monitors', {}).items():
-            entry_point = monitor.base.attributes.get('entry_point')
-            entry_point_string = format_entry_point_string('aiida.calculations.monitors', entry_point)
-            monitor_version_info = self.runner.plugin_version_provider.get_version_info(entry_point_string)
-            version_info['version'].setdefault('monitors', {})[key] = monitor_version_info['version']['plugin']
-
         self.node.base.attributes.set_many(version_info)
+        return version_info
 
     def _setup_metadata(self, metadata: dict) -> None:
         """Store the metadata on the ProcessNode."""

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Package for node ORM classes."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from functools import cached_property
 from logging import Logger

--- a/src/aiida/parsers/parser.py
+++ b/src/aiida/parsers/parser.py
@@ -10,6 +10,8 @@
 to allow the reading of the outputs of a calculation.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
@@ -28,6 +30,8 @@ LOGGER = log.AIIDA_LOGGER.getChild('parser')
 
 class Parser(ABC):
     """Base class for a Parser that can parse the outputs produced by a CalcJob process."""
+
+    CACHE_VERSION: int | None = None
 
     def __init__(self, node: 'CalcJobNode'):
         """Construct the Parser instance.


### PR DESCRIPTION
Recently, the hashing mechanism was changed to remove all version
information, both `aiida-core` and the plugin if applicable, from the
hash computation. The reason was that with that information, each
version change in core and plugin would essentially reset the cache.
By removing the version information, updating the code would no longer
invalidate all the cache.

The downside of this change, however, is that when the implementation of
a plugin, most notably `CalcJob` and `Parser` plugins, changes
significantly such that a change in its attributes/inputs would really
change its content, this would no longer be reflected in the hash, which
would remain identical. This could lead to false positives when users
update certain plugins.

To give some control to plugin developers in case of changes where the
hash would have to be effectively reset, the `CalcJob` and `Parser`
classes now define the `CACHE_VERSION` class attribute. By default this
is set to `None` but it can be set to an integer by a plugin developer.
At this point, it is stored in the `cache_version` attribute under the
`calc_job` or `parser` key, respectively. Since this attribute is
included in the hash calculation, changing the value would effectively
reset the cache for nodes generated with one of the plugins.

The concept _could_ have been added to the `Node` base class to stay
generic, however, this had complicates for `Data` nodes. Since the
version data would have to be stored in the attributes, in order to
prevent the risk from it being mutated or lost, it would interfere with
the actual data of the node. For example, the `Dict` node is entirely
defined by its attributes, so AiiDA cannot store any data in that
namespace. Luckily, not having this cache version information in nodes
other than `CalcJobNode`s is not a problematic, as the problem of
inducing false positives by changing plugin code is really only relevant
to `CalcJob` and `Parser` plugins.

~~Recently, the hashing mechanism was changed to remove all version
information, both `aiida-core` and the plugin if applicable, from the
hash computation. The reason was that with that information, each
version change in core and plugin would essentially reset the cache.
By removing the version information, updating the code would no longer
invalidate all the cache.~~

~~The downside of this change, however, is that when the implementation of
a plugin, most notably a `CalcJob` plugin, changes significantly such
that a change in its attributes/inputs would really change its content,
this would no longer be reflected in the hash, which would remain
identical. This could lead to false positives when users update certain
plugins.~~

~~To give some control to plugin developers in case of changes where the
hash would have to be effectively reset, the `Node` class now defines
the `CACHE_VERSION` class attribute. By default this is set to `None`
but a `Data` plugin can change it to some string value. To facilitate
the same API for process plugins, such as `CalcJob`'s, the
`CACHE_VERSION` attribute is also added to the `Process` base class.
This value is automatically added to the node's attributes, under the
key `_aiida_cache_version` such that is is included in the computed hash.
This way, a plugin developer can change this attribute in their plugin
to force the hash to change.~~

~~The version has to be stored in the attributes of the node and cannot
just be taken from the plugin's class attribute directly when computing
the hash, because in that case when the hash is recalculated in the
future, a potentially different value of `CACHE_VERSION` could be used
(whichever version the plugin has that is installed at that time).~~