### PR TITLE
docker CI: Increase pause of check container availability before running test

### DIFF
--- a/.docker/tests/conftest.py
+++ b/.docker/tests/conftest.py
@@ -42,8 +42,8 @@ def _docker_service_wait(docker_services):
         return '✔ broker:' in output and 'Daemon is running' in output
 
     docker_services.wait_until_responsive(
-        timeout=600.0,
-        pause=0.1,
+        timeout=960.0,
+        pause=2,
         check=lambda: is_container_ready(),
     )
 

--- a/.docker/tests/conftest.py
+++ b/.docker/tests/conftest.py
@@ -42,7 +42,7 @@ def _docker_service_wait(docker_services):
         return '✔ broker:' in output and 'Daemon is running' in output
 
     docker_services.wait_until_responsive(
-        timeout=960.0,
+        timeout=600.0,
         pause=2,
         check=lambda: is_container_ready(),
     )


### PR DESCRIPTION
I see the CI test on docker image failed randomly, this probably can solve the issue.