### PR TITLE
Fix problem that aiida-core-dev image not upload to registry

### DIFF
--- a/.docker/tests/conftest.py
+++ b/.docker/tests/conftest.py
@@ -42,8 +42,8 @@ def _docker_service_wait(docker_services):
         return '✔ broker:' in output and 'Daemon is running' in output
 
     docker_services.wait_until_responsive(
-        timeout=600.0,
-        pause=0.1,
+        timeout=960.0,
+        pause=2,
         check=lambda: is_container_ready(),
     )
 

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [aiida-core-base, aiida-core-with-services]
+        image: [aiida-core-base, aiida-core-with-services, aiida-core-dev]
     permissions:
       packages: write
 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [aiida-core-base, aiida-core-with-services]
+        image: [aiida-core-base, aiida-core-with-services, aiida-core-dev]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
After generate the `aiida-core-dev` image for both arm64 and amd64, it requires an extra step to merge the manifest so it appears in the registry in one entry. Then it need to push to registry. 
The changes in the CI files are missing and added by this PR.