### PR TITLE
Config: Refactor the `create_profile` function and method

### DIFF
--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -39,11 +39,39 @@ def command_create_profile(
     :param set_as_default: Whether to set the created profile as the new default.
     :param kwargs: Arguments to initialise instance of the selected storage implementation.
     """
+    from aiida.plugins.entry_point import get_entry_point_from_class
+
     if not storage_cls.read_only and kwargs.get('email', None) is None:
         raise click.BadParameter('The option is required for storages that are not read-only.', param_hint='--email')
 
+    email = kwargs.pop('email')
+    first_name = kwargs.pop('first_name')
+    last_name = kwargs.pop('last_name')
+    institution = kwargs.pop('institution')
+
+    _, storage_entry_point = get_entry_point_from_class(storage_cls.__module__, storage_cls.__name__)
+    assert storage_entry_point is not None
+
     try:
-        profile = create_profile(ctx.obj.config, storage_cls, name=profile.name, **kwargs)
+        profile = create_profile(
+            ctx.obj.config,
+            name=profile.name,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            institution=institution,
+            storage_backend=storage_entry_point.name,
+            storage_config=kwargs,
+            broker_backend='core.rabbitmq',
+            broker_config={
+                'broker_protocol': 'amqp',
+                'broker_username': 'guest',
+                'broker_password': 'guest',
+                'broker_host': '127.0.0.1',
+                'broker_port': 5672,
+                'broker_virtual_host': '',
+            },
+        )
     except (ValueError, TypeError, exceptions.EntryPointError, exceptions.StorageMigrationError) as exception:
         echo.echo_critical(str(exception))
 

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -9,10 +9,10 @@
 # ruff: noqa: E402
 """Modules related to the configuration of an AiiDA instance."""
 
+from __future__ import annotations
+
 # AUTO-GENERATED
-
 # fmt: off
-
 from .migrations import *
 from .options import *
 from .profile import *
@@ -56,6 +56,8 @@ from typing import TYPE_CHECKING, Any, Optional
 from aiida.common.warnings import AiidaDeprecationWarning
 
 if TYPE_CHECKING:
+    from aiida.orm import User
+
     from .config import Config
 
 # global variables for aiida
@@ -174,7 +176,7 @@ def get_profile() -> Optional['Profile']:
 
 
 @contextmanager
-def profile_context(profile: Optional[str] = None, allow_switch=False) -> 'Profile':
+def profile_context(profile: 'Profile' | str | None = None, allow_switch=False) -> 'Profile':
     """Return a context manager for temporarily loading a profile, and unloading on exit.
 
     :param profile: the name of the profile to load, by default will use the one marked as default in the config
@@ -194,35 +196,29 @@ def profile_context(profile: Optional[str] = None, allow_switch=False) -> 'Profi
         manager.load_profile(current_profile, allow_switch=True)
 
 
-def create_profile(
-    config: 'Config',
-    storage_cls,
-    *,
-    name: str,
+def create_default_user(
+    profile: Profile,
     email: str,
     first_name: Optional[str] = None,
     last_name: Optional[str] = None,
     institution: Optional[str] = None,
-    **kwargs,
-) -> Profile:
-    """Create a new profile, initialise its storage and create a default user.
+) -> User:
+    """Create a default user for the given profile.
 
-    :param config: The config instance.
-    :param storage_cls: The storage class obtained through loading the entry point from ``aiida.storage`` group.
-    :param name: Name of the profile.
+    If the profile's storage is read only, a random existing user will be queried and set as default. Otherwise a new
+    user is created with the provided details and set as user.
+
+    :param profile: The profile to create the user in.
     :param email: Email for the default user.
     :param first_name: First name for the default user.
     :param last_name: Last name for the default user.
     :param institution: Institution for the default user.
-    :param kwargs: Arguments to initialise instance of the selected storage implementation.
+    :returns: The user that was set as the default user.
     """
     from aiida.manage import get_manager
     from aiida.orm import User
 
-    storage_config = storage_cls.Model(**{k: v for k, v in kwargs.items() if v is not None}).model_dump()
-    profile: Profile = config.create_profile(name=name, storage_cls=storage_cls, storage_config=storage_config)
-
-    with profile_context(profile.name, allow_switch=True):
+    with profile_context(profile, allow_switch=True):
         manager = get_manager()
         storage = manager.get_profile_storage()
 
@@ -237,6 +233,49 @@ def create_profile(
         # real situations, but this safe guard is added to be safe.
         if user:
             manager.set_default_user_email(profile, user.email)
+
+    return
+
+
+def create_profile(
+    config: 'Config',
+    *,
+    storage_backend: str,
+    storage_config: dict[str, Any],
+    broker_backend: str | None = None,
+    broker_config: dict[str, Any] | None = None,
+    name: str,
+    email: str,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
+    institution: Optional[str] = None,
+    is_test_profile: bool = False,
+) -> Profile:
+    """Create a new profile, initialise its storage and create a default user.
+
+    :param config: The config instance.
+    :param name: Name of the profile.
+    :param email: Email for the default user.
+    :param first_name: First name for the default user.
+    :param last_name: Last name for the default user.
+    :param institution: Institution for the default user.
+    :param create_user: If `True`, creates a user that is set as the default user.
+    :param storage_backend: The entry point to the :class:`aiida.orm.implementation.storage_backend.StorageBackend`
+        implementation to use for the storage.
+    :param storage_config: The configuration necessary to initialise and connect to the storage backend.
+    :param broker_backend: The entry point to the :class:`aiida.brokers.Broker` implementation to use for the broker.
+    :param broker_config: The configuration necessary to initialise and connect to the broker.
+    """
+    profile: Profile = config.create_profile(
+        name=name,
+        storage_backend=storage_backend,
+        storage_config=storage_config,
+        broker_backend=broker_backend,
+        broker_config=broker_config,
+        is_test_profile=is_test_profile,
+    )
+
+    create_default_user(profile, email, first_name, last_name, institution)
 
     return profile
 

--- a/src/aiida/manage/configuration/settings.py
+++ b/src/aiida/manage/configuration/settings.py
@@ -81,12 +81,7 @@ def get_configuration_directory():
 
     :returns: The path of the configuration directory.
     """
-    dirpath_config: pathlib.Path | None = None
-
-    if environment_variable := os.environ.get(DEFAULT_AIIDA_PATH_VARIABLE):
-        dirpath_config = get_configuration_directory_from_envvar(environment_variable)
-    else:
-        dirpath_config = get_configuration_directory_from_cwd()
+    dirpath_config = get_configuration_directory_from_envvar() or get_configuration_directory_from_cwd()
 
     # If no existing configuration directory is found, fall back to the default
     if dirpath_config is None:
@@ -95,15 +90,20 @@ def get_configuration_directory():
     return dirpath_config
 
 
-def get_configuration_directory_from_envvar(environment_variable: str) -> pathlib.Path:
+def get_configuration_directory_from_envvar() -> pathlib.Path | None:
     """Return the path of a config directory from the ``AIIDA_PATH`` environment variable.
 
     The environment variable should be a colon separated string of filepaths that either point directly to a config
     directory or a path that contains a config directory. The first match is returned. If no existing config directory
     is found, the last path in the environment variable is used.
 
-    :returns: The path of the configuration directory.
+    :returns: The path of the configuration directory or ``None`` if ``AIIDA_PATH`` is not defined.
     """
+    environment_variable = os.environ.get(DEFAULT_AIIDA_PATH_VARIABLE)
+
+    if environment_variable is None:
+        return None
+
     # Loop over all the paths in the ``AIIDA_PATH`` variable to see if any of them contain a configuration folder
     for base_dir_path in [path for path in environment_variable.split(':') if path]:
         dirpath_config = pathlib.Path(base_dir_path).expanduser()

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -121,8 +121,8 @@ class Manager:
         elif not isinstance(profile, Profile):
             raise TypeError(f'profile must be None, a string, or a Profile instance, got: {type(profile)}')
 
-        # If a profile is loaded and the specified profile name is that of the currently loaded, do nothing
-        if self._profile and (self._profile.name == profile.name):
+        # If a profile is loaded and the specified profile UUID is that of the currently loaded, do nothing
+        if self._profile and (self._profile.uuid == profile.uuid):
             return self._profile
 
         if self._profile and self.profile_storage_loaded and not allow_switch:

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -4,15 +4,19 @@ import aiida
 import pytest
 from aiida.manage.configuration import Profile, create_profile, get_profile, profile_context
 from aiida.manage.manager import get_manager
-from aiida.storage.sqlite_dos.backend import SqliteDosStorage
-from aiida.storage.sqlite_temp.backend import SqliteTempBackend
 
 
-@pytest.mark.parametrize('cls', (SqliteTempBackend, SqliteDosStorage))
-def test_create_profile(isolated_config, tmp_path, cls):
+@pytest.mark.parametrize('entry_point', ('core.sqlite_temp', 'core.sqlite_dos'))
+def test_create_profile(isolated_config, tmp_path, entry_point):
     """Test :func:`aiida.manage.configuration.tools.create_profile`."""
     profile_name = 'testing'
-    profile = create_profile(isolated_config, cls, name=profile_name, email='test@localhost', filepath=str(tmp_path))
+    profile = create_profile(
+        isolated_config,
+        name=profile_name,
+        email='test@localhost',
+        storage_backend=entry_point,
+        storage_config={'filepath': str(tmp_path)},
+    )
     assert isinstance(profile, Profile)
     assert profile_name in isolated_config.profile_names
 


### PR DESCRIPTION
The `aiida.manage.configuration.create_profile` function and the
`Config.create_profile` method that it invokes are refactored to allow
defining the broker plugin and configuration. This is useful now that
the broker for a profile can be configured to be other than the default
RabbitMQ implementation. Most notably it can be set to `None` to run
AiiDA in a mode without a broker.