### PR TITLE
A fix and a slight rework to improve the `QbField` interface

### DIFF
--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -94,11 +94,13 @@ class QbField:
 
     @property
     def dtype(self) -> t.Optional[t.Any]:
-        return self._dtype
-
-    def get_root_type(self) -> t.Optional[t.Any]:
         """Return the primitive root type."""
         return extract_root_type(self._dtype)
+
+    @property
+    def annotation(self) -> t.Optional[t.Any]:
+        """Return the full type annotation."""
+        return self._dtype
 
     @property
     def is_attribute(self) -> bool:

--- a/src/aiida/orm/groups.py
+++ b/src/aiida/orm/groups.py
@@ -143,6 +143,7 @@ class Group(entities.Entity['BackendGroup', GroupCollection]):
             'extras',
             dtype=Dict[str, Any],
             is_attribute=False,
+            is_subscriptable=True,
             doc='The group extras',
         ),
         add_field(

--- a/tests/orm/test_fields/fields_Group.yml
+++ b/tests/orm/test_fields/fields_Group.yml
@@ -1,5 +1,5 @@
 description: QbStrField('description', dtype=str, is_attribute=False)
-extras: QbDictField('extras', dtype=Dict[str, Any], is_attribute=False)
+extras: QbDictField('extras', dtype=Dict[str, Any], is_attribute=False, is_subscriptable=True)
 label: QbStrField('label', dtype=str, is_attribute=False)
 pk: QbNumericField('pk', dtype=int, is_attribute=False)
 time: QbStrField('time', dtype=str, is_attribute=False)


### PR DESCRIPTION
- Missing `Group.fields.extras` subscriptability added
- `QbField.dtype` now returns root primitive type (more useful in practice)
- `QbField.annotation` provides the full type annotation