### PR TITLE
Caching: Rename `get_hash` to `compute_hash`

### DIFF
--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -87,7 +87,7 @@ class ProcessNodeCaching(NodeCaching):
         res.update(
             {
                 'inputs': {
-                    entry.link_label: entry.node.base.caching.get_hash()
+                    entry.link_label: entry.node.base.caching.compute_hash()
                     for entry in self._node.base.links.get_incoming(
                         link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)
                     )

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -983,15 +983,15 @@ class TestNodeCaching:
         assert data.base.caching.get_hash() == clone.base.caching.get_hash()
 
     def test_hashing_errors(self, aiida_caplog):
-        """Tests that ``get_hash`` fails in an expected manner."""
+        """Tests that ``compute_hash`` fails in an expected manner."""
         node = Data().store()
         node.__module__ = 'unknown'  # this will inhibit package version determination
-        result = node.base.caching.get_hash(ignore_errors=True)
+        result = node.base.caching.compute_hash(ignore_errors=True)
         assert result is None
         assert aiida_caplog.record_tuples == [(node.logger.name, logging.ERROR, 'Node hashing failed')]
 
         with pytest.raises(exceptions.HashingError, match='package version could not be determined'):
-            result = node.base.caching.get_hash(ignore_errors=False)
+            result = node.base.caching.compute_hash(ignore_errors=False)
         assert result is None
 
     def test_uuid_equality_fallback(self):


### PR DESCRIPTION
The `get_hash` method was actually recomputing the hash and not just returning the hash stored in the extras that was computed when the node got stored. The `get_hash` and `_get_hash` methods are renamed to `compute_hash` and `_compute_hash`, respectively. This allows `get_hash` to be reimplemented to simply return the hash stored in the extras.

Although technically speaking this is changing the implementation of public facing API, if users even use `get_hash()` it will have been to retrieve the hash for an already stored node, which is therefore equal to just returning the pre-computed hash stored in the extras. So effectively this should not be a breaking change.