### PR TITLE
Engine: Fix bug introduced when refactoring `upload_calculation`

### DIFF
--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -367,7 +367,8 @@ def _copy_local_files(logger, node, transport, inputs, local_copy_list):
                         shutil.copyfileobj(source, handle)
 
         # Now copy the contents of the temporary folder to the remote working directory using the transport
-        transport.put(f'{dirpath}/*', transport.getcwd())
+        for filepath in dirpath.iterdir():
+            transport.put(str(filepath), filepath.name)
 
 
 def _copy_sandbox_files(logger, node, transport, folder):

--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -367,8 +367,7 @@ def _copy_local_files(logger, node, transport, inputs, local_copy_list):
                         shutil.copyfileobj(source, handle)
 
         # Now copy the contents of the temporary folder to the remote working directory using the transport
-        for filepath in dirpath.iterdir():
-            transport.put(str(filepath), filepath.name)
+        transport.put(f'{dirpath}/*', transport.getcwd())
 
 
 def _copy_sandbox_files(logger, node, transport, folder):

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -354,7 +354,7 @@ class LocalTransport(Transport):
 
         the_destination = os.path.join(self.curdir, remotepath)
 
-        shutil.copytree(localpath, the_destination, symlinks=not dereference, dirs_exist_ok=overwrite)
+        shutil.copytree(localpath, the_destination, symlinks=not dereference)
 
     def rmtree(self, path):
         """Remove tree as rm -r would do

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -354,7 +354,7 @@ class LocalTransport(Transport):
 
         the_destination = os.path.join(self.curdir, remotepath)
 
-        shutil.copytree(localpath, the_destination, symlinks=not dereference)
+        shutil.copytree(localpath, the_destination, symlinks=not dereference, dirs_exist_ok=overwrite)
 
     def rmtree(self, path):
         """Remove tree as rm -r would do

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -171,7 +171,6 @@ def test_retrieve_files_from_list(
         (['sub', None], {'b': 'file_b'}),
         ([None, 'target'], {'target': {'sub': {'b': 'file_b'}, 'a': 'file_a'}}),
         (['sub', 'target'], {'target': {'b': 'file_b'}}),
-        (['a', 'target/filename'], {'target': {'filename': 'file_a'}}),
     ),
 )
 def test_upload_local_copy_list(
@@ -187,8 +186,6 @@ def test_upload_local_copy_list(
     calc_info.local_copy_list = [[folder.uuid] + local_copy_list]
 
     with LocalTransport() as transport:
-        # Create the ``target`` subdirectory to make sure that won't cause an exception but directories are merged
-        fixture_sandbox.get_subfolder('target', create=True)
         execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
 
     # Check that none of the files were written to the repository of the calculation node, since they were communicated

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -171,6 +171,7 @@ def test_retrieve_files_from_list(
         (['sub', None], {'b': 'file_b'}),
         ([None, 'target'], {'target': {'sub': {'b': 'file_b'}, 'a': 'file_a'}}),
         (['sub', 'target'], {'target': {'b': 'file_b'}}),
+        (['a', 'target/filename'], {'target': {'filename': 'file_a'}}),
     ),
 )
 def test_upload_local_copy_list(
@@ -186,6 +187,8 @@ def test_upload_local_copy_list(
     calc_info.local_copy_list = [[folder.uuid] + local_copy_list]
 
     with LocalTransport() as transport:
+        # Create the ``target`` subdirectory to make sure that won't cause an exception but directories are merged
+        fixture_sandbox.get_subfolder('target', create=True)
         execmanager.upload_calculation(node, transport, calc_info, fixture_sandbox)
 
     # Check that none of the files were written to the repository of the calculation node, since they were communicated


### PR DESCRIPTION
In 6898ff4d8c263cf08707c61411a005f6a7f731dd the implementation of the
processing of the `local_copy_list` in the `upload_calculation` method
was changed. Originally, the files specified by the `local_copy_list`
were first copied into the `SandboxFolder` before copying its contents
to the working directory using the transport. The commit allowed the
order in which the local and sandbox files were copied, so the local
files were now no longer copied through the sandbox. Rather, they were
copied to a temporary directory on disk, which was then copied over
using the transport. The problem is that if the latter would copy over a
directory that was already created by the copying of the sandbox, an
exception would be raised.

For example, if the sandbox contained the directory `folder` and the
`local_copy_list` contained the items `(_, 'file', './folder/file')`
this would work just fine in the original implementation as the `file`
would be written to the `folder` on the remote folder. The current
implementation, however, would write the file content to `folder/file`
in a local temporary directory, and then iterate over the directories
and copy them over. Essentially it would be doing:

    Transport.put('/tmpdir/folder', 'folder')

but since `folder` would already exist on the remote working directory
the local folder would be _nested_ and so the final path on the remote
would be `/workingdir/folder/folder/file`.

The correct approach is to copy each item of the `local_copy_list` from
the local temporary directory _individually_ using the `Transport.put`
interface and not iterate over the top-level entries of the temporary
directory at the end.