### PR TITLE
Fix/backup script alternative is backend implemented

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -262,5 +262,3 @@ py:exc seekpath.hpkot.EdgeCaseWarning
 
 py:class graphviz.graphs.Digraph
 py:class Digraph
-
-py:class typing_extensions.Literal

--- a/src/aiida/cmdline/commands/cmd_storage.py
+++ b/src/aiida/cmdline/commands/cmd_storage.py
@@ -206,9 +206,9 @@ def storage_backup(ctx, manager, dest: str, keep: int):
         storage.backup(dest, keep)
     except NotImplementedError:
         echo.echo_critical(
-            f'Profile {profile.name} uses the storage plugin '
-            f'{profile.storage_backend} which does not implement a backup mechanism.'
+            f'Profile {profile.name} uses the storage plugin `{profile.storage_backend}` which does not implement a '
+            'backup mechanism.'
         )
     except (ValueError, exceptions.StorageBackupError) as exception:
         echo.echo_critical(str(exception))
-    echo.echo_success(f'Data storage of profile `{profile.name}` backed up to `{dest}`')
+    echo.echo_success(f'Data storage of profile `{profile.name}` backed up to `{dest}`.')

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -483,10 +483,7 @@ class PsqlDosBackend(StorageBackend):
         results['repository'] = self.get_repository().get_info(detailed)
         return results
 
-    def is_backup_implemented(self):
-        return True
-
-    def _backup(
+    def _backup_storage(
         self,
         manager: backup_utils.BackupManager,
         path: pathlib.Path,
@@ -569,13 +566,13 @@ class PsqlDosBackend(StorageBackend):
             manager, container, path / 'container', prev_backup=prev_backup / 'container' if prev_backup else None
         )
 
-    def _backup_backend(
+    def _backup(
         self,
         dest: str,
         keep: Optional[int] = None,
     ):
         try:
             backup_manager = backup_utils.BackupManager(dest, keep=keep)
-            backup_manager.backup_auto_folders(lambda path, prev: self._backup(backup_manager, path, prev))
+            backup_manager.backup_auto_folders(lambda path, prev: self._backup_storage(backup_manager, path, prev))
         except backup_utils.BackupError as exc:
             raise exceptions.StorageBackupError(*exc.args) from exc

--- a/src/aiida/storage/sqlite_dos/backend.py
+++ b/src/aiida/storage/sqlite_dos/backend.py
@@ -146,10 +146,7 @@ class SqliteDosStorage(PsqlDosBackend):
         engine = create_sqla_engine(Path(self._profile.storage_config['filepath']) / 'database.sqlite')
         self._session_factory = scoped_session(sessionmaker(bind=engine, future=True, expire_on_commit=True))
 
-    def is_backup_implemented(self):
-        return False
-
-    def _backup_backend(
+    def _backup(
         self,
         dest: str,
         keep: Optional[int] = None,


### PR DESCRIPTION
@eimrek I kept the writing of the config.json in the backup directory initialization and just worked with that in the cleanup. I added some tests to make sure the functionality works. I also took the opportunity to replace the `config.json` literal with `aiida.manage.configuration.settings.DEFAULT_CONFIG_FILE_NAME` variable.