### PR TITLE
Devops: Increase timeout for the `test-install` workflow

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -189,7 +189,7 @@ jobs:
 
     needs: [install-with-pip]
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
It has been timing out recently because the test suite has grown steadily and was now regularly hitting the timeout.