### PR TITLE
`SqliteDosStorage`: Fix exception when importing archive

### DIFF
--- a/src/aiida/storage/sqlite_zip/models.py
+++ b/src/aiida/storage/sqlite_zip/models.py
@@ -158,21 +158,23 @@ DbNode.user = sa_orm.relationship(
     ),
 )
 
+MAP_ENTITY_TYPE_TO_MODEL = {
+    EntityTypes.USER: DbUser,
+    EntityTypes.AUTHINFO: DbAuthInfo,
+    EntityTypes.GROUP: DbGroup,
+    EntityTypes.NODE: DbNode,
+    EntityTypes.COMMENT: DbComment,
+    EntityTypes.COMPUTER: DbComputer,
+    EntityTypes.LOG: DbLog,
+    EntityTypes.LINK: DbLink,
+    EntityTypes.GROUP_NODE: DbGroupNodes,
+}
+
 
 @functools.lru_cache(maxsize=10)
 def get_model_from_entity(entity_type: EntityTypes) -> Tuple[Any, Set[str]]:
     """Return the Sqlalchemy model and column names corresponding to the given entity."""
-    model = {
-        EntityTypes.USER: DbUser,
-        EntityTypes.AUTHINFO: DbAuthInfo,
-        EntityTypes.GROUP: DbGroup,
-        EntityTypes.NODE: DbNode,
-        EntityTypes.COMMENT: DbComment,
-        EntityTypes.COMPUTER: DbComputer,
-        EntityTypes.LOG: DbLog,
-        EntityTypes.LINK: DbLink,
-        EntityTypes.GROUP_NODE: DbGroupNodes,
-    }[entity_type]
+    model = MAP_ENTITY_TYPE_TO_MODEL[entity_type]
     mapper = sa.inspect(model).mapper
     column_names = {col.name for col in mapper.c.values()}
     return model, column_names

--- a/tests/storage/sqlite_dos/test_backend.py
+++ b/tests/storage/sqlite_dos/test_backend.py
@@ -12,3 +12,16 @@ def test_model():
     filepath = pathlib.Path.cwd() / 'archive.aiida'
     model = SqliteDosStorage.Model(filepath=filepath.name)
     assert pathlib.Path(model.filepath).is_absolute()
+
+
+def test_archive_import(aiida_config, aiida_profile_factory):
+    """Test that archives can be imported."""
+    from aiida.orm import Node, QueryBuilder
+    from aiida.tools.archive.imports import import_archive
+
+    from tests.utils.archives import get_archive_file
+
+    with aiida_profile_factory(aiida_config, storage_backend='core.sqlite_dos'):
+        assert QueryBuilder().append(Node).count() == 0
+        import_archive(get_archive_file('calcjob/arithmetic.add.aiida'))
+        assert QueryBuilder().append(Node).count() > 0


### PR DESCRIPTION
Fixes #6316 
Fixes #5735 (not directly, but think it should be resolved now)

When an archive was imported into an `SqliteDosStorage` backend an exception was raised by sqlalchemy. It was treating the `uuid` column of the models as a UUID type but in reality it was a string. This is because the storage plugin inherits the implementation largely from the `core.psql_dos` plugin, but it converts the models, since the UUID types that are used by the PostgreSQL implementation are not supported by SQLite.

The problem was that for archive importing, the `bulk_insert` method was used, which calls the `_get_mapper_from_entity` method to map a given ORM entity to the corresponding database model. But since this method was inherited from `core.psql_dos`, it was returning the incorrect models. The problem is fixed by overriding it in `SqliteDosStorage` and returning the SQLite-adapted models.