### PR TITLE
Archive: Automatically create nested output directories

### DIFF
--- a/src/aiida/tools/archive/create.py
+++ b/src/aiida/tools/archive/create.py
@@ -365,6 +365,8 @@ def create_archive(
 
         if filename.exists():
             filename.unlink()
+
+        filename.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(tmp_filename, filename)
 
     EXPORT_LOGGER.report('Archive created successfully')

--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -37,6 +37,14 @@ def test_create_force(run_cli_command, tmp_path):
     run_cli_command(cmd_archive.create, options)
 
 
+def test_create_file_nested_directory(run_cli_command, tmp_path):
+    """Test that output files that contains nested directories are created automatically."""
+    filepath = tmp_path / 'some' / 'sub' / 'directory' / 'output.aiida'
+    options = [str(filepath)]
+    run_cli_command(cmd_archive.create, options)
+    assert filepath.exists()
+
+
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_all(run_cli_command, tmp_path, aiida_localhost):
     """Test that creating an archive for a set of various ORM entities works with the zip format."""


### PR DESCRIPTION
Fixes #6167

Creating an archive, either through `verdi archive create` or through the API `aiida.tools.archive.create_archive` would raise an exception if the output path contained nested directories that do not yet exist. These are now created automatically.