### PR TITLE
CI: Use uv installer

### DIFF
--- a/.github/actions/create-dev-env/action.yml
+++ b/.github/actions/create-dev-env/action.yml
@@ -14,7 +14,7 @@ runs:
     # See: https://github.com/actions/setup-python/issues/108
     # python3 is manually preinstalled in the arm64 VM self-hosted runner
   - name: Set Up Python 🐍
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v5
     with:
       python-version: 3.x
     if: ${{ inputs.architecture == 'amd64' }}

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -18,6 +18,9 @@ inputs:
     required: false
     type: boolean
 
+env:
+  UV_VERSION: 0.1.35
+
 runs:
   using: composite
   steps:
@@ -27,14 +30,18 @@ runs:
       python-version: ${{ inputs.python-version }}
 
   - name: Install uv installer
-    run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.35/uv-installer.sh | sh
+    run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/${{ env.UV_VERSION }}/uv-installer.sh | sh
     shell: bash
 
   - name: Install dependencies from requirements-py-*.txt
-    if: ${{ inputs.from-requirements == true }}
+    if: inputs.from-requirements == true
     run: uv pip install -v --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 
   - name: Install aiida-core 📦
-    run: uv pip install -v --system ${{ inputs.from-requirements == true && '--no-deps' || '' }} -e .${{ inputs.extras }}
+    run: uv pip install --system ${{ env.NO_DEPS }} -e .${{ inputs.extras }}
+    env:
+        # Don't install dependencies if they were installed through requirements file AND
+        # if no extras are required.
+      NO_DEPS: ${{ (inputs.from-requirements && inputs.extras == '')  && '--no-deps' || '' }}
     shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -31,10 +31,10 @@ runs:
     shell: bash
 
   - name: Install dependencies from requirements-py-*.txt
-    if: ${{ inputs.from-requirements }}
+    if: ${{ inputs.from-requirements == true }}
     run: uv pip install -v --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 
   - name: Install aiida-core 📦
-    run: uv pip install -v --system ${{ inputs.from-requirements && '--no-deps' || '' }} -e .${{ inputs.extras }}
+    run: uv pip install -v --system ${{ inputs.from-requirements == true && '--no-deps' || '' }} -e .${{ inputs.extras }}
     shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -6,17 +6,16 @@ inputs:
     description: Python version
     default: '3.9'              # Lowest supported version
     required: false
-    type: string
   extras:
     description: aiida-core extras (including brackets)
     default: ''
     required: false
-    type: string
+  # NOTE: Hard-learned lesson: we cannot use type=boolean here, apparently :-(
+  # https://stackoverflow.com/a/76294014
   from-requirements:
     description: Install aiida-core dependencies from pre-compiled requirements.txt file
-    default: true
+    default: 'true'
     required: false
-    type: boolean
 
 runs:
   using: composite
@@ -34,7 +33,7 @@ runs:
     shell: bash
 
   - name: Install dependencies from requirements-py-*.txt
-    if: ${{ inputs.from-requirements == true }}
+    if: ${{ inputs.from-requirements == 'true' }}
     run: uv pip install --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 
@@ -43,5 +42,9 @@ runs:
     env:
         # Don't install dependencies if they were installed through requirements file AND
         # if no extras are required.
-      NO_DEPS: ${{ (inputs.from-requirements == true && inputs.extras == '')  && '--no-deps' || '' }}
+        #
+        # If this syntax looks weird to you, dear reader, know that this is
+        # GHA's way to do ternary operator. :-/
+        # https://docs.github.com/en/actions/learn-github-actions/expressions#example
+      NO_DEPS: ${{ (inputs.from-requirements == 'true' && inputs.extras == '')  && '--no-deps' || '' }}
     shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -32,9 +32,9 @@ runs:
 
   - name: Install dependencies from requirements-py-*.txt
     if: ${{ inputs.from-requirements }}
-    run: uv pip install --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
+    run: uv pip install -v --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 
   - name: Install aiida-core 📦
-    run: uv pip install --system ${{ inputs.from-requirements && '--no-deps' || '' }} -e .${{ inputs.extras }}
+    run: uv pip install -v --system ${{ inputs.from-requirements && '--no-deps' || '' }} -e .${{ inputs.extras }}
     shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -35,7 +35,7 @@ runs:
 
   - name: Install dependencies from requirements-py-*.txt
     if: ${{ inputs.from-requirements == true }}
-    run: uv pip install -v --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
+    run: uv pip install --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 
   - name: Install aiida-core 📦
@@ -43,5 +43,5 @@ runs:
     env:
         # Don't install dependencies if they were installed through requirements file AND
         # if no extras are required.
-      NO_DEPS: ${{ (inputs.from-requirements && inputs.extras == '')  && '--no-deps' || '' }}
+      NO_DEPS: ${{ (inputs.from-requirements == true && inputs.extras == '')  && '--no-deps' || '' }}
     shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -1,0 +1,40 @@
+name: Install aiida-core
+description: Install aiida-core package and its Python dependencies
+
+inputs:
+  python-version:
+    description: Python version
+    default: '3.9'              # Lowest supported version
+    required: false
+    type: string
+  extras:
+    description: aiida-core extras (including brackets)
+    default: ''
+    required: false
+    type: string
+  from-requirements:
+    description: Install aiida-core dependencies from pre-compiled requirements.txt file
+    default: true
+    required: false
+    type: boolean
+
+runs:
+  using: composite
+  steps:
+  - name: Set Up Python 🐍
+    uses: actions/setup-python@v5
+    with:
+      python-version: ${{ inputs.python-version }}
+
+  - name: Install uv installer
+    run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.35/uv-installer.sh | sh
+    shell: bash
+
+  - name: Install dependencies from requirements-py-*.txt
+    if: ${{ inputs.from-requirements }}
+    run: uv pip install --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
+    shell: bash
+
+  - name: Install aiida-core 📦
+    run: uv pip install --system ${{ inputs.from-requirements && '--no-deps' || '' }} -e .${{ inputs.extras }}
+    shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Set Up Python 🐍
+  - name: Set Up Python
     uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
@@ -37,7 +37,7 @@ runs:
     run: uv pip install --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 
-  - name: Install aiida-core 📦
+  - name: Install aiida-core
     run: uv pip install --system ${{ env.NO_DEPS }} -e .${{ inputs.extras }}
     env:
         # Don't install dependencies if they were installed through requirements file AND

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -18,9 +18,6 @@ inputs:
     required: false
     type: boolean
 
-env:
-  UV_VERSION: 0.1.35
-
 runs:
   using: composite
   steps:
@@ -31,10 +28,13 @@ runs:
 
   - name: Install uv installer
     run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/${{ env.UV_VERSION }}/uv-installer.sh | sh
+    env:
+      UV_VERSION: 0.1.35
+      UV_URL: https://github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-installer.sh
     shell: bash
 
   - name: Install dependencies from requirements-py-*.txt
-    if: inputs.from-requirements == true
+    if: ${{ inputs.from-requirements == true }}
     run: uv pip install -v --system -r requirements/requirements-py-${{ inputs.python-version }}.txt
     shell: bash
 

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -27,10 +27,10 @@ runs:
       python-version: ${{ inputs.python-version }}
 
   - name: Install uv installer
-    run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/${{ env.UV_VERSION }}/uv-installer.sh | sh
+    run: curl --proto '=https' --tlsv1.2 -LsSf https://${{ env.UV_URL }} | sh
     env:
       UV_VERSION: 0.1.35
-      UV_URL: https://github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-installer.sh
+      UV_URL: github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-installer.sh
     shell: bash
 
   - name: Install dependencies from requirements-py-*.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,22 +48,12 @@ jobs:
         - 5672:5672
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+
+    - name: Install aiida-core
+      uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.10'
-
-    - name: Upgrade pip
-      run: |
-        pip install --upgrade pip
-        pip --version
-
-    - name: Install python dependencies
-      run: |
-        pip install -r requirements/requirements-py-3.10.txt
-        pip install --no-deps -e .
-        pip freeze
 
     - name: Run benchmarks
       run: pytest --benchmark-only --benchmark-json benchmark.json

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -84,21 +84,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql graphviz
 
-    - name: Install uv installer
-      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.35/uv-installer.sh | sh
-
     - name: Install aiida-core
-      run: |
-        uv pip install --system -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        uv pip install --system --no-deps -e .
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup environment
       run: .github/workflows/setup.sh
@@ -130,16 +122,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Install aiida-core
+      uses: ./.github/actions/install-aiida-core
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install uv installer
-      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.35/uv-installer.sh | sh
-
-    - name: Install python dependencies
-      run: uv pip install --system -e .
+        from-requirements: false
 
     - name: Run verdi
       run: |

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
@@ -82,28 +82,23 @@ jobs:
         - 5001:22
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql graphviz
 
-    - name: Upgrade pip and setuptools
-      # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy
-      run: |
-        pip install --upgrade pip
-        pip install setuptools==65.5.0
-        pip --version
+    - name: Install uv installer
+      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.35/uv-installer.sh | sh
 
     - name: Install aiida-core
       run: |
-        pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip install --no-deps -e .
-        pip freeze
+        uv pip install --system -r requirements/requirements-py-${{ matrix.python-version }}.txt
+        uv pip install --system --no-deps -e .
 
     - name: Setup environment
       run: .github/workflows/setup.sh
@@ -133,15 +128,18 @@ jobs:
         python-version: ['3.9', '3.12']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install uv installer
+      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.35/uv-installer.sh | sh
+
     - name: Install python dependencies
-      run: pip install -e .
+      run: uv pip install --system -e .
 
     - name: Run verdi
       run: |

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -126,7 +126,7 @@ jobs:
       uses: ./.github/actions/install-aiida-core
       with:
         python-version: ${{ matrix.python-version }}
-        from-requirements: false
+        from-requirements: 'false'
 
     - name: Run verdi
       run: |

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         python-version: '3.10'
         extras: '[pre-commit]'
+        from-requirements: false
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -14,12 +14,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
+    - uses: actions/checkout@v4
 
     - name: Install system dependencies
       # note libkrb5-dev is required as a dependency for the gssapi pip install
@@ -28,11 +23,10 @@ jobs:
         sudo apt install libkrb5-dev ruby ruby-dev
 
     - name: Install python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -r requirements/requirements-py-3.10.txt
-        pip install -e .[pre-commit]
-        pip freeze
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.10'
+        extras: '[pre-commit]'
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         python-version: '3.10'
         extras: '[pre-commit]'
-        from-requirements: true
+        from-requirements: 'true'
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         python-version: '3.10'
         extras: '[pre-commit]'
-        from-requirements: false
+        from-requirements: true
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -25,7 +25,8 @@ jobs:
 
     steps:
     - name: Checkout Repo ⚡️
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
     - name: Create dev environment 📦
       uses: ./.github/actions/create-dev-env
       with:

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout Repo ⚡️
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Create dev environment 📦
       uses: ./.github/actions/create-dev-env
       with:

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout Repo ⚡️
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Create dev environment 📦
       uses: ./.github/actions/create-dev-env
       with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install aiida-core and docs deps
-      uses: .github/actions/install-aiida-core
+      uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.9'
         extras: '[docs,tests,rest,atomic_tools]'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,15 +15,15 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+
+    - name: Install aiida-core and docs deps
+      uses: .github/actions/install-aiida-core
       with:
         python-version: '3.9'
-    - name: Install python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -e .[docs,tests,rest,atomic_tools]
+        extras: '[docs,tests,rest,atomic_tools]'
+        from-requirements: false
+
     - name: Build HTML docs
       id: linkcheck
       run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: '3.9'
         extras: '[docs,tests,rest,atomic_tools]'
-        from-requirements: false
+        from-requirements: 'false'
 
     - name: Build HTML docs
       id: linkcheck

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,32 +51,18 @@ jobs:
         - 15672:15672
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: eWaterCycle/setup-singularity@v7        # for containerized code test
       with:
         singularity-version: 3.8.7
-
-    - name: Cache Python dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-        restore-keys: pip-${{ matrix.python-version }}-tests
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql
 
     - name: Install aiida-core
-      id: install
-      run: |
-        pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip install --no-deps -e .
-        pip freeze
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup environment
       run: .github/workflows/setup.sh

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -46,26 +46,13 @@ jobs:
         - 15672:15672
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
+    - name: Install aiida-core
+      uses: ./.github/actions/install-aiida-core
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql
-
-    - name: Upgrade pip
-      run: |
-        pip install --upgrade pip
-        pip --version
-
-    - name: Install aiida-core
-      run: |
-        pip install -r requirements/requirements-py-3.9.txt
-        pip install --no-deps -e .
-        pip freeze
 
     - name: Run tests
       run: pytest -sv -k 'requires_rmq'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt install libkrb5-dev ruby ruby-dev
 
     - name: Install aiida-core and pre-commit
-      uses: .github/actions/install-aiida-core
+      uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.10'
         extras: '[pre-commit]'
@@ -83,7 +83,7 @@ jobs:
         sudo apt install postgresql graphviz
 
     - name: Install aiida-core
-      uses: .github/actions/install-aiida-core
+      uses: ./.github/actions/install-aiida-core
 
     - name: Run sub-set of test suite
       run: pytest -sv -k 'requires_rmq'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - run: python .github/workflows/check_release_tag.py $GITHUB_REF
@@ -32,22 +32,19 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
+    - uses: actions/checkout@v4
     - name: Install system dependencies
       # note libkrb5-dev is required as a dependency for the gssapi pip install
       run: |
         sudo apt update
         sudo apt install libkrb5-dev ruby ruby-dev
-    - name: Install python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -r requirements/requirements-py-3.10.txt
-        pip install -e .[pre-commit]
-        pip freeze
+
+    - name: Install aiida-core and pre-commit
+      uses: .github/actions/install-aiida-core
+      with:
+        python-version: '3.10'
+        extras: '[pre-commit]'
+
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
@@ -78,25 +75,16 @@ jobs:
         - 15672:15672
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
+    - uses: actions/checkout@v4
+
     - name: Install system dependencies
       run: |
         sudo apt update
         sudo apt install postgresql graphviz
 
-    - name: Upgrade pip
-      run: |
-        pip install --upgrade pip
-        pip --version
-
     - name: Install aiida-core
-      run: |
-        pip install -r requirements/requirements-py-3.9.txt
-        pip install --no-deps -e .
+      uses: .github/actions/install-aiida-core
+
     - name: Run sub-set of test suite
       run: pytest -sv -k 'requires_rmq'
 
@@ -110,9 +98,9 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: install flit

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -220,7 +220,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         extras: '[atomic_tools, docs, notebook, rest, tests, tui]'
-        from-requirements: false
+        from-requirements: 'false'
 
     - name: Setup AiiDA environment
       run: .github/workflows/setup.sh

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -28,10 +28,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
@@ -46,9 +46,6 @@ jobs:
   resolve-pip-dependencies:
     # Check whether the environments defined in the requirements/* files are
     # resolvable.
-    #
-    # This job should use the planned `pip resolve` command once released:
-    # https://github.com/pypa/pip/issues/7819
 
     needs: [validate-dependency-specification]
     if: github.repository == 'aiidateam/aiida-core'
@@ -61,24 +58,16 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Upgrade pip and setuptools
-      # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy
+    - name: Resolve dependencies from requirements file.
       run: |
-        pip install --upgrade pip
-        pip install setuptools==65.5.0
-        pip --version
-
-    - name: Create environment from requirements file.
-      run: |
-        pip install -r requirements/requirements-py-${{ matrix.python-version }}.txt
-        pip freeze
+        pip install --dry-run --ignore-installed -r requirements/requirements-py-${{ matrix.python-version }}.txt
 
   create-conda-environment:
     # Verify that we can create a valid conda environment from the environment.yml file.
@@ -89,7 +78,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
@@ -114,10 +103,10 @@ jobs:
         extras: ['', '[atomic_tools,docs,notebook,rest,tests,tui]']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
@@ -156,7 +145,7 @@ jobs:
           optional: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
@@ -221,29 +210,17 @@ jobs:
         - 5001:22
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v4
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql graphviz
 
-    - name: Upgrade pip and setuptools
-      # It is crucial to update `setuptools` or the installation of `pymatgen` can break
-      # Install specific version of setuptools, because 65.6.0 breaks a number of packages, such as numpy
-      run: |
-        pip install --upgrade pip
-        pip install setuptools==65.5.0
-        pip --version
-
     - name: Install aiida-core
-      run: |
-        pip install -e .[atomic_tools,docs,notebook,rest,tests,tui]
-
-    - run: pip freeze
+      uses: .github/actions/install-aiida-core
+      with:
+        python-version: ${{ matrix.python-version }}
+        extras: '[atomic_tools, docs, notebook, rest, tests, tui]'
+        from-requirements: false
 
     - name: Setup AiiDA environment
       run: .github/workflows/setup.sh
@@ -260,7 +237,7 @@ jobs:
     # Add python-version specific requirements/ file to the requirements.txt artifact.
     # This artifact can be used in the next step to automatically create a pull request
     # updating the requirements (in case they are  inconsistent with the pyproject.toml file).
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: requirements.txt
         path: requirements-py-${{ matrix.python-version }}.txt
@@ -277,10 +254,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 
@@ -307,14 +284,14 @@ jobs:
     # Check out the base branch so that we can prepare the pull request.
     - name: Checkout base branch
       if: steps.check_reqs.outcome == 'Failure'  # only run if requirements/ are inconsistent
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}
         clean: true
 
     - name: Download requirements.txt files
       if: steps.check_reqs.outcome == 'Failure'  # only run if requirements/ are inconsistent
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: requirements.txt
         path: requirements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
   - id: trailing-whitespace
     exclude: *exclude_pre_commit_hooks
 
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.28.2
+  hooks:
+  - id: check-github-workflows
+
 - repo: https://github.com/ikamensh/flynt/
   rev: 1.0.1
   hooks:


### PR DESCRIPTION
[uv](https://github.com/astral-sh/uv/issues/2155l) is the new cool kid in the town of Python packaging, from the creators of ruff. It currently serves as a (much) faster drop-in replacement for pip.

We've been using it for a couple of repos in AiiDAlab and it works great. For aiida-core, it cuts installation time from ~1m30s to ~10s, so it seems worthwhile. 

So far I've only touched jobs in `ci-code.yml`. If desired, I can make similar changes to other workflows that would benefit (e.g. pre-commit)