### PR TITLE
CI: Update pre-commit hooks

### DIFF
--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install python dependencies
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         extras: '[pre-commit]'
         from-requirements: 'false'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-merge-conflict
   - id: check-yaml
@@ -37,7 +37,7 @@ repos:
     args: [--line-length=120, --fail-on-change]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.5
+  rev: v0.4.1
   hooks:
   - id: ruff-format
     exclude: &exclude_ruff >
@@ -50,7 +50,7 @@ repos:
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.12.0
+  rev: v2.13.0
   hooks:
   - id: pretty-format-toml
     args: [--autofix]


### PR DESCRIPTION
A smattering of small updates to pre-commit hooks and pre-commit workflow in `ci-style.yml`
(partly overlapping with #6368)

-  ran `pre-commit autoupdate`
- remove flynt linter, according to [this ruff issue](https://github.com/astral-sh/ruff/issues/2102), most of it is already implemented in ruff, with the exception of FLY001 (consider replacing string concatenation with f-string). 

       -tc, --transform-concats`
                        Replace string concatenations (defined as +
                        operations involving string literals) with
                        f-strings. Available only if flynt is
                        installed with 3.8+ interpreter.

If this is deemed important enough I can revert this change.
- Don't install unneeded system dependencies in pre-commit run (done in #6368 as well)
- Run pre-commit with python 3.11 instead of 3.10. I was hoping to get some decent speedup from this, but it looks like only several seconds, likely because most of the time is spent installing / bulding pre-commit dependencies.