### PR TITLE
Devops: Install from abstract dependencies for pre-commit CI

### DIFF
--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -16,18 +16,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install system dependencies
-      # note libkrb5-dev is required as a dependency for the gssapi pip install
-      run: |
-        sudo apt update
-        sudo apt install libkrb5-dev ruby ruby-dev
-
     - name: Install python dependencies
       uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.10'
-        extras: '[pre-commit]'
-        from-requirements: 'true'
+        extras: '[atomic_tools,pre-commit,rest,tests,tui]'
+        from-requirements: 'false'
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -20,7 +20,7 @@ jobs:
       uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.10'
-        extras: '[atomic_tools,pre-commit,rest,tests,tui]'
+        extras: '[pre-commit]'
         from-requirements: 'false'
 
     - name: Run pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ notebook = [
   'notebook~=6.1,>=6.1.5'
 ]
 pre-commit = [
+  'aiida-core[atomic_tools,pre-commit,rest,tests,tui]',
   'mypy~=1.7.1',
   'packaging~=23.0',
   'pre-commit~=2.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ notebook = [
   'notebook~=6.1,>=6.1.5'
 ]
 pre-commit = [
-  'aiida-core[atomic_tools,pre-commit,rest,tests,tui]',
+  'aiida-core[atomic_tools,rest,tests,tui]',
   'mypy~=1.7.1',
   'packaging~=23.0',
   'pre-commit~=2.2',

--- a/src/aiida/storage/sqlite_zip/migrations/versions/main_0000a_replace_nulls.py
+++ b/src/aiida/storage/sqlite_zip/migrations/versions/main_0000a_replace_nulls.py
@@ -42,8 +42,8 @@ def upgrade():
     )
 
     # remove rows with null values, which may have previously resulted from deletion of a user or computer
-    op.execute(db_dbauthinfo.delete().where(db_dbauthinfo.c.aiidauser_id.is_(None)))  # type: ignore[arg-type]
-    op.execute(db_dbauthinfo.delete().where(db_dbauthinfo.c.dbcomputer_id.is_(None)))  # type: ignore[arg-type]
+    op.execute(db_dbauthinfo.delete().where(db_dbauthinfo.c.aiidauser_id.is_(None)))
+    op.execute(db_dbauthinfo.delete().where(db_dbauthinfo.c.dbcomputer_id.is_(None)))
 
     op.execute(db_dbauthinfo.update().where(db_dbauthinfo.c.enabled.is_(None)).values(enabled=True))
     op.execute(db_dbauthinfo.update().where(db_dbauthinfo.c.auth_params.is_(None)).values(auth_params={}))
@@ -60,8 +60,8 @@ def upgrade():
     )
 
     # remove rows with null values, which may have previously resulted from deletion of a node or user
-    op.execute(db_dbcomment.delete().where(db_dbcomment.c.dbnode_id.is_(None)))  # type: ignore[arg-type]
-    op.execute(db_dbcomment.delete().where(db_dbcomment.c.user_id.is_(None)))  # type: ignore[arg-type]
+    op.execute(db_dbcomment.delete().where(db_dbcomment.c.dbnode_id.is_(None)))
+    op.execute(db_dbcomment.delete().where(db_dbcomment.c.user_id.is_(None)))
 
     op.execute(db_dbcomment.update().where(db_dbcomment.c.content.is_(None)).values(content=''))
     op.execute(db_dbcomment.update().where(db_dbcomment.c.ctime.is_(None)).values(ctime=timezone.now()))


### PR DESCRIPTION
Fixes #6366

The workflow running pre-commit was installing from the requirements before installing `pip install .[pre-commit]`. The install from the requirements file was added because some hooks would fail due to import errors. The proper solution is simply to install all extras whose dependencies are imported during pre-commit checks.