### PR TITLE
Devops: Add the `slurm` service to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,10 @@ jobs:
         ports:
         - 5672:5672
         - 15672:15672
+      slurm:
+        image: xenonmiddleware/slurm:17
+        ports:
+        - 5001:22
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The nightly worklow is configuring a computer that is using the `core.slurm` scheduler plugin, however, the container did not have a SLURM service running.