### PR TITLE
Improve import times of aiida.orm and aiida.storage

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import functools
 import typing as t
 
-from packaging.version import parse
-
 from aiida.brokers.broker import Broker
 from aiida.common.log import AIIDA_LOGGER
 from aiida.manage.configuration import get_config_option
@@ -110,6 +108,8 @@ class RabbitmqBroker(Broker):
 
         :return: boolean whether the current RabbitMQ version is supported.
         """
+        from packaging.version import parse
+
         return parse('3.6.0') <= self.get_rabbitmq_version() < parse('3.8.15')
 
     def get_rabbitmq_version(self):
@@ -117,4 +117,6 @@ class RabbitmqBroker(Broker):
 
         :return: :class:`packaging.version.Version`
         """
+        from packaging.version import parse
+
         return parse(self.get_communicator().server_properties['version'].decode('utf-8'))

--- a/src/aiida/orm/nodes/data/code/abstract.py
+++ b/src/aiida/orm/nodes/data/code/abstract.py
@@ -45,7 +45,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
     _KEY_ATTRIBUTE_WRAP_CMDLINE_PARAMS: str = 'wrap_cmdline_params'
     _KEY_EXTRA_IS_HIDDEN: str = 'hidden'  # Should become ``is_hidden`` once ``Code`` is dropped
 
-    class Model(BaseModel):
+    class Model(BaseModel, defer_build=True):
         """Model describing required information to create an instance."""
 
         label: str = MetadataField(

--- a/src/aiida/orm/nodes/data/folder.py
+++ b/src/aiida/orm/nodes/data/folder.py
@@ -15,9 +15,11 @@ import io
 import pathlib
 import typing as t
 
-from aiida.repository import File
-
 from .data import Data
+
+if t.TYPE_CHECKING:
+    from aiida.repository import File
+
 
 __all__ = ('FolderData',)
 

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -38,13 +38,13 @@ from .attributes import NodeAttributes
 from .caching import NodeCaching
 from .comments import NodeComments
 from .links import NodeLinks
-from .repository import NodeRepository
 
 if TYPE_CHECKING:
     from importlib_metadata import EntryPoint
 
     from ..implementation import StorageBackend
     from ..implementation.nodes import BackendNode  # noqa: F401
+    from .repository import NodeRepository
 
 __all__ = ('Node',)
 
@@ -107,6 +107,8 @@ class NodeBase:
     @cached_property
     def repository(self) -> 'NodeRepository':
         """Return the repository for this node."""
+        from .repository import NodeRepository
+
         return NodeRepository(self._node)
 
     @cached_property

--- a/src/aiida/orm/nodes/repository.py
+++ b/src/aiida/orm/nodes/repository.py
@@ -12,10 +12,10 @@ import typing as t
 
 from aiida.common import exceptions
 from aiida.manage import get_config_option
-from aiida.repository import File, Repository
-from aiida.repository.backend import SandboxRepositoryBackend
 
 if t.TYPE_CHECKING:
+    from aiida.repository import File, Repository
+
     from .node import Node
 
 __all__ = ('NodeRepository',)
@@ -77,6 +77,9 @@ class NodeRepository:
 
         :return: the file repository instance.
         """
+        from aiida.repository import Repository
+        from aiida.repository.backend import SandboxRepositoryBackend
+
         if self._repository_instance is None:
             if self._node.is_stored:
                 backend = self._node.backend.get_repository()
@@ -100,6 +103,9 @@ class NodeRepository:
 
     def _store(self) -> None:
         """Store the repository in the backend."""
+        from aiida.repository import Repository
+        from aiida.repository.backend import SandboxRepositoryBackend
+
         if isinstance(self._repository.backend, SandboxRepositoryBackend):
             # Only if the backend repository is a sandbox do we have to clone its contents to the permanent repository.
             repository_backend = self._node.backend.get_repository()

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -74,7 +74,7 @@ class PsqlDosBackend(StorageBackend):
     The `django` backend was removed, to consolidate access to this storage.
     """
 
-    class Model(BaseModel):
+    class Model(BaseModel, defer_build=True):
         """Model describing required information to configure an instance of the storage."""
 
         database_engine: str = Field(

--- a/src/aiida/storage/sqlite_dos/backend.py
+++ b/src/aiida/storage/sqlite_dos/backend.py
@@ -100,7 +100,7 @@ class SqliteDosStorage(PsqlDosBackend):
 
     migrator = SqliteDosMigrator
 
-    class Model(BaseModel):
+    class Model(BaseModel, defer_build=True):
         """Model describing required information to configure an instance of the storage."""
 
         filepath: str = Field(

--- a/src/aiida/storage/sqlite_temp/backend.py
+++ b/src/aiida/storage/sqlite_temp/backend.py
@@ -43,7 +43,7 @@ class SqliteTempBackend(StorageBackend):
     and destroys it when it is garbage collected.
     """
 
-    class Model(BaseModel):
+    class Model(BaseModel, defer_build=True):
         filepath: str = Field(
             title='Temporary directory',
             description='Temporary directory in which to store data for this backend.',

--- a/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -27,7 +27,6 @@ from aiida.repository.common import File, FileType
 from aiida.storage.log import MIGRATE_LOGGER
 
 from ..utils import DB_FILENAME, REPO_FOLDER, create_sqla_engine
-from . import v1_db_schema as v1_schema
 from .utils import update_metadata
 
 _NODE_ENTITY_NAME = 'Node'
@@ -43,15 +42,6 @@ file_fields_to_model_fields: Dict[str, Dict[str, str]] = {
     _COMPUTER_ENTITY_NAME: {},
     _LOG_ENTITY_NAME: {'dbnode': 'dbnode_id'},
     _COMMENT_ENTITY_NAME: {'dbnode': 'dbnode_id', 'user': 'user_id'},
-}
-
-aiida_orm_to_backend = {
-    _USER_ENTITY_NAME: v1_schema.DbUser,
-    _GROUP_ENTITY_NAME: v1_schema.DbGroup,
-    _NODE_ENTITY_NAME: v1_schema.DbNode,
-    _COMMENT_ENTITY_NAME: v1_schema.DbComment,
-    _COMPUTER_ENTITY_NAME: v1_schema.DbComputer,
-    _LOG_ENTITY_NAME: v1_schema.DbLog,
 }
 
 LEGACY_TO_MAIN_REVISION = 'main_0000'
@@ -137,6 +127,17 @@ def _json_to_sqlite(
 ) -> None:
     """Convert a JSON archive format to SQLite."""
     from aiida.tools.archive.common import batch_iter
+
+    from . import v1_db_schema as v1_schema
+
+    aiida_orm_to_backend = {
+        _USER_ENTITY_NAME: v1_schema.DbUser,
+        _GROUP_ENTITY_NAME: v1_schema.DbGroup,
+        _NODE_ENTITY_NAME: v1_schema.DbNode,
+        _COMMENT_ENTITY_NAME: v1_schema.DbComment,
+        _COMPUTER_ENTITY_NAME: v1_schema.DbComputer,
+        _LOG_ENTITY_NAME: v1_schema.DbLog,
+    }
 
     MIGRATE_LOGGER.report('Converting DB to SQLite')
 

--- a/src/aiida/storage/sqlite_zip/utils.py
+++ b/src/aiida/storage/sqlite_zip/utils.py
@@ -9,12 +9,10 @@
 """Utilities for this backend."""
 
 import json
-import tarfile
 import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-from archive_path import read_file_in_tar, read_file_in_zip
 from sqlalchemy import event
 from sqlalchemy.future.engine import Engine, create_engine
 
@@ -64,6 +62,10 @@ def extract_metadata(path: Union[str, Path], *, search_limit: Optional[int] = 10
 
     :param search_limit: the maximum number of records to search for the metadata file in a zip file.
     """
+    import tarfile
+
+    from archive_path import read_file_in_tar, read_file_in_zip
+
     path = Path(path)
     if not path.exists():
         raise UnreachableStorage(f'path not found: {path}')


### PR DESCRIPTION
1. aiida.orm went from 600ms back to 300ms by deferring import of `aiida.storage`. 
2. Also some small improvements to both aiida.orm and aiida.storage, mainly from deferring build of pydantic models.

### Main branch

```console
Benchmark 1: python -c "import aiida.orm"
  Time (mean ± σ):     650.2 ms ±   9.2 ms    [User: 622.8 ms, System: 852.6 ms]
  Range (min … max):   641.0 ms … 663.2 ms    10 runs
 
Benchmark 1: python -c "import aiida.storage"
  Time (mean ± σ):     644.3 ms ±  12.0 ms    [User: 608.7 ms, System: 859.6 ms]
  Range (min … max):   632.4 ms … 671.6 ms    10 runs

Benchmark 1: verdi code list
  Time (mean ± σ):     926.9 ms ±  30.6 ms    [User: 871.6 ms, System: 852.1 ms]
  Range (min … max):   889.9 ms … 997.4 ms    10 runs
```

### This branch

```console 
Benchmark 1: python -c "import aiida.orm"
  Time (mean ± σ):     282.4 ms ±   6.3 ms    [User: 296.7 ms, System: 794.5 ms]
  Range (min … max):   273.1 ms … 290.3 ms    10 runs
 
Benchmark 1: python -c "import aiida.storage"
  Time (mean ± σ):     588.4 ms ±  16.3 ms    [User: 564.5 ms, System: 857.0 ms]
  Range (min … max):   560.4 ms … 610.8 ms    10 runs

Benchmark 1: verdi code list
  Time (mean ± σ):     910.0 ms ±  29.4 ms    [User: 862.8 ms, System: 872.7 ms]
  Range (min … max):   836.6 ms … 939.5 ms    10 runs
```