### PR TITLE
Add `aiida` as a `verdi` alias (for now?)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,9 +250,9 @@ tui = [
 ]
 
 [project.scripts]
+aiida = 'aiida.cmdline.commands.cmd_verdi:verdi'
 runaiida = 'aiida.cmdline.commands.cmd_run:run'
 verdi = 'aiida.cmdline.commands.cmd_verdi:verdi'
-aiida = 'aiida.cmdline.commands.cmd_verdi:verdi'
 
 [project.urls]
 Documentation = 'https://aiida.readthedocs.io'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ tui = [
 [project.scripts]
 runaiida = 'aiida.cmdline.commands.cmd_run:run'
 verdi = 'aiida.cmdline.commands.cmd_verdi:verdi'
+aiida = 'aiida.cmdline.commands.cmd_verdi:verdi'
 
 [project.urls]
 Documentation = 'https://aiida.readthedocs.io'


### PR DESCRIPTION
AiiDA should be represented by `aiida` at the command line. Seems obvious. Appears to have been the initial choice but gave way to `verdi` due to a conflict with the `aiida` python package itself. However, this appears to no longer be the case. See https://github.com/orgs/aiidateam/discussions/6381.

Of course, if agreed/accepted, we should consider how to proceed with the docs. At least three votes so far in favor of `aiida` going forward, `verdi` as legacy, so reflect this in docs.