### PR TITLE
Use uv installer in readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,9 @@ build:
     # Use uv to speed up the build
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     post_create_environment:
-    - pip install uv==0.1.44
+    - asdf plugin add uv
+    - asdf install uv 0.1.44
+    - asdf global uv 0.1.44
     post_install:
     - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[docs,tests,rest,atomic_tools]
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,18 +11,14 @@ build:
   - graphviz
   os: ubuntu-22.04
   tools:
-    python: '3.10'
-
-# Need to install the package itself such that the entry points are installed and the API doc can build properly
-python:
-  install:
-  - method: pip
-    path: .
-    extra_requirements:
-    - docs
-    - tests
-    - rest
-    - atomic_tools
+    python: '3.11'
+  jobs:
+    # Use uv to speed up the build
+    # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
+    post_create_environment:
+    - pip install uv==0.1.44
+    post_install:
+    - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[docs,tests,rest,atomic_tools]
 
 # Let the build fail if there are any warnings
 sphinx:


### PR DESCRIPTION
pip install phase of the docs build takes 88 seconds, uv is quite a bit faster. Together with upgrading to python 3.11, this saves around 90s, from 460s to 330s.