### PR TITLE
Capture `ImportTestRun` as `dry-run` success

### DIFF
--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -59,7 +59,6 @@ def test_import_archive(run_cli_command, newest_archive):
 def test_import_dry_run(run_cli_command, archive):
     """Test import dry-run"""
     result = run_cli_command(cmd_archive.import_archive, [archive, '--dry-run'])
-    print(result.output)
     assert f'import dry-run of archive {archive} completed' in result.output
 
 

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -49,6 +49,20 @@ def test_import_archive(run_cli_command, newest_archive):
     run_cli_command(cmd_archive.import_archive, options)
 
 
+@pytest.mark.parametrize(
+    'archive',
+    (
+        get_archive_file('arithmetic.add.aiida', filepath='calcjob'),
+        get_archive_file('export_0.9_simple.aiida', filepath=ARCHIVE_PATH),
+    ),
+)
+def test_import_dry_run(run_cli_command, archive):
+    """Test import dry-run"""
+    result = run_cli_command(cmd_archive.import_archive, [archive, '--dry-run'])
+    print(result.output)
+    assert f'import dry-run of archive {archive} completed' in result.output
+
+
 def test_import_to_group(run_cli_command, newest_archive):
     """Test import to existing Group and that Nodes are added correctly for multiple imports of the same,
     as well as separate, archives.


### PR DESCRIPTION
Fixes #6401

In the `_import_archive_and_migrate` function, the `ImportTestRun` exception is specifically captured, success communicated to the user, and the function returned to not print the final `echo_successs` which is issued after actual archive import into the profile.