### PR TITLE
CLI: Raise if no root node specified in `verdi node graph generate`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -510,6 +510,9 @@ def graph_generate(
         )
         root_node = None
 
+    if not root_node and not nodes:
+        echo.echo_critical('No root node specified, please specify one or more using the `-N/--nodes` option.')
+
     if root_node:
         echo.echo_deprecated(
             'Specifying the root node positionally is deprecated, please use the `-N/--nodes` option instead.'

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -277,6 +277,11 @@ class TestVerdiGraph:
         finally:
             delete_temporary_file(filename)
 
+    def test_no_nodes(self, run_cli_command):
+        """Test the command raises if no root node is specified."""
+        result = run_cli_command(cmd_node.graph_generate, [], raises=True)
+        assert 'Critical: No root node specified, please specify one or more' in result.output
+
     def test_multiple_nodes(self, run_cli_command):
         """Test the `-N/--nodes` option to specify multiple root nodes."""
         node = orm.Data().store()


### PR DESCRIPTION
Fixes #6397

The `root_node` positional argument was recently made optional since it was deprecated and replaced by the `-N/--nodes` option. However, the change forgot to check that at least one root node is specified. Not specifying any would result in an exception.