### PR TITLE
ORM: Fix deprecation warning being shown for new code types

### DIFF
--- a/src/aiida/orm/nodes/data/code/installed.py
+++ b/src/aiida/orm/nodes/data/code/installed.py
@@ -37,6 +37,7 @@ __all__ = ('InstalledCode',)
 class InstalledCode(Code):
     """Data plugin representing an executable code on a remote computer."""
 
+    _EMIT_CODE_DEPRECATION_WARNING: bool = False
     _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE: str = 'filepath_executable'
 
     class Model(AbstractCode.Model):

--- a/src/aiida/orm/nodes/data/code/legacy.py
+++ b/src/aiida/orm/nodes/data/code/legacy.py
@@ -75,13 +75,17 @@ class Code(AbstractCode):
     def __init__(self, remote_computer_exec=None, local_executable=None, input_plugin_name=None, files=None, **kwargs):
         super().__init__(**kwargs)
 
-        warn_deprecation(
-            'The `Code` class is deprecated. To create an instance, use the '
-            '`aiida.orm.nodes.data.code.installed.InstalledCode` or `aiida.orm.nodes.data.code.portable.PortableCode` '
-            'for a "remote" or "local" code, respectively. If you are using this class to compare type, e.g. in '
-            '`isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
-            version=3,
-        )
+        # The ``_EMIT_CODE_DEPRECATION_WARNING`` attribute is set in subclasses to avoid the deprecation message below
+        # is also shown when they are instantiated, since they are not deprecated.
+        if getattr(self, '_EMIT_CODE_DEPRECATION_WARNING', True):
+            warn_deprecation(
+                'The `Code` class is deprecated. To create an instance, use the '
+                '`aiida.orm.nodes.data.code.installed.InstalledCode` or '
+                '`aiida.orm.nodes.data.code.portable.PortableCode` for a "remote" or "local" code, respectively. If '
+                'you are using this class to compare type, e.g. in '
+                '`isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`.',
+                version=3,
+            )
 
         if remote_computer_exec and local_executable:
             raise ValueError('cannot set `remote_computer_exec` and `local_executable` at the same time')

--- a/src/aiida/orm/nodes/data/code/portable.py
+++ b/src/aiida/orm/nodes/data/code/portable.py
@@ -39,6 +39,7 @@ __all__ = ('PortableCode',)
 class PortableCode(Code):
     """Data plugin representing an executable code stored in AiiDA's storage."""
 
+    _EMIT_CODE_DEPRECATION_WARNING: bool = False
     _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE: str = 'filepath_executable'
 
     class Model(AbstractCode.Model):


### PR DESCRIPTION
The `InstalledCode` and `PortableCode` have been introduced already some time ago as the refactored version of the legacy `Code` class. The latter has been deprecated for that reason, but for backwards compatibility reasons, the new implementations still need to keep the legacy class as a base class. Unfortunately, this meant that the deprecation warning was also shown when users instantiated an instance of the new classes, which would be confusing.

The deprecation warning had already been moved from module level to the constructor of the `Code` class to prevent it from showing merely upon import of the `aiida.orm` package. As a final work around, the new classes define the `_EMIT_CODE_DEPRECATION_WARNING` class attribute which is checked in the `Code` constructor such that when set, the deprecation warning is skipped.