### PR TITLE
Make mypy pass with Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,9 +211,9 @@ notebook = [
 ]
 pre-commit = [
   'aiida-core[atomic_tools,rest,tests,tui]',
-  'mypy~=1.7.1',
+  'mypy~=1.10.0',
   'packaging~=23.0',
-  'pre-commit~=2.2',
+  'pre-commit~=3.5',
   'sqlalchemy[mypy]~=2.0',
   'tomli',
   'types-PyYAML'

--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -42,14 +42,20 @@ def get_strict_version():
     :returns: StrictVersion instance with the current version
     :rtype: :class:`!distutils.version.StrictVersion`
     """
-    from distutils.version import StrictVersion
+    import sys
 
-    from aiida.common.warnings import warn_deprecation
+    if sys.version_info >= (3, 12):
+        msg = 'Cannot use get_strict_version() with Python 3.12 and newer'
+        raise RuntimeError(msg)
+    else:
+        from distutils.version import StrictVersion
 
-    warn_deprecation(
-        'This method is deprecated as the `distutils` package it uses will be removed in Python 3.12.', version=3
-    )
-    return StrictVersion(__version__)
+        from aiida.common.warnings import warn_deprecation
+
+        warn_deprecation(
+            'This method is deprecated as the `distutils` package it uses will be removed in Python 3.12.', version=3
+        )
+        return StrictVersion(__version__)
 
 
 def get_version() -> str:

--- a/src/aiida/common/lang.py
+++ b/src/aiida/common/lang.py
@@ -71,7 +71,7 @@ def override_decorator(check=False) -> Callable[[MethodType], MethodType]:
 
                 return func(self, *args, **kwargs)
         else:
-            wrapped_fn = func
+            wrapped_fn = func  # type: ignore[assignment]
 
         return wrapped_fn  # type: ignore[return-value]
 

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -60,7 +60,8 @@ def start_daemon_worker(foreground: bool = False) -> None:
 
     signals = (signal.SIGTERM, signal.SIGINT)
     for s in signals:
-        runner.loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown_worker(runner)))
+        # https://github.com/python/mypy/issues/12557
+        runner.loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown_worker(runner)))  # type: ignore[misc]
 
     try:
         LOGGER.info('Starting a daemon worker')

--- a/src/aiida/engine/processes/functions.py
+++ b/src/aiida/engine/processes/functions.py
@@ -91,7 +91,7 @@ def get_stack_size(size: int = 2) -> int:  # type: ignore[return]
         while frame:  # type: ignore[truthy-bool]
             frame = frame.f_back  # type: ignore[assignment]
             size += 1
-        return size - 1
+        return size - 1  # type: ignore[unreachable]
 
 
 P = ParamSpec('P')


### PR DESCRIPTION
Mypy was failing for me locally on Fedora 39 with Python 3.12 due to missing `distutils` module.
I modified the deprecated `get_strict_version` function so that we raise explicitly for python 3.12 and above. This also fixed the mypy error.

Other drive-by changes:
 - Bump mypy version to 1.10.0 (needed to add a bunch of new type: ignore statements)
 - Bump pre-commit version