### PR TITLE
CLI: minor change on `verdi plugin list` logic to show description 

### DIFF
--- a/src/aiida/cmdline/commands/cmd_plugin.py
+++ b/src/aiida/cmdline/commands/cmd_plugin.py
@@ -49,7 +49,7 @@ def plugin_list(entry_point_group, entry_point):
         else:
             try:
                 if (inspect.isclass(plugin) and issubclass(plugin, Process)) or (
-                    False if not hasattr(plugin, 'is_process_function') else plugin.is_process_function
+                    hasattr(plugin, 'is_process_function') and plugin.is_process_function
                 ):
                     print_process_info(plugin)
                 else:

--- a/src/aiida/cmdline/commands/cmd_plugin.py
+++ b/src/aiida/cmdline/commands/cmd_plugin.py
@@ -48,15 +48,14 @@ def plugin_list(entry_point_group, entry_point):
             echo.echo_critical(str(exception))
         else:
             try:
-                if (inspect.isclass(plugin) and issubclass(plugin, Process)) or plugin.is_process_function:
+                if (inspect.isclass(plugin) and issubclass(plugin, Process)) or (
+                    False if not hasattr(plugin, 'is_process_function') else plugin.is_process_function
+                ):
                     print_process_info(plugin)
                 else:
                     echo.echo(str(plugin.get_description()))
             except AttributeError:
-                try:
-                    echo.echo(str(plugin.get_description()))
-                except AttributeError:
-                    echo.echo_error(f'No description available for {entry_point}')
+                echo.echo_error(f'No description available for {entry_point}')
     else:
         entry_points = get_entry_point_names(entry_point_group)
         if entry_points:

--- a/src/aiida/cmdline/commands/cmd_plugin.py
+++ b/src/aiida/cmdline/commands/cmd_plugin.py
@@ -53,7 +53,10 @@ def plugin_list(entry_point_group, entry_point):
                 else:
                     echo.echo(str(plugin.get_description()))
             except AttributeError:
-                echo.echo_error(f'No description available for {entry_point}')
+                try:
+                    echo.echo(str(plugin.get_description()))
+                except AttributeError:
+                    echo.echo_error(f'No description available for {entry_point}')
     else:
         entry_points = get_entry_point_names(entry_point_group)
         if entry_points:

--- a/tests/cmdline/commands/test_plugin.py
+++ b/tests/cmdline/commands/test_plugin.py
@@ -11,7 +11,7 @@
 import pytest
 from aiida.cmdline.commands import cmd_plugin
 from aiida.parsers import Parser
-from aiida.plugins import CalculationFactory, WorkflowFactory
+from aiida.plugins import CalculationFactory, ParserFactory, WorkflowFactory
 from aiida.plugins.entry_point import ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP
 
 
@@ -66,11 +66,10 @@ class CustomParser(Parser):
 
 
 def test_plugin_description(run_cli_command, entry_points):
-    """Test if `verdi plugin list` would show description of an external plugin."""
-    from aiida.plugins import ParserFactory
+    """Test that ``verdi plugin list`` uses ``get_description`` if defined."""
 
     entry_points.add(CustomParser, 'aiida.parsers:custom.parser')
     assert ParserFactory('custom.parser') is CustomParser
 
     result = run_cli_command(cmd_plugin.plugin_list, ['aiida.parsers', 'custom.parser'])
-    assert result.stdout_bytes.decode('utf-8').strip() == 'str69'
+    assert result.output.strip() == 'str69'

--- a/tests/cmdline/commands/test_plugin.py
+++ b/tests/cmdline/commands/test_plugin.py
@@ -10,6 +10,7 @@
 
 import pytest
 from aiida.cmdline.commands import cmd_plugin
+from aiida.parsers import Parser
 from aiida.plugins import CalculationFactory, WorkflowFactory
 from aiida.plugins.entry_point import ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP
 
@@ -56,3 +57,20 @@ def test_plugin_list_detail(run_cli_command, entry_point_string):
 
     result = run_cli_command(cmd_plugin.plugin_list, [entry_point_group, entry_point_name])
     assert entry_point.__doc__ in result.output
+
+
+class CustomParser(Parser):
+    @classmethod
+    def get_description(cls) -> str:
+        return 'str69'
+
+
+def test_plugin_description(run_cli_command, entry_points):
+    """Test if `verdi plugin list` would show description of an external plugin."""
+    from aiida.plugins import ParserFactory
+
+    entry_points.add(CustomParser, 'aiida.parsers:custom.parser')
+    assert ParserFactory('custom.parser') is CustomParser
+
+    result = run_cli_command(cmd_plugin.plugin_list, ['aiida.parsers', 'custom.parser'])
+    assert result.stdout_bytes.decode('utf-8').strip() == 'str69'


### PR DESCRIPTION
If a plugin that is not a `Process` but hasn't set `plugin.is_process_function=False` supports `get_description()`
 `aiida-core` should understand in this scenario, `plugin.is_process_function` is obviously `False`.
Currently, `AttributeError` could get caught by not having `is_process_function` instead of `get_description()`