### PR TITLE
CI: Update codecov action

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -103,8 +103,9 @@ jobs:
 
     - name: Upload coverage report
       if: matrix.python-version == 3.9 && github.repository == 'aiidateam/aiida-core'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         name: aiida-pytests-py3.9
         file: ./coverage.xml
         fail_ci_if_error: false  # don't fail job, if coverage upload fails

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,8 @@
 codecov:
   notify:
-    after_n_builds: 2
-    wait_for_ci: yes
-  require_ci_to_pass: yes
+    after_n_builds: 1
+    wait_for_ci: no
+  require_ci_to_pass: no
 
 coverage:
   precision: 2  # default, here for transparency


### PR DESCRIPTION
codecov-action@v4 made the CODECOV_TOKEN mandatory for PRs from the origin (and pushes to the origin). This token needs to be generated on codecov.io and added as a repository secret.