### PR TITLE
Fix publishing to DockerHub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         registry: docker.io
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Read build variables
       id: build_vars


### PR DESCRIPTION
Publish to docker.io unfortunately failed on main. Hopefully this is the only mistake :crossed_fingers: 

https://github.com/aiidateam/aiida-core/actions/runs/9254901990/job/25458533243