### PR TITLE
[devops] Run tests with sqlite backend

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -28,7 +28,7 @@ runs:
   - name: Install uv installer
     run: curl --proto '=https' --tlsv1.2 -LsSf https://${{ env.UV_URL }} | sh
     env:
-      UV_VERSION: 0.1.44
+      UV_VERSION: 0.2.5
       UV_URL: github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-installer.sh
     shell: bash
 

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -1,4 +1,4 @@
-name: continuous-integration-code
+name: ci-code
 
 on:
   push:
@@ -12,6 +12,9 @@ concurrency:
     # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
 
@@ -99,7 +102,9 @@ jobs:
       env:
         AIIDA_TEST_PROFILE: test_aiida
         AIIDA_WARN_v3: 1
-      run: pytest --cov aiida --verbose tests -m 'not nightly'
+      # Python 3.12 has a performance regression when running with code coverage
+      # so run code coverage only for python 3.9.
+      run: pytest -v tests -m 'not nightly' ${{ matrix.python-version == '3.9' && '--cov aiida' || '' }}
 
     - name: Upload coverage report
       if: matrix.python-version == 3.9 && github.repository == 'aiidateam/aiida-core'
@@ -110,15 +115,48 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: false  # don't fail job, if coverage upload fails
 
+
+  tests-presto:
+
+    needs: [check-requirements]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install graphviz
+      run: sudo apt update && sudo apt install graphviz
+
+    - name: Install aiida-core
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.11'
+
+    - name: Setup SSH on localhost
+      run: .github/workflows/setup_ssh.sh
+
+    - name: Run test suite
+      env:
+        AIIDA_WARN_v3: 0
+      run: pytest -m 'presto' --cov aiida
+
+    - name: Upload coverage report
+      if: github.repository == 'aiidateam/aiida-core'
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        name: aiida-pytests-presto
+        flags: presto
+        file: ./coverage.xml
+        fail_ci_if_error: false  # don't fail job, if coverage upload fails
+
+
   verdi:
 
+    needs: [check-requirements]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.9', '3.12']
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v4
@@ -126,10 +164,9 @@ jobs:
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: ${{ matrix.python-version }}
-        from-requirements: 'false'
+        python-version: '3.12'
 
-    - name: Run verdi
+    - name: Run verdi tests
       run: |
         verdi devel check-load-time
         verdi devel check-undesired-imports

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -1,4 +1,4 @@
-name: continuous-integration-style
+name: ci-style
 
 on:
   push:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
 
   nightly-tests:
@@ -91,7 +94,7 @@ jobs:
   rabbitmq-tests:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -131,6 +134,12 @@ jobs:
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql
+
+    - name: Setup SSH on localhost
+      run: .github/workflows/setup_ssh.sh
+
+    - name: Suppress RabbitMQ version warning
+      run: verdi config set warnings.rabbitmq_version False
 
     - name: Run tests
       id: tests

--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 set -ev
 
-ssh-keygen -q -t rsa -b 4096 -N "" -f "${HOME}/.ssh/id_rsa"
-ssh-keygen -y -f "${HOME}/.ssh/id_rsa" >> "${HOME}/.ssh/authorized_keys"
-ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
-
-# The permissions on the GitHub runner are 777 which will cause SSH to refuse the keys and cause authentication to fail
-chmod 755 "${HOME}"
+# Setup SSH on localhost
+${GITHUB_WORKSPACE}/.github/workflows/setup_ssh.sh
 
 # Replace the placeholders in configuration files with actual values
 CONFIG="${GITHUB_WORKSPACE}/.github/config"

--- a/.github/workflows/setup_ssh.sh
+++ b/.github/workflows/setup_ssh.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ev
+
+ssh-keygen -q -t rsa -b 4096 -N "" -f "${HOME}/.ssh/id_rsa"
+ssh-keygen -y -f "${HOME}/.ssh/id_rsa" >> "${HOME}/.ssh/authorized_keys"
+ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
+
+# The permissions on the GitHub runner are 777 which will cause SSH to refuse the keys and cause authentication to fail
+chmod 755 "${HOME}"

--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-# Test the loading time of `verdi`. This is and attempt to catch changes to the imports in `aiida.cmdline` that will
-# indirectly load the `aiida.orm` module which will trigger loading of the backend environment. This slows down `verdi`
-# significantly, making tab-completion unusable.
+# Test the loading time of `verdi`. This is an attempt to catch changes to the imports in `aiida.cmdline` that
+# would slow down `verdi` invocations and make tab-completion unusable.
 VERDI=`which verdi`
 
-# Typically, the loading time of `verdi` should be around ~0.2 seconds. When loading the database environment this
-# tends to go towards ~0.8 seconds. Since these timings are obviously machine and environment dependent, typically these
-# types of tests are fragile. But with a load limit of more than twice the ideal loading time, if exceeded, should give
-# a reasonably sure indication that the loading of `verdi` is unacceptably slowed down.
+# Typically, the loading time of `verdi` should be around ~0.2 seconds.
+# Typically these types of tests are fragile. But with a load limit of more than twice
+# the ideal loading time, if exceeded, should give a reasonably sure indication
+# that the loading of `verdi` is unacceptably slowed down.
 LOAD_LIMIT=0.4
 MAX_NUMBER_ATTEMPTS=5
 

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -192,8 +192,11 @@ py:class _asyncio.Future
 
 py:class tqdm.std.tqdm
 
+py:class _pytest.tmpdir.TempPathFactory
+py:class pytest.tmpdir.TempPathFactory
 py:class pytest.TempPathFactory
 py:class PGTest
+py:class pgtest.pgtest.PGTest
 
 py:class IPython.core.magic.Magics
 
@@ -206,8 +209,6 @@ py:class flask_restful.Api
 py:class flask_restful.Resource
 py:class flask.app.Flask
 py:class Flask
-
-py:class pytest.tmpdir.TempPathFactory
 
 py:class scoped_session
 py:class sqlalchemy.orm.decl_api.SqliteModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,8 +351,11 @@ ignore_errors = true
 module = 'plumpy'
 
 [tool.pytest.ini_options]
-addopts = '--benchmark-skip --durations=50 --strict-config --strict-markers -ra --cov-report xml --cov-append '
+addopts = '--benchmark-skip --durations=50 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
 filterwarnings = [
+  'ignore:.*and will be removed in NumPy 2.0.*:DeprecationWarning:ase:',
+  'ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:pytz|dateutil|tqdm|aio_pika:',
+  'ignore:datetime.datetime.utcnow:DeprecationWarning:aio_pika|pytz|pgtest:',
   'ignore::DeprecationWarning:babel:',
   'ignore::DeprecationWarning:frozendict:',
   'ignore::DeprecationWarning:sqlalchemy:',
@@ -360,9 +363,12 @@ filterwarnings = [
   'ignore::DeprecationWarning:pymatgen:',
   'ignore::DeprecationWarning:jsonbackend:',
   'ignore::DeprecationWarning:pkg_resources:',
+  'ignore:ast.* is deprecated.*:DeprecationWarning:docstring_parser:',
+  'ignore::SyntaxWarning:CifFile:',
   'ignore::pytest.PytestCollectionWarning',
   'ignore:Creating AiiDA configuration folder.*:UserWarning',
   'ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning',
+  'ignore:Identity map already had an identity for .* inside of an event handler within the flush?:sqlalchemy.exc.SAWarning',
   'ignore:The `aiida.orm.nodes.data.upf` module is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
   'ignore:The `Code` class is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
   'default::ResourceWarning'
@@ -370,6 +376,8 @@ filterwarnings = [
 markers = [
   'nightly: long running tests that should rarely be affected and so only run nightly',
   'requires_rmq: requires a connection (on port 5672) to RabbitMQ',
+  'requires_psql: requires a connection to PostgreSQL DB',
+  'presto: automatic marker meaning "not requires_rmq and not requires_psql"',
   'sphinx: set parameters for the sphinx `app` fixture'
 ]
 minversion = '7.0'

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -199,7 +199,6 @@ tomli==2.0.1
 tornado==6.3.2
 tqdm==4.65.0
 traitlets==5.9.0
-trogon==0.5.0
 typing-extensions==4.6.3
 tzdata==2023.3
 uc-micro-py==1.0.2

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -197,7 +197,6 @@ tinycss2==1.2.1
 tornado==6.3.2
 tqdm==4.65.0
 traitlets==5.9.0
-trogon==0.5.0
 typing-extensions==4.6.3
 tzdata==2023.3
 uc-micro-py==1.0.2

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -201,7 +201,6 @@ tomli==2.0.1
 tornado==6.3.2
 tqdm==4.65.0
 traitlets==5.9.0
-trogon==0.5.0
 typing-extensions==4.6.3
 tzdata==2023.3
 uc-micro-py==1.0.2

--- a/src/aiida/storage/psql_dos/migrations/utils/integrity.py
+++ b/src/aiida/storage/psql_dos/migrations/utils/integrity.py
@@ -161,7 +161,7 @@ def write_database_integrity_violation(results, headers, reason_message, action_
     :param reason_message: a human readable message detailing the reason of the integrity violation
     :param action_message: an optional human readable message detailing a performed action, if any
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
     from tempfile import NamedTemporaryFile
 
     from tabulate import tabulate
@@ -183,7 +183,7 @@ def write_database_integrity_violation(results, headers, reason_message, action_
             )
         )
 
-        handle.write(f'# {datetime.utcnow().isoformat()}\n')
+        handle.write(f'# {datetime.datetime.now(timezone.utc).isoformat()}\n')
         handle.write(f'# Violation reason: {reason_message}\n')
         handle.write(f'# Performed action: {action_message}\n')
         handle.write('\n')

--- a/src/aiida/tools/pytest_fixtures/__init__.py
+++ b/src/aiida/tools/pytest_fixtures/__init__.py
@@ -25,7 +25,7 @@ from .orm import (
     aiida_localhost,
     ssh_key,
 )
-from .storage import config_psql_dos, postgres_cluster
+from .storage import config_psql_dos, config_sqlite_dos, postgres_cluster
 
 __all__ = (
     'aiida_code_installed',
@@ -44,6 +44,7 @@ __all__ = (
     'aiida_profile_tmp',
     'aiida_profile',
     'config_psql_dos',
+    'config_sqlite_dos',
     'daemon_client',
     'entry_points',
     'postgres_cluster',

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -19,6 +19,8 @@ from aiida.orm import Int
 from kiwipy.rmq import RmqThreadCommunicator
 from packaging.version import parse
 
+pytestmark = pytest.mark.requires_rmq
+
 
 @pytest.mark.parametrize(
     ('version', 'supported'),
@@ -67,7 +69,6 @@ def test_get_rmq_url(args, kwargs, expected):
             utils.get_rmq_url(*args, **kwargs)
 
 
-@pytest.mark.requires_rmq
 @pytest.mark.parametrize('url', ('amqp://guest:guest@127.0.0.1:5672',))
 def test_communicator(url):
     """Test the instantiation of a ``kiwipy.rmq.RmqThreadCommunicator``.
@@ -77,19 +78,16 @@ def test_communicator(url):
     RmqThreadCommunicator.connect(connection_params={'url': url})
 
 
-@pytest.mark.requires_rmq
 def test_add_rpc_subscriber(communicator):
     """Test ``add_rpc_subscriber``."""
     communicator.add_rpc_subscriber(None)
 
 
-@pytest.mark.requires_rmq
 def test_add_broadcast_subscriber(communicator):
     """Test ``add_broadcast_subscriber``."""
     communicator.add_broadcast_subscriber(None)
 
 
-@pytest.mark.requires_rmq
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_duplicate_subscriber_identifier(aiida_code_installed, started_daemon_client, submit_and_await):
     """Test that a ``DuplicateSubscriberError`` in ``ProcessLauncher._continue`` does not except the process.
@@ -148,7 +146,6 @@ def rabbitmq_client(aiida_profile):
     )
 
 
-@pytest.mark.requires_rmq
 class TestRabbitmqManagementClient:
     """Tests for the :class:`aiida.brokers.rabbitmq.client.RabbitmqManagementClient`."""
 

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -16,6 +16,8 @@ from aiida import get_profile
 from aiida.cmdline.commands import cmd_daemon
 from aiida.engine.daemon.client import DaemonClient
 
+pytestmark = pytest.mark.requires_rmq
+
 
 def format_local_time(timestamp, format_str='%Y-%m-%d %H:%M:%S'):
     """Format a datetime object or UNIX timestamp in a human readable format
@@ -26,9 +28,9 @@ def format_local_time(timestamp, format_str='%Y-%m-%d %H:%M:%S'):
     :param timestamp: a datetime object or a float representing a UNIX timestamp
     :param format_str: optional string format to pass to strftime
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
 
-    return datetime.utcfromtimestamp(timestamp).strftime(format_str)
+    return datetime.fromtimestamp(timestamp, timezone.utc).strftime(format_str)
 
 
 def test_daemon_start(run_cli_command, stopped_daemon_client):

--- a/tests/cmdline/commands/test_devel.py
+++ b/tests/cmdline/commands/test_devel.py
@@ -15,6 +15,7 @@ from aiida.cmdline.commands import cmd_devel
 from aiida.orm import Node, ProcessNode, QueryBuilder
 
 
+@pytest.mark.requires_psql
 def test_run_sql(run_cli_command):
     """Test ``verdi devel run-sql``."""
     options = ['SELECT COUNT(*) FROM db_dbnode;']

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -371,6 +371,7 @@ class TestVerdiProcess:
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('numprocesses, percentage', ((0, 100), (1, 90)))
+@pytest.mark.requires_rmq
 def test_list_worker_slot_warning(run_cli_command, monkeypatch, numprocesses, percentage):
     """Test that the if the number of used worker process slots exceeds a threshold,
     that the warning message is displayed to the user when running `verdi process list`

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -15,6 +15,10 @@ from aiida.plugins import StorageFactory
 from aiida.tools.archive.create import create_archive
 from pgtest.pgtest import PGTest
 
+# NOTE: Most of these tests would work with sqlite_dos,
+# but would require generalizing a bunch of fixtures ('profile_factory' et al) in tests/conftest.py
+pytestmark = pytest.mark.requires_psql
+
 
 @pytest.fixture(scope='module')
 def pg_test_cluster():

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -16,6 +16,7 @@ from aiida.orm import Int
 from plumpy.process_comms import RemoteProcessThreadController
 
 
+@pytest.mark.requires_rmq
 def test_queues_list(run_cli_command):
     """Test the ``queues list``"""
     result = run_cli_command(cmd_rabbitmq.cmd_queues_list)

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -19,6 +19,8 @@ from aiida.manage import configuration
 from aiida.manage.external.postgres import Postgres
 from pgtest.pgtest import PGTest
 
+pytestmark = pytest.mark.requires_psql
+
 
 @pytest.fixture(scope='class')
 def pg_test_cluster():

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -26,7 +26,7 @@ def test_status(run_cli_command):
     assert 'The daemon is not running' in result.output
     assert result.exit_code is ExitCode.SUCCESS.value
 
-    for string in ['config', 'profile', 'postgres', 'broker', 'daemon']:
+    for string in ['config', 'profile', 'storage', 'broker', 'daemon']:
         assert string in result.output
 
     assert __version__ in result.output
@@ -48,10 +48,11 @@ def test_status_no_rmq(run_cli_command):
     assert 'rabbitmq' not in result.output
     assert result.exit_code is ExitCode.SUCCESS.value
 
-    for string in ['config', 'profile', 'postgres', 'daemon']:
+    for string in ['config', 'profile', 'storage', 'daemon']:
         assert string in result.output
 
 
+@pytest.mark.requires_psql
 def test_storage_unable_to_connect(run_cli_command):
     """Test `verdi status` when there is an unknown error while connecting to the storage."""
     profile = get_profile()

--- a/tests/common/test_hashing.py
+++ b/tests/common/test_hashing.py
@@ -12,7 +12,7 @@ import collections
 import hashlib
 import itertools
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import numpy as np
@@ -150,7 +150,7 @@ class TestMakeHashTest:
             == '714138f1114daa5fdc74c3483260742952b71b568d634c6093bb838afad76646'
         )
         assert (
-            make_hash(datetime.utcfromtimestamp(0))
+            make_hash(datetime.fromtimestamp(0, timezone.utc))
             == 'b4d97d9d486937775bcc25a5cba073f048348c3cd93d4460174a4f72a6feb285'
         )
 
@@ -167,7 +167,7 @@ class TestMakeHashTest:
     def test_datetime_precision_hashing(self):
         dt_prec = DatetimePrecision(datetime(2018, 8, 18, 8, 18), 10)
         assert make_hash(dt_prec) == '837ab70b3b7bd04c1718834a0394a2230d81242c442e4aa088abeab15622df37'
-        dt_prec_utc = DatetimePrecision(datetime.utcfromtimestamp(0), 0)
+        dt_prec_utc = DatetimePrecision(datetime.fromtimestamp(0, timezone.utc), 0)
         assert make_hash(dt_prec_utc) == '8c756ee99eaf9655bb00166839b9d40aa44eac97684b28f6e3c07d4331ae644e'
 
     def test_numpy_types(self):

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -19,6 +19,8 @@ from aiida.engine.daemon.client import (
     get_daemon_client,
 )
 
+pytestmark = pytest.mark.requires_rmq
+
 
 def test_ipc_socket_file_length_limit():
     """The maximum length of socket filepaths is often limited by the operating system.

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -1292,6 +1292,7 @@ def test_submit_return_exit_code(get_calcjob_builder, monkeypatch):
     assert node.exit_status == 418
 
 
+@pytest.mark.requires_rmq
 def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_and_await):
     """Test that a job can be restarted when it is launched and the daemon is restarted.
 

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -429,8 +429,8 @@ def test_function_default_label():
     assert node.description == CUSTOM_DESCRIPTION
 
 
-def test_launchers():
-    """Verify that the various launchers are working."""
+def test_run_launchers():
+    """Verify that the various non-daemon launchers are working."""
     result = run(function_return_true)
     assert result
 
@@ -439,6 +439,10 @@ def test_launchers():
     assert result == get_true_node()
     assert isinstance(node, orm.CalcFunctionNode)
 
+
+@pytest.mark.requires_rmq
+def test_submit_launchers():
+    """Verify that submit to daemon works."""
     # Process function can be submitted and will be run by a daemon worker as long as the function is importable
     # Note that the actual running is not tested here but is done so in `.github/system_tests/test_daemon.py`.
     node = submit(add_multiply, x=orm.Int(1), y=orm.Int(2), z=orm.Int(3))

--- a/tests/manage/external/test_postgres.py
+++ b/tests/manage/external/test_postgres.py
@@ -10,9 +10,11 @@
 
 from unittest import TestCase
 
+import pytest
 from aiida.manage.external.postgres import Postgres
 
 
+@pytest.mark.requires_psql
 class PostgresTest(TestCase):
     """Test the public API provided by the `Postgres` class"""
 

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -837,6 +837,11 @@ class TestNodeLinks:
 class TestNodeDelete:
     """Tests for deleting nodes."""
 
+    # TODO: Why is this failing for SQLite??
+    # sqlalchemy.orm.exc.ObjectDeletedError: Instance '<DbNode at 0x7f6a68845990>' has been deleted,
+    # or its row is otherwise not present.
+    # https://github.com/aiidateam/aiida-core/issues/6436
+    @pytest.mark.requires_psql
     def test_delete_through_backend(self):
         """Test deletion works correctly through the backend."""
         backend = get_manager().get_profile_storage()

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -24,6 +24,7 @@ from aiida.orm.utils.links import LinkQuadruple
 
 class TestBasic:
     @pytest.mark.usefixtures('aiida_profile_clean')
+    @pytest.mark.requires_psql
     def test_date_filters_support(self):
         """Verify that `datetime.date` is supported in filters."""
         from aiida.common import timezone
@@ -723,18 +724,21 @@ class TestRepresentations:
         qb = orm.QueryBuilder().append(orm.Data, project=['id', 'uuid']).order_by({orm.Data: 'id'})
         self.regress_str(str(qb))
 
+    @pytest.mark.requires_psql
     def test_as_sql(self):
         """Test ``qb.as_sql(inline=False)`` returns the correct string."""
         qb = orm.QueryBuilder()
         qb.append(orm.Node, project=['uuid'], filters={'extras.tag4': 'appl_pecoal'})
         self.regress_str(qb.as_sql(inline=False))
 
+    @pytest.mark.requires_psql
     def test_as_sql_inline(self):
         """Test ``qb.as_sql(inline=True)`` returns the correct string."""
         qb = orm.QueryBuilder()
         qb.append(orm.Node, project=['uuid'], filters={'extras.tag4': 'appl_pecoal'})
         self.regress_str(qb.as_sql(inline=True))
 
+    @pytest.mark.requires_psql
     def test_as_sql_literal_quote(self):
         """Test that literal values can be rendered."""
         qb = orm.QueryBuilder()
@@ -801,6 +805,7 @@ class TestRepresentations:
             assert sorted([uuid for (uuid,) in qb.all()]) == sorted([uuid for (uuid,) in qb_new.all()])
 
 
+@pytest.mark.requires_psql
 def test_analyze_query():
     """Test the query plan is correctly generated."""
     qb = orm.QueryBuilder()
@@ -843,6 +848,7 @@ class TestQueryBuilderCornerCases:
 
 
 class TestAttributes:
+    @pytest.mark.requires_psql
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_attribute_existence(self):
         # I'm storing a value under key whatever:
@@ -866,6 +872,7 @@ class TestAttributes:
         res_query = {str(_[0]) for _ in qb.all()}
         assert res_query == res_uuids
 
+    @pytest.mark.requires_psql
     def test_attribute_type(self):
         key = 'value_test_attr_type'
         n_int, n_float, n_str, n_str2, n_bool, n_arr = [orm.Data() for _ in range(6)]
@@ -1477,6 +1484,9 @@ class TestConsistency:
         for pk in pks:
             assert orm.load_node(pk).base.extras.get('key') == 'value'
 
+    # TODO: This test seems to hang (or takes a looong time), specifically in
+    # pydantic/_internal/_core_utils.py:400
+    @pytest.mark.requires_psql
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_iterall_with_store(self):
         """Test that nodes can be stored while being iterated using ``QueryBuilder.iterall``.
@@ -1499,6 +1509,8 @@ class TestConsistency:
         for pk, pk_clone in zip(pks, sorted(pk_clones)):
             assert orm.load_node(pk) == orm.load_node(pk_clone)
 
+    # TODO: This test seems to hang (or takes a looong time)
+    @pytest.mark.requires_psql
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_iterall_with_store_group(self):
         """Test that nodes can be stored and added to groups while being iterated using ``QueryBuilder.iterall``.
@@ -1563,6 +1575,9 @@ class TestManager:
     def init_db(self, backend):
         self.backend = backend
 
+    # This fails with sqlite with:
+    # sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such function: date_trunc
+    @pytest.mark.requires_psql
     def test_statistics(self):
         """Test if the statistics query works properly.
 
@@ -1599,6 +1614,9 @@ class TestManager:
 
         assert new_db_statistics == expected_db_statistics
 
+    # This fails with sqlite with:
+    # sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such function: date_trunc
+    @pytest.mark.requires_psql
     def test_statistics_default_class(self):
         """Test if the statistics query works properly.
 

--- a/tests/restapi/test_statistics.py
+++ b/tests/restapi/test_statistics.py
@@ -33,7 +33,10 @@ def linearize_namespace(tree_namespace, linear_namespace=None):
     return linear_namespace
 
 
+# This test does not work with SQLite since it uses the `statistics` endpoint,
+# which uses `date_trunc` under the hood, which is not implemented in SQLite.
 @pytest.mark.usefixtures('populate_restapi_database')
+@pytest.mark.requires_psql
 def test_count_consistency(restapi_server, server_url):
     """Test the consistency in values between full_type_count and statistics"""
     server = restapi_server()

--- a/tests/restapi/test_threaded_restapi.py
+++ b/tests/restapi/test_threaded_restapi.py
@@ -21,6 +21,14 @@ import requests
 NO_OF_REQUESTS = 100
 
 
+# This fails with SQLite backend:
+# ERROR tests/restapi/test_threaded_restapi.py::test_run_threaded_server - assert 30.0 == 1
+# where 30.0 = <bound method QueuePool.timeout of <sqlalchemy.pool.impl.QueuePool object at 0x>>()
+# where <bound method QueuePool.timeout of <sqlalchemy.pool.impl.QueuePool object at 0x>> =
+# <sqlalchemy.pool.impl.QueuePool object at 0x>.timeout
+# where <sqlalchemy.pool.impl.QueuePool object at 0x> = Engine(sqlite:////tmp/.../database.sqlite).pool
+# where Engine(sqlite:////tmp/.../database.sqlite) = <sqlalchemy.orm.session.Session object at 0x>.bind
+@pytest.mark.requires_psql
 @pytest.mark.usefixtures('restrict_db_connections')
 def test_run_threaded_server(restapi_server, server_url, aiida_localhost):
     """Run AiiDA REST API threaded in a separate thread and perform many sequential requests.

--- a/tests/storage/psql_dos/conftest.py
+++ b/tests/storage/psql_dos/conftest.py
@@ -14,8 +14,13 @@ from aiida.common.exceptions import MissingConfigurationError
 from aiida.manage.configuration import get_config
 
 try:
-    STORAGE_BACKEND_ENTRY_POINT = get_config().get_profile(os.environ.get('AIIDA_TEST_PROFILE', None)).storage_backend
+    if test_profile := os.environ.get('AIIDA_TEST_PROFILE'):
+        STORAGE_BACKEND_ENTRY_POINT = get_config().get_profile(test_profile).storage_backend
+    # TODO: The else branch is wrong
+    else:
+        STORAGE_BACKEND_ENTRY_POINT = 'core.psql_dos'
 except MissingConfigurationError:
+    # TODO: This is actually not true anymore!
     # Case when ``pytest`` is invoked without existing config, in which case it will rely on the automatic test profile
     # creation which currently always uses ``core.psql_dos`` for the storage backend
     STORAGE_BACKEND_ENTRY_POINT = 'core.psql_dos'

--- a/tests/storage/psql_dos/migrations/conftest.py
+++ b/tests/storage/psql_dos/migrations/conftest.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Tests for the migration engine (Alembic) as well as for the AiiDA migrations for SQLAlchemy."""
 
-from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -17,18 +16,6 @@ from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 from aiida.storage.psql_dos.utils import create_sqlalchemy_engine
 from pgtest.pgtest import PGTest
 from sqlalchemy import text
-
-
-def pytest_collection_modifyitems(config, items):
-    """Dynamically add the ``nightly`` marker to all tests in ``django_branch`` and ``sqlalchemy_branch`` modules."""
-    filepath_django = Path(__file__).parent / 'django_branch'
-    filepath_sqla = Path(__file__).parent / 'sqlalchemy_branch'
-
-    for item in items:
-        filepath_item = Path(item.fspath)
-
-        if filepath_item.is_relative_to(filepath_django) or filepath_item.is_relative_to(filepath_sqla):
-            item.add_marker(getattr(pytest.mark, 'nightly'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/tools/archive/test_schema.py
+++ b/tests/tools/archive/test_schema.py
@@ -10,6 +10,7 @@
 
 from contextlib import suppress
 
+import pytest
 import yaml
 from aiida import get_profile
 from aiida.storage.psql_dos.utils import create_sqlalchemy_engine
@@ -23,6 +24,7 @@ from sqlalchemy.engine import Inspector
 from tests.utils.archives import get_archive_file
 
 
+@pytest.mark.requires_psql
 def test_psql_sync_init(tmp_path):
     """Test the schema is in-sync with the ``psql_dos`` backend, when initialising a new archive."""
     # note, directly using the global profile's engine here left connections open
@@ -38,6 +40,7 @@ def test_psql_sync_init(tmp_path):
             raise AssertionError(f'Schema is not in-sync with the psql backend:\n{yaml.safe_dump(diffs)}')
 
 
+@pytest.mark.requires_psql
 def test_psql_sync_migrate(tmp_path):
     """Test the schema is in-sync with the ``psql_dos`` backend, when migrating an old archive to the latest version."""
     # note, directly using the global profile's engine here left connections open


### PR DESCRIPTION
The purpose of this PR is twofold:

1. Being able to run the test suite locally without requiring any services.
2. Run the full test suite with `sqlite_dos` as a storage backend 

Two new pytest markers are added to the test suite:

 - `requires_pgsql` for tests that are known to require PostgreSQL (i.e. do not work with SQLite)
 - `presto` which is an alias for `not requires_rmq and not requires_pgsql`. The tests are marked with `presto` automagically in `tests/conftest.py:pytest_collection_modifyitems`

Two new CI jobs are added: 
 - `test-presto` runs with `pytest -m presto` 
 - `test-sqlite` runs with `pytest -m `not requires_pgsql`. 
Perhaps we might retain only one of them?

In exchange for introducing two new ones, I removed the two verdi jobs and moved the corresponding tests (such as `verdi devel check-imports` after the normal test run. These are super fast and setting them up separately takes much more time then running them. Happy to discuss this though.