### PR TITLE
CLI: verdi profile setdefault to set-default

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -414,11 +414,13 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      delete      Delete one or more profiles.
-      list        Display a list of all available profiles.
-      setdefault  Set a profile as the default one.
-      setup       Set up a new profile.
-      show        Show details for a profile.
+      delete       Delete one or more profiles.
+      list         Display a list of all available profiles.
+      set-default  Set a profile as the default profile.
+      setdefault   (Deprecated) Set a profile as the default profile (use `verdi profile set-
+                   default`).
+      setup        Set up a new profile.
+      show         Show details for a profile.
 
 
 .. _reference:command-line:verdi-quicksetup:

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -78,7 +78,7 @@ def command_create_profile(
     echo.echo_success(f'Created new profile `{profile.name}`.')
 
     if set_as_default:
-        ctx.invoke(profile_setdefault, profile=profile)
+        ctx.invoke(profile_set_default, profile=profile)
 
 
 @verdi_profile.group(
@@ -147,10 +147,21 @@ def profile_show(profile):
     echo.echo_dictionary(config, fmt='yaml')
 
 
-@verdi_profile.command('setdefault')
+@verdi_profile.command('setdefault', deprecated='Please use `verdi profile set-default` instead.')
 @arguments.PROFILE(required=True, default=None)
 def profile_setdefault(profile):
-    """Set a profile as the default one."""
+    """Set a profile as the default profile (use `verdi profile set-default`)."""
+    _profile_set_default(profile)
+
+
+@verdi_profile.command('set-default')
+@arguments.PROFILE(required=True, default=None)
+def profile_set_default(profile):
+    """Set a profile as the default profile."""
+    _profile_set_default(profile)
+
+
+def _profile_set_default(profile):
     try:
         config = get_config()
     except (exceptions.MissingConfigurationError, exceptions.ConfigurationError) as exception:

--- a/src/aiida/cmdline/commands/cmd_user.py
+++ b/src/aiida/cmdline/commands/cmd_user.py
@@ -60,7 +60,7 @@ def user_list():
 @click.option(
     '--set-default',
     prompt='Set as default?',
-    help='Set the user as the default user for the current profile.',
+    help='Set the user as the default user.',
     is_flag=True,
     cls=options.interactive.InteractiveOption,
     contextual_default=lambda ctx: ctx.params['user'].is_default,

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -53,7 +53,7 @@ def mock_profiles(empty_config, profile_factory):
 
 @pytest.mark.parametrize(
     'command',
-    (cmd_profile.profile_list, cmd_profile.profile_setdefault, cmd_profile.profile_delete, cmd_profile.profile_show),
+    (cmd_profile.profile_list, cmd_profile.profile_set_default, cmd_profile.profile_delete, cmd_profile.profile_show),
 )
 def test_help(run_cli_command, command):
     """Tests help text for all ``verdi profile`` commands."""
@@ -73,7 +73,21 @@ def test_list(run_cli_command, mock_profiles):
 def test_setdefault(run_cli_command, mock_profiles):
     """Test the ``verdi profile setdefault`` command."""
     profile_list = mock_profiles()
-    run_cli_command(cmd_profile.profile_setdefault, [profile_list[1]], use_subprocess=False)
+    setdefault_result = run_cli_command(cmd_profile.profile_setdefault, [profile_list[1]], use_subprocess=False)
+    result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
+
+    assert 'Report: configuration folder:' in result.output
+    assert f'* {profile_list[1]}' in result.output
+
+    # test if deprecation warning is printed
+    assert 'Deprecated:' in setdefault_result.output
+    assert 'Deprecated:' in setdefault_result.stderr
+
+
+def test_set_default(run_cli_command, mock_profiles):
+    """Test the ``verdi profile set-default`` command."""
+    profile_list = mock_profiles()
+    run_cli_command(cmd_profile.profile_set_default, [profile_list[1]], use_subprocess=False)
     result = run_cli_command(cmd_profile.profile_list, use_subprocess=False)
 
     assert 'Report: configuration folder:' in result.output


### PR DESCRIPTION
Fixes #2910 

Since `verdi user` uses `set-default`, but `verdi profile` uses `setdefault`, we make the two consistent by using set-default for profile. Old command is marked as deprecated till version 3