### PR TITLE
Improve deprecated messages from `verdi setup` and `verdi code setup`

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -80,7 +80,7 @@ Below is a list with all available subcommands.
       list       List the available codes.
       relabel    Relabel a code.
       reveal     Reveal one or more hidden codes in `verdi code list`.
-      setup      Setup a new code.
+      setup      (Deprecated) Setup a new code (use `verdi code create`).
       show       Display detailed information for a code.
       test       Run tests for the given code to check whether it is usable.
 
@@ -531,7 +531,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Setup a new profile.
+      (Deprecated) Setup a new profile (use `verdi profile setup`).
 
       This method assumes that an empty PSQL database has been created and that the database
       user has been created.

--- a/src/aiida/cmdline/commands/cmd_code.py
+++ b/src/aiida/cmdline/commands/cmd_code.py
@@ -18,7 +18,7 @@ from aiida.cmdline.groups.dynamic import DynamicEntryPointCommandGroup
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.params.options.commands import code as options_code
 from aiida.cmdline.utils import echo, echo_tabulate
-from aiida.cmdline.utils.decorators import deprecated_command, with_dbenv
+from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common import exceptions
 
 
@@ -89,7 +89,7 @@ def set_code_builder(ctx, param, value):
 # because the ``LABEL`` option has a callback that relies on the computer being already set. Execution order is
 # guaranteed only for the interactive case, however. For the non-interactive case, the callback is called explicitly
 # once more in the command body to cover the case when the label is specified before the computer.
-@verdi_code.command('setup')
+@verdi_code.command('setup', deprecated='Please use `verdi code create` instead.')
 @options_code.ON_COMPUTER()
 @options_code.COMPUTER()
 @options_code.LABEL()
@@ -105,9 +105,8 @@ def set_code_builder(ctx, param, value):
 @options.CONFIG_FILE()
 @click.pass_context
 @with_dbenv()
-@deprecated_command('This command will be removed soon, use `verdi code create` instead.')
 def setup_code(ctx, non_interactive, **kwargs):
-    """Setup a new code."""
+    """Setup a new code (use `verdi code create`)."""
     from aiida.orm.utils.builders.code import CodeBuilder
 
     options_code.validate_label_uniqueness(ctx, None, kwargs['label'])

--- a/src/aiida/cmdline/commands/cmd_setup.py
+++ b/src/aiida/cmdline/commands/cmd_setup.py
@@ -17,8 +17,7 @@ from aiida.cmdline.utils import decorators, echo
 from aiida.manage.configuration import Profile, load_profile
 
 
-@verdi.command('setup')
-@decorators.deprecated_command('This command is deprecated, use `verdi profile setup core.psql_dos` instead.')
+@verdi.command('setup', deprecated='Please use `verdi profile setup` instead.')
 @options.NON_INTERACTIVE()
 @options_setup.SETUP_PROFILE()
 @options_setup.SETUP_USER_EMAIL()
@@ -68,7 +67,7 @@ def setup(
     test_profile,
     profile_uuid,
 ):
-    """Setup a new profile.
+    """Setup a new profile (use `verdi profile setup`).
 
     This method assumes that an empty PSQL database has been created and that the database user has been created.
     """

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -46,6 +46,21 @@ def test_help(run_cli_command):
     run_cli_command(cmd_code.setup_code, ['--help'])
 
 
+def test_code_setup_deprecation(run_cli_command):
+    """Checks if a deprecation warning is printed in stdout and stderr."""
+    # Checks if the deprecation warning is present when invoking the help page
+    result = run_cli_command(cmd_code.setup_code, ['--help'])
+    assert 'Deprecated:' in result.output
+    assert 'Deprecated:' in result.stderr
+
+    # Checks if the deprecation warning is present when invoking the command
+    # Runs setup in interactive mode and sends Ctrl+D (\x04) as input so we exit the prompts.
+    # This way we can check if the deprecated message was printed with the first prompt.
+    result = run_cli_command(cmd_code.setup_code, user_input='\x04', use_subprocess=True, raises=True)
+    assert 'Deprecated:' in result.output
+    assert 'Deprecated:' in result.stderr
+
+
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_code_list_no_codes_error_message(run_cli_command):
     """Test ``verdi code list`` when no codes exist."""

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -40,6 +40,20 @@ class TestVerdiSetup:
         self.pg_test = pg_test_cluster
         self.cli_runner = run_cli_command
 
+    def test_setup_deprecation(self):
+        """Checks if a deprecation warning is printed in stdout and stderr."""
+        # Checks if the deprecation warning is present when invoking the help page
+        result = self.cli_runner(cmd_setup.setup, ['--help'])
+        assert 'Deprecated:' in result.output
+        assert 'Deprecated:' in result.stderr
+
+        # Checks if the deprecation warning is present when invoking the command
+        # Runs setup in interactive mode and sends Ctrl+D (\x04) as input so we exit the prompts.
+        # This way we can check if the deprecation warning was printed with the first prompt.
+        result = self.cli_runner(cmd_setup.setup, user_input='\x04', use_subprocess=True, raises=True)
+        assert 'Deprecated:' in result.output
+        assert 'Deprecated:' in result.stderr
+
     def test_help(self):
         """Check that the `--help` option is eager, is not overruled and will properly display the help message.
 


### PR DESCRIPTION
### Goal
The two main problems I wanted to solve was to add a deprecation warning to the help page of `verdi setup` and `verdi code setup` (easy) as well as printing the deprecation warning before the user has to go through all the prompts (hard). The solution became quite complicated, so I made a second solution that does not do this and just accepts that it is printed afterwards. There are two commits, one for each solution. 

### Question
Right now my question is if the complexity introduced by making a new class `VerdiCommand` is worth to have the warning before the prompts. I am not sure. If we choose the second solution (warning comes after prompts), I would change some things (bring back the `deprecated_command` decorater as it gives us more flexibility).

### Technical aspects about the solution printing the warning before the prompt
Setting the `deprecated` flag from `click.command` is not enough, since the `click.option`s are parsed (and the prompts appear) before the command is invoked where the logic for printing the deprecated warning lies. Therefore I used  `VerdiCommandGroup.get_command` to print something before. This has the the effect that the deprecation warning is also printed when one requests the help page. One can argue if this is desired behavior.

In principle I thought I could just use click.command's `deprecated` flag to consume it (set it to false after a print) in `VerdiCommandGroup.get_command`, but then one gets problems with the validate_consistency test in the verdi-autodocs hook that does not know about this behavior and complains because the help page is not correct (deprecated flag changes also documentation). One could add also this logic to the validate_consistency.py but this adds another point where we need to know about the internal behavior of the cmdline that diverges from click, I was already not a big fan adding one.