### PR TITLE
CLI: Deprecate accepting `0` for `default_mpiprocs_per_machine`

### DIFF
--- a/src/aiida/cmdline/params/options/commands/computer.py
+++ b/src/aiida/cmdline/params/options/commands/computer.py
@@ -124,8 +124,7 @@ MPI_PROCS_PER_MACHINE = OverridableOption(
     prompt_fn=should_call_default_mpiprocs_per_machine,
     required=False,
     type=click.INT,
-    help='The default number of MPI processes that should be executed per machine (node), if not otherwise specified.'
-    'Use 0 to specify no default value.',
+    help='The default number of MPI processes that should be executed per machine (node), if not otherwise specified.',
 )
 
 DEFAULT_MEMORY_PER_MACHINE = OverridableOption(

--- a/src/aiida/orm/utils/builders/computer.py
+++ b/src/aiida/orm/utils/builders/computer.py
@@ -66,6 +66,7 @@ class ComputerBuilder:
 
     def new(self):
         """Build and return a new computer instance (not stored)"""
+        from aiida.common.warnings import warn_deprecation
         from aiida.manage import get_manager
         from aiida.orm import Computer
 
@@ -89,8 +90,12 @@ class ComputerBuilder:
         computer.set_shebang(self._get_and_count('shebang', used))
 
         mpiprocs_per_machine = self._get_and_count('mpiprocs_per_machine', used)
-        # In the command line, 0 means unspecified
         if mpiprocs_per_machine == 0:
+            warn_deprecation(
+                'Specifying `0` to not set `default_mpiprocs_per_machine` is deprecated. If you are in interactive '
+                'mode on the CLI, just specify `!` instead.',
+                version=3,
+            )
             mpiprocs_per_machine = None
         if mpiprocs_per_machine is not None:
             try:


### PR DESCRIPTION
Fixes #4225 

The `verdi computer setup` command would accept the value `0` for the `default_mpiprocs_per_machine` input. This was added as a value for users to indicate as to _not_ set a value for the property. But the CLI has the `!` marker for this purpose. The `ComputerBuilder` converts the `0` to `None` but this conversion now raises a deprecation warning.