### PR TITLE
Refactor: Replace deprecated `IOError` with `OSError`

### DIFF
--- a/.github/workflows/check_release_tag.py
+++ b/.github/workflows/check_release_tag.py
@@ -11,7 +11,7 @@ def get_version_from_module(content: str) -> str:
     try:
         module = ast.parse(content)
     except SyntaxError as exc:
-        raise IOError(f'Unable to parse module: {exc}')
+        raise OSError(f'Unable to parse module: {exc}')
     try:
         return next(
             ast.literal_eval(statement.value)
@@ -21,7 +21,7 @@ def get_version_from_module(content: str) -> str:
             if isinstance(target, ast.Name) and target.id == '__version__'
         )
     except StopIteration:
-        raise IOError('Unable to find __version__ in module')
+        raise OSError('Unable to find __version__ in module')
 
 
 if __name__ == '__main__':

--- a/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_parser.py
+++ b/docs/source/topics/calculations/include/snippets/calcjobs/arithmetic_add_parser.py
@@ -10,7 +10,7 @@ class ArithmeticAddParser(Parser):
         try:
             with output_folder.open(self.node.get_option('output_filename'), 'r') as handle:
                 result = self.parse_stdout(handle)
-        except (OSError, IOError):
+        except OSError:
             return self.exit_codes.ERROR_READING_OUTPUT_FILE
 
         if result is None:

--- a/docs/source/topics/transport_template.py
+++ b/docs/source/topics/transport_template.py
@@ -18,7 +18,7 @@ class NewTransport(Transport):
         """Change directory to 'path'.
 
         :param str path: path to change working directory into.
-        :raises: IOError, if the requested path does not exist
+        :raises: OSError, if the requested path does not exist
         :rtype: string
         """
 
@@ -35,7 +35,7 @@ class NewTransport(Transport):
         :param str remotesource: path of the remote source directory / file
         :param str remotedestination: path of the remote destination directory / file
 
-        :raises: IOError, if source or destination does not exist
+        :raises: OSError, if source or destination does not exist
         """
 
     def copyfile(self, remotesource, remotedestination, *args, **kwargs):
@@ -44,7 +44,7 @@ class NewTransport(Transport):
         :param str remotesource: path of the remote source directory / file
         :param str remotedestination: path of the remote destination directory / file
 
-        :raises IOError: if one of src or dst does not exist
+        :raises OSError: if one of src or dst does not exist
         """
 
     def copytree(self, remotesource, remotedestination, *args, **kwargs):
@@ -53,7 +53,7 @@ class NewTransport(Transport):
         :param str remotesource: path of the remote source directory / file
         :param str remotedestination: path of the remote destination directory / file
 
-        :raise IOError: if one of src or dst does not exist
+        :raise OSError: if one of src or dst does not exist
         """
 
     def exec_command_wait_bytes(self, command, stdin=None, **kwargs):
@@ -177,7 +177,7 @@ class NewTransport(Transport):
         "current folder".
 
         :param str path: path to be normalized
-        :raise IOError: if the path can't be resolved on the server
+        :raise OSError: if the path can't be resolved on the server
         """
 
     def put(self, localpath, remotepath, *args, **kwargs):
@@ -214,7 +214,7 @@ class NewTransport(Transport):
 
         :param str oldpath: existing name of the file or folder
         :param str newpath: new name for the file or folder
-        :raises IOError: if src/dst is not found
+        :raises OSError: if src/dst is not found
         :raises ValueError: if src/dst is not a valid string
         """
 
@@ -224,7 +224,7 @@ class NewTransport(Transport):
         This only works on files; for removing folders (directories), use rmdir.
 
         :param str path: path to file to remove
-        :raise IOError: if the path is a directory
+        :raise OSError: if the path is a directory
         """
 
     def rmdir(self, path):

--- a/src/aiida/cmdline/commands/cmd_calcjob.py
+++ b/src/aiida/cmdline/commands/cmd_calcjob.py
@@ -139,7 +139,7 @@ def calcjob_remotecat(calcjob, path):
             remote_folder.getfile(path, tmp_path.name)
             with open(tmp_path.name, 'rb') as handle:
                 shutil.copyfileobj(handle, sys.stdout.buffer)
-        except IOError as exception:
+        except OSError as exception:
             echo.echo_critical(str(exception))
 
 

--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -135,7 +135,7 @@ def _computer_create_temp_file(transport, scheduler, authinfo, computer):
 
     try:
         transport.chdir(workdir)
-    except IOError:
+    except OSError:
         transport.makedirs(workdir)
         transport.chdir(workdir)
 

--- a/src/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -91,7 +91,7 @@ def cif_content(data):
     for node in data:
         try:
             echo.echo(node.get_content())
-        except IOError as exception:
+        except OSError as exception:
             echo.echo_warning(f'could not read the content for CifData<{node.pk}>: {exception!s}')
 
 

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -39,7 +39,7 @@ def remote_ls(ls_long, path, datum):
 
     try:
         content = datum.listdir_withattributes(path=path)
-    except (IOError, OSError) as err:
+    except OSError as err:
         echo.echo_critical(f'Unable to access the remote folder or file, check if it exists.\nOriginal error: {err!s}')
     for metadata in content:
         if ls_long:
@@ -71,7 +71,7 @@ def remote_cat(datum, path):
             datum.getfile(path, tmpf.name)
             with open(tmpf.name, encoding='utf8') as fhandle:
                 sys.stdout.write(fhandle.read())
-    except IOError as err:
+    except OSError as err:
         echo.echo_critical(f'{err.errno}: {err!s}')
 
     try:

--- a/src/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
@@ -25,5 +25,5 @@ def singlefile_content(datum):
     """Show the content of the file."""
     try:
         echo.echo(datum.get_content())
-    except (IOError, OSError) as exception:
+    except OSError as exception:
         echo.echo_critical(f'could not read the content for SinglefileData<{datum.pk}>: {exception!s}')

--- a/src/aiida/common/files.py
+++ b/src/aiida/common/files.py
@@ -18,7 +18,7 @@ def md5_from_filelike(filelike, block_size_factor=128):
     :param block_size_factor: the file is read at chunks of size ``block_size_factor * md5.block_size``, where
         ``md5.block_size`` is the block_size used internally by the hashlib module.
     :returns: a string with the hexdigest md5.
-    :raises: no checks are done on the filelike object, so it may raise IOError if it cannot be read from.
+    :raises: no checks are done on the filelike object, so it may raise OSError if it cannot be read from.
     """
     md5 = hashlib.md5()
 
@@ -37,7 +37,7 @@ def md5_file(filepath, block_size_factor=128):
         ``md5.block_size`` is the block_size used internally by the hashlib module.
     :returns: a string with the hexdigest md5.
     :raises: No checks are done on the file, so if it doesn't exists it may
-        raise IOError.
+        raise OSError.
     """
     with open(filepath, 'rb', encoding=None) as handle:
         return md5_from_filelike(handle, block_size_factor=block_size_factor)
@@ -55,7 +55,7 @@ def sha1_file(filename, block_size_factor=128):
     :returns: a string with the hexdigest sha1.
 
     :raises: No checks are done on the file, so if it doesn't exists it may
-        raise IOError.
+        raise OSError.
     """
     sha1 = hashlib.sha1()
     with open(filename, 'rb', encoding=None) as fhandle:

--- a/src/aiida/common/folders.py
+++ b/src/aiida/common/folders.py
@@ -184,7 +184,7 @@ class Folder:
                     # This automatically overwrites files
                     shutil.copyfile(src, dest_abs_path)
                 else:
-                    raise IOError(f'destination already exists: {os.path.join(dest_abs_path)}')
+                    raise OSError(f'destination already exists: {os.path.join(dest_abs_path)}')
             else:
                 shutil.copyfile(src, dest_abs_path)
         elif os.path.isdir(src):
@@ -197,7 +197,7 @@ class Folder:
                     # This automatically overwrites files
                     shutil.copytree(src, dest_abs_path)
                 else:
-                    raise IOError(f'destination already exists: {os.path.join(dest_abs_path)}')
+                    raise OSError(f'destination already exists: {os.path.join(dest_abs_path)}')
             else:
                 shutil.copytree(src, dest_abs_path)
         else:
@@ -339,11 +339,11 @@ class Folder:
         :param move: if True, the srcdir is moved to the repository. Otherwise, it is only copied.
         :type move: bool
         :param overwrite: if True, the folder will be erased first.
-            if False, an IOError is raised if the folder already exists.
+            if False, an OSError is raised if the folder already exists.
             Whatever the value of this flag, parent directories will be created, if needed.
         :type overwrite: bool
 
-        :raises IOError: in case of problems accessing or writing the files.
+        :raises OSError: in case of problems accessing or writing the files.
         :raises OSError: in case of problems accessing or writing the files (from ``shutil`` module).
         :raises ValueError: if the section is not recognized.
         """
@@ -352,7 +352,7 @@ class Folder:
         if overwrite:
             self.erase()
         elif self.exists():
-            raise IOError(f'Location {self.abspath} already exists, and overwrite is set to False')
+            raise OSError(f'Location {self.abspath} already exists, and overwrite is set to False')
 
         # Create parent dir, if needed, with the right mode
         pardir = os.path.dirname(self.abspath)

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -192,7 +192,7 @@ class DaemonClient:
             try:
                 with open(self.circus_port_file, 'r', encoding='utf8') as fhandle:
                     return int(fhandle.read().strip())
-            except (ValueError, IOError):
+            except (ValueError, OSError):
                 raise RuntimeError('daemon is running so port file should have been there but could not read it')
         else:
             port = self.get_available_port()
@@ -241,7 +241,7 @@ class DaemonClient:
                 with open(self.circus_socket_file, 'r', encoding='utf8') as fhandle:
                     content = fhandle.read().strip()
                 return content
-            except (ValueError, IOError):
+            except (ValueError, OSError):
                 raise RuntimeError('daemon is running so sockets file should have been there but could not read it')
         else:
             # The SOCKET_DIRECTORY is already set, a temporary directory was already created and the same should be used
@@ -265,7 +265,7 @@ class DaemonClient:
                 with open(self.circus_pid_file, 'r', encoding='utf8') as fhandle:
                     content = fhandle.read().strip()
                 return int(content)
-            except (ValueError, IOError):
+            except (ValueError, OSError):
                 return None
         else:
             return None

--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -116,7 +116,7 @@ def upload_calculation(
         # If it already exists, no exception is raised
         try:
             transport.chdir(remote_working_directory)
-        except IOError:
+        except OSError:
             logger.debug(
                 f'[submission of calculation {node.pk}] Unable to '
                 f'chdir in {remote_working_directory}, trying to create it'
@@ -296,7 +296,7 @@ def _copy_remote_files(logger, node, computer, transport, remote_copy_list, remo
                     f'[submission of calculation {node.pk}] Unable to copy remote '
                     f'resource from {remote_abs_path} to {dest_rel_path}! NOT Stopping but just ignoring!.'
                 )
-            except (IOError, OSError):
+            except OSError:
                 logger.warning(
                     f'[submission of calculation {node.pk}] Unable to copy remote '
                     f'resource from {remote_abs_path} to {dest_rel_path}! Stopping.'
@@ -318,14 +318,14 @@ def _copy_remote_files(logger, node, computer, transport, remote_copy_list, remo
             try:
                 transport.makedirs(remote_dirname, ignore_existing=True)
                 transport.symlink(remote_abs_path, dest_rel_path)
-            except (IOError, OSError):
+            except OSError:
                 logger.warning(
                     f'[submission of calculation {node.pk}] Unable to create remote symlink '
                     f'from {remote_abs_path} to {dest_rel_path}! Stopping.'
                 )
                 raise
         else:
-            raise IOError(
+            raise OSError(
                 f'It is not possible to create a symlink between two different machines for calculation {node.pk}'
             )
 
@@ -459,7 +459,7 @@ def stash_calculation(calculation: CalcJobNode, transport: Transport) -> None:
 
             try:
                 transport.copy(str(source_filepath), str(target_filepath))
-            except (IOError, ValueError) as exception:
+            except (OSError, ValueError) as exception:
                 EXEC_LOGGER.warning(f'failed to stash {source_filepath} to {target_filepath}: {exception}')
             else:
                 EXEC_LOGGER.debug(f'stashed {source_filepath} to {target_filepath}')

--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -424,7 +424,7 @@ class BaseRestartWorkChain(WorkChain):
                 try:
                     called_descendant.outputs.remote_folder._clean()
                     cleaned_calcs.append(str(called_descendant.pk))
-                except (IOError, OSError, KeyError):
+                except (OSError, OSError, KeyError):
                     pass
 
         if cleaned_calcs:

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -60,8 +60,8 @@ class RemoteData(Data):
         with transport:
             try:
                 transport.chdir(self.get_remote_path())
-            except IOError:
-                # If the transport IOError the directory no longer exists and was deleted
+            except OSError:
+                # If the transport OSError the directory no longer exists and was deleted
                 return True
 
             return not transport.listdir()
@@ -78,9 +78,9 @@ class RemoteData(Data):
             try:
                 full_path = os.path.join(self.get_remote_path(), relpath)
                 transport.getfile(full_path, destpath)
-            except IOError as exception:
+            except OSError as exception:
                 if exception.errno == 2:  # file does not exist
-                    raise IOError(
+                    raise OSError(
                         'The required remote file {} on {} does not exist or has been deleted.'.format(
                             full_path, self.computer.label
                         )
@@ -99,9 +99,9 @@ class RemoteData(Data):
             try:
                 full_path = os.path.join(self.get_remote_path(), relpath)
                 transport.chdir(full_path)
-            except IOError as exception:
+            except OSError as exception:
                 if exception.errno in (2, 20):  # directory not existing or not a directory
-                    exc = IOError(
+                    exc = OSError(
                         f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
                         'directory or has been deleted.'
                     )
@@ -112,9 +112,9 @@ class RemoteData(Data):
 
             try:
                 return transport.listdir()
-            except IOError as exception:
+            except OSError as exception:
                 if exception.errno in (2, 20):  # directory not existing or not a directory
-                    exc = IOError(
+                    exc = OSError(
                         f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
                         'directory or has been deleted.'
                     )
@@ -135,9 +135,9 @@ class RemoteData(Data):
             try:
                 full_path = os.path.join(self.get_remote_path(), path)
                 transport.chdir(full_path)
-            except IOError as exception:
+            except OSError as exception:
                 if exception.errno in (2, 20):  # directory not existing or not a directory
-                    exc = IOError(
+                    exc = OSError(
                         f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
                         'directory or has been deleted.'
                     )
@@ -148,9 +148,9 @@ class RemoteData(Data):
 
             try:
                 return transport.listdir_withattributes()
-            except IOError as exception:
+            except OSError as exception:
                 if exception.errno in (2, 20):  # directory not existing or not a directory
-                    exc = IOError(
+                    exc = OSError(
                         f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
                         'directory or has been deleted.'
                     )

--- a/src/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/src/aiida/orm/nodes/process/calculation/calcjob.py
@@ -520,7 +520,7 @@ class CalcJobNode(CalculationNode):
 
         try:
             stdout = retrieved_node.base.repository.get_object_content(filename)
-        except IOError:
+        except OSError:
             stdout = None
 
         return stdout
@@ -538,7 +538,7 @@ class CalcJobNode(CalculationNode):
 
         try:
             stderr = retrieved_node.base.repository.get_object_content(filename)
-        except IOError:
+        except OSError:
             stderr = None
 
         return stderr

--- a/src/aiida/orm/utils/mixins.py
+++ b/src/aiida/orm/utils/mixins.py
@@ -45,7 +45,7 @@ class FunctionCalculationMixin:
 
         try:
             source_list, starting_line_number = inspect.getsourcelines(func)
-        except (IOError, OSError):
+        except OSError:
             pass
         else:
             self._set_function_starting_line_number(starting_line_number)
@@ -63,7 +63,7 @@ class FunctionCalculationMixin:
                     self.base.repository.put_object_from_filelike(  # type: ignore[attr-defined]
                         handle, self.FUNCTION_SOURCE_FILE_PATH
                     )
-        except (IOError, OSError):
+        except OSError:
             pass
 
     @property

--- a/src/aiida/orm/utils/remote.py
+++ b/src/aiida/orm/utils/remote.py
@@ -34,7 +34,7 @@ def clean_remote(transport, path):
     try:
         transport.chdir(basedir)
         transport.rmtree(relative_path)
-    except IOError:
+    except OSError:
         pass
 
 

--- a/src/aiida/parsers/plugins/templatereplacer/parser.py
+++ b/src/aiida/parsers/plugins/templatereplacer/parser.py
@@ -30,7 +30,7 @@ class TemplatereplacerParser(Parser):
         try:
             with output_folder.base.repository.open(output_file, 'r') as handle:
                 result = handle.read()
-        except (OSError, IOError):
+        except OSError:
             self.logger.exception(f'unable to parse the output for CalcJobNode<{self.node.pk}>')
             return self.exit_codes.ERROR_READING_OUTPUT_FILE
 

--- a/src/aiida/storage/psql_dos/migrations/utils/utils.py
+++ b/src/aiida/storage/psql_dos/migrations/utils/utils.py
@@ -372,7 +372,7 @@ def delete_numpy_array_from_repository(repository_path, uuid, name):
 
     try:
         os.remove(filepath)
-    except (IOError, OSError):
+    except OSError:
         pass
 
 

--- a/src/aiida/tools/archive/abstract.py
+++ b/src/aiida/tools/archive/abstract.py
@@ -111,7 +111,7 @@ class ArchiveWriterAbstract(ABC):
         """Delete the object from the archive.
 
         :param key: fully qualified identifier for the object within the repository.
-        :raise IOError: if the file could not be deleted.
+        :raise OSError: if the file could not be deleted.
         """
 
 

--- a/src/aiida/tools/archive/implementations/sqlite_zip/writer.py
+++ b/src/aiida/tools/archive/implementations/sqlite_zip/writer.py
@@ -192,7 +192,7 @@ class ArchiveWriterSqlZip(ArchiveWriterAbstract):
         return key
 
     def delete_object(self, key: str) -> None:
-        raise IOError(f'Cannot delete objects in {self._mode!r} mode')
+        raise OSError(f'Cannot delete objects in {self._mode!r} mode')
 
 
 class ArchiveAppenderSqlZip(ArchiveWriterSqlZip):
@@ -201,7 +201,7 @@ class ArchiveAppenderSqlZip(ArchiveWriterSqlZip):
     def delete_object(self, key: str) -> None:
         self._assert_in_context()
         if f'{utils.REPO_FOLDER}/{key}' in self._central_dir:
-            raise IOError(f'Cannot delete object {key!r} that has been added in the same append context')
+            raise OSError(f'Cannot delete object {key!r} that has been added in the same append context')
         self._deleted_paths.add(f'{utils.REPO_FOLDER}/{key}')
 
     def __enter__(self) -> 'ArchiveAppenderSqlZip':

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -107,9 +107,9 @@ class LocalTransport(Transport):
         """
         new_path = os.path.join(self.curdir, path)
         if not os.path.isdir(new_path):
-            raise IOError(f"'{new_path}' is not a valid directory")
+            raise OSError(f"'{new_path}' is not a valid directory")
         elif not os.access(new_path, os.R_OK):
-            raise IOError(f"Do not have read permission to '{new_path}'")
+            raise OSError(f"Do not have read permission to '{new_path}'")
 
         self._internal_dir = os.path.normpath(new_path)
 
@@ -202,13 +202,13 @@ class LocalTransport(Transport):
         :param path: path to modify
         :param mode: permission bits
 
-        :raise IOError: if path does not exist.
+        :raise OSError: if path does not exist.
         """
         if not path:
-            raise IOError('Directory not given in input')
+            raise OSError('Directory not given in input')
         real_path = os.path.join(self.curdir, path)
         if not os.path.exists(real_path):
-            raise IOError('Directory not given in input')
+            raise OSError('Directory not given in input')
         else:
             os.chmod(real_path, mode)
 
@@ -225,14 +225,14 @@ class LocalTransport(Transport):
         :param overwrite: if True overwrites remotepath.
                                  Default = False
 
-        :raise IOError: if remotepath is not valid
+        :raise OSError: if remotepath is not valid
         :raise ValueError: if localpath is not valid
         """
         dereference = kwargs.get('dereference', args[0] if args else True)
         overwrite = kwargs.get('overwrite', args[1] if len(args) > 1 else True)
         ignore_nonexisting = kwargs.get('ignore_noexisting', args[2] if len(args) > 2 else False)
         if not remotepath:
-            raise IOError('Input remotepath to put function must be a non empty string')
+            raise OSError('Input remotepath to put function must be a non empty string')
         if not localpath:
             raise ValueError('Input localpath to put function must be a non empty string')
 
@@ -294,13 +294,13 @@ class LocalTransport(Transport):
         :param overwrite: if True overwrites remotepath
                                  Default = False
 
-        :raise IOError: if remotepath is not valid
+        :raise OSError: if remotepath is not valid
         :raise ValueError: if localpath is not valid
         :raise OSError: if localpath does not exist
         """
         overwrite = kwargs.get('overwrite', args[0] if args else True)
         if not remotepath:
-            raise IOError('Input remotepath to putfile must be a non empty string')
+            raise OSError('Input remotepath to putfile must be a non empty string')
         if not localpath:
             raise ValueError('Input localpath to putfile must be a non empty string')
 
@@ -327,14 +327,14 @@ class LocalTransport(Transport):
         :param overwrite: if True overwrites remotepath.
                                Default = False
 
-        :raise IOError: if remotepath is not valid
+        :raise OSError: if remotepath is not valid
         :raise ValueError: if localpath is not valid
         :raise OSError: if localpath does not exist
         """
         dereference = kwargs.get('dereference', args[0] if args else True)
         overwrite = kwargs.get('overwrite', args[1] if len(args) > 1 else True)
         if not remotepath:
-            raise IOError('Input remotepath to putfile must be a non empty string')
+            raise OSError('Input remotepath to putfile must be a non empty string')
         if not localpath:
             raise ValueError('Input localpath to putfile must be a non empty string')
 
@@ -370,7 +370,7 @@ class LocalTransport(Transport):
             elif exception.errno == errno.ENOTDIR:
                 os.remove(the_path)
             else:
-                raise IOError(exception)
+                raise OSError(exception)
 
     # please refactor: issue #1781
 
@@ -386,7 +386,7 @@ class LocalTransport(Transport):
         :param overwrite: if True overwrites localpath
                                default = False
 
-        :raise IOError: if 'remote' remotepath is not valid
+        :raise OSError: if 'remote' remotepath is not valid
         :raise ValueError: if 'local' localpath is not valid
         """
         dereference = kwargs.get('dereference', args[0] if args else True)
@@ -395,7 +395,7 @@ class LocalTransport(Transport):
         if not localpath:
             raise ValueError('Input localpath to get function must be a non empty string')
         if not remotepath:
-            raise IOError('Input remotepath to get function must be a non empty string')
+            raise OSError('Input remotepath to get function must be a non empty string')
 
         if not os.path.isabs(localpath):
             raise ValueError('Destination must be an absolute path')
@@ -409,7 +409,7 @@ class LocalTransport(Transport):
             if len(to_copy_list) > 1:
                 # I can't scp more than one file on a single file
                 if os.path.isfile(localpath):
-                    raise IOError('Remote localpath is not a directory')
+                    raise OSError('Remote localpath is not a directory')
                 # I can't scp more than one file in a non existing directory
                 elif not os.path.exists(localpath):  # this should hold only for files
                     raise OSError('Remote directory does not exist')
@@ -438,7 +438,7 @@ class LocalTransport(Transport):
         elif ignore_nonexisting:
             pass
         else:
-            raise IOError(f'The remote path {remotepath} does not exist')
+            raise OSError(f'The remote path {remotepath} does not exist')
 
     def getfile(self, remotepath, localpath, *args, **kwargs):
         """Copies a file recursively from 'remote' remotepath to
@@ -449,7 +449,7 @@ class LocalTransport(Transport):
         :param overwrite: if True overwrites localpath.
                                Default = False
 
-        :raise IOError if 'remote' remotepath is not valid or not found
+        :raise OSError if 'remote' remotepath is not valid or not found
         :raise ValueError: if 'local' localpath is not valid
         :raise OSError: if unintentionally overwriting
         """
@@ -457,10 +457,10 @@ class LocalTransport(Transport):
         if not localpath:
             raise ValueError('Input localpath to get function must be a non empty string')
         if not remotepath:
-            raise IOError('Input remotepath to get function must be a non empty string')
+            raise OSError('Input remotepath to get function must be a non empty string')
         the_source = os.path.join(self.curdir, remotepath)
         if not os.path.exists(the_source):
-            raise IOError('Source not found')
+            raise OSError('Source not found')
         if not os.path.isabs(localpath):
             raise ValueError('Destination must be an absolute path')
         if os.path.exists(localpath) and not overwrite:
@@ -477,14 +477,14 @@ class LocalTransport(Transport):
         :param dereference: follow symbolic links. Default = True
         :param overwrite: if True overwrites localpath. Default = False
 
-        :raise IOError: if 'remote' remotepath is not valid
+        :raise OSError: if 'remote' remotepath is not valid
         :raise ValueError: if 'local' localpath is not valid
         :raise OSError: if unintentionally overwriting
         """
         dereference = kwargs.get('dereference', args[0] if args else True)
         overwrite = kwargs.get('overwrite', args[1] if len(args) > 1 else True)
         if not remotepath:
-            raise IOError('Remotepath must be a non empty string')
+            raise OSError('Remotepath must be a non empty string')
         if not localpath:
             raise ValueError('Localpaths must be a non empty string')
 
@@ -492,7 +492,7 @@ class LocalTransport(Transport):
             raise ValueError('Localpaths must be an absolute path')
 
         if not self.isdir(remotepath):
-            raise IOError(f'Input remotepath is not a folder: {remotepath}')
+            raise OSError(f'Input remotepath is not a folder: {remotepath}')
 
         if os.path.exists(localpath) and not overwrite:
             raise OSError("Can't overwrite existing files")
@@ -662,7 +662,7 @@ class LocalTransport(Transport):
             try:
                 return os.listdir(the_path)
             except OSError as err:
-                exc = IOError(str(err))
+                exc = OSError(str(err))
                 exc.errno = err.errno
                 raise exc
         else:
@@ -797,7 +797,7 @@ class LocalTransport(Transport):
         :param str oldpath: existing name of the file or folder
         :param str newpath: new name for the file or folder
 
-        :raises IOError: if src/dst is not found
+        :raises OSError: if src/dst is not found
         :raises ValueError: if src/dst is not a valid string
         """
         if not oldpath:
@@ -805,9 +805,9 @@ class LocalTransport(Transport):
         if not newpath:
             raise ValueError(f'Destination {newpath} is not a valid string')
         if not os.path.exists(oldpath):
-            raise IOError(f'Source {oldpath} does not exist')
+            raise OSError(f'Source {oldpath} does not exist')
         if not os.path.exists(newpath):
-            raise IOError(f'Destination {newpath} does not exist')
+            raise OSError(f'Destination {newpath} does not exist')
 
         shutil.move(oldpath, newpath)
 

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -248,7 +248,7 @@ class Transport(abc.ABC):
         """Change directory to 'path'
 
         :param str path: path to change working directory into.
-        :raises: IOError, if the requested path does not exist
+        :raises: OSError, if the requested path does not exist
         :rtype: str
         """
 
@@ -284,7 +284,7 @@ class Transport(abc.ABC):
         :param recursive: if True copy directories recursively, otherwise only copy the specified file(s)
         :type recursive: bool
 
-        :raises: IOError, if one of src or dst does not exist
+        :raises: OSError, if one of src or dst does not exist
         """
 
     @abc.abstractmethod
@@ -297,7 +297,7 @@ class Transport(abc.ABC):
         :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
         :type dereference: bool
 
-        :raises IOError: if one of src or dst does not exist
+        :raises OSError: if one of src or dst does not exist
         """
 
     @abc.abstractmethod
@@ -310,7 +310,7 @@ class Transport(abc.ABC):
         :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
         :type dereference: bool
 
-        :raise IOError: if one of src or dst does not exist
+        :raise OSError: if one of src or dst does not exist
         """
 
     def copy_from_remote_to_remote(self, transportdestination, remotesource, remotedestination, **kwargs):
@@ -570,7 +570,7 @@ class Transport(abc.ABC):
 
         :param str path: path to be normalized
 
-        :raise IOError: if the path can't be resolved on the server
+        :raise OSError: if the path can't be resolved on the server
         """
 
     @abc.abstractmethod
@@ -608,7 +608,7 @@ class Transport(abc.ABC):
 
         :param str path: path to file to remove
 
-        :raise IOError: if the path is a directory
+        :raise OSError: if the path is a directory
         """
 
     @abc.abstractmethod
@@ -618,7 +618,7 @@ class Transport(abc.ABC):
         :param str oldpath: existing name of the file or folder
         :param str newpath: new name for the file or folder
 
-        :raises IOError: if oldpath/newpath is not found
+        :raises OSError: if oldpath/newpath is not found
         :raises ValueError: if oldpath/newpath is not a valid string
         """
 
@@ -677,7 +677,7 @@ class Transport(abc.ABC):
             return username.strip()
 
         self.logger.error(f"Problem executing whoami. Exit code: {retval}, stdout: '{username}', stderr: '{stderr}'")
-        raise IOError(f'Error while executing whoami. Exit code: {retval}')
+        raise OSError(f'Error while executing whoami. Exit code: {retval}')
 
     @abc.abstractmethod
     def path_exists(self, path):

--- a/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
+++ b/tests/storage/psql_dos/migrations/django_branch/test_0026_0027_traj_data.py
@@ -73,7 +73,7 @@ def test_traj_data(perform_migrations: PsqlDosMigrator):
     perform_migrations.migrate_up('django@django_0027')
 
     # it should no longer be in the repository
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         utils.load_numpy_array_from_repository(repo_path, node_uuid, name)
 
     # and instead, it should be in the attributes

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_6_trajectory_data.py
@@ -96,5 +96,5 @@ def test_trajectory_data(perform_migrations: PsqlDosMigrator):
         assert node.attributes['symbols'] == ['H', 'O', 'C']
         assert get_node_array(node, repo_path, 'velocities').tolist() == velocities.tolist()
         assert get_node_array(node, repo_path, 'positions').tolist() == positions.tolist()
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             get_node_array(node, repo_path, 'symbols')

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -277,7 +277,7 @@ class TestDirectoryManipulation:
             transport.rmdir(dest_directory)
 
     def test_dir_permissions_creation_modification(self, custom_transport):
-        """Verify if chmod raises IOError when trying to change bits on a
+        """Verify if chmod raises OSError when trying to change bits on a
         non-existing folder
         """
         with custom_transport as transport:
@@ -315,11 +315,11 @@ class TestDirectoryManipulation:
 
             # change permissions of an empty string, non existing folder.
             fake_dir = ''
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.chmod(fake_dir, 0o777)
 
             fake_dir = 'pippo'
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 # chmod to a non existing folder
                 transport.chmod(fake_dir, 0o777)
 
@@ -350,7 +350,7 @@ class TestDirectoryManipulation:
 
             old_cwd = transport.getcwd()
 
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.chdir(directory)
 
             new_cwd = transport.getcwd()
@@ -382,7 +382,7 @@ class TestDirectoryManipulation:
             fake_folder = 'pippo'
             assert not transport.isfile(fake_folder)
             assert not transport.isdir(fake_folder)
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.chdir(fake_folder)
 
     def test_chdir_to_empty_string(self, custom_transport):
@@ -482,9 +482,9 @@ class TestPutGetFile:
                 transport.putfile(retrieved_file_name, remote_file_name)
 
             # remote_file_name does not exist
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.get(remote_file_name, retrieved_file_name)
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.getfile(remote_file_name, retrieved_file_name)
 
             transport.put(local_file_name, remote_file_name)
@@ -534,9 +534,9 @@ class TestPutGetFile:
                 transport.putfile('', remote_file_name)
 
             # remote path is an empty string
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.put(local_file_name, '')
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.putfile(local_file_name, '')
 
             transport.put(local_file_name, remote_file_name)
@@ -544,9 +544,9 @@ class TestPutGetFile:
             transport.putfile(local_file_name, remote_file_name)
 
             # remote path is an empty string
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.get('', retrieved_file_name)
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.getfile('', retrieved_file_name)
 
             # local path is an empty string
@@ -952,11 +952,11 @@ class TestPutGetTree:
                 transport.puttree(retrieved_subfolder, remote_subfolder)
 
             # remote_file_name does not exist
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.get('non_existing', retrieved_subfolder)
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.getfile('non_existing', retrieved_subfolder)
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.gettree('non_existing', retrieved_subfolder)
 
             transport.put(local_subfolder, remote_subfolder)
@@ -1010,13 +1010,13 @@ class TestPutGetTree:
                 transport.puttree('', remote_subfolder)
 
             # remote path is an empty string
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.puttree(local_subfolder, '')
 
             transport.puttree(local_subfolder, remote_subfolder)
 
             # remote path is an empty string
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 transport.gettree('', retrieved_subfolder)
 
             # local path is an empty string


### PR DESCRIPTION
Fixes #4082 

PEP 3151 reworked the builtin exception hierarchy and `IOError` was deprecated (kept as an alias) in favor of `OSError`. The change was implemented in Python 3.3: https://peps.python.org/pep-3151