### PR TITLE
CI: Run Docker workflow only for pushes to origin

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,7 +67,7 @@ jobs:
         images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ matrix.target }}
         tags: |
           type=ref,event=pr
-          type=ref,event=branch,enable={{!is_default_branch}}
+          type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
           type=edge,enable={{is_default_branch}}
           type=raw,value=aiida-${{ env.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
           type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,6 +67,7 @@ jobs:
         images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ matrix.target }}
         tags: |
           type=ref,event=pr
+          type=ref,event=branch,enable={{!is_default_branch}}
           type=edge,enable={{is_default_branch}}
           type=raw,value=aiida-${{ env.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
           type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,12 @@
 name: Docker Images
 
+# This workflow needs permissions to publish images to ghcr.io,
+# so it does not work for forks. Therefore, we only trigger it
+# on pushes to aiidateam/aiida-core repo.
 on:
-  pull_request:
-    paths-ignore:
-    - '**.md'
-    - '**.txt'
-    - docs/**
-    - tests/**
   push:
     branches:
-    - main
-    - support/**
+    - '*'
     tags:
     - v*
     paths-ignore:
@@ -32,7 +28,7 @@ env:
 jobs:
   # We build only amd64 first to catch failures faster.
   build-amd64:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    if: ${{ github.repository == 'aiidateam/aiida-core' }}
     uses: ./.github/workflows/docker-build.yml
     with:
       runsOn: ubuntu-22.04


### PR DESCRIPTION
This workflow needs permissions to publish images to ghcr.io, so it does not work for forks. Therefore, let's only trigger it on pushes to aiidateam/aiida-core repo.

I have an idea on how to support forks, basically just running the build and testing it in a single workflow without a push to ghcr.io. But that will be cleaner as a completely separate worfkflow. I'll submit a follow-up PR for that.