### PR TITLE
Devops: Add tox environment that runs tests with sqlite backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -431,6 +431,13 @@ deps =
     py311: -rrequirements/requirements-py-3.11.txt
     py312: -rrequirements/requirements-py-3.12.txt
 
+[testenv:py{39,310,311,312}-presto]
+passenv =
+    PYTHONASYNCIODEBUG
+setenv =
+    AIIDA_WARN_v3 =
+commands = pytest -m 'presto' {posargs}
+
 [testenv:py{39,310,311,312}]
 passenv =
     PYTHONASYNCIODEBUG

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -533,7 +533,7 @@ def test_code_test(run_cli_command):
 
 
 @pytest.fixture
-def command_options(request, aiida_localhost, tmp_path):
+def command_options(request, aiida_localhost, tmp_path, bash_path):
     """Return tuple of list of options and entry point."""
     options = [request.param, '-n', '--label', str(uuid.uuid4())]
 
@@ -553,7 +553,7 @@ def command_options(request, aiida_localhost, tmp_path):
                 '--computer',
                 str(aiida_localhost.pk),
                 '--filepath-executable',
-                '/usr/bin/bash',
+                str(bash_path.absolute()),
                 '--engine-command',
                 engine_command,
                 '--image-name',

--- a/tests/common/test_timezone.py
+++ b/tests/common/test_timezone.py
@@ -40,19 +40,6 @@ def test_now():
     assert from_tz >= ref - dt
 
 
-def test_make_aware():
-    """Test the :func:`aiida.common.timezone.make_aware` function.
-
-    This should make a naive datetime object aware using the timezone of the operating system.
-    """
-    system_tzinfo = datetime.now(timezone.utc).astimezone()  # This is how to get the timezone of the OS.
-    naive = datetime(1970, 1, 1)
-    aware = make_aware(naive)
-    assert is_aware(aware)
-    assert aware.tzinfo.tzname(aware) == system_tzinfo.tzname()
-    assert aware.tzinfo.utcoffset(aware) == system_tzinfo.utcoffset()
-
-
 def test_make_aware_already_aware():
     """Test the :func:`aiida.common.timezone.make_aware` function for an already aware datetime.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import copy
 import dataclasses
 import os
 import pathlib
+import subprocess
 import types
 import typing as t
 import warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -860,3 +860,17 @@ def serialize_file_hierarchy():
         return serialized
 
     return factory
+
+
+@pytest.fixture(scope='session')
+def bash_path() -> Path:
+    run_process = subprocess.run(['which', 'bash'], capture_output=True, check=True)
+    path = run_process.stdout.decode('utf-8').strip()
+    return Path(path)
+
+
+@pytest.fixture(scope='session')
+def cat_path() -> Path:
+    run_process = subprocess.run(['which', 'cat'], capture_output=True, check=True)
+    path = run_process.stdout.decode('utf-8').strip()
+    return Path(path)

--- a/tests/orm/data/code/test_installed.py
+++ b/tests/orm/data/code/test_installed.py
@@ -17,29 +17,29 @@ from aiida.orm import Computer
 from aiida.orm.nodes.data.code.installed import InstalledCode
 
 
-def test_constructor_raises(aiida_localhost):
+def test_constructor_raises(aiida_localhost, bash_path):
     """Test the constructor when it is supposed to raise."""
     with pytest.raises(TypeError, match=r'missing .* required positional arguments'):
         InstalledCode()
 
     with pytest.raises(TypeError, match=r'Got object of type .*'):
-        InstalledCode(computer=aiida_localhost, filepath_executable=pathlib.Path('/usr/bin/bash'))
+        InstalledCode(computer=aiida_localhost, filepath_executable=bash_path)
 
     with pytest.raises(TypeError, match=r'Got object of type .*'):
         InstalledCode(computer='computer', filepath_executable='/usr/bin/bash')
 
 
-def test_constructor(aiida_localhost):
+def test_constructor(aiida_localhost, bash_path):
     """Test the constructor."""
-    filepath_executable = '/usr/bin/bash'
+    filepath_executable = str(bash_path.absolute())
     code = InstalledCode(computer=aiida_localhost, filepath_executable=filepath_executable)
     assert code.computer.pk == aiida_localhost.pk
     assert code.filepath_executable == pathlib.PurePath(filepath_executable)
 
 
-def test_validate(aiida_localhost):
+def test_validate(aiida_localhost, bash_path):
     """Test the validator is called before storing."""
-    filepath_executable = '/usr/bin/bash'
+    filepath_executable = str(bash_path.absolute())
     code = InstalledCode(computer=aiida_localhost, filepath_executable=filepath_executable)
 
     code.computer = aiida_localhost
@@ -53,18 +53,18 @@ def test_validate(aiida_localhost):
     assert code.is_stored
 
 
-def test_can_run_on_computer(aiida_localhost):
+def test_can_run_on_computer(aiida_localhost, bash_path):
     """Test the :meth:`aiida.orm.nodes.data.code.installed.InstalledCode.can_run_on_computer` method."""
-    code = InstalledCode(computer=aiida_localhost, filepath_executable='/usr/bin/bash')
+    code = InstalledCode(computer=aiida_localhost, filepath_executable=str(bash_path.absolute()))
     computer = Computer()
 
     assert code.can_run_on_computer(aiida_localhost)
     assert not code.can_run_on_computer(computer)
 
 
-def test_filepath_executable(aiida_localhost):
+def test_filepath_executable(aiida_localhost, bash_path, cat_path):
     """Test the :meth:`aiida.orm.nodes.data.code.installed.InstalledCode.filepath_executable` property."""
-    filepath_executable = '/usr/bin/bash'
+    filepath_executable = str(bash_path.absolute())
     code = InstalledCode(computer=aiida_localhost, filepath_executable=filepath_executable)
     assert code.filepath_executable == pathlib.PurePath(filepath_executable)
 
@@ -74,7 +74,7 @@ def test_filepath_executable(aiida_localhost):
     assert code.filepath_executable == pathlib.PurePath(filepath_executable)
 
     # Change through the property
-    filepath_executable = '/usr/bin/cat'
+    filepath_executable = str(cat_path.absolute())
     code.filepath_executable = filepath_executable
     assert code.filepath_executable == pathlib.PurePath(filepath_executable)
 
@@ -101,7 +101,7 @@ def computer(request, aiida_computer_local, aiida_computer_ssh):
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('computer', ('core.local', 'core.ssh'), indirect=True)
-def test_validate_filepath_executable(ssh_key, computer):
+def test_validate_filepath_executable(ssh_key, computer, bash_path):
     """Test the :meth:`aiida.orm.nodes.data.code.installed.InstalledCode.validate_filepath_executable` method."""
     filepath_executable = '/usr/bin/not-existing'
     code = InstalledCode(computer=computer, filepath_executable=filepath_executable)
@@ -117,19 +117,19 @@ def test_validate_filepath_executable(ssh_key, computer):
     with pytest.raises(ValidationError, match=r'The provided remote absolute path .* does not exist on the computer\.'):
         code.validate_filepath_executable()
 
-    code.filepath_executable = '/usr/bin/bash'
+    code.filepath_executable = str(bash_path.absolute())
     code.validate_filepath_executable()
 
 
-def test_full_label(aiida_localhost):
+def test_full_label(aiida_localhost, bash_path):
     """Test the :meth:`aiida.orm.nodes.data.code.installed.InstalledCode.full_label` property."""
     label = 'some-label'
-    code = InstalledCode(label=label, computer=aiida_localhost, filepath_executable='/usr/bin/bash')
+    code = InstalledCode(label=label, computer=aiida_localhost, filepath_executable=str(bash_path.absolute()))
     assert code.full_label == f'{label}@{aiida_localhost.label}'
 
 
-def test_get_execname(aiida_localhost):
+def test_get_execname(aiida_localhost, bash_path):
     """Test the deprecated :meth:`aiida.orm.nodes.data.code.installed.InstalledCode.get_execname` method."""
-    code = InstalledCode(label='some-label', computer=aiida_localhost, filepath_executable='/usr/bin/bash')
+    code = InstalledCode(label='some-label', computer=aiida_localhost, filepath_executable=str(bash_path.absolute()))
     with pytest.warns(AiidaDeprecationWarning):
-        assert code.get_execname() == '/usr/bin/bash'
+        assert code.get_execname() == str(bash_path.absolute())

--- a/tests/orm/data/code/test_portable.py
+++ b/tests/orm/data/code/test_portable.py
@@ -17,13 +17,13 @@ from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.orm.nodes.data.code.portable import PortableCode
 
 
-def test_constructor_raises(tmp_path):
+def test_constructor_raises(tmp_path, bash_path):
     """Test the constructor when it is supposed to raise."""
     with pytest.raises(TypeError, match=r'missing .* required positional argument'):
         PortableCode()
 
     with pytest.raises(TypeError, match=r'Got object of type .*'):
-        PortableCode(filepath_executable=pathlib.Path('/usr/bin/bash'), filepath_files=tmp_path)
+        PortableCode(filepath_executable=bash_path, filepath_files=tmp_path)
 
     with pytest.raises(TypeError, match=r'Got object of type .*'):
         PortableCode(filepath_executable='bash', filepath_files='string')

--- a/tests/tools/pytest_fixtures/test_configuration.py
+++ b/tests/tools/pytest_fixtures/test_configuration.py
@@ -1,24 +1,22 @@
 """Test the pytest fixtures."""
 
-import tempfile
 
-
-def test_aiida_config():
+def test_aiida_config(tmp_path_factory):
     """Test that ``aiida_config`` fixture is loaded by default and creates a config instance in temp directory."""
     from aiida.manage.configuration import get_config
     from aiida.manage.configuration.config import Config
 
     config = get_config()
     assert isinstance(config, Config)
-    assert config.dirpath.startswith(tempfile.gettempdir())
+    assert config.dirpath.startswith(str(tmp_path_factory.getbasetemp()))
 
 
-def test_aiida_config_tmp(aiida_config_tmp):
+def test_aiida_config_tmp(aiida_config_tmp, tmp_path_factory):
     """Test that ``aiida_config_tmp`` returns a config instance in temp directory."""
     from aiida.manage.configuration.config import Config
 
     assert isinstance(aiida_config_tmp, Config)
-    assert aiida_config_tmp.dirpath.startswith(tempfile.gettempdir())
+    assert aiida_config_tmp.dirpath.startswith(str(tmp_path_factory.getbasetemp()))
 
 
 def test_aiida_profile():


### PR DESCRIPTION
The problem with the current tox test environments is that they do require psql database which require a service running in the background. With the merge of #6425, we can use the sqlite backend to run tests more encapsulated with less dependencies on global configurations.

I still need to figure out how to set up a ssh config in a virtual-environment-friendly way. We could just run the `.github/workflow/setup_ssh.sh` file, but then it messes too much with existing ssh configuration. One could  add an include in `${HOME}/.ssh/config` to include another config file that is stored locally in the tox environment.
```
Include ${AIIDA_DEV_TOX_ENVIRONMENT}/custom_ssh_config
```
This just adds one line to the user config, that only works inside the tox environment. So does not have any effect outside of the environment to the functionality of ssh.