### PR TITLE
[devops] Build and test Docker image on PRs from forks

### DIFF
--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -13,7 +13,6 @@ variable "ORGANIZATION" {
 }
 
 variable "REGISTRY" {
-  default = "ghcr.io/"
 }
 
 variable "PLATFORMS" {
@@ -35,18 +34,8 @@ group "default" {
   targets = "${TARGETS}"
 }
 
-target "aiida-core-base-meta" {
-  tags = tags("aiida-core-base")
-}
-target "aiida-core-with-services-meta" {
-  tags = tags("aiida-core-with-services")
-}
-target "aiida-core-dev-meta" {
-  tags = tags("aiida-core-dev")
-}
-
 target "aiida-core-base" {
-  inherits = ["aiida-core-base-meta"]
+  tags = tags("aiida-core-base")
   context = "aiida-core-base"
   contexts = {
     src = ".."
@@ -58,7 +47,7 @@ target "aiida-core-base" {
   }
 }
 target "aiida-core-with-services" {
-  inherits = ["aiida-core-with-services-meta"]
+  tags = tags("aiida-core-with-services")
   context = "aiida-core-with-services"
   contexts = {
     aiida-core-base = "target:aiida-core-base"
@@ -70,7 +59,7 @@ target "aiida-core-with-services" {
   }
 }
 target "aiida-core-dev" {
-  inherits = ["aiida-core-dev-meta"]
+  tags = tags("aiida-core-dev")
   context = "aiida-core-dev"
   contexts = {
     src = ".."

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,73 @@
+# This workflow is only meant to be run on PRs from forked repositoritories.
+# The full workflow that is run on pushes to origin is in docker.yml
+# The difference here is that we do not upload to ghcr.io,
+# and thus don't need a GITHUB_TOKEN secret.
+name: Build & Test Docker Images
+
+env:
+  BUILDKIT_PROGRESS: plain
+  FORCE_COLOR: 1
+
+on:
+  pull_request:
+    paths-ignore:
+    - '**.md'
+    - '**.txt'
+    - docs/**
+    - tests/**
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    name: build and test amd64 images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: .docker
+
+    steps:
+
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build images
+      uses: docker/bake-action@v4
+      with:
+        # Load to Docker engine for testing
+        load: true
+        workdir: .docker/
+        set: |
+          *.platform=amd64
+          *.cache-to=type=gha,scope=${{ github.workflow }},mode=max
+          *.cache-from=type=gha,scope=${{ github.workflow }}
+        files: |
+          docker-bake.hcl
+          build.json
+
+    - name: Set Up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: pip
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Test aiida-core-base
+      run: pytest -s --variant aiida-core-base
+
+    - name: Test aiida-core-with-services
+      run: pytest -s --variant aiida-core-with-services
+
+    - name: Test aiida-core-dev
+      run: pytest -s --variant aiida-core-dev tests/

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -48,7 +48,7 @@ jobs:
         workdir: .docker/
         set: |
           *.platform=amd64
-          *.cache-to=type=gha,scope=${{ github.workflow }},mode=max
+          *.cache-to=type=gha,scope=${{ github.workflow }},mode=min
           *.cache-from=type=gha,scope=${{ github.workflow }}
         files: |
           docker-bake.hcl
@@ -64,10 +64,10 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Test aiida-core-base
-      run: pytest -s --variant aiida-core-base
+      run: pytest -s --variant aiida-core-base tests/
 
     - name: Test aiida-core-with-services
-      run: pytest -s --variant aiida-core-with-services
+      run: pytest -s --variant aiida-core-with-services tests/
 
     - name: Test aiida-core-dev
       run: pytest -s --variant aiida-core-dev tests/


### PR DESCRIPTION
The strategy here is simple: Build and test Docker images in a single workflow, without pushing to ghcr.io. That way we don't need access to GITHUB_TOKEN. 

The downside is that one cannot download the image for local debugging. But if that is needed, I guess one can either build locally, or re-open the PR from origin.

I think @unkcpz had something else in mind, allowing forks access to secrets via `pull_request_target` event. I am not sure if that is safe / desirable, let's discuss that in #6446. This PR should work in the meantime.

Closes #6449 
Accompanies #6446 