### PR TITLE
CLI: Add the `verdi profile configure-rabbitmq` command

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -391,13 +391,13 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      delete       Delete one or more profiles.
-      list         Display a list of all available profiles.
-      set-default  Set a profile as the default profile.
-      setdefault   (Deprecated) Set a profile as the default profile (use `verdi profile set-
-                   default`).
-      setup        Set up a new profile.
-      show         Show details for a profile.
+      configure-rabbitmq  Configure RabbitMQ for a profile.
+      delete              Delete one or more profiles.
+      list                Display a list of all available profiles.
+      set-default         Set a profile as the default profile.
+      setdefault          (Deprecated) Set a profile as the default profile.
+      setup               Set up a new profile.
+      show                Show details for a profile.
 
 
 .. _reference:command-line:verdi-quicksetup:

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -128,6 +128,26 @@ def profile_setup():
     """Set up a new profile."""
 
 
+@verdi_profile.command('configure-rabbitmq')  # type: ignore[arg-type]
+@arguments.PROFILE(default=defaults.get_default_profile)
+@setup.SETUP_BROKER_PROTOCOL()
+@setup.SETUP_BROKER_USERNAME()
+@setup.SETUP_BROKER_PASSWORD()
+@setup.SETUP_BROKER_HOST()
+@setup.SETUP_BROKER_PORT()
+@setup.SETUP_BROKER_VIRTUAL_HOST()
+@options.NON_INTERACTIVE()
+@click.pass_context
+def profile_configure_rabbitmq(ctx, profile, **kwargs):
+    """Configure RabbitMQ for a profile.
+
+    Enable RabbitMQ for a profile that was created without a broker, or reconfigure existing connection details.
+    """
+    profile.set_process_controller(name='core.rabbitmq', config=kwargs)
+    ctx.obj.config.update_profile(profile)
+    ctx.obj.config.store()
+
+
 @verdi_profile.command('list')
 def profile_list():
     """Display a list of all available profiles."""
@@ -179,7 +199,7 @@ def profile_show(profile):
 @verdi_profile.command('setdefault', deprecated='Please use `verdi profile set-default` instead.')
 @arguments.PROFILE(required=True, default=None)
 def profile_setdefault(profile):
-    """Set a profile as the default profile (use `verdi profile set-default`)."""
+    """Set a profile as the default profile."""
     _profile_set_default(profile)
 
 

--- a/src/aiida/cmdline/params/options/commands/setup.py
+++ b/src/aiida/cmdline/params/options/commands/setup.py
@@ -50,6 +50,8 @@ def get_profile_attribute_default(attribute_tuple, ctx):
     try:
         data = ctx.params['profile'].dictionary
         for part in parts:
+            if data is None:
+                return default
             data = data[part]
         return data
     except KeyError:


### PR DESCRIPTION
Now that profiles can be created without defining a broker, a command
is needed that can add a RabbitMQ connection configuration. The new
command `verdi profile configure-rabbitmq` enables a broker for a
profile if it wasn't already, and allows configuring the connection
parameters.