### PR TITLE
Devops: Remove `verdi tui` from CLI reference documentation

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -634,21 +634,6 @@ Below is a list with all available subcommands.
       version    Print the current version of the storage schema.
 
 
-.. _reference:command-line:verdi-tui:
-
-``verdi tui``
--------------
-
-.. code:: console
-
-    Usage:  [OPTIONS]
-
-      Open Textual TUI.
-
-    Options:
-      --help  Show this message and exit.
-
-
 .. _reference:command-line:verdi-user:
 
 ``verdi user``

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -119,6 +119,14 @@ def validate_verdi_documentation():
     block = [f"{header}\n{'=' * len(header)}\n{message}\n\n"]
 
     for name, command in sorted(verdi.commands.items()):
+        if name == 'tui':
+            # This command is only generated when the optional dependency ``trogon`` is installed. It provides a TUI
+            # version of ``verdi``. However, since it is optional, if a development environment does not have it
+            # installed, this check will always fail as the generated docs are different. Since ``trogon`` significantly
+            # slows down tab-completion of ``verdi``, many dev environments do not want to have it installed. As a
+            # workaround, we are excluding this command from the automatically generated reference documentation.
+            continue
+
         ctx = click.Context(command, terminal_width=width)
 
         header_label = f'.. _reference:command-line:verdi-{name}:'


### PR DESCRIPTION
The `verdi-autodocs` pre-commit hook automatically generates the reference documentation for `verdi`. It does so based on the available commands. The `verdi tui` command is added dynamically if and only if the optional dependency `trogon` is installed.

Since having the dependency installed slows down the loading time `verdi` significantly, many dev environments prefer not to install it. However, this leads to the `verdi-autodocs` hook always failing as it removes the `verdi tui` section from the docs. The developer then has to manually reset the changes and run `git commit` with `--no-verify`.

This is annoying enough that as a workaround the `verdi-autodocs` hook now skips the `verdi tui` command when generating the docs.