### PR TITLE
Engine: Improve error message when submitting without broker

### DIFF
--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -111,8 +111,16 @@ def submit(
         raise InvalidOperation('Cannot use top-level `submit` from within another process, use `self.submit` instead')
 
     runner = manager.get_manager().get_runner()
+
+    if runner.controller is None:
+        raise InvalidOperation(
+            'Cannot submit because the runner does not have a process controller, probably because the profile does '
+            'not define a broker like RabbitMQ. If a RabbitMQ server is available, the profile can be configured to '
+            'use it with `verdi profile configure-rabbitmq`. Otherwise, use :meth:`aiida.engine.launch.run` instead to '
+            'run the process in the local Python interpreter instead of submitting it to the daemon.'
+        )
+
     assert runner.persister is not None, 'runner does not have a persister'
-    assert runner.controller is not None, 'runner does not have a controller'
 
     process_inited = instantiate_process(runner, process, **inputs)
 


### PR DESCRIPTION
Fixes #6374 

The `aiida.engine.launch.submit` method was just raising a vague `AssertionError` in case the runner did not have a communicator, which is the case if it was constructed without a communicator which in turn happens for profiles that do not configure a broker.

Since profiles without brokers are now supported and users are bound to try to submit anyway, the error message should be clearer.