### PR TITLE
Docker image tweaks

### DIFF
--- a/.docker/aiida-core-base/Dockerfile
+++ b/.docker/aiida-core-base/Dockerfile
@@ -104,9 +104,6 @@ USER ${SYSTEM_UID}
 # Pin python version here
 ARG PYTHON_VERSION
 
-# Pin mamba version here
-ARG MAMBA_VERSION
-
 # Download and install Micromamba, and initialize Conda prefix.
 #   <https://github.com/mamba-org/mamba#micromamba>
 #   Similar projects using Micromamba:
@@ -137,7 +134,7 @@ RUN set -x && \
         --prefix="${CONDA_DIR}" \
         --yes \
         "${PYTHON_SPECIFIER}" \
-        "mamba=${MAMBA_VERSION}" && \
+        mamba && \
     rm micromamba && \
     # Pin major.minor version of python
     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
@@ -146,8 +143,9 @@ RUN set -x && \
     fix-permissions "/home/${SYSTEM_USER}"
 
 # Add ~/.local/bin to PATH where the dependencies get installed via pip
-# This require the package installed with `--user` flag in pip
+# This require the package installed with `--user` flag in pip, which we set as default.
 ENV PATH=${PATH}:/home/${SYSTEM_USER}/.local/bin
+ENV PIP_USER 1
 
 # Switch to root to install AiiDA and set AiiDA as service
 # Install AiiDA from source code

--- a/.docker/aiida-core-with-services/Dockerfile
+++ b/.docker/aiida-core-with-services/Dockerfile
@@ -22,8 +22,7 @@ RUN mamba install --yes \
 # Install erlang.
 RUN apt-get update --yes && \
      apt-get install --yes --no-install-recommends \
-     erlang \
-     xz-utils && \
+     erlang && \
      apt-get clean && rm -rf /var/lib/apt/lists/* && \
      # Install rabbitmq.
      wget -c --no-check-certificate https://github.com/rabbitmq/rabbitmq-server/releases/download/v${RMQ_VERSION}/rabbitmq-server-generic-unix-${RMQ_VERSION}.tar.xz && \

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -43,7 +43,6 @@ target "aiida-core-base" {
   platforms = "${PLATFORMS}"
   args = {
     "PYTHON_VERSION" = "${PYTHON_VERSION}"
-    "MAMBA_VERSION" = "1.5.2"
   }
 }
 target "aiida-core-with-services" {


### PR DESCRIPTION
Some tweaks to Docker images

- Don't pin mamba version, I think we always want the latest version (similar to pip). Relatedly, the latest versions of conda actually use the libmamba resolver so there's probably little benefit of using mamba over conda now. But I haven't explored it in detailed yet so I did not change it in this PR.
- set PIP_USER=1, which will make the `--user` flag to pip default. We want users to install to `~/.local` since the home directory is preserved on a volume when the container stops. We do the same in aiidalab-docker-stack
- xz-utils package was being installed twice 