### PR TITLE
CI: Add Dependabot config for maintaining GH actions

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -28,7 +28,7 @@ runs:
   - name: Install uv installer
     run: curl --proto '=https' --tlsv1.2 -LsSf https://${{ env.UV_URL }} | sh
     env:
-      UV_VERSION: 0.2.5
+      UV_VERSION: 0.2.9
       UV_URL: github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-installer.sh
     shell: bash
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    gha-dependencies:
+      patterns:
+      - '*'

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -139,17 +139,7 @@ jobs:
     - name: Run test suite
       env:
         AIIDA_WARN_v3: 0
-      run: pytest -m 'presto' --cov aiida
-
-    - name: Upload coverage report
-      if: github.repository == 'aiidateam/aiida-core'
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        name: aiida-pytests-presto
-        flags: presto
-        file: ./coverage.xml
-        fail_ci_if_error: false  # don't fail job, if coverage upload fails
+      run: pytest -m 'presto'
 
 
   verdi:

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -155,6 +155,7 @@ jobs:
       uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.12'
+        from-requirements: 'false'
 
     - name: Run verdi tests
       run: |

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches-ignore: [gh-pages]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
 
   pre-commit:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,6 +7,9 @@ on:
     branches-ignore: [gh-pages]
     paths: [docs/**]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
 
   docs-linkcheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     tags:
     - v[0-9]+.[0-9]+.[0-9]+*
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
 
   check-release-tag:
@@ -33,11 +36,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install system dependencies
-      # note libkrb5-dev is required as a dependency for the gssapi pip install
-      run: |
-        sudo apt update
-        sudo apt install libkrb5-dev ruby ruby-dev
 
     - name: Install aiida-core and pre-commit
       uses: ./.github/actions/install-aiida-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,39 +52,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    services:
-      postgres:
-        image: postgres:10
-        env:
-          POSTGRES_DB: test_aiida
-          POSTGRES_PASSWORD: ''
-          POSTGRES_HOST_AUTH_METHOD: trust
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-        - 5432:5432
-      rabbitmq:
-        image: rabbitmq:3.8.14-management
-        ports:
-        - 5672:5672
-        - 15672:15672
-
     steps:
     - uses: actions/checkout@v4
 
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install postgresql graphviz
+        sudo apt install graphviz
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.11'
 
     - name: Run sub-set of test suite
-      run: pytest -sv -k 'requires_rmq'
+      run: pytest -sv -m presto
 
   publish:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,21 +52,39 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_DB: test_aiida
+          POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - 5432:5432
+      rabbitmq:
+        image: rabbitmq:3.8.14-management
+        ports:
+        - 5672:5672
+        - 15672:15672
+
     steps:
     - uses: actions/checkout@v4
 
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install graphviz
+        sudo apt install postgresql graphviz
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
-      with:
-        python-version: '3.11'
 
     - name: Run sub-set of test suite
-      run: pytest -sv -m presto
+      run: pytest -sv -k 'requires_rmq'
 
   publish:
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,8 @@ build:
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     post_create_environment:
     - asdf plugin add uv
-    - asdf install uv 0.1.44
-    - asdf global uv 0.1.44
+    - asdf install uv 0.2.9
+    - asdf global uv 0.2.9
     post_install:
     - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[docs,tests,rest,atomic_tools]
 


### PR DESCRIPTION
Last PR related to CI (promise!), I saved the perhaps controversial change for last. :-) 

Added a dependabot config for maintaining GH actions (NOT Python dependencies). It updates monthly, and should be even less frequent since we typically don't pin to the exact versions of the Actions, and major version updates are infrequent.

Also tried to simplify a bit the release workflow by utilizing the newly added `pytest -m presto` tests.