### PR TITLE
🐛 `RabbitmqBroker`: catch `ConnectionError` for `__str__`

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -34,7 +34,10 @@ class RabbitmqBroker(Broker):
         self._prefix = f'aiida-{self._profile.uuid}'
 
     def __str__(self):
-        return f'RabbitMQ v{self.get_rabbitmq_version()} @ {self.get_url()}'
+        try:
+            return f'RabbitMQ v{self.get_rabbitmq_version()} @ {self.get_url()}'
+        except ConnectionError:
+            return f'RabbitMQ @ {self.get_url()} <Connection failed>'
 
     def close(self):
         """Close the broker."""

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -22,6 +22,19 @@ from packaging.version import parse
 pytestmark = pytest.mark.requires_rmq
 
 
+def test_str_method(monkeypatch, manager):
+    """Test the `__str__` method of the `RabbitmqBroker`."""
+
+    def raise_connection_error():
+        raise ConnectionError
+
+    broker = manager.get_broker()
+    assert 'RabbitMQ v' in str(broker)
+
+    monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
+    assert 'RabbitMQ @' in str(broker)
+
+
 @pytest.mark.parametrize(
     ('version', 'supported'),
     (


### PR DESCRIPTION
The current implementation of the `RabbitmqBroker.__str__()` method always prints both the version and the URL of the RabbitMQ server. However, the `get_rabbitmq_version()` method fails with a `ConnectionError` in case the RabbitMQ broker is not able to connect to the server.

This issue would bubble up into the `verdi status` command, since this prints the string representation of the `RabbitmqBroker` in the message that reports the connection failure. At this point the `ConnectionError` is no longer caught, and hence the user is exposed to the full traceback.

Here we adapt the `RabbitmqBroker.__str__()` method to catch the `ConnectionError` and only return the URL in this case.