### PR TITLE
👌 Improve usage of `configure-rabbitmq`

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -329,23 +329,26 @@ Below is a list with all available subcommands.
       the newly created profile uses the new PostgreSQL database instead of SQLite.
 
     Options:
-      --profile-name TEXT       Name of the profile. By default, a unique name starting with
-                                `presto` is automatically generated.  [default: (dynamic)]
-      --email TEXT              Email of the default user.  [default: (dynamic)]
-      --use-postgres            When toggled on, the profile uses a PostgreSQL database
-                                instead of an SQLite one. The connection details to the
-                                PostgreSQL server can be configured with the relevant options.
-                                The command attempts to automatically create a user and
-                                database to use for the profile, but this can fail depending
-                                on the configuration of the server.
-      --postgres-hostname TEXT  The hostname of the PostgreSQL server.
-      --postgres-port INTEGER   The port of the PostgreSQL server.
-      --postgres-username TEXT  The username of the PostgreSQL user that is authorized to
-                                create new databases.
-      --postgres-password TEXT  The password of the PostgreSQL user that is authorized to
-                                create new databases.
-      -n, --non-interactive     Never prompt, such as for sudo password.
-      --help                    Show this message and exit.
+      --profile-name TEXT             Name of the profile. By default, a unique name starting
+                                      with `presto` is automatically generated.  [default:
+                                      (dynamic)]
+      --email TEXT                    Email of the default user.  [default: (dynamic)]
+      --use-postgres                  When toggled on, the profile uses a PostgreSQL database
+                                      instead of an SQLite one. The connection details to the
+                                      PostgreSQL server can be configured with the relevant
+                                      options. The command attempts to automatically create a
+                                      user and database to use for the profile, but this can
+                                      fail depending on the configuration of the server.
+      --postgres-hostname TEXT        The hostname of the PostgreSQL server.
+      --postgres-port INTEGER         The port of the PostgreSQL server.
+      --postgres-username TEXT        The username of the PostgreSQL user that is authorized
+                                      to create new databases.
+      --postgres-password TEXT        The password of the PostgreSQL user that is authorized
+                                      to create new databases.
+      -n, --non-interactive / -I, --interactive
+                                      Never prompt, such as for sudo password.  [default:
+                                      (--interactive)]
+      --help                          Show this message and exit.
 
 
 .. _reference:command-line:verdi-process:
@@ -412,8 +415,11 @@ Below is a list with all available subcommands.
       (Deprecated) Setup a new profile in a fully automated fashion.
 
     Options:
-      -n, --non-interactive           In non-interactive mode, the CLI never prompts but
-                                      simply uses default values for options that define one.
+      -n, --non-interactive / -I, --interactive
+                                      In non-interactive mode, the CLI never prompts for
+                                      options but simply uses default values for options that
+                                      define one. In interactive mode, the CLI will prompt for
+                                      each interactive option.   [default: (--interactive)]
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you generate. The
                                       email address is exported along with the data, when
@@ -516,8 +522,11 @@ Below is a list with all available subcommands.
       user has been created.
 
     Options:
-      -n, --non-interactive           In non-interactive mode, the CLI never prompts but
-                                      simply uses default values for options that define one.
+      -n, --non-interactive / -I, --interactive
+                                      In non-interactive mode, the CLI never prompts for
+                                      options but simply uses default values for options that
+                                      define one. In interactive mode, the CLI will prompt for
+                                      each interactive option.   [default: (--interactive)]
       --profile PROFILE               The name of the new profile.  [required]
       --email EMAIL                   Email address associated with the data you generate. The
                                       email address is exported along with the data, when

--- a/src/aiida/brokers/rabbitmq/defaults.py
+++ b/src/aiida/brokers/rabbitmq/defaults.py
@@ -29,7 +29,15 @@ BROKER_DEFAULTS = AttributeDict(
 )
 
 
-def detect_rabbitmq_config() -> dict[str, t.Any] | None:
+def detect_rabbitmq_config(
+    protocol: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+    virtual_host: str | None = None,
+    heartbeat: int | None = None,
+) -> dict[str, t.Any] | None:
     """Try to connect to a RabbitMQ server with the default connection parameters.
 
     :returns: The connection parameters if the RabbitMQ server was successfully connected to, or ``None`` otherwise.
@@ -37,13 +45,13 @@ def detect_rabbitmq_config() -> dict[str, t.Any] | None:
     from kiwipy.rmq.threadcomms import connect
 
     connection_params = {
-        'protocol': os.getenv('AIIDA_BROKER_PROTOCOL', BROKER_DEFAULTS['protocol']),
-        'username': os.getenv('AIIDA_BROKER_USERNAME', BROKER_DEFAULTS['username']),
-        'password': os.getenv('AIIDA_BROKER_PASSWORD', BROKER_DEFAULTS['password']),
-        'host': os.getenv('AIIDA_BROKER_HOST', BROKER_DEFAULTS['host']),
-        'port': os.getenv('AIIDA_BROKER_PORT', BROKER_DEFAULTS['port']),
-        'virtual_host': os.getenv('AIIDA_BROKER_VIRTUAL_HOST', BROKER_DEFAULTS['virtual_host']),
-        'heartbeat': os.getenv('AIIDA_BROKER_HEARTBEAT', BROKER_DEFAULTS['heartbeat']),
+        'protocol': protocol or os.getenv('AIIDA_BROKER_PROTOCOL', BROKER_DEFAULTS['protocol']),
+        'username': username or os.getenv('AIIDA_BROKER_USERNAME', BROKER_DEFAULTS['username']),
+        'password': password or os.getenv('AIIDA_BROKER_PASSWORD', BROKER_DEFAULTS['password']),
+        'host': host or os.getenv('AIIDA_BROKER_HOST', BROKER_DEFAULTS['host']),
+        'port': port or int(os.getenv('AIIDA_BROKER_PORT', BROKER_DEFAULTS['port'])),
+        'virtual_host': virtual_host or os.getenv('AIIDA_BROKER_VIRTUAL_HOST', BROKER_DEFAULTS['virtual_host']),
+        'heartbeat': heartbeat or int(os.getenv('AIIDA_BROKER_HEARTBEAT', BROKER_DEFAULTS['heartbeat'])),
     }
 
     LOGGER.info(f'Attempting to connect to RabbitMQ with parameters: {connection_params}')

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -136,7 +136,7 @@ def profile_setup():
 @setup.SETUP_BROKER_HOST()
 @setup.SETUP_BROKER_PORT()
 @setup.SETUP_BROKER_VIRTUAL_HOST()
-@options.NON_INTERACTIVE()
+@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
 @click.pass_context
 def profile_configure_rabbitmq(ctx, profile, **kwargs):
     """Configure RabbitMQ for a profile.

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -130,6 +130,7 @@ def profile_setup():
 
 @verdi_profile.command('configure-rabbitmq')  # type: ignore[arg-type]
 @arguments.PROFILE(default=defaults.get_default_profile)
+@options.FORCE()
 @setup.SETUP_BROKER_PROTOCOL()
 @setup.SETUP_BROKER_USERNAME()
 @setup.SETUP_BROKER_PASSWORD()
@@ -138,14 +139,29 @@ def profile_setup():
 @setup.SETUP_BROKER_VIRTUAL_HOST()
 @options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
 @click.pass_context
-def profile_configure_rabbitmq(ctx, profile, **kwargs):
+def profile_configure_rabbitmq(ctx, profile, non_interactive, force, **kwargs):
     """Configure RabbitMQ for a profile.
 
     Enable RabbitMQ for a profile that was created without a broker, or reconfigure existing connection details.
     """
+    from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
+
+    connection_params = {key.lstrip('broker_'): value for key, value in kwargs.items() if key.startswith('broker_')}
+
+    broker_config = detect_rabbitmq_config(**connection_params)
+
+    if broker_config is None:
+        echo.echo_warning(f'Unable to connect to RabbitMQ server with configuration: {connection_params}')
+        if not force:
+            click.confirm('Do you want to continue with the provided configuration?', abort=True)
+    else:
+        echo.echo_success('Connected to RabbitMQ with the provided connection parameters')
+
     profile.set_process_controller(name='core.rabbitmq', config=kwargs)
     ctx.obj.config.update_profile(profile)
     ctx.obj.config.store()
+
+    echo.echo_success(f'RabbitMQ configuration for `{profile.name}` updated to: {connection_params}')
 
 
 @verdi_profile.command('list')

--- a/src/aiida/cmdline/params/options/interactive.py
+++ b/src/aiida/cmdline/params/options/interactive.py
@@ -167,9 +167,9 @@ class InteractiveOption(ConditionalOption):
     def is_interactive(ctx: click.Context) -> bool:
         """Return whether the command is being run non-interactively.
 
-        This is the case if the ``non_interactive`` parameter in the context is set to ``True``.
+        This is the case if the ``non_interactive`` parameter in the context is set to ``False``.
 
-        :return: ``True`` if being run non-interactively, ``False`` otherwise.
+        :return: ``True`` if being run interactively, ``False`` otherwise.
         """
         return not ctx.params.get('non_interactive', False)
 

--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -344,11 +344,15 @@ ARCHIVE_FORMAT = OverridableOption(
 )
 
 NON_INTERACTIVE = OverridableOption(
-    '-n',
-    '--non-interactive',
-    is_flag=True,
+    '-n/-I',
+    '--non-interactive/--interactive',
     is_eager=True,
-    help='In non-interactive mode, the CLI never prompts but simply uses default values for options that define one.',
+    help=(
+        'In non-interactive mode, the CLI never prompts for options but simply uses default values for options that '
+        'define one. In interactive mode, the CLI will prompt for each interactive option. '
+    ),
+    default=False,
+    show_default='--interactive',
 )
 
 DRY_RUN = OverridableOption('-n', '--dry-run', is_flag=True, help='Perform a dry run.')

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -287,6 +287,13 @@ def test_configure_rabbitmq(run_cli_command, isolated_config):
     run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=False)
     assert profile.process_control_backend == 'core.rabbitmq'
 
+    # Verify that running in non-interactive mode is the default
+    options = [
+        profile_name,
+    ]
+    run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=True)
+    assert profile.process_control_backend == 'core.rabbitmq'
+
     # Call it again to check it works to reconfigure existing broker connection parameters
     options = [profile_name, '-n', '--broker-host', 'rabbitmq.broker.com']
     run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=False)


### PR DESCRIPTION
Implements the suggestions in https://github.com/aiidateam/aiida-core/pull/6454#issuecomment-2155873817.

Example UX:

```python
❯ brew services stop rabbitmq
Stopping `rabbitmq`... (might take a while)
==> Successfully stopped `rabbitmq` (label: homebrew.mxcl.rabbitmq)
❯ verdi presto
Report: Option `--use-postgres` not enabled: configuring the profile to use SQLite.
Report: RabbitMQ server not found: configuring the profile without a broker.
Report: Initialising the storage backend.
Report: Storage initialisation completed.
Success: Created new profile `presto-7`.
Success: Configured the localhost as a computer.
❯ verdi status
 ✔ version:     AiiDA v2.5.1.post0
 ✔ config:      /Users/mbercx/project/core/.aiida
 ✔ profile:     presto-7
 ✔ storage:     SqliteDosStorage[/Users/mbercx/project/core/.aiida/repository/sqlite_dos_9334f1ac2f1f42d2b51724491fdb9030]: open,
 ⏺ broker:      No broker defined for this profile: certain functionality not available.
 ⏺ daemon:      No broker defined for this profile: daemon is not available.
❯ brew services start rabbitmq
==> Successfully started `rabbitmq` (label: homebrew.mxcl.rabbitmq)
❯ verdi profile configure-rabbitmq
Success: Successfully connected to RabbitMQ server.
❯ verdi status
 ✔ version:     AiiDA v2.5.1.post0
 ✔ config:      /Users/mbercx/project/core/.aiida
 ✔ profile:     presto-7
 ✔ storage:     SqliteDosStorage[/Users/mbercx/project/core/.aiida/repository/sqlite_dos_9334f1ac2f1f42d2b51724491fdb9030]: open,
Warning: RabbitMQ v3.13.1 is not supported and will cause unexpected problems!
Warning: It can cause long-running workflows to crash and jobs to be submitted multiple times.
Warning: See https://github.com/aiidateam/aiida-core/wiki/RabbitMQ-version-to-use for details.
 ✔ broker:      RabbitMQ v3.13.1 @ amqp://guest:guest@127.0.0.1:5672?heartbeat=600
 ⏺ daemon:      The daemon is not running.
```