### PR TITLE
CLI: Allow higher than index 10 for `verdi presto`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -32,7 +32,7 @@ def get_default_presto_profile_name():
 
     for profile_name in profile_names:
         if match := re.search(r'presto[-]?(\d+)?', profile_name):
-            indices.append(match.group(1) or '0')
+            indices.append(int(match.group(1) or '0'))
 
     if not indices:
         return DEFAULT_PROFILE_NAME_PREFIX

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -80,3 +80,11 @@ def test_presto_use_postgres_fail(run_cli_command):
     options = ['--non-interactive', '--use-postgres', '--postgres-port', str(5000)]
     result = run_cli_command(verdi_presto, options, raises=True)
     assert 'Failed to connect to the PostgreSQL server' in result.output
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_presto_overdose(run_cli_command, config_with_profile_factory):
+    """Test that ``verdi presto`` still works for users that have over 10 presto profiles."""
+    config_with_profile_factory(name='presto-10')
+    result = run_cli_command(verdi_presto)
+    assert 'Created new profile `presto-11`.' in result.output


### PR DESCRIPTION
Fixes #6476

When the user is using `verdi presto` to create more than 11 profiles, the command will fåail because `presto-10` already exists. This is due to the fact that the `get_default_presto_profile_name()` function sorts the existing indices as strings, which means `10` will precede `9` and hence the "last index" would be `9`, making the new index `10`, which already exists.

Here we fix this issue by casting the extracted existing indices as integers, so the sorting works as intended.