### PR TITLE
devops: Don't collect code coverage in test-install.yml

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -229,7 +229,7 @@ jobs:
       env:
         AIIDA_TEST_PROFILE: test_aiida
         AIIDA_WARN_v3: 1
-      run: pytest --cov aiida --verbose tests -m 'not nightly'
+      run: pytest --verbose tests -m 'not nightly'
 
     - name: Freeze test environment
       run: pip freeze | sed '1d' | tee requirements-py-${{ matrix.python-version }}.txt


### PR DESCRIPTION
This should cut down the CI time by at least 10 minutes for these tests.

In the future we might consider using the `presto` tests instead of running the full test suite.