### PR TITLE
CLI: Remove the RabbitMQ options from `verdi profile setup`

### DIFF
--- a/src/aiida/brokers/rabbitmq/defaults.py
+++ b/src/aiida/brokers/rabbitmq/defaults.py
@@ -36,10 +36,10 @@ def detect_rabbitmq_config(
     host: str | None = None,
     port: int | None = None,
     virtual_host: str | None = None,
-    heartbeat: int | None = None,
-) -> dict[str, t.Any] | None:
+) -> dict[str, t.Any]:
     """Try to connect to a RabbitMQ server with the default connection parameters.
 
+    :raises ConnectionError: If the connection failed with the provided connection parameters
     :returns: The connection parameters if the RabbitMQ server was successfully connected to, or ``None`` otherwise.
     """
     from kiwipy.rmq.threadcomms import connect
@@ -51,7 +51,6 @@ def detect_rabbitmq_config(
         'host': host or os.getenv('AIIDA_BROKER_HOST', BROKER_DEFAULTS['host']),
         'port': port or int(os.getenv('AIIDA_BROKER_PORT', BROKER_DEFAULTS['port'])),
         'virtual_host': virtual_host or os.getenv('AIIDA_BROKER_VIRTUAL_HOST', BROKER_DEFAULTS['virtual_host']),
-        'heartbeat': heartbeat or int(os.getenv('AIIDA_BROKER_HEARTBEAT', BROKER_DEFAULTS['heartbeat'])),
     }
 
     LOGGER.info(f'Attempting to connect to RabbitMQ with parameters: {connection_params}')
@@ -59,7 +58,7 @@ def detect_rabbitmq_config(
     try:
         connect(connection_params=connection_params)
     except ConnectionError:
-        return None
+        raise ConnectionError(f'Failed to connect with following connection parameters: {connection_params}')
 
     # The profile configuration expects the keys of the broker config to be prefixed with ``broker_``.
     return {f'broker_{key}': value for key, value in connection_params.items()}

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -50,7 +50,13 @@ def detect_postgres_config(
     postgres_password: str,
     non_interactive: bool,
 ) -> dict[str, t.Any]:
-    """."""
+    """Attempt to connect to the given PostgreSQL server and create a new user and database.
+
+    :raises ConnectionError: If no connection could be established to the PostgreSQL server or a user and database
+        could not be created.
+    :returns: The connection configuration for the newly created user and database as can be used directly for the
+        storage configuration of the ``core.psql_dos`` storage plugin.
+    """
     import secrets
 
     from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
@@ -65,7 +71,7 @@ def detect_postgres_config(
     postgres = Postgres(interactive=not non_interactive, quiet=False, dbinfo=dbinfo)
 
     if not postgres.is_connected:
-        echo.echo_critical(f'Failed to connect to the PostgreSQL server using parameters: {dbinfo}')
+        raise ConnectionError(f'Failed to connect to the PostgreSQL server using parameters: {dbinfo}')
 
     database_name = f'aiida-{profile_name}'
     database_username = f'aiida-{profile_name}'
@@ -76,7 +82,7 @@ def detect_postgres_config(
             dbname=database_name, dbuser=database_username, dbpass=database_password
         )
     except Exception as exception:
-        echo.echo_critical(f'Unable to automatically create the PostgreSQL user and database: {exception}')
+        raise ConnectionError(f'Unable to automatically create the PostgreSQL user and database: {exception}')
 
     return {
         'database_hostname': postgres_hostname,
@@ -175,23 +181,33 @@ def verdi_presto(
         'postgres_password': postgres_password,
         'non_interactive': non_interactive,
     }
-    storage_config: dict[str, t.Any] = detect_postgres_config(**postgres_config_kwargs) if use_postgres else {}
-    storage_backend = 'core.psql_dos' if storage_config else 'core.sqlite_dos'
+
+    storage_backend: str = 'core.sqlite_dos'
+    storage_config: dict[str, t.Any] = {}
 
     if use_postgres:
-        echo.echo_report(
-            '`--use-postgres` enabled and database creation successful: configuring the profile to use PostgreSQL.'
-        )
+        try:
+            storage_config = detect_postgres_config(**postgres_config_kwargs)
+        except ConnectionError as exception:
+            echo.echo_critical(str(exception))
+        else:
+            echo.echo_report(
+                '`--use-postgres` enabled and database creation successful: configuring the profile to use PostgreSQL.'
+            )
+            storage_backend = 'core.psql_dos'
     else:
         echo.echo_report('Option `--use-postgres` not enabled: configuring the profile to use SQLite.')
 
-    broker_config = detect_rabbitmq_config()
-    broker_backend = 'core.rabbitmq' if broker_config is not None else None
+    broker_backend = None
+    broker_config = None
 
-    if broker_config is None:
-        echo.echo_report('RabbitMQ server not found: configuring the profile without a broker.')
+    try:
+        broker_config = detect_rabbitmq_config()
+    except ConnectionError as exception:
+        echo.echo_report(f'RabbitMQ server not found ({exception}): configuring the profile without a broker.')
     else:
         echo.echo_report('RabbitMQ server detected: configuring the profile with a broker.')
+        broker_backend = 'core.rabbitmq'
 
     try:
         profile = create_profile(

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -32,8 +32,11 @@ def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
     """Test the ``verdi presto`` without RabbitMQ."""
     from aiida.brokers.rabbitmq import defaults
 
+    def detect_rabbitmq_config(**kwargs):
+        raise ConnectionError()
+
     # Patch the RabbitMQ detection function to pretend it could not find the service
-    monkeypatch.setattr(defaults, 'detect_rabbitmq_config', lambda: None)
+    monkeypatch.setattr(defaults, 'detect_rabbitmq_config', lambda: detect_rabbitmq_config())
 
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile `presto`.' in result.output

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -299,7 +299,7 @@ def test_configure_rabbitmq(run_cli_command, isolated_config):
     # Verify that configuring with incorrect options and `--force` raises a warning but still configures the broker
     options = [profile_name, '-f', '--broker-port', '1234']
     cli_result = run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=False)
-    assert 'Unable to connect to RabbitMQ server with configuration:' in cli_result.stdout
+    assert 'Unable to connect to RabbitMQ server: Failed to connect' in cli_result.stdout
     assert profile.process_control_config['broker_port'] == 1234
 
     # Call it again to check it works to reconfigure existing broker connection parameters


### PR DESCRIPTION
For the vast majority of use cases, users will have a default setup for RabbitMQ and so the default configuration will be adequate and so they will not need the options in the command. On the flipside, showing the options by default can makes the command harder to use as users will take pause to think what value to pass.

Since there is the `verdi profile configure-rabbitmq` command now that allows to configure or reconfigure the RabbitMQ connection parameters for an existing profile, it is fine to remove these options from the profile setup. Advanced users that need to customize the connection parameters can resort to that separate command.