### PR TITLE
Auto-load default AiiDA profile

### DIFF
--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from aiida.common.log import AIIDA_LOGGER
+
 if TYPE_CHECKING:
     import asyncio
 
@@ -29,6 +31,7 @@ if TYPE_CHECKING:
 __all__ = ('get_manager',)
 
 MANAGER: Optional['Manager'] = None
+LOGGER = AIIDA_LOGGER.getChild('manage')
 
 
 def get_manager() -> 'Manager':
@@ -261,6 +264,7 @@ class Manager:
             try:
                 default_profile = get_default_profile()
                 profile = self.load_profile(default_profile)
+                LOGGER.report(f'Loaded default profile: {profile}.')
             except (TypeError, InvalidOperation) as e:
                 raise ConfigurationError(
                     "Default profile couldn't be loaded. Consider loading one manually via `aiida.load_profile()`."


### PR DESCRIPTION
Idea originally brought up by @mbercx. I thought this should be quick to do, so I just went ahead with it.

I can see how this could possibly lead to issues, as the profile is loaded *silently* in the background, without the user specifying it, so people might end up accidentally working within the wrong profile. Nonetheless, we can evaluate if it's an acceptable risk considering the gained benefit that one doesn't have to manually run `load_profile` every time. So, happy to discuss :)

PS: Wondering if `get_default_profile` should be under `aiida.cmdline.utils.defaults` or moved out of `cmdline` in a more general location?

Edit: Also running `load_profile("<profile>")` leads to:
```python
InvalidOperation: cannot switch to profile "<profile>" because profile "<default_profile>" storage is already loaded and allow_switch is False
```
though, this can be easily resolved by setting `allow_switch=True`.