### PR TITLE
CLI: Fail early in `verdi presto` when profile name already exists

### DIFF
--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -174,6 +174,9 @@ def verdi_presto(
     from aiida.manage.configuration import create_profile, load_profile
     from aiida.orm import Computer
 
+    if profile_name in ctx.obj.config.profile_names:
+        raise click.BadParameter(f'The profile `{profile_name}` already exists.', param_hint='--profile-name')
+
     postgres_config_kwargs = {
         'profile_name': profile_name,
         'postgres_hostname': postgres_hostname,


### PR DESCRIPTION
Fixes #6482 

If an explicit profile name is specified with `-p/--profile-name` it should be validated as soon as possible and error if the profile already exists, before anything else is done. This prevents, for example, that a PostgreSQL user and database are created that are then not cleaned up.