### PR TITLE
Engine: Catch `NotImplementedError`in `get_process_state_change_timestamp`

### DIFF
--- a/src/aiida/engine/utils.py
+++ b/src/aiida/engine/utils.py
@@ -316,9 +316,13 @@ def get_process_state_change_timestamp(process_type: Optional[str] = None) -> Op
     for process_type_key in process_types:
         key = PROCESS_STATE_CHANGE_KEY.format(process_type_key)
         try:
-            time_stamp = backend.get_global_variable(key)
-            if time_stamp is not None:
-                timestamps.append(datetime.fromisoformat(str(time_stamp)))
+            try:
+                timestamp = backend.get_global_variable(key)
+            except NotImplementedError:
+                pass
+            else:
+                if timestamp is not None:
+                    timestamps.append(datetime.fromisoformat(str(timestamp)))
         except KeyError:
             continue
 


### PR DESCRIPTION
The `get_process_state_change_timestamp` utility calls the method `get_global_variable` on the storage backend to get the timestamp of the latest process state change, which is typically stored in the `db_dbsetting` table. However, not all storage plugins implement, most notably the `core.sqlite_zip` plugin. Since this is read-only, the settings table is never used and requesting the timestamp of the last process state change does not make sense.

Since this utility is used in `verdi process list`, the command would error since the `NotImplementedError` was not caught. This is now the case and `verdi process list` will show "never" as the last state change.