### PR TITLE
Daemon: Fix `DbLogHandler` not being configured

### DIFF
--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -44,7 +44,7 @@ def start_daemon_worker(foreground: bool = False) -> None:
         write to the daemon log file.
     """
     daemon_client = get_daemon_client()
-    configure_logging(daemon=not foreground, daemon_log_file=daemon_client.daemon_log_file)
+    configure_logging(with_orm=True, daemon=not foreground, daemon_log_file=daemon_client.daemon_log_file)
 
     LOGGER.debug(f'sys.executable: {sys.executable}')
     LOGGER.debug(f'sys.path: {sys.path}')

--- a/src/aiida/workflows/arithmetic/multiply_add.py
+++ b/src/aiida/workflows/arithmetic/multiply_add.py
@@ -49,7 +49,7 @@ class MultiplyAddWorkChain(WorkChain):
         """Add two numbers using the `ArithmeticAddCalculation` calculation job plugin."""
         inputs = {'x': self.ctx.product, 'y': self.inputs.z, 'code': self.inputs.code}
         future = self.submit(ArithmeticAddCalculation, **inputs)
-
+        self.report(f'Submitted the `ArithmeticAddCalculation`: {future}')
         return ToContext(addition=future)
 
     def validate_result(self):

--- a/tests/engine/daemon/test_worker.py
+++ b/tests/engine/daemon/test_worker.py
@@ -10,6 +10,8 @@
 
 import pytest
 from aiida.engine.daemon.worker import shutdown_worker
+from aiida.orm import Log
+from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
 
 @pytest.mark.requires_rmq
@@ -24,3 +26,17 @@ async def test_shutdown_worker(manager):
     finally:
         # Reset the runner of the manager, because once closed it cannot be reused by other tests.
         manager._runner = None
+
+
+@pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+def test_logging_configuration(aiida_code_installed, submit_and_await):
+    """Integration test to verify that the daemon has the logging properly configured including the ``DbLogHandler``.
+
+    This is a regression test to make sure that the ``DbLogHandler`` is properly configured for daemon workers, which
+    ensures that log messages are written to the log table in the database for the corresponding node.
+    """
+    code = aiida_code_installed('add')
+    node = submit_and_await(MultiplyAddWorkChain, x=1, y=2, z=3, code=code)
+    logs = Log.collection.get_logs_for(node)
+    assert len(logs) == 1
+    assert 'Submitted the `ArithmeticAddCalculation`' in next(log.message for log in logs)

--- a/tests/tools/dumping/test_processes.py
+++ b/tests/tools/dumping/test_processes.py
@@ -465,4 +465,4 @@ def test_generate_parent_readme(tmp_path, generate_workchain_multiply_add):
     # Check for outputs of `verdi process status/report/show`
     assert 'Finished [0] [3:result]' in contents
     assert 'Property     Value' in contents
-    assert 'No log messages' in contents
+    assert 'There are 1 log messages for this calculation' in contents


### PR DESCRIPTION
Processes run through the daemon would no longer have their log messages attached to the database. This would result in `verdi process report` returning nothing.

The problem is that the `start_worker` function would call `configure_logging` without setting `with_orm=True` and so the `DbLogHandler` would essentially be undone. An integration test is added as a regression test.