### PR TITLE
ORM: Cache the logger adapter for `ProcessNode`

### DIFF
--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Module with `Node` sub class for processes."""
 
-from __future__ import annotations
 
 import enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
@@ -259,7 +258,6 @@ class ProcessNode(Sealable, Node):
             return self._logger
 
         # First time the property is called after the node is stored, create the logger adapter
-        # if self._logger_adapter is None:
         if not hasattr(self, '_logger_adapter'):
             self._logger_adapter = create_logger_adapter(self._logger, self)
 

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Module with `Node` sub class for processes."""
 
-
 import enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import enum
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 from plumpy.process_states import ProcessState
@@ -166,11 +165,6 @@ class ProcessNode(Sealable, Node):
 
     _unstorable_message = 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
-    # This is set on the instance the first time the ``logger`` property is called. It cannot be initialized in the
-    # constructor because that would not go for instances that are loaded from the database which do not pass through
-    # the constructor.
-    _logger_adapter: logging.LoggerAdapter | None = None
-
     def __str__(self) -> str:
         base = super().__str__()
         if self.process_type:
@@ -259,13 +253,14 @@ class ProcessNode(Sealable, Node):
         """
         from aiida.orm.utils.log import create_logger_adapter
 
-        # If the node is not yet stored, there is no point in creating the logger adapter yet as the ``DbLogHandler``
-        # it configures only is triggered for stored nodes otherwise it cannot link the log message to the node.
+        # If the node is not yet stored, there is no point in creating the logger adapter yet, as the ``DbLogHandler``
+        # it configures, is only triggered for stored nodes, otherwise it cannot link the log message to the node.
         if not self.pk:
             return self._logger
 
         # First time the property is called after the node is stored, create the logger adapter
-        if self._logger_adapter is None:
+        # if self._logger_adapter is None:
+        if not hasattr(self, '_logger_adapter'):
             self._logger_adapter = create_logger_adapter(self._logger, self)
 
         return self._logger_adapter


### PR DESCRIPTION
The logger adapter was recreated each time the `logger` property of the `ProcessNode` was invoked. It is now cached on the node instance as its contents should not change for the lifetime of the node.