### PR TITLE
CLI: Only configure logging in `set_log_level` callback once

### DIFF
--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -175,7 +175,7 @@ def graph_traversal_rules(rules):
     return decorator
 
 
-def set_log_level(_ctx, _param, value):
+def set_log_level(ctx, _param, value):
     """Configure the logging for the CLI command being executed.
 
     Note that we cannot use the most obvious approach of directly setting the level on the various loggers. The reason
@@ -192,12 +192,15 @@ def set_log_level(_ctx, _param, value):
     """
     from aiida.common import log
 
+    if log.CLI_ACTIVE:
+        return value
+
     log.CLI_ACTIVE = True
 
     # If the value is ``None``, it means the option was not specified, but we still configure logging for the CLI
     # However, we skip this when we are in a tab-completion context.
     if value is None:
-        if not _ctx.resilient_parsing:
+        if not ctx.resilient_parsing:
             configure_logging()
         return None
 


### PR DESCRIPTION
All `verdi` commands automatically have the `-v/--verbosity` option added. This option has a callback `set_log_level` that is invoked for each subcommand. The callback is supposed to call `configure_logging` to setup the logging configuration.

Besides it being unnecessary to call it multiple times for each subcommand, it would actually cause a bug in that once the profile storage would have been loaded (through the callback of the profile option), which would have called `configure_logging` with `with_orm=True` to make sure the `DbLogHandler` was properly configured, another call to `set_log_level` would call `configure_logging` with the default values (where `with_orm=False`) and so the `DbLogHandler` would be removed. This would result in process log messages not being persisted in the database. This would be manifested when running an AiiDA process through a script invoked through `verdi` or any other CLI that uses the verbosity option provided by `aiida-core`.

Since the `set_log_level` only has to make sure that the logging is configured at least once, a guard is added to skip the configuration once the `aiida.common.log.CLI_ACTIVE` global has been set by a previous invocation.