### PR TITLE
Docstring: clarify copy() doesn't do recursive=False for directories

### DIFF
--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -1118,11 +1118,13 @@ class SshTransport(Transport):
         Flags used: ``-r``: recursive copy; ``-f``: force, makes the command non interactive;
         ``-L`` follows symbolic links
 
-        :param  remotesource: file to copy from
+        :param remotesource: file to copy from
         :param remotedestination: file to copy to
         :param dereference: if True, copy content instead of copying the symlinks only
             Default = False.
-        :param recursive: if True copy directories recursively, otherwise only copy the specified file(s)
+        :param recursive: if True copy directories recursively.
+            Note that if the `remotesource` is a directory, `recursive` should always be set to True.
+            Default = True.
         :type recursive: bool
         :raise OSError: if the cp execution failed.
 


### PR DESCRIPTION
Fixes #6483 

As discussed in issue #6483, by reading the current docstring under the `copy()` method; some people, including myself, may find it confusing and thinking `copy('src/', recursive=False)` may copy all files in `'src/'` while skipping nested directories. 

While the actual behaviour is similar to `cp` command, raising an `OSError` in that case.  

The updated docstring in this PR clarifies that `recursive` should always be set `True` for directories.

