### PR TITLE
Tests: Fix `tests.orm.nodes.test_node:test_delete_through_backend`

### DIFF
--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -837,17 +837,13 @@ class TestNodeLinks:
 class TestNodeDelete:
     """Tests for deleting nodes."""
 
-    # TODO: Why is this failing for SQLite??
-    # sqlalchemy.orm.exc.ObjectDeletedError: Instance '<DbNode at 0x7f6a68845990>' has been deleted,
-    # or its row is otherwise not present.
-    # https://github.com/aiidateam/aiida-core/issues/6436
-    @pytest.mark.requires_psql
     def test_delete_through_backend(self):
         """Test deletion works correctly through the backend."""
         backend = get_manager().get_profile_storage()
 
         data_one = Data().store()
         data_two = Data().store()
+        data_two_pk = data_two.pk
         calculation = CalculationNode()
         calculation.base.links.add_incoming(data_one, LinkType.INPUT_CALC, 'input_one')
         calculation.base.links.add_incoming(data_two, LinkType.INPUT_CALC, 'input_two')
@@ -866,7 +862,7 @@ class TestNodeDelete:
 
         assert len(Log.collection.get_logs_for(data_one)) == 1
         assert Log.collection.get_logs_for(data_one)[0].pk == log_one.pk
-        assert len(Log.collection.get_logs_for(data_two)) == 0
+        assert len(Log.collection.find({'dbnode_id': data_two_pk})) == 0
 
     def test_delete_collection_logs(self):
         """Test deletion works correctly through objects collection."""


### PR DESCRIPTION
Fixes #6436 

The test was failing with a `core.sqlite_dos` storage plugin for the test profile. The problem is that the last assert was checking that the logs for `data_two` were deleted because `data_two` itself had been deleted. However, since it was deleted, the ORM instance can no longer be used either, which was causing an exception. Instead, its pk should be recorded before deleting the node, and the final check should just use the pk directly.

It is not quite clear why this test was not failing for the default `core.psql_dos` storage plugin that is used for tests. It should not be backend specific since both use SQLAlchemy for the ORM.