### PR TITLE
`QueryBuilder`: Remove implementation for `has_key` in SQLite storage

### DIFF
--- a/src/aiida/storage/sqlite_zip/orm.py
+++ b/src/aiida/storage/sqlite_zip/orm.py
@@ -284,17 +284,12 @@ class SqliteQueryBuilder(SqlaQueryBuilder):
             type_filter, casted_entity = _cast_json_type(database_entity, value)
             return case((type_filter, casted_entity.ilike(value, escape='\\')), else_=False)
 
-        # if operator == 'contains':
-        # to-do, see: https://github.com/sqlalchemy/sqlalchemy/discussions/7836
+        if operator == 'contains':
+            # to-do, see: https://github.com/sqlalchemy/sqlalchemy/discussions/7836
+            raise NotImplementedError('The operator `contains` is not implemented for SQLite-based storage plugins.')
 
         if operator == 'has_key':
-            return case(
-                (
-                    func.json_type(database_entity) == 'object',
-                    func.json_each(database_entity).table_valued('key', joins_implicitly=True).c.key == value,
-                ),
-                else_=False,
-            )
+            raise NotImplementedError('The operator `has_key` is not implemented for SQLite-based storage plugins.')
 
         if operator == 'in':
             type_filter, casted_entity = _cast_json_type(database_entity, value[0])

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -241,7 +241,10 @@ class TestVerdiCalculation:
         retrieved.base.repository._repository.put_object_from_filelike(io.BytesIO(b'5\n'), 'aiida.out')
         retrieved.base.repository._update_repository_metadata()
 
-    def test_calcjob_cleanworkdir_basic(self, pytestconfig):
+    # This currently fails with sqlite backend since the filtering relies on the `has_key` filter which is not
+    # implemented in SQLite, see https://github.com/aiidateam/aiida-core/pull/6497
+    @pytest.mark.requires_psql
+    def test_calcjob_cleanworkdir_basic(self):
         """Test verdi calcjob cleanworkdir"""
         # Specifying no filtering options and no explicit calcjobs should exit with non-zero status
         options = []
@@ -261,17 +264,12 @@ class TestVerdiCalculation:
         # The flag should have been set
         assert self.result_job.outputs.remote_folder.base.extras.get('cleaned') is True
 
-        # TODO: This currently fails with sqlite backend,
-        # since the filtering relies on the `has_key` filter which is not implemented in SQLite.
-        # https://github.com/aiidateam/aiida-core/issues/6256
-        marker_opt = pytestconfig.getoption('-m')
-        if 'not requires_psql' in marker_opt or 'presto' in marker_opt:
-            pytest.xfail('Known sqlite backend failure')
         # Do it again should fail as the calcjob has been cleaned
         options = ['-f', str(self.result_job.uuid)]
         result = self.cli_runner.invoke(command.calcjob_cleanworkdir, options)
         assert result.exception is not None, result.output
 
+    @pytest.mark.requires_psql
     def test_calcjob_cleanworkdir_advanced(self):
         # Check applying both p and o filters
         for flag_p in ['-p', '--past-days']:

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1537,6 +1537,7 @@ class TestConsistency:
         for pk, pk_clone in zip(pks, [e[1] for e in sorted(pks_clone)]):
             assert orm.load_node(pk) == orm.load_node(pk_clone)
 
+    @pytest.mark.requires_psql
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_iterall_persistence(self, manager):
         """Test that mutations made during ``QueryBuilder.iterall`` context are automatically committed and persisted.

--- a/tests/storage/sqlite/test_orm.py
+++ b/tests/storage/sqlite/test_orm.py
@@ -89,8 +89,9 @@ from aiida.storage.sqlite_temp import SqliteTempBackend
         ({'attributes.integer': {'in': [5, 6, 7]}}, 0),
         ({'attributes.integer': {'in': [1, 2, 3]}}, 1),
         # object operators
-        ({'attributes.dict': {'has_key': 'k'}}, 0),
-        ({'attributes.dict': {'has_key': 'key1'}}, 1),
+        # Reenable when ``has_key`` operator is implemented, see https://github.com/aiidateam/aiida-core/issues/6498
+        # ({'attributes.dict': {'has_key': 'k'}}, 0),
+        # ({'attributes.dict': {'has_key': 'key1'}}, 1),
     ),
     ids=json.dumps,
 )

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -162,6 +162,7 @@ class TestQueryWithAiidaObjects:
         """Initialize the profile."""
         self.computer = aiida_localhost
 
+    @pytest.mark.requires_psql
     def test_with_subclasses(self):
         from aiida.plugins import DataFactory
 


### PR DESCRIPTION
Fixes #6256

The SQLite based storage plugins implemented the `has_key` operator for the `QueryBuilder`, however, the implementation is incorrect. At the very least the negation operator does not work. Since this can silently return incorrect query results, it is best to remove the implementation and raise an `NotImplementedError`. The same is done for `contains` which was not yet implemented but also didn't yet raise an explicit exception.