### PR TITLE
Fixtures: Make `pgtest` truly an optional dependency

### DIFF
--- a/src/aiida/tools/pytest_fixtures/storage.py
+++ b/src/aiida/tools/pytest_fixtures/storage.py
@@ -7,7 +7,6 @@ import typing as t
 from uuid import uuid4
 
 import pytest
-from pgtest.pgtest import PGTest
 
 if t.TYPE_CHECKING:
     from pgtest.pgtest import PGTest
@@ -19,6 +18,8 @@ class PostgresCluster:
         self.cluster = None
 
     def _create(self):
+        from pgtest.pgtest import PGTest
+
         try:
             self.cluster = PGTest()
         except OSError as e:
@@ -59,7 +60,6 @@ class PostgresCluster:
         return postgres_config
 
 
-# TODO: Update docstring accordingly
 @pytest.fixture(scope='session')
 def postgres_cluster():
     """Create a temporary and isolated PostgreSQL cluster using ``pgtest`` and cleanup after the yield.


### PR DESCRIPTION
The pytest fixtures were improved to allow running with a `core.sqlite_dos` storage for the test profile, making PostgreSQL completely optional. However, the current fixture still imports the `pgtest` package at module level making it a requirement, despite it only being relevant when running the tests with a `core.psql_dos` storage plugin.

Here the import is moved inside the `PostgresCluster._create` method which is only called when the test suite actually uses a PSQL based storage plugin.