### PR TITLE
Update `redirects.txt` of installation pages

### DIFF
--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -13,6 +13,11 @@ install/installation.rst installation/index.rst
 install/configuration.rst howto/installation.rst
 install/updating_installation.rst howto/installation.rst
 install/troubleshooting.rst installation/troubleshooting.rst
+intro/get_started.rst installation/index.rst
+intro/install_system.rst installation/index.rst
+intro/install_conda.rst installation/index.rst
+intro/installation.rst installation/index.rst
+intro/run_docker.rst installation/docker.rst
 restapi/index.rst reference/rest_api.rst
 verdi/verdi_user_guide.rst topics/cli.rst
 working_with_aiida/index.rst howto/index.rst

--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -18,6 +18,9 @@ intro/install_system.rst installation/index.rst
 intro/install_conda.rst installation/index.rst
 intro/installation.rst installation/index.rst
 intro/run_docker.rst installation/docker.rst
+intro/tutorial.md tutorials/index.rst
+intro/about.rst intro/index.rst
+intro/index.rst installation/index.rst
 restapi/index.rst reference/rest_api.rst
 verdi/verdi_user_guide.rst topics/cli.rst
 working_with_aiida/index.rst howto/index.rst

--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -20,7 +20,6 @@ intro/installation.rst installation/index.rst
 intro/run_docker.rst installation/docker.rst
 intro/tutorial.md tutorials/index.rst
 intro/about.rst intro/index.rst
-intro/index.rst installation/index.rst
 restapi/index.rst reference/rest_api.rst
 verdi/verdi_user_guide.rst topics/cli.rst
 working_with_aiida/index.rst howto/index.rst


### PR DESCRIPTION
Fixes #6508 

In PR #6455, the structure of the installation section was modified. While some of the `redirects.txt` of the docs were updated, some were missing. Therefore, currently, the main Google search results for "aiida core installation" are broken (at least on my machine, for example `intro/get_started.rst` and `intro/install_system.rst`, see below).

This should be fixed ASAP.

<img src="https://github.com/aiidateam/aiida-core/assets/41700727/7d219de0-0e2d-45a0-8456-036e92226c27" width="50%">

