### PR TITLE
Docs: Fix typo in pytest plugins codeblock

### DIFF
--- a/docs/source/topics/plugins.rst
+++ b/docs/source/topics/plugins.rst
@@ -344,7 +344,7 @@ To make use of these fixtures, create a ``conftest.py`` file in your ``tests`` f
 
 .. code-block:: python
 
-   pytest_plugins = 'aiida.tools.pytest_fixtures
+   pytest_plugins = 'aiida.tools.pytest_fixtures'
 
 Just by adding this line, the fixtures that are provided by the :mod:`~aiida.tools.pytest_fixtures` module are automatically imported.
 The module provides the following fixtures:


### PR DESCRIPTION
Fixes #6512 

The codeblock for adding the pytest fixtures is missing a single quote at the end, added it as a quick fix for Issue #6512 