### PR TITLE
Docs: Add `PluggableSchemaValidator` to nitpick exceptions

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -142,6 +142,7 @@ py:meth fail
 py:class ComputedFieldInfo
 py:class pydantic.fields.Field
 py:class pydantic.main.BaseModel
+py:class PluggableSchemaValidator
 
 py:class requests.models.Response
 py:class requests.Response


### PR DESCRIPTION
Fixes #6514 

This class comes from `pydantic` and as of `pydantic==2.8.2` this is causing a warning because Sphinx cannot find the cross-reference.