### PR TITLE
Docs: prevent search engines to index historical versions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,6 +171,9 @@ html_show_sphinx = False
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = False
 
+# This is to tell search engines to index only stable and latest version
+html_extra_path = ['robots.txt']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /projects/aiida-core/en/latest/
+Allow: /projects/aiida-core/en/stable/
+Disallow: /


### PR DESCRIPTION
Fixes #6516 ,
I suggest to merge this immediately if the tests has passed, and build is successful.

The only way to know if this resolves the issue is to wait a few days and see if Google indexes are updated.