### PR TITLE
Docker Image: Fix release tag in publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,6 +59,12 @@ jobs:
         vars=$(cat build.json | jq -c '[.variable | to_entries[] | {"key": .key, "value": .value.default}] | from_entries')
         echo "vars=$vars" | tee -a "${GITHUB_OUTPUT}"
 
+    - id: get-version
+      if: ${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
+      run: |
+        tag="${{ github.ref_name }}"
+        echo "AIIDA_VERSION=${tag#v}" >> $GITHUB_OUTPUT
+
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
@@ -69,7 +75,7 @@ jobs:
           type=ref,event=pr
           type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
           type=edge,enable={{is_default_branch}}
-          type=raw,value=aiida-${{ env.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
+          type=raw,value=aiida-${{ steps.get-version.outputs.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
           type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           type=raw,value=postgresql-${{ env.PGSQL_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1


### PR DESCRIPTION
Fixes #6510.

Looks like this works, see this [test run](https://github.com/aiidateam/aiida-core/actions/runs/9807907715?pr=6520) which generated the [aiida-2.6.x-test](https://github.com/aiidateam/aiida-core/pkgs/container/aiida-core-base/239748429?tag=aiida-2.6.x-test) tag on ghcr.io.