### PR TITLE
Mark test_leak_ssh_calcjob as nightly

### DIFF
--- a/tests/engine/test_memory_leaks.py
+++ b/tests/engine/test_memory_leaks.py
@@ -44,7 +44,7 @@ def check_memory_leaks():
     assert not process_instances, f'Memory leak: process instances remain in memory: {process_instances}'
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
+# @pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
 @pytest.mark.usefixtures('aiida_profile', 'check_memory_leaks')
 def test_leak_run_process():
     """Test whether running a dummy process leaks memory."""
@@ -65,6 +65,7 @@ def test_leak_local_calcjob(aiida_code_installed):
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
+@pytest.mark.nightly
 @pytest.mark.usefixtures('aiida_profile', 'check_memory_leaks')
 def test_leak_ssh_calcjob(aiida_computer_ssh):
     """Test whether running a CalcJob over SSH leaks memory.

--- a/tests/engine/test_memory_leaks.py
+++ b/tests/engine/test_memory_leaks.py
@@ -44,7 +44,7 @@ def check_memory_leaks():
     assert not process_instances, f'Memory leak: process instances remain in memory: {process_instances}'
 
 
-# @pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
 @pytest.mark.usefixtures('aiida_profile', 'check_memory_leaks')
 def test_leak_run_process():
     """Test whether running a dummy process leaks memory."""


### PR DESCRIPTION
This is by far the slowest test in the test suite (takes roughly 10% of overall time!). Perhaps it could be moved to nightly tests? 