### PR TITLE
`SqliteDosStorage`: Catch locked database when setting global variable

### DIFF
--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -431,7 +431,7 @@ class Process(PlumpyProcess):
             self.node.set_process_state(self._state.LABEL)  # type: ignore[arg-type]
 
         self._save_checkpoint()
-        set_process_state_change_timestamp(self)
+        set_process_state_change_timestamp(self.node)
         super().on_entered(from_state)
 
     @override

--- a/src/aiida/engine/utils.py
+++ b/src/aiida/engine/utils.py
@@ -18,6 +18,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator, List, Optional, Tuple, Type, Union
 
 if TYPE_CHECKING:
+    from aiida.orm import ProcessNode
+
     from .processes import Process, ProcessBuilder
     from .runners import Runner
 
@@ -259,7 +261,7 @@ def loop_scope(loop) -> Iterator[None]:
         asyncio.set_event_loop(current)
 
 
-def set_process_state_change_timestamp(process: 'Process') -> None:
+def set_process_state_change_timestamp(node: 'ProcessNode') -> None:
     """Set the global setting that reflects the last time a process changed state, for the process type
     of the given process, to the current timestamp. The process type will be determined based on
     the class of the calculation node it has as its database container.
@@ -270,15 +272,15 @@ def set_process_state_change_timestamp(process: 'Process') -> None:
     from aiida.manage import get_manager
     from aiida.orm import CalculationNode, ProcessNode, WorkflowNode
 
-    if isinstance(process.node, CalculationNode):
+    if isinstance(node, CalculationNode):
         process_type = 'calculation'
-    elif isinstance(process.node, WorkflowNode):
+    elif isinstance(node, WorkflowNode):
         process_type = 'work'
-    elif isinstance(process.node, ProcessNode):
+    elif isinstance(node, ProcessNode):
         # This will only occur for testing, as in general users cannot launch plain Process classes
         return
     else:
-        raise ValueError(f'unsupported calculation node type {type(process.node)}')
+        raise ValueError(f'unsupported calculation node type {type(node)}')
 
     key = PROCESS_STATE_CHANGE_KEY.format(process_type)
     description = PROCESS_STATE_CHANGE_DESCRIPTION.format(process_type)

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -9,6 +9,7 @@
 """Test engine utilities such as the exponential backoff mechanism."""
 
 import asyncio
+import contextlib
 
 import pytest
 from aiida import orm
@@ -16,9 +17,11 @@ from aiida.engine import calcfunction, workfunction
 from aiida.engine.utils import (
     InterruptableFuture,
     exponential_backoff_retry,
+    get_process_state_change_timestamp,
     instantiate_process,
     interruptable_task,
     is_process_function,
+    set_process_state_change_timestamp,
 )
 
 ITERATION = 0
@@ -225,3 +228,52 @@ class TestInterruptableTask:
 
         result = await task_fut
         assert result == 'NOT ME!!!'
+
+
+@pytest.mark.parametrize('with_transaction', (True, False))
+@pytest.mark.parametrize('monkeypatch_process_state_change', (True, False))
+def test_set_process_state_change_timestamp(manager, with_transaction, monkeypatch_process_state_change, monkeypatch):
+    """Test :func:`aiida.engine.utils.set_process_state_change_timestamp`.
+
+    This function is known to except when the ``core.sqlite_dos`` storage plugin is used and multiple processes are run.
+    The function is called each time a process changes state and since it is updating the same row in the settings table
+    the limitation of SQLite to not allow concurrent writes to the same page causes an exception to be thrown because
+    the database is locked. This exception is caught in ``set_process_state_change_timestamp`` and simply is ignored.
+    This test makes sure that if this happens, any other state changes, e.g. an extra being set on a node, are not
+    accidentally reverted, when the changes are performed in an explicit transaction or not.
+    """
+    storage = manager.get_profile_storage()
+
+    node = orm.CalculationNode().store()
+    extra_key = 'some_key'
+    extra_value = 'some value'
+
+    # Initialize the process state change timestamp so it is possible to check whether it was changed or not at the
+    # end of the test.
+    set_process_state_change_timestamp(node)
+    current_timestamp = get_process_state_change_timestamp()
+    assert current_timestamp is not None
+
+    if monkeypatch_process_state_change:
+
+        def set_global_variable(*_, **__):
+            from sqlalchemy.exc import OperationalError
+
+            raise OperationalError('monkey failure', None, '', '')
+
+        monkeypatch.setattr(storage, 'set_global_variable', set_global_variable)
+
+    transaction_context = storage.transaction if with_transaction else contextlib.nullcontext
+
+    with transaction_context():
+        node.base.extras.set(extra_key, extra_value)
+        set_process_state_change_timestamp(node)
+
+    # The node extra should always have been set, regardless if the process state change excepted
+    assert node.base.extras.get(extra_key) == extra_value
+
+    # The process state change should have changed if the storage plugin was not monkeypatched to fail
+    if monkeypatch_process_state_change:
+        assert get_process_state_change_timestamp() == current_timestamp
+    else:
+        assert get_process_state_change_timestamp() != current_timestamp


### PR DESCRIPTION
Fixes #6532 

When running multiple processes simultaneously, even for a single runner whether local or daemonized, `sqlalchemy.exc.OperationError` exceptions would be thrown. They were due to the `set_process_state_change_timestamp` utility function which updates a row in the `DbSetting` table. The function is called each time a `Process` changes state.

This would cause problems for the `SqliteDosStorage` as that uses SQLite as the database which usually allows at most one writer to proceed concurrently. Luckily, this is the only place where this would crop up, as this is the only place in the database where different processes can touch the same row. SQLite is being operated in WAL mode in which case concurrent operations are supported as long as they touch different pages. This translates roughly to it being ok for different processes writing to the database as long as they are not touching the same rows. Since in AiiDA each process can only ever be run by a single runner, there should never be runners that are writing to the same row in a table.

The one exception is the writing of the `'process|state_change|.*` key in the `DbSetting` table during each process state change. This value is only used by `verdi process list` where it is displayed at the end, in order to give the user a sense of whether any processes are actually being run.

In that sense, it is not quite critical that every call is successful. Therefore, the `SqliteDosStorage` overrides the `set_global_variable` method to catch the `OperationalError` so that the failure can simply be logged and the process is not excepted. Since the reason for the failure is the fact that another process is already updating the timestamp, it is not critical if another writing is skipped. It will simply be updated again at a later stage.