### PR TITLE
CLI: `verdi computer test` report correct failed tests

### DIFF
--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -605,7 +605,7 @@ def computer_test(user, print_traceback, computer):
             message += '\n  Use the `--print-traceback` option to see the full traceback.'
 
         echo.echo(message)
-        echo.echo_warning(f'{1} out of {num_tests} tests failed')
+        echo.echo_warning('1 out of 1 tests failed')
 
 
 @verdi_computer.command('delete')


### PR DESCRIPTION
Fix #6530 

If the opening of the transport would fail in `verdi computer test` it would always report:

    Warning: 1 out of 0 tests failed

Since opening the connection is the first test performed and its failure is dealt with separately, the message can simply be hardcoded to 1 out of 1 tests having failed.