### PR TITLE
Devops: Fix pymatgen import causing mypy to fail

### DIFF
--- a/tests/orm/nodes/data/test_jsonable.py
+++ b/tests/orm/nodes/data/test_jsonable.py
@@ -6,7 +6,7 @@ import math
 import pytest
 from aiida.orm import load_node
 from aiida.orm.nodes.data.jsonable import JsonableData
-from pymatgen.core import Molecule
+from pymatgen.core.structure import Molecule
 
 
 class JsonableClass:


### PR DESCRIPTION
The `pymatgen==2024.07.18` release removed the exposing of `Molecule` in `pymatgen.core` causing `mypy` to fail. The import is updated to reflect the actual origin of the definition.