### PR TITLE
Docker: Make warning test insensitive to deprecation warnings 

### DIFF
--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pytest
 from packaging.version import parse
@@ -32,8 +33,10 @@ def test_verdi_status(aiida_exec, container_user):
     assert '✔ broker:' in output
     assert 'Daemon is running' in output
 
-    # check that we have suppressed the warnings
-    assert 'Warning' not in output
+    # Check that we have suppressed the warnings coming from using an install from repo and newer RabbitMQ version.
+    # Make sure to match only lines that start with ``Warning:`` because otherwise deprecation warnings from other
+    # packages that we cannot control may fail the test.
+    assert not re.match('^Warning:.*', output)
 
 
 def test_computer_setup_success(aiida_exec, container_user):


### PR DESCRIPTION
The Docker image is supposed to configure the profile such that warnings
about using a development version of `aiida-core` and a modern version
of RabbitMQ are silenced. The test was checking that `Warning` did not
appear in the output of `verdi status`, however, this would result in
false positives in case a deprecation warning would be printed due to
downstream dependencies that we cannot necessarily control. The test is
made more specific to check for a line starting with `Warning:` which
should reduce the chance for false positives.