### PR TITLE
Cast job_id to str to conform with type of _jobs_cache

### DIFF
--- a/src/aiida/engine/processes/calcjobs/manager.py
+++ b/src/aiida/engine/processes/calcjobs/manager.py
@@ -114,7 +114,7 @@ class JobsList:
             self.logger.info(f'AuthInfo<{self._authinfo.pk}>: successfully retrieved status of active jobs')
 
             for job_id, job_info in scheduler_response.items():
-                jobs_cache[job_id] = job_info
+                jobs_cache[str(job_id)] = job_info
 
             return jobs_cache
 


### PR DESCRIPTION
fixes #6542

As @sphuber pointed out in https://github.com/aiidateam/aiida-hyperqueue/pull/30#discussion_r1686038683, this is only a workaround. The ultimate solution should be using dataclass for `JobInfo`.