### PR TITLE
CLI: Fix `verdi storage migrate` for profile without broker

### DIFF
--- a/src/aiida/cmdline/commands/cmd_storage.py
+++ b/src/aiida/cmdline/commands/cmd_storage.py
@@ -41,12 +41,14 @@ def storage_migrate(force):
     from aiida.engine.daemon.client import get_daemon_client
     from aiida.manage import get_manager
 
-    client = get_daemon_client()
-    if client.is_daemon_running:
-        echo.echo_critical('Migration aborted, the daemon for the profile is still running.')
-
     manager = get_manager()
     profile = manager.get_profile()
+
+    if profile.process_control_backend:
+        client = get_daemon_client()
+        if client.is_daemon_running:
+            echo.echo_critical('Migration aborted, the daemon for the profile is still running.')
+
     storage_cls = profile.storage_cls
 
     if not force:

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -36,6 +36,15 @@ def tests_storage_info(aiida_localhost, run_cli_command):
 
 
 @pytest.mark.usefixtures('stopped_daemon_client')
+def tests_storage_migrate_no_broker(aiida_config_tmp, aiida_profile_factory, run_cli_command):
+    """Test the ``verdi storage migrate`` command for a profile without a broker."""
+    with aiida_profile_factory(aiida_config_tmp) as profile:
+        assert profile.process_control_backend is None
+        result = run_cli_command(cmd_storage.storage_migrate, parameters=['--force'], use_subprocess=False)
+        assert 'Migrating to the head of the main branch' in result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
 def tests_storage_migrate_force(run_cli_command):
     """Test the ``verdi storage migrate`` command (with force option)."""
     result = run_cli_command(cmd_storage.storage_migrate, parameters=['--force'])


### PR DESCRIPTION
Fixes #6546 

The command needs to make sure the daemon of the profile is not running so it instantiates the `DaemonClient` but this raises for profiles that do not define a broker. Since the daemon cannot be started for brokerless profiles anyway the command does not have to check in this case.