### PR TITLE
Docs: in `get_daemon_client` example, `profile_name` is the right option, not `profile`

### DIFF
--- a/docs/source/topics/daemon.rst
+++ b/docs/source/topics/daemon.rst
@@ -41,7 +41,7 @@ It is also possible to explicitly specify a profile:
 
 .. code-block:: python
 
-    client = get_daemon_client(profile='some-profile')
+    client = get_daemon_client(profile_name='some-profile')
 
 The daemon can be started and stopped through the client:
 


### PR DESCRIPTION
https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/daemon.html#