### PR TITLE
CLI: progress bar added for `verdi storage maintain` with `disk_object_store` backend

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - circus~=0.18.0
 - click-spinner~=0.1.8
 - click~=8.1
-- disk-objectstore~=1.1
+- disk-objectstore~=1.2
 - docstring_parser
 - get-annotations~=0.1
 - python-graphviz~=0.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   'circus~=0.18.0',
   'click-spinner~=0.1.8',
   'click~=8.1',
-  'disk-objectstore~=1.1',
+  'disk-objectstore~=1.2',
   'docstring-parser',
   'get-annotations~=0.1;python_version<"3.10"',
   'graphviz~=0.19',

--- a/requirements/requirements-py-3.10.txt
+++ b/requirements/requirements-py-3.10.txt
@@ -42,7 +42,7 @@ debugpy==1.6.7
 decorator==5.1.1
 defusedxml==0.7.1
 deprecation==2.1.0
-disk-objectstore==1.1.0
+disk-objectstore==1.2.0
 docstring-parser==0.15
 docutils==0.20.1
 exceptiongroup==1.1.1

--- a/requirements/requirements-py-3.11.txt
+++ b/requirements/requirements-py-3.11.txt
@@ -42,7 +42,7 @@ debugpy==1.6.7
 decorator==5.1.1
 defusedxml==0.7.1
 deprecation==2.1.0
-disk-objectstore==1.1.0
+disk-objectstore==1.2.0
 docstring-parser==0.15
 docutils==0.20.1
 executing==1.2.0

--- a/requirements/requirements-py-3.12.txt
+++ b/requirements/requirements-py-3.12.txt
@@ -42,7 +42,7 @@ debugpy==1.8.0
 decorator==5.1.1
 defusedxml==0.7.1
 deprecation==2.1.0
-disk-objectstore==1.1.0
+disk-objectstore==1.2.0
 docstring-parser==0.15
 docutils==0.20.1
 executing==2.0.0

--- a/requirements/requirements-py-3.9.txt
+++ b/requirements/requirements-py-3.9.txt
@@ -42,7 +42,7 @@ debugpy==1.6.7
 decorator==5.1.1
 defusedxml==0.7.1
 deprecation==2.1.0
-disk-objectstore==1.1.0
+disk-objectstore==1.2.0
 docstring-parser==0.15
 docutils==0.20.1
 exceptiongroup==1.2.1


### PR DESCRIPTION
This is the complementary PR for https://github.com/aiidateam/disk-objectstore/pull/171

Now one can easily test the changes here, as @giovannipizzi and @unkcpz requested. 

### Note
This PR should only merge after the one mentioned above, for this reason I marked this one as draft.
Also I should remember to tag and update the dependency,

### Note 2
Don't worry about test failing, it's only because it depends on a released version of `disk-objectstore` 
Ideally for testing, you can pull the [PR](https://github.com/aiidateam/disk-objectstore/pull/171) and install with `pip install -e .`