### PR TITLE
Kill descendant processes in `core.direct` schedulers plugin

### DIFF
--- a/src/aiida/schedulers/plugins/direct.py
+++ b/src/aiida/schedulers/plugins/direct.py
@@ -354,9 +354,18 @@ class DirectScheduler(BashCliScheduler):
 
         return stdout.strip()
 
-    def _get_kill_command(self, jobid):
-        """Return the command to kill the job with specified jobid."""
-        submit_command = f'kill {jobid}'
+    def _get_kill_command(self, process_id):
+        """Return the command to kill the process with specified id and all its descendants."""
+        from psutil import Process
+
+        # get a list of the process id of all descendants
+        process = Process(int(process_id))
+        children = process.children(recursive=True)
+        process_ids = [process_id]
+        process_ids.extend([str(child.pid) for child in children])
+        process_ids_str = ' '.join(process_ids)
+
+        submit_command = f'kill {process_ids_str}'
 
         self.logger.info(f'killing job {jobid}')
 

--- a/tests/schedulers/test_direct.py
+++ b/tests/schedulers/test_direct.py
@@ -83,6 +83,7 @@ def test_kill_job(scheduler, tmpdir):
                      we kill this process       we check if still running
     """
     import multiprocessing
+    import time
 
     from aiida.transports.plugins.local import LocalTransport
     from psutil import Process
@@ -98,12 +99,12 @@ def test_kill_job(scheduler, tmpdir):
     forked_process = multiprocessing.Process(target=run_sleep_100)
     forked_process.start()
     while len(forked_process_children := Process(forked_process.pid).children(recursive=True)) != 2:
-        pass
+        time.sleep(0.1)
     bash_process = forked_process_children[0]
     sleep_process = forked_process_children[1]
     with LocalTransport() as transport:
         scheduler.set_transport(transport)
         scheduler.kill_job(forked_process.pid)
     while bash_process.is_running() or sleep_process.is_running():
-        pass
+        time.sleep(0.1)
     forked_process.join()

--- a/tests/schedulers/test_direct.py
+++ b/tests/schedulers/test_direct.py
@@ -72,13 +72,6 @@ def test_submit_script_with_num_cores_per_mpiproc(scheduler, template):
     assert f'export OMP_NUM_THREADS={num_cores_per_mpiproc}' in result
 
 
-def run_sleep_100():
-    """Util function for `test_kill_job`. Has to be outside of test to be pickable."""
-    import subprocess
-
-    subprocess.run(['sleep', '100'], check=False)
-
-
 @pytest.mark.timeout(timeout=10)
 def test_kill_job(scheduler):
     """Test if kill_job kill all descendant children from the process.
@@ -93,6 +86,11 @@ def test_kill_job(scheduler):
 
     from aiida.transports.plugins.local import LocalTransport
     from psutil import Process
+
+    def run_sleep_100():
+        import subprocess
+
+        subprocess.run(['sleep', '100'], check=False)
 
     forked_process = multiprocessing.Process(target=run_sleep_100)
     forked_process.start()


### PR DESCRIPTION
Fixes #6571

In the direct scheduler we use `psutil` to obtain a list of descendant processes so we can kill all of them. This issue does not happen in the other scheduler as the job scheduler takes care of this. Here we have to manage the killing of the descendants by ourself.