### PR TITLE
DevOps: Pin bake-action to v5.5.0 to fix Docker build

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -41,7 +41,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Build images
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v5.5.0
       with:
         # Load to Docker engine for testing
         load: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Build and upload to ghcr.io 📤
       id: build
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v5.5.0
       with:
         push: true
         workdir: .docker/


### PR DESCRIPTION
As a quickfix suggested by @danielhollas in https://github.com/aiidateam/aiida-core/pull/6573#issuecomment-2378850120 we pin the bake action to v5.5.0