### PR TITLE
Update process status in the database before broadcasting that process status has changed (fix #6579)

### DIFF
--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -419,8 +419,6 @@ class Process(PlumpyProcess):
 
         from aiida.engine.utils import set_process_state_change_timestamp
 
-        super().on_entered(from_state)
-
         if self._state.LABEL is ProcessState.EXCEPTED:
             # The process is already excepted so simply update the process state on the node and let the process
             # complete the state transition to the terminal state. If another exception is raised during this exception
@@ -443,6 +441,8 @@ class Process(PlumpyProcess):
 
         self._save_checkpoint()
         set_process_state_change_timestamp(self.node)
+
+        super().on_entered(from_state)
 
     @override
     def on_terminated(self) -> None:


### PR DESCRIPTION
Fix for #6579

Processes start to broadcast their event before they update their process status in the database. This can cause issues if the next process directly tries to access the last process state retrieving it from the database while it has not been updated in the database.

TODO: test