### PR TITLE
ORM: Add `get_size_on_disk` method to `RemoteData`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -97,7 +97,7 @@ def remote_show(datum):
     '--method',
     type=click.STRING,
     default='du',
-    help='The method that should be used to evaluate the size (either ``du`` or ``lstat``.)',
+    help='The method that should be used to evaluate the size (either ``du`` or ``stat``.)',
 )
 @click.option(
     '-p',
@@ -116,14 +116,14 @@ def remote_show(datum):
     help='Return the size in bytes or human-readable format?',
 )
 def remote_size(node, method, path, return_bytes):
-    """Obtain the total size of a file or directory at a given path that is stored as a ``RemoteData`` object."""
+    """Obtain the total size of a file or directory at a given path that is stored via a ``RemoteData`` object."""
     try:
         # `method` might change, if `du` fails, so the variable is reassigned.
         total_size, method = node.get_size_on_disk(relpath=path, method=method, return_bytes=return_bytes)
         remote_path = Path(node.get_remote_path())
         full_path = remote_path / path if path is not None else remote_path
-        echo.echo(
-            f'Estimated total size of file/directory `{full_path}` on the Computer '
+        echo.echo_success(
+            f'Estimated total size of path `{full_path}` on the Computer '
             f'<{node.computer.label}> obtained via `{method}`: {total_size}'
         )
     except (OSError, FileNotFoundError, NotImplementedError) as exc:

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -13,7 +13,7 @@ import stat
 import click
 
 from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.params import arguments, types
+from aiida.cmdline.params import arguments, types, options
 from aiida.cmdline.utils import echo
 
 
@@ -87,3 +87,11 @@ def remote_show(datum):
     """Show information for a RemoteData object."""
     echo.echo(f'- Remote computer name: {datum.computer.label}')
     echo.echo(f'- Remote folder full path: {datum.get_remote_path()}')
+
+
+@remote.command('size')
+@arguments.NODE()
+def remote_size(node):
+    """Print the total size of a RemoteData object."""
+    print(node)
+    total_size = node.get_size_on_disk()

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -118,13 +118,13 @@ def remote_show(datum):
 def remote_size(node, method, path, return_bytes):
     """Obtain the total size of a file or directory at a given path that is stored via a ``RemoteData`` object."""
     try:
-        # `method` might change, if `du` fails, so the variable is reassigned.
-        total_size, method = node.get_size_on_disk(relpath=path, method=method, return_bytes=return_bytes)
+        # `method` might change, if `du` fails, so assigning to new variable here
+        total_size, used_method = node.get_size_on_disk(relpath=path, method=method, return_bytes=return_bytes)
         remote_path = Path(node.get_remote_path())
         full_path = remote_path / path if path is not None else remote_path
         echo.echo_success(
             f'Estimated total size of path `{full_path}` on the Computer '
-            f'<{node.computer.label}> obtained via `{method}`: {total_size}'
+            f'<{node.computer.label}> obtained via `{used_method}`: {total_size}'
         )
     except (OSError, FileNotFoundError, NotImplementedError) as exc:
         echo.echo_critical(str(exc))

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -13,7 +13,7 @@ import stat
 import click
 
 from aiida.cmdline.commands.cmd_data import verdi_data
-from aiida.cmdline.params import arguments, types, options
+from aiida.cmdline.params import arguments, types
 from aiida.cmdline.utils import echo
 
 

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -106,15 +106,25 @@ def remote_show(datum):
     default=None,
     help='Relative path of the object of the ``RemoteData`` node for which the size should be evaluated.',
 )
-def remote_size(node, method, path):
-    """Print the total size of a RemoteData object."""
+@click.option(
+    '-b',
+    '--bytes',
+    'return_bytes',
+    type=bool,
+    is_flag=True,
+    default=False,
+    help='Return the size in bytes or human-readable format?',
+)
+def remote_size(node, method, path, return_bytes):
+    """Obtain the total size of a file or directory at a given path that is stored as a ``RemoteData`` object."""
     try:
-        total_size, method = node.get_size_on_disk(relpath=path, method=method)
+        # `method` might change, if `du` fails, so the variable is reassigned.
+        total_size, method = node.get_size_on_disk(relpath=path, method=method, return_bytes=return_bytes)
         remote_path = Path(node.get_remote_path())
         full_path = remote_path / path if path is not None else remote_path
         echo.echo(
-            f'Estimated total size of directory `{full_path}` on the Computer '
-            f'`{node.computer.label}` obtained via `{method}`: {total_size}'
+            f'Estimated total size of file/directory `{full_path}` on the Computer '
+            f'<{node.computer.label}> obtained via `{method}`: {total_size}'
         )
-    except FileNotFoundError as exc:
+    except (OSError, FileNotFoundError, NotImplementedError) as exc:
         echo.echo_critical(str(exc))

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -90,21 +90,21 @@ def remote_show(datum):
     echo.echo(f'- Remote folder full path: {datum.get_remote_path()}')
 
 
-@remote.command("size")
+@remote.command('size')
 @arguments.NODE()
 @click.option(
-    "-m",
-    "--method",
+    '-m',
+    '--method',
     type=click.STRING,
-    default="du",
-    help="The method that should be used to evaluate the size (either ``du`` or ``lstat``.)",
+    default='du',
+    help='The method that should be used to evaluate the size (either ``du`` or ``lstat``.)',
 )
 @click.option(
-    "-p",
-    "--path",
+    '-p',
+    '--path',
     type=click.Path(),
     default=None,
-    help="Relative path of the object of the ``RemoteData`` node for which the size should be evaluated.",
+    help='Relative path of the object of the ``RemoteData`` node for which the size should be evaluated.',
 )
 def remote_size(node, method, path):
     """Print the total size of a RemoteData object."""
@@ -113,8 +113,8 @@ def remote_size(node, method, path):
         remote_path = Path(node.get_remote_path())
         full_path = remote_path / path if path is not None else remote_path
         echo.echo(
-            f"Estimated total size of directory `{full_path}` on the Computer "
-            f"`{node.computer.label}` obtained via `{method}`: {total_size}"
+            f'Estimated total size of directory `{full_path}` on the Computer '
+            f'`{node.computer.label}` obtained via `{method}`: {total_size}'
         )
     except FileNotFoundError as exc:
         echo.echo_critical(str(exc))

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -579,10 +579,8 @@ def format_directory_size(size_in_bytes: int) -> str:
     Converts a size in bytes to a human-readable string with the appropriate prefix.
 
     :param size_in_bytes: Size in bytes.
-    :type size_in_bytes: int
     :raises ValueError: If the size is negative.
     :return: Human-readable size string with a prefix (e.g., "1.23 KB", "5.67 MB").
-    :rtype: str
 
     The function converts a given size in bytes to a more readable format by
     adding the appropriate unit suffix (e.g., KB, MB, GB). It uses the binary

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -572,3 +572,37 @@ class DatetimePrecision:
 
         self.dtobj = dtobj
         self.precision = precision
+
+
+def format_directory_size(size_in_bytes: int) -> str:
+    """
+    Converts a size in bytes to a human-readable string with the appropriate prefix.
+
+    :param size_in_bytes: Size in bytes.
+    :type size_in_bytes: int
+    :raises ValueError: If the size is negative.
+    :return: Human-readable size string with a prefix (e.g., "1.23 KB", "5.67 MB").
+    :rtype: str
+
+    The function converts a given size in bytes to a more readable format by
+    adding the appropriate unit suffix (e.g., KB, MB, GB). It uses the binary
+    system (base-1024) for unit conversions.
+
+    Example:
+        >>> format_directory_size(123456789)
+        '117.74 MB'
+    """
+    if size_in_bytes < 0:
+        raise ValueError('Size cannot be negative.')
+
+    # Define size prefixes
+    prefixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    factor = 1024  # 1 KB = 1024 B
+    index = 0
+
+    while size_in_bytes >= factor and index < len(prefixes) - 1:
+        size_in_bytes /= factor
+        index += 1
+
+    # Format the size to two decimal places
+    return f'{size_in_bytes:.2f} {prefixes[index]}'

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -594,7 +594,7 @@ def format_directory_size(size_in_bytes: int) -> str:
         raise ValueError('Size cannot be negative.')
 
     # Define size prefixes
-    prefixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    prefixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
     factor = 1024  # 1 KB = 1024 B
     index = 0
 

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -575,8 +575,7 @@ class DatetimePrecision:
 
 
 def format_directory_size(size_in_bytes: int) -> str:
-    """
-    Converts a size in bytes to a human-readable string with the appropriate prefix.
+    """Converts a size in bytes to a human-readable string with the appropriate prefix.
 
     :param size_in_bytes: Size in bytes.
     :raises ValueError: If the size is negative.

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -14,6 +14,7 @@ import logging
 import os
 from pathlib import Path
 
+from aiida.common.exceptions import NotExistent
 from aiida.orm import AuthInfo
 from aiida.orm.fields import add_field
 from aiida.transports import Transport
@@ -212,13 +213,23 @@ class RemoteData(Data):
         """
 
         from aiida.common.utils import format_directory_size
+        from aiida.manage import get_manager
 
         if relpath is None:
             relpath = Path('.')
 
-        authinfo = self.get_authinfo()
+        print('self: ', self, type(self))
+        # raise SystemExit
+        try:
+            authinfo = self.get_authinfo()
+        except NotExistent:
+            manager = get_manager()
+            # authinfo =
+        print(authinfo)
         full_path = Path(self.get_remote_path()) / relpath
+        print(full_path)
         computer_label = self.computer.label if self.computer is not None else ''
+        print(computer_label)
 
         with authinfo.get_transport() as transport:
             if not transport.path_exists(str(full_path)):

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -14,7 +14,6 @@ import logging
 import os
 from pathlib import Path
 
-from aiida.common.exceptions import NotExistent
 from aiida.orm import AuthInfo
 from aiida.orm.fields import add_field
 from aiida.transports import Transport

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -201,16 +201,16 @@ class RemoteData(Data):
         method: str = 'du',
         return_bytes: bool = False,
     ) -> int | str:
-        """Connects to the remote Computer of the `RemoteData` ojbect and returns the total size of a file or a
+        """Connects to the remote Computer of the `RemoteData` object and returns the total size of a file or a
         directory at the given `relpath` in a human-readable format.
 
         :param relpath: File or directory path for which the total size should be returned, relative to
-        ``self.get_remote_path()``.
+            ``self.get_remote_path()``.
         :param method: Method to be used to evaluate the directory/file size (either ``du`` or ``lstat``).
         :param return_bytes: Return the total byte size is int, or in human-readable format.
 
-        :raises: ``FileNotFoundError``, if file or directory does not exist anymore on the remote ``Computer``.
-        :raises: ``NotImplementedError``, if a method other than ``du`` or ``lstat`` is selected.
+        :raises FileNotFoundError: If file or directory does not exist anymore on the remote ``Computer``.
+        :raises NotImplementedError: If a method other than ``du`` or ``lstat`` is selected.
 
         :return: Total size of given file or directory.
         """

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -252,7 +252,7 @@ class RemoteData(Data):
         :param transport: Open transport instance.
         :raises NotImplementedError: When ``exec_command_wait`` is not implemented, e.g., for the FirecREST plugin.
         :raises RuntimeError: When ``du`` command cannot be successfully executed.
-        :return: Total size of directory recursively in bytes.
+        :return: Total size of directory in bytes (including all its contents).
         """
 
         try:
@@ -278,7 +278,7 @@ class RemoteData(Data):
         :param full_path: Full path of which the size should be evaluated.
         :param transport: Open transport instance.
         :raises OSError: When directory given by ``full_path`` not existing or not a directory.
-        :return: Total size of directory recursively in bytes.
+        :return: Total size of directory in bytes (including all its contents).
         """
         try:
             total_size = 0

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -228,7 +228,6 @@ class RemoteData(Data):
                 )
                 raise FileNotFoundError(exc_message)
 
-
             try:
                 total_size: int = self._get_size_on_disk_du(full_path, transport)
 

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -228,9 +228,7 @@ class RemoteData(Data):
 
         with authinfo.get_transport() as transport:
             if not transport.path_exists(str(full_path)):
-                exc_message = (
-                    f'The required remote path {full_path} on Computer <{computer_label}> ' 'does not exist.'
-                )
+                exc_message = f'The required remote path {full_path} on Computer <{computer_label}> ' 'does not exist.'
                 raise FileNotFoundError(exc_message)
 
             if method not in ('du', 'stat'):

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -232,9 +232,8 @@ class RemoteData(Data):
                 raise FileNotFoundError(exc_message)
 
             if method not in ('du', 'stat'):
-                raise NotImplementedError(
-                    f'Specified method `{method}` for evaluating the size on disk not implemented.'
-                )
+                exc_message = f'Specified method `{method}` is not an valid input. Please choose either `du` or `stat`.'
+                raise ValueError(exc_message)
 
             if method == 'du':
                 try:

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -195,7 +195,7 @@ class RemoteData(Data):
     def get_authinfo(self):
         return AuthInfo.get_collection(self.backend).get(dbcomputer=self.computer, aiidauser=self.user)
 
-    def get_size_on_disk(self, relpath: Path | None = None, method: str = "du") -> str:
+    def get_size_on_disk(self, relpath: Path | None = None, method: str = 'du') -> str:
         """
         Connects to the remote folder and returns the total size of all files in the directory recursively in a
         human-readable format.
@@ -211,55 +211,53 @@ class RemoteData(Data):
         from aiida.common.utils import format_directory_size
 
         if relpath is None:
-            relpath = Path(".")
+            relpath = Path('.')
 
         authinfo = self.get_authinfo()
         full_path = Path(self.get_remote_path()) / relpath
-        computer_label = self.computer.label if self.computer is not None else ""
+        computer_label = self.computer.label if self.computer is not None else ''
 
         with authinfo.get_transport() as transport:
             if not transport.path_exists(str(full_path)):
                 exc_message = (
-                    f"The required remote folder {full_path} on Computer <{computer_label}> "
-                    "does not exist, is not a directory or has been deleted."
+                    f'The required remote folder {full_path} on Computer <{computer_label}> '
+                    'does not exist, is not a directory or has been deleted.'
                 )
                 raise FileNotFoundError(exc_message)
 
-            if method not in ("du", "lstat"):
+            if method not in ('du', 'lstat'):
                 raise NotImplementedError(
-                    f"Specified method `{method}` for evaluating the size on disk not implemented."
+                    f'Specified method `{method}` for evaluating the size on disk not implemented.'
                 )
 
-            if method == "du":
+            if method == 'du':
                 try:
                     total_size: int = self._get_size_on_disk_du(full_path, transport)
 
                 except (RuntimeError, NotImplementedError):
                     lstat_warn = (
-                        "Problem executing `du` command. Will return total file size based on `lstat`. "
-                        "Take the result with a grain of salt, as `lstat` does not consider the file system block size,"
-                        " but instead returns the true size of the files in bytes, which differs from the actual space"
-                        "requirements on disk."
+                        'Problem executing `du` command. Will return total file size based on `lstat`. '
+                        'Take the result with a grain of salt, as `lstat` does not consider the file system block size,'
+                        ' but instead returns the true size of the files in bytes, which differs from the actual space'
+                        'requirements on disk.'
                     )
 
                     _logger.warning(lstat_warn)
-                    method = "lstat"
+                    method = 'lstat'
 
                 else:
-                    _logger.report("Obtained size on the remote using `du`.")
+                    _logger.report('Obtained size on the remote using `du`.')
 
             # No elif here, but another if, to allow that the method is internally changed to `lstat`, if `du` fails
-            if method == "lstat":
+            if method == 'lstat':
                 try:
                     total_size: int = self._get_size_on_disk_lstat(full_path, transport)
-                    print(f"TOTAL_SIZE: {total_size}")
+                    print(f'TOTAL_SIZE: {total_size}')
 
                 except OSError:
-                    _logger.critical(
-                        "Could not evaluate directory size using either `du` or `lstat`."
-                    )
+                    _logger.critical('Could not evaluate directory size using either `du` or `lstat`.')
                 else:
-                    _logger.report("Obtained size on the remote using `lstat`.")
+                    _logger.report('Obtained size on the remote using `lstat`.')
 
             return format_directory_size(size_in_bytes=total_size), method
 
@@ -275,19 +273,15 @@ class RemoteData(Data):
         """
 
         try:
-            retval, stdout, stderr = transport.exec_command_wait(
-                f"du -s --bytes {full_path}"
-            )
+            retval, stdout, stderr = transport.exec_command_wait(f'du -s --bytes {full_path}')
             if not stderr and retval == 0:
-                total_size: int = int(stdout.split("\t")[0])
+                total_size: int = int(stdout.split('\t')[0])
                 return total_size
             else:
-                raise RuntimeError(f"Error executing `du` command: {stderr}")
+                raise RuntimeError(f'Error executing `du` command: {stderr}')
 
         except NotImplementedError as exc:
-            raise NotImplementedError(
-                "`exec_command_wait` not implemented for the current transport plugin."
-            ) from exc
+            raise NotImplementedError('`exec_command_wait` not implemented for the current transport plugin.') from exc
 
     def _get_size_on_disk_lstat(self, full_path: Path, transport: Transport) -> int:
         """
@@ -302,21 +296,21 @@ class RemoteData(Data):
         :raises OSError: When directory given by ``full_path`` not existing or not a directory.
         :return: Total size of directory in bytes (including all its contents).
         """
-        def _get_size_on_disk_lstat_recursive(full_path, transport):
 
+        def _get_size_on_disk_lstat_recursive(full_path, transport):
             current_size = 0
 
             contents = self.listdir_withattributes(full_path)
 
             for item in contents:
-                item_path = full_path / item["name"]
+                item_path = full_path / item['name']
                 # Add size of current item (file or directory metadata)
                 # breakpoint()
                 # print(f'ITEM: {item["name"]}, {item["attributes"]["st_size"]}({item_path})')
-                current_size += item["attributes"]["st_size"]
+                current_size += item['attributes']['st_size']
 
                 # If it's a directory, recursively get size of contents
-                if item["isdir"]:
+                if item['isdir']:
                     # print(item["name"])
                     current_size += _get_size_on_disk_lstat_recursive(item_path, transport)
 
@@ -333,8 +327,8 @@ class RemoteData(Data):
             if exception.errno in (2, 20):
                 # directory not existing or not a directory
                 exc = OSError(
-                    f"The required remote folder {full_path} on {self.computer.label} does not exist, is not a "
-                    "directory or has been deleted."
+                    f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
+                    'directory or has been deleted.'
                 )
                 exc.errno = exception.errno
                 raise exc from exception

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -103,7 +103,7 @@ class RemoteData(Data):
             full_path = os.path.join(self.get_remote_path(), relpath)
             if not transport.isdir(full_path):
                 raise OSError(
-                    f'The required remote folder {full_path} on {self.computer.label} does not exist, is not a '
+                    f'The required remote path {full_path} on {self.computer.label} does not exist, is not a '
                     'directory or has been deleted.'
                 )
 
@@ -206,20 +206,21 @@ class RemoteData(Data):
 
         :param relpath: File or directory path for which the total size should be returned, relative to
             ``self.get_remote_path()``.
-        :param method: Method to be used to evaluate the directory/file size (either ``du`` or ``lstat``).
+        :param method: Method to be used to evaluate the directory/file size (either ``du`` or ``stat``).
         :param return_bytes: Return the total byte size is int, or in human-readable format.
 
         :raises FileNotFoundError: If file or directory does not exist anymore on the remote ``Computer``.
-        :raises NotImplementedError: If a method other than ``du`` or ``lstat`` is selected.
+        :raises NotImplementedError: If a method other than ``du`` or ``stat`` is selected.
 
         :return: Total size of given file or directory.
         """
 
         from aiida.common.utils import format_directory_size
 
+        total_size = -1
+
         # Initialize it here and only return if set. Avoid repeating the code in the `else` of the try-except-else
         # blocks for each method
-        total_size: int | None = None
         if relpath is None:
             relpath = Path('.')
 
@@ -234,7 +235,7 @@ class RemoteData(Data):
                 )
                 raise FileNotFoundError(exc_message)
 
-            if method not in ('du', 'lstat'):
+            if method not in ('du', 'stat'):
                 raise NotImplementedError(
                     f'Specified method `{method}` for evaluating the size on disk not implemented.'
                 )
@@ -242,41 +243,38 @@ class RemoteData(Data):
             if method == 'du':
                 try:
                     total_size: int = self._get_size_on_disk_du(full_path, transport)
+                    _logger.report('Obtained size on the remote using `du`.')
+                    if return_bytes:
+                        return total_size, method
+                    else:
+                        return format_directory_size(size_in_bytes=total_size), method
 
                 except (RuntimeError, NotImplementedError):
                     # NotImplementedError captures the fact that, e.g., FirecREST does not allow for `exec_command_wait`
-                    lstat_warn = (
-                        'Problem executing `du` command. Will return total file size based on `lstat`. '
-                        'Take the result with a grain of salt, as `lstat` does not consider the file system block '
-                        'size, but instead returns the true size of the file contents in bytes, which is usually '
-                        'smaller than the actual space requirements on disk.'
+                    stat_warn = (
+                        'Problem executing `du` command. Will return total file size based on `stat` as fallback. '
                     )
 
-                    _logger.warning(lstat_warn)
-                    method = 'lstat'
+                    _logger.warning(stat_warn)
 
-                else:
-                    _logger.report('Obtained size on the remote using `du`.')
-
-            # No elif here, but another if, to allow that the method is internally changed to `lstat`, if `du` fails.
-            if method == 'lstat':
+            if method == 'stat' or total_size < 0:
                 try:
-                    total_size: int = self._get_size_on_disk_lstat(full_path, transport)
+                    total_size: int = self._get_size_on_disk_stat(full_path, transport)
+                    _logger.report('Obtained size on the remote using `stat`.')
+                    _logger.warning(
+                        'Take the result with a grain of salt, as `stat` returns the apparent size of files, '
+                        'not their actual disk usage.'
+                    )
+                    if return_bytes:
+                        return total_size, 'stat'
+                    else:
+                        return format_directory_size(size_in_bytes=total_size), 'stat'
 
                 # This should typically not even be reached, as the OSError occours if the path is not a directory or
                 # does not exist. Though, we check for its existence already in the beginning of this method.
                 except OSError:
-                    _logger.critical('Could not evaluate directory size using either `du` or `lstat`.')
+                    _logger.critical('Could not evaluate directory size using either `du` or `stat`.')
                     raise
-
-                else:
-                    _logger.report('Obtained size on the remote using `lstat`.')
-
-            if total_size is not None:
-                if return_bytes:
-                    return total_size, method
-                else:
-                    return format_directory_size(size_in_bytes=total_size), method
 
     def _get_size_on_disk_du(self, full_path: Path, transport: Transport) -> int:
         """Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using
@@ -293,23 +291,23 @@ class RemoteData(Data):
 
         try:
             retval, stdout, stderr = transport.exec_command_wait(f'du -s --bytes {full_path}')
-            if not stderr and retval == 0:
-                total_size: int = int(stdout.split('\t')[0])
-                return total_size
-            else:
-                raise RuntimeError(f'Error executing `du` command: {stderr}')
-
         except NotImplementedError as exc:
             raise NotImplementedError('`exec_command_wait` not implemented for the current transport plugin.') from exc
 
-    def _get_size_on_disk_lstat(self, full_path: Path, transport: Transport) -> int:
-        """Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using
-        the ``lstat`` command.
+        if stderr or retval != 0:
+            raise RuntimeError(f'Error executing `du` command: {stderr}')
+        else:
+            total_size: int = int(stdout.split('\t')[0])
+            return total_size
 
-        Connects to the remote folder and returns the total size of all files in the directory in bytes using ``lstat``.
+    def _get_size_on_disk_stat(self, full_path: Path, transport: Transport) -> int:
+        """Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using
+        the ``stat`` command.
+
+        Connects to the remote folder and returns the total size of all files in the directory in bytes using ``stat``.
         Note that even if a file is only 1 byte, on disk, it still occupies one full disk block size.  As such, getting
         accurate measures of the total expected size on disk when retrieving a ``RemoteData`` is not straightforward
-        with ``lstat``, as one would need to consider the occupied block sizes for each file, as well as repository
+        with ``stat``, as one would need to consider the occupied block sizes for each file, as well as repository
         metadata. Thus, this function only serves as a fallback in the absence of the ``du`` command, and the returned
         estimate is expected to be smaller than the size on disk that is actually occupied.
 
@@ -321,7 +319,7 @@ class RemoteData(Data):
         :return: Total size of the file/directory in bytes (including all its contents).
         """
 
-        def _get_size_on_disk_lstat_recursive(full_path: Path, transport: Transport):
+        def _get_size_on_disk_stat_recursive(full_path: Path, transport: Transport):
             """Helper function for recursive directory traversal."""
 
             total_size = 0
@@ -334,19 +332,16 @@ class RemoteData(Data):
 
                 # If it's a directory, recursively get size of contents
                 if item['isdir']:
-                    total_size += _get_size_on_disk_lstat_recursive(item_path, transport)
+                    total_size += _get_size_on_disk_stat_recursive(item_path, transport)
 
             return total_size
 
-        # `RemoteData.listdir_withattributes` only works for directories
-        # Here, also allow returning the size of a file
         if transport.isfile(path=str(full_path)):
             return transport.get_attribute(str(full_path))['st_size']
 
-        else:
-            try:
-                return _get_size_on_disk_lstat_recursive(full_path, transport)
+        try:
+            return _get_size_on_disk_stat_recursive(full_path, transport)
 
-            except OSError:
-                # Not a directory or not existing anymore. Exception is captured outside in `get_size_on_disk`.
-                raise
+        except OSError:
+            # Not a directory or not existing anymore. Exception is captured outside in `get_size_on_disk`.
+            raise

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -201,9 +201,8 @@ class RemoteData(Data):
         method: str = 'du',
         return_bytes: bool = False,
     ) -> int | str:
-        """
-        Connects to the remote Computer of the `RemoteData` ojbect and returns the total size of a file or a directory
-        at the given `relpath` in a human-readable format.
+        """Connects to the remote Computer of the `RemoteData` ojbect and returns the total size of a file or a
+        directory at the given `relpath` in a human-readable format.
 
         :param relpath: File or directory path for which the total size should be returned, relative to
         ``self.get_remote_path()``.
@@ -280,9 +279,8 @@ class RemoteData(Data):
                     return format_directory_size(size_in_bytes=total_size), method
 
     def _get_size_on_disk_du(self, full_path: Path, transport: Transport) -> int:
-        """
-        Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using the
-        ``du`` command.
+        """Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using
+        the ``du`` command.
 
         :param full_path: Full path of file or directory for which the size should be evaluated.
         :param transport: Open transport instance.
@@ -305,9 +303,8 @@ class RemoteData(Data):
             raise NotImplementedError('`exec_command_wait` not implemented for the current transport plugin.') from exc
 
     def _get_size_on_disk_lstat(self, full_path: Path, transport: Transport) -> int:
-        """
-        Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using the
-        ``lstat`` command.
+        """Returns the total size of a file/directory at the given ``full_path`` on the remote Computer in bytes using
+        the ``lstat`` command.
 
         Connects to the remote folder and returns the total size of all files in the directory in bytes using ``lstat``.
         Note that even if a file is only 1 byte, on disk, it still occupies one full disk block size.  As such, getting

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -92,7 +92,7 @@ def test_get_size_on_disk(request, fixture):
 def test_get_size_on_disk_sizes(tmp_path, num_char, sizes, request, fixture):
     """Test the different implementations implementations to obtain the size of a RemoteData on disk."""
 
-    remote_data = request.getfixturevalue(fixture) # (num_char=num_char)
+    remote_data = request.getfixturevalue(fixture)  # (num_char=num_char)
 
     content = b'a' * num_char
     (tmp_path / 'file.txt').write_bytes(content)
@@ -157,4 +157,4 @@ def test_get_size_on_disk_lstat(request, fixture):
 
         # Raises OSError for non-existent directory
         with pytest.raises(OSError, match='The required remote folder.*'):
-            remote_data._get_size_on_disk_lstat(transport=transport, full_path = full_path / 'non-existent')
+            remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path / 'non-existent')

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -8,13 +8,15 @@
 ###########################################################################
 """Tests for the :mod:`aiida.orm.nodes.data.remote.base.RemoteData` module."""
 
+from pathlib import Path
+
 import pytest
 
 from aiida.orm import RemoteData
 
 
 @pytest.fixture
-def remote_data(tmp_path, aiida_localhost):
+def remote_data_local(tmp_path, aiida_localhost):
     """Return a non-empty ``RemoteData`` instance."""
     node = RemoteData(computer=aiida_localhost)
     node.set_remote_path(str(tmp_path))
@@ -22,12 +24,77 @@ def remote_data(tmp_path, aiida_localhost):
     (tmp_path / 'file.txt').write_bytes(b'some content')
     return node
 
+@pytest.fixture
+def remote_data_ssh(tmp_path, aiida_computer_ssh):
+    """Return a non-empty ``RemoteData`` instance."""
+    # Compared to `aiida_localhost`, `aiida_computer_ssh` doesn't return an actual `Computer`, but just a factory
+    # Thus, we need to call the factory here passing the label to actually create the `Computer` instance
+    localhost_ssh = aiida_computer_ssh(label='localhost-ssh')
+    node = RemoteData(computer=localhost_ssh)
+    node.set_remote_path(str(tmp_path))
+    node.store()
+    (tmp_path / 'file.txt').write_bytes(b'some content')
+    return node
 
-def test_clean(remote_data):
+@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+def test_clean(request, fixture):
     """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
+
+    remote_data = request.getfixturevalue(fixture)
+
     assert not remote_data.is_empty
     assert not remote_data.is_cleaned
-
     remote_data._clean()
     assert remote_data.is_empty
     assert remote_data.is_cleaned
+
+@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+def test_get_size_on_disk_du(request, fixture, monkeypatch):
+    """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
+
+    remote_data = request.getfixturevalue(fixture)
+
+    # Normal call
+    authinfo = remote_data.get_authinfo()
+    full_path = Path(remote_data.get_remote_path())
+
+    with authinfo.get_transport() as transport:
+        size_on_disk = remote_data._get_size_on_disk_du(transport=transport, full_path=full_path)
+    assert size_on_disk == 4108
+
+    # Monkeypatch transport exec_command_wait command to simulate `du` failure
+    def mock_exec_command_wait(command):
+        return (1, '', 'Error executing `du` command')
+
+    monkeypatch.setattr(transport, 'exec_command_wait', mock_exec_command_wait)
+    with pytest.raises(RuntimeError) as excinfo:
+        remote_data._get_size_on_disk_du(full_path, transport)
+
+
+@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+def test_get_size_on_disk_lstat(request, fixture):
+    """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
+
+    remote_data = request.getfixturevalue(fixture)
+
+    authinfo = remote_data.get_authinfo()
+    full_path = Path(remote_data.get_remote_path())
+
+    with authinfo.get_transport() as transport:
+        size_on_disk = remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path)
+    assert size_on_disk == 12
+
+
+@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+def test_get_size_on_disk(request, fixture):
+    """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
+
+    remote_data = request.getfixturevalue(fixture)
+
+    # Check here for human-readable output string, as integer byte values are checked in `test_get_size_on_disk_[du|lstat]`
+    size_on_disk = remote_data.get_size_on_disk()
+    assert size_on_disk == '4.01 KB'
+
+    # Path/file non-existent
+    with pytest.raises(FileNotFoundError, match='.*does not exist, is not a directory.*'):
+        remote_data.get_size_on_disk(relpath=Path('non-existent'))

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -83,7 +83,7 @@ def test_get_size_on_disk_params(remote_data_factory, mode, setup, results):
     ids=['1-byte', '10-bytes', '100-bytes', '1000-bytes', '1e6-bytes'],
 )
 def test_get_size_on_disk_sizes(remote_data_factory, mode, content, sizes):
-    """Test the different implementations implementations to obtain the size of a RemoteData on disk."""
+    """Test the different implementations to obtain the size of a ``RemoteData`` on disk."""
 
     remote_data = remote_data_factory(mode=mode, content=content)
 

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -20,13 +20,14 @@ from aiida.orm import RemoteData
 @pytest.fixture
 def remote_data_factory(tmp_path, aiida_computer_local, aiida_computer_ssh):
     """Factory fixture to create RemoteData instances."""
+
     def _create_remote_data(mode: str, content: str | bytes = b'some content'):
         if mode == 'local':
             computer = aiida_computer_local(label='localhost')
         elif mode == 'ssh':
             computer = aiida_computer_ssh(label='localhost-ssh')
         else:
-            raise ValueError(f"Unknown mode: {mode}")
+            raise ValueError(f'Unknown mode: {mode}')
 
         node = RemoteData(computer=computer)
         node.set_remote_path(str(tmp_path))
@@ -69,17 +70,17 @@ def test_get_size_on_disk_params(remote_data_factory, mode, setup, results):
     assert (size_on_disk, method) == results
 
 
-@pytest.mark.parametrize("mode", ("local", "ssh"))
+@pytest.mark.parametrize('mode', ('local', 'ssh'))
 @pytest.mark.parametrize(
-    "content, sizes",
+    'content, sizes',
     (
-        (b"a", {"du": 4097, "stat": 1, "human": "4.00 KB"}),
-        (10 * b"a", {"du": 4106, "stat": 10, "human": "4.01 KB"}),
-        (100 * b"a", {"du": 4196, "stat": 100, "human": "4.10 KB"}),
-        (1000 * b"a", {"du": 5096, "stat": 1000, "human": "4.98 KB"}),
-        (1000000 * b"a", {"du": 1004096, "stat": int(1e6), "human": "980.56 KB"}),
+        (b'a', {'du': 4097, 'stat': 1, 'human': '4.00 KB'}),
+        (10 * b'a', {'du': 4106, 'stat': 10, 'human': '4.01 KB'}),
+        (100 * b'a', {'du': 4196, 'stat': 100, 'human': '4.10 KB'}),
+        (1000 * b'a', {'du': 5096, 'stat': 1000, 'human': '4.98 KB'}),
+        (1000000 * b'a', {'du': 1004096, 'stat': int(1e6), 'human': '980.56 KB'}),
     ),
-    ids=["1-byte", "10-bytes", "100-bytes", "1000-bytes", "1e6-bytes"],
+    ids=['1-byte', '10-bytes', '100-bytes', '1000-bytes', '1e6-bytes'],
 )
 def test_get_size_on_disk_sizes(remote_data_factory, mode, content, sizes):
     """Test the different implementations implementations to obtain the size of a RemoteData on disk."""

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -68,8 +68,8 @@ def test_clean(request, fixture):
     (
         (('du', False), ('4.01 KB', 'du')),
         (('du', True), (4108, 'du')),
-        (('lstat', False), ('12.00 B', 'lstat')),
-        (('lstat', True), (12, 'lstat')),
+        (('stat', False), ('12.00 B', 'stat')),
+        (('stat', True), (12, 'stat')),
     ),
 )
 def test_get_size_on_disk_params(request, fixture, setup, results):
@@ -84,11 +84,11 @@ def test_get_size_on_disk_params(request, fixture, setup, results):
 @pytest.mark.parametrize(
     'num_char, sizes',
     (
-        (1, {'du': 4097, 'lstat': 1, 'human': '4.00 KB'}),
-        (10, {'du': 4106, 'lstat': 10, 'human': '4.01 KB'}),
-        (100, {'du': 4196, 'lstat': 100, 'human': '4.10 KB'}),
-        (1000, {'du': 5096, 'lstat': 1000, 'human': '4.98 KB'}),
-        (int(1e6), {'du': 1004096, 'lstat': int(1e6), 'human': '980.56 KB'}),
+        (1, {'du': 4097, 'stat': 1, 'human': '4.00 KB'}),
+        (10, {'du': 4106, 'stat': 10, 'human': '4.01 KB'}),
+        (100, {'du': 4196, 'stat': 100, 'human': '4.10 KB'}),
+        (1000, {'du': 5096, 'stat': 1000, 'human': '4.98 KB'}),
+        (int(1e6), {'du': 1004096, 'stat': int(1e6), 'human': '980.56 KB'}),
     ),
 )
 @pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])
@@ -106,23 +106,23 @@ def test_get_size_on_disk_sizes(tmp_path, num_char, sizes, request, fixture):
 
     with authinfo.get_transport() as transport:
         size_on_disk_du = remote_data._get_size_on_disk_du(transport=transport, full_path=full_path)
-        size_on_disk_lstat = remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path)
+        size_on_disk_stat = remote_data._get_size_on_disk_stat(transport=transport, full_path=full_path)
         size_on_disk_human, _ = remote_data.get_size_on_disk()
 
     assert size_on_disk_du == sizes['du']
-    assert size_on_disk_lstat == sizes['lstat']
+    assert size_on_disk_stat == sizes['stat']
     assert size_on_disk_human == sizes['human']
 
 
 @pytest.mark.parametrize(
     'num_char, relpath, sizes',
     (
-        (1, '.', {'du': 12291, 'lstat': 8195, 'human': '12.00 KB'}),
-        (100, '.', {'du': 12588, 'lstat': 8492, 'human': '12.29 KB'}),
-        (int(1e6), '.', {'du': 3012288, 'lstat': 3008192, 'human': '2.87 MB'}),
-        (1, 'subdir1', {'du': 8194, 'lstat': 4098, 'human': '8.00 KB'}),
-        (100, 'subdir1', {'du': 8392, 'lstat': 4296, 'human': '8.20 KB'}),
-        (int(1e6), 'subdir1', {'du': 2008192, 'lstat': 2004096, 'human': '1.92 MB'}),
+        (1, '.', {'du': 12291, 'stat': 8195, 'human': '12.00 KB'}),
+        (100, '.', {'du': 12588, 'stat': 8492, 'human': '12.29 KB'}),
+        (int(1e6), '.', {'du': 3012288, 'stat': 3008192, 'human': '2.87 MB'}),
+        (1, 'subdir1', {'du': 8194, 'stat': 4098, 'human': '8.00 KB'}),
+        (100, 'subdir1', {'du': 8392, 'stat': 4296, 'human': '8.20 KB'}),
+        (int(1e6), 'subdir1', {'du': 2008192, 'stat': 2004096, 'human': '1.92 MB'}),
     ),
 )
 def test_get_size_on_disk_nested(aiida_localhost, tmp_path, num_char, relpath, sizes):
@@ -149,12 +149,12 @@ def test_get_size_on_disk_nested(aiida_localhost, tmp_path, num_char, relpath, s
 
     with authinfo.get_transport() as transport:
         size_on_disk_du = remote_data._get_size_on_disk_du(transport=transport, full_path=full_path)
-        size_on_disk_lstat = remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path)
+        size_on_disk_stat = remote_data._get_size_on_disk_stat(transport=transport, full_path=full_path)
 
         size_on_disk_human, _ = remote_data.get_size_on_disk(relpath=relpath)
 
     assert size_on_disk_du == sizes['du']
-    assert size_on_disk_lstat == sizes['lstat']
+    assert size_on_disk_stat == sizes['stat']
     assert size_on_disk_human == sizes['human']
 
 
@@ -206,8 +206,8 @@ def test_get_size_on_disk_du(request, fixture, monkeypatch):
 
 
 @pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])
-def test_get_size_on_disk_lstat(request, fixture):
-    """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData._get_size_on_disk_lstat` private method."""
+def test_get_size_on_disk_stat(request, fixture):
+    """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData._get_size_on_disk_stat` private method."""
     # No additional parametrization here, as already done in `test_get_size_on_disk_sizes`.
 
     remote_data = request.getfixturevalue(fixture)
@@ -216,9 +216,9 @@ def test_get_size_on_disk_lstat(request, fixture):
     full_path = Path(remote_data.get_remote_path())
 
     with authinfo.get_transport() as transport:
-        size_on_disk = remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path)
+        size_on_disk = remote_data._get_size_on_disk_stat(transport=transport, full_path=full_path)
         assert size_on_disk == 12
 
         # Raises OSError for non-existent directory
         with pytest.raises(OSError, match='The required remote folder.*'):
-            remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path / 'non-existent')
+            remote_data._get_size_on_disk_stat(transport=transport, full_path=full_path / 'non-existent')

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -156,7 +156,7 @@ def test_get_size_on_disk_excs(remote_data_factory, mode):
         remote_data.get_size_on_disk(relpath=Path('non-existent'))
 
     # Non-valid method
-    with pytest.raises(NotImplementedError, match='.*for evaluating the size on disk not implemented.'):
+    with pytest.raises(ValueError, match='.*is not an valid input. Please choose either.*.'):
         remote_data.get_size_on_disk(method='fake-du')
 
 

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -18,7 +18,7 @@ from aiida.orm import RemoteData
 
 
 @pytest.fixture
-def remote_data_local(tmp_path, aiida_computer_local, content: str = b'some content'): # num_char: int | None = None):
+def remote_data_local(tmp_path, aiida_computer_local, content: str = b'some content'):  # num_char: int | None = None):
     """Return a non-empty ``RemoteData`` instance."""
     aiida_localhost = aiida_computer_local(label='localhost')
     node = RemoteData(computer=aiida_localhost)
@@ -29,7 +29,7 @@ def remote_data_local(tmp_path, aiida_computer_local, content: str = b'some cont
 
 
 @pytest.fixture
-def remote_data_ssh(tmp_path, aiida_computer_ssh, content: str = b'some content'): #num_char: int | None = None):
+def remote_data_ssh(tmp_path, aiida_computer_ssh, content: str = b'some content'):  # num_char: int | None = None):
     """Return a non-empty ``RemoteData`` instance."""
     aiida_localhost_ssh = aiida_computer_ssh(label='localhost-ssh')
     node = RemoteData(computer=aiida_localhost_ssh)
@@ -75,10 +75,10 @@ def test_get_size_on_disk_params(request, fixture, setup, results):
     'content, sizes',
     (
         (b'a', {'du': 4097, 'stat': 1, 'human': '4.00 KB'}),
-        (10*b'a', {'du': 4106, 'stat': 10, 'human': '4.01 KB'}),
-        (100*b'a', {'du': 4196, 'stat': 100, 'human': '4.10 KB'}),
-        (1000*b'a', {'du': 5096, 'stat': 1000, 'human': '4.98 KB'}),
-        (int(1e6),*b'a', {'du': 1004096, 'stat': int(1e6), 'human': '980.56 KB'}),
+        (10 * b'a', {'du': 4106, 'stat': 10, 'human': '4.01 KB'}),
+        (100 * b'a', {'du': 4196, 'stat': 100, 'human': '4.10 KB'}),
+        (1000 * b'a', {'du': 5096, 'stat': 1000, 'human': '4.98 KB'}),
+        (int(1e6), *b'a', {'du': 1004096, 'stat': int(1e6), 'human': '980.56 KB'}),
     ),
 )
 @pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -24,6 +24,7 @@ def remote_data_local(tmp_path, aiida_localhost):
     (tmp_path / 'file.txt').write_bytes(b'some content')
     return node
 
+
 @pytest.fixture
 def remote_data_ssh(tmp_path, aiida_computer_ssh):
     """Return a non-empty ``RemoteData`` instance."""
@@ -36,7 +37,8 @@ def remote_data_ssh(tmp_path, aiida_computer_ssh):
     (tmp_path / 'file.txt').write_bytes(b'some content')
     return node
 
-@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+
+@pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])
 def test_clean(request, fixture):
     """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
 
@@ -48,7 +50,8 @@ def test_clean(request, fixture):
     assert remote_data.is_empty
     assert remote_data.is_cleaned
 
-@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+
+@pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])
 def test_get_size_on_disk_du(request, fixture, monkeypatch):
     """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
 
@@ -67,11 +70,11 @@ def test_get_size_on_disk_du(request, fixture, monkeypatch):
         return (1, '', 'Error executing `du` command')
 
     monkeypatch.setattr(transport, 'exec_command_wait', mock_exec_command_wait)
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(RuntimeError, match='Error executing `du`.*'):
         remote_data._get_size_on_disk_du(full_path, transport)
 
 
-@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+@pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])
 def test_get_size_on_disk_lstat(request, fixture):
     """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
 
@@ -85,13 +88,14 @@ def test_get_size_on_disk_lstat(request, fixture):
     assert size_on_disk == 12
 
 
-@pytest.mark.parametrize('fixture', ["remote_data_local", "remote_data_ssh"])
+@pytest.mark.parametrize('fixture', ['remote_data_local', 'remote_data_ssh'])
 def test_get_size_on_disk(request, fixture):
     """Test the :meth:`aiida.orm.nodes.data.remote.base.RemoteData.clean` method."""
 
     remote_data = request.getfixturevalue(fixture)
 
-    # Check here for human-readable output string, as integer byte values are checked in `test_get_size_on_disk_[du|lstat]`
+    # Check here for human-readable output string, as integer byte values are checked in
+    # `test_get_size_on_disk_[du|lstat]`
     size_on_disk = remote_data.get_size_on_disk()
     assert size_on_disk == '4.01 KB'
 

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -82,6 +82,7 @@ def test_get_size_on_disk(request, fixture):
     with pytest.raises(FileNotFoundError, match='.*does not exist, is not a directory.*'):
         remote_data.get_size_on_disk(relpath=Path('non-existent'))
 
+
 @pytest.mark.parametrize(
     'num_char, relpath, sizes',
     (
@@ -94,22 +95,21 @@ def test_get_size_on_disk(request, fixture):
     ),
 )
 def test_get_size_on_disk_nested(aiida_localhost, tmp_path, num_char, relpath, sizes):
-
-    sub_dir1 = tmp_path / "subdir1"
+    sub_dir1 = tmp_path / 'subdir1'
     sub_dir1.mkdir()
 
-    sub_dir2 = tmp_path / "subdir1" / "subdir2"
+    sub_dir2 = tmp_path / 'subdir1' / 'subdir2'
     sub_dir2.mkdir()
 
     # Create some files with known sizes
-    file1 = sub_dir1 / "file1.txt"
-    file1.write_text("a"*num_char)
+    file1 = sub_dir1 / 'file1.txt'
+    file1.write_text('a' * num_char)
 
-    file2 = sub_dir2 / "file2.bin"
-    file2.write_bytes(b"a" * num_char)
+    file2 = sub_dir2 / 'file2.bin'
+    file2.write_bytes(b'a' * num_char)
 
-    file3 = tmp_path / "file3.txt"
-    file3.write_text("a" * num_char)
+    file3 = tmp_path / 'file3.txt'
+    file3.write_text('a' * num_char)
 
     remote_data = RemoteData(computer=aiida_localhost, remote_path=tmp_path)
 
@@ -117,7 +117,6 @@ def test_get_size_on_disk_nested(aiida_localhost, tmp_path, num_char, relpath, s
     full_path = Path(remote_data.get_remote_path()) / relpath
 
     with authinfo.get_transport() as transport:
-
         size_on_disk_du = remote_data._get_size_on_disk_du(transport=transport, full_path=full_path)
         size_on_disk_lstat = remote_data._get_size_on_disk_lstat(transport=transport, full_path=full_path)
 


### PR DESCRIPTION
Required for PR #6578.

By default, the `get_size_on_disk` method calls the method `_get_size_on_disk_du` that uses `du` to obtain the total directory size in bytes. If the call to `du` fails for whatever reason, recursive `stat` is being used, though, that is discouraged as `stat` returns the apparent size of files, not the actual disk usage.

I further extended the existing tests for `RemoteData` to use both, `LocalTransport`, as well as `SshTransport`, and test for the functionality added in this PR.

Pinging also @npaulish, as she's currently working on retrieving `RemoteData` objects.