### PR TITLE
Update the issue template with the Discourse group

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,4 @@
 contact_links:
-- name: AiiDA Discussions
-  url: https://github.com/aiidateam/aiida-core/discussions
-  about: For aiida-core questions and discussion
-- name: AiiDA Users Forum
-  url: http://www.aiida.net/mailing-list/
+- name: AiiDA Discourse group
+  url: https://aiida.discourse.group
   about: For general questions and discussion


### PR DESCRIPTION
The AiiDA GitHub discussions platform has been disabled. We want people now to ask questions and start discussions in the Discourse group. Furthermore, as the mailing list is also deprecated, the link to the mailing list has been also removed as it just further links to our Discourse group.

This updates the template when you create a new issue. See current one https://github.com/aiidateam/aiida-core/issues/new/choose