### PR TITLE
CLI: Handle `None` process states in build_call_graph

### DIFF
--- a/src/aiida/cmdline/utils/ascii_vis.py
+++ b/src/aiida/cmdline/utils/ascii_vis.py
@@ -29,7 +29,7 @@ def calc_info(node, call_link_label: bool = False) -> str:
         raise TypeError(f'Unknown type: {type(node)}')
 
     process_label = node.process_label
-    process_state = node.process_state.value.capitalize()
+    process_state = 'None' if node.process_state is None else node.process_state.value.capitalize()
     exit_status = node.exit_status
 
     if call_link_label and (caller := node.caller):

--- a/tests/cmdline/utils/test_ascii_vis.py
+++ b/tests/cmdline/utils/test_ascii_vis.py
@@ -1,0 +1,20 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the :mod:`aiida.cmdline.utils.ascii_vis` module."""
+
+from aiida.orm.nodes.process.process import ProcessNode
+
+
+def test_build_call_graph():
+    from aiida.cmdline.utils.ascii_vis import build_call_graph
+
+    node = ProcessNode()
+
+    call_graph = build_call_graph(node)
+    assert call_graph == 'None<None> None'


### PR DESCRIPTION
The process definition allows a None state but the build_call_graph utils function intended for creating printable output of the call graph does crash in this case.  A None state indicates some undefined behavior in the code, but the application should not fail because of the formatting of the output.  This commit makes build_call_graph handle None states. Partial fix for #6585.