### PR TITLE
Put a single CalcJob with a transport request

### DIFF
--- a/src/aiida/engine/runners.py
+++ b/src/aiida/engine/runners.py
@@ -261,7 +261,7 @@ class Runner:
 
                 # TODO: only do this if the node is CalcJob?
                 # or you think it is fine for every process we open one anyway?
-                # The downside will be the long opening SSH connection might be killed from 
+                # The downside will be the long opening SSH connection might be killed from
                 # server side then it will trigger the expo mechanism. (TBD)
                 authinfo = process_inited.node.get_authinfo()
                 with self.transport.request_transport(authinfo):

--- a/src/aiida/engine/runners.py
+++ b/src/aiida/engine/runners.py
@@ -258,7 +258,15 @@ class Runner:
             try:
                 signal.signal(signal.SIGINT, kill_process)
                 signal.signal(signal.SIGTERM, kill_process)
-                process_inited.execute()
+
+                # TODO: only do this if the node is CalcJob?
+                # or you think it is fine for every process we open one anyway?
+                # The downside will be the long opening SSH connection might be killed from 
+                # server side then it will trigger the expo mechanism. (TBD)
+                authinfo = process_inited.node.get_authinfo()
+                with self.transport.request_transport(authinfo):
+                    process_inited.execute()
+
             finally:
                 signal.signal(signal.SIGINT, original_handler_int)
                 signal.signal(signal.SIGTERM, original_handler_term)


### PR DESCRIPTION
This maybe a good solution for #6595 to keep the SSH open for the lifetime of a single CalcJob.