### PR TITLE
Re-Implement `has_key` Filter Operator for SQLite Backend

### DIFF
--- a/src/aiida/storage/sqlite_zip/orm.py
+++ b/src/aiida/storage/sqlite_zip/orm.py
@@ -17,7 +17,7 @@ import json
 from functools import singledispatch
 from typing import Any, List, Optional, Tuple, Union
 
-from sqlalchemy import JSON, case, func
+from sqlalchemy import JSON, case, func, select
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql import ColumnElement
 
@@ -289,7 +289,11 @@ class SqliteQueryBuilder(SqlaQueryBuilder):
             raise NotImplementedError('The operator `contains` is not implemented for SQLite-based storage plugins.')
 
         if operator == 'has_key':
-            raise NotImplementedError('The operator `has_key` is not implemented for SQLite-based storage plugins.')
+            return (
+                select(database_entity)
+                .where(func.json_each(database_entity).table_valued('key', joins_implicitly=True).c.key == value)
+                .exists()
+            )
 
         if operator == 'in':
             type_filter, casted_entity = _cast_json_type(database_entity, value[0])

--- a/tests/cmdline/commands/test_calcjob.py
+++ b/tests/cmdline/commands/test_calcjob.py
@@ -241,9 +241,6 @@ class TestVerdiCalculation:
         retrieved.base.repository._repository.put_object_from_filelike(io.BytesIO(b'5\n'), 'aiida.out')
         retrieved.base.repository._update_repository_metadata()
 
-    # This currently fails with sqlite backend since the filtering relies on the `has_key` filter which is not
-    # implemented in SQLite, see https://github.com/aiidateam/aiida-core/pull/6497
-    @pytest.mark.requires_psql
     def test_calcjob_cleanworkdir_basic(self):
         """Test verdi calcjob cleanworkdir"""
         # Specifying no filtering options and no explicit calcjobs should exit with non-zero status
@@ -269,7 +266,6 @@ class TestVerdiCalculation:
         result = self.cli_runner.invoke(command.calcjob_cleanworkdir, options)
         assert result.exception is not None, result.output
 
-    @pytest.mark.requires_psql
     def test_calcjob_cleanworkdir_advanced(self):
         # Check applying both p and o filters
         for flag_p in ['-p', '--past-days']:

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1537,7 +1537,6 @@ class TestConsistency:
         for pk, pk_clone in zip(pks, [e[1] for e in sorted(pks_clone)]):
             assert orm.load_node(pk) == orm.load_node(pk_clone)
 
-    @pytest.mark.requires_psql
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_iterall_persistence(self, manager):
         """Test that mutations made during ``QueryBuilder.iterall`` context are automatically committed and persisted.

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -162,7 +162,6 @@ class TestQueryWithAiidaObjects:
         """Initialize the profile."""
         self.computer = aiida_localhost
 
-    @pytest.mark.requires_psql
     def test_with_subclasses(self):
         from aiida.plugins import DataFactory
 


### PR DESCRIPTION
This PR addresses the issues described in #6552 and uncovered in #6256. The `has_key` operator implementation for the SQLite backend was previously removed in #6497 due to problematic behavior and the potential for silent failures.

In this PR, `has_key` is reintroduced by adopting @giovannipizzi's implementation from #6552. Additionally, unit tests for JSON filters have been re-enabled and extended. The new tests are able to identify failures in the original implementation and pass with the current one.