### PR TITLE
Update changelog up to release v2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2.6.3 - 2024-11-6
+
+### Fixes
+- CLI: Fix exception for `verdi plugin list` (#6560) [[c3b10b7]](https://github.com/aiidateam/aiida-core/commit/c3b10b759a9cd062800ef120591d5c7fd0ae4ee7)
+- `DirectScheduler`: Ensure killing child processes (#6572) [[fddffca]](https://github.com/aiidateam/aiida-core/commit/fddffca67b4f7e3b76b19df7db8e1511c449d2d9)   
+- Engine: Fix state change broadcast before process node is updated  (#6580) [[867353c]](https://github.com/aiidateam/aiida-core/commit/867353c415c61d94a2427d5225dd5224a1b95fb9)
+
+### Devops
+- Docker: Replace sleep with `s6-notifyoncheck` (#6475) [[9579378b]](https://github.com/aiidateam/aiida-core/commit/9579378ba063237baa5b73380eb8e9f0a28529ee)
+- Fix failed docker CI using more reasoning grep regex to parse python version (#6581) [[332a4a91]](https://github.com/aiidateam/aiida-core/commit/332a4a915771afedcb144463b012558e4669e529)
+- DevOps: Fix json query in reading the docker names to filter out fields not starting with aiida (#6573) [[e1467edc]](https://github.com/aiidateam/aiida-core/commit/e1467edca902867e53605e0e60b67f8767bf8d3e)
+
+
 ## v2.6.2 - 2024-08-07
 
 ### Fixes
@@ -31,7 +44,7 @@
 
 ## v2.6.1 - 2024-07-01
 
-### Fixes:
+### Fixes
 - Fixtures: Make `pgtest` truly an optional dependency [[9fe8fd2e0]](https://github.com/aiidateam/aiida-core/commit/9fe8fd2e0b88e746ee2156eccb71b7adbab6b2c5)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,7 @@ verdi = 'aiida.cmdline.commands.cmd_verdi:verdi'
 Documentation = 'https://aiida.readthedocs.io'
 Home = 'http://www.aiida.net/'
 Source = 'https://github.com/aiidateam/aiida-core'
+Changelog = 'https://github.com/aiidateam/aiida-core/blob/main/CHANGELOG.md'
 
 [tool.flit.module]
 name = 'aiida'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,10 +255,10 @@ runaiida = 'aiida.cmdline.commands.cmd_run:run'
 verdi = 'aiida.cmdline.commands.cmd_verdi:verdi'
 
 [project.urls]
+Changelog = 'https://github.com/aiidateam/aiida-core/blob/main/CHANGELOG.md'
 Documentation = 'https://aiida.readthedocs.io'
 Home = 'http://www.aiida.net/'
 Source = 'https://github.com/aiidateam/aiida-core'
-Changelog = 'https://github.com/aiidateam/aiida-core/blob/main/CHANGELOG.md'
 
 [tool.flit.module]
 name = 'aiida'


### PR DESCRIPTION
This includes the updates of the changelog up to the v2.6.3 release with several fixes:
* Fixes the urls of commits in v2.6.2 release
* Adds missing date in v2.6.3 release

Furthermore a link of the changelog to pyproject.toml has been added. This makes the url to the changelog appear for releases on pypi.