### PR TITLE
CI: quick fix on benchmark CI using uv run pytest

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
     paths-ignore: [docs/**]
+  pull_request:
+    branches-ignore: [gh-pages]
+    paths: [.github/workflows/benchmark*]
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -54,9 +57,10 @@ jobs:
       uses: ./.github/actions/install-aiida-core
       with:
         python-version: '3.10'
+        from-lock: 'true'
 
     - name: Run benchmarks
-      run: pytest --db-backend psql --benchmark-only --benchmark-json benchmark.json tests/
+      run: uv run pytest --db-backend psql --benchmark-only --benchmark-json benchmark.json tests/
 
     - name: Store benchmark result
       uses: aiidateam/github-action-benchmark@v3


### PR DESCRIPTION
supersede #6651 

The benchmark CI only triggered when push to main and it is failed after https://github.com/aiidateam/aiida-core/pull/6640.
I mimic the change in https://github.com/aiidateam/aiida-core/commit/32f9229ef8d18ded56a63050413517abd3789768 for the fix, hope I did it right.

I also make the CI can be triggered for pull request when either benchmark config files changed.