### PR TITLE
ORM: Add `from_bytes` `classmethod` to `orm.SinglefileData`

### DIFF
--- a/src/aiida/orm/nodes/data/singlefile.py
+++ b/src/aiida/orm/nodes/data/singlefile.py
@@ -39,6 +39,17 @@ class SinglefileData(Data):
         """
         return cls(io.StringIO(content), filename, **kwargs)
 
+    @classmethod
+    def from_bytes(
+        cls, content: bytes, filename: str | pathlib.Path | None = None, **kwargs: t.Any
+    ) -> 'SinglefileData':
+        """Construct a new instance and set ``content`` as its contents.
+
+        :param content: The content as bytes.
+        :param filename: Specify filename to use (defaults to ``file.txt``).
+        """
+        return cls(io.BytesIO(content), filename, **kwargs)
+
     def __init__(
         self, file: str | pathlib.Path | t.IO, filename: str | pathlib.Path | None = None, **kwargs: t.Any
     ) -> None:

--- a/tests/orm/nodes/data/test_singlefile.py
+++ b/tests/orm/nodes/data/test_singlefile.py
@@ -189,18 +189,40 @@ def test_from_string():
     content = 'some\ncontent'
     node = SinglefileData.from_string(content).store()
     assert node.get_content() == content
+    assert node.get_content('rb') == content.encode()
     assert node.filename == SinglefileData.DEFAULT_FILENAME
 
     content = 'some\ncontent'
     filename = 'custom_filename.dat'
     node = SinglefileData.from_string(content, filename).store()
     assert node.get_content() == content
+    assert node.get_content('rb') == content.encode()
+    assert node.filename == filename
+
+
+def test_from_bytes():
+    """Test the :meth:`aiida.orm.nodes.data.singlefile.SinglefileData.from_bytes` classmethod."""
+    content = b'some\ncontent'
+    node = SinglefileData.from_bytes(content).store()
+    assert node.get_content(mode='rb') == content
+    assert node.get_content(mode='r') == content.decode('utf-8')
+    assert node.filename == SinglefileData.DEFAULT_FILENAME
+
+    content = b'some\ncontent'
+    filename = 'custom_filename.dat'
+    node = SinglefileData.from_bytes(content, filename).store()
+    assert node.get_content(mode='rb') == content
+    assert node.get_content(mode='r') == content.decode('utf-8')
     assert node.filename == filename
 
 
 def test_get_content():
     """Test the :meth:`aiida.orm.nodes.data.singlefile.SinglefileData.get_content` method."""
+    content = 'some\ncontent'
+    node = SinglefileData.from_string(content).store()
+    assert node.get_content() == content
+    assert node.get_content('rb') == content.encode()
     content = b'some\ncontent'
-    node = SinglefileData.from_string(content.decode('utf-8')).store()
+    node = SinglefileData.from_bytes(content).store()
     assert node.get_content() == content.decode('utf-8')
     assert node.get_content('rb') == content


### PR DESCRIPTION
As noted together with @elinscott and @mikibonacci: `orm.SinglefileData` supports _getting_ its content as bytes via `get_content`, but did not support _setting_ its contents from bytes directly. This is now made possible with the `from_bytes` `classmethod`. A few notes on the implementation:

- One could also modify the existing `from_string` method, and adapt the behavior depending on the type of the content being passed. However, I feel like the name `from_string`, in that case, is misleading. It would be more suitable if the method were called `from_content` (or similar, more generic), however, that is not the case, and we cannot modify it due to backwards-compatibility reasons.
- Users could, in principle, just use `.decode('utf-8')` themselves on the bytes object they want to store before calling `.from_string()`, but it might be more convenient to allow directly passing the bytes object via `from_bytes`, as to not have the burden of conversion on the user.
- The functionality tested in the `test_get_content` function is now already being tested in the (already existing) `test_from_string` and the (new) `test_from_bytes` functions, which check the content of the `SinglefileData` node after storing. However, I still left it for completeness.