### PR TITLE
Add overview of common `core` plugins to RTD

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,15 +148,15 @@
 
          To the architecture guide
 
-   .. grid-item-card:: :fa:`sitemap;mr-1` Common plugins
+   .. grid-item-card:: :fa:`puzzle-piece;mr-1` Core plugins
       :text-align: center
       :shadow: md
 
-      Commonly used general AiiDA plugins to extend core functionality
+      Commonly used AiiDA plugins to extend core functionality
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
-      .. button-ref:: internals/index
+      .. button-ref:: reference/core_plugins
          :ref-type: doc
          :click-parent:
          :expand:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,6 +148,23 @@
 
          To the architecture guide
 
+   .. grid-item-card:: :fa:`sitemap;mr-1` Common plugins
+      :text-align: center
+      :shadow: md
+
+      Commonly used general AiiDA plugins to extend core functionality
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-ref:: internals/index
+         :ref-type: doc
+         :click-parent:
+         :expand:
+         :color: primary
+         :outline:
+
+         To the plugin overview
+
 ------------------------------
 
 .. admonition:: Need support?

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -114,23 +114,6 @@
 
          To the topics
 
-   .. grid-item-card:: :fa:`cogs;mr-1` API Reference
-      :text-align: center
-      :shadow: md
-
-      Comprehensive documentation of CLI, Python API and REST API.
-
-      +++++++++++++++++++++++++++++++++++++++++++++
-
-      .. button-ref:: reference/index
-         :ref-type: doc
-         :click-parent:
-         :expand:
-         :color: primary
-         :outline:
-
-         To the reference guide
-
    .. grid-item-card:: :fa:`sitemap;mr-1` Internal Architecture
       :text-align: center
       :shadow: md
@@ -165,6 +148,23 @@
 
          To the plugin overview
 
+   .. grid-item-card:: :fa:`cogs;mr-1` API Reference
+      :text-align: center
+      :shadow: md
+
+      Comprehensive documentation of CLI, Python API and REST API.
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-ref:: reference/index
+         :ref-type: doc
+         :click-parent:
+         :expand:
+         :color: primary
+         :outline:
+
+         To the reference guide
+
 ------------------------------
 
 .. admonition:: Need support?
@@ -189,6 +189,7 @@
    tutorials/index
    howto/index
    topics/index
+   reference/core_plugins
    reference/index
    internals/index
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -189,9 +189,9 @@
    tutorials/index
    howto/index
    topics/index
+   internals/index
    reference/core_plugins
    reference/index
-   internals/index
 
 ===========
 How to cite

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -1,0 +1,134 @@
+.. _reference:core_plugins:
+
+============================
+Common plugins to AiiDA core
+============================
+
+.. abc
+
+.. aiida-shell
+.. aiida-workgraph
+
+.. aiida-submission-controller
+.. aiida-hyperqueue
+
+.. aiida-project
+.. aiida-plugin-cutter
+
+.. aiida-code-registry
+.. aiida-pythonjob
+
+.. grid:: 1 2 2 4
+   :gutter: 3
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 1
+      :text-align: center
+      :shadow: md
+
+      AiiDA shell
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link:: https://github.com/sphuber/aiida-shell
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 2
+      :text-align: center
+      :shadow: md
+
+      AiiDA WorkGraph
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link:: https://github.com/aiidateam/aiida-workgraph
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 3
+      :text-align: center
+      :shadow: md
+
+      AiiDA submission controller
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link:: https://github.com/aiidateam/aiida-submission-controller/
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 4
+      :text-align: center
+      :shadow: md
+
+      AiiDA hyperqueue
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link:: https://github.com/aiidateam/aiida-hyperqueue
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 5
+      :text-align: center
+      :shadow: md
+
+      AiiDA project
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link:: https://github.com/aiidateam/aiida-project
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 6
+      :text-align: center
+      :shadow: md
+
+      AiiDA plugin cookiecutter
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link::https://github.com/aiidateam/aiida-plugin-cutter
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 7
+      :text-align: center
+      :shadow: md
+
+      AiiDA code registry
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link::https://github.com/aiidateam/aiida-code-registry
+         :color: primary
+         :outline:
+
+         Go to GitHub
+
+   .. grid-item-card:: :fa:`icon;mr-1` Title 8
+      :text-align: center
+      :shadow: md
+
+      AiiDA PythonJob
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link::https://github.com/aiidateam/aiida-pythonjob
+         :color: primary
+         :outline:
+
+         Go to GitHub

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -19,11 +19,11 @@ Common plugins to AiiDA core
 .. grid:: 1 2 2 4
    :gutter: 3
 
-   .. grid-item-card:: :fa:`icon;mr-1` Title 1
+   .. grid-item-card:: :fa:`icon;mr-1` AiiDA shell
       :text-align: center
       :shadow: md
 
-      AiiDA shell
+      Plugin that makes running shell commands easy.
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
@@ -31,7 +31,7 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         Go to GitHub
+         AiiDA shell
 
    .. grid-item-card:: :fa:`icon;mr-1` Title 2
       :text-align: center

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -4,6 +4,8 @@
 Common plugins to AiiDA core
 ============================
 
+.. Non domain-specific plugins
+
 .. aiida-shell
 .. aiida-workgraph
 
@@ -11,15 +13,32 @@ Common plugins to AiiDA core
 .. aiida-hyperqueue
 
 .. aiida-project
-.. aiida-plugin-cutter
-
 .. aiida-code-registry
+
+.. aiida-plugin-cutter
 .. aiida-pythonjob
+
+
+This page lists common non domain-specific AiiDA plugins that extend the core functionality.
 
 .. grid:: 1 2 2 4
    :gutter: 3
 
-   .. grid-item-card:: :fa:`icon;mr-1` AiiDA shell
+   .. grid-item-card:: AiiDA WorkGraph
+      :text-align: center
+      :shadow: md
+
+      Efficiently design and manage flexible workflows with AiiDA.
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link:: https://github.com/aiidateam/aiida-workgraph
+         :color: primary
+         :outline:
+
+         ``aiida-workgraph`` on GitHub
+
+   .. grid-item-card:: AiiDA shell
       :text-align: center
       :shadow: md
 
@@ -31,27 +50,13 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         AiiDA shell
+         ``aiida-shell`` on GitHub
 
-   .. grid-item-card:: :fa:`icon;mr-1` Title 2
+   .. grid-item-card:: AiiDA submission controller
       :text-align: center
       :shadow: md
 
-      AiiDA WorkGraph
-
-      +++++++++++++++++++++++++++++++++++++++++++++
-
-      .. button-link:: https://github.com/aiidateam/aiida-workgraph
-         :color: primary
-         :outline:
-
-         Go to GitHub
-
-   .. grid-item-card:: :fa:`icon;mr-1` Title 3
-      :text-align: center
-      :shadow: md
-
-      AiiDA submission controller
+      Classes to help managing large numbers of submissions.
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
@@ -59,13 +64,13 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         Go to GitHub
+         ``aiida-submission-controller`` on GitHub
 
-   .. grid-item-card:: :fa:`icon;mr-1` Title 4
+   .. grid-item-card:: AiiDA hyperqueue
       :text-align: center
       :shadow: md
 
-      AiiDA hyperqueue
+      Plugin for the HyperQueue metascheduler enabling sub-node jobs.
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
@@ -73,13 +78,13 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         Go to GitHub
+         ``aiida-hyperqueue`` on GitHub
 
-   .. grid-item-card:: :fa:`icon;mr-1` Title 5
+   .. grid-item-card:: AiiDA project
       :text-align: center
       :shadow: md
 
-      AiiDA project
+      AiiDA project manager with custom Python environments and isolated project directories.
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
@@ -87,27 +92,13 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         Go to GitHub
+         ``aiida-project`` on GitHub
 
-   .. grid-item-card:: :fa:`icon;mr-1` Title 6
+   .. grid-item-card:: AiiDA code registry
       :text-align: center
       :shadow: md
 
-      AiiDA plugin cookiecutter
-
-      +++++++++++++++++++++++++++++++++++++++++++++
-
-      .. button-link::https://github.com/aiidateam/aiida-plugin-cutter
-         :color: primary
-         :outline:
-
-         Go to GitHub
-
-   .. grid-item-card:: :fa:`icon;mr-1` Title 7
-      :text-align: center
-      :shadow: md
-
-      AiiDA code registry
+      Registry of simulation codes and computers for easy setup in AiiDA.
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
@@ -115,13 +106,27 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         Go to GitHub
+         ``aiida-code-registry`` on GitHub
 
-   .. grid-item-card:: :fa:`icon;mr-1` Title 8
+   .. grid-item-card:: AiiDA plugin cutter
       :text-align: center
       :shadow: md
 
-      AiiDA PythonJob
+      Cookie cutter recipe for AiiDA plugins.
+
+      +++++++++++++++++++++++++++++++++++++++++++++
+
+      .. button-link::https://github.com/aiidateam/aiida-plugin-cutter
+         :color: primary
+         :outline:
+
+         ``aiida-plugin-cutter`` on GitHub
+
+   .. grid-item-card:: AiiDA PythonJob
+      :text-align: center
+      :shadow: md
+
+      Run non-AiiDA Python functions on a remote computer (pre-alpha).
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
@@ -129,4 +134,17 @@ Common plugins to AiiDA core
          :color: primary
          :outline:
 
-         Go to GitHub
+         ``aiida-pythonjob`` on GitHub
+
+
+Honorable mentions
+===================
+
+- `aiida-firecrest <https://github.com/aiidateam/aiida-firecrest>`_: Transport/Scheduler plugins for interfacing with
+  FirecREST (RESTful services gateway and interface for managing HPC resources).
+- `aiida-resource-registry <https://github.com/aiidateam/aiida-resource-registry>`_: Registry of simulation codes and computers for easy setup in AiiDAlab.
+- `aiida-restapi <https://github.com/aiidateam/aiida-restapi>`_: RESTful AiiDA Web API for data queries and workflow management.
+- `aiida-diff <https://github.com/aiidateam/aiida-diff>`_: AiiDA demo plugin that computes the difference between two
+  files.
+
+The full list of available plugins can be found on the `AiiDA plugin registry <https://aiidateam.github.io/aiida-registry/>`

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -1,8 +1,8 @@
 .. _reference:core_plugins:
 
-============================
-Common plugins to AiiDA core
-============================
+=======
+Plugins
+=======
 
 This page lists common AiiDA plugins which are not specific to any research domain, but extend the core functionality:
 

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -4,7 +4,7 @@
 Common plugins to AiiDA core
 ============================
 
-This page lists common AiiDA plugins which are not specific to any research domain, but extend the core functionality.
+This page lists common AiiDA plugins which are not specific to any research domain, but extend the core functionality:
 
 .. grid:: 1 2 2 4
    :gutter: 3
@@ -21,7 +21,7 @@ This page lists common AiiDA plugins which are not specific to any research doma
          :color: primary
          :outline:
 
-         ``aiida-workgraph`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA shell
       :text-align: center
@@ -35,7 +35,7 @@ This page lists common AiiDA plugins which are not specific to any research doma
          :color: primary
          :outline:
 
-         ``aiida-shell`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA submission controller
       :text-align: center
@@ -49,7 +49,7 @@ This page lists common AiiDA plugins which are not specific to any research doma
          :color: primary
          :outline:
 
-         ``aiida-submission-controller`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA hyperqueue
       :text-align: center
@@ -63,7 +63,7 @@ This page lists common AiiDA plugins which are not specific to any research doma
          :color: primary
          :outline:
 
-         ``aiida-hyperqueue`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA project
       :text-align: center
@@ -77,7 +77,7 @@ This page lists common AiiDA plugins which are not specific to any research doma
          :color: primary
          :outline:
 
-         ``aiida-project`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA code registry
       :text-align: center
@@ -87,11 +87,11 @@ This page lists common AiiDA plugins which are not specific to any research doma
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
-      .. button-link::https://github.com/aiidateam/aiida-code-registry
+      .. button-link:: https://github.com/aiidateam/aiida-code-registry
          :color: primary
          :outline:
 
-         ``aiida-code-registry`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA plugin cutter
       :text-align: center
@@ -101,11 +101,11 @@ This page lists common AiiDA plugins which are not specific to any research doma
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
-      .. button-link::https://github.com/aiidateam/aiida-plugin-cutter
+      .. button-link:: https://github.com/aiidateam/aiida-plugin-cutter
          :color: primary
          :outline:
 
-         ``aiida-plugin-cutter`` on GitHub
+         Go to GitHub
 
    .. grid-item-card:: AiiDA PythonJob
       :text-align: center
@@ -115,11 +115,11 @@ This page lists common AiiDA plugins which are not specific to any research doma
 
       +++++++++++++++++++++++++++++++++++++++++++++
 
-      .. button-link::https://github.com/aiidateam/aiida-pythonjob
+      .. button-link:: https://github.com/aiidateam/aiida-pythonjob
          :color: primary
          :outline:
 
-         ``aiida-pythonjob`` on GitHub
+         Go to GitHub
 
 
 Honorable mentions
@@ -132,4 +132,4 @@ Honorable mentions
 - `aiida-diff <https://github.com/aiidateam/aiida-diff>`_: AiiDA demo plugin that computes the difference between two
   files.
 
-The full list of available plugins can be found on the `AiiDA plugin registry <https://aiidateam.github.io/aiida-registry/>`
+The full list of available plugins can be found on the `AiiDA plugin registry <https://aiidateam.github.io/aiida-registry/>`_.

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -4,8 +4,6 @@
 Common plugins to AiiDA core
 ============================
 
-.. abc
-
 .. aiida-shell
 .. aiida-workgraph
 

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -1,8 +1,8 @@
 .. _reference:core_plugins:
 
-=======
-Plugins
-=======
+============
+Core plugins
+============
 
 This page lists common AiiDA plugins which are not specific to any research domain, but extend the core functionality:
 

--- a/docs/source/reference/core_plugins.rst
+++ b/docs/source/reference/core_plugins.rst
@@ -4,22 +4,7 @@
 Common plugins to AiiDA core
 ============================
 
-.. Non domain-specific plugins
-
-.. aiida-shell
-.. aiida-workgraph
-
-.. aiida-submission-controller
-.. aiida-hyperqueue
-
-.. aiida-project
-.. aiida-code-registry
-
-.. aiida-plugin-cutter
-.. aiida-pythonjob
-
-
-This page lists common non domain-specific AiiDA plugins that extend the core functionality.
+This page lists common AiiDA plugins which are not specific to any research domain, but extend the core functionality.
 
 .. grid:: 1 2 2 4
    :gutter: 3

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -9,4 +9,5 @@ Reference
    api/index
    rest_api
    cheatsheet
+   core_plugins
    _changelog.md


### PR DESCRIPTION
Fixes #6290.

This PR adds another panel to the RTD index page (compiled version from the change of this PR can be found [here](https://aiida--6654.org.readthedocs.build/projects/aiida-core/en/6654/)), like so:
![image](https://github.com/user-attachments/assets/ab85ec4e-be31-4b7e-9dbd-1d0883492409)

Which then leads to a [new page](https://aiida--6654.org.readthedocs.build/projects/aiida-core/en/6654/reference/core_plugins.html) under the reference section that looks like this:
![image](https://github.com/user-attachments/assets/0e5ee7a4-ab7b-4e69-aae5-deaa3d6e9be2)

Originally, I wanted to have, e.g., "`aiida-shell` on GitHub" as text of the button on the bottom that leads to the GitHub repository, however, that overflows the panel for some of them, such as `aiida-submission-controller`. So now it's just "Go to GitHub" for all of them. Added further plugins, such as `aiida-firecrest` in the bottom under "Honorable mentions". Please take a quick look at the page, @agoscinski and @khsrali, and let me know if you would improve something. Thanks!