### PR TITLE
CI: Add matrix testing for both SQLite and PostgreSQL database backends

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -27,6 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.12']
+        database-backend: [psql]
+        include:
+        - python-version: '3.9'
+          database-backend: sqlite
 
     services:
       postgres:
@@ -79,7 +83,7 @@ jobs:
       run: |
         ${{ matrix.python-version == '3.9' && 'unset CI' || '' }}
         ${{ matrix.python-version == '3.9' && 'VIRTUAL_ENV=$PWD/.venv' || '' }}
-        pytest -n auto --db-backend psql -m 'not nightly' tests/ ${{ matrix.python-version == '3.9' && '--cov aiida' || '' }}
+        pytest -n auto --db-backend ${{ matrix.database-backend }} -m 'not nightly' tests/ ${{ matrix.python-version == '3.9' && '--cov aiida' || '' }}
 
     - name: Upload coverage report
       if: matrix.python-version == 3.9 && github.repository == 'aiidateam/aiida-core'
@@ -89,7 +93,6 @@ jobs:
         name: aiida-pytests-py3.9
         file: ./coverage.xml
         fail_ci_if_error: false  # don't fail job, if coverage upload fails
-
 
   tests-presto:
 

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -451,7 +451,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.
+                                      leading forward slash.  [default: ""]
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -69,7 +69,7 @@ def test_tasks_revive_without_daemon(run_cli_command):
     assert run_cli_command(cmd_rabbitmq.cmd_tasks_revive, raises=True)
 
 
-@pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_revive(run_cli_command, monkeypatch, aiida_code_installed, submit_and_await):
     """Test ``tasks revive``."""
     code = aiida_code_installed(default_calc_job_plugin='core.arithmetic.add', filepath_executable='/bin/bash')

--- a/tests/tools/archive/orm/test_codes.py
+++ b/tests/tools/archive/orm/test_codes.py
@@ -35,7 +35,7 @@ def test_that_solo_code_is_exported_correctly(aiida_profile, tmp_path, aiida_loc
     assert orm.load_node(code_uuid).label == code_label
 
 
-def test_input_code(aiida_profile, tmp_path, aiida_localhost):
+def test_input_code(aiida_profile_clean, tmp_path, aiida_localhost):
     """This test checks that when a calculation is exported then the
     corresponding code is also exported. It also checks that the links
     are also in place after the import.
@@ -59,7 +59,7 @@ def test_input_code(aiida_profile, tmp_path, aiida_localhost):
     export_file = tmp_path / 'export.aiida'
     create_archive([calc], filename=export_file)
 
-    aiida_profile.reset_storage()
+    aiida_profile_clean.reset_storage()
 
     import_archive(export_file)
 


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflows (`ci-code` and `test-install`) to include testing for both SQLite and PostgreSQL database backends. This will also increase the testing coverage over SQLite specific codebase.