### PR TITLE
Exclude from git the .python-version used by pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ pplot_out/
 
 # docker
 docker-bake.override.json
+
+# pyenv
+.python-version


### PR DESCRIPTION
Just a handy change for myself, since I need to test for both py39 and py312 and the [`pyenv`](https://github.com/pyenv/pyenv) is used.