### PR TITLE
CI: Deprecated Function in `pymatgen` Fails the CI Tests

### DIFF
--- a/src/aiida/orm/nodes/data/structure.py
+++ b/src/aiida/orm/nodes/data/structure.py
@@ -94,6 +94,13 @@ def has_ase():
 
 
 def has_pymatgen():
+    from monty.dev import deprecated
+
+    def noop(*args, **kwargs):
+        pass
+
+    deprecated.raise_deadline_warning = noop
+
     """:return: True if the pymatgen module can be imported, False otherwise."""
     try:
         import pymatgen  # noqa: F401


### PR DESCRIPTION
CI tests are currently failing due to [a known issue](https://github.com/materialsproject/pymatgen/issues/4243). Specifically, with older versions of `monty`, the deprecation of the `pymatgen` function `is_rare_earth_metal` raises an error instead of a warning in CI environments. The `monty` team has already released a newer version that fixes this issue. However, the latest version of `monty` requires `python>=3.10`, which is not fully compatible with the Python version range supported by AiiDA.

This PR is created to address this problem.