### PR TITLE
Use uv lockfile in readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,12 +15,14 @@ build:
   jobs:
     # Use uv to speed up the build
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
-    post_create_environment:
+    pre_create_environment:
     - asdf plugin add uv
-    - asdf install uv 0.2.9
-    - asdf global uv 0.2.9
-    post_install:
-    - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[docs,tests,rest,atomic_tools]
+    - asdf install uv 0.5.16
+    - asdf global uv 0.5.16
+    create_environment:
+    - uv venv
+    install:
+    - uv pip install .[docs,tests,rest,atomic_tools]
 
 # Let the build fail if there are any warnings
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,8 @@ build:
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     pre_create_environment:
     - asdf plugin add uv
-    - asdf install uv 0.5.16
-    - asdf global uv 0.5.16
+    - asdf install uv 0.5.17
+    - asdf global uv 0.5.17
     create_environment:
     - uv venv
     install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,12 +22,10 @@ build:
     create_environment:
     - uv venv
     install:
-    - uv pip install .[docs,tests,rest,atomic_tools]
-
-# Let the build fail if there are any warnings
-sphinx:
-  builder: html
-  fail_on_warning: true
+    - uv sync --extra docs --extra tests --extra rest --extra atomic_tools
+    build:
+      html:
+      - uv run sphinx-build -T -W --keep-going -b html -d _build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
 
 search:
   ranking:


### PR DESCRIPTION
Now that we have a bit of good experience with uv lockfile, it would be nice to use it in more places to make various CI jobs more stable. Here I am using it for the RTD docs build. We've already been using uv there so that change is relatively straightforward. 

Coincidentaly, ReadTheDocs made some updates to make the configuration with uv nicer, just a couple of days ago see https://github.com/readthedocs/readthedocs.org/issues/11289#issuecomment-2575933870 for details.

This also updates the uv version in RTD config.