### PR TITLE
Timeout for single pytest to 240s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,7 +387,7 @@ minversion = '7.0'
 testpaths = [
   'tests'
 ]
-timeout = 60
+timeout = 240
 xfail_strict = true
 
 [tool.ruff]


### PR DESCRIPTION
In https://github.com/aiidateam/aiida-core/pull/6674 I set timeout to 60s, but 60s for some tests are too short. 
There is an issue open to discuss whether we need to move those to nightly, see https://github.com/aiidateam/aiida-core/issues/6526 for more discussion.

Really sorry for the https://github.com/aiidateam/aiida-core/pull/6674, didn't expect 60s still too short. 