### PR TITLE
Fix verdi devel check-undesired-imports when tui extra is installed

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -126,8 +126,6 @@ jobs:
       with:
         python-version: '3.12'
         from-lock: 'true'
-        # NOTE: The `verdi devel check-undesired-imports` fails if
-        # the 'tui' extra is installed.
         extras: ''
 
     - name: Run verdi tests

--- a/src/aiida/cmdline/commands/cmd_devel.py
+++ b/src/aiida/cmdline/commands/cmd_devel.py
@@ -61,12 +61,11 @@ def devel_check_load_time():
 def devel_check_undesired_imports():
     """Check that verdi does not import python modules it shouldn't.
 
-    Note: The blacklist was taken from the list of packages in the 'atomic_tools' extra but can be extended.
+    This is to keep the verdi CLI snappy, especially for tab-completion.
     """
     loaded_modules = 0
 
-    for modulename in [
-        'asyncio',
+    unwanted_modules = [
         'requests',
         'plumpy',
         'disk_objectstore',
@@ -78,7 +77,12 @@ def devel_check_undesired_imports():
         'spglib',
         'pymysql',
         'yaml',
-    ]:
+    ]
+    # trogon powers the optional TUI and uses asyncio.
+    # Check for asyncio only when the optional tui extras are not installed.
+    if 'trogon' not in sys.modules:
+        unwanted_modules += 'asyncio'
+    for modulename in unwanted_modules:
         if modulename in sys.modules:
             echo.echo_warning(f'Detected loaded module "{modulename}"')
             loaded_modules += 1


### PR DESCRIPTION
Fixes #6691.

To test the fix run

```
uv sync --extra tui
uv run verdi devel check-undesired-imports
```

This will fail on main with
```
Warning: Detected loaded module "asyncio"
Critical: Detected 1 unwanted modules
```