### PR TITLE
CI: Set runners to ubuntu-24.04

### DIFF
--- a/.github/system_tests/test_containerized_code.py
+++ b/.github/system_tests/test_containerized_code.py
@@ -19,11 +19,8 @@ def test_add_singularity():
     builder.y = orm.Int(6)
     builder.metadata.options.resources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
 
-    print('Running containerized code')
     results, node = run_get_node(builder)
 
-    print(f'{results=}')
-    print(f'{node=}')
     assert node.is_finished_ok
     assert 'sum' in results
     assert 'remote_folder' in results

--- a/.github/system_tests/test_containerized_code.py
+++ b/.github/system_tests/test_containerized_code.py
@@ -19,8 +19,11 @@ def test_add_singularity():
     builder.y = orm.Int(6)
     builder.metadata.options.resources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
 
+    print('Running containerized code')
     results, node = run_get_node(builder)
 
+    print(f'{results=}')
+    print(f'{node=}')
     assert node.is_finished_ok
     assert 'sum' in results
     assert 'remote_folder' in results

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -20,7 +20,7 @@ jobs:
 
   tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     strategy:
@@ -93,7 +93,7 @@ jobs:
 
   tests-presto:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -118,7 +118,7 @@ jobs:
 
   verdi:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -26,7 +26,7 @@ jobs:
   build-and-test:
     if: ${{ github.event.pull_request.head.repo.fork }}
     name: build and test amd64 images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -14,7 +14,7 @@ jobs:
 
   docs-linkcheck:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,12 +70,11 @@ jobs:
         from-lock: 'true'
 
     - name: Setup environment
-      # NOTE: virtual env in .venv created by uv in previous step
-      run: source .venv/bin/activate && .github/workflows/setup.sh
+      run: .github/workflows/setup.sh
 
     - name: Run tests
       id: tests
-      run: source .venv/bin/activate && .github/workflows/tests_nightly.sh
+      run: .github/workflows/tests_nightly.sh
 
     - name: Slack notification
       # Always run this step (otherwise it would be skipped if any of the previous steps fail) but only if the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
   nightly-tests:
 
     if: github.repository == 'aiidateam/aiida-core'      # Prevent running the builds on forks as well
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -95,7 +95,7 @@ jobs:
   # Run a subset of test suite to ensure compatibility with latest RabbitMQ releases
   rabbitmq-tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
   nightly-tests:
 
     if: github.repository == 'aiidateam/aiida-core'      # Prevent running the builds on forks as well
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Only run this job on the main repository and not on forks
     if: github.repository == 'aiidateam/aiida-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
   pre-commit:
 
     needs: [check-release-tag]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     steps:
@@ -50,7 +50,7 @@ jobs:
   tests:
 
     needs: [check-release-tag]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     services:
@@ -75,7 +75,7 @@ jobs:
 
     needs: [check-release-tag, pre-commit, tests]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout source

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -26,7 +26,7 @@ jobs:
     # Note: The specification is also validated by the pre-commit hook.
 
     if: github.repository == 'aiidateam/aiida-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -56,7 +56,7 @@ jobs:
 
     needs: [validate-dependency-specification]
     if: github.repository == 'aiidateam/aiida-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -76,7 +76,7 @@ jobs:
   install-with-pip:
 
     if: github.repository == 'aiidateam/aiida-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     strategy:
@@ -107,7 +107,7 @@ jobs:
     # Verify that we can install AiiDA with conda.
 
     if: github.repository == 'aiidateam/aiida-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
 
     strategy:
@@ -159,7 +159,7 @@ jobs:
   tests:
 
     needs: [install-with-pip]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     strategy:


### PR DESCRIPTION
GitHub is rolling out a change where `ubuntu-latest` will start to point to ubuntu-24.04.