### PR TITLE
Use uv-pre-commit to validate lockfile

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -33,7 +33,7 @@ runs:
   - name: Set up uv
     uses: astral-sh/setup-uv@v5.2.1
     with:
-      version: 0.5.21
+      version: 0.5.22
       python-version: ${{ inputs.python-version }}
 
   - name: Install dependencies from uv lock

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -31,7 +31,7 @@ runs:
       python-version: ${{ inputs.python-version }}
 
   - name: Set up uv
-    uses: astral-sh/setup-uv@v5.2.0
+    uses: astral-sh/setup-uv@v5.2.1
     with:
       version: 0.5.x
       python-version: ${{ inputs.python-version }}

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -33,7 +33,7 @@ runs:
   - name: Set up uv
     uses: astral-sh/setup-uv@v5.2.1
     with:
-      version: 0.5.x
+      version: 0.5.21
       python-version: ${{ inputs.python-version }}
 
   - name: Install dependencies from uv lock

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -85,7 +85,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: aiida-pytests-py3.9
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false  # don't fail job, if coverage upload fails
 
   tests-presto:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -45,9 +45,6 @@ jobs:
     - name: Install utils/ dependencies
       run: uv pip install --system -r utils/requirements.txt
 
-    - name: Validate uv lockfile
-      run: uv lock --check
-
     - name: Validate conda environment file
       run: python ./utils/dependency_management.py validate-environment-yml
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: '3.11'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5.2.0
+      uses: astral-sh/setup-uv@v5.2.1
       with:
         version: 0.5.x
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v5.2.1
       with:
-        version: 0.5.x
+        version: latest
 
     - name: Install utils/ dependencies
       run: uv pip install --system -r utils/requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       )$
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.5.21
+  rev: 0.5.22
   hooks:
     # Check and update the uv lockfile
   - id: uv-lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       )$
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.5.20
+  rev: 0.5.21
   hooks:
     # Check and update the uv lockfile
   - id: uv-lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autofix_prs: true
   autoupdate_commit_msg: 'Devops: Update pre-commit dependencies'
   autoupdate_schedule: quarterly
-  skip: [mypy, check-uv-lock, generate-conda-environment, validate-conda-environment, verdi-autodocs]
+  skip: [mypy, generate-conda-environment, validate-conda-environment, verdi-autodocs]
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -55,6 +55,12 @@ repos:
         tests/.*|
         environment.yml|
       )$
+
+- repo: https://github.com/astral-sh/uv-pre-commit
+  rev: 0.5.20
+  hooks:
+    # Check and update the uv lockfile
+  - id: uv-lock
 
 - repo: local
 
@@ -185,18 +191,6 @@ repos:
         src/aiida/transports/plugins/local.py|
         src/aiida/transports/plugins/ssh.py|
         src/aiida/workflows/arithmetic/multiply_add.py|
-      )$
-
-  - id: check-uv-lock
-    name: Check uv lockfile up to date
-    # NOTE: This will not automatically update the lockfile
-    entry: uv lock --check
-    language: system
-    pass_filenames: false
-    files: >-
-      (?x)^(
-        pyproject.toml|
-        uv.lock|
       )$
 
   - id: generate-conda-environment

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,8 @@ build:
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     pre_create_environment:
     - asdf plugin add uv
-    - asdf install uv 0.5.21
-    - asdf global uv 0.5.21
+    - asdf install uv 0.5.22
+    - asdf global uv 0.5.22
     create_environment:
     - uv venv
     install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,8 @@ build:
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     pre_create_environment:
     - asdf plugin add uv
-    - asdf install uv 0.5.20
-    - asdf global uv 0.5.20
+    - asdf install uv 0.5.21
+    - asdf global uv 0.5.21
     create_environment:
     - uv venv
     install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -516,4 +516,6 @@ commands = molecule {posargs:test}
 """
 
 [tool.uv]
-required-version = ">=0.5.20"
+# NOTE: When you bump the minimum uv version, you also need
+# to bump it in .pre-commit-config.yaml and .github/actions/install-aiida-core/action.yml
+required-version = ">=0.5.21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -516,6 +516,8 @@ commands = molecule {posargs:test}
 """
 
 [tool.uv]
-# NOTE: When you bump the minimum uv version, you also need
-# to bump it in .pre-commit-config.yaml and .github/actions/install-aiida-core/action.yml
+# NOTE: When you bump the minimum uv version, you also need to change it in:
+# .pre-commit-config.yaml
+# .github/actions/install-aiida-core/action.yml
+# .readthedocs.yml
 required-version = ">=0.5.21"


### PR DESCRIPTION
The previous uv hook that checked whether uv lockfile is up-to-date required the developer to have uv installed. Using the official `uv-pre-commit` hook, this is no longer the case. The hook also updates the lock automatically, instead of just checking its status. 

Here's the output that I got when I bumped the mypy package in pyproject.toml

```console
❯ pre-commit run uv-lock --all
uv-lock..................................................................Failed
- hook id: uv-lock
- files were modified by this hook

warning: `VIRTUAL_ENV=/home/hollas/.cache/pre-commit/repovyb9qrvk/py_env-python3.12` does not match the project environment path `.venv` and will be ignored
Resolved 263 packages in 2.50s
Updated mypy v1.13.0 -> v1.14.1
```

(the warning is a bit unfortunate interaction between uv and pre-commit, I opened astral-sh/uv-pre-commit#36 and asked if it could be hidden so that it is not confusing for devs)