### PR TITLE
Devops: Add explicit `sphinx.configuration` key to RTD conf

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,6 +25,7 @@ build:
 # Let the build fail if there are any warnings
 sphinx:
   builder: html
+  configuration: docs/source/conf.py
   fail_on_warning: true
 
 search:


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/