### PR TITLE
Set minimum uv version in pyproject.toml

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -31,7 +31,7 @@ runs:
       python-version: ${{ inputs.python-version }}
 
   - name: Set up uv
-    uses: astral-sh/setup-uv@v5
+    uses: astral-sh/setup-uv@v5.2.0
     with:
       version: 0.5.x
       python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -76,10 +76,7 @@ jobs:
         AIIDA_WARN_v3: 1
       # NOTE1: Python 3.12 has a performance regression when running with code coverage
       # so run code coverage only for python 3.9.
-      # TODO: Remove a workaround for VIRTUAL_ENV once the setup-uv action is updated
-      # https://github.com/astral-sh/setup-uv/issues/219
       run: |
-        ${{ matrix.python-version == '3.9' && 'VIRTUAL_ENV=$PWD/.venv' || '' }}
         pytest -n auto --db-backend ${{ matrix.database-backend }} -m 'not nightly' tests/ ${{ matrix.python-version == '3.9' && '--cov aiida' || '' }}
 
     - name: Upload coverage report

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: '3.11'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v5.2.0
       with:
         version: 0.5.x
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -211,8 +211,5 @@ jobs:
       env:
         AIIDA_TEST_PROFILE: test_aiida
         AIIDA_WARN_v3: 1
-      # TODO: Remove a workaround for VIRTUAL_ENV once the setup-uv action is updated
-      # https://github.com/astral-sh/setup-uv/issues/219
       run: |
-        ${{ matrix.python-version == '3.9' && 'VIRTUAL_ENV=$PWD/.venv' || '' }}
         pytest -n auto --db-backend psql -m 'not nightly' tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -510,3 +510,6 @@ passenv =
     AIIDA_TEST_WORKERS
 commands = molecule {posargs:test}
 """
+
+[tool.uv]
+required-version = ">=0.5.20"


### PR DESCRIPTION
This sets the minimum uv version pyproject.toml, which is needed to have a consistent lockfile. 
When a dev has an outdated uv version, they'll get an error

```
❯ uv self update 0.5.19
info: Checking for updates...
success: Upgraded uv from v0.5.20 to v0.5.19! https://github.com/astral-sh/uv/releases/tag/0.5.19
❯ uv lock
error: Required version `>=0.5.20` does not match the running version `0.5.19`
```

Even better solution for a stable uv version will be to have it in enforced in a pre-commit hook, as in #6699, but that PR is blocked for now.

I've also pinned the `setup-uv` action to a specific version to prevent accidental regressions since that action is still undergoing heavy development. The new 5.2.0 also allows us to drop a VIRTUAL_ENV workaround. :tada: 

Closes #6712 