### PR TITLE
Use Github arm runners for docker arm build tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,17 +62,11 @@ jobs:
       images: ${{ needs.build.outputs.images }}
       registry: ghcr.io
 
-  # IMPORTANT: To save arm64 runners resources,
-  # we run the test only when pushing to main.
-  # We also only test the aiida-core-dev image.
   test-arm64:
     needs: build
-    if: >-
-      github.repository == 'aiidateam/aiida-core'
-      && (github.ref_type == 'tag' || github.ref_name == 'main')
     uses: ./.github/workflows/docker-test.yml
     with:
-      runsOn: buildjet-4vcpu-ubuntu-2204-arm
+      runsOn: ubuntu-22.04-arm
       images: ${{ needs.build.outputs.images }}
       target: aiida-core-dev
 


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

See also aiidalab/aiidalab-docker-stack#514