### PR TITLE
WIP: Use inline script dependencies (PEP-723) for utils/*py scripts

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -42,11 +42,8 @@ jobs:
       with:
         version: latest
 
-    - name: Install utils/ dependencies
-      run: uv pip install --system -r utils/requirements.txt
-
     - name: Validate conda environment file
-      run: python ./utils/dependency_management.py validate-environment-yml
+      run: uv run --script ./utils/dependency_management.py validate-environment-yml
 
   create-conda-environment:
     # Verify that we can create a valid conda environment from the environment.yml file.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,9 +56,9 @@ repos:
         environment.yml|
       )$
 
-  #- repo: file:///home/hollas/atmospec/uv-pre-commit
-- repo: https://github.com/danielhollas/uv-pre-commit
-  rev: uv-run
+- repo: file:///home/hollas/atmospec/uv-pre-commit
+  #- repo: https://github.com/danielhollas/uv-pre-commit
+  rev: c2c5e6a1c7d17dd3c237aae6557d15a142b89b8c
   hooks:
     # Check and update the uv lockfile
   - id: uv-lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -217,7 +217,7 @@ repos:
       )$
 
   - id: verdi-autodocs
-    name: Automatically generating verdi docs
+    name: Generate verdi docs
     entry: python ./utils/validate_consistency.py verdi-autodocs
     language: system
     pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,7 +191,6 @@ repos:
         src/aiida/transports/cli.py|
         src/aiida/transports/plugins/local.py|
         src/aiida/transports/plugins/ssh.py|
-        src/aiida/workflows/arithmetic/multiply_add.py|
       )$
 
 
@@ -323,7 +322,6 @@ repos:
         src/aiida/transports/cli.py|
         src/aiida/transports/plugins/local.py|
         src/aiida/transports/plugins/ssh.py|
-        src/aiida/workflows/arithmetic/multiply_add.py|
       )$
 
   - id: generate-conda-environment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,11 +56,144 @@ repos:
         environment.yml|
       )$
 
-- repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.5.22
+  #- repo: file:///home/hollas/atmospec/uv-pre-commit
+- repo: https://github.com/danielhollas/uv-pre-commit
+  rev: uv-run
   hooks:
     # Check and update the uv lockfile
   - id: uv-lock
+  - id: uv-run
+    name: Update conda environment file
+    args: [./utils/dependency_management.py, generate-environment-yml]
+    files: >-
+      (?x)^(
+        pyproject.toml|
+        utils/dependency_management.py
+      )$
+  - id: uv-run
+    name: Validate environment.yml
+    args: [./utils/dependency_management.py, validate-environment-yml]
+    files: >-
+      (?x)^(
+        pyproject.toml|
+        utils/dependency_management.py|
+        environment.yml
+      )$
+  - id: uv-run
+    name: mypy type check
+    args: [mypy, --config-file=pyproject.toml]
+    pass_filenames: true
+    types: [python]
+    exclude: >-
+      (?x)^(
+        .github/.*|
+        .molecule/.*|
+        .docker/.*|
+        docs/.*|
+        utils/.*|
+        tests/.*|
+
+        src/aiida/calculations/arithmetic/add.py|
+        src/aiida/calculations/diff_tutorial/calculations.py|
+        src/aiida/calculations/templatereplacer.py|
+        src/aiida/calculations/transfer.py|
+        src/aiida/cmdline/commands/cmd_archive.py|
+        src/aiida/cmdline/commands/cmd_calcjob.py|
+        src/aiida/cmdline/commands/cmd_code.py|
+        src/aiida/cmdline/commands/cmd_computer.py|
+        src/aiida/cmdline/commands/cmd_data/cmd_list.py|
+        src/aiida/cmdline/commands/cmd_data/cmd_upf.py|
+        src/aiida/cmdline/commands/cmd_devel.py|
+        src/aiida/cmdline/commands/cmd_group.py|
+        src/aiida/cmdline/commands/cmd_node.py|
+        src/aiida/cmdline/commands/cmd_shell.py|
+        src/aiida/cmdline/commands/cmd_storage.py|
+        src/aiida/cmdline/params/options/commands/setup.py|
+        src/aiida/cmdline/params/options/interactive.py|
+        src/aiida/cmdline/params/options/main.py|
+        src/aiida/cmdline/params/options/multivalue.py|
+        src/aiida/cmdline/params/types/group.py|
+        src/aiida/cmdline/utils/ascii_vis.py|
+        src/aiida/cmdline/utils/common.py|
+        src/aiida/cmdline/utils/echo.py|
+        src/aiida/common/extendeddicts.py|
+        src/aiida/common/utils.py|
+        src/aiida/engine/daemon/execmanager.py|
+        src/aiida/engine/processes/calcjobs/manager.py|
+        src/aiida/engine/processes/calcjobs/monitors.py|
+        src/aiida/engine/processes/calcjobs/tasks.py|
+        src/aiida/engine/processes/control.py|
+        src/aiida/engine/processes/ports.py|
+        src/aiida/manage/configuration/__init__.py|
+        src/aiida/manage/configuration/config.py|
+        src/aiida/manage/external/rmq/launcher.py|
+        src/aiida/manage/tests/main.py|
+        src/aiida/manage/tests/pytest_fixtures.py|
+        src/aiida/orm/comments.py|
+        src/aiida/orm/computers.py|
+        src/aiida/orm/implementation/storage_backend.py|
+        src/aiida/orm/nodes/comments.py|
+        src/aiida/orm/nodes/data/array/bands.py|
+        src/aiida/orm/nodes/data/array/trajectory.py|
+        src/aiida/orm/nodes/data/cif.py|
+        src/aiida/orm/nodes/data/remote/base.py|
+        src/aiida/orm/nodes/data/structure.py|
+        src/aiida/orm/nodes/data/upf.py|
+        src/aiida/orm/nodes/process/calculation/calcjob.py|
+        src/aiida/orm/nodes/process/process.py|
+        src/aiida/orm/utils/builders/code.py|
+        src/aiida/orm/utils/builders/computer.py|
+        src/aiida/orm/utils/calcjob.py|
+        src/aiida/orm/utils/node.py|
+        src/aiida/repository/backend/disk_object_store.py|
+        src/aiida/repository/backend/sandbox.py|
+        src/aiida/restapi/common/utils.py|
+        src/aiida/restapi/resources.py|
+        src/aiida/restapi/run_api.py|
+        src/aiida/restapi/translator/base.py|
+        src/aiida/restapi/translator/computer.py|
+        src/aiida/restapi/translator/group.py|
+        src/aiida/restapi/translator/nodes/.*|
+        src/aiida/restapi/translator/user.py|
+        src/aiida/schedulers/plugins/direct.py|
+        src/aiida/schedulers/plugins/lsf.py|
+        src/aiida/schedulers/plugins/pbsbaseclasses.py|
+        src/aiida/schedulers/plugins/sge.py|
+        src/aiida/schedulers/plugins/slurm.py|
+        src/aiida/storage/psql_dos/migrations/utils/integrity.py|
+        src/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py|
+        src/aiida/storage/psql_dos/migrations/utils/migrate_repository.py|
+        src/aiida/storage/psql_dos/migrations/utils/parity.py|
+        src/aiida/storage/psql_dos/migrations/utils/reflect.py|
+        src/aiida/storage/psql_dos/migrations/utils/utils.py|
+        src/aiida/storage/psql_dos/migrations/versions/1de112340b16_django_parity_1.py|
+        src/aiida/storage/psql_dos/migrator.py|
+        src/aiida/storage/psql_dos/models/.*|
+        src/aiida/storage/psql_dos/orm/.*|
+        src/aiida/storage/sqlite_temp/backend.py|
+        src/aiida/storage/sqlite_zip/backend.py|
+        src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py|
+        src/aiida/storage/sqlite_zip/migrator.py|
+        src/aiida/storage/sqlite_zip/models.py|
+        src/aiida/storage/sqlite_zip/orm.py|
+        src/aiida/tools/data/array/kpoints/legacy.py|
+        src/aiida/tools/data/array/kpoints/seekpath.py|
+        src/aiida/tools/data/orbital/orbital.py|
+        src/aiida/tools/data/orbital/realhydrogen.py|
+        src/aiida/tools/dbimporters/plugins/.*|
+        src/aiida/tools/graph/age_entities.py|
+        src/aiida/tools/graph/age_rules.py|
+        src/aiida/tools/graph/deletions.py|
+        src/aiida/tools/graph/graph_traversers.py|
+        src/aiida/tools/groups/paths.py|
+        src/aiida/tools/query/calculation.py|
+        src/aiida/tools/query/mapping.py|
+        src/aiida/transports/cli.py|
+        src/aiida/transports/plugins/local.py|
+        src/aiida/transports/plugins/ssh.py|
+        src/aiida/workflows/arithmetic/multiply_add.py|
+      )$
+
 
 - repo: local
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,15 +17,17 @@ build:
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     pre_create_environment:
     - asdf plugin add uv
-    - asdf install uv 0.5.22
-    - asdf global uv 0.5.22
+    - asdf install uv 0.5.28
+    - asdf global uv 0.5.28
     create_environment:
-    - uv venv
+    - uv venv $READTHEDOCS_VIRTUALENV_PATH
     install:
-    - uv sync --extra docs --extra tests --extra rest --extra atomic_tools
-    build:
-      html:
-      - uv run sphinx-build -T -W --keep-going -b html -d _build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
+    - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --extra docs --extra tests --extra rest --extra atomic_tools
+
+sphinx:
+  builder: html
+  fail_on_warning: true
+  configuration: docs/source/conf.py
 
 search:
   ranking:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,8 +19,6 @@ build:
     - asdf plugin add uv
     - asdf install uv 0.5.28
     - asdf global uv 0.5.28
-    create_environment:
-    - uv venv $READTHEDOCS_VIRTUALENV_PATH
     install:
     - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --extra docs --extra tests --extra rest --extra atomic_tools
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,9 +1,0 @@
-###########################################################################
-# Copyright (c), The AiiDA team. All rights reserved.                     #
-# This file is part of the AiiDA code.                                    #
-#                                                                         #
-# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
-# For further information on the license, see the LICENSE.txt file        #
-# For further information please visit http://www.aiida.net               #
-###########################################################################
-"""Utilities for installation and pre-commit checks & more."""

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,5 +1,0 @@
-click==7.1.2
-packaging==23.1
-pyyaml==6.0.1
-requests==2.25.1
-tomli==2.0.0

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -8,6 +8,12 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Autogenerate verdi CLI documentation from click."""
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "click",
+# ]
+# ///
 
 import os
 

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -8,12 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """Autogenerate verdi CLI documentation from click."""
-# /// script
-# requires-python = ">=3.9"
-# dependencies = [
-#     "click",
-# ]
-# ///
 
 import os
 


### PR DESCRIPTION
This is kinda blocked on astral-sh/uv-pre-commit#37 without which we cannot use `uv run` in pre-commit without requiring a global uv installation for every dev.

EDIT: A note for myself, would be good to move the mypy configuration to pyproject.toml, specifically the list of excluded files. https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude But I am not sure if we would need to still keep the config in pre-commit as well.