### PR TITLE
Dumping: Check non-empty input node repositories

### DIFF
--- a/src/aiida/tools/dumping/processes.py
+++ b/src/aiida/tools/dumping/processes.py
@@ -286,12 +286,13 @@ class ProcessDumper:
         if self.include_inputs:
             input_links = calculation_node.base.links.get_incoming(link_type=LinkType.INPUT_CALC)
             all_input_nodes = input_links.all_nodes()
-            all_have_repositories = all([hasattr(p.base, 'repository') for p in all_input_nodes])
+            all_have_repositories = all([hasattr(node.base, 'repository') for node in all_input_nodes])
             if all_have_repositories:
-                non_empty_repository = any([len(n.base.repository.list_objects()) > 0 for n in all_input_nodes])
+                non_empty_repository = any([len(node.base.repository.list_objects()) > 0 for node in all_input_nodes])
                 if non_empty_repository:
                     self._dump_calculation_io(
-                        parent_path=output_path / io_dump_mapping.inputs, link_triples=input_links
+                        parent_path=output_path / io_dump_mapping.inputs,
+                        link_triples=input_links,
                     )
 
         # Dump the node_outputs apart from `retrieved`

--- a/src/aiida/tools/dumping/processes.py
+++ b/src/aiida/tools/dumping/processes.py
@@ -285,7 +285,14 @@ class ProcessDumper:
         # Dump the node_inputs
         if self.include_inputs:
             input_links = calculation_node.base.links.get_incoming(link_type=LinkType.INPUT_CALC)
-            self._dump_calculation_io(parent_path=output_path / io_dump_mapping.inputs, link_triples=input_links)
+            all_input_nodes = input_links.all_nodes()
+            all_have_repositories = all([hasattr(p.base, 'repository') for p in all_input_nodes])
+            if all_have_repositories:
+                non_empty_repository = any([len(n.base.repository.list_objects()) > 0 for n in all_input_nodes])
+                if non_empty_repository:
+                    self._dump_calculation_io(
+                        parent_path=output_path / io_dump_mapping.inputs, link_triples=input_links
+                    )
 
         # Dump the node_outputs apart from `retrieved`
         if self.include_outputs:

--- a/tests/tools/dumping/test_processes.py
+++ b/tests/tools/dumping/test_processes.py
@@ -203,6 +203,9 @@ def test_dump_multiply_add(tmp_path, generate_workchain_multiply_add):
     assert all([input_file.is_file() for input_file in input_files])
     assert all([output_file.is_file() for output_file in output_files])
 
+    missing_dir = dump_parent_path / node_inputs_relpath
+    assert not missing_dir.exists()
+
     # Flat dumping
     dump_parent_path = tmp_path / 'wc-dump-test-multiply-add-flat'
     process_dumper = ProcessDumper(flat=True)
@@ -327,6 +330,9 @@ def test_dump_calculation_add(tmp_path, generate_calculation_node_add):
 
     assert all([input_file.is_file() for input_file in input_files])
     assert all([output_file.is_file() for output_file in output_files])
+
+    missing_dir = dump_parent_path / node_inputs_relpath
+    assert not missing_dir.exists()
 
 
 # Tests for helper methods


### PR DESCRIPTION
Adding a small check to the process-dumping that incoming nodes actually do have associated `NodeRepository`s (that might actually not even be necessary, probably _all_ `Node`s have that by construction 🤔), and that these repositories actually do hold objects. This avoids empty `node_inputs` directories being created when dumping.