### PR TITLE
Enforce context usage of Container within migrator

### DIFF
--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -532,8 +532,8 @@ class Config:
                 profile.storage_cls.initialise(profile)
         except Exception as exception:
             raise StorageMigrationError(
-                f'Storage backend initialisation failed, probably because the configuration is incorrect:\n{exception}'
-            )
+                'Initialisation of the storage backend failed. Please check the traceback.'
+            ) from exception
         LOGGER.report('Storage initialisation completed.')
 
         self.add_profile(profile)

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -9,7 +9,6 @@
 """SqlAlchemy implementation of `aiida.orm.implementation.backends.Backend`."""
 
 import functools
-import gc
 import pathlib
 from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Set, Union
@@ -188,15 +187,13 @@ class PsqlDosBackend(StorageBackend):
         # close the connection
 
         engine = self._session_factory.bind
-        if engine is not None:
-            engine.dispose()  # type: ignore[union-attr]
         self._session_factory.expunge_all()
         self._session_factory.close()
         self._session_factory = None
 
-        # Without this, sqlalchemy keeps a weakref to a session
-        # in sqlalchemy.orm.session._sessions
-        gc.collect()
+        # IMPORTANT: Dispose engine only after sessions have been closed
+        if engine is not None:
+            engine.dispose()  # type: ignore[union-attr]
 
     def _clear(self) -> None:
         from aiida.storage.psql_dos.models.settings import DbSetting

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -460,7 +460,7 @@ def test_create_profile_raises(config_with_profile, monkeypatch, entry_points):
     with pytest.raises(ValueError, match=r'The entry point `.*` could not be loaded'):
         config.create_profile(profile_name, 'core.non_existant', {})
 
-    with pytest.raises(exceptions.StorageMigrationError, match='Storage backend initialisation failed.*'):
+    with pytest.raises(exceptions.StorageMigrationError, match='Initialisation of the storage backend failed.*'):
         config.create_profile(profile_name, 'core.sqlite_temp', {})
 
 


### PR DESCRIPTION
As mentioned in issue #6739, this is to enforce the correct usage of the container so all acquired resources are correctly released.

~TODO Need to test with py313 if open file descriptors are closed~ works

This PR goes together with https://github.com/aiidateam/disk-objectstore/pull/179