### PR TITLE
CI: Ignore `mamba` Warning Message on `stderr` to Prevent JSON Parsing Errors

### DIFF
--- a/.docker/requirements.txt
+++ b/.docker/requirements.txt
@@ -1,4 +1,4 @@
 docker~=7.0.0
 pytest~=8.2.0
 requests~=2.32.0
-pytest-docker~=3.1.0
+pytest-docker~=3.2.0

--- a/.docker/tests/test_aiida.py
+++ b/.docker/tests/test_aiida.py
@@ -6,7 +6,7 @@ from packaging.version import parse
 
 
 def test_correct_python_version_installed(aiida_exec, python_version):
-    info = json.loads(aiida_exec('mamba list --json --full-name python').decode())[0]
+    info = json.loads(aiida_exec('mamba list --json --full-name python', ignore_stderr=True).decode())[0]
     assert info['name'] == 'python'
     assert parse(info['version']) == parse(python_version)
 
@@ -15,7 +15,7 @@ def test_correct_pgsql_version_installed(aiida_exec, pgsql_version, variant):
     if variant == 'aiida-core-base':
         pytest.skip('PostgreSQL is not installed in the base image')
 
-    info = json.loads(aiida_exec('mamba list --json --full-name postgresql').decode())[0]
+    info = json.loads(aiida_exec('mamba list --json --full-name postgresql', ignore_stderr=True).decode())[0]
     assert info['name'] == 'postgresql'
     assert parse(info['version']).major == parse(pgsql_version).major
 


### PR DESCRIPTION
This PR addresses the CI issue caused by the deprecated `--no-python-version-warning` in mamba, which interferes with JSON parsing in tests.

To resolve this:
+ Upgraded `pytest-docker` to version 3.2.0, which introduces the `ignore_stderr` feature.
+ Updated test cases (`test_correct_python_version_installed` and `test_correct_pgsql_version_installed`) to include `ignore_stderr=True`, ensuring that warning messages on `stderr` do not disrupt JSON parsing.

Hopefully this improvement ensures future robustness against JSON parsing issues caused by warnings in `stderr`.

Closes #6745.

cc @GeigerJ2, @unkcpz, and @agoscinski.