### PR TITLE
Transport: SshTransport bug in method rename #6725 solved

### DIFF
--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -1368,16 +1368,13 @@ class SshTransport(BlockingTransport):
         oldpath = str(oldpath)
         newpath = str(newpath)
 
-        if not self.isfile(oldpath):
-            if not self.isdir(oldpath):
+        """The code now checks if oldpath exists and raises an OSError if not. A check is added to ensure that newpath doesn't already exist (using FileExistsError), to avoid unintentional overwriting."""
+
+        if not self.isfile(oldpath) and not self.isdir(oldpath):
                 raise OSError(f'Source {oldpath} does not exist')
-        # TODO: this seems to be a bug (?)
-        # why to raise an OSError if the newpath does not exist?
-        # ofcourse newpath shouldn't exist, that's why we are renaming it!
-        # issue opened here: https://github.com/aiidateam/aiida-core/issues/6725
-        if not self.isfile(newpath):
-            if not self.isdir(newpath):
-                raise OSError(f'Destination {newpath} does not exist')
+
+        if self.isfile(newpath) or self.isdir(newpath):
+                raise FileExistsError(f'Destination {newpath}already exists')
 
         return self.sftp.rename(oldpath, newpath)
 

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -1371,10 +1371,10 @@ class SshTransport(BlockingTransport):
         """The code now checks if oldpath exists and raises an OSError if not. A check is added to ensure that newpath doesn't already exist (using FileExistsError), to avoid unintentional overwriting."""
 
         if not self.isfile(oldpath) and not self.isdir(oldpath):
-                raise OSError(f'Source {oldpath} does not exist')
+            raise OSError(f'Source {oldpath} does not exist')
 
         if self.isfile(newpath) or self.isdir(newpath):
-                raise FileExistsError(f'Destination {newpath}already exists')
+            raise FileExistsError(f'Destination {newpath}already exists')
 
         return self.sftp.rename(oldpath, newpath)
 


### PR DESCRIPTION
The comment in the code indicates a potential bug or misunderstanding around raising an OSError when newpath does not exist. The purpose of renaming is usually to move or rename a file or folder to a new location, so newpath doesn't need to exist. I think, the check might want to verify if newpath already exists to prevent overwriting existing files/folders unintentionally.
In my view it could be adjusted by raising an error if newpath exists rather than if it does not. A more appropriate exception might be FileExistsError.

The new code now checks if oldpath exists and raises an OSError if not.
 Also the added check to ensure that newpath doesn't already exist (with using FileExistsError), to avoid unintentional overwriting.
 
 
 Please let me know if its right,and I would really like to keep contributing more 