### PR TITLE
Replace usage of aiida.common.utils.strip_prefix with built-in removeprefix

### DIFF
--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -446,20 +446,6 @@ def join_labels(labels, join_symbol='|', threshold=1.0e-6):
     return new_labels
 
 
-def strip_prefix(full_string, prefix):
-    """Strip the prefix from the given string and return it. If the prefix is not present
-    the original string will be returned unaltered
-
-    :param full_string: the string from which to remove the prefix
-    :param prefix: the prefix to remove
-    :return: the string with prefix removed
-    """
-    if full_string.startswith(prefix):
-        return full_string.rsplit(prefix)[1]
-
-    return full_string
-
-
 class Capturing:
     """This class captures stdout and returns it
     (as a list, split by lines).

--- a/src/aiida/orm/utils/node.py
+++ b/src/aiida/orm/utils/node.py
@@ -12,7 +12,6 @@ import logging
 import warnings
 
 from aiida.common import exceptions
-from aiida.common.utils import strip_prefix
 from aiida.orm.fields import EntityFieldMeta
 
 __all__ = (
@@ -49,19 +48,19 @@ def load_node_class(type_string):
     # This exception needs to be there to make migrations work that rely on the old type string starting with `node.`
     # Since now the type strings no longer have that prefix, we simply strip it and continue with the normal logic.
     if base_path.startswith('node.'):
-        base_path = strip_prefix(base_path, 'node.')
+        base_path = base_path.removeprefix('node.')
 
     # Data nodes are the only ones with sub classes that are still external, so if the plugin is not available
     # we fall back on the base node type
     if base_path.startswith('data.'):
-        entry_point_name = strip_prefix(base_path, 'data.')
+        entry_point_name = base_path.removeprefix('data.')
         try:
             return load_entry_point('aiida.data', entry_point_name)
         except exceptions.MissingEntryPointError:
             return Data
 
     if base_path.startswith('process'):
-        entry_point_name = strip_prefix(base_path, 'nodes.')
+        entry_point_name = base_path.removeprefix('data.')
         return load_entry_point('aiida.node', entry_point_name)
 
     # At this point we really have an anomalous type string. At some point, storing nodes with unresolvable type strings
@@ -99,7 +98,7 @@ def get_type_string_from_class(class_module, class_name):
 
     # Sequentially and **in order** strip the prefixes if present
     for prefix in prefixes:
-        type_string = strip_prefix(type_string, prefix)
+        type_string = type_string.removeprefix(prefix)
 
     # This needs to be here as long as `aiida.orm.nodes.data` does not live in `aiida.orm.nodes.data` because all the
     # `Data` instances will have a type string that starts with `data.` instead of `nodes.`, so in order to match any

--- a/src/aiida/restapi/common/identifiers.py
+++ b/src/aiida/restapi/common/identifiers.py
@@ -135,7 +135,6 @@ def load_entry_point_from_full_type(full_type):
     :raises `~aiida.common.exceptions.EntryPointError`: if the corresponding entry point cannot be loaded
     """
     from aiida.common import EntryPointError
-    from aiida.common.utils import strip_prefix
     from aiida.plugins.entry_point import is_valid_entry_point_string, load_entry_point, load_entry_point_from_string
 
     data_prefix = 'data.'
@@ -151,7 +150,7 @@ def load_entry_point_from_full_type(full_type):
             raise EntryPointError(f'could not load entry point `{process_type}`')
 
     elif node_type.startswith(data_prefix):
-        base_name = strip_prefix(node_type, data_prefix)
+        base_name = node_type.removeprefix(data_prefix)
         entry_point_name = base_name.rsplit('.', 2)[0]
 
         try:
@@ -229,20 +228,19 @@ class Namespace(MutableMapping):
 
     def _infer_full_type(self, full_type):
         """Infer the full type based on the current namespace path and the given full type of the leaf."""
-        from aiida.common.utils import strip_prefix
 
         if full_type or self._path is None:
             return full_type
 
-        full_type = strip_prefix(self._path, 'node.')
+        full_type = self._path.removeprefix('node.')
 
         if full_type.startswith('process.'):
             for basepath, full_type_template in self.process_full_type_mapping.items():
                 if full_type.startswith(basepath):
-                    plugin_name = strip_prefix(full_type, basepath)
+                    plugin_name = full_type.removeprefix(basepath)
                     if plugin_name.startswith(DEFAULT_NAMESPACE_LABEL):
                         temp_type_template = self.process_full_type_mapping_unplugged[basepath]
-                        plugin_name = strip_prefix(plugin_name, DEFAULT_NAMESPACE_LABEL + '.')
+                        plugin_name = plugin_name.removeprefix(DEFAULT_NAMESPACE_LABEL + '.')
                         full_type = temp_type_template.format(plugin_name=plugin_name)
                     else:
                         full_type = full_type_template.format(plugin_name=plugin_name)


### PR DESCRIPTION
I've removed the deprecated **strip_prefix** function, its imports, and use cases, and replaced it with the built-in **removeprefix** function, fixes #6705 