### PR TITLE
[QueryBuilder] Implement `get_creation_statistics` for SQLite backend

### DIFF
--- a/src/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -33,7 +33,7 @@ from sqlalchemy.types import Boolean, DateTime, Float, Integer, String
 from aiida.common.exceptions import NotExistent
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation.querybuilder import QUERYBUILD_LOGGER, BackendQueryBuilder, QueryDictType
-from aiida.storage import psql_dos, sqlite_dos
+from aiida.storage import psql_dos, sqlite_dos, sqlite_temp, sqlite_zip
 
 from .joiner import JoinReturn, SqlaJoiner
 
@@ -803,7 +803,11 @@ class SqlaQueryBuilder(BackendQueryBuilder):
         backend_class = self._backend.__class__
         date_format = '%Y-%m-%d'
 
-        if backend_class == sqlite_dos.backend.SqliteDosStorage:
+        if backend_class in {
+            sqlite_dos.backend.SqliteDosStorage,
+            sqlite_zip.SqliteZipBackend,
+            sqlite_temp.SqliteTempBackend,
+        }:
             cday = sa_func.strftime(date_format, sa_func.datetime(self.Node.ctime, 'localtime'))
 
             def date_to_str(d):

--- a/src/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -816,7 +816,7 @@ class SqlaQueryBuilder(BackendQueryBuilder):
 
         else:
             raise NotImplementedError(f'unsupported dialect: {dialect}')
-        
+
         stat_query = session.query(
             cday.label('cday'),
             sa_func.count(self.Node.id),

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -1581,9 +1581,6 @@ class TestManager:
     def init_db(self, backend):
         self.backend = backend
 
-    # This fails with sqlite with:
-    # sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such function: date_trunc
-    @pytest.mark.requires_psql
     def test_statistics(self):
         """Test if the statistics query works properly.
 
@@ -1620,9 +1617,6 @@ class TestManager:
 
         assert new_db_statistics == expected_db_statistics
 
-    # This fails with sqlite with:
-    # sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such function: date_trunc
-    @pytest.mark.requires_psql
     def test_statistics_default_class(self):
         """Test if the statistics query works properly.
 

--- a/tests/restapi/test_statistics.py
+++ b/tests/restapi/test_statistics.py
@@ -33,10 +33,7 @@ def linearize_namespace(tree_namespace, linear_namespace=None):
     return linear_namespace
 
 
-# This test does not work with SQLite since it uses the `statistics` endpoint,
-# which uses `date_trunc` under the hood, which is not implemented in SQLite.
 @pytest.mark.usefixtures('populate_restapi_database')
-@pytest.mark.requires_psql
 def test_count_consistency(restapi_server, server_url):
     """Test the consistency in values between full_type_count and statistics"""
     server = restapi_server()


### PR DESCRIPTION
This PR improves backend parity between two database backends by implementing `get_creation_statistics` for the SQLite backend. It achieves this by using an alternative method to implement `date_trunc`, which is available in PostgreSQL but not in SQLite.

Closes #6747.