### PR TITLE
#6657 Fix TarFile.extract DeprecationWarning for Python 3.12+ using filter data and hasattr

### DIFF
--- a/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -125,6 +125,7 @@ def perform_v1_migration(
 
     return working / DB_FILENAME
 
+
 def _json_to_sqlite(
     outpath: Path, data: dict, node_repos: Dict[str, List[Tuple[str, Optional[str]]]], batch_size: int = 100
 ) -> None:

--- a/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -78,7 +78,11 @@ def perform_v1_migration(
             temp_folder = working / 'temp_unpack'
             with tarfile.open(_inpath, 'r') as tar:
                 MIGRATE_LOGGER.report('Extracting tar archive...(may take a while)')
-                tar.extractall(temp_folder)
+                # https://docs.python.org/3/library/tarfile.html#supporting-older-python-versions
+                if hasattr(tarfile, 'data_filter'):
+                    tar.extractall(temp_folder, filter='data')
+                else:
+                    tar.extractall(temp_folder)
             yield temp_folder
             MIGRATE_LOGGER.report('Removing extracted tar archive...')
             shutil.rmtree(temp_folder)
@@ -120,7 +124,6 @@ def perform_v1_migration(
     update_metadata(metadata, LEGACY_TO_MAIN_REVISION)
 
     return working / DB_FILENAME
-
 
 def _json_to_sqlite(
     outpath: Path, data: dict, node_repos: Dict[str, List[Tuple[str, Optional[str]]]], batch_size: int = 100


### PR DESCRIPTION
## Summary
Hi @danielhollas, I'm Sairam. I’ve addressed the DeprecationWarning for tarfile.extractall() on Python 3.12+ by adding a hasattr() check for data_filter after reading through the official docs and the previous changes

## Changes Made
-Replaced version check with hasattr() for backward compatibility.
-Applied the data filter for secure extraction when available.


## Reason
This ensures compatibility across Python versions and prepares for the default behavior in Python 3.14 while enhancing security.

## Testing
- Verified that the extraction runs without warnings on Python 3.12.
- Ensured compatibility with earlier Python versions.

Closes #6657
