### PR TITLE
Add `_updatable_objects` to Node to enable `mutable` repository storage for active processes

### DIFF
--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -180,6 +180,10 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
     # Requires Sealable mixin, but needs empty tuple for base class
     _updatable_attributes: Tuple[str, ...] = tuple()
 
+    # A tuple of object names that can be updated even after node is stored
+    # Requires Sealable mixin, but needs empty tuple for base class
+    _updatable_objects: Tuple[str, ...] = tuple()
+
     # A tuple of attribute names that will be ignored when creating the hash.
     _hash_ignored_attributes: Tuple[str, ...] = tuple()
 

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -140,6 +140,18 @@ def test_sealed():
         node.base.repository.put_object_from_bytes(b'content', 'path')
 
 
+def test_updatable_objects():
+    node = CalcJobNode()
+    node._updatable_objects = ['not_raise']
+    node.store()
+    node.base.repository.put_object_from_bytes(b'content', 'not_raise')
+    with pytest.raises(exceptions.ModificationNotAllowed):
+        node.base.repository.put_object_from_bytes(b'content', 'raise')
+    node.seal()
+    with pytest.raises(exceptions.ModificationNotAllowed):
+        node.base.repository.put_object_from_bytes(b'content', 'not_raise')
+
+
 def test_get_object_raises():
     """Test the ``NodeRepository.get_object`` method when it is supposed to raise."""
     node = Data()


### PR DESCRIPTION
All attributes in AiiDA are stored in the SQL database, which can become inefficient for handling **large data**. For example, the `checkpoint` data in WorkChain, or the `pickle` binary data in WorkGraph. To improve performance, it would be beneficial to store large data in the file repository (`base.repository`) instead.  However, unlike `attributes`, the repository does not support `updatable` objects in the same way as `updatable` attributes.  This PR introduces `_updatable_objects` to enable **mutable** repository storage for active processes while preserving AiiDA's immutability rules.

I tested this in WorkGraph, and it works.

Open this PR for discussion! 