### PR TITLE
`CI`: `RTD` tail errors and warnings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,7 +25,7 @@ build:
     - uv sync --extra docs --extra tests --extra rest --extra atomic_tools
     build:
       html:
-      - uv run sphinx-build -T -W --keep-going -b html -d _build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
+      - uv run sphinx-build -T -W --keep-going -b html -d _build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html -w sphinx.log || (cat sphinx.log && exit 1)
 
 search:
   ranking:

--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -72,20 +72,11 @@ async def upload_calculation(
 ) -> RemoteData | None:
     """Upload a `CalcJob` instance
 
-        inputs = {
-        'metadata': {
-            'computer': Computer.collection.get(label="localhost"),
-            'options': {
-                'resources': {'num_machines': 1},
-                'stash': {
-                    'stash_mode': StashMode.COPY.value,
-                    'target_base': '/scratch/my_stashing/',
-                    'source_list': ['aiida.in', '_aiidasubmit.sh'],
-                },
-            },
-        },
-        'source_node': node_1,
-    }
+    :param node: the `CalcJobNode`.
+    :param transport: an already opened transport to use to submit the calculation.
+    :param calc_info: the calculation info datastructure returned by `CalcJob.presubmit`
+    :param folder: temporary local file system folder containing the inputs written by `CalcJob.prepare_for_submission`
+    :returns: The ``RemoteData`` representing the working directory on the remote if, or ``None`` if  ``dry_run=True``.
     """
     # If the calculation already has a `remote_folder`, simply return. The upload was apparently already completed
     # before, which can happen if the daemon is restarted and it shuts down after uploading but before getting the

--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -72,11 +72,20 @@ async def upload_calculation(
 ) -> RemoteData | None:
     """Upload a `CalcJob` instance
 
-    :param node: the `CalcJobNode`.
-    :param transport: an already opened transport to use to submit the calculation.
-    :param calc_info: the calculation info datastructure returned by `CalcJob.presubmit`
-    :param folder: temporary local file system folder containing the inputs written by `CalcJob.prepare_for_submission`
-    :returns: The ``RemoteData`` representing the working directory on the remote if, or ``None`` if  ``dry_run=True``.
+        inputs = {
+        'metadata': {
+            'computer': Computer.collection.get(label="localhost"),
+            'options': {
+                'resources': {'num_machines': 1},
+                'stash': {
+                    'stash_mode': StashMode.COPY.value,
+                    'target_base': '/scratch/my_stashing/',
+                    'source_list': ['aiida.in', '_aiidasubmit.sh'],
+                },
+            },
+        },
+        'source_node': node_1,
+    }
     """
     # If the calculation already has a `remote_folder`, simply return. The upload was apparently already completed
     # before, which can happen if the daemon is restarted and it shuts down after uploading but before getting the


### PR DESCRIPTION
Fix https://github.com/aiidateam/aiida-core/issues/6728

So if RTD, fails and you check the website you see:
![Screenshot_20250227_140017](https://github.com/user-attachments/assets/dadd5cc7-4bf4-4461-be1b-5a9b4286bc6e)

Then one has to search manually for 'WARNING' to find the problem. Unfortunately some browsers, like mine does not support exact matching (e.g. all capital letters, etc) then I often end up walking through all deprecation warnings that are irrelevant. Or I just have to copy-paste everything in a text file and the search for it.

This PR, simply after executing the command searchs for `WARNING` and `ERROR` and tails them in the end. 
So the final outcome, in case of a failed build will look like this:

```
(good) examples/pw_tutorial.html --> external_redirects.html
(good) examples/wannier90_tutorial.html --> external_redirects.html
build finished with problems, 6 warnings.
/aiida-core/src/aiida/calculations/stash.py:docstring of aiida.calculations.stash.StashCalculation:9: ERROR: Unexpected indentation. [docutils]
/aiida-core/src/aiida/calculations/stash.py:docstring of aiida.calculations.stash.StashCalculation:11: ERROR: Unexpected indentation. [docutils]
/aiida-core/src/aiida/calculations/stash.py:docstring of aiida.calculations.stash.StashCalculation:14: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/aiida-core/src/aiida/calculations/stash.py:docstring of aiida.calculations.stash.StashCalculation:15: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/aiida-core/src/aiida/calculations/stash.py:docstring of aiida.calculations.stash.StashCalculation:16: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
/aiida-core/src/aiida/calculations/stash.py:docstring of aiida.calculations.stash.StashCalculation:18: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
```

