### PR TITLE
`CI`: remove matrix redundancy between `test-install` and `ci`

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']  # 3.9 and 3.13 are tested via ci-code.yml
 
     services:
       postgres:


### PR DESCRIPTION
Fix for https://github.com/aiidateam/aiida-core/issues/6779

As of now, two set of tests, are redundant for no apparant reasons. 
For example, see for the first commit that I made in this PR:
https://github.com/aiidateam/aiida-core/actions/runs/13631859178/job/38101273251?pr=6780#step:7:1
and
https://github.com/aiidateam/aiida-core/actions/runs/13631859180/job/38101194890?pr=6780#step:7:1

The second one has only an extra flag `--cov aiida`, which is irrelevant in terms of redundancy. 
I don't see a reason why these tests has to be run two times.

This PR, removes that to save time on CI.