### PR TITLE
Docs: add google-site-verification meta tag

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,9 @@
 :sd_hide_title:
 
+.. HTML meta tag to verify aiida.readthedocs.io in Google Search Console (aiidateam account)
+.. meta::
+   :google-site-verification: wLcoklPmiTRQs5TXRD6At5hNXGYSwexWnx0wygU4Uxk
+
 .. grid::
    :reverse:
    :gutter: 2 3 3 3


### PR DESCRIPTION
This PR adds a meta tag to verify AiiDA docs (`aiida.readthedocs.io`) in the Google Search console under the "aiidateam" google account. This allows us to

* see what pages of our documentation get indexed by google (and why), helping to debug if/why old pages show up in google search.
* and also to see insights such as which google search queries people use to find aiida docs.

Note, this seems google-specific, but if we manage to tune our setup with this tool, it will most likely also be reflected with other search engines. 