### PR TITLE
Unify hostname/machine parameter naming (fixes #6726).

### DIFF
--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -52,7 +52,7 @@ class LocalTransport(BlockingTransport):
         self._internal_dir = None
 
         # Just to avoid errors
-        self._machine = kwargs.pop('machine', None)
+        self._machine = self.hostname
         if self._machine and self._machine != 'localhost':
             self.logger.debug('machine was passed, but it is not localhost')
 

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -383,7 +383,7 @@ class SshTransport(BlockingTransport):
         self._proxy = None
         self._proxies = []
 
-        self._machine = kwargs.pop('machine')
+        self._machine = self.hostname
 
         self._client = paramiko.SSHClient()
         self._load_system_host_keys = kwargs.pop('load_system_host_keys', False)

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -126,7 +126,7 @@ class AsyncSshTransport(AsyncTransport):
         # by default, 'machine_or_host' is set to 'machine' in the __init__ method, if not provided.
         # NOTE: to guarantee a connection,
         # a computer with core.ssh_async transport plugin should be configured before any instantiation.
-        self.machine = kwargs.pop('machine_or_host', kwargs.pop('machine'))
+        self.machine = self.hostname
         self._max_io_allowed = kwargs.pop('max_io_allowed', self._DEFAULT_max_io_allowed)
         self.script_before = kwargs.pop('script_before', 'None')
 

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -121,7 +121,19 @@ class Transport(abc.ABC):
         self._enters = 0
 
         # for accessing the identity of the underlying machine
-        self.hostname = kwargs.get('machine')
+        import warnings
+
+        if 'hostname' in kwargs:
+            self.hostname = kwargs.pop('hostname')
+        elif 'machine' in kwargs:
+            self.hostname = kwargs.pop('machine')
+            warnings.warn(
+                "The 'machine' parameter is deprecated, use 'hostname' instead",
+                DeprecationWarning,
+                stacklevel=2
+            )
+        else:
+            self.hostname = None
 
     def __repr__(self):
         return f'<{self.__class__.__name__}: {self!s}>'

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -128,9 +128,7 @@ class Transport(abc.ABC):
         elif 'machine' in kwargs:
             self.hostname = kwargs.pop('machine')
             warnings.warn(
-                "The 'machine' parameter is deprecated, use 'hostname' instead",
-                DeprecationWarning,
-                stacklevel=2
+                "The 'machine' parameter is deprecated, use 'hostname' instead", DeprecationWarning, stacklevel=2
             )
         else:
             self.hostname = None


### PR DESCRIPTION
# Issue
When setting up a computer with `verdi computer setup`, users enter "Hostname" but must use `machine=` in transport code. Internally it's stored as `self.hostname`, causing confusion (issue #6726).

# Fix
Standardized parameter naming:
- Base Transport: Accepts `hostname=` (preferred) and `machine=` (deprecated with warning)
- Transport plugins: Modified to use `self.hostname` consistently