### PR TITLE
`Transport`: Add `OpenSSH` as backend option to `AsyncSshTransport`

### DIFF
--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -34,6 +34,7 @@ from aiida.orm import CalcJobNode, Code, FolderData, Node, PortableCode, RemoteD
 from aiida.orm.utils.log import get_dblogger_extra
 from aiida.repository.common import FileType
 from aiida.schedulers.datastructures import JobState
+from aiida.transports import has_magic
 
 if TYPE_CHECKING:
     from aiida.transports import Transport
@@ -465,7 +466,7 @@ async def stash_calculation(calculation: CalcJobNode, transport: Transport) -> N
         target_basepath = target_base / uuid[:2] / uuid[2:4] / uuid[4:]
 
         for source_filename in source_list:
-            if transport.has_magic(source_filename):
+            if has_magic(source_filename):
                 copy_instructions = []
                 for globbed_filename in await transport.glob_async(source_basepath / source_filename):
                     target_filepath = target_basepath / Path(globbed_filename).relative_to(source_basepath)
@@ -679,7 +680,7 @@ async def retrieve_files_from_list(
         if isinstance(item, (list, tuple)):
             tmp_rname, tmp_lname, depth = item
             # if there are more than one file I do something differently
-            if transport.has_magic(tmp_rname):
+            if has_magic(tmp_rname):
                 remote_names = await transport.glob_async(workdir.joinpath(tmp_rname))
                 local_names = []
                 for rem in remote_names:
@@ -702,7 +703,7 @@ async def retrieve_files_from_list(
         else:
             abs_item = item if item.startswith('/') else str(workdir.joinpath(item))
 
-            if transport.has_magic(abs_item):
+            if has_magic(abs_item):
                 remote_names = await transport.glob_async(abs_item)
                 local_names = [os.path.split(rem)[1] for rem in remote_names]
             else:

--- a/src/aiida/transports/plugins/__init__.py
+++ b/src/aiida/transports/plugins/__init__.py
@@ -12,10 +12,13 @@
 
 # fmt: off
 
+from .async_backend import *
 from .ssh import *
 
 __all__ = (
     'SshTransport',
+    '_AsyncSSH',
+    '_OpenSSH',
     'convert_to_bool',
     'parse_sshconfig',
 )

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -1,0 +1,712 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+This module instruct a `_AsynchronousSSHBackend` class that backends `AsyncSshTransport`.
+It also provides two implementation classes: `_AsyncSSH` and `_OpenSSH`, which are used to
+interact with remote machines over SSH.
+
+The `_AsyncSSH` class uses the `asyncssh` library to execute commands and transfer files,
+while the `_OpenSSH` class uses the `ssh` command line client.
+"""
+
+import abc
+import asyncio
+import logging
+import posixpath
+from typing import Optional
+
+import asyncssh
+from asyncssh import SFTPFileAlreadyExists
+
+from aiida.common.escaping import escape_for_bash
+from aiida.transports.transport import (
+    TransportInternalError,
+    has_magic,
+)
+
+__all__ = ('_AsyncSSH', '_OpenSSH')
+
+
+class _AsynchronousSSHBackend(abc.ABC):
+    """
+    This is a base class for the backend adaptors of `AsyncSshTransport` class.
+    It defines the interface for the methods that need to be implemented by the subclasses.
+    Note: Subclasses should not be part of the public API and should not be used directly.
+    """
+
+    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+        self.bash_command = bash_command + '-c '
+        self.machine = machine
+        self.logger = logger
+
+    @abc.abstractmethod
+    async def open(self):
+        """Open the connection"""
+
+    @abc.abstractmethod
+    async def close(self):
+        """Close the connection"""
+
+    @abc.abstractmethod
+    async def get(self, remotepath: str, localpath: str, dereference: bool, preserve: bool, recursive: bool):
+        """Get a file or directory from the remote machine.
+        :param remotepath: The path to the file or directory on the remote machine
+        :param localpath: The path to the file or directory on the local machine
+        :param dereference: Whether to follow symlinks
+        :param preserve: Whether to preserve the file attributes
+        :param recursive: Whether to copy directories recursively.
+        If `remotepath` is a file, set this to `False`, `True` otherwise.
+
+        :raises OSError: If failed for whatever reason
+        """
+
+    @abc.abstractmethod
+    async def put(self, localpath: str, remotepath: str, dereference: bool, preserve: bool, recursive: bool):
+        """Put a file or directory on the remote machine.
+        :param localpath: The path to the file or directory on the local machine
+        :param remotepath: The path to the file or directory on the remote machine
+        :param dereference: Whether to follow symlinks
+        :param preserve: Whether to preserve the file attributes
+        :param recursive: Whether to copy directories recursively.
+        If `localpath` is a file, set this to `False`, `True` otherwise.
+
+        :raises OSError: If failed for whatever reason
+        """
+
+    @abc.abstractmethod
+    async def run(self, command: str, stdin: Optional[str] = None, timeout: Optional[int] = None):
+        """Run a command on the remote machine.
+        :param command: The command to run
+        :param stdin: The input to send to the command
+        :param timeout: The timeout in seconds
+        :return: The return code, str(stdout), and str(stderr)
+        """
+
+    @abc.abstractmethod
+    async def lstat(self, path: str):
+        """Get the stat of a file or directory.
+        :param path: The path to the file or directory
+        :return: An instance of `Stat` class
+        """
+
+    @abc.abstractmethod
+    async def isdir(self, path: str):
+        """Check if a path is a directory."""
+
+    @abc.abstractmethod
+    async def isfile(self, path: str):
+        """Check if a path is a file."""
+
+    @abc.abstractmethod
+    async def listdir(self, path: str):
+        """List the contents of a directory.
+        :param path: The path to the directory
+        :return: A list of file and directory names
+        """
+
+    @abc.abstractmethod
+    async def mkdir(self, path: str, exist_ok: bool = False, parents: bool = False):
+        """Create a directory.
+        :param path: The path to the directory
+        :param exist_ok: If `True`, do not raise an error if the directory already exists
+        :param parents: If `True`, create parent directories if they do not exist
+        """
+
+    @abc.abstractmethod
+    async def remove(self, path: str):
+        """Remove a file.
+        :param path: The path to the file.
+        :raises OSError: If the path is a directory.
+        """
+
+    @abc.abstractmethod
+    async def rename(self, oldpath: str, newpath: str):
+        """Rename a file or directory.
+        :param oldpath: The old path and name
+        :param newpath: The new path and name
+        """
+
+    @abc.abstractmethod
+    async def rmdir(self, path: str):
+        """Remove an empty directory.
+        :param path: The path to the directory
+
+        :raises OSError: If the directory is not empty.
+        """
+
+    @abc.abstractmethod
+    async def rmtree(self, path: str):
+        """Remove a directory and all its contents.
+        :param path: The path to the directory
+
+        :raises OSError: If it fails for whatever reason.
+        """
+
+    @abc.abstractmethod
+    async def path_exists(self, path: str):
+        """Check if a path exists.
+        :param path: The path to check
+        :return: `True` if the path exists, `False` otherwise
+        """
+
+    @abc.abstractmethod
+    async def symlink(self, source: str, destination: str):
+        """Create a single link from source to destination.
+        No magic is allowed in source or destination.
+        :param source: The source path
+        :param destination: The destination path
+        """
+
+    @abc.abstractmethod
+    async def glob(self, path: str):
+        """Return a list of files and directories matching the glob pattern.
+        :param path: A path potentially containing the glob pattern
+
+        :return: A list of matching files and directories
+
+        :raises OSError: If the path does not exist or no matching files/folders are found.
+        """
+
+    @abc.abstractmethod
+    async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
+        """Change the permissions of a file or directory.
+        :param path: The path to the file or directory
+        :param mode: Th permissions to set (An integer number base 10 -- not octal!)
+        :param follow_symlinks: If `True`, change the permissions of the target of a symlink
+        """
+
+    @abc.abstractmethod
+    async def chown(self, path: str, uid: int, gid: int):
+        """Change the ownership of a file or directory.
+        :param path: The path to the file or directory
+        :param uid: The user ID to set
+        :param gid: The group ID to set
+        """
+
+    @abc.abstractmethod
+    async def copy(
+        self,
+        remotesource: str,
+        remotedestination: str,
+        dereference: bool,
+        recursive: bool,
+        preserve: bool,
+    ):
+        """Copy a file or directory from one location to another.
+        :param remotesource: The source path on the remote machine
+        :param remotedestination: The destination path on the remote machine
+        :param dereference: Whether to follow symlinks
+        :param recursive: Whether to copy directories recursively.
+        If `remotesource` is a file, set this to `False`, `True` otherwise.
+        :param preserve: Whether to preserve the file attributes
+
+        :raises OSError: If failed for whatever reason
+        """
+
+
+class _AsyncSSH(_AsynchronousSSHBackend):
+    """A backend class that uses asyncssh to execute commands and transfer files.
+    This class is not part of the public api and should not be used directly.
+    Note: This class is not part of the public API and should not be used directly.
+    """
+
+    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+        super().__init__(machine, logger, bash_command)
+
+    async def open(self):
+        self._conn = await asyncssh.connect(self.machine)
+        self._sftp = await self._conn.start_sftp_client()
+
+    async def close(self):
+        self._conn.close()
+        await self._conn.wait_closed()
+
+    async def get(self, remotepath: str, localpath: str, dereference: bool, preserve: bool, recursive: bool):
+        try:
+            return await self._sftp.get(
+                remotepaths=remotepath,
+                localpath=localpath,
+                preserve=preserve,
+                recurse=recursive,
+                follow_symlinks=dereference,
+            )
+        except asyncssh.Error as exc:
+            raise OSError from exc
+
+    async def put(self, localpath: str, remotepath: str, dereference: bool, preserve: bool, recursive: bool):
+        try:
+            return await self._sftp.put(
+                localpaths=localpath,
+                remotepath=remotepath,
+                preserve=preserve,
+                recurse=recursive,
+                follow_symlinks=dereference,
+            )
+        except asyncssh.Error as exc:
+            raise OSError from exc
+
+    async def run(self, command: str, stdin: Optional[str] = None, timeout: Optional[int] = None):
+        result = await self._conn.run(
+            self.bash_command + escape_for_bash(command),
+            input=stdin,
+            check=False,
+            timeout=timeout,
+        )
+        # Since the command is str, both stdout and stderr are strings
+        return (result.returncode, ''.join(str(result.stdout)), ''.join(str(result.stderr)))
+
+    async def lstat(self, path: str):
+        # The return object from asyncssh is compatible with `class::Stat`
+        return await self._sftp.lstat(path)
+
+    async def isdir(self, path: str):
+        return await self._sftp.isdir(path)
+
+    async def isfile(self, path: str):
+        return await self._sftp.isfile(path)
+
+    async def listdir(self, path: str):
+        return list(await self._sftp.listdir(path))
+
+    async def mkdir(self, path: str, exist_ok: bool = False, parents: bool = False):
+        try:
+            if parents:
+                await self._sftp.makedirs(path, exist_ok=exist_ok)
+            else:
+                # note: mkdir() in asyncssh does not support the exist_ok parameter
+                # we handle it via a try-except block
+                await self._sftp.mkdir(path)
+        except SFTPFileAlreadyExists:
+            # SFTPFileAlreadyExists is only supported in asyncssh version 6.0.0 and later
+            if not exist_ok:
+                raise FileExistsError(f'Directory already exists: {path}')
+        except asyncssh.sftp.SFTPFailure as exc:
+            if self._sftp.version < 6:
+                if not exist_ok:
+                    raise FileExistsError(f'Directory already exists: {path}')
+            else:
+                raise TransportInternalError(f'Error while creating directory {path}: {exc}')
+
+    async def remove(self, path: str):
+        # TODO: check if asyncssh does return SFTPFileIsADirectory in this case
+        # if that's the case, we can get rid of the isfile check
+        # https://github.com/aiidateam/aiida-core/issues/6719
+        if await self.isdir(path):
+            raise OSError(f'The path {path} is a directory')
+        else:
+            await self._sftp.remove(path)
+
+    async def rename(self, oldpath: str, newpath: str):
+        await self._sftp.rename(oldpath, newpath)
+
+    async def rmdir(self, path: str):
+        try:
+            await self._sftp.rmdir(path)
+        except asyncssh.sftp.SFTPFailure:
+            raise OSError(f'Error while removing directory {path}: probably directory is not empty')
+
+    async def rmtree(self, path: str):
+        try:
+            await self._sftp.rmtree(path, ignore_errors=False)
+        except asyncssh.Error as exc:
+            raise OSError(f'Error while removing directory tree {path}: {exc}')
+
+    async def path_exists(self, path: str):
+        return await self._sftp.exists(path)
+
+    async def symlink(self, source: str, destination: str):
+        """Create a single link from source to destination.
+        No magic is allowed in source or destination.
+        """
+        await self._sftp.symlink(source, destination)
+
+    async def glob(self, path: str):
+        try:
+            return await self._sftp.glob(path)
+        except asyncssh.sftp.SFTPNoSuchFile:
+            raise OSError(f'Either the remote path {path} does not exist, or a matching file/folder not found.')
+
+    async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
+        await self._sftp.chmod(path, mode, follow_symlinks=follow_symlinks)
+
+    async def chown(self, path: str, uid: int, gid: int):
+        await self._sftp.chown(path, uid, gid, follow_symlinks=True)
+
+    async def copy(
+        self,
+        remotesource: str,
+        remotedestination: str,
+        dereference: bool,
+        recursive: bool,
+        preserve: bool,
+    ):
+        # SFTP.copy() supports remote copy only in very recent version _OpenSSH 9.0 and later.
+        # For the older versions, it downloads the file and uploads it again!
+        # For performance reasons, we should check if the remote copy is supported, if so use
+        # self._sftp.mcopy() & self._sftp.copy() otherwise send a `cp` command to the remote machine.
+        # See here: https://github.com/ronf/asyncssh/issues/724
+        if self._sftp.supports_remote_copy:
+            try:
+                if has_magic(remotesource):
+                    await self._sftp.mcopy(
+                        remotesource,
+                        remotedestination,
+                        preserve=preserve,
+                        recurse=recursive,
+                        follow_symlinks=dereference,
+                        remote_only=True,
+                    )
+                else:
+                    if not await self.path_exists(remotesource):
+                        raise FileNotFoundError(f'The remote path {remotesource} does not exist')
+                    await self._sftp.copy(
+                        remotesource,
+                        remotedestination,
+                        preserve=preserve,
+                        recurse=recursive,
+                        follow_symlinks=dereference,
+                        remote_only=True,
+                    )
+            except asyncssh.sftp.SFTPNoSuchFile as exc:
+                # note: one could just create directories, but aiida engine expects this behavior
+                # see `execmanager.py`::_copy_remote_files for more details
+                raise FileNotFoundError(
+                    f'The remote path {remotedestination} is not reachable,'
+                    f'perhaps the parent folder does not exists: {exc}'
+                )
+            except asyncssh.sftp.SFTPFailure as exc:
+                raise OSError(f'Error while copying {remotesource} to {remotedestination}: {exc}')
+        else:
+            self.logger.warning('The remote copy is not supported, using the `cp` command to copy the file/folder')
+            # I copy pasted the whole logic below from SshTransport class:
+
+            async def _exec_cp(cp_exe: str, cp_flags: str, src: str, dst: str):
+                """Execute the ``cp`` command on the remote machine."""
+                # to simplify writing the above copy function
+                command = f'{cp_exe} {cp_flags} {escape_for_bash(src)} {escape_for_bash(dst)}'
+
+                retval, stdout, stderr = await self.run(command)
+
+                if retval == 0:
+                    if stderr.strip():
+                        self.logger.warning(f'There was nonempty stderr in the cp command: {stderr}')
+                else:
+                    self.logger.error(
+                        "Problem executing cp. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
+                            retval, stdout, stderr, command
+                        )
+                    )
+                    if 'No such file or directory' in str(stderr):
+                        raise FileNotFoundError(f'Error while executing cp: {stderr}')
+
+                    raise OSError(
+                        'Error while executing cp. Exit code: {}, '
+                        "stdout: '{}', stderr: '{}', "
+                        "command: '{}'".format(retval, stdout, stderr, command)
+                    )
+
+            cp_exe = 'cp'
+            cp_flags = '-f'
+
+            if recursive:
+                cp_flags += ' -r'
+
+            if preserve:
+                cp_flags += ' -p'
+
+            if dereference:
+                # use -L; --dereference is not supported on mac
+                cp_flags += ' -L'
+
+            if has_magic(remotesource):
+                to_copy_list = await self.glob(remotesource)
+
+                if len(to_copy_list) > 1:
+                    if not await self.path_exists(remotedestination) or await self.isfile(remotedestination):
+                        raise OSError("Can't copy more than one file in the same destination file")
+
+                for file in to_copy_list:
+                    await _exec_cp(cp_exe, cp_flags, file, remotedestination)
+
+            else:
+                await _exec_cp(cp_exe, cp_flags, remotesource, remotedestination)
+
+
+class _OpenSSH(_AsynchronousSSHBackend):
+    """A backend class that executes _OpenSSH commands directly in a shell.
+    This class is not part of the public api and should not be used directly.
+    Note: This class is not part of the public API and should not be used directly.
+    """
+
+    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+        super().__init__(machine, logger, bash_command)
+
+    async def openssh_execute(self, commands, stdin: Optional[str] = None, timeout: Optional[float] = None):
+        """
+        Execute a command using the _OpenSSH command line client.
+        :param commands: The list of commands to execute
+        :param timeout: The timeout in seconds
+        :return: The return code, stdout, and stderr
+        """
+        process = await asyncio.create_subprocess_exec(
+            *commands, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+
+        if stdin:
+            process.stdin.write(stdin.encode())  # type: ignore[union-attr]
+            await process.stdin.drain()  # type: ignore[union-attr]
+            process.stdin.close()  # type: ignore[union-attr]
+
+        if timeout is None:
+            stdout, stderr = await process.communicate()
+        else:
+            try:
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                return -1, '', 'Timeout exceeded'
+
+        return process.returncode, stdout.decode(), stderr.decode()
+
+    def ssh_command_generator(self, raw_command: str):
+        """
+        Generate the command to execute
+        :param raw_command: The command to execute
+        """
+        # if "'" in raw_command:
+        treated_raw_command = f'"{raw_command}"'
+        # else:
+        #     treated_raw_command = f"\'{raw_command}\'"
+        return ['ssh', self.machine, self.bash_command + treated_raw_command]
+
+    async def mkdir(self, path: str, exist_ok: bool = False, parents: bool = False):
+        if parents and not exist_ok:
+            if await self.path_exists(path):
+                raise FileExistsError(f'Directory already exists: {path}')
+
+        commands = self.ssh_command_generator(f"mkdir {'-p' if parents else ''} {path}")
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            if 'File exists' in stderr:
+                if not exist_ok:
+                    raise FileExistsError(f'Directory already exists: {path}')
+            else:
+                raise OSError(f'Failed to create directory: {path}')
+
+    async def chown(self, path: str, uid: int, gid: int) -> None:
+        commands = self.ssh_command_generator(f'chown {uid}:{gid} {path}')
+
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Failed to change ownership: {path}')
+
+    async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
+        # chmod works with octal numbers, so we have to convert the mode to octal
+        mode = oct(mode)[2:]  # type: ignore[assignment]
+        commands = self.ssh_command_generator(f"chmod {'-h' if not follow_symlinks else ''} {mode} {path}")
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Failed to change permissions: {path}')
+
+    async def glob(self, path: str):
+        commands = self.ssh_command_generator(f'find {path} -maxdepth 0')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Either the path {path} does not exist, or a matching file/folder not found.')
+
+        return list(stdout.strip().split())
+
+    async def symlink(self, source: str, destination: str):
+        """Create a single link from source to destination.
+        No magic is allowed in source or destination.
+        """
+
+        commands = self.ssh_command_generator(f'ln -s {source} {destination}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Failed to create symlink: {source} -> {destination}')
+
+    async def path_exists(self, path: str):
+        commands = self.ssh_command_generator(f'test -e {path}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if stderr:
+            # this should not happen, but just in case for debugging
+            self.logger.debug(f'Unexpected stderr: {stderr}')
+            raise OSError(stderr)
+        return returncode == 0
+
+    async def rmtree(self, path: str):
+        commands = self.ssh_command_generator(f'rm -rf {path}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Failed to remove path: {path}')
+
+    async def rmdir(self, path: str):
+        commands = self.ssh_command_generator(f'rmdir {path}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError('Failed to remove directory')
+
+    async def rename(self, oldpath: str, newpath: str):
+        commands = self.ssh_command_generator(f'mv {oldpath} {newpath}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Failed to rename path: {oldpath} -> {newpath}')
+
+    async def remove(self, path: str):
+        commands = self.ssh_command_generator(f'rm {path}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        if returncode != 0:
+            raise OSError(f'Failed to remove path: {path}')
+
+    async def listdir(self, path: str):
+        commands = self.ssh_command_generator(f'ls {path}')
+        # '-d' is used prevents recursive listing of directories.
+        # This is useful when 'path' includes glob patterns.
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+        if returncode != 0:
+            raise FileNotFoundError
+        return list(stdout.strip().split())
+
+    async def isdir(self, path: str):
+        commands = self.ssh_command_generator(f'test -d {path}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+        return returncode == 0
+
+    async def isfile(self, path: str):
+        commands = self.ssh_command_generator(f'test -f {path}')
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+        return returncode == 0
+
+    async def lstat(self, path: str):
+        # order of stat matters
+        commands = self.ssh_command_generator(f"stat -c '%s %u %g %a %X %Y' {path}")
+        returncode, stdout, stderr = await self.openssh_execute(commands)
+
+        stdout = stdout.strip()
+        if not stdout:
+            raise FileNotFoundError
+
+        # order matters
+        return Stat(*stdout.split())
+
+    async def run(self, command: str, stdin: Optional[str] = None, timeout: Optional[float] = None):
+        # Not sure if sending the entire command as a single string is a good idea
+        # This is a hack to escape the $ character in the stdin
+        command = command.replace('$', r'\$')
+        command = command.replace('\\$', r'\$')
+        commands = self.ssh_command_generator(command)
+
+        returncode, stdout, stderr = await self.openssh_execute(commands, stdin, timeout)
+        return returncode, stdout, stderr
+
+    async def get(self, remotepath: str, localpath: str, dereference: bool, preserve: bool, recursive: bool):
+        options = []
+        if preserve:
+            options.append('-p')
+        if dereference:
+            # options.append("-L")
+            # symlinks has to resolved manually
+            pass
+        if recursive:
+            options.append('-r')
+
+        returncode, stdout, stderr = await self.openssh_execute(
+            ['scp', *options, f'{self.machine}:{remotepath}', localpath]
+        )
+        if returncode != 0:
+            raise OSError({stderr})
+
+    async def put(self, localpath: str, remotepath: str, dereference: bool, preserve: bool, recursive: bool):
+        options = []
+        if preserve:
+            options.append('-p')
+        if dereference:
+            # options.append("-L")
+            # symlinks has to resolved manually
+            pass
+        if recursive:
+            options.append('-r')
+
+        returncode, stdout, stderr = await self.openssh_execute(
+            ['scp', *options, localpath, f'{self.machine}:{remotepath}']
+        )
+        if returncode != 0:
+            raise OSError({stderr})
+
+    async def open(self):
+        pass
+
+    async def close(self):
+        pass
+
+    async def copy(
+        self,
+        remotesource: str,
+        remotedestination: str,
+        dereference: bool,
+        recursive: bool,
+        preserve: bool,
+    ):
+        options = []
+        if preserve:
+            options.append('-p')
+        if dereference:
+            # options.append("-L")
+            # symlinks has to resolved manually
+            pass
+        if recursive:
+            options.append('-r')
+
+        if has_magic(remotesource):
+            to_copy_list = await self.glob(remotesource)
+
+            if len(to_copy_list) > 1:
+                if not await self.path_exists(remotedestination) or await self.isfile(remotedestination):
+                    raise OSError("Can't copy more than one file in the same destination file")
+
+        elif not await self.path_exists(remotesource):
+            raise FileNotFoundError(f'The remote path {remotesource} does not exist')
+
+        parent_directory = posixpath.dirname(remotedestination)
+        if not await self.path_exists(parent_directory):
+            # note: one could just create directories, but aiida engine expects this behavior
+            # see `execmanager.py`::_copy_remote_files for more details
+            raise FileNotFoundError(
+                f'The remote path {remotedestination} is not reachable,'
+                f'perhaps the parent folder does not exist: {parent_directory}'
+            )
+
+        returncode, stdout, stderr = await self.openssh_execute(
+            ['scp', *options, f'{self.machine}:{remotesource}', f'{self.machine}:{remotedestination}']
+        )
+        if returncode != 0:
+            raise OSError(f'Failed to copy from {remotesource} to {remotedestination} : {stderr}')
+
+
+class Stat:
+    def __init__(self, size, uid, gid, permissions, atime, mtime):
+        self.size = int(size)
+        self.uid = int(uid)
+        self.gid = int(gid)
+        # convert the octal permissions to decimal
+        self.permissions = int(permissions, 8)
+        self.atime = int(atime)
+        self.mtime = int(mtime)

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 from aiida.common.warnings import warn_deprecation
 from aiida.transports import cli as transport_cli
-from aiida.transports.transport import BlockingTransport, TransportInternalError, TransportPath
+from aiida.transports.transport import BlockingTransport, TransportInternalError, TransportPath, has_magic
 
 
 # refactor or raise the limit: issue #1784
@@ -266,8 +266,8 @@ class LocalTransport(BlockingTransport):
         if not os.path.isabs(localpath):
             raise ValueError('Source must be an absolute path')
 
-        if self.has_magic(localpath):
-            if self.has_magic(remotepath):
+        if has_magic(localpath):
+            if has_magic(remotepath):
                 raise ValueError('Pathname patterns are not allowed in the remotepath')
 
             to_copy_list = glob.glob(localpath)  # using local glob here
@@ -435,8 +435,8 @@ class LocalTransport(BlockingTransport):
         if not os.path.isabs(localpath):
             raise ValueError('Destination must be an absolute path')
 
-        if self.has_magic(remotepath):
-            if self.has_magic(localpath):
+        if has_magic(remotepath):
+            if has_magic(localpath):
                 raise ValueError('Pathname patterns are not allowed in the localpath')
             to_copy_list = self.glob(remotepath)
 
@@ -569,7 +569,7 @@ class LocalTransport(BlockingTransport):
             raise ValueError('Input remotesource to copy must be a non empty object')
         if not remotedestination:
             raise ValueError('Input remotedestination to copy must be a non empty object')
-        if not self.has_magic(remotesource):
+        if not has_magic(remotesource):
             if not os.path.exists(os.path.join(self.curdir, remotesource)):
                 raise FileNotFoundError('Source not found')
         if self.normalize(remotesource) == self.normalize(remotedestination):
@@ -582,8 +582,8 @@ class LocalTransport(BlockingTransport):
 
         the_destination = os.path.join(self.curdir, remotedestination)
 
-        if self.has_magic(remotesource):
-            if self.has_magic(remotedestination):
+        if has_magic(remotesource):
+            if has_magic(remotedestination):
                 raise ValueError('Pathname patterns are not allowed in the remotedestination')
 
             to_copy_list = self.glob(remotesource)
@@ -898,8 +898,8 @@ class LocalTransport(BlockingTransport):
         remotesource = os.path.normpath(str(remotesource))
         remotedestination = os.path.normpath(str(remotedestination))
 
-        if self.has_magic(remotesource):
-            if self.has_magic(remotedestination):
+        if has_magic(remotesource):
+            if has_magic(remotedestination):
                 # if there are patterns in dest, I don't know which name to assign
                 raise ValueError('Remotedestination cannot have patterns')
 

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -21,7 +21,7 @@ from aiida.cmdline.params.types.path import AbsolutePathOrEmptyParamType
 from aiida.common.escaping import escape_for_bash
 from aiida.common.warnings import warn_deprecation
 
-from ..transport import BlockingTransport, TransportInternalError, TransportPath
+from ..transport import BlockingTransport, TransportInternalError, TransportPath, has_magic
 
 __all__ = ('SshTransport', 'convert_to_bool', 'parse_sshconfig')
 
@@ -866,8 +866,8 @@ class SshTransport(BlockingTransport):
         if not os.path.isabs(localpath):
             raise ValueError('The localpath must be an absolute path')
 
-        if self.has_magic(localpath):
-            if self.has_magic(remotepath):
+        if has_magic(localpath):
+            if has_magic(remotepath):
                 raise ValueError('Pathname patterns are not allowed in the destination')
 
             # use the imported glob to analyze the path locally
@@ -1049,8 +1049,8 @@ class SshTransport(BlockingTransport):
         if not os.path.isabs(localpath):
             raise ValueError('The localpath must be an absolute path')
 
-        if self.has_magic(remotepath):
-            if self.has_magic(localpath):
+        if has_magic(remotepath):
+            if has_magic(localpath):
                 raise ValueError('Pathname patterns are not allowed in the destination')
             # use the self glob to analyze the path remotely
             to_copy_list = self.glob(remotepath)
@@ -1268,10 +1268,10 @@ class SshTransport(BlockingTransport):
                 + f'Found instead {remotedestination} as remotedestination'
             )
 
-        if self.has_magic(remotedestination):
+        if has_magic(remotedestination):
             raise ValueError('Pathname patterns are not allowed in the destination')
 
-        if self.has_magic(remotesource):
+        if has_magic(remotesource):
             to_copy_list = self.glob(remotesource)
 
             if len(to_copy_list) > 1:
@@ -1615,8 +1615,8 @@ class SshTransport(BlockingTransport):
         source = os.path.normpath(remotesource)
         dest = os.path.normpath(remotedestination)
 
-        if self.has_magic(source):
-            if self.has_magic(dest):
+        if has_magic(source):
+            if has_magic(dest):
                 # if there are patterns in dest, I don't know which name to assign
                 raise ValueError('`remotedestination` cannot have patterns')
 

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -16,17 +16,14 @@ import os
 from pathlib import Path, PurePath
 from typing import Optional, Union
 
-import asyncssh
 import click
-from asyncssh import SFTPFileAlreadyExists
 
-from aiida.common.escaping import escape_for_bash
 from aiida.common.exceptions import InvalidOperation
 from aiida.transports.transport import (
     AsyncTransport,
     Transport,
-    TransportInternalError,
     TransportPath,
+    has_magic,
     validate_positive_number,
 )
 
@@ -45,19 +42,9 @@ def validate_script(ctx, param, value: str):
     return value
 
 
-def validate_machine(ctx, param, value: str):
-    async def attempt_connection():
-        try:
-            await asyncssh.connect(value)
-        except Exception:
-            return False
-        return True
-
-    if not asyncio.run(attempt_connection()):
-        raise click.BadParameter("Couldn't connect! " 'Please make sure `ssh {value}` would work without password')
-    else:
-        click.echo(f'`ssh {value}` successful!')
-
+def validate_backend(ctx, param, value: str):
+    if value not in ['asyncssh', 'openssh']:
+        raise click.BadParameter(f'{value} is not a valid backend, choose either `asyncssh` or `openssh`')
     return value
 
 
@@ -79,7 +66,6 @@ class AsyncSshTransport(AsyncTransport):
                 'help': 'Password-less host-setup to connect, as in command `ssh <your-host-name>`. '
                 "You'll need to have a `Host <your-host-name>` entry defined in your `~/.ssh/config` file.",
                 'non_interactive_default': True,
-                'callback': validate_machine,
             },
         ),
         (
@@ -106,6 +92,19 @@ class AsyncSshTransport(AsyncTransport):
                 'callback': validate_script,
             },
         ),
+        (
+            'backend',
+            {
+                'type': str,
+                'default': 'asyncssh',
+                'prompt': 'Type of async backend to use, `asyncssh` or `openssh`',
+                'help': '`openssh` uses the `ssh` command line tool to connect to the remote machine,'
+                'e.g. it is useful in case of multiplexing. '
+                'The `asyncssh` backend is the default and is recommended for most use cases.',
+                'non_interactive_default': True,
+                'callback': validate_backend,
+            },
+        ),
     ]
 
     @classmethod
@@ -129,6 +128,16 @@ class AsyncSshTransport(AsyncTransport):
         self.machine = kwargs.pop('machine_or_host', kwargs.pop('machine'))
         self._max_io_allowed = kwargs.pop('max_io_allowed', self._DEFAULT_max_io_allowed)
         self.script_before = kwargs.pop('script_before', 'None')
+
+        if kwargs.get('backend') == 'openssh':
+            from .async_backend import _OpenSSH
+
+            self.async_backend = _OpenSSH(self.machine, self.logger, self._bash_command_str)
+        else:
+            # default backend is asyncssh
+            from .async_backend import _AsyncSSH
+
+            self.async_backend = _AsyncSSH(self.machine, self.logger, self._bash_command_str)  # type: ignore[assignment]
 
         self._concurrent_io = 0
 
@@ -157,9 +166,7 @@ class AsyncSshTransport(AsyncTransport):
         if self.script_before != 'None':
             os.system(f'{self.script_before}')
 
-        self._conn = await asyncssh.connect(self.machine)
-        self._sftp = await self._conn.start_sftp_client()
-
+        await self.async_backend.open()
         self._is_open = True
 
         return self
@@ -172,8 +179,7 @@ class AsyncSshTransport(AsyncTransport):
         if not self._is_open:
             raise InvalidOperation('Cannot close the transport: it is already closed')
 
-        self._conn.close()
-        await self._conn.wait_closed()
+        await self.async_backend.close()
         self._is_open = False
 
     def __str__(self):
@@ -220,8 +226,8 @@ class AsyncSshTransport(AsyncTransport):
         if not os.path.isabs(localpath):
             raise ValueError('The localpath must be an absolute path')
 
-        if self.has_magic(remotepath):
-            if self.has_magic(localpath):
+        if has_magic(remotepath):
+            if has_magic(localpath):
                 raise ValueError('Pathname patterns are not allowed in the destination')
             # use the self glob to analyze the path remotely
             to_copy_list = await self.glob_async(remotepath)
@@ -302,16 +308,12 @@ class AsyncSshTransport(AsyncTransport):
 
         try:
             await self._lock()
-            await self._sftp.get(
-                remotepaths=remotepath,
-                localpath=localpath,
-                preserve=preserve,
-                recurse=False,
-                follow_symlinks=dereference,
+            await self.async_backend.get(
+                remotepath=remotepath, localpath=localpath, dereference=dereference, preserve=preserve, recursive=False
             )
             await self._unlock()
-        except (OSError, asyncssh.Error) as exc:
-            raise OSError(f'Error while uploading file {localpath}: {exc}')
+        except OSError as exc:
+            raise OSError(f'Error while downloading file {remotepath}: {exc}')
 
     async def gettree_async(
         self,
@@ -373,16 +375,17 @@ class AsyncSshTransport(AsyncTransport):
         for content_ in content_list:
             try:
                 await self._lock()
-                await self._sftp.get(
-                    remotepaths=PurePath(remotepath) / content_,
+                parentpath = str(PurePath(remotepath) / content_)
+                await self.async_backend.get(
+                    remotepath=parentpath,
                     localpath=localpath,
+                    dereference=dereference,
                     preserve=preserve,
-                    recurse=True,
-                    follow_symlinks=dereference,
+                    recursive=True,
                 )
                 await self._unlock()
-            except (OSError, asyncssh.Error) as exc:
-                raise OSError(f'Error while uploading file {localpath}: {exc}')
+            except OSError as exc:
+                raise OSError(f'Error while downloading file {parentpath}: {exc}')
 
     async def put_async(
         self,
@@ -425,8 +428,12 @@ class AsyncSshTransport(AsyncTransport):
         if not os.path.isabs(localpath):
             raise ValueError('The localpath must be an absolute path')
 
-        if self.has_magic(localpath):
-            if self.has_magic(remotepath):
+        if not os.path.isabs(remotepath):
+            # Historically remotepath could be a relative path, but it is not supported anymore.
+            raise OSError('The remotepath must be an absolute path')
+
+        if has_magic(localpath):
+            if has_magic(remotepath):
                 raise ValueError('Pathname patterns are not allowed in the destination')
 
             # use the imported glob to analyze the path locally
@@ -504,20 +511,20 @@ class AsyncSshTransport(AsyncTransport):
         if not os.path.isabs(localpath):
             raise ValueError('The localpath must be an absolute path')
 
+        if not os.path.isabs(remotepath):
+            # Historically remotepath could be a relative path, but it is not supported anymore.
+            raise OSError('The remotepath must be an absolute path')
+
         if await self.isfile_async(remotepath) and not overwrite:
             raise OSError('Destination already exists: not overwriting it')
 
         try:
             await self._lock()
-            await self._sftp.put(
-                localpaths=localpath,
-                remotepath=remotepath,
-                preserve=preserve,
-                recurse=False,
-                follow_symlinks=dereference,
+            await self.async_backend.put(
+                localpath=localpath, remotepath=remotepath, dereference=dereference, preserve=preserve, recursive=False
             )
             await self._unlock()
-        except (OSError, asyncssh.Error) as exc:
+        except OSError as exc:
             raise OSError(f'Error while uploading file {localpath}: {exc}')
 
     async def puttree_async(
@@ -583,16 +590,17 @@ class AsyncSshTransport(AsyncTransport):
         for content_ in content_list:
             try:
                 await self._lock()
-                await self._sftp.put(
-                    localpaths=PurePath(localpath) / content_,
+                parentpath = str(PurePath(localpath) / content_)
+                await self.async_backend.put(
+                    localpath=parentpath,
                     remotepath=remotepath,
+                    dereference=dereference,
                     preserve=preserve,
-                    recurse=True,
-                    follow_symlinks=dereference,
+                    recursive=True,
                 )
                 await self._unlock()
-            except (OSError, asyncssh.Error) as exc:
-                raise OSError(f'Error while uploading file {PurePath(localpath)/content_}: {exc}')
+            except OSError as exc:
+                raise OSError(f'Error while uploading file {parentpath}: {exc}')
 
     async def copy_async(
         self,
@@ -624,7 +632,7 @@ class AsyncSshTransport(AsyncTransport):
 
         remotesource = str(remotesource)
         remotedestination = str(remotedestination)
-        if self.has_magic(remotedestination):
+        if has_magic(remotedestination):
             raise ValueError('Pathname patterns are not allowed in the destination')
 
         if not remotedestination:
@@ -632,99 +640,13 @@ class AsyncSshTransport(AsyncTransport):
         if not remotesource:
             raise ValueError('remotesource must be a non empty string')
 
-        # SFTP.copy() supports remote copy only in very recent version OpenSSH 9.0 and later.
-        # For the older versions, it downloads the file and uploads it again!
-        # For performance reasons, we should check if the remote copy is supported, if so use
-        # self._sftp.mcopy() & self._sftp.copy() otherwise send a `cp` command to the remote machine.
-        # See here: https://github.com/ronf/asyncssh/issues/724
-        if self._sftp.supports_remote_copy:
-            try:
-                if self.has_magic(remotesource):
-                    await self._sftp.mcopy(
-                        remotesource,
-                        remotedestination,
-                        preserve=preserve,
-                        recurse=recursive,
-                        follow_symlinks=dereference,
-                        remote_only=True,
-                    )
-                else:
-                    if not await self.path_exists_async(remotesource):
-                        raise FileNotFoundError(f'The remote path {remotesource} does not exist')
-
-                    await self._sftp.copy(
-                        remotesource,
-                        remotedestination,
-                        preserve=preserve,
-                        recurse=recursive,
-                        follow_symlinks=dereference,
-                        remote_only=True,
-                    )
-            except asyncssh.sftp.SFTPNoSuchFile as exc:
-                # note: one could just create directories, but aiida engine expects this behavior
-                # see `execmanager.py`::_copy_remote_files for more details
-                raise FileNotFoundError(
-                    f'The remote path {remotedestination} is not reachable,'
-                    f'perhaps the parent folder does not exists: {exc}'
-                )
-            except asyncssh.sftp.SFTPFailure as exc:
-                raise OSError(f'Error while copying {remotesource} to {remotedestination}: {exc}')
-        else:
-            self.logger.warning('The remote copy is not supported, using the `cp` command to copy the file/folder')
-            # I copy pasted the whole logic below from SshTransport class:
-
-            async def _exec_cp(cp_exe: str, cp_flags: str, src: str, dst: str):
-                """Execute the ``cp`` command on the remote machine."""
-                # to simplify writing the above copy function
-                command = f'{cp_exe} {cp_flags} {escape_for_bash(src)} {escape_for_bash(dst)}'
-
-                retval, stdout, stderr = await self.exec_command_wait_async(command)
-
-                if retval == 0:
-                    if stderr.strip():
-                        self.logger.warning(f'There was nonempty stderr in the cp command: {stderr}')
-                else:
-                    self.logger.error(
-                        "Problem executing cp. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
-                            retval, stdout, stderr, command
-                        )
-                    )
-                    if 'No such file or directory' in str(stderr):
-                        raise FileNotFoundError(f'Error while executing cp: {stderr}')
-
-                    raise OSError(
-                        'Error while executing cp. Exit code: {}, '
-                        "stdout: '{}', stderr: '{}', "
-                        "command: '{}'".format(retval, stdout, stderr, command)
-                    )
-
-            cp_exe = 'cp'
-            cp_flags = '-f'
-
-            if recursive:
-                cp_flags += ' -r'
-
-            if preserve:
-                cp_flags += ' -p'
-
-            if dereference:
-                # use -L; --dereference is not supported on mac
-                cp_flags += ' -L'
-
-            if self.has_magic(remotesource):
-                to_copy_list = await self.glob_async(remotesource)
-
-                if len(to_copy_list) > 1:
-                    if not await self.path_exists_async(remotedestination) or await self.isfile_async(
-                        remotedestination
-                    ):
-                        raise OSError("Can't copy more than one file in the same destination file")
-
-                for file in to_copy_list:
-                    await _exec_cp(cp_exe, cp_flags, file, remotedestination)
-
-            else:
-                await _exec_cp(cp_exe, cp_flags, remotesource, remotedestination)
+        await self.async_backend.copy(
+            remotesource=remotesource,
+            remotedestination=remotedestination,
+            dereference=dereference,
+            recursive=recursive,
+            preserve=preserve,
+        )
 
     async def copyfile_async(
         self,
@@ -826,13 +748,8 @@ class AsyncSshTransport(AsyncTransport):
         copy_list = []
 
         for source in remotesources:
-            if self.has_magic(source):
-                try:
-                    copy_list += await self.glob_async(source)
-                except asyncssh.sftp.SFTPNoSuchFile:
-                    raise OSError(
-                        f'Either the remote path {source} does not exist, or a matching file/folder not found.'
-                    )
+            if has_magic(source):
+                copy_list += await self.glob_async(source)
             else:
                 if not await self.path_exists_async(source):
                     raise OSError(f'The remote path {source} does not exist')
@@ -932,13 +849,11 @@ class AsyncSshTransport(AsyncTransport):
             workdir = str(workdir)
             command = f'cd {workdir} && ( {command} )'
 
-        bash_commmand = self._bash_command_str + '-c '
-
-        result = await self._conn.run(
-            bash_commmand + escape_for_bash(command), input=stdin, check=False, timeout=timeout
+        return await self.async_backend.run(
+            command=command,
+            stdin=stdin,
+            timeout=timeout,
         )
-        # Since the command is str, both stdout and stderr are strings
-        return (result.returncode, ''.join(str(result.stdout)), ''.join(str(result.stderr)))
 
     async def get_attribute_async(self, path: TransportPath):
         """Return an object FixedFieldsAttributeDict for file in a given path,
@@ -966,22 +881,21 @@ class AsyncSshTransport(AsyncTransport):
         path = str(path)
         from aiida.transports.util import FileAttribute
 
-        asyncssh_attr = await self._sftp.lstat(path)
+        obj_stat = await self.async_backend.lstat(path)
         aiida_attr = FileAttribute()
-        # map the asyncssh class into the aiida one
         for key in aiida_attr._valid_fields:
             if key == 'st_size':
-                aiida_attr[key] = asyncssh_attr.size
+                aiida_attr[key] = obj_stat.size
             elif key == 'st_uid':
-                aiida_attr[key] = asyncssh_attr.uid
+                aiida_attr[key] = obj_stat.uid
             elif key == 'st_gid':
-                aiida_attr[key] = asyncssh_attr.gid
+                aiida_attr[key] = obj_stat.gid
             elif key == 'st_mode':
-                aiida_attr[key] = asyncssh_attr.permissions
+                aiida_attr[key] = obj_stat.permissions
             elif key == 'st_atime':
-                aiida_attr[key] = asyncssh_attr.atime
+                aiida_attr[key] = obj_stat.atime
             elif key == 'st_mtime':
-                aiida_attr[key] = asyncssh_attr.mtime
+                aiida_attr[key] = obj_stat.mtime
             else:
                 raise NotImplementedError(f'Mapping the {key} attribute is not implemented')
         return aiida_attr
@@ -1002,7 +916,7 @@ class AsyncSshTransport(AsyncTransport):
 
         path = str(path)
 
-        return await self._sftp.isdir(path)
+        return await self.async_backend.isdir(path)
 
     async def isfile_async(self, path: TransportPath):
         """Return True if the given path is a file, False otherwise.
@@ -1020,7 +934,7 @@ class AsyncSshTransport(AsyncTransport):
 
         path = str(path)
 
-        return await self._sftp.isfile(path)
+        return await self.async_backend.isfile(path)
 
     async def listdir_async(self, path: TransportPath, pattern=None):
         """Return a list of the names of the entries in the given path.
@@ -1037,12 +951,12 @@ class AsyncSshTransport(AsyncTransport):
         """
         path = str(path)
         if not pattern:
-            list_ = list(await self._sftp.listdir(path))
+            list_ = await self.async_backend.listdir(path)
         else:
             patterned_path = pattern if pattern.startswith('/') else Path(path).joinpath(pattern)
             # I put the type ignore here because the asyncssh.sftp.glob()
-            # method alwyas returns a sequence of str, if input is str
-            list_ = list(await self._sftp.glob(patterned_path))  # type: ignore[arg-type]
+            # method always returns a sequence of str, if input is str
+            list_ = list(await self.glob_async(patterned_path))
 
         for item in ['..', '.']:
             if item in list_:
@@ -1092,52 +1006,34 @@ class AsyncSshTransport(AsyncTransport):
 
         :param path: absolute path to directory to create
         :param bool ignore_existing: if set to true, it doesn't give any error
-                if the leaf directory does already exist
+                if the directory already exists
 
         :type path:  :class:`Path <pathlib.Path>`, :class:`PurePosixPath <pathlib.PurePosixPath>`, or `str`
 
         :raises: OSError, if directory at path already exists
         """
         path = str(path)
-
         try:
-            await self._sftp.makedirs(path, exist_ok=ignore_existing)
-        except SFTPFileAlreadyExists as exc:
+            await self.async_backend.mkdir(path=path, exist_ok=ignore_existing, parents=True)
+        except FileExistsError as exc:
             raise OSError(f'Error while creating directory {path}: {exc}, directory already exists')
-        except asyncssh.sftp.SFTPFailure as exc:
-            if (self._sftp.version < 6) and not ignore_existing:
-                raise OSError(f'Error while creating directory {path}: {exc}, probably it already exists')
-            else:
-                raise TransportInternalError(f'Error while creating directory {path}: {exc}')
 
     async def mkdir_async(self, path: TransportPath, ignore_existing=False):
         """Create a directory.
 
         :param path: absolute path to directory to create
         :param bool ignore_existing: if set to true, it doesn't give any error
-                if the leaf directory does already exist
+                if the directory already exists
 
         :type path:  :class:`Path <pathlib.Path>`, :class:`PurePosixPath <pathlib.PurePosixPath>`, or `str`
 
         :raises: OSError, if directory at path already exists
         """
         path = str(path)
-
         try:
-            await self._sftp.mkdir(path)
-        except SFTPFileAlreadyExists as exc:
-            # note: mkdir() in asyncssh does not support the exist_ok parameter
-            if ignore_existing:
-                return
+            await self.async_backend.mkdir(path=path, exist_ok=ignore_existing, parents=False)
+        except FileExistsError as exc:
             raise OSError(f'Error while creating directory {path}: {exc}, directory already exists')
-        except asyncssh.sftp.SFTPFailure as exc:
-            if self._sftp.version < 6:
-                if ignore_existing:
-                    return
-                else:
-                    raise OSError(f'Error while creating directory {path}: {exc}, probably it already exists')
-            else:
-                raise TransportInternalError(f'Error while creating directory {path}: {exc}')
 
     async def normalize_async(self, path: TransportPath):
         raise NotImplementedError('Not implemented, waiting for a use case.')
@@ -1153,13 +1049,7 @@ class AsyncSshTransport(AsyncTransport):
         :raise OSError: if the path is a directory
         """
         path = str(path)
-        # TODO: check if asyncssh does return SFTPFileIsADirectory in this case
-        # if that's the case, we can get rid of the isfile check
-        # https://github.com/aiidateam/aiida-core/issues/6719
-        if await self.isdir_async(path):
-            raise OSError(f'The path {path} is a directory')
-        else:
-            await self._sftp.remove(path)
+        await self.async_backend.remove(path)
 
     async def rename_async(self, oldpath: TransportPath, newpath: TransportPath):
         """
@@ -1179,10 +1069,10 @@ class AsyncSshTransport(AsyncTransport):
         if not oldpath or not newpath:
             raise ValueError('oldpath and newpath must be non-empty strings')
 
-        if await self._sftp.exists(newpath):
+        if await self.path_exists_async(newpath):
             raise OSError(f'Cannot rename {oldpath} to {newpath}: destination exists')
 
-        await self._sftp.rename(oldpath, newpath)
+        await self.async_backend.rename(oldpath, newpath)
 
     async def rmdir_async(self, path: TransportPath):
         """Remove the folder named path.
@@ -1193,10 +1083,7 @@ class AsyncSshTransport(AsyncTransport):
         :type path:  :class:`Path <pathlib.Path>`, :class:`PurePosixPath <pathlib.PurePosixPath>`, or `str`
         """
         path = str(path)
-        try:
-            await self._sftp.rmdir(path)
-        except asyncssh.sftp.SFTPFailure:
-            raise OSError(f'Error while removing directory {path}: probably directory is not empty')
+        await self.async_backend.rmdir(path)
 
     async def rmtree_async(self, path: TransportPath):
         """Remove the folder named path, and all its contents.
@@ -1208,10 +1095,7 @@ class AsyncSshTransport(AsyncTransport):
         :raises OSError: if the operation fails
         """
         path = str(path)
-        try:
-            await self._sftp.rmtree(path, ignore_errors=False)
-        except asyncssh.Error as exc:
-            raise OSError(f'Error while removing directory tree {path}: {exc}')
+        await self.async_backend.rmtree(path)
 
     async def path_exists_async(self, path: TransportPath):
         """Returns True if path exists, False otherwise.
@@ -1221,7 +1105,7 @@ class AsyncSshTransport(AsyncTransport):
         :type path:  :class:`Path <pathlib.Path>`, :class:`PurePosixPath <pathlib.PurePosixPath>`, or `str`
         """
         path = str(path)
-        return await self._sftp.exists(path)
+        return await self.async_backend.path_exists(path)
 
     async def whoami_async(self):
         """Get the remote username
@@ -1257,19 +1141,19 @@ class AsyncSshTransport(AsyncTransport):
         remotesource = str(remotesource)
         remotedestination = str(remotedestination)
 
-        if self.has_magic(remotesource):
-            if self.has_magic(remotedestination):
+        if has_magic(remotesource):
+            if has_magic(remotedestination):
                 raise ValueError('`remotedestination` cannot have patterns')
 
             # find all files matching pattern
-            for this_source in await self._sftp.glob(remotesource):
+            for this_source in await self.glob_async(remotesource):
                 # create the name of the link: take the last part of the path
-                this_dest = os.path.join(remotedestination, os.path.split(this_source)[-1])  # type: ignore [arg-type]
+                this_dest = os.path.join(remotedestination, os.path.split(this_source)[-1])
                 # in the line above I am sure that this_source is a string,
                 # since asyncssh.sftp.glob() returns only str if argument remotesource is a str
-                await self._sftp.symlink(this_source, this_dest)
+                await self.async_backend.symlink(this_source, this_dest)
         else:
-            await self._sftp.symlink(remotesource, remotedestination)
+            await self.async_backend.symlink(remotesource, remotedestination)
 
     async def glob_async(self, pathname: TransportPath):
         """Return a list of paths matching a pathname pattern.
@@ -1284,7 +1168,7 @@ class AsyncSshTransport(AsyncTransport):
         :return: a list of paths matching the pattern.
         """
         pathname = str(pathname)
-        return await self._sftp.glob(pathname)
+        return await self.async_backend.glob(pathname)
 
     async def chmod_async(self, path: TransportPath, mode: int, follow_symlinks: bool = True):
         """Change the permissions of a file.
@@ -1302,10 +1186,10 @@ class AsyncSshTransport(AsyncTransport):
         path = str(path)
         if not path:
             raise OSError('Input path is an empty argument.')
-        try:
-            await self._sftp.chmod(path, mode, follow_symlinks=follow_symlinks)
-        except asyncssh.sftp.SFTPNoSuchFile as exc:
-            raise OSError(f'Error {exc}, directory does not exists')
+        if await self.path_exists_async(path):
+            await self.async_backend.chmod(path, mode, follow_symlinks=follow_symlinks)
+        else:
+            raise OSError(f'Error, path {path} does not exist')
 
     async def chown_async(self, path: TransportPath, uid: int, gid: int):
         """Change the owner and group id of a file.
@@ -1323,10 +1207,11 @@ class AsyncSshTransport(AsyncTransport):
         path = str(path)
         if not path:
             raise OSError('Input path is an empty argument.')
-        try:
-            await self._sftp.chown(path, uid, gid, follow_symlinks=True)
-        except asyncssh.sftp.SFTPNoSuchFile as exc:
-            raise OSError(f'Error {exc}, directory does not exists')
+
+        if await self.path_exists_async(path):
+            await self.async_backend.chown(path, uid, gid)
+        else:
+            raise OSError(f'Error, path {path} does not exist')
 
     async def copy_from_remote_to_remote_async(
         self,

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import psutil
 import pytest
 
-from aiida.plugins import SchedulerFactory, TransportFactory, entry_point
+from aiida.plugins import SchedulerFactory, TransportFactory
 from aiida.transports import Transport
 
 # TODO : test for copy with pattern
@@ -55,17 +55,23 @@ def tmp_path_local(tmp_path_factory):
 # Skip for any transport plugins that are locally installed but are not part of `aiida-core`
 @pytest.fixture(
     scope='function',
-    params=[name for name in entry_point.get_entry_point_names('aiida.transports') if name.startswith('core.')],
+    params=[
+        ('core.local', None),
+        ('core.ssh', None),
+        ('core.ssh_async', 'asyncssh'),
+        ('core.ssh_async', 'openssh'),
+    ],
 )
 def custom_transport(request, tmp_path_factory, monkeypatch) -> Transport:
     """Fixture that parametrizes over all the registered implementations of the ``CommonRelaxWorkChain``."""
-    plugin = TransportFactory(request.param)
+    plugin = TransportFactory(request.param[0])
 
-    if request.param == 'core.ssh':
+    if request.param[0] == 'core.ssh':
         kwargs = {'machine': 'localhost', 'timeout': 30, 'load_system_host_keys': True, 'key_policy': 'AutoAddPolicy'}
-    elif request.param == 'core.ssh_async':
+    elif request.param[0] == 'core.ssh_async':
         kwargs = {
             'machine': 'localhost',
+            'backend': request.param[1],
         }
     else:
         kwargs = {}
@@ -144,6 +150,7 @@ def test_listdir(custom_transport, tmp_path_remote):
     """Create directories, verify listdir, delete a folder with subfolders"""
     with custom_transport as transport:
         list_of_dir = ['1', '-f a&', 'as', 'a2', 'a4f']
+        list_of_dir = ['1', '-f', 'as', 'a2', 'a4f']
         list_of_files = ['a', 'b']
         for this_dir in list_of_dir:
             transport.mkdir(tmp_path_remote / this_dir)
@@ -176,6 +183,7 @@ def test_listdir_withattributes(custom_transport, tmp_path_remote):
 
     with custom_transport as transport:
         list_of_dir = ['1', '-f a&', 'as', 'a2', 'a4f']
+        list_of_dir = ['1', '-f', 'as', 'a2', 'a4f']
         list_of_files = ['a', 'b']
         for this_dir in list_of_dir:
             transport.mkdir(tmp_path_remote / this_dir)
@@ -231,7 +239,6 @@ def test_dir_permissions_creation_modification(custom_transport, tmp_path_remote
         directory = tmp_path_remote / 'test'
 
         transport.makedirs(directory)
-
         # change permissions
         transport.chmod(directory, 0o777)
 
@@ -1276,7 +1283,7 @@ def test_compress_error_handling(custom_transport: Transport, tmp_path_remote: P
         with pytest.raises(OSError, match=f"{tmp_path_remote / 'non_existing'} does not exist"):
             transport.compress('tar', tmp_path_remote / 'non_existing', tmp_path_remote / 'archive.tar', '/')
 
-        # if a matching pattern if remote source is not found
+        # if a matching pattern of the remote source is not found
         with pytest.raises(OSError, match='does not exist, or a matching file/folder not found'):
             transport.compress('tar', tmp_path_remote / 'non_existing*', tmp_path_remote / 'archive.tar', '/')
 


### PR DESCRIPTION
This PR, does two things:

1) adds an extra plugin to support OpenSSH
2) proposes change in the backend of `AsyncSshTransport`

The idea is to have `OpenSSH` plugin as part of `AsyncSshTransport` giving advantage to a user can easily re-configuring a computer, by switching between `OpenSSH` and `asyncssh` backends.