### PR TITLE
Usage of groups in WorkChain

### DIFF
--- a/groupexample/runner.py
+++ b/groupexample/runner.py
@@ -1,0 +1,14 @@
+
+
+from aiida import load_profile, engine, orm
+from someworkchain import SomeWorkchain
+load_profile()
+
+x = orm.QueryBuilder().append(orm.Group, filters={'label': {'==': 'some'}}).first(flat=True)
+
+if x is None:
+    x = orm.Group(label="some").store()
+
+node = engine.run(SomeWorkchain, x=x)
+l = node['result']
+print([node for node in l.nodes])

--- a/groupexample/someworkchain.py
+++ b/groupexample/someworkchain.py
@@ -1,0 +1,28 @@
+"""Implementation of the MultiplyAddWorkChain for testing and demonstration purposes."""
+
+from aiida.engine import WorkChain, calcfunction
+from aiida import orm
+
+
+
+@calcfunction
+def add_structure(x: orm.Group):
+    x.add_nodes([orm.StructureData(next(x.nodes).cell).store()])
+    return x
+
+
+class SomeWorkchain(WorkChain):
+    """WorkChain to multiply two numbers and add a third, for testing and demonstration purposes."""
+
+    @classmethod
+    def define(cls, spec):
+        """Specify inputs and outputs."""
+        super().define(spec)
+        spec.input('x', valid_type=orm.Group)
+        spec.outline(
+            cls.add_structure,
+        )
+        spec.output('result', valid_type=orm.Group)
+
+    def add_structure(self):
+        self.out('result', add_structure(self.inputs.x))

--- a/src/aiida/engine/processes/functions.py
+++ b/src/aiida/engine/processes/functions.py
@@ -604,8 +604,9 @@ class FunctionProcess(Process):
 
         if result is None or isinstance(result, ExitCode):  # type: ignore[redundant-expr]
             return result  # type: ignore[unreachable]
-
-        if isinstance(result, Data):  # type: ignore[unreachable]
+        
+        from aiida.orm import Group
+        if isinstance(result, Group) or isinstance(result, Data):  # type: ignore[unreachable]
             self.out(self.SINGLE_OUTPUT_LINKNAME, result)  # type: ignore[unreachable]
         elif isinstance(result, collections.abc.Mapping):
             for name, value in result.items():

--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -672,10 +672,10 @@ class Process(PlumpyProcess):
             if link_label not in outputs_new:
                 continue
 
-            if isinstance(self.node, orm.CalculationNode):
-                output.base.links.add_incoming(self.node, LinkType.CREATE, link_label)
-            elif isinstance(self.node, orm.WorkflowNode):
-                output.base.links.add_incoming(self.node, LinkType.RETURN, link_label)
+            #if isinstance(self.node, orm.CalculationNode):
+            #    output.base.links.add_incoming(self.node, LinkType.CREATE, link_label)
+            #elif isinstance(self.node, orm.WorkflowNode):
+            #    output.base.links.add_incoming(self.node, LinkType.RETURN, link_label)
 
             output.store()
 

--- a/src/aiida/orm/groups.py
+++ b/src/aiida/orm/groups.py
@@ -411,3 +411,13 @@ class ImportGroup(Group):
 
 class UpfFamily(Group):
     """Group that represents a pseudo potential family containing `UpfData` nodes."""
+
+#from aiida.orm.nodes.data import Data
+
+#class DataGroup(Group, Data):
+#    """Group that represents a pseudo potential family containing `UpfData` nodes."""
+
+from aiida.orm.nodes.data.base import to_aiida_type
+@to_aiida_type.register(Group)
+def _(value):
+    return value

--- a/src/aiida/orm/implementation/utils.py
+++ b/src/aiida/orm/implementation/utils.py
@@ -92,7 +92,8 @@ def clean_value(value):
             return new_val
 
         # Anything else we do not understand and we refuse
-        raise exceptions.ValidationError(f'type `{type(val)}` is not supported as it is not json-serializable')
+        return val
+        #raise exceptions.ValidationError(f'type `{type(val)}` is not supported as it is not json-serializable')
 
     if isinstance(value, BaseType):
         return clean_builtin(value.value)

--- a/src/aiida/orm/nodes/data/list.py
+++ b/src/aiida/orm/nodes/data/list.py
@@ -16,7 +16,6 @@ from .data import Data
 
 __all__ = ('List',)
 
-
 class List(Data, MutableSequence):
     """`Data` sub class to represent a list."""
 

--- a/src/aiida/orm/nodes/links.py
+++ b/src/aiida/orm/nodes/links.py
@@ -55,7 +55,7 @@ class NodeLinks:
         :raise ValueError: if the proposed link is invalid
         """
         self.validate_incoming(source, link_type, link_label)
-        source.base.links.validate_outgoing(self._node, link_type, link_label)
+        #source.base.links.validate_outgoing(self._node, link_type, link_label)
 
         if self._node.is_stored and source.is_stored:
             self._node.backend_entity.add_incoming(source.backend_entity, link_type, link_label)

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -501,8 +501,8 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
             raise exceptions.ModificationNotAllowed(f'Node<{self.pk}> is already stored')
 
         # For each node of a cached incoming link, check that all its incoming links are stored
-        for link_triple in self.base.links.incoming_cache:
-            link_triple.node._verify_are_parents_stored()
+        #for link_triple in self.base.links.incoming_cache:
+        #    link_triple.node._verify_are_parents_stored()
 
         for link_triple in self.base.links.incoming_cache:
             if not link_triple.node.is_stored:

--- a/src/aiida/orm/utils/links.py
+++ b/src/aiida/orm/utils/links.py
@@ -141,8 +141,8 @@ def validate_link(
     from aiida.orm import CalculationNode, Data, Node, WorkflowNode
 
     type_check(link_type, LinkType, f'link_type should be a LinkType enum but got: {type(link_type)}')
-    type_check(source, Node, f'source should be a `Node` but got: {type(source)}')
-    type_check(target, Node, f'target should be a `Node` but got: {type(target)}')
+    #type_check(source, Node, f'source should be a `Node` but got: {type(source)}')
+    #type_check(target, Node, f'target should be a `Node` but got: {type(target)}')
 
     if source.backend != target.backend:
         raise ValueError(
@@ -177,6 +177,7 @@ def validate_link(
     type_source, type_target, outdegree, indegree = link_mapping[link_type]
 
     if not isinstance(source, type_source) or not isinstance(target, type_target):
+        return
         raise ValueError(f'cannot add a {link_type} link from {type(source)} to {type(target)}')
 
     if outdegree == 'unique_triple' or indegree == 'unique_triple':


### PR DESCRIPTION
This is just a hack to test the technical feasibility to reuse the orm.Groups in WorkChain. In the end we want to design a custom data type for it that is separate from this Group but it seems we can reuse a lot of code from orm.Group since it works.

So this PR works one also has to comment out the port validation in plumpy
https://github.com/aiidateam/plumpy/blob/3c8d17a273b38c79248b75a0814b472915ec2465/src/plumpy/processes.py#L789-L792
https://github.com/aiidateam/plumpy/blob/3c8d17a273b38c79248b75a0814b472915ec2465/src/plumpy/processes.py#L1404-L1406