### PR TITLE
Add back pre-commit job for mypy type-checking

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,32 @@
+name: pre-commit
+# NOTE: This job is not duplicating pre-commit.ci job,
+# since that once skips running mypy type-checking\
+# due to technical limitations of pre-commit.ci runners.
+
+on:
+  push:
+    branches-ignore: [gh-pages]
+  pull_request:
+    branches-ignore: [gh-pages]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+
+  pre-commit:
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install python dependencies
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.11'
+        from-lock: 'true'
+
+    - name: Run pre-commit
+      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: '3.9' # lowest possible support
+        python-version: '3.13'
         from-lock: 'true'
 
     - name: Run pre-commit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: '3.13'
+        python-version: '3.11'
         from-lock: 'true'
 
     - name: Run pre-commit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: '3.11'
+        python-version: '3.9' # lowest possible support
         from-lock: 'true'
 
     - name: Run pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: false
+  autofix_prs: true
   autoupdate_commit_msg: 'Devops: Update pre-commit dependencies'
   autoupdate_schedule: quarterly
   skip: [mypy, generate-conda-environment, validate-conda-environment, verdi-autodocs]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -201,7 +201,8 @@ repos:
     files: >-
       (?x)^(
         pyproject.toml|
-        utils/dependency_management.py
+        utils/dependency_management.py|
+        environment.yml|
       )$
 
   - id: validate-conda-environment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: true
+  autofix_prs: false
   autoupdate_commit_msg: 'Devops: Update pre-commit dependencies'
   autoupdate_schedule: quarterly
   skip: [mypy, generate-conda-environment, validate-conda-environment, verdi-autodocs]

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -451,7 +451,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.
+                                      leading forward slash.  [default: ""]
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.

--- a/environment.yml
+++ b/environment.yml
@@ -37,4 +37,4 @@ dependencies:
 - typing-extensions~=4.0
 - upf_to_json~=0.9.2
 - wrapt~=1.11
-- chardet~=5.2.0 # [win]
+- chardet~=5.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,6 @@ exclude = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
 disallow_any_generics = false
 disallow_incomplete_defs = false
 disallow_subclassing_any = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,7 @@ exclude = [
 ]
 
 [tool.mypy]
+python_version = "3.9"
 disallow_any_generics = false
 disallow_incomplete_defs = false
 disallow_subclassing_any = false

--- a/src/aiida/orm/nodes/data/code/portable.py
+++ b/src/aiida/orm/nodes/data/code/portable.py
@@ -63,7 +63,7 @@ class PortableCode(Code):
             description='Relative filepath of executable with directory of code files.',
             short_name='-X',
             priority=1,
-            orm_to_model=lambda node, _: str(node.filepath_executable),
+            orm_to_model=lambda node, _: str(node.filepath_executable),  # type: ignore[attr-defined]
         )
         filepath_files: str = MetadataField(
             ...,
@@ -72,7 +72,7 @@ class PortableCode(Code):
             short_name='-F',
             is_attribute=False,
             priority=2,
-            orm_to_model=_export_filpath_files_from_repo,
+            orm_to_model=_export_filpath_files_from_repo,  # type: ignore[arg-type]
         )
 
     def __init__(
@@ -104,7 +104,7 @@ class PortableCode(Code):
         if not filepath_files_path.is_dir():
             raise ValueError(f'The filepath `{filepath_files}` is not a directory.')
 
-        self.filepath_executable = filepath_executable
+        self.filepath_executable = filepath_executable  # type: ignore[assignment] # should be fixed in mypy 1.15 see mypy/commit/1eb9d4c
         self.base.repository.put_object_from_tree(str(filepath_files))
 
     def _validate(self):

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -13,13 +13,13 @@ from __future__ import annotations
 import base64
 import datetime
 from functools import cached_property
-from logging import Logger
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 from uuid import UUID
 
 from aiida.common import exceptions
 from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
+from aiida.common.log import AIIDA_LOGGER
 from aiida.common.pydantic import MetadataField
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
@@ -42,6 +42,8 @@ from .links import NodeLinks
 
 if TYPE_CHECKING:
     from importlib_metadata import EntryPoint
+
+    from aiida.common.log import AiidaLoggerType
 
     from ..implementation import StorageBackend
     from ..implementation.nodes import BackendNode  # noqa: F401
@@ -174,8 +176,8 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
             cls.__query_type_string = get_query_type_from_type_string(cls._plugin_type_string)  # type: ignore[misc]
         return cls.__query_type_string
 
-    # This will be set by the metaclass call
-    _logger: Optional[Logger] = None
+    # This will be set by the metaclass call but we set default
+    _logger: AiidaLoggerType = AIIDA_LOGGER
 
     # A tuple of attribute names that can be updated even after node is stored
     # Requires Sealable mixin, but needs empty tuple for base class
@@ -407,7 +409,7 @@ class Node(Entity['BackendNode', NodeCollection], metaclass=AbstractNodeMeta):
         return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
 
     @property
-    def logger(self) -> Optional[Logger]:
+    def logger(self) -> Optional[AiidaLoggerType]:
         """Return the logger configured for this Node.
 
         :return: Logger object

--- a/src/aiida/storage/sqlite_zip/utils.py
+++ b/src/aiida/storage/sqlite_zip/utils.py
@@ -72,7 +72,7 @@ def _json_contains(lhs: Union[str, bytes, bytearray, dict, list], rhs: Union[str
             rhs = json.loads(rhs)
     except json.JSONDecodeError:
         return 0
-    return int(_contains(lhs, rhs))
+    return int(_contains(lhs, rhs))  # type: ignore[arg-type]
 
 
 def register_json_contains(dbapi_connection, _):


### PR DESCRIPTION
Add back pre-commit CI job that runs all pre-commit hooks, including mypy, see #6831 for details.

Here are mypy failures that are currently present on main:

```
src/aiida/storage/sqlite_zip/utils.py:75: error: Argument 1 to "_contains" has incompatible type "str | bytes | bytearray | dict[Any, Any] | list[Any]"; expected "dict[Any, Any] | list[Any]"  [arg-type]
src/aiida/storage/sqlite_zip/utils.py:75: error: Argument 2 to "_contains" has incompatible type "str | bytes | bytearray | dict[Any, Any] | list[Any]"; expected "dict[Any, Any] | list[Any]"  [arg-type]
Found 2 errors in 1 file (checked 457 source files)
```

I wasn't sure how to fix them, as they seem to be false-positives so I just added type-ignores for now.

Closes #6831