### PR TITLE
fix(Group Node): rename `time` field to `ctime` for consistency with other node types

### DIFF
--- a/src/aiida/orm/groups.py
+++ b/src/aiida/orm/groups.py
@@ -134,7 +134,7 @@ class Group(entities.Entity['BackendGroup', GroupCollection]):
             doc='The group description',
         ),
         add_field(
-            'time',
+            'ctime',
             dtype=str,
             is_attribute=False,
             doc='The time of the group creation',


### PR DESCRIPTION
I tried to query some group with a `ctime` filter, but got this error:

```
ValueError: ctime is not a column of aliased(DbGroup)
Valid columns are:
id
uuid
label
type_string
time
description
extras
user_id
```
the `time` should be `ctime.