### PR TITLE
Docker: fix relative paths, required after upgrade to `bake-action@v6`

### DIFF
--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -36,9 +36,9 @@ group "default" {
 
 target "aiida-core-base" {
   tags = tags("aiida-core-base")
-  context = "aiida-core-base"
+  context = ".docker/aiida-core-base"
   contexts = {
-    src = ".."
+    src = "."
   }
   platforms = "${PLATFORMS}"
   args = {
@@ -47,7 +47,7 @@ target "aiida-core-base" {
 }
 target "aiida-core-with-services" {
   tags = tags("aiida-core-with-services")
-  context = "aiida-core-with-services"
+  context = ".docker/aiida-core-with-services"
   contexts = {
     aiida-core-base = "target:aiida-core-base"
   }
@@ -59,9 +59,9 @@ target "aiida-core-with-services" {
 }
 target "aiida-core-dev" {
   tags = tags("aiida-core-dev")
-  context = "aiida-core-dev"
+  context = ".docker/aiida-core-dev"
   contexts = {
-    src = ".."
+    src = "."
     aiida-core-with-services = "target:aiida-core-with-services"
   }
   platforms = "${PLATFORMS}"

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -45,14 +45,14 @@ jobs:
       with:
         # Load to Docker engine for testing
         load: true
-        workdir: .docker/
+        source: .
         set: |
           *.platform=amd64
           *.cache-to=type=gha,scope=${{ github.workflow }},mode=min
           *.cache-from=type=gha,scope=${{ github.workflow }}
         files: |
-          docker-bake.hcl
-          build.json
+          .docker/docker-bake.hcl
+          .docker/build.json
 
     - name: Set Up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Solving stupid backward non-compatible errors of docker after upgrade.