### PR TITLE
Allow CalcJob as an input node

### DIFF
--- a/src/aiida/calculations/arithmetic/add.py
+++ b/src/aiida/calculations/arithmetic/add.py
@@ -24,6 +24,7 @@ class ArithmeticAddCalculation(CalcJob):
         :param spec: the calculation job process spec to define.
         """
         super().define(spec)
+        spec.input('calcj', valid_type=orm.CalcJobNode, required=False, help='The left operand.')
         spec.input('x', valid_type=(orm.Int, orm.Float), help='The left operand.')
         spec.input('y', valid_type=(orm.Int, orm.Float), help='The right operand.')
         spec.output('sum', valid_type=(orm.Int, orm.Float), help='The sum of the left and right operand.')

--- a/src/aiida/calculations/arithmetic/add.py
+++ b/src/aiida/calculations/arithmetic/add.py
@@ -24,7 +24,6 @@ class ArithmeticAddCalculation(CalcJob):
         :param spec: the calculation job process spec to define.
         """
         super().define(spec)
-        spec.input('calcj', valid_type=orm.CalcJobNode, required=False, help='The left operand.')
         spec.input('x', valid_type=(orm.Int, orm.Float), help='The left operand.')
         spec.input('y', valid_type=(orm.Int, orm.Float), help='The right operand.')
         spec.output('sum', valid_type=(orm.Int, orm.Float), help='The sum of the left and right operand.')

--- a/src/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/src/aiida/orm/nodes/process/calculation/calcjob.py
@@ -15,6 +15,7 @@ from aiida.common import exceptions
 from aiida.common.datastructures import CalcJobState
 from aiida.common.lang import classproperty
 from aiida.orm.fields import add_field
+from aiida.orm.nodes.data.base import to_aiida_type
 
 from ..process import ProcessNodeCaching
 from .calculation import CalculationNode
@@ -550,3 +551,8 @@ class CalcJobNode(CalculationNode):
         if not state:
             return ''
         return state.value
+
+
+@to_aiida_type.register(CalcJobNode)
+def _(value):
+    return value

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -126,12 +126,29 @@ class ProcessNodeLinks(NodeLinks):
         """Validate adding a link of the given type from ourself to a given node.
 
         Adding an outgoing link from a sealed node is forbidden.
+        We make an exception for the ``INPUT_CALC`` link type.
+        This will not break the DAG because the source ``CalculationNode`` will be already stored and sealed.
+        Therefore a loop scenario like this is not going to be possible:
+
+        .. code-block:: text
+
+            +-------------------+
+            | CalculationNode A |  <-----NOT POSSIBLE----
+            +-------------------+                       |
+                |                                       |
+                |                                       |
+                v                                       |
+            +-------------------+                    +------------------+
+            | CalculationNode B |  ----------->      |    DataNode B    |
+            +-------------------+                    +------------------+
 
         :param target: the node to which the link is going
         :param link_type: the link type
         :param link_label: the link label
         :raise aiida.common.ModificationNotAllowed: if the source node (self) is sealed
+            and the link type is not ``INPUT_CALC``.
         """
+
         if self._node.is_sealed and link_type is not LinkType.INPUT_CALC:
             raise exceptions.ModificationNotAllowed('Cannot add a link from a sealed node')
 

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -132,7 +132,7 @@ class ProcessNodeLinks(NodeLinks):
         :param link_label: the link label
         :raise aiida.common.ModificationNotAllowed: if the source node (self) is sealed
         """
-        if self._node.is_sealed:
+        if self._node.is_sealed and link_type is not LinkType.INPUT_CALC:
             raise exceptions.ModificationNotAllowed('Cannot add a link from a sealed node')
 
         super().validate_outgoing(target, link_type=link_type, link_label=link_label)

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -108,17 +108,25 @@ class ProcessNodeLinks(NodeLinks):
         by the engine in one go. If a link is being added after the node is stored, it is most likely not by the engine
         and it should not be allowed.
 
+        Adding an input link from a unsealed `CalculationNode` is forbidden, because it would break the DAG.
+
         :param source: the node from which the link is coming
         :param link_type: the link type
         :param link_label: the link label
         :raise TypeError: if `source` is not a Node instance or `link_type` is not a `LinkType` enum
         :raise ValueError: if the proposed link is invalid
+        :raise aiida.common.ModificationNotAllowed: if the source node is not sealed
+            and the link type is not ``INPUT_CALC``.
         """
+
         if self._node.is_sealed:
             raise exceptions.ModificationNotAllowed('Cannot add a link to a sealed node')
 
         if self._node.is_stored:
             raise ValueError('attempted to add an input link after the process node was already stored.')
+
+        if link_type is LinkType.INPUT_CALC and not source.is_sealed:
+            raise exceptions.ModificationNotAllowed('Cannot add a link from a `CalculationNode`, if not sealed.')
 
         super().validate_incoming(source, link_type, link_label)
 

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -118,6 +118,7 @@ class ProcessNodeLinks(NodeLinks):
         :raise aiida.common.ModificationNotAllowed: if the source node is not sealed
             and the link type is not ``INPUT_CALC``.
         """
+        from aiida.orm.nodes.process.calculation.calcjob import CalcJobNode
 
         if self._node.is_sealed:
             raise exceptions.ModificationNotAllowed('Cannot add a link to a sealed node')
@@ -125,7 +126,7 @@ class ProcessNodeLinks(NodeLinks):
         if self._node.is_stored:
             raise ValueError('attempted to add an input link after the process node was already stored.')
 
-        if link_type is LinkType.INPUT_CALC and not source.is_sealed:
+        if isinstance(source, CalcJobNode) and link_type is LinkType.INPUT_CALC and not source.is_sealed:
             raise exceptions.ModificationNotAllowed('Cannot add a link from a `CalculationNode`, if not sealed.')
 
         super().validate_incoming(source, link_type, link_label)

--- a/src/aiida/orm/utils/links.py
+++ b/src/aiida/orm/utils/links.py
@@ -166,17 +166,19 @@ def validate_link(
     # type can be defined, as long as the link label is unique for the sub set of links of that type. Finally, for
     # `unique_triple` the triple of node, link type and link label has to be unique.
     link_mapping = {
-        LinkType.CALL_CALC: (WorkflowNode, CalculationNode, 'unique_triple', 'unique'),
-        LinkType.CALL_WORK: (WorkflowNode, WorkflowNode, 'unique_triple', 'unique'),
-        LinkType.CREATE: (CalculationNode, Data, 'unique_pair', 'unique'),
-        LinkType.INPUT_CALC: (Data, CalculationNode, 'unique_triple', 'unique_pair'),
-        LinkType.INPUT_WORK: (Data, WorkflowNode, 'unique_triple', 'unique_pair'),
-        LinkType.RETURN: (WorkflowNode, Data, 'unique_pair', 'unique_triple'),
+        LinkType.CALL_CALC: ({WorkflowNode}, CalculationNode, 'unique_triple', 'unique'),
+        LinkType.CALL_WORK: ({WorkflowNode}, WorkflowNode, 'unique_triple', 'unique'),
+        LinkType.CREATE: ({CalculationNode}, Data, 'unique_pair', 'unique'),
+        LinkType.INPUT_CALC: ({Data, CalculationNode}, CalculationNode, 'unique_triple', 'unique_pair'),
+        LinkType.INPUT_WORK: ({Data}, WorkflowNode, 'unique_triple', 'unique_pair'),
+        LinkType.RETURN: ({WorkflowNode}, Data, 'unique_pair', 'unique_triple'),
     }
 
-    type_source, type_target, outdegree, indegree = link_mapping[link_type]
+    type_sources, type_target, outdegree, indegree = link_mapping[link_type]
 
-    if not isinstance(source, type_source) or not isinstance(target, type_target):
+    if all([not isinstance(source, type_source) for type_source in type_sources]) or not isinstance(
+        target, type_target
+    ):
         raise ValueError(f'cannot add a {link_type} link from {type(source)} to {type(target)}')
 
     if outdegree == 'unique_triple' or indegree == 'unique_triple':

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -127,3 +127,22 @@ class TestCalcJobNode:
         else:
             node.set_retrieve_list(retrieve_list)
             assert node.get_retrieve_list() == retrieve_list
+
+    def test_link_validation(self):
+        """Test that the link validation works as expected.
+        Especially, that a `CalcJobNode` can be input to another `CalcJobNode`,
+        as long as the source is sealed, but not the target.
+        """
+
+        node = CalcJobNode(
+            computer=self.computer,
+        )
+        node.store()
+        node.seal()
+
+        node2 = CalcJobNode(
+            computer=self.computer,
+        )
+        node2.base.links.add_incoming(node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
+        node2.store()
+        node2.seal()

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -129,20 +129,17 @@ class TestCalcJobNode:
             assert node.get_retrieve_list() == retrieve_list
 
     def test_link_validation(self):
-        """Test that the link validation works as expected.
-        Especially, that a `CalcJobNode` can be input to another `CalcJobNode`,
-        as long as the source is sealed, but not the target.
-        """
+        """Test that a `CalcJobNode` can be input to another `CalcJobNode` if the source is sealed and the target is not."""
+
+        incoming_node = CalcJobNode(
+            computer=self.computer,
+        )
+        incoming_node.store()
+        incoming_node.seal()
 
         node = CalcJobNode(
             computer=self.computer,
         )
+        node.base.links.add_incoming(incoming_node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
         node.store()
-        node.seal()
-
-        node2 = CalcJobNode(
-            computer=self.computer,
-        )
-        node2.base.links.add_incoming(node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
-        node2.store()
         node2.seal()

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -129,7 +129,8 @@ class TestCalcJobNode:
             assert node.get_retrieve_list() == retrieve_list
 
     def test_link_validation(self):
-        """Test that a `CalcJobNode` can be input to another `CalcJobNode` if the source is sealed and the target is not."""
+        """Test that a `CalcJobNode` can be input to another `CalcJobNode` if the source is sealed and
+        the target is not."""
 
         incoming_node = CalcJobNode(
             computer=self.computer,

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -142,4 +142,4 @@ class TestCalcJobNode:
         )
         node.base.links.add_incoming(incoming_node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
         node.store()
-        node2.seal()
+        node.seal()

--- a/tests/orm/nodes/test_calcjob.py
+++ b/tests/orm/nodes/test_calcjob.py
@@ -132,15 +132,22 @@ class TestCalcJobNode:
         """Test that a `CalcJobNode` can be input to another `CalcJobNode` if the source is sealed and
         the target is not."""
 
-        incoming_node = CalcJobNode(
+        from aiida.common.exceptions import ModificationNotAllowed
+
+        input_node = CalcJobNode(
             computer=self.computer,
         )
-        incoming_node.store()
-        incoming_node.seal()
 
         node = CalcJobNode(
             computer=self.computer,
         )
-        node.base.links.add_incoming(incoming_node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
+
+        with pytest.raises(ModificationNotAllowed, match='Cannot add a link from a `CalculationNode`, if not sealed.'):
+            node.base.links.add_incoming(input_node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
+
+        input_node.store()
+        input_node.seal()
+
+        node.base.links.add_incoming(input_node, link_type=LinkType.INPUT_CALC, link_label='input_calculation')
         node.store()
         node.seal()


### PR DESCRIPTION
Hello, I am not sure if this clashes with some aiida core principle but the tests pass and when trying it out I get the right result. See for this workflow
```python
from aiida import load_profile
load_profile()
from aiida import orm, plugins
from aiida.engine import run

ArithmeticAddCalculation = plugins.CalculationFactory('core.arithmetic.add')
node = run(ArithmeticAddCalculation, code=orm.load_code("bash@localhost"), x=orm.Int(1), y=orm.Int(2))
node = run(ArithmeticAddCalculation, calcj=node, code=orm.load_code("bash@localhost"), x=orm.Int(1), y=orm.Int(2))
```
Output provenance
![image (1)](https://github.com/user-attachments/assets/8580dd9a-14d1-4a4e-a882-c796feb9c6f1)