### PR TITLE
Use TextIOWrapper for opening file from repository in text mode

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - circus~=0.19.0
 - click-spinner~=0.1.8
 - click<8.3,>=8.1.0
-- disk-objectstore~=1.3.0
+- disk-objectstore~=1.4.0
 - docstring_parser
 - get-annotations~=0.1
 - python-graphviz~=0.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   'circus~=0.19.0',
   'click-spinner~=0.1.8',
   'click>=8.1.0,<8.3',
-  'disk-objectstore~=1.3.0',
+  'disk-objectstore~=1.4.0',
   'docstring-parser',
   'get-annotations~=0.1;python_version<"3.10"',
   'graphviz~=0.19',

--- a/src/aiida/orm/nodes/repository.py
+++ b/src/aiida/orm/nodes/repository.py
@@ -199,7 +199,8 @@ class NodeRepository:
             ``put_object_from_filelike`` instead.
 
         :param path: the relative path of the object within the repository.
-        :return: yield a byte stream object.
+        :param mode: (str) the type of stream object to be returned, 'r' for text handler, 'rb' for byte handler.
+        :return: yield a stream object, (byte or text)
         :raises TypeError: if the path is not a string and relative path.
         :raises FileNotFoundError: if the file does not exist.
         :raises IsADirectoryError: if the object is a directory and not a file.

--- a/src/aiida/orm/nodes/repository.py
+++ b/src/aiida/orm/nodes/repository.py
@@ -210,7 +210,7 @@ class NodeRepository:
 
         with self._repository.open(path) as handle:
             if 'b' not in mode:
-                yield io.StringIO(handle.read().decode('utf-8'))
+                yield io.TextIOWrapper(handle, encoding='utf-8')
             else:
                 yield handle
 

--- a/src/aiida/tools/data/cif.py
+++ b/src/aiida/tools/data/cif.py
@@ -125,7 +125,7 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
             constructor_kwargs[argument] = parameters.pop(argument)
 
     with cif.open() as handle:
-        # CifParser can only accept StringIO streams
+        # CifParser can only accept StringIO streams.
         parser = CifParser(io.StringIO(handle.read()), **constructor_kwargs)
 
     try:

--- a/src/aiida/tools/data/cif.py
+++ b/src/aiida/tools/data/cif.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Tools to operate on `CifData` nodes."""
 
+import io
+
 from aiida.engine import calcfunction
 from aiida.orm import CifData
 from aiida.orm.implementation.utils import clean_value
@@ -123,7 +125,8 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
             constructor_kwargs[argument] = parameters.pop(argument)
 
     with cif.open() as handle:
-        parser = CifParser(handle, **constructor_kwargs)
+        # CifParser can only accept StringIO streams
+        parser = CifParser(io.StringIO(handle.read()), **constructor_kwargs)
 
     try:
         structures = parser.parse_structures(**parameters)

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -267,12 +267,12 @@ def test_open_text():
     """Test the ``NodeRepository.open`` method in text mode."""
     node = Data()
     node.base.repository.put_object_from_bytes(b'content', 'file')
-    
+
     # The 'r' case
     with node.base.repository.open('file', 'r') as handle:
         assert isinstance(handle, io.TextIOWrapper)
         assert handle.read() == 'content'
-       
+
     # The 'rb' case
     with node.base.repository.open('file', 'rb') as handle:
         assert handle.read() == b'content'

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -1,5 +1,6 @@
 """Tests for the :mod:`aiida.orm.nodes.repository` module."""
 
+import io
 import pathlib
 
 import pytest
@@ -260,3 +261,13 @@ def test_as_path():
     with node.base.repository.as_path('relative/path.dat') as filepath:
         assert filepath.read_bytes() == b'content_relative'
     assert not filepath.exists()
+
+
+def test_open_text():
+    """Test the ``NodeRepository.open`` method in text mode."""
+    node = Data()
+    node.base.repository.put_object_from_bytes(b'content', 'file')
+
+    with node.base.repository.open('file', 'r') as handle:
+        assert isinstance(handle, io.TextIOWrapper)
+        assert handle.read() == 'content'

--- a/tests/orm/nodes/test_repository.py
+++ b/tests/orm/nodes/test_repository.py
@@ -267,7 +267,12 @@ def test_open_text():
     """Test the ``NodeRepository.open`` method in text mode."""
     node = Data()
     node.base.repository.put_object_from_bytes(b'content', 'file')
-
+    
+    # The 'r' case
     with node.base.repository.open('file', 'r') as handle:
         assert isinstance(handle, io.TextIOWrapper)
         assert handle.read() == 'content'
+       
+    # The 'rb' case
+    with node.base.repository.open('file', 'rb') as handle:
+        assert handle.read() == b'content'

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'win32'",
@@ -190,7 +190,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0,<8.3" },
     { name = "click-spinner", specifier = "~=0.1.8" },
     { name = "coverage", marker = "extra == 'tests'", specifier = "~=7.0" },
-    { name = "disk-objectstore", specifier = "~=1.3.0" },
+    { name = "disk-objectstore", specifier = "~=1.4.0" },
     { name = "docstring-parser" },
     { name = "docutils", marker = "extra == 'tests'", specifier = "~=0.20" },
     { name = "flask", marker = "extra == 'rest'", specifier = "~=2.3.3" },
@@ -1329,16 +1329,16 @@ wheels = [
 
 [[package]]
 name = "disk-objectstore"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/f8/028d480ffe1f331ca47663dc407ae443303b3db6da16e310866472dd3343/disk_objectstore-1.3.0.tar.gz", hash = "sha256:f0653574990402fd91a5d91b0a64ea541fb349baed02edfe7e90cf7bf3d5270c", size = 7390310, upload-time = "2025-04-17T12:56:02.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/06/2f76aef59917d47e372158580db988bae1d09f73f5a22721cf88cb5b1dd1/disk_objectstore-1.4.0.tar.gz", hash = "sha256:4d9ea7617dd2de1c817255d7c8123f69e106f6daa0d4c0bdd09ab919ddbc49c8", size = 7390473, upload-time = "2025-10-06T08:35:53.392Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/d7/e1f178515454ca4ba7e437db3e19b07854bc7573c2130a2dbf3f1beb6362/disk_objectstore-1.3.0-py3-none-any.whl", hash = "sha256:a97fd6cbb9636ff8b6515d15f6d5d8c021910c701267805382ed32540d294e79", size = 70538, upload-time = "2025-04-17T12:56:00.414Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/95/fc379912f1c2b336de2af95331da764b6f09e3f8fabc6050cd7b71a6b895/disk_objectstore-1.4.0-py3-none-any.whl", hash = "sha256:e29d33e51a1196468062f30a79126b3d82ef9fcca6a505f7984cdfc8bed72f5e", size = 70636, upload-time = "2025-10-06T08:35:51.915Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In the current implementation, the contents of a file are wrapped in a `StringIO` if a user tries to open a file from the repository in text mode (i.e. with `folderdata.open('somefile.txt', 'r')`). This means the entire file is loaded into memory, which can cause a significant increase in memory usage for large text files. This PR proposed to instead wrap the binary stream in a `TextIOWrapper` for streaming based access in text mode to avoid having to load the entire file into memory.

A small change was also necessary for the `cif`-file interface, since apparently the `CifParser` from pymatgen only accepts filenames or `StringIO` streams.

This PR depends on a PR for the disk-objectstore dependency (see https://github.com/aiidateam/disk-objectstore/pull/192) that adds some attributes to custom streaming types that are required by `TextIOWrapper`.