### PR TITLE
RTD: add a developer comment in `.readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,7 +20,8 @@ build:
     - asdf install uv 0.5.22
     - asdf global uv 0.5.22
     create_environment:
-    - uv venv
+    - uv venv RTD
+    - . RTD/bin/activate
     install:
     - uv sync --extra docs --extra tests --extra rest --extra atomic_tools
     build:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,8 +20,9 @@ build:
     - asdf install uv 0.5.22
     - asdf global uv 0.5.22
     create_environment:
-    - uv venv RTD
-    - . RTD/bin/activate
+    # Create a virtual environment in '.venv/' folder
+    # which is picked up automatically by `uv sync` and `uv run` commands below
+    - uv venv
     install:
     - uv sync --extra docs --extra tests --extra rest --extra atomic_tools
     build:


### PR DESCRIPTION
My environment: `uv 0.5.23`
Required by `aiida-core`: `>=0.5.21`

When I run locally, I get:
```
$ uv venv
Using CPython 3.13.0 interpreter at: /usr/local/bin/python3.13
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
```

Which means the created environment is not activated.

However this is not a problem, since `uv sync` & `uv run` both pick up the created environment automatically. 

This PR clarifies the behavior for developers. 