### PR TITLE
 Issue #6687: Fix QueryBuilder filtering for AbstractCode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,9 @@ requires-python = '>=3.9'
 'core.arithmetic.add_multiply' = 'aiida.workflows.arithmetic.add_multiply:add_multiply'
 'core.arithmetic.multiply_add' = 'aiida.workflows.arithmetic.multiply_add:MultiplyAddWorkChain'
 
+[project.entry-points.'aiida.orm']
+'core.code.abstract' = 'aiida.orm.nodes.data.code.abstract:AbstractCode'
+
 [project.optional-dependencies]
 atomic_tools = [
   'PyCifRW~=4.4',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ requires-python = '>=3.9'
 'core.bool' = 'aiida.orm.nodes.data.bool:Bool'
 'core.cif' = 'aiida.orm.nodes.data.cif:CifData'
 'core.code' = 'aiida.orm.nodes.data.code.legacy:Code'
+'core.code.abstract' = 'aiida.orm.nodes.data.code.abstract:AbstractCode'
 'core.code.containerized' = 'aiida.orm.nodes.data.code.containerized:ContainerizedCode'
 'core.code.installed' = 'aiida.orm.nodes.data.code.installed:InstalledCode'
 'core.code.portable' = 'aiida.orm.nodes.data.code.portable:PortableCode'
@@ -196,9 +197,6 @@ requires-python = '>=3.9'
 [project.entry-points.'aiida.workflows']
 'core.arithmetic.add_multiply' = 'aiida.workflows.arithmetic.add_multiply:add_multiply'
 'core.arithmetic.multiply_add' = 'aiida.workflows.arithmetic.multiply_add:MultiplyAddWorkChain'
-
-[project.entry-points.'aiida.orm']
-'core.code.abstract' = 'aiida.orm.nodes.data.code.abstract:AbstractCode'
 
 [project.optional-dependencies]
 atomic_tools = [

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -1336,16 +1336,13 @@ def _get_node_type_filter(classifiers: Classifier, subclassing: bool) -> dict:
     from aiida.common.escaping import escape_for_sql_like
     from aiida.orm.utils.node import get_query_type_from_type_string
 
-    # value = classifiers.ormclass_type_string
-
-    # if not subclassing:
-    #     filters = {'==': value}
-    # else:
-    #     # Note: the query_type_string always ends with a dot. This ensures that "like {str}%" matches *only*
-    #     # the query type string
-    #     filters = {'like': f'{escape_for_sql_like(get_query_type_from_type_string(value))}%'}
-
     value = classifiers.ormclass_type_string
+
+    # Since `AbstractCode` was introduced later and does not have a direct entry point,
+    # filtering for `data.core.code.abstract%` does not return any results. However, both
+    # `InstalledCode` and `PortableCode` (which inherit from `AbstractCode`) use `data.core.code.%`
+    # as their node type. To ensure `AbstractCode` queries correctly return all code instances,
+    # we adjust the filter to `data.core.code%`, matching all subclasses properly.
 
     if value == 'data.core.code.abstract':
         value = 'data.core.code'  # Ensure it matches all codes
@@ -1353,8 +1350,8 @@ def _get_node_type_filter(classifiers: Classifier, subclassing: bool) -> dict:
     if not subclassing:
         filters = {'==': value}
     else:
+        # Note: the query_type_string always ends with a dot. This ensures that "like {str}%" matches *only*
         filters = {'like': f'{escape_for_sql_like(get_query_type_from_type_string(value))}%'}
-
 
     return filters
 

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -1336,14 +1336,25 @@ def _get_node_type_filter(classifiers: Classifier, subclassing: bool) -> dict:
     from aiida.common.escaping import escape_for_sql_like
     from aiida.orm.utils.node import get_query_type_from_type_string
 
+    # value = classifiers.ormclass_type_string
+
+    # if not subclassing:
+    #     filters = {'==': value}
+    # else:
+    #     # Note: the query_type_string always ends with a dot. This ensures that "like {str}%" matches *only*
+    #     # the query type string
+    #     filters = {'like': f'{escape_for_sql_like(get_query_type_from_type_string(value))}%'}
+
     value = classifiers.ormclass_type_string
+
+    if value == 'data.core.code.abstract':
+        value = 'data.core.code'  # Ensure it matches all codes
 
     if not subclassing:
         filters = {'==': value}
     else:
-        # Note: the query_type_string always ends with a dot. This ensures that "like {str}%" matches *only*
-        # the query type string
         filters = {'like': f'{escape_for_sql_like(get_query_type_from_type_string(value))}%'}
+
 
     return filters
 

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -1343,7 +1343,7 @@ def _get_node_type_filter(classifiers: Classifier, subclassing: bool) -> dict:
     # while the 'core.code' entry point is claimed by the Legacy Code class.
     # So to get all the code types, including the Legacy Code, we adjust the filter to 'data.core.code'.
     # Note, this only make sense if `subclassing` parameter is True!
-    if subclassing and value == 'data.core.code.abstract.AbstractCode.':
+    if value == 'data.core.code.abstract.AbstractCode.':
         value = 'data.core.code.'
 
     if not subclassing:

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -1338,19 +1338,19 @@ def _get_node_type_filter(classifiers: Classifier, subclassing: bool) -> dict:
 
     value = classifiers.ormclass_type_string
 
-    # Since `AbstractCode` was introduced later and does not have a direct entry point,
-    # filtering for `data.core.code.abstract%` does not return any results. However, both
-    # `InstalledCode` and `PortableCode` (which inherit from `AbstractCode`) use `data.core.code.%`
-    # as their node type. To ensure `AbstractCode` queries correctly return all code instances,
-    # we adjust the filter to `data.core.code%`, matching all subclasses properly.
-
-    if value == 'data.core.code.abstract':
-        value = 'data.core.code'  # Ensure it matches all codes
+    # Users searching for `AbstractCode` (sub)classes want to get all the codes (Portable, Installed etc.)
+    # Unfortunately, because AbstractCode was introduced later, its entry point is 'data.core.code.abstract',
+    # while the 'core.code' entry point is claimed by the Legacy Code class.
+    # So to get all the code types, including the Legacy Code, we adjust the filter to 'data.core.code'.
+    # Note, this only make sense if `subclassing` parameter is True!
+    if subclassing and value == 'data.core.code.abstract.AbstractCode.':
+        value = 'data.core.code.'
 
     if not subclassing:
         filters = {'==': value}
     else:
         # Note: the query_type_string always ends with a dot. This ensures that "like {str}%" matches *only*
+        # the query type string
         filters = {'like': f'{escape_for_sql_like(get_query_type_from_type_string(value))}%'}
 
     return filters

--- a/tests/orm/nodes/data/test_data.py
+++ b/tests/orm/nodes/data/test_data.py
@@ -154,7 +154,11 @@ def generate_class_instance(tmp_path, aiida_localhost):
 
 @pytest.fixture(
     scope='function',
-    params=[entry_point for entry_point in plugins.get_entry_points('aiida.data') if entry_point.name != 'core.code'],
+    params=[
+        entry_point
+        for entry_point in plugins.get_entry_points('aiida.data')
+        if entry_point.name not in ('core.code', 'core.code.abstract')
+    ],
 )
 def data_plugin(request):
     """Fixture that parametrizes over all the registered entry points of the ``aiida.data`` entry point group."""

--- a/tests/orm/test_fields/fields_aiida.data.core.code.abstract.AbstractCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.abstract.AbstractCode.yml
@@ -1,0 +1,25 @@
+append_text: QbStrField('append_text', dtype=<class 'str'>, is_attribute=True)
+attributes: QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
+  is_attribute=False, is_subscriptable=True)
+computer: QbNumericField('computer', dtype=typing.Optional[int], is_attribute=False)
+ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
+default_calc_job_plugin: QbStrField('default_calc_job_plugin', dtype=typing.Optional[str],
+  is_attribute=True)
+description: QbStrField('description', dtype=<class 'str'>, is_attribute=True)
+extras: QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
+  is_attribute=False, is_subscriptable=True)
+label: QbStrField('label', dtype=<class 'str'>, is_attribute=True)
+mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
+node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
+pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
+prepend_text: QbStrField('prepend_text', dtype=<class 'str'>, is_attribute=True)
+process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
+repository_content: QbDictField('repository_content', dtype=typing.Optional[dict[str,
+  bytes]], is_attribute=False)
+repository_metadata: QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
+  typing.Any]], is_attribute=False)
+source: QbDictField('source', dtype=typing.Optional[dict], is_attribute=True, is_subscriptable=True)
+use_double_quotes: QbField('use_double_quotes', dtype=<class 'bool'>, is_attribute=True)
+user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
+uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+with_mpi: QbField('with_mpi', dtype=typing.Optional[bool], is_attribute=True)

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -852,13 +852,15 @@ class TestQueryBuilderCornerCases:
         qb = orm.QueryBuilder().append(orm.Data, filters={'or': [{}, {}]})
         assert qb.count() == count
 
-    def test_abstract_code_filtering(self):
+    @pytest.mark.usefixtures('aiida_profile_clean')
+    def test_abstract_code_filtering(self, tmp_path):
         """Test that querying for AbstractCode correctly returns all code instances.
 
         This tests the fix for issue #6687, where QueryBuilder couldn't find codes
         when looking for AbstractCode due to a node_type mismatch.
         """
         # Set up test environment
+
         computer = orm.Computer(
             label='test_computer_abstract',
             hostname='localhost',
@@ -873,35 +875,34 @@ class TestQueryBuilderCornerCases:
             filepath_executable='/bin/bash',
         ).store()
 
+        (tmp_path / 'exec').touch()
         portable_code = orm.PortableCode(
             label='test_portable_abstract',
-            filepath_executable='/bin/bash',
+            filepath_executable='exec',
+            filepath_files=tmp_path,
         ).store()
 
-        try:
-            # Test 1: AbstractCode query should find all code types
-            qb_abstract = orm.QueryBuilder().append(orm.AbstractCode)
-            abstract_results = qb_abstract.all(flat=True)
-            assert installed_code in abstract_results, 'InstalledCode not found with AbstractCode query'
-            assert portable_code in abstract_results, 'PortableCode not found with AbstractCode query'
+        # Test 1: AbstractCode query should find all code types
+        qb_abstract = orm.QueryBuilder().append(orm.AbstractCode)
+        abstract_results = qb_abstract.all(flat=True)
+        assert (
+            installed_code in abstract_results
+        ), f'InstalledCode not found with AbstractCode query. Result: {abstract_results}'
+        assert (
+            portable_code in abstract_results
+        ), f'PortableCode not found with AbstractCode query. Result: {abstract_results}'
 
-            # Test 2: Verify specific code type queries work as expected
-            qb_installed = orm.QueryBuilder().append(orm.InstalledCode)
-            installed_results = qb_installed.all(flat=True)
-            assert installed_code in installed_results
-            assert portable_code not in installed_results
+        # Test 2: Verify specific code type queries work as expected
+        qb_installed = orm.QueryBuilder().append(orm.InstalledCode)
+        installed_results = qb_installed.all(flat=True)
+        assert installed_code in installed_results
+        assert portable_code not in installed_results
 
-            # Test 3: Test with basic filtering
-            qb_filtered = orm.QueryBuilder().append(orm.AbstractCode, filters={'label': 'test_installed_abstract'})
-            filtered_results = qb_filtered.all(flat=True)
-            assert len(filtered_results) == 1
-            assert installed_code in filtered_results
-
-        finally:
-            # Clean up
-            portable_code.delete()
-            installed_code.delete()
-            computer.delete()
+        # Test 3: Test with basic filtering
+        qb_filtered = orm.QueryBuilder().append(orm.AbstractCode, filters={'label': 'test_installed_abstract'})
+        filtered_results = qb_filtered.all(flat=True)
+        assert len(filtered_results) == 1
+        assert installed_code in filtered_results
 
 
 class TestAttributes:


### PR DESCRIPTION
Continuing from #6857 

> This PR fixes an issue in QueryBuilder where filtering for AbstractCode was not working correctly. The update ensures that queries involving AbstractCode return expected results.
>Changes Made:
1.Fixed filtering logic in querybuilder.py.
2.Updated pyproject.toml accordingly.
3.Added pytest tests for QueryBuilder functionality, as previously requested.


Closes #6687