### PR TITLE
Add defer_build to pydantic models for faster aiida.orm import time

### DIFF
--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -181,7 +181,7 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType], metaclass=Enti
     _CLS_COLLECTION: Type[CollectionType] = Collection  # type: ignore[assignment]
     _logger = log.AIIDA_LOGGER.getChild('orm.entities')
 
-    class Model(BaseModel):
+    class Model(BaseModel, defer_build=True):
         pk: Optional[int] = MetadataField(
             None,
             description='The primary key of the entity. Can be `None` if the entity is not yet stored.',

--- a/src/aiida/orm/utils/mixins.py
+++ b/src/aiida/orm/utils/mixins.py
@@ -183,7 +183,7 @@ class Sealable:
 
     SEALED_KEY = 'sealed'
 
-    class Model(pydantic.BaseModel):
+    class Model(pydantic.BaseModel, defer_build=True):
         sealed: bool = MetadataField(description='Whether the node is sealed')
 
     @classproperty


### PR DESCRIPTION
Adding `defer_build` attribute to these two pydantic Model classes saves around 80ms of import time for the `aiida.orm` module. 

Here I am comparing with the 2.6.3 baseline (Benchmark 1)

### Current main
```
❯ hyperfine -w 1 "uv run --no-config --directory /tmp python -c 'import aiida.orm'" "uv run python -c 'import aiida.orm'"

  Benchmark 1: uv run --no-config --directory /tmp python -c 'import aiida.orm'
  Time (mean ± σ):     267.3 ms ±   4.9 ms    [User: 307.3 ms, System: 781.5 ms]
  Range (min … max):   261.7 ms … 276.3 ms    11 runs

  Benchmark 2: uv run python -c 'import aiida.orm'
  Time (mean ± σ):     444.8 ms ±  10.4 ms    [User: 463.9 ms, System: 777.7 ms]
  Range (min … max):   433.2 ms … 462.4 ms    10 runs
```

### This PR

```
Benchmark 1: uv run --no-config --directory /tmp python -c 'import aiida.orm'
  Time (mean ± σ):     266.4 ms ±   3.0 ms    [User: 299.5 ms, System: 792.9 ms]
  Range (min … max):   263.1 ms … 270.6 ms    11 runs
 
Benchmark 2: uv run python -c 'import aiida.orm'
  Time (mean ± σ):     365.9 ms ±  25.5 ms    [User: 393.8 ms, System: 748.0 ms]
  Range (min … max):   336.9 ms … 409.5 ms    10 runs
 
Summary
  uv run --no-config --directory /tmp python -c 'import aiida.orm' ran
    1.37 ± 0.10 times faster than uv run python -c 'import aiida.orm'
```

Regarding the the rest of the slow down, I am still investigating, but this saving is significant enough that it imho warrants inclusion in 2.7.

Part of the slow down (20ms) is that we're now calling the `hasattr` method much more (2k more calls) (using cProfile and pstats modules)

2.6.3
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
6324/5757    0.001    0.000    0.038    0.000 {built-in method builtins.hasattr}
```

This PR

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
8177/7191    0.003    0.000    0.058    0.000 {built-in method builtins.hasattr}
```
```