### PR TITLE
Filter active processes for the default user when running `verdi process repair`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -407,7 +407,7 @@ def computer_enable(computer, user):
 def computer_disable(computer, user):
     """Disable the computer for the given user.
 
-    Thi can be useful, for example, when a computer is under maintenance.
+    This can be useful, for example, when a computer is under maintenance.
     """
     from aiida.common.exceptions import NotExistent
 

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -552,7 +552,7 @@ def process_repair(manager, broker, dry_run, force):
         else:
             echo.echo_success('No unreferenced database connections found.')
 
-    active_processes = get_active_processes(project='id')
+    active_processes = [process.pk for process in get_active_processes() if process.user.is_default]
     process_tasks = get_process_tasks(broker)
 
     set_active_processes = set(active_processes)

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -509,11 +509,13 @@ def process_watch(broker, processes, most_recent_node):
 @verdi_process.command('repair')
 @options.DRY_RUN()
 @options.FORCE(help='Do not ask for confirmation when terminating database connections.')
+@options.USER(help='Filter to repair processes belonging to a specific user (by email).')
+@options.ALL_USERS(help='Filter to repair processes for all users')
 @decorators.only_if_daemon_not_running()
 @decorators.with_manager
 @decorators.with_broker
-def process_repair(manager, broker, dry_run, force):
-    """Automatically repair all stuck processes.
+def process_repair(manager, broker, dry_run, force, user, all_users):
+    """Automatically repair all stuck processes (optionally filtered by user).
 
     N.B.: This command requires the daemon to be stopped.
 
@@ -552,7 +554,10 @@ def process_repair(manager, broker, dry_run, force):
         else:
             echo.echo_success('No unreferenced database connections found.')
 
-    active_processes = [process.pk for process in get_active_processes() if process.user.is_default]
+    active_processes = get_active_processes(
+        user=None if all_users else user if user else profile.default_user_email,
+        project='id',
+    )
     process_tasks = get_process_tasks(broker)
 
     set_active_processes = set(active_processes)

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -515,7 +515,7 @@ def process_watch(broker, processes, most_recent_node):
 @decorators.with_manager
 @decorators.with_broker
 def process_repair(manager, broker, dry_run, force, user, all_users):
-    """Automatically repair all stuck processes (optionally filtered by user).
+    """Automatically repair all stuck processes.
 
     N.B.: This command requires the daemon to be stopped.
 
@@ -525,8 +525,15 @@ def process_repair(manager, broker, dry_run, force, user, all_users):
     worker to complete it and will effectively be "stuck". Any process task that does not correspond to an active
     process is useless and should be discarded. Finally, duplicate process tasks are also problematic and are discarded.
     """
-    from aiida.engine.processes.control import get_active_processes, get_process_tasks, iterate_process_tasks
+    from aiida.engine.processes.control import (
+        get_active_processes,
+        get_process_tasks,
+        iterate_process_tasks,
+    )
     from aiida.storage.psql_dos.backend import PsqlDosBackend
+
+    if all_users and user:
+        raise click.BadOptionUsage('user', 'cannot specify both `--user` and `--all-users` at the same time.')
 
     # Terminate unreferenced database connections that could be holding locks
     # Note: Use `type()` instead of `isinstance()` because SqliteDosBackend inherits from PsqlDosBackend
@@ -554,34 +561,32 @@ def process_repair(manager, broker, dry_run, force, user, all_users):
         else:
             echo.echo_success('No unreferenced database connections found.')
 
-    active_processes = get_active_processes(
-        user=None if all_users else user if user else profile.default_user_email,
-        project='id',
-    )
-    process_tasks = get_process_tasks(broker)
+    selected_user = None if all_users else user.email if user else profile.default_user_email
+    active_processes = get_active_processes(user=selected_user, project='id')
+    active_processes_set = set(active_processes)
 
-    set_active_processes = set(active_processes)
-    set_process_tasks = set(process_tasks)
+    process_tasks = get_process_tasks(broker, user=selected_user)
+    process_tasks_set = set(process_tasks)
 
     echo.echo_info(f'Active processes: {active_processes}')
     echo.echo_info(f'Process tasks: {process_tasks}')
 
     state_inconsistent = False
 
-    if len(process_tasks) != len(set_process_tasks):
+    if len(process_tasks) != len(process_tasks_set):
         state_inconsistent = True
-        echo.echo_warning('There are duplicates process tasks: ', nl=False)
+        echo.echo_warning('There are duplicate process tasks: ', nl=False)
         echo.echo(set(x for x in process_tasks if process_tasks.count(x) > 1))
 
-    if set_process_tasks.difference(set_active_processes):
+    if process_tasks_set.difference(active_processes_set):
         state_inconsistent = True
         echo.echo_warning('There are process tasks for terminated processes: ', nl=False)
-        echo.echo(set_process_tasks.difference(set_active_processes))
+        echo.echo(process_tasks_set.difference(active_processes_set))
 
-    if set_active_processes.difference(set_process_tasks):
+    if active_processes_set.difference(process_tasks_set):
         state_inconsistent = True
         echo.echo_warning('There are active processes without process task: ', nl=False)
-        echo.echo(set_active_processes.difference(set_process_tasks))
+        echo.echo(active_processes_set.difference(process_tasks_set))
 
     if not state_inconsistent:
         echo.echo_success('No inconsistencies detected between database and broker.')
@@ -599,13 +604,13 @@ def process_repair(manager, broker, dry_run, force, user, all_users):
     # Eliminate duplicate tasks and tasks that correspond to terminated process
     for task in iterate_process_tasks(broker):
         pid = task.body.get('args', {}).get('pid', None)
-        if pid not in set_active_processes:
+        if pid in process_tasks_set and pid not in active_processes_set:
             with task.processing() as outcome:
                 outcome.set_result(False)
             echo.echo_report(f'Acknowledged task `{pid}`')
 
     # Revive zombie processes that no longer have a process task
-    zombies = set_active_processes.difference(set_process_tasks)
+    zombies = active_processes_set.difference(process_tasks_set)
     if zombies:
         from aiida.brokers.zeromq.broker import ZeromqBroker
 

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -16,7 +16,7 @@ from aiida.common.exceptions import AiidaException
 from aiida.common.log import AIIDA_LOGGER
 from aiida.engine.daemon.client import DaemonException, get_daemon_client
 from aiida.manage.manager import get_manager
-from aiida.orm import ProcessNode, QueryBuilder
+from aiida.orm import ProcessNode, QueryBuilder, User
 from aiida.tools.query.calculation import CalculationQueryBuilder
 
 LOGGER = AIIDA_LOGGER.getChild('process_control')
@@ -26,15 +26,25 @@ class ProcessTimeoutException(AiidaException):
     """Raised when action to communicate with a process times out."""
 
 
-def get_active_processes(paused: bool = False, project: str | list[str] = '*') -> list[ProcessNode] | list[t.Any]:
+def get_active_processes(
+    paused: bool = False,
+    project: str | list[str] = '*',
+    user: str | None = None,
+) -> list[ProcessNode] | list[t.Any]:
     """Return all active processes, i.e., those with a process state of created, waiting or running.
 
     :param paused: Boolean, if True, filter for processes that are paused.
     :param project: Single or list of properties to project. By default projects the entire node.
+    :param user: Email of the user to filter for processes belonging to a specific user.
     :return: A list of process nodes of active processes.
     """
     filters = CalculationQueryBuilder().get_filters(process_state=('created', 'waiting', 'running'), paused=paused)
-    builder = QueryBuilder().append(ProcessNode, filters=filters, project=project)
+    builder = QueryBuilder()
+    qb_kwargs: dict[str, str] = {}
+    if user:
+        builder.append(User, filters={'email': user}, tag='user')
+        qb_kwargs = {'with_user': 'user'}
+    builder.append(ProcessNode, filters=filters, project=project, **qb_kwargs)
     return builder.all(flat=True)
 
 

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -36,15 +36,14 @@ def get_active_processes(
     :param paused: Boolean, if True, filter for processes that are paused.
     :param project: Single or list of properties to project. By default projects the entire node.
     :param user: Email of the user to filter for processes belonging to a specific user.
+        If None, no filtering is applied and all active processes are returned.
     :return: A list of process nodes of active processes.
     """
     filters = CalculationQueryBuilder().get_filters(process_state=('created', 'waiting', 'running'), paused=paused)
     builder = QueryBuilder()
-    qb_kwargs: dict[str, str] = {}
+    builder.append(ProcessNode, filters=filters, project=project, tag='process')
     if user:
-        builder.append(User, filters={'email': user}, tag='user')
-        qb_kwargs = {'with_user': 'user'}
-    builder.append(ProcessNode, filters=filters, project=project, **qb_kwargs)
+        builder.append(User, filters={'email': user}, with_node='process')
     return builder.all(flat=True)
 
 
@@ -56,9 +55,10 @@ def iterate_process_tasks(broker: Broker) -> collections.abc.Iterator[kiwipy.rmq
     yield from broker.iterate_tasks()
 
 
-def get_process_tasks(broker: Broker) -> list[int]:
+def get_process_tasks(broker: Broker, user: str | None = None) -> list[int]:
     """Return the list of process pks that have a process task in the RabbitMQ process queue.
 
+    :param user: Email of the user to filter process tasks by.
     :returns: A list of process pks that have a corresponding process task with RabbitMQ.
     """
     pks = []
@@ -69,7 +69,14 @@ def get_process_tasks(broker: Broker) -> list[int]:
         except KeyError:
             pass
 
-    return pks
+    if user is None or not pks:
+        return pks
+
+    owned_pks = QueryBuilder()
+    owned_pks.append(ProcessNode, filters={'id': {'in': pks}}, project='id', tag='process')
+    owned_pks.append(User, filters={'email': user}, with_node='process')
+    owned_pks_set = set(owned_pks.all(flat=True))
+    return [pk for pk in pks if pk in owned_pks_set]
 
 
 def revive_processes(processes: list[ProcessNode], *, wait: bool = False) -> None:

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -15,7 +15,7 @@ import typing as t
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -1021,7 +1021,7 @@ def test_process_repair_running_daemon(run_cli_command):
 def test_process_repair_consistent(monkeypatch, run_cli_command):
     """Test the ``verdi process repair`` command when everything is consistent."""
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2, 3])
-    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2, 3])
+    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [1, 2, 3])
 
     result = run_cli_command(cmd_process.process_repair, use_subprocess=False)
     assert 'No inconsistencies detected between database and broker.' in result.output
@@ -1031,10 +1031,10 @@ def test_process_repair_consistent(monkeypatch, run_cli_command):
 def test_process_repair_duplicate_tasks(monkeypatch, run_cli_command):
     """Test the ``verdi process repair`` command when there are duplicate tasks."""
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2])
-    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2, 2])
+    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [1, 2, 2])
 
     result = run_cli_command(cmd_process.process_repair, use_subprocess=False)
-    assert 'There are duplicates process tasks:' in result.output
+    assert 'There are duplicate process tasks:' in result.output
     assert 'Inconsistencies detected between database and broker.' in result.output
 
 
@@ -1042,7 +1042,7 @@ def test_process_repair_duplicate_tasks(monkeypatch, run_cli_command):
 def test_process_repair_additional_tasks(monkeypatch, run_cli_command):
     """Test the ``verdi process repair`` command when there are additional tasks."""
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2])
-    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2, 3])
+    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [1, 2, 3])
 
     result = run_cli_command(cmd_process.process_repair, use_subprocess=False)
     assert 'There are process tasks for terminated processes:' in result.output
@@ -1054,7 +1054,7 @@ def test_process_repair_additional_tasks(monkeypatch, run_cli_command):
 def test_process_repair_missing_tasks(monkeypatch, run_cli_command):
     """Test the ``verdi process repair`` command when there are missing tasks."""
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2, 3])
-    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2])
+    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [1, 2])
 
     result = run_cli_command(cmd_process.process_repair, use_subprocess=False)
     assert 'There are active processes without process task:' in result.output
@@ -1066,7 +1066,7 @@ def test_process_repair_missing_tasks(monkeypatch, run_cli_command):
 def test_process_repair_dry_run(monkeypatch, run_cli_command):
     """Test the ``verdi process repair`` command with ``--dry-run```."""
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2, 3, 4])
-    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2])
+    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [1, 2])
 
     result = run_cli_command(cmd_process.process_repair, ['--dry-run'], raises=True, use_subprocess=False)
     assert 'Inconsistencies detected between database and broker.' in result.output
@@ -1077,11 +1077,81 @@ def test_process_repair_dry_run(monkeypatch, run_cli_command):
 def test_process_repair_verbosity(monkeypatch, run_cli_command):
     """Test the ``verdi process repair`` command with ``-v INFO```."""
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2, 3, 4])
-    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2])
+    monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [1, 2])
 
     result = run_cli_command(cmd_process.process_repair, ['-v', 'INFO'], use_subprocess=False)
     assert 'Active processes: [1, 2, 3, 4]' in result.output
     assert 'Process tasks: [1, 2]' in result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_process_repair_all_users(monkeypatch, run_cli_command):
+    """Test the ``verdi process repair`` command with ``--all-users```."""
+    get_active_processes = MagicMock(return_value=[1, 2, 3, 4])
+    get_process_tasks = MagicMock(return_value=[1, 2])
+    monkeypatch.setattr(process_control, 'get_active_processes', get_active_processes)
+    monkeypatch.setattr(process_control, 'get_process_tasks', get_process_tasks)
+
+    result = run_cli_command(cmd_process.process_repair, ['--all-users'], use_subprocess=False)
+    assert 'Inconsistencies detected between database and broker.' in result.output
+    assert 'Attempting to fix inconsistencies' in result.output
+    get_active_processes.assert_called_once_with(user=None, project='id')
+    get_process_tasks.assert_called_once_with(ANY, user=None)
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_process_repair_single_user(monkeypatch, run_cli_command, default_user):
+    """Test the ``verdi process repair`` command with a single user."""
+    get_active_processes = MagicMock(return_value=[1, 2, 3, 4])
+    get_process_tasks = MagicMock(return_value=[1, 2])
+    monkeypatch.setattr(process_control, 'get_active_processes', get_active_processes)
+    monkeypatch.setattr(process_control, 'get_process_tasks', get_process_tasks)
+
+    result = run_cli_command(cmd_process.process_repair, ['--user', default_user.email], use_subprocess=False)
+    assert 'Inconsistencies detected between database and broker.' in result.output
+    assert 'Attempting to fix inconsistencies' in result.output
+    get_active_processes.assert_called_once_with(user=default_user.email, project='id')
+    get_process_tasks.assert_called_once_with(ANY, user=default_user.email)
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_process_repair_user_and_all_users_exclusive(run_cli_command, default_user):
+    """Test that ``--user`` and ``--all-users`` cannot be specified together."""
+    result = run_cli_command(
+        cmd_process.process_repair,
+        ['--user', default_user.email, '--all-users'],
+        raises=True,
+        use_subprocess=False,
+    )
+
+    assert result.exit_code == ExitCode.USAGE_ERROR
+    assert 'cannot specify both `--user` and `--all-users`' in result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_process_repair_does_not_acknowledge_tasks_of_other_users(monkeypatch, run_cli_command, default_user):
+    """Test that repairing the default user does not acknowledge another user's task in the shared queue."""
+    from aiida.orm import User
+
+    selected_process = CalcJobNode(user=default_user)
+    selected_process.set_process_state(ProcessState.FINISHED)
+    selected_process.store()
+
+    other_user = User('other@example.com').store()
+    other_process = CalcJobNode(user=other_user)
+    other_process.set_process_state(ProcessState.WAITING)
+    other_process.store()
+
+    selected_task = MagicMock()
+    selected_task.body = {'args': {'pid': selected_process.pk}}
+    other_task = MagicMock()
+    other_task.body = {'args': {'pid': other_process.pk}}
+    monkeypatch.setattr(process_control, 'iterate_process_tasks', lambda *args: iter([selected_task, other_task]))
+
+    run_cli_command(cmd_process.process_repair, use_subprocess=False)
+
+    selected_task.processing.assert_called_once_with()
+    other_task.processing.assert_not_called()
 
 
 @pytest.mark.requires_psql
@@ -1097,7 +1167,7 @@ class TestProcessRepairUnreferencedConnections:
         without any RabbitMQ inconsistencies to repair.
         """
         monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [])
-        monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [])
+        monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args, **kwargs: [])
 
     @pytest.fixture
     def mock_unreferenced_connection(self, monkeypatch):

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -34,7 +34,7 @@ def test_tasks_list_running_daemon(run_cli_command):
 @pytest.mark.usefixtures('stopped_daemon_client')
 def test_tasks_list(monkeypatch, run_cli_command):
     """Test the ``tasks list`` command when everything is consistent."""
-    monkeypatch.setattr(control, 'get_process_tasks', lambda *args: [1, 2, 3])
+    monkeypatch.setattr(control, 'get_process_tasks', lambda *args, **kwargs: [1, 2, 3])
 
     result = run_cli_command(cmd_rabbitmq.cmd_tasks_list, use_subprocess=False)
     assert result.output == '1\n2\n3\n'
@@ -57,7 +57,7 @@ def test_tasks_analyze_consistent(monkeypatch, run_cli_command):
     This is a copy of the test for the equivalent ``verdi process repair`` since it just forwards to that command.
     """
     monkeypatch.setattr(control, 'get_active_processes', lambda *args, **kwargs: [1, 2, 3])
-    monkeypatch.setattr(control, 'get_process_tasks', lambda *args: [1, 2, 3])
+    monkeypatch.setattr(control, 'get_process_tasks', lambda *args, **kwargs: [1, 2, 3])
 
     result = run_cli_command(cmd_rabbitmq.cmd_tasks_analyze, use_subprocess=False)
     assert 'No inconsistencies detected between database and broker.' in result.output

--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -1,12 +1,14 @@
 """Tests for the :mod:`aiida.engine.processes.control` module."""
 
+from types import SimpleNamespace
+
 import pytest
 from plumpy.process_comms import RemoteProcessThreadController
 
 from aiida.engine import ProcessState
 from aiida.engine.launch import submit
 from aiida.engine.processes import control
-from aiida.orm import Int
+from aiida.orm import CalcJobNode, Int, User
 from tests.utils.processes import WaitProcess
 
 
@@ -27,6 +29,51 @@ def test_daemon_not_running(action, caplog):
     """Test that control methods warns if the daemon is not running."""
     action(all_entries=True)
     assert 'The daemon is not running' in caplog.records[0].message
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_get_active_processes_user_filter(default_user):
+    """Test that ``get_active_processes`` filters by user without including terminated processes."""
+    other_user = User('other@example.com').store()
+
+    selected_process = CalcJobNode(user=default_user)
+    selected_process.set_process_state(ProcessState.WAITING)
+    selected_process.store()
+
+    other_process = CalcJobNode(user=other_user)
+    other_process.set_process_state(ProcessState.WAITING)
+    other_process.store()
+
+    terminated_process = CalcJobNode(user=default_user)
+    terminated_process.set_process_state(ProcessState.FINISHED)
+    terminated_process.store()
+
+    assert control.get_active_processes(project='id') == [selected_process.pk, other_process.pk]
+    assert control.get_active_processes(project='id', user=default_user.email) == [selected_process.pk]
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_get_process_tasks_user_filter(default_user):
+    """Test that ``get_process_tasks`` filters task PIDs by user and preserves duplicates."""
+    other_user = User('other@example.com').store()
+
+    selected_process = CalcJobNode(user=default_user).store()
+    other_process = CalcJobNode(user=other_user).store()
+
+    tasks = [
+        SimpleNamespace(body={'args': {'pid': selected_process.pk}}),
+        SimpleNamespace(body={'args': {'pid': other_process.pk}}),
+        SimpleNamespace(body={'args': {'pid': selected_process.pk}}),
+    ]
+
+    class Broker:
+        """Provide the task iterator used by ``get_process_tasks``."""
+
+        def iterate_tasks(self):
+            yield from tasks
+
+    assert control.get_process_tasks(Broker()) == [selected_process.pk, other_process.pk, selected_process.pk]
+    assert control.get_process_tasks(Broker(), user=default_user.email) == [selected_process.pk, selected_process.pk]
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')


### PR DESCRIPTION
This PR applies a filter on the active processes picked up by `verdi process repair`. The command takes the difference between the set of active processes and queued processes and adds the difference to the broker queue. However, in recent developments of a shared AiiDA setup, the database table of queued jobs (`DbQueue`) may hold jobs from different profiles (multiple profiles share the database). The broker should not pick up jobs from a profile different from the default user. Here, I apply this exact filter on active jobs (`if process.user.is_default`). This ensures that the broker does not pick up jobs from any other profile attached to the database.

I don't believe this breaks anything, as there should be no other user with active processes. Here, by active I mean jobs which the broker should correctly attempt to repair. I believe the concept of `User` in AiiDA was mostly to differentiate imported processes and data. But these processes should not be active (e.g. running, waiting). So the filter in the end makes no difference for single-profile-use database use cases.