### PR TITLE
Doc: Fixing doc references after `click` 8.2 release

### DIFF
--- a/src/aiida/cmdline/groups/verdi.py
+++ b/src/aiida/cmdline/groups/verdi.py
@@ -88,10 +88,11 @@ class VerdiCommand(click.Command):
     is printed after the prompting for parameters, which for interactive commands mean the deprecation warning comes too
     late, when the user has already provided all prompts.
 
-    Here, the :meth:`click.Command.parse_args` method is overridden, which is called before the interactive options
-    start to prompt, such that the deprecation warning can be printed. The :meth:`click.Command.invoke` method is also
-    overridden in order to skip the printing of the deprecation message handled by ``click`` as that would result in
-    the deprecation message being printed twice.
+    Here, the `click.Command.parse_args
+    <https://github.com/pallets/click/blob/f8d811e5d5644aca8d32eebff196bf7c659ebf45/src/click/core.py#L1369>`_ method is
+    overridden, which is called before the interactive options start to prompt, such that the deprecation warning can be
+    printed. The :meth:`click.Command.invoke` method is also overridden in order to skip the printing of the deprecation
+    message handled by ``click`` as that would result in the deprecation message being printed twice.
     """
 
     def parse_args(self, ctx: click.Context, args: t.List[str]) -> t.List[str]:
@@ -99,7 +100,8 @@ class VerdiCommand(click.Command):
 
         Then context is modified as necessary.
 
-        This is automatically invoked by :meth:`click.BaseCommand.make_context`.
+        This is automatically invoked by `click.BaseCommand.make_context
+        <https://github.com/pallets/click/blob/f8d811e5d5644aca8d32eebff196bf7c659ebf45/src/click/core.py#L884>`_.
         """
         if self.deprecated:
             # We are abusing click.Command `deprecated` member variable by using a


### PR DESCRIPTION
`click` released v8.2.0 and by that broke the references to their doc. `click` only keeps one version of the documentation so we cannot reference a different API. Thus we reference the functions by the GitHub link for v8.1.0.