### PR TITLE
Include usage of filter_size for importing logs, user, computer

### DIFF
--- a/src/aiida/tools/archive/imports.py
+++ b/src/aiida/tools/archive/imports.py
@@ -262,11 +262,18 @@ def _import_users(
     # get matching emails from the backend
     output_email_id: Dict[str, int] = {}
     if input_id_email:
-        output_email_id = dict(
-            orm.QueryBuilder(backend=backend_to)
-            .append(orm.User, filters={'email': {'in': list(input_id_email.values())}}, project=['email', 'id'])
-            .all(batch_size=query_params.batch_size)
-        )
+        output_email_id = {
+            key: value
+            for query_results in [
+                dict(
+                    orm.QueryBuilder(backend=backend_to)
+                    .append(orm.User, filters={'email': {'in': chunk}}, project=['email', 'id'])
+                    .all(batch_size=query_params.batch_size)
+                )
+                for _, chunk in batch_iter(set(input_id_email.values()), query_params.filter_size)
+            ]
+            for key, value in query_results.items()
+        }
 
     new_users = len(input_id_email) - len(output_email_id)
     existing_users = len(output_email_id)
@@ -300,11 +307,18 @@ def _import_computers(
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
     if input_id_uuid:
-        backend_uuid_id = dict(
-            orm.QueryBuilder(backend=backend_to)
-            .append(orm.Computer, filters={'uuid': {'in': list(input_id_uuid.values())}}, project=['uuid', 'id'])
-            .all(batch_size=query_params.batch_size)
-        )
+        backend_uuid_id = {
+            key: value
+            for query_results in [
+                dict(
+                    orm.QueryBuilder(backend=backend_to)
+                    .append(orm.Computer, filters={'uuid': {'in': chunk}}, project=['uuid', 'id'])
+                    .all(batch_size=query_params.batch_size)
+                )
+                for _, chunk in batch_iter(set(input_id_uuid.values()), query_params.filter_size)
+            ]
+            for key, value in query_results.items()
+        }
 
     new_computers = len(input_id_uuid) - len(backend_uuid_id)
     existing_computers = len(backend_uuid_id)
@@ -460,17 +474,20 @@ def _import_nodes(
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
-    input_id_uuid_uuids = list(input_id_uuid.values())
 
     if input_id_uuid:
-        for _, batch in batch_iter(input_id_uuid_uuids, query_params.filter_size):
-            backend_uuid_id.update(
+        backend_uuid_id = {
+            key: value
+            for query_results in [
                 dict(
                     orm.QueryBuilder(backend=backend_to)
-                    .append(orm.Node, filters={'uuid': {'in': batch}}, project=['uuid', 'id'])
+                    .append(orm.Node, filters={'uuid': {'in': chunk}}, project=['uuid', 'id'])
                     .all(batch_size=query_params.batch_size)
                 )
-            )
+                for _, chunk in batch_iter(set(input_id_uuid.values()), query_params.filter_size)
+            ]
+            for key, value in query_results.items()
+        }
 
     new_nodes = len(input_id_uuid) - len(backend_uuid_id)
 
@@ -544,12 +561,20 @@ def _import_logs(
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
+
     if input_id_uuid:
-        backend_uuid_id = dict(
-            orm.QueryBuilder(backend=backend_to)
-            .append(orm.Log, filters={'uuid': {'in': list(input_id_uuid.values())}}, project=['uuid', 'id'])
-            .all(batch_size=query_params.batch_size)
-        )
+        backend_uuid_id = {
+            key: value
+            for query_results in [
+                dict(
+                    orm.QueryBuilder(backend=backend_to)
+                    .append(orm.Log, filters={'uuid': {'in': chunk}}, project=['uuid', 'id'])
+                    .all(batch_size=query_params.batch_size)
+                )
+                for _, chunk in batch_iter(set(input_id_uuid.values()), query_params.filter_size)
+            ]
+            for key, value in query_results.items()
+        }
 
     new_logs = len(input_id_uuid) - len(backend_uuid_id)
     existing_logs = len(backend_uuid_id)


### PR DESCRIPTION
Sqlite only accepts a limited number of parameters so we reduce the query into chunks. For that the parameter `filter_size` is already provided but is not used in every use case.

Building the query for the matching nodes from the backend can for surpass the sqlite limit of allowed query parameters and thus result in failure when importing the archive. In this PR we implement the usage of the `filter_size` which limits the number of parameters in the query for importing logs, user and computers.

Fixes https://github.com/aiidateam/aiida-core/issues/6876 (I think both are only due to `_import_logs` not using `filter_size`)

Since this does not fully cover the usage of `filter_size` in all queries but seems to already fix #6876 I opened a new issue https://github.com/aiidateam/aiida-core/issues/6907 to keep this in mind.