### PR TITLE
Release `v2.6.4`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,6 +24,7 @@ build:
 
 # Let the build fail if there are any warnings
 sphinx:
+  configuration: docs/source/conf.py
   builder: html
   fail_on_warning: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## v2.6.3 - 2024-11-TODO
+
+## v2.6.3 - 2024-11-06
 
 ### Fixes
 - CLI: Fix exception for `verdi plugin list` (#6560) [[c3b10b7]](https://github.com/aiidateam/aiida-core/commit/c3b10b759a9cd062800ef120591d5c7fd0ae4ee7)
@@ -16,30 +17,30 @@
 ## v2.6.2 - 2024-08-07
 
 ### Fixes
-- `LocalTransport`: Fix typo for `ignore_nonexisting` in `put` (#6471) [[ecda558d0]](https://github.com/v2.6.1/commit/ecda558d08c5608880308f69a21c05fe918be89f)
-- CLI: `verdi computer test` report correct failed tests (#6536) [[9c3f2bb58]](https://github.com/v2.6.1/commit/9c3f2bb589f1a6cc920ed2fbf0627924d8fce954)
-- CLI: Fix `verdi storage migrate` for profile without broker (#6550) [[389fc487d]](https://github.com/v2.6.1/commit/389fc487d092c2e34713d228e38c8164608bab2d)
-- CLI: Fix bug `verdi presto` when tab-completing without config (#6535) [[efcf75e40]](https://github.com/v2.6.1/commit/efcf75e405dcef8ca8c51b19d6262ca81f4413c3)
-- Engine: Change signature of `set_process_state_change_timestamp` [[923fd9f6e]](https://github.com/v2.6.1/commit/923fd9f6ec3cb39b8985ac149985046e720438f8)
-- Engine: Ensure node is sealed when process excepts (#6549) [[e3ed9a2f3]](https://github.com/v2.6.1/commit/e3ed9a2f3bf84e72cdc4c90e21494dc2b9c1cd56)
-- Engine: Fix bug in upload calculation for `PortableCode` with SSH (#6519) [[740ae2040]](https://github.com/v2.6.1/commit/740ae20408e4e3047c26c91221de5b96b8d7afbe)
-- Engine: Ignore failing process state change for `core.sqlite_dos` [[fb4f9815f]](https://github.com/v2.6.1/commit/fb4f9815fbd3bfe053cc0d1e3abb5b86bbc9dffd)
+- `LocalTransport`: Fix typo for `ignore_nonexisting` in `put` (#6471) [[ecda558d0]](https://github.com/aiidteam/commit/ecda558d08c5608880308f69a21c05fe918be89f)
+- CLI: `verdi computer test` report correct failed tests (#6536) [[9c3f2bb58]](https://github.com/aiidateam/commit/9c3f2bb589f1a6cc920ed2fbf0627924d8fce954)
+- CLI: Fix `verdi storage migrate` for profile without broker (#6550) [[389fc487d]](https://github.com/aiidateam/commit/389fc487d092c2e34713d228e38c8164608bab2d)
+- CLI: Fix bug `verdi presto` when tab-completing without config (#6535) [[efcf75e40]](https://github.com/aiidateam/commit/efcf75e405dcef8ca8c51b19d6262ca81f4413c3)
+- Engine: Change signature of `set_process_state_change_timestamp` [[923fd9f6e]](https://github.com/aiidateam/commit/923fd9f6ec3cb39b8985ac149985046e720438f8)
+- Engine: Ensure node is sealed when process excepts (#6549) [[e3ed9a2f3]](https://github.com/aiidateam/commit/e3ed9a2f3bf84e72cdc4c90e21494dc2b9c1cd56)
+- Engine: Fix bug in upload calculation for `PortableCode` with SSH (#6519) [[740ae2040]](https://github.com/aiidateam/commit/740ae20408e4e3047c26c91221de5b96b8d7afbe)
+- Engine: Ignore failing process state change for `core.sqlite_dos` [[fb4f9815f]](https://github.com/aiidateam/commit/fb4f9815fbd3bfe053cc0d1e3abb5b86bbc9dffd)
 
 ### Dependencies
-- Pin requirement to minor version `sphinx~=7.2.0` (#6527) [[25cb73188]](https://github.com/v2.6.1/commit/25cb731880d45045773f7674fee9367d792aeda9)
+- Pin requirement to minor version `sphinx~=7.2.0` (#6527) [[25cb73188]](https://github.com/aiidateam/commit/25cb731880d45045773f7674fee9367d792aeda9)
 
 ### Documentation
-- Add `PluggableSchemaValidator` to nitpick exceptions (#6515) [[0ce3c0025]](https://github.com/v2.6.1/commit/0ce3c0025384e95006d43e98da2a96b2cfadde70)
-- Add `robots.txt` to only allow indexing of `latest` and `stable` (#6517) [[a492e3492]](https://github.com/v2.6.1/commit/a492e349288ee90896193575edf319c2b7ea4c85)
-- Add succint overview of limitations of no-services profile [[d7ca5657b]](https://github.com/v2.6.1/commit/d7ca5657b0dec83cb8a440d0b8e11c9c84e38149)
-- Correct signature of `get_daemon_client` example snippet (#6554) [[92d391658]](https://github.com/v2.6.1/commit/92d391658e5e92113ad9a32d61444e23342ee0ae)
-- Fix typo in pytest plugins codeblock (#6513) [[eb23688fe]](https://github.com/v2.6.1/commit/eb23688febacb5b828d0f45ebdeedee65d0c00fe)
-- Move limitations warning to top of quick install [[493e529a7]](https://github.com/v2.6.1/commit/493e529a7aec052f81d1bbfed33e5b44db9434e2)
-- Remove note in installation guide regarding Python requirement [[9aa2044e4]](https://github.com/v2.6.1/commit/9aa2044e4ce665d64bb3a1c26f166512287aa28b)
-- Update `redirects.txt` for installation pages (#6509) [[508a9fb2a]](https://github.com/v2.6.1/commit/508a9fb2a7f6eb6f31b40b3f28d13c96f7875503)
+- Add `PluggableSchemaValidator` to nitpick exceptions (#6515) [[0ce3c0025]](https://github.com/aiidateam/commit/0ce3c0025384e95006d43e98da2a96b2cfadde70)
+- Add `robots.txt` to only allow indexing of `latest` and `stable` (#6517) [[a492e3492]](https://github.com/aiidateam/commit/a492e349288ee90896193575edf319c2b7ea4c85)
+- Add succint overview of limitations of no-services profile [[d7ca5657b]](https://github.com/aiidateam/commit/d7ca5657b0dec83cb8a440d0b8e11c9c84e38149)
+- Correct signature of `get_daemon_client` example snippet (#6554) [[92d391658]](https://github.com/aiidateam/commit/92d391658e5e92113ad9a32d61444e23342ee0ae)
+- Fix typo in pytest plugins codeblock (#6513) [[eb23688fe]](https://github.com/aiidateam/commit/eb23688febacb5b828d0f45ebdeedee65d0c00fe)
+- Move limitations warning to top of quick install [[493e529a7]](https://github.com/aiidateam/commit/493e529a7aec052f81d1bbfed33e5b44db9434e2)
+- Remove note in installation guide regarding Python requirement [[9aa2044e4]](https://github.com/aiidateam/commit/9aa2044e4ce665d64bb3a1c26f166512287aa28b)
+- Update `redirects.txt` for installation pages (#6509) [[508a9fb2a]](https://github.com/aiidateam/commit/508a9fb2a7f6eb6f31b40b3f28d13c96f7875503)
 
 ### Devops
-- Fix pymatgen import causing mypy to fail (#6540) [[813374fe1]](https://github.com/v2.6.1/commit/813374fe1ee003c8c05f9aa191147ec928dfa918)
+- Fix pymatgen import causing mypy to fail (#6540) [[813374fe1]](https://github.com/aiidateam/commit/813374fe1ee003c8c05f9aa191147ec928dfa918)
 
 
 ## v2.6.1 - 2024-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## v2.6.4 - 2025-05-22
+
+### Fixes
+- Dependencies: Pin click to `~=8.1.0` (#6888) [[e1d55fa]](https://github.com/aiidateam/aiida-core/commit/e1d55fa0d6c268db7a25e9740679a5a0fbe412b8)
+
+
 ## v2.6.3 - 2024-11-06
 
 ### Fixes

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -140,6 +140,7 @@ py:meth click.Option.get_default
 py:meth fail
 
 py:class ComputedFieldInfo
+py:class BaseModel
 py:class pydantic.fields.Field
 py:class pydantic.main.BaseModel
 py:class PluggableSchemaValidator

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -450,7 +450,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.
+                                      leading forward slash.  [default: ""]
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
 - kiwipy[rmq]~=0.7.7
 - importlib-metadata~=6.0
 - numpy~=1.21
-- paramiko>=2.7.2,~=2.7
+- paramiko<3.0.0,>=2.7.2
 - plumpy~=0.21.6
 - pgsu~=0.2.1
 - psutil~=5.6

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - aio-pika~=6.6
 - circus~=0.18.0
 - click-spinner~=0.1.8
-- click~=8.1
+- click~=8.1.0
 - disk-objectstore~=1.1
 - docstring_parser
 - get-annotations~=0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   'kiwipy[rmq]~=0.7.7',
   'importlib-metadata~=6.0',
   'numpy~=1.21',
-  'paramiko~=2.7,>=2.7.2',
+  'paramiko<3.0.0,>=2.7.2',
   'plumpy~=0.21.6',
   'pgsu~=0.2.1',
   'psutil~=5.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   'aio-pika~=6.6',
   'circus~=0.18.0',
   'click-spinner~=0.1.8',
-  'click~=8.1',
+  'click~=8.1.0',
   'disk-objectstore~=1.1',
   'docstring-parser',
   'get-annotations~=0.1;python_version<"3.10"',

--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -27,7 +27,7 @@ __copyright__ = (
     'For further information please visit http://www.aiida.net/. All rights reserved.'
 )
 __license__ = 'MIT license, see LICENSE.txt file.'
-__version__ = '2.6.3'
+__version__ = '2.6.4'
 __authors__ = 'The AiiDA team.'
 __paper__ = (
     'S. P. Huber et al., "AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and '

--- a/src/aiida/cmdline/commands/cmd_devel.py
+++ b/src/aiida/cmdline/commands/cmd_devel.py
@@ -61,12 +61,11 @@ def devel_check_load_time():
 def devel_check_undesired_imports():
     """Check that verdi does not import python modules it shouldn't.
 
-    Note: The blacklist was taken from the list of packages in the 'atomic_tools' extra but can be extended.
+    This is to keep the verdi CLI snappy, especially for tab-completion.
     """
     loaded_modules = 0
 
-    for modulename in [
-        'asyncio',
+    unwanted_modules = [
         'requests',
         'plumpy',
         'disk_objectstore',
@@ -78,7 +77,12 @@ def devel_check_undesired_imports():
         'spglib',
         'pymysql',
         'yaml',
-    ]:
+    ]
+    # trogon powers the optional TUI and uses asyncio.
+    # Check for asyncio only when the optional tui extras are not installed.
+    if 'trogon' not in sys.modules:
+        unwanted_modules += 'asyncio'
+    for modulename in unwanted_modules:
         if modulename in sys.modules:
             echo.echo_warning(f'Detected loaded module "{modulename}"')
             loaded_modules += 1

--- a/src/aiida/cmdline/groups/verdi.py
+++ b/src/aiida/cmdline/groups/verdi.py
@@ -88,10 +88,11 @@ class VerdiCommand(click.Command):
     is printed after the prompting for parameters, which for interactive commands mean the deprecation warning comes too
     late, when the user has already provided all prompts.
 
-    Here, the :meth:`click.Command.parse_args` method is overridden, which is called before the interactive options
-    start to prompt, such that the deprecation warning can be printed. The :meth:`click.Command.invoke` method is also
-    overridden in order to skip the printing of the deprecation message handled by ``click`` as that would result in
-    the deprecation message being printed twice.
+    Here, the `click.Command.parse_args
+    <https://github.com/pallets/click/blob/f8d811e5d5644aca8d32eebff196bf7c659ebf45/src/click/core.py#L1369>`_ method is
+    overridden, which is called before the interactive options start to prompt, such that the deprecation warning can be
+    printed. The :meth:`click.Command.invoke` method is also overridden in order to skip the printing of the deprecation
+    message handled by ``click`` as that would result in the deprecation message being printed twice.
     """
 
     def parse_args(self, ctx: click.Context, args: t.List[str]) -> t.List[str]:
@@ -99,7 +100,8 @@ class VerdiCommand(click.Command):
 
         Then context is modified as necessary.
 
-        This is automatically invoked by :meth:`click.BaseCommand.make_context`.
+        This is automatically invoked by `click.BaseCommand.make_context
+        <https://github.com/pallets/click/blob/f8d811e5d5644aca8d32eebff196bf7c659ebf45/src/click/core.py#L884>`_.
         """
         if self.deprecated:
             # We are abusing click.Command `deprecated` member variable by using a

--- a/src/aiida/common/pydantic.py
+++ b/src/aiida/common/pydantic.py
@@ -42,6 +42,6 @@ def MetadataField(  # noqa: N802
 
     for key, value in (('priority', priority), ('short_name', short_name), ('option_cls', option_cls)):
         if value is not None:
-            field_info.metadata.append({key: value})
+            field_info.metadata.append({key: value})  # type: ignore[union-attr]
 
     return field_info

--- a/tests/cmdline/groups/test_dynamic.py
+++ b/tests/cmdline/groups/test_dynamic.py
@@ -17,7 +17,7 @@ class CustomClass:
         union_type: t.Union[int, float] = Field(title='Union type')
         without_default: str = Field(title='Without default')
         with_default: str = Field(title='With default', default='default')
-        with_default_factory: str = Field(title='With default factory', default_factory=lambda: True)
+        with_default_factory: str = Field(title='With default factory', default_factory=lambda: True)  # type: ignore[assignment]
 
 
 def test_list_options(entry_points):


### PR DESCRIPTION
Release to mainly contain the fix #6888

I had to adapt the click fix #6888 to not end up in cherry-picking all devops changes as well as other new dependencies (like the updated disk-objetcstore since git also tracks this as a change due to the added comma). The added first the commits that have a corresponding commit on the main branch (most of them are highly adapted make them independent on other changes), then I added further changes that are completely disconnected from main just to make pre-commit, RTD, conda tests work. The fixes to the changelog do not have a corresponding commit in the main branch as we did the `CHANGELOG.md` there correctly.


EDIT:
Docker image build is failing but it was not working for any `2.6.x` release and now 2-4 weeks before the release of `v2.7.0` is not worth the time to fix it for this release as it is working for the next minor release and release candidate versions are already uploaded.