### PR TITLE
Store default profile in aiida_profile_factory

### DIFF
--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -141,6 +141,7 @@ def aiida_profile_factory():
             is_test_profile=True,
         )
         config.set_default_profile(profile.name)
+        config.store()
 
         def reset_storage():
             """Reset the storage of the profile.

--- a/tests/tools/pytest_fixtures/test_configuration.py
+++ b/tests/tools/pytest_fixtures/test_configuration.py
@@ -1,14 +1,29 @@
 """Test the pytest fixtures."""
 
+from pathlib import Path
+
+from aiida.manage.configuration import get_config, load_config
+from aiida.manage.configuration.settings import DEFAULT_CONFIG_FILE_NAME
+
 
 def test_aiida_config(tmp_path_factory):
     """Test that ``aiida_config`` fixture is loaded by default and creates a config instance in temp directory."""
-    from aiida.manage.configuration import get_config
-    from aiida.manage.configuration.config import Config
+    from aiida.manage.configuration import CONFIG
 
-    config = get_config()
-    assert isinstance(config, Config)
+    config = get_config(create=False)
+    assert config is CONFIG
     assert config.dirpath.startswith(str(tmp_path_factory.getbasetemp()))
+    assert Path(config.dirpath, DEFAULT_CONFIG_FILE_NAME).is_file()
+    assert config._default_profile
+
+
+def test_aiida_config_file(tmp_path_factory):
+    """Test that ``aiida_config`` fixture stores the configuration in a config file in a temp directory."""
+    # Unlike get_config, load_config always loads the configuration from a file
+    config = load_config(create=False)
+    assert config.dirpath.startswith(str(tmp_path_factory.getbasetemp()))
+    assert Path(config.dirpath, DEFAULT_CONFIG_FILE_NAME).is_file()
+    assert config._default_profile
 
 
 def test_aiida_config_tmp(aiida_config_tmp, tmp_path_factory):


### PR DESCRIPTION
tl;dr: the `aiida_profile_factory` created a new default profile, but the default profile was not being persisted in the config file on disk, meaning commands being ran through a subprocess could fail with "no default profile defined", which is what we [saw in aiidalab-widgets-base](https://github.com/aiidalab/aiidalab-widgets-base/actions/runs/15021832003/job/42212645488?pr=677). This bug is present already in 2.6 so might be worth backporting. 

---

For some reason, while the  `Config.set_default_profile()` function sets the default profile on a config object in memory, it does not store it in the config file on disk, and user needs to subsequently call `config.store()` if they want to persist it. This call was missing in the new pytest fixture in `aiida.tools.pytest_fixtures`, although it is present in the deprecated fixtures in `aiida.manage.tests`

https://github.com/aiidateam/aiida-core/blob/e1d55fa0d6c268db7a25e9740679a5a0fbe412b8/src/aiida/manage/tests/pytest_fixtures.py#L307

#### Why did we not hit this issue in the aiida-core test suite?

Because for verdi commands run externally via subprocess, we were always passing the profile explicitly via a command line argument, see:

https://github.com/aiidateam/aiida-core/blob/e1d55fa0d6c268db7a25e9740679a5a0fbe412b8/tests/conftest.py#L756

Part of #6881

@sphuber I am assuming that this was not a conscious decision?

Side note: I find the semantics of the various Config.set_* commands confusing, because some store the changes in the file, and some don't.