### PR TITLE
Fix legacy pytest fixtures

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -133,3 +133,55 @@ jobs:
         verdi devel check-load-time
         verdi devel check-undesired-imports
         .github/workflows/verdi.sh
+
+
+  test-pytest-fixtures:
+    # Who watches the watchmen?
+    # Here we test the pytest fixtures in isolation from the rest of aiida-core test suite,
+    # since they can be used outside of aiida core context, e.g. in plugins.
+    # Unlike in other workflows in this file, we purposefully don't setup a test profile.
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_DB: test_aiida
+          POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - 5432:5432
+      rabbitmq:
+        image: rabbitmq:3.8.14-management
+        ports:
+        - 5672:5672
+        - 15672:15672
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install aiida-core
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.9'
+        from-lock: 'true'
+        extras: tests
+
+    - name: Test legacy pytest fixtures
+      run: pytest --cov aiida --noconftest src/aiida/manage/tests/test_pytest_fixtures.py
+
+    - name: Upload coverage report
+      if: github.repository == 'aiidateam/aiida-core'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        name: test-pytest-fixtures
+        files: ./coverage.xml
+        fail_ci_if_error: false  # don't fail job, if coverage upload fails

--- a/src/aiida/manage/tests/pytest_fixtures.py
+++ b/src/aiida/manage/tests/pytest_fixtures.py
@@ -179,7 +179,7 @@ def aiida_instance(
             current_profile = configuration.get_profile()
             current_path_variable = os.environ.get(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
 
-        dirpath_config = tmp_path_factory.mktemp('config')
+        dirpath_config = tmp_path_factory.mktemp('config') / settings.DEFAULT_CONFIG_DIR_NAME
         os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(dirpath_config)
         AiiDAConfigDir.set(dirpath_config)
         configuration.CONFIG = configuration.load_config(create=True)

--- a/src/aiida/manage/tests/test_pytest_fixtures.py
+++ b/src/aiida/manage/tests/test_pytest_fixtures.py
@@ -1,0 +1,18 @@
+"""Tests for the :mod:`aiida.manage.tests.pytest_fixtures` module."""
+
+pytest_plugins = ['aiida.manage.tests.pytest_fixtures']
+
+
+def test_deamon_client(daemon_client):
+    if daemon_client.is_daemon_running:
+        daemon_client.stop_daemon(wait=True)
+    daemon_client.start_daemon()
+    daemon_client.stop_daemon(wait=True)
+
+
+def test_started_daemon_client(started_daemon_client):
+    assert started_daemon_client.is_daemon_running
+
+
+def test_stopped_daemon_client(stopped_daemon_client):
+    assert not stopped_daemon_client.is_daemon_running


### PR DESCRIPTION
Closes #6881.

This fixes a tricky bug in the legacy pytest fixtures introduced in #6610. 
Due to convoluted reasons explained below, this bug apparently only manifested for the `daemon_client` fixtures, which were failing to start the deamon with the error:

```python
aiida.engine.daemon.client.DaemonException: The daemon failed to start with error:
/home/runner/work/aiida-core/aiida-core/src/aiida/manage/configuration/settings.py:109: UserWarning: Creating AiiDA configuration folder `/tmp/pytest-of-runner/pytest-0/config0/.aiida`.
  warnings.warn(f'Creating AiiDA configuration folder `{path}`.')
Usage: verdi [OPTIONS] COMMAND [ARGS]...
Try 'verdi --help' for help.

Error: Invalid value for '-p' / '--profile': profile `db643428-7e94-487b-8022-17afc87e5204` does not exist
```

In the first commit of this PR, I've added a new CI job that specifically tests these fixtures, and you can see that they are failing: https://github.com/aiidateam/aiida-core/actions/runs/15454591396/job/43504227763

So the problem was that since #6610, the temporary config folder was set differently than before: Instead of for example `/tmp/pytest/config/.aiida`  it would be `/tmp/pytest/config/`.
This happened to work fine for most cases, but not for the daemon fixtures, because:

1. These fixtures use the `DaemonClient.start_daemon` method to start the daemon with the given test profile and configuration. 
https://github.com/aiidateam/aiida-core/blob/e768b70383ee605feeafd05862a17b8481447880/src/aiida/engine/daemon/client.py#L516

2. The daemon process is started using a subprocess call to `verdi daemon start-circus`
https://github.com/aiidateam/aiida-core/blob/e768b70383ee605feeafd05862a17b8481447880/src/aiida/engine/daemon/client.py#L140

3. To ensure that the verdi command picks up the correct configuration and profile, the subprocess call sets the `AIIDA_PATH` variable to the current config folder.
https://github.com/aiidateam/aiida-core/blob/e768b70383ee605feeafd05862a17b8481447880/src/aiida/engine/daemon/client.py#L225

4. The launched verdi command parses the AIIDA_PATH in `aiida.manage.configurations.settings._get_configuration_directory_from_envvar` . This function however has a rather confusing logic where if `AIIDA_PATH` is set to a path that does not end with `.aiida/` folder, the `.aiida` folder gets appended automatically.
5. :boom: 

The smoking gun was there all along --- this innocent warning 

```
UserWarning: Creating AiiDA configuration folder /tmp/pytest-of-runner/pytest-0/config0/.aiida
```
 was telling us what had happened: The verdi command thought the config folder was `/tmp/pytest-of-runner/pytest-0/config0/.aiida`, whereas we've set it to `/tmp/pytest-of-runner/pytest-0/config0/`. It then went on to create and empty configuration, and then promptly failed as it did not contain the given profile.

The fix and tests here are intentionally minimal to speed up review for 2.7.0 release. 
There are couple of follow-ups:
1. I added more tests for both legacy and new pytest fixtures in #6882 
2. Added type checking to legacy fixtures in #6903. 
3. I think the logic in `_get_configuration_directory_from_envvar` should be extended so that this problem would not appear in the first place. I'll open a separate issue for that.

