### PR TITLE
Rename `--force-kill` option to `--force` in kill action

### DIFF
--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -331,14 +331,14 @@ def process_status(call_link_label, most_recent_node, max_depth, processes):
 @options.WAIT()
 @OverridableOption(
     '-F',
-    '--force-kill',
+    '--force',
     is_flag=True,
     default=False,
     help='Kills the process without waiting for a confirmation if the job has been killed.\n'
     'Note: This may lead to orphaned jobs on your HPC and should be used with caution.',
 )()
 @decorators.with_dbenv()
-def process_kill(processes, all_entries, timeout, wait, force_kill):
+def process_kill(processes, all_entries, timeout, wait, force):
     """Kill running processes.
 
     Kill one or multiple running processes."""
@@ -355,7 +355,7 @@ def process_kill(processes, all_entries, timeout, wait, force_kill):
     if all_entries:
         click.confirm('Are you sure you want to kill all processes?', abort=True)
 
-    if force_kill:
+    if force:
         echo.echo_warning('Force kill is enabled. This may lead to orphaned jobs on your HPC.')
         msg_text = 'Force killed through `verdi process kill`'
     else:
@@ -365,7 +365,7 @@ def process_kill(processes, all_entries, timeout, wait, force_kill):
             control.kill_processes(
                 processes,
                 msg_text=msg_text,
-                force_kill=force_kill,
+                force=force,
                 all_entries=all_entries,
                 timeout=timeout,
                 wait=wait,

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -173,7 +173,7 @@ def kill_processes(
     processes: list[ProcessNode] | None = None,
     *,
     msg_text: str = 'Killed through `aiida.engine.processes.control.kill_processes`',
-    force_kill: bool = False,
+    force: bool = False,
     all_entries: bool = False,
     timeout: float = 5.0,
     wait: bool = False,
@@ -202,7 +202,7 @@ def kill_processes(
         return
 
     controller = get_manager().get_process_controller()
-    action = functools.partial(controller.kill_process, msg_text=msg_text, force_kill=force_kill)
+    action = functools.partial(controller.kill_process, msg_text=msg_text, force_kill=force)
     _perform_actions(processes, action, 'kill', 'killing', timeout, wait)
 
 


### PR DESCRIPTION
`verdi process kill --force-kill` is too redundant so we simplify the command.

Shouldn't pre-commit fail and update `docs/source/topics/cli.rst`? EDIT: I see it is only for the first depth of the verdi commands automatically generated.

I stopped renaming at the point where it enters plumpy