### PR TITLE
Doc: Update the RTD regarding `verdi process {kill|pause|play}`

### DIFF
--- a/docs/source/topics/cli.rst
+++ b/docs/source/topics/cli.rst
@@ -52,11 +52,19 @@ For example, ``verdi process kill --help`` shows::
         Kill running processes.
 
     Options:
-        -t, --timeout FLOAT  Time in seconds to wait for a response before timing
-                             out.  [default: 5.0]
-        --wait / --no-wait   Wait for the action to be completed otherwise return as
-                             soon as it's scheduled.
-        -h, --help           Show this message and exit.
+        -a, --all                       Kill all processes if no specific processes
+                                        are specified.
+        -t, --timeout FLOAT RANGE       Time in seconds to wait for a response
+                                        before timing out. If timeout is 0 the
+                                        command does not wait for response.
+                                        [default: inf; 0<=x<=inf]
+        -F, --force                     Kills the process without waiting for a
+                                        confirmation if the job has been killed.
+                                        Note: This may lead to orphaned jobs on your
+                                        HPC and should be used with caution.
+        -v, --verbosity [notset|debug|info|report|warning|error|critical]
+                                        Set the verbosity of the output.
+        -h, --help                      Show this message and exit.
 
 All help strings consist of three parts:
 

--- a/docs/source/topics/cli.rst
+++ b/docs/source/topics/cli.rst
@@ -55,8 +55,9 @@ For example, ``verdi process kill --help`` shows::
         -a, --all                       Kill all processes if no specific processes
                                         are specified.
         -t, --timeout FLOAT RANGE       Time in seconds to wait for a response
-                                        before timing out. If timeout is 0 the
-                                        command does not wait for response.
+                                        before timing out. If the timeout is 0 the
+                                        command returns immediately and attempts to
+                                        kill the process in the background.
                                         [default: inf; 0<=x<=inf]
         -F, --force                     Kills the process without waiting for a
                                         confirmation if the job has been killed.

--- a/docs/source/topics/processes/usage.rst
+++ b/docs/source/topics/processes/usage.rst
@@ -728,10 +728,12 @@ If the runner has successfully received the request and scheduled the callback, 
 The 'scheduled' indicates that the actual killing might not necessarily have happened just yet.
 This means that even after having called ``verdi process kill`` and getting the success message, the corresponding process may still be listed as active in the output of ``verdi process list``.
 
-By default, the ``pause``, ``play`` and ``kill`` commands will only ask for the confirmation of the runner that the request has been scheduled and not actually wait for the command to have been executed.
-To change this behavior, you can use the ``--wait`` flag to actually wait for the action to be completed.
-If workers are under heavy load, it may take some time for them to respond to the request and for the command to finish.
-If you know that your daemon runners may be experiencing a heavy load, you can also increase the time that the command waits before timing out, with the ``-t/--timeout`` flag.
+To change this behavior, you can use the ``-t / --timeout <FLOAT>`` option to specify a timeout after which the command will stop the action.
+If you set the timeout to ``0```, the command returns immediately without waiting for a response.
+A process is only gracefully killed if AiiDA is able to cancel the associated scheduler job.
+By default, the ``pause``, ``play`` and ``kill`` commands wait until the action has been executed, either failed or succeeded.
+If you want to kill the process regardless of whether the scheduler job is successfully cancelled, you can use the ``-F / --force`` option.
+In this case, a cancellation request is still sent to the scheduler, but the command does not wait for a successful response and proceeds to kill the AiiDA process.
 
 
 .. rubric:: Footnotes

--- a/docs/source/topics/processes/usage.rst
+++ b/docs/source/topics/processes/usage.rst
@@ -733,7 +733,7 @@ If you set the timeout to ``0```, the command returns immediately without waitin
 A process is only gracefully killed if AiiDA is able to cancel the associated scheduler job.
 By default, the ``pause``, ``play`` and ``kill`` commands wait until the action has been executed, either failed or succeeded.
 If you want to kill the process regardless of whether the scheduler job is successfully cancelled, you can use the ``-F / --force`` option.
-In this case, a cancellation request is still sent to the scheduler, but the command does not wait for a successful response and proceeds to kill the AiiDA process.
+In this case, a cancellation request is still sent to the scheduler, but the command does not wait for a response and proceeds to kill the AiiDA process.
 
 
 .. rubric:: Footnotes

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -32,7 +32,7 @@ ACTION_TIMEOUT = OverridableOption(
     default=float('inf'),
     show_default=True,
     help='Time in seconds to wait for a response before timing out. '
-    'If timeout is 0 the command does not wait for response.',
+    'If the timeout is 0 the command returns immediately and attempts to kill the process in the background.',
 )
 
 


### PR DESCRIPTION
The doc updates consider the recent changes on the `verdi process {kill|pause|play}` commands including the changes in commits b6d0fe50, e768b703, ec9d53e9, 5167e2c