### PR TITLE
Cleanup warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,7 +378,7 @@ ignore_errors = true
 module = 'plumpy'
 
 [tool.pytest.ini_options]
-addopts = '--benchmark-skip --durations=50 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
+addopts = '--benchmark-skip --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
 filterwarnings = [
   'ignore:.*and will be removed in NumPy 2.0.*:DeprecationWarning:ase:',
   'ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:pytz|dateutil|tqdm|aio_pika:',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,7 +378,7 @@ ignore_errors = true
 module = 'plumpy'
 
 [tool.pytest.ini_options]
-addopts = '--benchmark-skip --durations=50 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
+addopts = '--benchmark-skip --durations=5 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
 filterwarnings = [
   'ignore:.*and will be removed in NumPy 2.0.*:DeprecationWarning:ase:',
   'ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:pytz|dateutil|tqdm|aio_pika:',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,6 +398,8 @@ filterwarnings = [
   'ignore:Identity map already had an identity for .* inside of an event handler within the flush?:sqlalchemy.exc.SAWarning',
   'ignore:The `aiida.orm.nodes.data.upf` module is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
   'ignore:The `Code` class is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
+  # https://github.com/aiidateam/plumpy/issues/283
+  'ignore:There is no current event loop:DeprecationWarning:plumpy',
   'default::ResourceWarning'
 ]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,6 +400,8 @@ filterwarnings = [
   'ignore:The `Code` class is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
   # https://github.com/aiidateam/plumpy/issues/283
   'ignore:There is no current event loop:DeprecationWarning:plumpy',
+  # spglib deprecation
+  'ignore:dict interface is deprecated:DeprecationWarning',
   'default::ResourceWarning'
 ]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,7 +378,7 @@ ignore_errors = true
 module = 'plumpy'
 
 [tool.pytest.ini_options]
-addopts = '--benchmark-skip --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
+addopts = '--benchmark-skip --durations=50 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
 filterwarnings = [
   'ignore:.*and will be removed in NumPy 2.0.*:DeprecationWarning:ase:',
   'ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:pytz|dateutil|tqdm|aio_pika:',

--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -372,7 +372,7 @@ def node_delete(identifier, dry_run, force, clean_workdir, **traversal_rules):
         from aiida.orm.utils.remote import clean_mapping_remote_paths, get_calcjob_remote_paths
         from aiida.tools.graph.graph_traversers import get_nodes_delete
 
-        backend = get_manager().get_backend()
+        backend = get_manager().get_profile_storage()
         # For here we ignore missing nodes will be raised via func:``delete_nodes`` in the next block
         pks_set_to_delete = get_nodes_delete(
             pks, get_links=False, missing_callback=lambda missing_pks: None, backend=backend, **traversal_rules

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -248,7 +248,7 @@ class Manager:
         """
         from aiida.common.warnings import warn_deprecation
 
-        warn_deprecation('get_backend() is deprecated, use get_profile_storage() instead', version=3)
+        warn_deprecation('get_backend() is deprecated, use get_profile_storage() instead', version=3, stacklevel=3)
         return self.get_profile_storage()
 
     def get_profile_storage(self) -> 'StorageBackend':

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -606,7 +606,7 @@ class TestVerdiDelete:
 
                 for i in range(n_calcjobs):
                     calcjob_node = CalcJobNode(computer=aiida_localhost)
-                    calcjob_node.add_incoming(workflow_node, link_type=LinkType.CALL_CALC, link_label='call')
+                    calcjob_node.base.links.add_incoming(workflow_node, link_type=LinkType.CALL_CALC, link_label='call')
 
                     workdir = tmp_path / f'calcjob_{uuid.uuid4()}'
                     workdir.mkdir()
@@ -637,22 +637,22 @@ class TestVerdiDelete:
         if nodes_deleted:
             for workflow_pk in self.workflow_pks:
                 with pytest.raises(NotExistent):
-                    WorkflowNode.objects.get(pk=workflow_pk)
+                    WorkflowNode.collection.get(pk=workflow_pk)
 
             for calcjob_pk in self.calcjob_pks:
                 with pytest.raises(NotExistent):
-                    CalcJobNode.objects.get(pk=calcjob_pk)
+                    CalcJobNode.collection.get(pk=calcjob_pk)
 
             for remote_pk in self.remote_pks:
                 with pytest.raises(NotExistent):
-                    RemoteData.objects.get(pk=remote_pk)
+                    RemoteData.collection.get(pk=remote_pk)
         else:
             for workflow_pk in self.workflow_pks:
-                WorkflowNode.objects.get(pk=workflow_pk)
+                WorkflowNode.collection.get(pk=workflow_pk)
             for calcjob_pk in self.calcjob_pks:
-                CalcJobNode.objects.get(pk=calcjob_pk)
+                CalcJobNode.collection.get(pk=calcjob_pk)
             for remote_pk in self.remote_pks:
-                RemoteData.objects.get(pk=remote_pk)
+                RemoteData.collection.get(pk=remote_pk)
 
         for remote_folder in self.remote_folders:
             if folders_deleted:

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -95,14 +95,11 @@ class MockFunctions:
 
 
 @pytest.fixture(scope='function')
-@pytest.mark.usefixtures('started_daemon_client')
-def fork_worker_context(aiida_profile):
+def fork_worker_context(aiida_profile, started_daemon_client):
     """Runs daemon worker on a new process with redirected stdout and stderr streams."""
     import multiprocessing
 
-    from aiida.engine.daemon.client import get_daemon_client
-
-    client = get_daemon_client(aiida_profile)
+    client = started_daemon_client
     nb_workers = client.get_number_of_workers()
     # The workers are decreased to zero to ensure that the worker that is
     # subsequently started through this fixture is the one that receives all

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2095,7 +2095,7 @@ class TestStructureDataFromPymatgen:
             )
             tmpf.flush()
             pymatgen_parser = CifParser(tmpf.name)
-            pymatgen_struct = pymatgen_parser.get_structures()[0]
+            pymatgen_struct = pymatgen_parser.parse_structures(primitive=True)[0]
 
         structs_to_test = [StructureData(pymatgen=pymatgen_struct), StructureData(pymatgen_structure=pymatgen_struct)]
 


### PR DESCRIPTION
Split from #6883.

Changes here bring down the number of warnings when running presto tests from over 100 to 30.

See inline comments for more details, most of the changes are straightforward, just removing usage of deprecated methods.