### PR TITLE
`AsyncSshTransport`: Rename `machine_or_host` to `host` and simplify prompts

### DIFF
--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -58,13 +58,15 @@ class AsyncSshTransport(AsyncTransport):
         (
             # the underscore is added to avoid conflict with the machine property
             # which is passed to __init__ as parameter `machine=computer.hostname`
-            'machine_or_host',
+            'host',
             {
                 'type': str,
-                'prompt': 'Machine(or host) name as in `ssh <your-host-name>` command.'
-                ' (It should be a password-less setup)',
-                'help': 'Password-less host-setup to connect, as in command `ssh <your-host-name>`. '
-                "You'll need to have a `Host <your-host-name>` entry defined in your `~/.ssh/config` file.",
+                'prompt': "Host as in 'ssh <HOST>' (needs to be a password-less setup in your ssh config)",
+                'help': (
+                    'Password-less host-setup to connect, as in command `ssh <HOST>`.'
+                    ' You need to have a `Host <HOST>` entry defined in your `~/.ssh/config` file.'
+                    " Note, if not provided, we will use the 'hostname' that was set by you during setup."
+                ),
                 'non_interactive_default': True,
             },
         ),
@@ -73,7 +75,7 @@ class AsyncSshTransport(AsyncTransport):
             {
                 'type': int,
                 'default': _DEFAULT_max_io_allowed,
-                'prompt': 'Maximum number of concurrent I/O operations.',
+                'prompt': 'Maximum number of concurrent I/O operations',
                 'help': 'Depends on various factors, such as your network bandwidth, the server load, etc.'
                 ' (An experimental number)',
                 'non_interactive_default': True,
@@ -120,12 +122,12 @@ class AsyncSshTransport(AsyncTransport):
         super().__init__(*args, **kwargs)
         # the machine is passed as `machine=computer.hostname` in the codebase
         # 'machine' is immutable.
-        # 'machine_or_host' is mutable, so it can be changed via command:
+        # 'host' is mutable, so it can be changed via command:
         # 'verdi computer configure core.ssh_async <LABEL>'.
-        # by default, 'machine_or_host' is set to 'machine' in the __init__ method, if not provided.
+        # by default, 'host' is set to 'machine' in the __init__ method, if not provided.
         # NOTE: to guarantee a connection,
         # a computer with core.ssh_async transport plugin should be configured before any instantiation.
-        self.machine = kwargs.pop('machine_or_host', kwargs.pop('machine'))
+        self.machine = kwargs.pop('host', kwargs.pop('machine'))
         self._max_io_allowed = kwargs.pop('max_io_allowed', self._DEFAULT_max_io_allowed)
         self.script_before = kwargs.pop('script_before', 'None')
 

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -1013,7 +1013,7 @@ def test_computer_test_use_login_shell(run_cli_command, aiida_localhost, monkeyp
 # comment on 'core.ssh_async':
 # It is important that 'ssh localhost' is functional in your test environment.
 # It should connect without asking for a password.
-@pytest.mark.parametrize('transport_type, config', [('core.ssh_async', ['--machine-or-host', 'localhost'])])
+@pytest.mark.parametrize('transport_type, config', [('core.ssh_async', ['--host', 'localhost'])])
 def test_computer_setup_with_various_transport(run_cli_command, aiida_computer, transport_type, config):
     """Test setup of computer with ``core.ssh_async`` entry points.
 


### PR DESCRIPTION
By only using the term `host` we do not need to consider both names simplifying the prompt texts. Since the keyword we want the user to specify is called `Host` in the ssh config, it should be clear what is meant by this. While we also support the case if a password-less connection to a machine can be achieved without specifying it in the ssh config (e.g. by default ssh key), by ignoring this possibility it simplifies the prompt texts. In addition, it is explained that the `hostname` is ignored which we do to still support `core.ssh`. 