### PR TITLE
`Transport`: fixing the suggestion for parameter `host`

### DIFF
--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -111,7 +111,11 @@ class AsyncSshTransport(AsyncTransport):
 
     @classmethod
     def _get_host_suggestion_string(cls, computer):
-        """Return a suggestion for the parameter machine."""
+        """Return a suggestion for the parameter 'host'.
+        Note: the name of this methood is not arbitrary! In order to be picked up during
+        `verdi computer configure` command, it has to be in the following format:
+        `_get_<PARAMETER_NAME>_suggestion_string`
+        """
         # Originally set as 'Hostname' during `verdi computer setup`
         # and is passed as `machine=computer.hostname` in the codebase
         # unfortunately, name of hostname and machine are used interchangeably in the aiida-core codebase

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -110,7 +110,7 @@ class AsyncSshTransport(AsyncTransport):
     ]
 
     @classmethod
-    def _get_machine_suggestion_string(cls, computer):
+    def _get_host_suggestion_string(cls, computer):
         """Return a suggestion for the parameter machine."""
         # Originally set as 'Hostname' during `verdi computer setup`
         # and is passed as `machine=computer.hostname` in the codebase


### PR DESCRIPTION
Turns out the name of the suggestive function `_get_<PARAMETER>_suggestion_string` is not arbitrary. 
And had to be adopted with a change of name in PR #6914 

```bash
$ verdi -p presto-3 computer configure core.ssh_async delete_me
Report: enter ? for help.
Report: enter ! to ignore the default and set no value.
Host as in 'ssh <HOST>' (needs to be a password-less setup in your ssh config): 
```

vs

```bash
$ verdi -p presto-3 computer configure core.ssh_async delete_me
Report: enter ? for help.
Report: enter ! to ignore the default and set no value.
Host as in 'ssh <HOST>' (needs to be a password-less setup in your ssh config) [HOST]: 
```