### PR TITLE
Transport: set non-interactive default for `--safe-interval`

### DIFF
--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -69,7 +69,7 @@ class Transport(abc.ABC):
 
     # This is used as a global default in case subclasses don't redefine this,
     # but this should  be redefined in plugins where appropriate
-    _DEFAULT_SAFE_OPEN_INTERVAL = 30.0
+    _DEFAULT_SAFE_OPEN_INTERVAL = 15.0
 
     # To be defined in the subclass
     # See the ssh or local plugin to see the format
@@ -100,6 +100,7 @@ class Transport(abc.ABC):
                 'prompt': 'Connection cooldown time (s)',
                 'help': 'Minimum time interval in seconds between opening new connections.',
                 'callback': validate_positive_number,
+                'non_interactive_default': True,
             },
         ),
     ]

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -100,6 +100,7 @@ class Transport(abc.ABC):
                 'prompt': 'Connection cooldown time (s)',
                 'help': 'Minimum time interval in seconds between opening new connections.',
                 'callback': validate_positive_number,
+                'default': _DEFAULT_SAFE_OPEN_INTERVAL,
                 'non_interactive_default': True,
             },
         ),


### PR DESCRIPTION
Fixes https://github.com/aiidateam/aiida-core/issues/6014

Following feedback from @marnik on [this comment](https://github.com/aiidateam/aiida-core/issues/6941#issuecomment-3072400137)

1) We set the already existing default value for `--safe-interval` as *also* non-interactive default
2) I allow myself to reduce the very long 30 sec. to 15 seconds. This was long discussed in other issues, see for example my other [benchmark comment](https://github.com/aiidateam/aiida-core/issues/6544#issuecomment-2407529994) and the [stale PR](https://github.com/aiidateam/aiida-core/pull/6599) where there was a debate between 5.0 seconds or 3.0 seconds. Either way, that PR can stay open, meanwhile we reduce here from 30.0 to 15.0 seconds. This should not hurt anybody..