### PR TITLE
Cleanup verdi tests

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -129,10 +129,7 @@ jobs:
         extras: ''
 
     - name: Run verdi tests
-      run: |
-        verdi devel check-load-time
-        verdi devel check-undesired-imports
-        .github/workflows/verdi.sh
+      run: .github/workflows/verdi.sh
 
 
   test-pytest-fixtures:

--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+verdi devel check-load-time
+verdi devel check-undesired-imports
+
 # Test the loading time of `verdi`. This is an attempt to catch changes to the imports in `aiida.cmdline` that
 # would slow down `verdi` invocations and make tab-completion unusable.
 VERDI=`which verdi`
 
-# Typically, the loading time of `verdi` should be around ~0.2 seconds.
+# Typically, the loading time of `verdi` should be around <0.2 seconds.
 # Typically these types of tests are fragile. But with a load limit of more than twice
 # the ideal loading time, if exceeded, should give a reasonably sure indication
 # that the loading of `verdi` is unacceptably slowed down.
-LOAD_LIMIT=0.4
+LOAD_LIMIT=0.3
 MAX_NUMBER_ATTEMPTS=5
 
 iteration=0
@@ -16,7 +21,7 @@ iteration=0
 while true; do
 
     iteration=$((iteration+1))
-    load_time=$(/usr/bin/time -q -f "%e" $VERDI 2>&1 > /dev/null)
+    load_time=$(/usr/bin/time -q -f "%e" $VERDI -h 2>&1 > /dev/null)
 
     if (( $(echo "$load_time < $LOAD_LIMIT" | bc -l) )); then
         echo "SUCCESS: loading time $load_time at iteration $iteration below $LOAD_LIMIT"
@@ -36,15 +41,18 @@ done
 
 # Test that we can also run the CLI via `python -m aiida`,
 # that it returns a 0 exit code, and contains the expected stdout.
-echo "Invoking verdi via `python -m aiida`"
-OUTPUT=$(python -m aiida 2>&1)
+echo "Invoking verdi via 'python -m aiida -h'"
+OUTPUT=$(python -m aiida -h 2>&1)
 RETVAL=$?
-echo $OUTPUT
 if [ $RETVAL -ne 0 ]; then
     echo "'python -m aiida' exitted with code $RETVAL"
+    echo "=== OUTPUT ==="
+    echo $OUTPUT
     exit 2
 fi
 if [[ $OUTPUT != *"command line interface of AiiDA"* ]]; then
     echo "'python -m aiida' did not contain the expected stdout:"
+    echo "=== OUTPUT ==="
+    echo $OUTPUT
     exit 2
 fi

--- a/src/aiida/cmdline/commands/cmd_devel.py
+++ b/src/aiida/cmdline/commands/cmd_devel.py
@@ -54,7 +54,7 @@ def devel_check_load_time():
                 f'potential `verdi` speed problem: `{loaded}` module is imported which is not in: {allowed}'
             )
 
-    echo.echo_success('no issues detected')
+    echo.echo_success('no load time issues detected')
 
 
 @verdi_devel.command('check-undesired-imports')
@@ -65,7 +65,7 @@ def devel_check_undesired_imports():
     """
     loaded_modules = 0
 
-    unwanted_modules = [
+    undesired_modules = [
         'requests',
         'plumpy',
         'disk_objectstore',
@@ -81,15 +81,15 @@ def devel_check_undesired_imports():
     # trogon powers the optional TUI and uses asyncio.
     # Check for asyncio only when the optional tui extras are not installed.
     if 'trogon' not in sys.modules:
-        unwanted_modules += 'asyncio'
-    for modulename in unwanted_modules:
+        undesired_modules += 'asyncio'
+    for modulename in undesired_modules:
         if modulename in sys.modules:
             echo.echo_warning(f'Detected loaded module "{modulename}"')
             loaded_modules += 1
 
     if loaded_modules > 0:
-        echo.echo_critical(f'Detected {loaded_modules} unwanted modules')
-    echo.echo_success('no issues detected')
+        echo.echo_critical(f'Detected {loaded_modules} undesired modules')
+    echo.echo_success('no undesired modules detected')
 
 
 @verdi_devel.command('validate-plugins')


### PR DESCRIPTION
Various cleanups in verdi.sh tests
    
- In click 8.2.0, just running `verdi` or `python -m aiida` without any arguments returns non-zero exit code. In verdi.sh we add `-h` to workaround this.
- Move verdi devel check-* commands to verdi.sh
- Reduce verdi CLI load limit to 300ms in verdi.sh. The original limit of 400ms was before I made many performance optimizations in 2.6 so it should be fine to decrease it. I've never see it fail with the new value over at #6883. If it becomes flaky we can change back.

Split from #6883. Towards supporting click 8.2