### PR TITLE
Remove migration output capturing for SqliteZipBackend initialisation

### DIFF
--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -528,8 +528,7 @@ class Config:
 
         LOGGER.report('Initialising the storage backend.')
         try:
-            with contextlib.redirect_stdout(io.StringIO()):
-                profile.storage_cls.initialise(profile)
+            profile.storage_cls.initialise(profile)
         except Exception as exception:
             raise StorageMigrationError(
                 f'Storage backend initialisation failed, probably because the configuration is incorrect:\n{exception}'

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -16,8 +16,6 @@ See https://github.com/pydantic/pydantic/issues/2678 for details).
 from __future__ import annotations
 
 import codecs
-import contextlib
-import io
 import json
 import os
 import shutil


### PR DESCRIPTION
With capturing (previous behavior):
```shell
❯ verdi profile setup core.sqlite_zip --profile-name test4 --first-name a --last-name b --email a@b --institution a --non-interactive --filepath acwf-verification_unaries-verification-PBE-v1_results_gpaw.aiida
Success: RabbitMQ server detected with connection parameters: {'broker_protocol': 'amqp', 'broker_username': 'guest', 'broker_password': 'guest', 'broker_host': '127.0.0.1', 'broker_port': 5672, 'broker_virtual_host': ''}
Report: RabbitMQ can be reconfigured with `verdi profile configure-rabbitmq`.
Report: Initialising the storage backend.
Report: Storage initialisation completed.
Success: Created new profile `test4`.
Success: test4 set as default profile
```

Without capturing (this PR):
```shell
❯ verdi profile setup core.sqlite_zip --profile-name test3 --first-name a --last-name b --email a@b --institution a --non-interactive --filepath acwf-verification_unaries-verification-PBE-v1_results_gpaw.aiida
Success: RabbitMQ server detected with connection parameters: {'broker_protocol': 'amqp', 'broker_username': 'guest', 'broker_password': 'guest', 'broker_host': '127.0.0.1', 'broker_port': 5672, 'broker_virtual_host': ''}
Report: RabbitMQ can be reconfigured with `verdi profile configure-rabbitmq`.
Report: Initialising the storage backend.
Report: Migrating existing SqliteZipBackend
Report: Legacy migrations required from zip format
Report: Extracting data.json ...
Report: Legacy migration pathway: 0.10 -> 0.11 -> 0.12 -> 0.13
Report: legacy '0.13' -> 'main_0000' conversion required
Report: Initialising new archive...
Report: Unique repository files written: 13512
Report: Converting DB to SQLite
Report: Performing SQLite migrations:
Report: - main_0000 -> main_0000a
Report: - main_0000a -> main_0000b
Report: - main_0000b -> main_0001
Report: Finalising the migration ...
Report: Storage initialisation completed.
Success: Created new profile `test3`.
Success: test3 set as default profile
```

While it makes the output more verbose, I think this is actually a _good_ thing, as the user knows what's going on, rather than the output just being stuck on `Report: Initialising the storage backend.`, which it can be for a considerable amount of time if the archive is big.

Further, the archive is actually replaced in-place with the migrated version, hence it would be good to know for the user that a migration is occurring in the first place. This process can lead to memory errors and fails for read-only file systems (both of which we encountered when setting up the new Renku v2 integration), and capturing the migration output makes it hard to know what's going on.