### PR TITLE
Remove ci section from `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,3 @@
-ci:
-  autofix_prs: true
-  autoupdate_commit_msg: 'Devops: Update pre-commit dependencies'
-  autoupdate_schedule: quarterly
-  skip: [mypy, generate-conda-environment, validate-conda-environment, verdi-autodocs]
-
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0


### PR DESCRIPTION
We still have a `.github/workflows/pre-commit.yml` file, so we are still actually running pre-commit via CI. Via `.pre-commit-config.yaml`, we couldn't run `mypy` and some other tools, as one couldn't install dependencies, and the setup as we had it would automatically add commits on top of the PRs which many of us found annoying. With the change of this PR, pre-commit will still be run on the PR, but the check will just fail, which is probably the desired behavior of most anyway.

Ping @danielhollas @agoscinski @khsrali @unkcpz 