### PR TITLE
Add typing to `cmdline/commands` module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,6 @@ repos:
         src/aiida/calculations/diff_tutorial/calculations.py|
         src/aiida/calculations/templatereplacer.py|
         src/aiida/calculations/transfer.py|
-        src/aiida/cmdline/commands/cmd_computer.py|
         src/aiida/cmdline/commands/cmd_devel.py|
         src/aiida/cmdline/commands/cmd_group.py|
         src/aiida/cmdline/commands/cmd_storage.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,6 @@ repos:
         src/aiida/calculations/transfer.py|
         src/aiida/cmdline/commands/cmd_devel.py|
         src/aiida/cmdline/commands/cmd_group.py|
-        src/aiida/cmdline/commands/cmd_storage.py|
         src/aiida/common/extendeddicts.py|
         src/aiida/common/utils.py|
         src/aiida/engine/daemon/execmanager.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,16 +90,10 @@ repos:
         src/aiida/calculations/diff_tutorial/calculations.py|
         src/aiida/calculations/templatereplacer.py|
         src/aiida/calculations/transfer.py|
-        src/aiida/cmdline/commands/cmd_archive.py|
-        src/aiida/cmdline/commands/cmd_calcjob.py|
         src/aiida/cmdline/commands/cmd_code.py|
         src/aiida/cmdline/commands/cmd_computer.py|
-        src/aiida/cmdline/commands/cmd_data/cmd_list.py|
-        src/aiida/cmdline/commands/cmd_data/cmd_upf.py|
         src/aiida/cmdline/commands/cmd_devel.py|
         src/aiida/cmdline/commands/cmd_group.py|
-        src/aiida/cmdline/commands/cmd_node.py|
-        src/aiida/cmdline/commands/cmd_shell.py|
         src/aiida/cmdline/commands/cmd_storage.py|
         src/aiida/common/extendeddicts.py|
         src/aiida/common/utils.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,8 +90,6 @@ repos:
         src/aiida/calculations/diff_tutorial/calculations.py|
         src/aiida/calculations/templatereplacer.py|
         src/aiida/calculations/transfer.py|
-        src/aiida/cmdline/commands/cmd_devel.py|
-        src/aiida/cmdline/commands/cmd_group.py|
         src/aiida/common/extendeddicts.py|
         src/aiida/common/utils.py|
         src/aiida/engine/daemon/execmanager.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,6 @@ repos:
         src/aiida/tools/graph/age_rules.py|
         src/aiida/tools/graph/deletions.py|
         src/aiida/tools/graph/graph_traversers.py|
-        src/aiida/tools/groups/paths.py|
         src/aiida/tools/query/calculation.py|
         src/aiida/tools/query/mapping.py|
         src/aiida/transports/cli.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,6 @@ repos:
         src/aiida/calculations/diff_tutorial/calculations.py|
         src/aiida/calculations/templatereplacer.py|
         src/aiida/calculations/transfer.py|
-        src/aiida/cmdline/commands/cmd_code.py|
         src/aiida/cmdline/commands/cmd_computer.py|
         src/aiida/cmdline/commands/cmd_devel.py|
         src/aiida/cmdline/commands/cmd_group.py|

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -453,7 +453,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.  [default: ""]
+                                      leading forward slash.
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -453,7 +453,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.
+                                      leading forward slash.  [default: ""]
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.

--- a/src/aiida/cmdline/commands/cmd_archive.py
+++ b/src/aiida/cmdline/commands/cmd_archive.py
@@ -8,11 +8,13 @@
 ###########################################################################
 """`verdi archive` command."""
 
+from __future__ import annotations
+
 import logging
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import List, Tuple
+from typing import NoReturn
 
 import click
 from click_spinner import spinner
@@ -211,7 +213,7 @@ def create(
         'test_run': dry_run,
     }
 
-    if AIIDA_LOGGER.level <= logging.REPORT:
+    if AIIDA_LOGGER.level <= logging.REPORT:  # type: ignore[attr-defined]
         set_progress_bar_tqdm(leave=AIIDA_LOGGER.level <= logging.INFO)
     else:
         set_progress_reporter(None)
@@ -255,7 +257,7 @@ def migrate(input_file, output_file, force, in_place, version):
             'no output file specified. Please add --in-place flag if you would like to migrate in place.'
         )
 
-    if AIIDA_LOGGER.level <= logging.REPORT:
+    if AIIDA_LOGGER.level <= logging.REPORT:  # type: ignore[attr-defined]
         set_progress_bar_tqdm(leave=AIIDA_LOGGER.level <= logging.INFO)
     else:
         set_progress_reporter(None)
@@ -384,7 +386,7 @@ def import_archive(
         echo.echo_deprecated('the `--test-run` option is deprecated. Use `-n/--dry-run` option instead')
         dry_run = test_run
 
-    if AIIDA_LOGGER.level <= logging.REPORT:
+    if AIIDA_LOGGER.level <= logging.REPORT:  # type: ignore[attr-defined]
         set_progress_bar_tqdm(leave=AIIDA_LOGGER.level <= logging.INFO)
     else:
         set_progress_reporter(None)
@@ -411,25 +413,20 @@ def import_archive(
         _import_archive_and_migrate(ctx, archive, web_based, import_kwargs, migration)
 
 
-def _echo_exception(msg: str, exception, warn_only: bool = False):
-    """Correctly report and exception.
+def _echo_exception(msg: str, exception: Exception) -> NoReturn:
+    """Report an exception and exit.
 
     :param msg: The message prefix
     :param exception: the exception raised
-    :param warn_only: If True only print a warning, otherwise calls sys.exit with a non-zero exit status
-
     """
     from aiida.tools.archive.imports import IMPORT_LOGGER
 
     message = f'{msg}: {exception.__class__.__name__}: {exception!s}'
-    if warn_only:
-        echo.echo_warning(message)
-    else:
-        IMPORT_LOGGER.info('%s', traceback.format_exc())
-        echo.echo_critical(message)
+    IMPORT_LOGGER.info('%s', traceback.format_exc())
+    echo.echo_critical(message)
 
 
-def _gather_imports(archives, webpages) -> List[Tuple[str, bool]]:
+def _gather_imports(archives: list[str], webpages: list[str] | None) -> list[tuple[str, bool]]:
     """Gather archives to import and sort into local files and URLs.
 
     :returns: list of (archive path, whether it is web based)
@@ -465,7 +462,7 @@ def _gather_imports(archives, webpages) -> List[Tuple[str, bool]]:
 
 def _import_archive_and_migrate(
     ctx: click.Context, archive: str, web_based: bool, import_kwargs: dict, try_migration: bool
-):
+) -> None:
     """Perform the archive import.
 
     :param archive: the path or URL to the archive

--- a/src/aiida/cmdline/commands/cmd_calcjob.py
+++ b/src/aiida/cmdline/commands/cmd_calcjob.py
@@ -8,7 +8,10 @@
 ###########################################################################
 """`verdi calcjob` commands."""
 
+from __future__ import annotations
+
 import os
+import typing as t
 
 import click
 
@@ -16,6 +19,9 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.types import CalculationParamType
 from aiida.cmdline.utils import decorators, echo
+
+if t.TYPE_CHECKING:
+    from aiida import orm
 
 
 @verdi.group('calcjob')
@@ -126,7 +132,7 @@ def calcjob_inputcat(calcjob, path):
 @arguments.CALCULATION('calcjob', type=CalculationParamType(sub_classes=('aiida.node:process.calculation.calcjob',)))
 @click.argument('path', type=str, required=False)
 @decorators.with_dbenv()
-def calcjob_remotecat(calcjob, path):
+def calcjob_remotecat(calcjob: orm.CalcJobNode, path: str | None):
     """Show the contents of a file in the remote working directory.
 
     The file to show can be specified using the PATH argument. If PATH is not specified, the default output file path
@@ -288,7 +294,7 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force, exit
     clean_mapping_remote_paths(path_mapping)
 
 
-def get_remote_and_path(calcjob, path=None):
+def get_remote_and_path(calcjob: orm.CalcJobNode, path: str | None = None) -> tuple[orm.RemoteData, str]:
     """Return the remote folder output node and process the path argument.
 
     :param calcjob: The ``CalcJobNode`` whose remote_folder to be returned.
@@ -327,7 +333,7 @@ def get_remote_and_path(calcjob, path=None):
         ) from exception
 
     # Try to get the default output filename from the node's associated process class spec
-    port = process_class.spec_options.get('output_filename')
+    port = process_class.spec_options.get('output_filename')  # type: ignore[attr-defined]
     if port and port.has_default():
         path = port.default
 

--- a/src/aiida/cmdline/commands/cmd_code.py
+++ b/src/aiida/cmdline/commands/cmd_code.py
@@ -58,7 +58,7 @@ def code_create():
     """Create a new code."""
 
 
-def get_default(key, ctx):
+def get_default(key: str, ctx: click.Context) -> 'Any | None':
     """Get the default argument using a user instance property
 
     :param key: The name of the property to use
@@ -66,7 +66,7 @@ def get_default(key, ctx):
     :return: The default value, or None
     """
     try:
-        value = getattr(ctx.code_builder, key)
+        value = getattr(ctx.code_builder, key)  # type: ignore[attr-defined]
         if value == '':
             value = None
     except KeyError:
@@ -75,21 +75,21 @@ def get_default(key, ctx):
     return value
 
 
-def get_computer_name(ctx):
-    return getattr(ctx.code_builder, 'computer').label
+def get_computer_name(ctx: click.Context) -> str:
+    return getattr(ctx.code_builder, 'computer').label  # type: ignore[attr-defined]
 
 
-def get_on_computer(ctx):
-    return not getattr(ctx.code_builder, 'is_local')()
+def get_on_computer(ctx: click.Context) -> bool:
+    return not getattr(ctx.code_builder, 'is_local')()  # type: ignore[attr-defined]
 
 
-def set_code_builder(ctx, param, value):
+def set_code_builder(ctx: click.Context, _param: Any, value: Any) -> Any:
     """Set the code spec for defaults of following options."""
     from aiida.orm.utils.builders.code import CodeBuilder
 
     # TODO(danielhollas): CodeBuilder is deprecated, rewrite this somehow?
     with warnings.catch_warnings(record=True):
-        ctx.code_builder = CodeBuilder.from_code(value)
+        ctx.code_builder = CodeBuilder.from_code(value)  # type: ignore[attr-defined]
     return value
 
 

--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -646,7 +646,7 @@ def computer_delete(computer, dry_run):
         return not confirm
 
     if associated_nodes_pk:
-        delete_nodes(associated_nodes_pk, dry_run=dry_run or _dry_run_callback)  # type: ignore[arg-type]
+        delete_nodes(associated_nodes_pk, dry_run=dry_run or _dry_run_callback)
 
     if dry_run:
         return

--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -16,7 +16,8 @@ from math import isclose
 
 import click
 
-from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup, verdi
+from aiida.cmdline import VerdiCommandGroup
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.commands import computer as options_computer
 from aiida.cmdline.utils import echo, echo_tabulate
@@ -627,7 +628,7 @@ def computer_delete(computer, dry_run):
     # Sofar, we can only get this info with QueryBuilder
     builder = QueryBuilder()
     builder.append(Computer, filters={'label': label}, tag='computer')
-    builder.append(Node, with_computer='computer', project=Node.fields.pk)
+    builder.append(Node, with_computer='computer', project=Node.fields.pk)  # type: ignore[arg-type]
     associated_nodes_pk = builder.all(flat=True)
 
     echo.echo_report(f'This computer has {len(associated_nodes_pk)} associated nodes')
@@ -645,7 +646,7 @@ def computer_delete(computer, dry_run):
         return not confirm
 
     if associated_nodes_pk:
-        delete_nodes(associated_nodes_pk, dry_run=dry_run or _dry_run_callback)
+        delete_nodes(associated_nodes_pk, dry_run=dry_run or _dry_run_callback)  # type: ignore[arg-type]
 
     if dry_run:
         return
@@ -716,7 +717,7 @@ def computer_config_show(computer, user, defaults, as_option_string):
             if config.get(option.name) or config.get(option.name) is False:
                 if t_opt.get('switch'):
                     option_value = (
-                        option.opts[-1] if config.get(option.name) else f"--no-{option.name.replace('_', '-')}"
+                        option.opts[-1] if config.get(option.name) else f"--no-{option.name.replace('_', '-')}"  # type: ignore[union-attr]
                     )
                 elif t_opt.get('is_flag'):
                     is_default = config.get(option.name) == transport_cli.transport_option_default(

--- a/src/aiida/cmdline/commands/cmd_data/cmd_list.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_list.py
@@ -36,7 +36,11 @@ def query(datatype, project, past_days, group_pks, all_users):
     qbl = orm.QueryBuilder()
     if all_users is False:
         user = orm.User.collection.get_default()
-        qbl.append(orm.User, tag='creator', filters={'email': user.email})
+        if user is None:
+            # TODO: Print warning
+            qbl.append(orm.User, tag='creator')
+        else:
+            qbl.append(orm.User, tag='creator', filters={'email': user.email})
     else:
         qbl.append(orm.User, tag='creator')
 

--- a/src/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -79,8 +79,8 @@ def upf_listfamilies(elements, with_description):
     query.distinct()
     if query.count() > 0:
         for res in query.dict():
-            group_label = res.get('group').get('label')
-            group_desc = res.get('group').get('description')
+            group_label = res.get('group', {}).get('label')
+            group_desc = res.get('group', {}).get('description')
             query = orm.QueryBuilder()
             query.append(orm.Group, tag='thisgroup', filters={'label': {'like': group_label}})
             query.append(UpfData, project=['id'], with_group='thisgroup')

--- a/src/aiida/cmdline/commands/cmd_devel.py
+++ b/src/aiida/cmdline/commands/cmd_devel.py
@@ -115,8 +115,11 @@ def devel_run_sql(sql):
 
     from aiida.storage.psql_dos.utils import create_sqlalchemy_engine
 
-    assert get_profile().storage_backend == 'core.psql_dos'
-    with create_sqlalchemy_engine(get_profile().storage_config).connect() as connection:
+    profile = get_profile()
+    if profile is None:
+        echo.echo_critical('Could not load default profile')
+    assert profile.storage_backend == 'core.psql_dos'
+    with create_sqlalchemy_engine(profile.storage_config).connect() as connection:  # type: ignore[arg-type]
         result = connection.execute(text(sql)).fetchall()
 
     if isinstance(result, (list, tuple)):
@@ -147,7 +150,7 @@ def devel_launch_arithmetic_add(code, daemon, sleep):
     """
     from shutil import which
 
-    from aiida.engine import run, submit
+    from aiida.engine import run_get_node, submit
     from aiida.orm import InstalledCode, Int, load_code
 
     default_calc_job_plugin = 'core.arithmetic.add'
@@ -157,10 +160,12 @@ def devel_launch_arithmetic_add(code, daemon, sleep):
             code = load_code('bash@localhost')
         except exceptions.NotExistent:
             localhost = prepare_localhost()
+            if not (bash_path := which('bash')):
+                echo.echo_critical('Could not find bash executable')
             code = InstalledCode(
                 label='bash',
                 computer=localhost,
-                filepath_executable=which('bash'),
+                filepath_executable=bash_path,
                 default_calc_job_plugin=default_calc_job_plugin,
             ).store()
         else:
@@ -177,7 +182,7 @@ def devel_launch_arithmetic_add(code, daemon, sleep):
         node = submit(builder)
         echo.echo_success(f'Submitted calculation `{node}`')
     else:
-        _, node = run.get_node(builder)
+        _, node = run_get_node(builder)
         if node.is_finished_ok:
             echo.echo_success(f'ArithmeticAddCalculation<{node.pk}> finished successfully.')
         else:
@@ -198,7 +203,7 @@ def devel_launch_multiply_add(code, daemon):
 
     from aiida.engine import run_get_node, submit
     from aiida.orm import InstalledCode, Int, load_code
-    from aiida.plugins.factories import WorkflowFactory
+    from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
     default_calc_job_plugin = 'core.arithmetic.add'
 
@@ -206,17 +211,18 @@ def devel_launch_multiply_add(code, daemon):
         try:
             code = load_code('bash@localhost')
         except exceptions.NotExistent:
+            if not (bash_path := which('bash')):
+                echo.echo_critical('Could not find bash executable')
             localhost = prepare_localhost()
             code = InstalledCode(
                 label='bash',
                 computer=localhost,
-                filepath_executable=which('bash'),
+                filepath_executable=bash_path,
                 default_calc_job_plugin=default_calc_job_plugin,
             ).store()
         else:
             assert code.default_calc_job_plugin == default_calc_job_plugin
 
-    multiply_add = WorkflowFactory('core.arithmetic.multiply_add')
     inputs = {
         'x': Int(1),
         'y': Int(1),
@@ -225,10 +231,10 @@ def devel_launch_multiply_add(code, daemon):
     }
 
     if daemon:
-        node = submit(multiply_add, inputs=inputs)
+        node = submit(MultiplyAddWorkChain, inputs=inputs)
         echo.echo_success(f'Submitted workflow `{node}`')
     else:
-        _, node = run_get_node(multiply_add, inputs)
+        _, node = run_get_node(MultiplyAddWorkChain, inputs)
         if node.is_finished_ok:
             echo.echo_success(f'MultiplyAddWorkChain<{node.pk}> finished successfully.')
         else:

--- a/src/aiida/cmdline/commands/cmd_group.py
+++ b/src/aiida/cmdline/commands/cmd_group.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """`verdi group` commands"""
 
+from typing import Any
+
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -65,8 +67,8 @@ def group_remove_nodes(group, nodes, clear, force):
                 echo.echo_critical(f'None of the specified nodes are in {group}.')
 
             if len(node_pks) > len(group_node_pks):
-                node_pks = set(node_pks).difference(set(group_node_pks))
-                echo.echo_warning(f'{len(node_pks)} nodes with PK {node_pks} are not in {group}.')
+                nodes_not_in_group = set(node_pks).difference(set(group_node_pks))
+                echo.echo_warning(f'{len(nodes_not_in_group)} nodes with PK {nodes_not_in_group} are not in {group}.')
 
             message = f'Are you sure you want to remove {len(group_node_pks)} nodes from {group}?'
 
@@ -105,7 +107,7 @@ def group_move_nodes(source_group, target_group, force, nodes, all_entries):
         else:
             echo.echo_critical('Neither NODES or the `-a, --all` option was specified.')
 
-    node_pks = [node.pk for node in nodes]
+    node_pks = {node.pk for node in nodes}
 
     if not all_entries:
         query = QueryBuilder()
@@ -214,7 +216,7 @@ def group_delete(
         from aiida.common.escaping import escape_for_sql_like
 
         builder = orm.QueryBuilder()
-        filters = {}
+        filters: dict[str, Any] = {}
 
         # Note: we could have set 'core' as a default value for type_string,
         # but for the sake of uniform interface, we decided to keep the default value of None.
@@ -248,7 +250,9 @@ def group_delete(
             user_email = user.email
         else:
             # By default: only groups of this user
-            user_email = orm.User.collection.get_default().email
+            if not (default_user := orm.User.collection.get_default()):
+                echo.echo_critical('Could not get default user')
+            user_email = default_user.email
 
         # Query groups that belong to all users
         if not all_users:
@@ -465,7 +469,7 @@ def group_list(
     from aiida.common.escaping import escape_for_sql_like
 
     builder = orm.QueryBuilder()
-    filters = {}
+    filters: dict[str, Any] = {}
 
     if not all_entries:
         if '%' in type_string or '_' in type_string:
@@ -493,7 +497,9 @@ def group_list(
         user_email = user.email
     else:
         # By default: only groups of this user
-        user_email = orm.User.collection.get_default().email
+        if not (default_user := orm.User.collection.get_default()):
+            echo.echo_critical('Could not get default user')
+        user_email = default_user.email
 
     # Query groups that belong to all users
     if not all_users:

--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -8,8 +8,11 @@
 ###########################################################################
 """`verdi node` command."""
 
+from __future__ import annotations
+
 import datetime
 import pathlib
+from typing import TYPE_CHECKING
 
 import click
 
@@ -21,6 +24,9 @@ from aiida.cmdline.utils import decorators, echo, echo_tabulate, multi_line_inpu
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common import exceptions, timezone
 from aiida.common.links import GraphTraversalRules
+
+if TYPE_CHECKING:
+    from aiida.orm import Node
 
 
 @verdi.group('node')
@@ -270,7 +276,7 @@ def node_show(nodes, print_groups):
                 echo_tabulate(table, headers=['PK', 'Label', 'Group type'])
 
 
-def echo_node_dict(nodes, keys, fmt, identifier, raw, use_attrs=True):
+def echo_node_dict(nodes: list[Node], keys: list, fmt: str, identifier: str, raw: bool, use_attrs: bool = True) -> None:
     """Show the attributes or extras of one or more nodes."""
     all_nodes = []
     for node in nodes:
@@ -279,7 +285,7 @@ def echo_node_dict(nodes, keys, fmt, identifier, raw, use_attrs=True):
             id_value = node.pk
         else:
             id_name = 'UUID'
-            id_value = node.uuid
+            id_value = node.uuid  # type: ignore[assignment]
 
         if use_attrs:
             node_dict = node.base.attributes.all
@@ -439,7 +445,7 @@ def rehash(nodes, entry_point, force):
 
     # If no explicit entry point is defined, rehash all nodes, which are either Data nodes or ProcessNodes
     if entry_point is None:
-        classes = (Data, ProcessNode)
+        classes: tuple = (Data, ProcessNode)
     else:
         classes = (entry_point,)
 
@@ -464,7 +470,7 @@ def rehash(nodes, entry_point, force):
     else:
         builder = QueryBuilder()
         builder.append(classes, tag='node')
-        to_hash = builder.iterall()
+        to_hash = builder.iterall()  # type: ignore[assignment]
         num_nodes = builder.count()
 
     if not num_nodes:

--- a/src/aiida/cmdline/commands/cmd_shell.py
+++ b/src/aiida/cmdline/commands/cmd_shell.py
@@ -13,7 +13,7 @@ import os
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils import decorators
 from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 
 
@@ -28,7 +28,7 @@ from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 @click.option(
     '-i',
     '--interface',
-    type=click.Choice(AVAILABLE_SHELLS.keys()),
+    type=click.Choice(AVAILABLE_SHELLS.keys()),  # type: ignore[arg-type]
     help='Specify an interactive interpreter interface.',
 )
 def shell(plain, no_startup, interface):
@@ -38,10 +38,6 @@ def shell(plain, no_startup, interface):
             # Don't bother loading IPython, because the user wants plain Python.
             raise ImportError
 
-        # If a non-plain python interpreter is requested, check that there is at least one type of shell available
-        if not AVAILABLE_SHELLS:
-            echo.echo_critical('No shells are available')
-
         run_shell(interface=interface)
     except ImportError:
         import code
@@ -49,7 +45,7 @@ def shell(plain, no_startup, interface):
         # Set up a dictionary to serve as the environment for the shell, so
         # that tab completion works on objects that are imported at runtime.
         # See ticket 5082.
-        imported_objects = {}
+        imported_objects = {}  # type: ignore[var-annotated]
         try:  # Try activating rlcompleter, because it's handy.
             import readline
         except ImportError:

--- a/src/aiida/cmdline/commands/cmd_storage.py
+++ b/src/aiida/cmdline/commands/cmd_storage.py
@@ -40,6 +40,8 @@ def storage_version():
 
     try:
         profile = get_profile()
+        if profile is None:
+            echo.echo_critical('Could not load default profile')
         head_version = profile.storage_cls.version_head()
         profile_version = profile.storage_cls.version_profile(profile)
         echo.echo(f'Latest storage schema version: {head_version!r}')
@@ -69,6 +71,8 @@ def storage_migrate(force):
 
     manager = get_manager()
     profile = manager.get_profile()
+    if profile is None:
+        echo.echo_critical('Could not load default profile')
 
     if profile.process_control_backend:
         client = get_daemon_client()
@@ -100,7 +104,6 @@ def storage_migrate(force):
         except click.Abort:
             echo.echo('\n')
             echo.echo_critical('Migration aborted, the data has not been affected.')
-            return
 
     try:
         storage_cls.migrate(profile)
@@ -187,7 +190,7 @@ def storage_maintain(ctx, full, no_repack, force, dry_run, compress):
     if not dry_run and not force and not click.confirm('Are you sure you want continue in this mode?'):
         return
 
-    if STORAGE_LOGGER.level <= logging.REPORT:
+    if STORAGE_LOGGER.level <= logging.REPORT:  # type: ignore[attr-defined]
         # Only keep the first tqdm bar if it is info. To keep the nested bar information one needs report level
         set_progress_bar_tqdm(leave=STORAGE_LOGGER.level <= logging.INFO)
     else:

--- a/src/aiida/tools/groups/paths.py
+++ b/src/aiida/tools/groups/paths.py
@@ -179,7 +179,7 @@ class GroupPath:
         query = orm.QueryBuilder()
         filters = {'label': self.path}
         query.append(self.cls, subclassing=False, filters=filters, project='id')
-        return query.all(flat=True)  # type: ignore[return-value]
+        return query.all(flat=True)
 
     @property
     def is_virtual(self) -> bool:

--- a/src/aiida/tools/groups/paths.py
+++ b/src/aiida/tools/groups/paths.py
@@ -8,11 +8,13 @@
 ###########################################################################
 """Provides functionality for managing large numbers of AiiDA Groups, via label delimitation."""
 
+from __future__ import annotations
+
 import re
 import warnings
 from collections import namedtuple
 from functools import total_ordering
-from typing import Any, Iterator, List, Optional, Tuple
+from typing import Any, Iterator
 
 from aiida import orm
 from aiida.common.exceptions import NotExistent
@@ -60,7 +62,9 @@ class GroupPath:
     See tests for usage examples.
     """
 
-    def __init__(self, path: str = '', cls: orm.groups.Group = orm.Group, warn_invalid_child: bool = True) -> None:
+    def __init__(
+        self, path: str = '', cls: type[orm.groups.Group] = orm.Group, warn_invalid_child: bool = True
+    ) -> None:
         """Instantiate the class.
 
         :param path: The initial path of the group.
@@ -77,7 +81,7 @@ class GroupPath:
         self._path_list = self._path_string.split(self._delimiter) if path else []
         self._warn_invalid_child = warn_invalid_child
 
-    def _validate_path(self, path):
+    def _validate_path(self, path: str) -> str:
         """Validate the supplied path."""
         if path == self._delimiter:
             return ''
@@ -109,12 +113,12 @@ class GroupPath:
         return self._path_string
 
     @property
-    def path_list(self) -> List[str]:
+    def path_list(self) -> list[str]:
         """Return a list of the path components."""
         return self._path_list[:]
 
     @property
-    def key(self) -> Optional[str]:
+    def key(self) -> str | None:
         """Return the final component of the the path."""
         if self._path_list:
             return self._path_list[-1]
@@ -126,12 +130,12 @@ class GroupPath:
         return self._delimiter
 
     @property
-    def cls(self) -> orm.groups.Group:
+    def cls(self) -> type[orm.groups.Group]:
         """Return the cls used to query for and instantiate a ``Group`` with."""
         return self._cls
 
     @property
-    def parent(self) -> Optional['GroupPath']:
+    def parent(self) -> GroupPath | None:
         """Return the parent path."""
         if self.path_list:
             return GroupPath(
@@ -155,7 +159,7 @@ class GroupPath:
         """Return a child ``GroupPath``, with a new path formed by appending ``path`` to the current path."""
         return self.__truediv__(path)
 
-    def get_group(self) -> Optional['GroupPath']:
+    def get_group(self) -> GroupPath | None:
         """Return the concrete group associated with this path."""
         try:
             return orm.QueryBuilder().append(self.cls, subclassing=False, filters={'label': self.path}).one()[0]
@@ -163,7 +167,7 @@ class GroupPath:
             return None
 
     @property
-    def group_ids(self) -> List[int]:
+    def group_ids(self) -> list[int]:
         """Return all the UUID associated with this GroupPath.
 
         :returns: and empty list, if no group associated with this label,
@@ -175,18 +179,18 @@ class GroupPath:
         query = orm.QueryBuilder()
         filters = {'label': self.path}
         query.append(self.cls, subclassing=False, filters=filters, project='id')
-        return query.all(flat=True)
+        return query.all(flat=True)  # type: ignore[return-value]
 
     @property
     def is_virtual(self) -> bool:
         """Return whether there is one or more concrete groups associated with this path."""
         return len(self.group_ids) == 0
 
-    def get_or_create_group(self) -> Tuple[orm.Group, bool]:
+    def get_or_create_group(self) -> tuple[orm.Group, bool]:
         """Return the concrete group associated with this path or, create it, if it does not already exist."""
         return self.cls.collection.get_or_create(label=self.path)
 
-    def delete_group(self):
+    def delete_group(self) -> None:
         """Delete the concrete group associated with this path.
 
         :raises: GroupNotFoundError, GroupNotUniqueError
@@ -248,7 +252,7 @@ class GroupPath:
                     yield sub_child
 
     def walk_nodes(
-        self, filters: Optional[dict] = None, node_class: Optional[orm.Node] = None, query_batch: Optional[int] = None
+        self, filters: dict | None = None, node_class: type[orm.Node] | None = None, query_batch: int | None = None
     ) -> Iterator[WalkNodeResult]:
         """Recursively iterate through all nodes of this path and its children.
 
@@ -273,7 +277,7 @@ class GroupPath:
             yield WalkNodeResult(GroupPath(label, cls=self.cls), node)
 
     @property
-    def browse(self):
+    def browse(self) -> GroupAttr:
         """Return a ``GroupAttr`` instance, for attribute access to children."""
         return GroupAttr(self)
 
@@ -303,7 +307,7 @@ class GroupAttr:
         """Return the ``GroupPath``."""
         return self._group_path
 
-    def __dir__(self):
+    def __dir__(self) -> list[Any]:
         """Return a list of available attributes."""
         return [c.path_list[-1] for c in self._group_path.children if REGEX_ATTR.match(c.path_list[-1])]
 


### PR DESCRIPTION
Based on top of #6954 

This completes the typing of the `aiida.cmdline` module. :tada: 

NOTE: There are somewhat more "type: ignore"s than I'd like, but at the same time all these files are specific to individual verdi commands, and are not imported anywhere, and therefore this doesn't weaken the typing anywhere else.