### PR TITLE
Mark orm.entities.Entity/Comment classes as generic in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -475,6 +475,11 @@ select = [
   'NPY201'  # numpy compatibility
 ]
 
+# Mark some classes as generic, per https://docs.astral.sh/ruff/settings/#lint_pyflakes_extend-generics
+# Needed due to https://github.com/astral-sh/ruff/issues/9298
+[tool.ruff.lint.pyflakes]
+extend-generics = ["aiida.orm.entities.Entity", "aiida.orm.entities.Collection"]
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/src/aiida/orm/authinfos.py
+++ b/src/aiida/orm/authinfos.py
@@ -23,7 +23,7 @@ from .users import User
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import StorageBackend
-    from aiida.orm.implementation.authinfos import BackendAuthInfo  # noqa: F401
+    from aiida.orm.implementation.authinfos import BackendAuthInfo
     from aiida.transports import Transport
 
 __all__ = ('AuthInfo',)

--- a/src/aiida/orm/comments.py
+++ b/src/aiida/orm/comments.py
@@ -17,7 +17,7 @@ from aiida.manage import get_manager
 from . import entities
 
 if TYPE_CHECKING:
-    from aiida.orm.implementation import StorageBackend
+    from aiida.orm.implementation import BackendComment, StorageBackend
 
     from .nodes.node import Node
     from .users import User

--- a/src/aiida/orm/computers.py
+++ b/src/aiida/orm/computers.py
@@ -21,7 +21,7 @@ from . import entities, users
 
 if TYPE_CHECKING:
     from aiida.orm import AuthInfo, User
-    from aiida.orm.implementation import StorageBackend
+    from aiida.orm.implementation import BackendComputer, StorageBackend
     from aiida.schedulers import Scheduler
     from aiida.transports import Transport
 

--- a/src/aiida/orm/groups.py
+++ b/src/aiida/orm/groups.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
     from aiida.orm import Node, User
     from aiida.orm.implementation import StorageBackend
-    from aiida.orm.implementation.groups import BackendGroup  # noqa: F401
+    from aiida.orm.implementation.groups import BackendGroup
 
 __all__ = ('AutoGroup', 'Group', 'ImportGroup', 'UpfFamily')
 

--- a/src/aiida/orm/logs.py
+++ b/src/aiida/orm/logs.py
@@ -21,7 +21,7 @@ from . import entities
 if TYPE_CHECKING:
     from aiida.orm import Node
     from aiida.orm.implementation import StorageBackend
-    from aiida.orm.implementation.logs import BackendLog  # noqa: F401
+    from aiida.orm.implementation.logs import BackendLog
     from aiida.orm.querybuilder import FilterType, OrderByType
 
 __all__ = ('ASCENDING', 'DESCENDING', 'Log', 'OrderSpecifier')

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from aiida.common.log import AiidaLoggerType
 
     from ..implementation import StorageBackend
-    from ..implementation.nodes import BackendNode  # noqa: F401
+    from ..implementation.nodes import BackendNode
     from .repository import NodeRepository
 
 __all__ = ('Node',)

--- a/src/aiida/orm/users.py
+++ b/src/aiida/orm/users.py
@@ -18,7 +18,7 @@ from . import entities
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import StorageBackend
-    from aiida.orm.implementation.users import BackendUser  # noqa: F401
+    from aiida.orm.implementation.users import BackendUser
 
 __all__ = ('User',)
 


### PR DESCRIPTION
This is needed because otherwise ruff gets confused, see https://github.com/astral-sh/ruff/issues/9298 for detailed explanation.

This allows us to get rid of bunch of noqa's. :tada: 

Split from #6704 