### PR TITLE
Add more stub packages for type checking of 3rd party packages

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -204,6 +204,7 @@ py:class RmqThreadCommunicator
 py:class _asyncio.Future
 
 py:class tqdm.std.tqdm
+py:class tqdm
 
 py:class _pytest.tmpdir.TempPathFactory
 py:class pytest.tmpdir.TempPathFactory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
   'Programming Language :: Python :: 3.13',
   'Topic :: Scientific/Engineering'
 ]
+# NOTE: When updating versions of some packages, such as requests or paramiko,
+# you need to also update the versions of corresponding stub packages
+# in the 'pre-commit' group e.g. 'types-requests'
 dependencies = [
   'alembic~=1.8',
   'archive-path~=0.4.2',
@@ -229,6 +232,9 @@ notebook = [
   'jupyter~=1.0',
   'notebook~=6.1,>=6.1.5'
 ]
+# NOTE: THe versions of the `types-*` stubs packages should match
+# the versions of the actual packages see:
+# https://github.com/python/typeshed?tab=readme-ov-file#package-versioning-for-third-party-stubs
 pre-commit = [
   'aiida-core[atomic_tools,rest,tests,tui]',
   'mypy~=1.18.0',
@@ -236,7 +242,15 @@ pre-commit = [
   'pre-commit~=3.5',
   'sqlalchemy[mypy]~=2.0',
   'tomli',
-  'types-PyYAML'
+  'types-click-spinner~=0.1.8',
+  'types-docutils~=0.20',
+  'types-PyYAML~=6.0',
+  'types-paramiko~=3.0',
+  'types-psutil~=5.6',
+  'types-pytz~=2021.1',
+  'types-tabulate>=0.9.0,<0.10.0',
+  'types-tqdm~=4.45',
+  'types-requests~=2.0'
 ]
 rest = [
   'flask-cors~=3.0',
@@ -343,47 +357,18 @@ module = 'tests.*'
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  'ase.*',
-  'asyncssh.*',
   'bpython.*',
   'bs4.*',
-  'CifFile.*',
   'circus.*',
-  'click_spinner.*',
-  'docutils.*',
-  'flask_cors.*',
   'flask_restful.*',
   'get_annotations.*',
   'graphviz.*',
-  'importlib._bootstrap.*',
-  'IPython.*',
   'kiwipy.*',
-  'matplotlib.*',
   'mayavi.*',
-  'MySQLdb.*',
-  'numpy.*',
-  'paramiko.*',
   'pgsu.*',
   'pgtest.*',
-  'phonopy.*',
-  'psutil.*',
-  'psycopg.*',
-  'pymatgen.*',
-  'pymysql.*',
-  'pyparsing.*',
-  'pympler.*',
-  'pytz.*',
-  'requests.*',
-  'ruamel.*',
-  'scipy.*',
-  'seekpath.*',
-  'spglib.*',
-  'sphinxcontrib.details.*',
-  'tabulate.*',
-  'tqdm.*',
   'trogon.*',
-  'wrapt.*',
-  'upf_to_json.*'
+  'wrapt.*'
 ]
 
 [tool.pytest.ini_options]

--- a/src/aiida/common/progress_reporter.py
+++ b/src/aiida/common/progress_reporter.py
@@ -16,9 +16,14 @@ and indeed a valid implementation is::
 
 """
 
+from __future__ import annotations
+
 from functools import partial
 from types import TracebackType
-from typing import Any, Callable, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Type
+
+if TYPE_CHECKING:
+    from tqdm import tqdm
 
 __all__ = (
     'TQDM_BAR_FORMAT',
@@ -79,11 +84,11 @@ class ProgressReporterAbstract:
 
     def __exit__(
         self, exctype: Optional[Type[BaseException]], excinst: Optional[BaseException], exctb: Optional[TracebackType]
-    ):
+    ) -> Literal[False]:
         """Exit the contextmanager."""
         return False
 
-    def set_description_str(self, text: Optional[str] = None, refresh: bool = True):
+    def set_description_str(self, text: Optional[str] = None, refresh: bool = True) -> None:
         """Set the text shown by the progress reporter.
 
         :param text: The text to show
@@ -92,7 +97,7 @@ class ProgressReporterAbstract:
         """
         self._desc = text
 
-    def update(self, n: int = 1):
+    def update(self, n: int = 1) -> None:
         """Update the progress counter.
 
         :param n: Increment to add to the internal counter of iterations
@@ -100,7 +105,7 @@ class ProgressReporterAbstract:
         """
         self._increment += n
 
-    def reset(self, total: Optional[int] = None):
+    def reset(self, total: Optional[int] = None) -> None:
         """Resets current iterations to 0.
 
         :param total: If not None, update number of expected iterations.
@@ -118,10 +123,10 @@ class ProgressReporterNull(ProgressReporterAbstract):
     """
 
 
-PROGRESS_REPORTER: Type[ProgressReporterAbstract] = ProgressReporterNull
+PROGRESS_REPORTER: type[ProgressReporterAbstract] | type[tqdm[Any]] = ProgressReporterNull
 
 
-def get_progress_reporter() -> Type[ProgressReporterAbstract]:
+def get_progress_reporter() -> type[ProgressReporterAbstract] | type[tqdm[Any]]:
     """Return the progress reporter
 
     Example Usage::
@@ -136,7 +141,9 @@ def get_progress_reporter() -> Type[ProgressReporterAbstract]:
     return PROGRESS_REPORTER
 
 
-def set_progress_reporter(reporter: Optional[Type[ProgressReporterAbstract]] = None, **kwargs: Any):
+def set_progress_reporter(
+    reporter: type[ProgressReporterAbstract] | type[tqdm[Any]] | None = None, **kwargs: Any
+) -> None:
     """Set the progress reporter implementation
 
     :param reporter: A progress reporter for a process.  If None, reset to ``ProgressReporterNull``.
@@ -164,7 +171,9 @@ def set_progress_reporter(reporter: Optional[Type[ProgressReporterAbstract]] = N
         PROGRESS_REPORTER = reporter
 
 
-def set_progress_bar_tqdm(bar_format: Optional[str] = TQDM_BAR_FORMAT, leave: Optional[bool] = False, **kwargs: Any):
+def set_progress_bar_tqdm(
+    bar_format: Optional[str] = TQDM_BAR_FORMAT, leave: Optional[bool] = False, **kwargs: Any
+) -> None:
     """Set a `tqdm <https://github.com/tqdm/tqdm>`__ implementation of the progress reporter interface.
 
     See :func:`~aiida.common.progress_reporter.set_progress_reporter` for details.
@@ -180,7 +189,7 @@ def set_progress_bar_tqdm(bar_format: Optional[str] = TQDM_BAR_FORMAT, leave: Op
     set_progress_reporter(tqdm, bar_format=bar_format, leave=leave, **kwargs)
 
 
-def create_callback(progress_reporter: ProgressReporterAbstract) -> Callable[[str, Any], None]:
+def create_callback(progress_reporter: ProgressReporterAbstract | tqdm) -> Callable[[str, Any], None]:
     """Create a callback function to update the progress reporter.
 
     :returns: a callback to report on the process, ``callback(action, value)``,
@@ -193,7 +202,7 @@ def create_callback(progress_reporter: ProgressReporterAbstract) -> Callable[[st
 
     """
 
-    def _callback(action: str, value: Any):
+    def _callback(action: str, value: Any) -> None:
         if action == 'init':
             progress_reporter.reset(value['total'])
             progress_reporter.set_description_str(value['description'])

--- a/src/aiida/sphinxext/process.py
+++ b/src/aiida/sphinxext/process.py
@@ -156,7 +156,7 @@ class AiidaProcessDirective(SphinxDirective):
 
     def build_port_content(self, name, port):
         """Build the content that describes a single port."""
-        res = []
+        res: list = []
         res.append(addnodes.literal_strong(text=name))
         res.append(nodes.Text(', '))
         res.append(nodes.emphasis(text=self.format_valid_types(port.valid_type)))

--- a/src/aiida/tools/archive/create.py
+++ b/src/aiida/tools/archive/create.py
@@ -16,7 +16,7 @@ import shutil
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Iterable, Optional, Sequence, Union
+from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
 from tabulate import tabulate
 
@@ -757,11 +757,11 @@ def get_init_summary(
     compression: int,
 ) -> str:
     """Get summary for archive initialisation"""
-    parameters = [['Path', str(outfile)], ['Version', archive_version], ['Compression', compression]]
+    parameters: list[list[Any]] = [['Path', str(outfile)], ['Version', archive_version], ['Compression', compression]]
 
     result = f"\n{tabulate(parameters, headers=['Archive Parameters', ''])}"
 
-    inclusions = [
+    inclusions: list[list[Any]] = [
         ['Computers/Nodes/Groups/Users', 'All' if collect_all else 'Selected'],
         ['Computer Authinfos', include_authinfos],
         ['Node Comments', include_comments],

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,15 @@ pre-commit = [
     { name = "sqlalchemy", extra = ["mypy"] },
     { name = "tomli" },
     { name = "trogon" },
+    { name = "types-click-spinner" },
+    { name = "types-docutils" },
+    { name = "types-paramiko" },
+    { name = "types-psutil" },
+    { name = "types-pytz" },
     { name = "types-pyyaml" },
+    { name = "types-requests" },
+    { name = "types-tabulate" },
+    { name = "types-tqdm" },
 ]
 rest = [
     { name = "flask" },
@@ -249,7 +257,15 @@ requires-dist = [
     { name = "tomli", marker = "extra == 'pre-commit'" },
     { name = "tqdm", specifier = "~=4.45" },
     { name = "trogon", marker = "extra == 'tui'" },
-    { name = "types-pyyaml", marker = "extra == 'pre-commit'" },
+    { name = "types-click-spinner", marker = "extra == 'pre-commit'", specifier = "~=0.1.8" },
+    { name = "types-docutils", marker = "extra == 'pre-commit'", specifier = "~=0.20" },
+    { name = "types-paramiko", marker = "extra == 'pre-commit'", specifier = "~=3.0" },
+    { name = "types-psutil", marker = "extra == 'pre-commit'", specifier = "~=5.6" },
+    { name = "types-pytz", marker = "extra == 'pre-commit'", specifier = "~=2021.1" },
+    { name = "types-pyyaml", marker = "extra == 'pre-commit'", specifier = "~=6.0" },
+    { name = "types-requests", marker = "extra == 'pre-commit'", specifier = "~=2.0" },
+    { name = "types-tabulate", marker = "extra == 'pre-commit'", specifier = ">=0.9.0,<0.10.0" },
+    { name = "types-tqdm", marker = "extra == 'pre-commit'", specifier = "~=4.45" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = "~=4.1" },
     { name = "upf-to-json", specifier = "~=0.9.2" },
     { name = "wrapt", specifier = "~=1.11" },
@@ -5720,6 +5736,45 @@ wheels = [
 ]
 
 [[package]]
+name = "types-click-spinner"
+version = "0.1.13.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/5b/9657d649f78e57a5f1f74add406e6ed00b2e762a25092e45e6916a9618ff/types_click_spinner-0.1.13.20250809.tar.gz", hash = "sha256:0ef42f147e41ed5a3ecfc7435b0e64ba28e7a7185c9b917e9e321f5116c095b7", size = 8011, upload-time = "2025-08-09T03:15:48.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/75/e82b57de1a7a4b492d472f9ba40c107b4fd0ff2fae495b2d0edf8731bf54/types_click_spinner-0.1.13.20250809-py3-none-any.whl", hash = "sha256:16853f983f0a19916194ce5630190a893b7d71601ba27a2adbd2bb73a2fe1885", size = 8000, upload-time = "2025-08-09T03:15:48.098Z" },
+]
+
+[[package]]
+name = "types-docutils"
+version = "0.22.2.20250924"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/6d/60326ba08f44629f778937d5021a342da996682d932261d48b4043c437f7/types_docutils-0.22.2.20250924.tar.gz", hash = "sha256:a13fb412676c164edec7c2f26fe52ab7b0b7c868168dacc4298f6a8069298f3d", size = 56679, upload-time = "2025-09-24T02:53:26.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/2b/844f3a6e972515ef0890fd8bf631890b6d74c8eacb1acbf31a72820c3b45/types_docutils-0.22.2.20250924-py3-none-any.whl", hash = "sha256:a6d52e21fa70998d34d13db6891ea35920bbb20f91459ca528a3845fd0b9ec03", size = 91873, upload-time = "2025-09-24T02:53:24.824Z" },
+]
+
+[[package]]
+name = "types-paramiko"
+version = "3.5.0.20250801"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/c4/4df427c835e9c795662241410732ab936c6f58be798ec25ce7015771c448/types_paramiko-3.5.0.20250801.tar.gz", hash = "sha256:e79ff84eaf44f2a5ad811743edef5d9c0cd6632a264a526f00405b87db1ec99b", size = 28838, upload-time = "2025-08-01T03:48:52.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/5b/0f0bb1e45f7547d081ae9d490a88c6f6031d0f2c97459236e0a2a8b27207/types_paramiko-3.5.0.20250801-py3-none-any.whl", hash = "sha256:3e02a0fcf2b7e7b213e0cd569f7223ff9af417052a4d149d84172ebaa6fd742e", size = 39705, upload-time = "2025-08-01T03:48:51.855Z" },
+]
+
+[[package]]
+name = "types-psutil"
+version = "5.9.5.20240516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/41/5d3d2f7b7e819e85820eadececc121ab805c0cb4cab5d88defb0a37eabed/types-psutil-5.9.5.20240516.tar.gz", hash = "sha256:bb296f59fc56458891d0feb1994717e548a1bcf89936a2877df8792b822b4696", size = 14771, upload-time = "2024-05-16T02:21:20.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/b0/872fd0f7b3998f18447a49b0ebae95994c9f589c79443551030caa8f94f0/types_psutil-5.9.5.20240516-py3-none-any.whl", hash = "sha256:83146ded949a10167d9895e567b3b71e53ebc5e23fd8363eab62b3c76cce7b89", size = 18356, upload-time = "2024-05-16T02:21:18.398Z" },
+]
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20250708"
 source = { registry = "https://pypi.org/simple" }
@@ -5729,12 +5784,54 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pytz"
+version = "2021.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/17/2659c505bb3959a3af652a6927cf27c5e001ef70e60e890439b212750963/types-pytz-2021.3.8.tar.gz", hash = "sha256:41253a3a2bf028b6a3f17b58749a692d955af0f74e975de94f6f4d2d3cd01dbd", size = 3253, upload-time = "2022-05-07T09:18:46.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/1e/20eb34cec046272b2d8dc53cdfe1556a86869db69c96eda7472502a1a579/types_pytz-2021.3.8-py3-none-any.whl", hash = "sha256:aef4a917ab28c585d3f474bfce4f4b44b91e95d9d47d4de29dd845e0db8e3910", size = 3422, upload-time = "2022-05-07T09:18:45.197Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250516"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250913"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113, upload-time = "2025-09-13T02:40:02.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1", size = 20658, upload-time = "2025-09-13T02:40:01.115Z" },
+]
+
+[[package]]
+name = "types-tabulate"
+version = "0.9.0.20241207"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/43/16030404a327e4ff8c692f2273854019ed36718667b2993609dc37d14dd4/types_tabulate-0.9.0.20241207.tar.gz", hash = "sha256:ac1ac174750c0a385dfd248edc6279fa328aaf4ea317915ab879a2ec47833230", size = 8195, upload-time = "2024-12-07T02:54:42.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/86/a9ebfd509cbe74471106dffed320e208c72537f9aeb0a55eaa6b1b5e4d17/types_tabulate-0.9.0.20241207-py3-none-any.whl", hash = "sha256:b8dad1343c2a8ba5861c5441370c3e35908edd234ff036d4298708a1d4cf8a85", size = 8307, upload-time = "2024-12-07T02:54:41.031Z" },
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.67.0.20250809"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d0/cf498fc630d9fdaf2428b93e60b0e67b08008fec22b78716b8323cf644dc/types_tqdm-4.67.0.20250809.tar.gz", hash = "sha256:02bf7ab91256080b9c4c63f9f11b519c27baaf52718e5fdab9e9606da168d500", size = 17200, upload-time = "2025-08-09T03:17:43.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/13/3ff0781445d7c12730befce0fddbbc7a76e56eb0e7029446f2853238360a/types_tqdm-4.67.0.20250809-py3-none-any.whl", hash = "sha256:1a73053b31fcabf3c1f3e2a9d5ecdba0f301bde47a418cd0e0bdf774827c5c57", size = 24020, upload-time = "2025-08-09T03:17:42.453Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Some python packages do not contain types, but they have separate "stub" packages that provide type information for them. It is much better to install these stub packages to have a stronger type-checking of code that uses these libraries. 