### PR TITLE
devops: Remove flynt hook from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,6 @@ repos:
   hooks:
   - id: check-github-workflows
 
-- repo: https://github.com/ikamensh/flynt/
-  rev: 1.0.1
-  hooks:
-  - id: flynt
-    args: [--line-length=120, --fail-on-change]
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.8.6
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,6 +472,7 @@ select = [
   'PLR',  # pylint-refactor
   'PLW',  # pylint-warning
   'RUF',  # ruff
+  'FLY',  # flynt
   'NPY201'  # numpy compatibility
 ]
 

--- a/src/aiida/orm/users.py
+++ b/src/aiida/orm/users.py
@@ -93,7 +93,7 @@ class User(entities.Entity['BackendUser', UserCollection]):
         except ValueError:
             pass
         else:
-            email = '@'.join([email_name, domain_part.lower()])
+            email = f'{email_name}@{domain_part.lower()}'
         return email
 
     @property

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -199,7 +199,7 @@ def test_noninteractive_upload(run_cli_command, non_interactive_editor):
 def test_interactive_remote(run_cli_command, aiida_localhost, non_interactive_editor):
     """Test interactive remote code setup."""
     label = 'interactive_remote'
-    user_input = '\n'.join(['yes', aiida_localhost.label, label, 'desc', 'core.arithmetic.add', '/remote/path', 'y'])
+    user_input = '\n'.join(['yes', aiida_localhost.label, label, 'desc', 'core.arithmetic.add', '/remote/path', 'y'])  # noqa: FLY002
     run_cli_command(cmd_code.setup_code, user_input=user_input)
     assert isinstance(load_code(label), InstalledCode)
 
@@ -210,7 +210,7 @@ def test_interactive_upload(run_cli_command, non_interactive_editor):
     label = 'interactive_upload'
     dirname = os.path.dirname(__file__)
     basename = os.path.basename(__file__)
-    user_input = '\n'.join(['no', label, 'description', 'core.arithmetic.add', dirname, basename, 'y'])
+    user_input = '\n'.join(['no', label, 'description', 'core.arithmetic.add', dirname, basename, 'y'])  # noqa: FLY002
     run_cli_command(cmd_code.setup_code, user_input=user_input)
     assert isinstance(load_code(label), PortableCode)
 
@@ -220,7 +220,7 @@ def test_mixed(run_cli_command, aiida_localhost, non_interactive_editor):
     """Test mixed (interactive/from config) code setup."""
     label = 'mixed_remote'
     options = ['--description=description', '--on-computer', '--remote-abs-path=/remote/path']
-    user_input = '\n'.join([aiida_localhost.label, label, 'core.arithmetic.add', 'y'])
+    user_input = '\n'.join([aiida_localhost.label, label, 'core.arithmetic.add', 'y'])  # noqa: FLY002
     run_cli_command(cmd_code.setup_code, options, user_input=user_input)
     assert isinstance(load_code(label), InstalledCode)
 
@@ -410,7 +410,7 @@ def test_code_setup_remote_duplicate_full_label_interactive(
     assert isinstance(load_code(label), InstalledCode)
 
     label_unique = 'label-unique'
-    user_input = '\n'.join(
+    user_input = '\n'.join(  # noqa: FLY002
         ['yes', aiida_localhost.label, label, label_unique, 'd', 'core.arithmetic.add', '/bin/bash', 'y']
     )
     run_cli_command(cmd_code.setup_code, user_input=user_input)

--- a/tests/orm/nodes/data/test_upf.py
+++ b/tests/orm/nodes/data/test_upf.py
@@ -6,6 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# ruff: noqa: FLY002
 """This module contains tests for UpfData and UpfData related functions."""
 
 import json

--- a/tests/tools/archive/migration/test_prov_redesign.py
+++ b/tests/tools/archive/migration/test_prov_redesign.py
@@ -201,7 +201,7 @@ def test_group_name_and_type_change(tmp_path, aiida_profile):
     groups_label = ['Users', 'UpfData']
     upf_filename = 'Al.test_file.UPF'
     # regular upf file version 2 header
-    upf_contents = '\n'.join(
+    upf_contents = '\n'.join(  # noqa: FLY002
         [
             '<UPF version="2.0.1">',
             'Human readable section is completely irrelevant for parsing!',


### PR DESCRIPTION
Most of the rules from the flynt linter (encourages usage of f-strings) are implemented in ruff ([FLY category](https://docs.astral.sh/ruff/rules/#flynt-fly)) so let's just use that since ruff is much faster.

Interestingly, ruff seems to be better at identifying more places that could be converted into f-strings. However, in many of the new cases I felt the current code is more readable, so I just added a `noqa` comment.