### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Introduction of ruff as new linter and formatter (#6233)
+64c5e6a82d8bb515d07fea84b611dc35cce1263b


### PR DESCRIPTION
Commits listed in this file are ignored when doing `git blame`, such that automatic formatting changes (such as the introduction of ruff in #6233) don't obfuscate the origin of the actual code changes.

Ping @danielhollas 