### PR TITLE
Add check-added-large-files pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: v5.0.0
   hooks:
   - id: check-merge-conflict
+  - id: check-added-large-files
   - id: check-yaml
   - id: double-quote-string-fixer
   - id: end-of-file-fixer


### PR DESCRIPTION
This hooks forbids commiting large files (by default >0.5Mb). If such files need to be added, simply run `git commit --no-verify`.

```console
❯ cp tests/data/50k-int-nodes-2.7.1.post0.aiida .
❯ git add 50k-int-nodes-2.7.1.post0.aiida 
❯ pre-commit run
check for merge conflicts................................................Passed
check for added large files..............................................Failed
- hook id: check-added-large-files
- exit code: 1

50k-int-nodes-2.7.1.post0.aiida (9389 KB) exceeds 500 KB.

```