### PR TITLE
Add dev dependency group

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -8,9 +8,7 @@ inputs:
     required: false
   extras:
     description: list of optional dependencies
-    # NOTE: The default 'pre-commit' extra recursively contains
-    # other extras needed to run the tests.
-    default: pre-commit
+    default: ''
     required: false
   # NOTE: Hard-learned lesson: we cannot use type=boolean here, apparently :-(
   # https://stackoverflow.com/a/76294014

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -113,6 +113,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         from-lock: 'false'
+        extras: tests
         resolution-strategy: lowest-direct
 
     - name: Setup SSH on localhost

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,6 @@
 name: pre-commit
 # NOTE: This job is not duplicating pre-commit.ci job,
-# since that once skips running mypy type-checking\
+# since that once skips running mypy type-checking
 # due to technical limitations of pre-commit.ci runners.
 
 on:
@@ -27,6 +27,7 @@ jobs:
       with:
         python-version: '3.11'
         from-lock: 'true'
+        extras: pre-commit
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,13 @@
 build-backend = 'flit_core.buildapi'
 requires = ['flit_core >=3.4,<4']
 
+# The "dev" dependency group is automatically synced by uv
+# and should thus contain all necessary deps for local development.
+[dependency-groups]
+dev = [
+  "aiida-core[atomic_tools,rest,tests,pre-commit,tests,docs]"
+]
+
 [project]
 authors = [{name = 'The AiiDA team', email = 'developers@aiida.net'}]
 classifiers = [
@@ -236,7 +243,7 @@ notebook = [
 # the versions of the actual packages see:
 # https://github.com/python/typeshed?tab=readme-ov-file#package-versioning-for-third-party-stubs
 pre-commit = [
-  'aiida-core[atomic_tools,rest,tests,tui]',
+  'aiida-core[tests]',
   'mypy~=1.18.0',
   'packaging~=23.0',
   'pre-commit~=3.5',
@@ -265,6 +272,7 @@ ssh_kerberos = [
   'pyasn1~=0.4.8'
 ]
 tests = [
+  'aiida-core[atomic_tools,rest]',
   'aiida-export-migration-tests==0.9.0',
   'pg8000~=1.13',
   'pgtest~=1.3,>=1.3.1',

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,6 @@ pre-commit = [
     { name = "sphinx" },
     { name = "sqlalchemy", extra = ["mypy"] },
     { name = "tomli" },
-    { name = "trogon" },
     { name = "types-click-spinner" },
     { name = "types-docutils" },
     { name = "types-paramiko" },
@@ -157,11 +156,22 @@ ssh-kerberos = [
 ]
 tests = [
     { name = "aiida-export-migration-tests" },
+    { name = "ase" },
     { name = "coverage" },
     { name = "docutils" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "flask-restful" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pg8000" },
     { name = "pgtest" },
+    { name = "pycifrw" },
+    { name = "pymatgen", version = "2024.8.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pymatgen", version = "2025.6.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pympler" },
+    { name = "pymysql" },
+    { name = "pyparsing" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
@@ -170,15 +180,24 @@ tests = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "python-memcached" },
+    { name = "seekpath" },
+    { name = "spglib" },
     { name = "sphinx" },
 ]
 tui = [
     { name = "trogon" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "aiida-core", extra = ["atomic-tools", "docs", "pre-commit", "rest", "tests"] },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "aiida-core", extras = ["atomic-tools", "rest", "tests", "tui"], marker = "extra == 'pre-commit'" },
+    { name = "aiida-core", extras = ["atomic-tools", "rest"], marker = "extra == 'tests'" },
+    { name = "aiida-core", extras = ["tests"], marker = "extra == 'pre-commit'" },
     { name = "aiida-export-migration-tests", marker = "extra == 'tests'", specifier = "==0.9.0" },
     { name = "alembic", specifier = "~=1.8" },
     { name = "archive-path", specifier = "~=0.4.2" },
@@ -271,6 +290,9 @@ requires-dist = [
     { name = "wrapt", specifier = "~=1.11" },
 ]
 provides-extras = ["atomic-tools", "bpython", "docs", "notebook", "pre-commit", "rest", "ssh-kerberos", "tests", "tui"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "aiida-core", extras = ["atomic-tools", "rest", "tests", "pre-commit", "tests", "docs"] }]
 
 [[package]]
 name = "aiida-export-migration-tests"


### PR DESCRIPTION
uv will install development dependencies from "dev" dependency group by default. This includes testing, pre-commit, and docs dependencies to simplify the development process.

### Test plan

1. Clone a fresh repo
2. Run `uv run pytest tests/test_conftest.py` and it should work