### PR TITLE
[CLI]: make top-level `verdi` pluginable via entry points

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -80,8 +80,7 @@ Below is a list with all available subcommands.
       list       List the available codes.
       relabel    Relabel a code.
       reveal     Reveal one or more hidden codes in `verdi code list`.
-      setup      Setup a new code (use `verdi code create`). (DEPRECATED: Please use `verdi
-                 code create` instead.)
+      setup      (Deprecated) Setup a new code (use `verdi code create`).
       show       Display detailed information for a code.
       test       Run tests for the given code to check whether it is usable.
 
@@ -402,8 +401,7 @@ Below is a list with all available subcommands.
       dump                Dump all data in an AiiDA profile's storage to disk.
       list                Display a list of all available profiles.
       set-default         Set a profile as the default profile.
-      setdefault          Set a profile as the default profile. (DEPRECATED: Please use `verdi
-                          profile set-default` instead.)
+      setdefault          (Deprecated) Set a profile as the default profile.
       setup               Set up a new profile.
       show                Show details for a profile.
 
@@ -417,9 +415,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Setup a new profile in a fully automated fashion. (DEPRECATED: This command is
-      deprecated. For a fully automated alternative, use `verdi presto --use-postgres`
-      instead. For full control, use `verdi profile setup core.psql_dos`.)
+      (Deprecated) Setup a new profile in a fully automated fashion.
 
     Options:
       -n, --non-interactive / -I, --interactive
@@ -457,7 +453,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.  [default: ""]
+                                      leading forward slash.
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.
@@ -523,10 +519,10 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      Setup a new profile (use `verdi profile setup`).
+      (Deprecated) Setup a new profile (use `verdi profile setup`).
 
       This method assumes that an empty PSQL database has been created and that the database
-      user has been created. (DEPRECATED: Please use `verdi profile setup` instead.)
+      user has been created.
 
     Options:
       -n, --non-interactive / -I, --interactive

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -80,7 +80,8 @@ Below is a list with all available subcommands.
       list       List the available codes.
       relabel    Relabel a code.
       reveal     Reveal one or more hidden codes in `verdi code list`.
-      setup      (Deprecated) Setup a new code (use `verdi code create`).
+      setup      Setup a new code (use `verdi code create`). (DEPRECATED: Please use `verdi
+                 code create` instead.)
       show       Display detailed information for a code.
       test       Run tests for the given code to check whether it is usable.
 
@@ -401,7 +402,8 @@ Below is a list with all available subcommands.
       dump                Dump all data in an AiiDA profile's storage to disk.
       list                Display a list of all available profiles.
       set-default         Set a profile as the default profile.
-      setdefault          (Deprecated) Set a profile as the default profile.
+      setdefault          Set a profile as the default profile. (DEPRECATED: Please use `verdi
+                          profile set-default` instead.)
       setup               Set up a new profile.
       show                Show details for a profile.
 
@@ -415,7 +417,9 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      (Deprecated) Setup a new profile in a fully automated fashion.
+      Setup a new profile in a fully automated fashion. (DEPRECATED: This command is
+      deprecated. For a fully automated alternative, use `verdi presto --use-postgres`
+      instead. For full control, use `verdi profile setup core.psql_dos`.)
 
     Options:
       -n, --non-interactive / -I, --interactive
@@ -453,7 +457,7 @@ Below is a list with all available subcommands.
       --broker-host HOSTNAME          Hostname for the message broker.  [default: 127.0.0.1]
       --broker-port INTEGER           Port for the message broker.  [default: 5672]
       --broker-virtual-host TEXT      Name of the virtual host for the message broker without
-                                      leading forward slash.
+                                      leading forward slash.  [default: ""]
       --repository DIRECTORY          Absolute path to the file repository.
       --test-profile                  Designate the profile to be used for running the test
                                       suite only.
@@ -519,10 +523,10 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS]
 
-      (Deprecated) Setup a new profile (use `verdi profile setup`).
+      Setup a new profile (use `verdi profile setup`).
 
       This method assumes that an empty PSQL database has been created and that the database
-      user has been created.
+      user has been created. (DEPRECATED: Please use `verdi profile setup` instead.)
 
     Options:
       -n, --non-interactive / -I, --interactive

--- a/src/aiida/cmdline/commands/cmd_verdi.py
+++ b/src/aiida/cmdline/commands/cmd_verdi.py
@@ -12,12 +12,14 @@ import click
 
 from aiida import __version__
 
-from ..groups import VerdiCommandGroup
 from ..params import options, types
+from ..utils.pluginable import Pluginable
 
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
-@click.group(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
+@click.group(
+    cls=Pluginable, entry_point_group='aiida.cmdline.verdi', context_settings={'help_option_names': ['--help', '-h']}
+)
 @options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
 @options.VERBOSITY()
 @click.version_option(__version__, package_name='aiida_core', message='AiiDA version %(version)s')

--- a/src/aiida/cmdline/utils/pluginable.py
+++ b/src/aiida/cmdline/utils/pluginable.py
@@ -29,7 +29,7 @@ class Pluginable(VerdiCommandGroup):
         if not self._exclude_external_plugins:
             subcommands.extend(get_entry_point_names(self._entry_point_group))
 
-        return subcommands
+        return sorted(subcommands)
 
     def get_command(self, ctx, name):
         """Try to load a subcommand from entry points, else defer to super."""

--- a/src/aiida/plugins/entry_point.py
+++ b/src/aiida/plugins/entry_point.py
@@ -87,6 +87,7 @@ ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP = {
     'aiida.cmdline.computer.configure': 'aiida.cmdline.computer.configure',
     'aiida.cmdline.data': 'aiida.cmdline.data',
     'aiida.cmdline.data.structure.import': 'aiida.cmdline.data.structure.import',
+    'aiida.cmdline.verdi': 'aiida.cmdline.verdi',
     'aiida.data': 'aiida.orm.nodes.data',
     'aiida.groups': 'aiida.orm.groups',
     'aiida.orm': 'aiida.orm',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -765,8 +765,7 @@ def run_cli_command_runner(command, parameters, user_input, initialize_ctx_obj, 
     """Run CLI command through ``click.testing.CliRunner``."""
     from click.testing import CliRunner
 
-    from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup
-    from aiida.cmdline.groups.verdi import LazyVerdiObjAttributeDict
+    from aiida.cmdline.groups.verdi import LazyVerdiObjAttributeDict, VerdiCommandGroup
 
     if initialize_ctx_obj:
         config = get_config()


### PR DESCRIPTION
#### Why is this change needed?
Two new possible use-cases require top-level `verdi` extensibility:
- Introducing a new `aiida-gui` package that should expose `verdi gui`.
- The new aiida-restapi package that may need to expose the new `restapi`

#### This PR
mirrors the same pattern used by `verdi data`:
- Declares the `verdi` Click group with `cls=Pluginable` and `entry_point_group="aiida.cmdline.verdi"`.
- Enables external packages to contribute first-level commands (e.g. `verdi gui`) without touching aiida-core.

#### Affect on the performance of `verdi`
One concern is that loading the entry point from the plugins will cause `verdi` to have a slow response.

Benchmark: `verdi --help` measured with and without this change shows an additional ~50 ms on average in my environment. This overhead is negligible compared to the benefits. Thanks @danielhollas  for the tip.

<img width="807" height="205" alt="image" src="https://github.com/user-attachments/assets/a0b097a5-733c-4c8c-9066-9a02efa730e9" />

#### Name conflicts
Improving conflict handling is out of scope for this PR and can be addressed for all Pluginable groups in a further PR..