### PR TITLE
Drop api-auto-docs for now

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -236,7 +236,6 @@ py:class sqlalchemy.sql.compiler.TypeCompiler
 py:class sqlalchemy.sql.elements.BooleanClauseList
 py:meth sqlalchemy.orm.unitofwork.UOWTransaction.register_object
 
-py:class sphinx.ext.autodoc.ClassDocumenter
 py:class sphinx.util.docutils.SphinxDirective
 py:class ModuleAnalyzer
 py:class BuildEnvironment

--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -32,8 +32,6 @@ datatypes/kpoints.rst topics/data_types.rst
 datatypes/bands.rst topics/data_types.rst
 backup/index.rst howto/installation.rst
 
-# fix https://www.materialscloud.org/dmp
-apidoc/aiida.orm.rst reference/apidoc/aiida.orm.rst
 querying/querybuilder/usage.rst howto/data.rst
 # datatypes/index.rst TO BE ADDED IN #4469
 

--- a/docs/source/reference/api/index.rst
+++ b/docs/source/reference/api/index.rst
@@ -5,4 +5,3 @@ AiiDA API
    :maxdepth: 1
 
    public
-   ../apidoc/aiida.rst


### PR DESCRIPTION
When using the search bar, all un-related api results is shown and makes it incredibly difficult to fetch the result of actual documentation.

<img width="1470" height="833" alt="image" src="https://github.com/user-attachments/assets/3921dcd8-2f08-4a73-9bc6-7b3fd6f5e580" />


I first, aimed to remove api-doc from the search results. But sphinx doesn't allow it. I struggled two hours with no success. 
@edan-bainglass also looked up these references:
https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_search_scorer
https://docs.readthedocs.com/dev/latest/search-integration.html

Unfortunately it seems not doable. Or requires two days of work to make it.
We suggest to drop api-auto-docs for now, as an urgent solution. If one finds a solution in future they can safely revert this PR/commit.
