### PR TITLE
Remove dead code supporting old pymatgen versions

### DIFF
--- a/src/aiida/orm/nodes/data/structure.py
+++ b/src/aiida/orm/nodes/data/structure.py
@@ -102,18 +102,6 @@ def has_pymatgen():
     return True
 
 
-def get_pymatgen_version():
-    """:return: string with pymatgen version, None if can not import."""
-    if not has_pymatgen():
-        return None
-    try:
-        from pymatgen import __version__
-    except ImportError:
-        # this was changed in version 2022.0.3
-        from pymatgen.core import __version__
-    return __version__
-
-
 def has_spglib():
     """:return: True if the spglib module can be imported, False otherwise."""
     try:
@@ -1827,14 +1815,7 @@ class StructureData(Data):
                 if len(kind.symbols) != 1 or (len(kind.weights) != 1 or sum(kind.weights) < 1.0):
                     raise ValueError('Cannot set partial occupancies and spins at the same time')
                 spin = -1 if kind.name.endswith('1') else 1 if kind.name.endswith('2') else 0
-                try:
-                    specie = Specie(kind.symbols[0], oxidation_state, properties={'spin': spin})
-                except TypeError:
-                    # As of v2023.9.2, the ``properties`` argument is removed and the ``spin`` argument should be used.
-                    # See: https://github.com/materialsproject/pymatgen/commit/118c245d6082fe0b13e19d348fc1db9c0d512019
-                    # The ``spin`` argument was introduced in v2023.6.28.
-                    # See: https://github.com/materialsproject/pymatgen/commit/9f2b3939af45d5129e0778d371d814811924aeb6
-                    specie = Specie(kind.symbols[0], oxidation_state, spin=spin)
+                specie = Specie(kind.symbols[0], oxidation_state, spin=spin)
                 species.append(specie)
         else:
             # case when no spin are defined

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -25,7 +25,6 @@ from aiida.orm.nodes.data.structure import (
     _atomic_masses,
     ase_refine_cell,
     get_formula,
-    get_pymatgen_version,
     has_ase,
     has_pymatgen,
     has_spglib,
@@ -68,11 +67,6 @@ skip_ase = pytest.mark.skipif(not has_ase(), reason='Unable to import ase')
 skip_spglib = pytest.mark.skipif(not has_spglib(), reason='Unable to import spglib')
 skip_pycifrw = pytest.mark.skipif(not has_pycifrw(), reason='Unable to import PyCifRW')
 skip_pymatgen = pytest.mark.skipif(not has_pymatgen(), reason='Unable to import pymatgen')
-
-
-@skip_pymatgen
-def test_get_pymatgen_version():
-    assert isinstance(get_pymatgen_version(), str)
 
 
 class TestCifData:


### PR DESCRIPTION
Just a small cleanup, we now require pymatgen 2024 so we can remove some old code that supported older versions.