### PR TITLE
Feature: Pause BaseRestartWorkChain on unhandled errors, rather than failing

### DIFF
--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -193,7 +193,7 @@ class BaseRestartWorkChain(WorkChain):
         """If the process was paused by a handler, change the process status to provide information to user."""
         super().on_paused(msg)
         if self.ctx.paused_by_handler:
-            self.node.set_process_status('Need user inspection, see: verdi process report.')
+            self.node.set_process_status(f"Need user inspection, see: 'verdi process report {self.node.pk}'")
 
     def setup(self) -> None:
         """Initialize context variables that are used during the logical flow of the `BaseRestartWorkChain`."""


### PR DESCRIPTION
Allow base restart to be paused in case unhandled errors occur.
@giovannipizzi,  did I forget something important from our discussion?
@mbercx, how should we bring this into aiida-quantumespresso? Which defaults? (see my test for PwBaseWorkchian below)
@mikibonacci @superstar54 @edan-bainglass @AndresOrtegaGuerrero, how would you bring this to QE-app?


Two inputs are added:
-**pause_for_unknown_errors**. The process is paused, the status shows that inspection from the user is needed
-**restart_once_for_unknown_errors**. The process is resubmitted once, if it fails again the Workchain is killed (pause False) or paused (pause True)
Tested on a PwBaseWorkchain, inserting the following modification:
```
        spec.expose_inputs(BaseRestartWorkChain,
                           include=('pause_for_unknown_errors', 'restart_once_for_unknown_errors'),)
        
        spec.input('pause_for_unknown_errors', valid_type=orm.Bool, required=False, default=lambda: orm.Bool(False),
                   help='If True, the workchain will pause instead of aborting when an unknown error is encountered.')
        spec.input('restart_once_for_unknown_errors', valid_type=orm.Bool, required=False, default=lambda: orm.Bool(False),
                   help='If True, the workchain will attempt a single restart when an unknown error is encountered.')
```
For testing, I manually killed the pw.x process with the bash command ```kill```

**Case True True: fail, pause, fail, pause, succeed**
<img width="911" height="145" alt="image" src="https://github.com/user-attachments/assets/111a0997-431e-4dea-8eb0-1969fe039863" />

**Case True False: pause, succeed:**
<img width="926" height="75" alt="image" src="https://github.com/user-attachments/assets/5b3a8b71-132e-42b2-8dc7-b326ffd3f5b5" />

**Case True False: pause, pasue, succeed:**
<img width="883" height="96" alt="image" src="https://github.com/user-attachments/assets/48834c2d-5975-4162-8209-64843d2962b2" />

**Case False True: fail, fail**
<img width="947" height="98" alt="image" src="https://github.com/user-attachments/assets/30e6a86c-a9ec-495d-92a2-04cc2d93b936" />

**Case False False: fail**
<img width="856" height="63" alt="image" src="https://github.com/user-attachments/assets/ecb5e0f5-9c85-46e1-a98c-fbdaae4e2bca" />


**Test with bulk-Si phonons:**
<img width="741" height="113" alt="image" src="https://github.com/user-attachments/assets/7bb4ebaa-c3c7-4069-8c5f-dac1a4b703bb" />
<img width="367" height="240" alt="image" src="https://github.com/user-attachments/assets/e43a420a-fc90-4530-ab15-0ecdff80910e" />
<img width="944" height="193" alt="image" src="https://github.com/user-attachments/assets/c260fe8d-ab9f-411f-be8f-61acf657b77c" />
<img width="369" height="336" alt="image" src="https://github.com/user-attachments/assets/7b567061-e4f7-4ef8-bab5-1fd160cb8f2f" />

