### PR TITLE
Better code coverage from tests using `subprocess`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,7 @@ core = 'sysmon'
 omit = [
   "src/aiida/tools/_dumping/**/*"
 ]
+patch = ['subprocess']
 
 [tool.flit.module]
 name = 'aiida'


### PR DESCRIPTION
In many tests we use `subprocess` module to ensure isolation. Collecting code coverage from such tests requires additional `coveragepy` configuration, see
https://coverage.readthedocs.io/en/7.11.0/config.html#run-patch

This is clearly important, as the coverage is increased by over 2% on this PR.

Follow-up to #7042.

(note: this is partially a fix for a regression from #7042. In earlier versions, the subprocess coverage was handled by `pytest-cov` plugin, but this support was dropped in the latest 7.0 version, in favour of a (more robust) support directly in `coveragepy`. See changelog for details: https://pytest-cov.readthedocs.io/en/latest/changelog.html#id1)