### PR TITLE
🐛 `TrajectoryData`: Add `pbc`

### DIFF
--- a/docs/source/topics/data_types.rst
+++ b/docs/source/topics/data_types.rst
@@ -801,7 +801,8 @@ This sections lists these data types and provides some important examples of the
   +===================================================================+======================+=================================================================================+===================================+
   | :ref:`StructureData <topics:data_types:materials:structure>`      | ``structure``        | The cell, periodic boundary conditions, atomic positions, species and kinds.    |  \\-                              |
   +-------------------------------------------------------------------+----------------------+---------------------------------------------------------------------------------+-----------------------------------+
-  | :ref:`TrajectoryData <topics:data_types:materials:trajectory>`    | ``array.trajectory`` | The structure species and the shape of the cell, step and position arrays.      | The array data in numpy format.   |
+  | :ref:`TrajectoryData <topics:data_types:materials:trajectory>`    | ``array.trajectory`` | The structure species, periodic boundary conditions, and the shape of the cell, | The array data in numpy format.   |
+  |                                                                   |                      | step and position arrays.                                                       |                                   |
   +-------------------------------------------------------------------+----------------------+---------------------------------------------------------------------------------+-----------------------------------+
   | :ref:`UpfData <topics:data_types:materials:upf>`                  | ``upf``              | The MD5 of the UPF and the element of the pseudopotential.                      | The pseudopotential file.         |
   +-------------------------------------------------------------------+----------------------+---------------------------------------------------------------------------------+-----------------------------------+
@@ -900,15 +901,81 @@ TrajectoryData
 
 The :py:class:`~aiida.orm.nodes.data.array.trajectory.TrajectoryData` data type represents a sequences of StructureData objects, where the number of atomic kinds and sites does not change over time.
 Beside the coordinates, it can also optionally store velocities.
-If you have a list of :py:class:`~aiida.orm.nodes.data.structure.StructureData` instances called ``structure_list`` that represent the trajectory of your system, you can create a :py:class:`~aiida.orm.nodes.data.array.trajectory.TrajectoryData` instance from this list:
+As of version 2.8, periodic boundary conditions can be explicitly specified and are stored for the entire trajectory.
 
-.. code-block:: ipython
+For example, to create a simple two-step trajectory from a list of structures:
 
-  In [1]: TrajectoryData = DataFactory('core.array.trajectory')
+.. code-block:: python
 
-  In [2]: trajectory = TrajectoryData(structure_list)
+  from aiida import orm
+
+  # Create step 1
+  cell = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+  structure1 = orm.StructureData(cell=cell, pbc=(True, True, False))
+  structure1.append_atom(position=(0.0, 0.0, 0.0), symbols='H')
+  structure1.append_atom(position=(0.5, 0.5, 0.5), symbols='H')
+
+  # Create step 2
+  structure2 = orm.StructureData(cell=cell, pbc=(True, True, False))
+  structure2.append_atom(position=(0.1, 0.0, 0.0), symbols='H')
+  structure2.append_atom(position=(0.6, 0.5, 0.5), symbols='H')
+
+  # Create the trajectory from the structure list
+  trajectory = orm.TrajectoryData([structure1, structure2])
+
+Alternatively, you can create a trajectory by directly setting the arrays using the :py:meth:`~aiida.orm.nodes.data.array.trajectory.TrajectoryData.set_trajectory` method:
+
+.. code-block:: python
+
+  import numpy as np
+
+  trajectory = orm.TrajectoryData()
+
+  trajectory.set_trajectory(
+      symbols=['H', 'H'],
+      positions=np.array([
+          [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],  # Step 1
+          [[0.1, 0.0, 0.0], [0.6, 0.5, 0.5]],  # Step 2
+      ]),
+      cells=np.array([
+          [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],  # Step 1
+          [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],  # Step 2
+      ]),
+      pbc=(True, True, False)  # Periodic in x,y but not z
+  )
+
+This example creates a trajectory with two time steps for a two-atom system.
+The ``positions`` array has shape ``(2, 2, 3)`` representing 2 steps, 2 atoms, and 3 coordinates.
+The ``cells`` array has shape ``(2, 3, 3)`` representing 2 steps and a 3×3 cell matrix.
 
 Note that contrary with the :py:class:`~aiida.orm.nodes.data.structure.StructureData` data type, the cell and atomic positions are stored a ``numpy`` array in the repository and not in the database.
+
+Periodic Boundary Conditions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.8
+
+Starting from version 2.8, ``TrajectoryData`` supports explicit periodic boundary conditions via the ``pbc`` property.
+The periodic boundary conditions apply to all steps in the trajectory:
+
+.. code-block:: python
+
+  trajectory.pbc
+  # (True, True, False)
+
+When creating a trajectory from structure lists, the periodic boundary conditions are automatically extracted:
+
+.. code-block:: python
+
+  trajectory = TrajectoryData(structure_list)
+  trajectory.pbc  # Extracted from the StructureData instances
+  # (True, True, False)
+
+Note that all structures in the list must have the same periodic boundary conditions, otherwise a ``ValueError`` is raised.
+
+.. warning::
+
+   For backward compatibility, ``TrajectoryData`` created before version 2.8 will have ``trajectory.pbc`` return ``None``.
 
 Exporting
 ^^^^^^^^^

--- a/src/aiida/orm/nodes/data/array/trajectory.py
+++ b/src/aiida/orm/nodes/data/array/trajectory.py
@@ -8,10 +8,13 @@
 ###########################################################################
 """AiiDA class to deal with crystal structure trajectories."""
 
+from __future__ import annotations
+
 import collections.abc
-from typing import List
+from typing import List, Optional, Tuple
 
 from aiida.common.pydantic import MetadataField
+from aiida.common.warnings import warn_deprecation
 
 from .array import ArrayData
 
@@ -27,13 +30,14 @@ class TrajectoryData(ArrayData):
         units_positions: str = MetadataField(alias='units|positions', description='Unit of positions')
         units_times: str = MetadataField(alias='units|times', description='Unit of time')
         symbols: List[str] = MetadataField(description='List of symbols')
+        pbc: Optional[Tuple[bool, bool, bool]] = MetadataField(description='Periodic boundary conditions')
 
     def __init__(self, structurelist=None, **kwargs):
         super().__init__(**kwargs)
         if structurelist is not None:
             self.set_structurelist(structurelist)
 
-    def _internal_validate(self, stepids, cells, symbols, positions, times, velocities):
+    def _internal_validate(self, stepids, cells, symbols, positions, times, velocities, pbc):
         """Internal function to validate the type and shape of the arrays. See
         the documentation of py:meth:`.set_trajectory` for a description of the
         valid shape and type of the parameters.
@@ -82,8 +86,22 @@ class TrajectoryData(ArrayData):
                     'have shape (s,n,3), '
                     'with s=number of steps and n=number of symbols'
                 )
+        if pbc is not None:
+            if not (isinstance(pbc, (list, tuple)) and len(pbc) == 3 and all(isinstance(val, bool) for val in pbc)):
+                raise ValueError('`pbc` must be a list/tuple of length three with boolean values.')
+            if cells is None and any(pbc):
+                raise ValueError('Periodic boundary conditions are only possible when a cell is defined.')
 
-    def set_trajectory(self, symbols, positions, stepids=None, cells=None, times=None, velocities=None):
+    def set_trajectory(
+        self,
+        symbols,
+        positions,
+        stepids=None,
+        cells=None,
+        times=None,
+        velocities=None,
+        pbc: None | list[bool] | tuple[bool, bool, bool] = None,
+    ):
         r"""Store the whole trajectory, after checking that types and dimensions
         are correct.
 
@@ -131,14 +149,28 @@ class TrajectoryData(ArrayData):
         :param velocities: if specified, must be a float array with the same
                       dimensions of the ``positions`` array.
                       The array contains the velocities in the atoms.
+        :param pbc: periodic boundary conditions of the structure. Should be a list of
+            length three with booleans indicating if the structure is periodic in that
+            direction. The same periodic boundary conditions are set for each step.
 
         .. todo :: Choose suitable units for velocities
         """
         import numpy
 
-        self._internal_validate(stepids, cells, symbols, positions, times, velocities)
-        # set symbols as attribute for easier querying
+        if cells is None:
+            pbc = pbc or (False, False, False)
+        elif pbc is None:
+            warn_deprecation(
+                "When 'cells' is not None, the periodic boundary conditions should be explicitly specified via"
+                "the 'pbc' keyword argument. Defaulting to '[True, True, True]', but this will raise in v3.0.0.",
+                version=3,
+            )
+            pbc = (True, True, True)
+
+        self._internal_validate(stepids, cells, symbols, positions, times, velocities, pbc)
+        # set symbols/pbc as attributes for easier querying
         self.base.attributes.set('symbols', list(symbols))
+        self.base.attributes.set('pbc', tuple(pbc))
         self.set_array('positions', positions)
         if stepids is not None:  # use input stepids
             self.set_array('steps', stepids)
@@ -189,7 +221,12 @@ class TrajectoryData(ArrayData):
                 raise ValueError('Symbol lists have to be the same for all of the supplied structures')
         symbols = list(symbols_first)
         positions = numpy.array([[list(s.position) for s in x.sites] for x in structurelist])
-        self.set_trajectory(stepids=stepids, cells=cells, symbols=symbols, positions=positions)
+        pbc_set = {structure.pbc for structure in structurelist}
+        if len(pbc_set) == 1:
+            pbc = pbc_set.pop()
+        else:
+            raise ValueError(f'All structures should have the same `pbc`, found: {pbc_set}')
+        self.set_trajectory(stepids=stepids, cells=cells, symbols=symbols, positions=positions, pbc=pbc)
 
     def _validate(self):
         """Verify that the required arrays are present and that their type and
@@ -206,6 +243,7 @@ class TrajectoryData(ArrayData):
                 self.get_positions(),
                 self.get_times(),
                 self.get_velocities(),
+                self.pbc,
             )
         # Should catch TypeErrors, ValueErrors, and KeyErrors for missing arrays
         except Exception as exception:
@@ -263,6 +301,20 @@ class TrajectoryData(ArrayData):
         :raises KeyError: if the trajectory has not been set yet.
         """
         return self.base.attributes.get('symbols')
+
+    @property
+    def pbc(self) -> tuple[bool, bool, bool] | None:
+        """Return the tuple of periodic boundary conditions.
+
+        Returns a tuple of length three with booleans indicating if the structure is
+        periodic in that direction.
+
+        .. versionadded:: 2.8
+
+            For ``TrajectoryData`` created with earliers versions than v2.8 this property will return None.
+
+        """
+        return self.base.attributes.get('pbc', None)
 
     def get_positions(self):
         """Return the array of positions, if it has already been set.
@@ -384,7 +436,7 @@ class TrajectoryData(ArrayData):
                     'passed {}, but the symbols are {}'.format(sorted(kind_names), sorted(symbols))
                 )
 
-        struc = StructureData(cell=cell)
+        struc = StructureData(cell=cell, pbc=self.pbc)
         if custom_kinds is not None:
             for _k in custom_kinds:
                 struc.append_kind(_k)

--- a/tests/orm/test_fields/fields_aiida.data.core.array.trajectory.TrajectoryData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.trajectory.TrajectoryData.yml
@@ -9,6 +9,7 @@ extras: QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]
 label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
 mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
 node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
+pbc: QbField('pbc', dtype=typing.Optional[typing.Tuple[bool, bool, bool]], is_attribute=True)
 pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
 process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
 repository_content: QbDictField('repository_content', dtype=typing.Optional[dict[str,


### PR DESCRIPTION
>[!NOTE]
> There is a lot of code debt in the `TrajectoryData`, and the API is quite old and not optimal. Fixing all of that is beyond the scope of this PR, and probably we should redesign it in `aiida-atomistic`.

Fixes https://github.com/aiidateam/aiida-core/issues/6376
Fixes https://github.com/aiidateam/aiida-core/issues/7037

Pinging @danielhollas, @rikigigi and @dbidoggia for review, since they raised the original issues.

The current changes try to remain backwards-compatible for `get_step_data`, i.e. it now keeps on returning the same tuple of length 5. However, this does mean that the method does not return the `pbc`. For the `get_step_structure` method, I directly set the `pbc` from the property obtained from the attributes.