### PR TITLE
Fix whoami_async call in sync context

### DIFF
--- a/src/aiida/calculations/unstash.py
+++ b/src/aiida/calculations/unstash.py
@@ -109,7 +109,7 @@ class UnstashCalculation(CalcJob):
             else:  # UnstashTargetMode.NewRemoteData.value
                 computer = self.inputs.metadata.get('computer')
                 with computer.get_transport() as transport:
-                    remote_user = transport.whoami_async()
+                    remote_user = transport.whoami()
                 remote_working_directory = computer.get_workdir().format(username=remote_user)
 
                 # The following line is set at calcjob::presubmit, but we need it here


### PR DESCRIPTION
This fixes a RuntimeWarning in tests/calculations/test_stash.py

>  tests/conftest.py:199: RuntimeWarning: coroutine 'BlockingTransport.whoami_async' was never awaited
>    return process.prepare_for_submission(folder)

I've verified that the code now works by printing the output of the `whoami` call. 
But not sure how to test this since on localhost this doesn't actually influence the `remote_working_directory` variable from

```python
 with computer.get_transport() as transport:
   remote_user = transport.whoami() 
remote_working_directory = computer.get_workdir().format(username=remote_user)
```