### PR TITLE
Install typing_extensions for all Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   'sqlalchemy>=2.0.20,<3',
   'tabulate>=0.9.0,<0.10.0',
   'tqdm~=4.45',
-  'typing-extensions~=4.1;python_version<"3.11"',
+  'typing-extensions~=4.1',
   'upf_to_json~=0.9.2',
   'wrapt~=1.11',
   'chardet~=5.2.0;platform_system=="Windows"'

--- a/src/aiida/common/extendeddicts.py
+++ b/src/aiida/common/extendeddicts.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections.abc import KeysView, Mapping
 from typing import Any
 
-from aiida.common.typing import Self
+from typing_extensions import Self
 
 from . import exceptions
 

--- a/src/aiida/common/folders.py
+++ b/src/aiida/common/folders.py
@@ -20,9 +20,11 @@ import tempfile
 import typing as t
 from collections.abc import Iterator
 
+from typing_extensions import Self
+
 from . import timezone
 from .lang import type_check
-from .typing import FilePath, Self
+from .typing import FilePath
 
 # If True, tries to make everything (dirs, files) group-writable.
 # Otherwise, tries to make everything only readable and writable by the user.

--- a/src/aiida/common/typing.py
+++ b/src/aiida/common/typing.py
@@ -11,14 +11,6 @@
 from __future__ import annotations
 
 import pathlib
-import sys
 from typing import Union
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
-__all__ = ('FilePath', 'Self')
 
 FilePath = Union[str, pathlib.PurePath]

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, TypeVar, overload
 from uuid import UUID
 
-from aiida.common.typing import Self
+from typing_extensions import Self
 
 from .lang import classproperty
 

--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -23,11 +23,8 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 from typing import Mapping as MappingType
 
-try:
-    # typing.assert_never available since 3.11
-    from typing import assert_never
-except ImportError:
-    from typing_extensions import assert_never
+# typing.assert_never available since 3.11
+from typing_extensions import assert_never
 
 from aiida.common import AIIDA_LOGGER, exceptions
 from aiida.common.datastructures import CalcInfo, FileCopyOperation

--- a/src/aiida/engine/processes/functions.py
+++ b/src/aiida/engine/processes/functions.py
@@ -49,11 +49,8 @@ except AttributeError:
     # This type is not available for Python 3.9 and older
     UnionType = None  # type: ignore[assignment,misc]
 
-try:
-    from typing import ParamSpec
-except ImportError:
-    # Fallback for Python 3.9 and older
-    from typing_extensions import ParamSpec  # type: ignore[assignment]
+# Fallback for Python 3.9 and older
+from typing_extensions import ParamSpec
 
 try:
     get_annotations = inspect.get_annotations

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -19,12 +19,12 @@ from typing import TYPE_CHECKING, Any, Generic, List, NoReturn, Optional, Type, 
 from plumpy.base.utils import call_with_super_check, super_check
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
+from typing_extensions import Self
 
 from aiida.common import exceptions, log
 from aiida.common.exceptions import EntryPointError, InvalidOperation, NotExistent
 from aiida.common.lang import classproperty, type_check
 from aiida.common.pydantic import MetadataField, get_metadata
-from aiida.common.typing import Self
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
 

--- a/src/aiida/orm/groups.py
+++ b/src/aiida/orm/groups.py
@@ -14,10 +14,11 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Sequence, Tuple, Type, Union, cast
 
+from typing_extensions import Self
+
 from aiida.common import exceptions
 from aiida.common.lang import classproperty, type_check
 from aiida.common.pydantic import MetadataField
-from aiida.common.typing import Self
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
 

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -16,12 +16,13 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generic, Iterator, List, NoReturn, Optional, Tuple, Type, TypeVar
 from uuid import UUID
 
+from typing_extensions import Self
+
 from aiida.common import exceptions
 from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.pydantic import MetadataField
-from aiida.common.typing import Self
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
 from aiida.orm.utils.node import (

--- a/src/aiida/tools/_dumping/utils.py
+++ b/src/aiida/tools/_dumping/utils.py
@@ -11,17 +11,13 @@
 from __future__ import annotations
 
 import os
-import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Set, Type, Union
 
-if sys.version_info >= (3, 11):
-    # typing.assert_never available since 3.11
-    from typing import assert_never
-else:
-    from typing_extensions import assert_never
+# typing.assert_never available since 3.11
+from typing_extensions import assert_never
 
 from aiida import orm
 from aiida.common import AIIDA_LOGGER, timezone

--- a/src/aiida/tools/archive/abstract.py
+++ b/src/aiida/tools/archive/abstract.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, Literal, Optional, Type, TypeVar, Union, overload
 
-from aiida.common.typing import Self
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from aiida.orm import QueryBuilder

--- a/src/aiida/tools/graph/age_entities.py
+++ b/src/aiida/tools/graph/age_entities.py
@@ -10,19 +10,14 @@
 
 from __future__ import annotations
 
-import sys
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 from typing import Any, Literal, TypedDict, overload
 
-from aiida import orm
-from aiida.common.typing import Self
-from aiida.orm.utils.links import LinkQuadruple
+from typing_extensions import Self, TypeAlias
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+from aiida import orm
+from aiida.orm.utils.links import LinkQuadruple
 
 VALID_ENTITY_CLASSES = (orm.Node, orm.Group)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'win32'",
@@ -61,7 +61,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tabulate" },
     { name = "tqdm" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
     { name = "upf-to-json" },
     { name = "wrapt" },
 ]
@@ -282,7 +282,7 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'pre-commit'", specifier = "~=2.0" },
     { name = "types-tabulate", marker = "extra == 'pre-commit'", specifier = ">=0.9.0,<0.10.0" },
     { name = "types-tqdm", marker = "extra == 'pre-commit'", specifier = "~=4.45" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = "~=4.1" },
+    { name = "typing-extensions", specifier = "~=4.1" },
     { name = "upf-to-json", specifier = "~=0.9.2" },
     { name = "wrapt", specifier = "~=1.11" },
 ]


### PR DESCRIPTION
We currently use typing_extensions for several important typing features (Self, TypeAlias, ParamSpec), but we only install it for Python versions <3.11. But in practice, many other aiida-core dependencies depend on this package (sqlalchemy, pydantic) so it ends up being installed even on Python 3.14.

```console
❯ uv pip show typing-extensions
Name: typing-extensions
Version: 4.15.0
Location: /home/hollas/atmospec/aiida-core/.venv/lib/python3.14/site-packages
Requires:
Required-by: alembic, asyncssh, beautifulsoup4, mypy, myst-nb, pydantic, pydantic-core, pydata-sphinx-theme, sqlalchemy, typing-inspection
```

So let's just install it for all Python versions which let's us avoid the awkward `try...except` import dance. 

Split from #7091. 