### PR TITLE
Truncate `verdi archive info` output node list

### DIFF
--- a/tests/cmdline/commands/test_archive_create.py
+++ b/tests/cmdline/commands/test_archive_create.py
@@ -208,3 +208,26 @@ def test_info_empty_archive(run_cli_command):
     filename_input = get_archive_file('empty.aiida', filepath='export/migrate')
     result = run_cli_command(cmd_archive.archive_info, [filename_input], raises=True)
     assert 'archive file unreadable' in result.output
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_info_entities_starting_set_truncation(run_cli_command, tmp_path):
+    """Test that entities_starting_set is truncated in non-detailed mode and shown fully with --detailed."""
+    # Create 10 nodes to test truncation (should show 5 + message)
+    nodes = [Dict().store() for _ in range(10)]
+    filename_output = tmp_path / 'archive.aiida'
+
+    # Create archive with 10 nodes
+    options = ['-N'] + [str(node.pk) for node in nodes] + ['--', filename_output]
+    run_cli_command(cmd_archive.create, options)
+
+    # Test without --detailed (should be truncated)
+    result = run_cli_command(cmd_archive.archive_info, [filename_output])
+    assert '... and 5 more (use --detailed to show all)' in result.output
+
+    # Test with --detailed (should show all)
+    result_detailed = run_cli_command(cmd_archive.archive_info, ['--detailed', filename_output])
+    assert '... and 5 more (use --detailed to show all)' not in result_detailed.output
+    # All 10 UUIDs should be present in detailed mode
+    for node in nodes:
+        assert str(node.uuid) in result_detailed.output


### PR DESCRIPTION
Going from such an output (which could list hundreds or thousands of node UUIDs):
```
metadata:
  export_version: main_0001
  aiida_version: 2.7.1.post0
  key_format: sha256
  compression: 6
  ctime: '2025-11-11T09:05:28.039627'
  creation_parameters:
    entities_starting_set:
      node:
      - 95e1a89a-7a86-4117-a7ad-98a30b268e9c
      - 615e23e7-0fc2-4432-9412-6f7040b558d9
      - 84896f67-7a0a-4cdc-90c0-912de02bd548
      - 23aaeae2-1998-482e-8a08-b223a508e929
      - f50e8b2c-ac28-44da-aecb-be33a40e590e
      - 05f5eab8-b856-4258-a793-797682a0db43
      - bd17bb84-6bce-4464-bc15-3338ab6b4337
      - d93049fb-7453-4b24-be81-d3ff31bec8ac
      - 45350dce-f6d4-46e1-81fd-52ca9af6fbf4
      - d24aa03c-ac65-4a5d-b2eb-07899f49c505
      - 06e4e608-f30e-4f3d-bfc8-a3790363dba8
      - 4aad060e-fd8d-4d02-b45e-6752acfd9230
      - d1cd0aea-2f58-4b25-9b85-274338fdd590
      - e41a59ac-f434-43ff-af33-e4d21089301d
      - 43c2b8ac-2fae-4c67-a334-edf2309f6185
      - 11a10580-a825-462b-a1e8-bda8bc98aad0
      - c031c917-0181-409b-8cb5-595ed2240427
      - b51cff65-3a12-4093-abd9-5b888e5c621c
      - 0c7c8f3e-8313-42b4-8021-efb707bd6160
      - ca83d8e2-8bbd-41a2-a5e9-c35b60dbad27
    include_authinfos: false
...
```

to such an output (currently, threshold of 5 is hardcoded):
```
metadata:
  export_version: main_0001
  aiida_version: 2.7.1.post0
  key_format: sha256
  compression: 6
  ctime: '2025-11-11T09:05:04.106709'
  creation_parameters:
    entities_starting_set:
      node:
      - bfa1ace8-ac1b-46b7-b055-7404d84684ee
      - 8d986514-215c-4a8b-80df-9643c0200a47
      - c10c941f-4dc6-4ed9-b7fc-ab55b28a2b93
      - d6eceaeb-e6b1-4efb-a894-08abd1756e40
      - a87bf896-3f5c-4942-bb55-50c2ea8afdcd
      - '... and 15 more (use --detailed to show all)'
    include_authinfos: false
...
```