### PR TITLE
Fix progress bar stuck during archive import

### DIFF
--- a/src/aiida/tools/archive/imports.py
+++ b/src/aiida/tools/archive/imports.py
@@ -233,7 +233,7 @@ def _add_new_entities(
         if ufield not in backend_unique_id:
             ufields.append(ufield)
 
-    with get_progress_reporter()(desc=f'Importing new {etype.value}(s)', total=total) as progress:
+    with get_progress_reporter()(desc=f'Adding new {etype.value}(s)', total=total) as progress:
         # For UX: batch large ID lists so queries start returning results faster
         # Even though the improved IN clause handles any size, query planning for 500k+ IDs can be slow
         query_batch_size = 50_000


### PR DESCRIPTION
After removing filter_size batching in the QueryBuilder IN clause optimization in #6998, the `_add_new_entities` function's progress bar was broken.

__Before PR #6998__

```python
for nrows, ufields_batch in batch_iter(ufields, filter_size):  # ~1000 IDs per batch
    rows = [transform(row) for row in QueryBuilder(...).dict()]  # ❌ List comprehension blocks
    bulk_insert(rows)
    progress.update(nrows)  # ✅ Updates every ~1000 entities
```

Progress updates:
- From `filter_size` batching only (every ~1000 entities)
- NOT from QueryBuilder streaming (blocked by list comprehension)
- Each batch still had a blocking collection phase

__After PR #6998 (Broken)__

```python
rows = [transform(row) for row in QueryBuilder(...).dict()]  # ❌ Blocks for ALL
bulk_insert(rows)
progress.update(len(rows))  # ❌ Updates once at end

Progress updates: None until the very end
```

__With this PR (restored AND improved)__

```python
for _, ufields_batch in batch_iter(ufields, 50_000):  # 50k IDs per batch
    query = QueryBuilder(...).append(..., filters={unique_field: {'in': ufields_batch}})
    for nrows, rows_batch in batch_iter(query.dict(), batch_size, transform):  # ✅ NEW!
        bulk_insert(rows_batch)
        progress.update(nrows)  # ✅ Updates every ~10k entities
```
Progress updates:
- Re-introduced query batching (50k instead of 1k&mdash;purely for UX, not due to SQL restrictions)
- NEW: Added QueryBuilder streaming-based updates (every ~10k entities&mdash;previously blocked by list comprehension) 