### PR TITLE
Adding the `verdi computer goto` command

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -107,6 +107,7 @@ Below is a list with all available subcommands.
       duplicate  Duplicate a computer allowing to change some parameters.
       enable     Enable the computer for the given user.
       export     Export the setup or configuration of a computer.
+      goto       Open a shell connecting to the remote computer.
       list       List all available computers.
       relabel    Relabel a computer.
       setup      Create a new computer.

--- a/docs/source/topics/transport_template.py
+++ b/docs/source/topics/transport_template.py
@@ -115,7 +115,7 @@ class NewTransport(Transport):
         :param str localpath: local_folder_path
         """
 
-    def gotocomputer_command(self, remotedir):
+    def gotocomputer_command(self, remotedir=None):
         """Return a string to be run using os.system in order to connect via the transport to the remote directory.
 
         Expected behaviors:

--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -8,6 +8,7 @@
 ###########################################################################
 """`verdi computer` command."""
 
+import os
 import pathlib
 import traceback
 from copy import deepcopy
@@ -446,6 +447,29 @@ def computer_list(all_entries, raw):
     highlight = lambda comp: comp.is_configured and comp.is_user_enabled(user)  # noqa: E731
     hide = lambda comp: not (comp.is_configured and comp.is_user_enabled(user)) and not all_entries  # noqa: E731
     echo.echo_formatted_list(computers, ['label'], sort=sort, highlight=highlight, hide=hide)
+
+
+@verdi_computer.command('goto')
+@arguments.COMPUTER()
+def computer_goto(computer):
+    """Open a shell connecting to the remote computer.
+
+    This command opens a ssh connection to the remote
+    computer specified on the command line.
+    """
+    from aiida.common.exceptions import NotExistent
+
+    try:
+        transport = computer.get_transport()
+    except NotExistent as exception:
+        echo.echo_critical(repr(exception))
+
+    try:
+        command = transport.gotocomputer_command()
+        echo.echo_report('going to the remote work directory...')
+        os.system(command)
+    except NotImplementedError:
+        echo.echo_report(f'gotocomputer is not implemented for {transport}')
 
 
 @verdi_computer.command('show')

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -852,7 +852,7 @@ class LocalTransport(BlockingTransport):
 
         return retval, output_text, stderr_text
 
-    def gotocomputer_command(self, remotedir: TransportPath):
+    def gotocomputer_command(self, remotedir: Optional[TransportPath] = None):
         """Return a string to be run using os.system in order to connect
         via the transport to the remote directory.
 
@@ -863,7 +863,6 @@ class LocalTransport(BlockingTransport):
 
         :param str remotedir: the full path of the remote directory
         """
-        remotedir = str(remotedir)
         connect_string = self._gotocomputer_string(remotedir)
         cmd = f'bash -c {connect_string}'
         return cmd

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -13,6 +13,7 @@ import io
 import os
 import re
 from stat import S_ISDIR, S_ISREG
+from typing import Optional
 
 import click
 
@@ -1561,12 +1562,10 @@ class SshTransport(BlockingTransport):
 
         return (retval, b''.join(stdout_bytes), b''.join(stderr_bytes))
 
-    def gotocomputer_command(self, remotedir: TransportPath):
+    def gotocomputer_command(self, remotedir: Optional[TransportPath] = None):
         """Specific gotocomputer string to connect to a given remote computer via
         ssh and directly go to the calculation folder.
         """
-        remotedir = str(remotedir)
-
         further_params = []
         if 'username' in self._connect_args:
             further_params.append(f"-l {escape_for_bash(self._connect_args['username'])}")
@@ -1585,7 +1584,7 @@ class SshTransport(BlockingTransport):
 
         further_params_str = ' '.join(further_params)
 
-        connect_string = self._gotocomputer_string(remotedir)
+        connect_string = self._gotocomputer_string(remotedir=remotedir)
         cmd = f'ssh -t {self._machine} {further_params_str} {connect_string}'
         return cmd
 

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -1304,13 +1304,13 @@ class AsyncSshTransport(AsyncTransport):
                     os.path.join(sandbox.abspath, filename), remotedestination, **kwargs_put
                 )
 
-    def gotocomputer_command(self, remotedir: TransportPath):
+    def gotocomputer_command(self, remotedir: Optional[TransportPath] = None):
         """Return a string to be used to connect to the remote computer.
 
         :param remotedir: the remote directory to connect to
 
         :type remotedir:  :class:`Path <pathlib.Path>`, :class:`PurePosixPath <pathlib.PurePosixPath>`, or `str`
         """
-        connect_string = self._gotocomputer_string(remotedir)
+        connect_string = self._gotocomputer_string(remotedir=remotedir)
         cmd = f'ssh -t {self.machine} {connect_string}'
         return cmd

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -279,8 +279,11 @@ class Transport(abc.ABC):
         """
         return self._safe_open_interval
 
-    def _gotocomputer_string(self, remotedir):
+    def _gotocomputer_string(self, remotedir=None):
         """Command executed when goto computer."""
+        if remotedir is None:
+            return self._bash_command_str
+        remotedir = str(remotedir)
         connect_string = (
             """ "if [ -d {escaped_remotedir} ] ;"""
             """ then cd {escaped_remotedir} ; {bash_command} ; else echo '  ** The directory' ; """
@@ -820,7 +823,7 @@ class Transport(abc.ABC):
         """
 
     @abc.abstractmethod
-    def gotocomputer_command(self, remotedir: TransportPath):
+    def gotocomputer_command(self, remotedir: Optional[TransportPath] = None):
         """Return a string to be run using os.system in order to connect
         via the transport to the remote directory.
 

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -279,7 +279,7 @@ class Transport(abc.ABC):
         """
         return self._safe_open_interval
 
-    def _gotocomputer_string(self, remotedir=None):
+    def _gotocomputer_string(self, remotedir: Optional[TransportPath] = None):
         """Command executed when goto computer."""
         if remotedir is None:
             return self._bash_command_str


### PR DESCRIPTION
While one could simply do `ssh loginname` if the transport is ssh and the .ssh/config has been setup correctly, this might not always be the case, and this allows testing the `goto` functionality even when no calculations have been submitted yet, or when the last calculation submitted to the given computer was a long time ago and it would take a lot of time to find it (with also the possibility that the remote folder was deleted).

Note: I'm making the remotedir parameter optional. This is in principle backward-incompatible, in a sense (meaning that the new `computer goto` command will not work for external plugins that require this parameter. The rest will stil work - so it's not a real backward-incompatibility, only new functionality will not work and can be easily fixed).

If this is a problem, we can probably pass `remotedir='.'` which works at least with `core.local`, but I'm not sure if this will work all the times.