### PR TITLE
Fix `UnboundLocalError` in `ZipfileBackendRepository`

### DIFF
--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -513,13 +513,15 @@ class ZipfileBackendRepository(_RoBackendRepository):
 
     @contextmanager
     def open(self, key: str) -> Iterator[BinaryIO]:
+        handle = None
         try:
             handle = self._zipfile.open(f'{self._folder}/{key}')
             yield cast(BinaryIO, handle)
         except KeyError:
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
         finally:
-            handle.close()
+            if handle is not None:
+                handle.close()
 
 
 class FolderBackendRepository(_RoBackendRepository):


### PR DESCRIPTION
Description provided in the commit message:

_If a file/key is missing when importing an archive, the `open` method in `ZipfileBackendRepository` fails with an `UnboundLocalError` because the `handle` variable is referenced before assignment._

_This was initially discovered when working on the following issue on discourse: https://aiida.discourse.group/t/error-archive-import/696_


This fix also ensures that the user actually sees that the archive import, in case of the discourse issue, fails due to a missing file and not a strange `UnboundLocalError` related to the file handle.
