### PR TITLE
👌 `SshTransport`: no deprecation warning for internal calls

### DIFF
--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -566,6 +566,7 @@ class Transport(abc.ABC):
         Get working directory
         :return: a string identifying the current working directory
         """
+
         warn_deprecation(
             '`getcwd()` is deprecated and will be removed in the next major version.',
             version=3,


### PR DESCRIPTION
Fixes #7113 

An alternative solution to https://github.com/aiidateam/aiida-core/pull/7128