### PR TITLE
✨ `BaseRestartWorkChain`: add `pause_on_max_iterations` input 

### DIFF
--- a/docs/source/howto/workchains_restart.rst
+++ b/docs/source/howto/workchains_restart.rst
@@ -93,6 +93,28 @@ This is controlled by the ``max_iterations`` input, which defaults to ``5``:
 If the subprocess fails and is restarted repeatedly until ``max_iterations`` is reached without succeeding, the work chain will abort with exit code ``401`` (``ERROR_MAXIMUM_ITERATIONS_EXCEEDED``).
 
 
+**Pausing on maximum iterations**
+
+.. versionadded:: 2.8
+
+You can configure the ``BaseRestartWorkChain`` to pause when reaching the maximum number of iterations, allowing you to inspect the situation and decide whether to continue or abort.
+This is controlled by the ``pause_on_max_iterations`` input:
+
+.. code-block:: python
+
+    inputs = {
+        'max_iterations': 1,
+        'pause_on_max_iterations': True,
+        # ... other inputs
+    }
+    submit(SomeBaseWorkChain, **inputs)
+
+When ``pause_on_max_iterations`` is ``True`` and the maximum iteration limit is reached:
+
+1. The iteration counter is reset to zero.
+2. The work chain pauses for user inspection.
+3. You can resume using ``verdi process play <PK>`` or kill the work chain using ``verdi process kill <PK>``.
+
 Handler overrides
 -----------------
 

--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -389,7 +389,6 @@ class BaseRestartWorkChain(WorkChain):
                     self.report(f'Aborting! Last ran: {self.ctx.process_name}<{node.pk}>')
                     return self.exit_codes.ERROR_MAXIMUM_ITERATIONS_EXCEEDED
 
-                self.ctx.iteration = 0
                 pause_process = True
 
             if node.is_finished_ok and last_report.exit_code.status == 0:
@@ -412,6 +411,7 @@ class BaseRestartWorkChain(WorkChain):
                     f'`verdi process play {self.node.pk}`, or kill the work chain using '
                     f'`verdi process kill {self.node.pk}`.'
                 )
+                self.ctx.iteration = 0
                 self.pause(f"Paused for user inspection, see: 'verdi process report {self.node.pk}'")
 
             return None

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -38,6 +38,11 @@ class SomeWorkChain(engine.BaseRestartWorkChain):
     def handler_c(self, _):
         return
 
+    @engine.process_handler()
+    def handler_d(self, node):
+        if node.exit_status == 1:
+            return engine.ProcessHandlerReport()
+
     def not_a_handler(self, _):
         pass
 
@@ -55,17 +60,18 @@ def test_get_process_handlers():
         'handler_a',
         'handler_b',
         'handler_c',
+        'handler_d',
     ]
 
 
 @pytest.mark.parametrize(
     'inputs, priorities',
     (
-        ({}, [100, 200]),
-        ({'handler_overrides': {'handler_c': {'enabled': True}}}, [0, 100, 200]),
-        ({'handler_overrides': {'handler_a': {'priority': 50}}}, [50, 100]),
-        ({'handler_overrides': {'handler_a': {'enabled': False}}}, [100]),
-        ({'handler_overrides': {'handler_a': False}}, [100]),  # This notation is deprecated
+        ({}, [0, 100, 200]),
+        ({'handler_overrides': {'handler_c': {'enabled': True}}}, [0, 0, 100, 200]),
+        ({'handler_overrides': {'handler_a': {'priority': 50}}}, [0, 50, 100]),
+        ({'handler_overrides': {'handler_a': {'enabled': False}}}, [0, 100]),
+        ({'handler_overrides': {'handler_a': False}}, [0, 100]),  # This notation is deprecated
     ),
 )
 def test_get_process_handlers_by_priority(generate_work_chain, inputs, priorities):
@@ -81,6 +87,7 @@ def test_get_process_handlers_by_priority(generate_work_chain, inputs, prioritie
     assert getattr(SomeWorkChain, 'handler_a').priority == 200
     assert getattr(SomeWorkChain, 'handler_b').priority == 100
     assert getattr(SomeWorkChain, 'handler_c').priority == 0
+    assert getattr(SomeWorkChain, 'handler_d').priority == 0
     assert getattr(SomeWorkChain, 'handler_a').enabled
     assert getattr(SomeWorkChain, 'handler_b').enabled
     assert not getattr(SomeWorkChain, 'handler_c').enabled
@@ -196,6 +203,90 @@ def test_run_process(generate_work_chain, generate_calculation_node, monkeypatch
     assert isinstance(result, engine.ToContext)
     assert isinstance(result['children'], Awaitable)
     assert process.node.base.extras.get(SomeWorkChain._considered_handlers_extra) == [[]]
+
+
+@pytest.mark.requires_rmq
+@pytest.mark.parametrize('max_iterations', (1, 2, 3))
+@pytest.mark.parametrize('pause_on_max_iterations', (False, True))
+def test_global_max_iterations(generate_work_chain, generate_calculation_node, max_iterations, pause_on_max_iterations):
+    """Test the global `max_iterations` input."""
+    process = generate_work_chain(
+        SomeWorkChain, {'pause_on_max_iterations': pause_on_max_iterations, 'max_iterations': max_iterations}
+    )
+    process.setup()
+    process.ctx.children = []
+
+    if max_iterations > 1:
+        # Trigger `handler_without_max_iter` max_iterations - 1 times
+        while process.ctx.iteration < max_iterations - 1:
+            process.ctx.children.append(generate_calculation_node(exit_status=1))
+            process.ctx.iteration += 1
+            result = process.inspect_process()
+            assert result is None  # No exit code
+
+    # One more trigger - `max_iterations` is reached
+    process.ctx.children.append(generate_calculation_node(exit_status=1))
+    process.ctx.iteration += 1
+    result = process.inspect_process()
+
+    if pause_on_max_iterations:
+        assert process.ctx.iteration == 0  # Counter should be reset
+        assert result is None  # No exit code
+        assert process.paused
+    else:
+        assert process.ctx.iteration == max_iterations
+        assert result == engine.BaseRestartWorkChain.exit_codes.ERROR_MAXIMUM_ITERATIONS_EXCEEDED
+
+
+class WorkChainWithFinishHandler(engine.BaseRestartWorkChain):
+    """WorkChain with a handler that sets is_finished."""
+
+    _process_class = engine.CalcJob
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.expose_outputs(engine.CalcJob)
+
+    def setup(self):
+        super().setup()
+        self.ctx.inputs = {}
+
+    @engine.process_handler(priority=100)
+    def handler_that_finishes(self, node):
+        """Handler that marks work as finished even with non-zero exit."""
+        if node.exit_status == 1:
+            self.ctx.is_finished = True
+            self.results()
+            return engine.ProcessHandlerReport(do_break=False, exit_code=engine.ExitCode(42, 'CUSTOM_FINISH'))
+
+
+@pytest.mark.requires_rmq
+def test_handler_sets_is_finished(generate_work_chain, generate_calculation_node, aiida_localhost):
+    """Test the case when a handler sets ctx.is_finished=True."""
+
+    # Test with max_iterations=1 to make sure the pausing logic isn't triggered
+    process = generate_work_chain(WorkChainWithFinishHandler, {'max_iterations': orm.Int(1)})
+    process.setup()
+
+    # First trigger - handler sets is_finished
+    process.ctx.children = [
+        # Add outputs to the `CalcJob` to check if they are attached when the workflow is finished
+        generate_calculation_node(
+            exit_status=1,
+            outputs={
+                'retrieved': orm.FolderData(),
+                'remote_folder': orm.RemoteData(computer=aiida_localhost, remote_path='/tmp'),
+            },
+        )
+    ]
+    process.ctx.iteration = 1
+    result = process.inspect_process()
+
+    assert result.status == 42
+    assert process.ctx.is_finished is True
+    assert 'retrieved' in process.outputs
+    assert 'remote_folder' in process.outputs
 
 
 class OutputNamespaceWorkChain(engine.WorkChain):

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -217,7 +217,6 @@ def test_global_max_iterations(generate_work_chain, generate_calculation_node, m
     process.ctx.children = []
 
     if max_iterations > 1:
-        # Trigger `handler_without_max_iter` max_iterations - 1 times
         while process.ctx.iteration < max_iterations - 1:
             process.ctx.children.append(generate_calculation_node(exit_status=1))
             process.ctx.iteration += 1


### PR DESCRIPTION
@cpignedoli this is a rough draft PR for you to test! I have to sign off for the day, but already wanted to get your feedback.

To be clear: this is not ready for proper review. ^^ It's based on/blocked by https://github.com/aiidateam/aiida-core/pull/7116, `pre-commit` was ignored, no tests, no documentation changes. Just to see if it already works as expected and to get feedback on one question: 

1. if the process is paused because the max iterations of a handler was hit, which counters do we reset? Right now, only the corresponding handler counter is reset, or the global one in case that was hit. Should all counters be reset? Or should we reset the global counter as well in case we hit the max iterations of a single error handler?

Some code that may help in testing:

```python
from aiida import orm, engine, load_profile
from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
from ase.build import bulk

load_profile('dev')

code = orm.load_code("pw@localhost")

structure = orm.StructureData(ase=bulk('Si'))

builder = PwBaseWorkChain.get_builder_from_protocol(
    code, structure,
    protocol='precise'
)
# builder.max_iterations = 1
builder.handler_overrides = {
    'handle_out_of_walltime': {
        'max_iterations': 1
    }
}
builder.pause_on_max_iterations = True
builder.pw.parameters['CONTROL']['max_seconds'] = 3

engine.submit(builder)
```