### PR TITLE
Stashing: Add validation to prevent stashing from running CalcJob

### DIFF
--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -696,7 +696,14 @@ This approach lets you stash files **only after a successful calculation**. This
 
 **Typical use case:** You want to avoid keeping files from failed calculations, or need to run custom post-processing scripts.
 
-This method requires specifying the ``remote_folder`` of the original calculation as ``source_node``. Example:
+This method requires specifying the ``remote_folder`` of the original calculation as ``source_node``.
+
+.. note::
+
+   If the ``source_node`` was created by a calculation, that calculation must be sealed (finished). AiiDA will reject a ``RemoteData`` node whose creator is still running, to prevent stashing incomplete files.
+   Please use either the direct stashing method (via metadata.options.stash), or package the ``StashCalculation`` in a workflow to ensure proper sequencing.'
+
+Example:
 
 .. code-block:: python
 

--- a/tests/calculations/test_stash.py
+++ b/tests/calculations/test_stash.py
@@ -368,6 +368,87 @@ done
         assert unstashed_file.read_text() == expected_content
 
 
+def test_source_node_validation_unsealed_creator(aiida_localhost, tmp_path):
+    """Test that StashCalculation rejects source_node if its creator is not sealed (still running)."""
+    from aiida.common.links import LinkType
+
+    source = tmp_path / 'source'
+    source.mkdir()
+
+    # Create an unsealed CalcJobNode (simulates a running calculation)
+    calcjob = orm.CalcJobNode(computer=aiida_localhost)
+    calcjob.set_options({'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}})
+    calcjob.store()
+    # CalcJobNode is stored but NOT sealed - simulates a running job
+
+    # Create RemoteData and link it to the unsealed CalcJobNode
+    remote_data = orm.RemoteData(computer=aiida_localhost, remote_path=str(source))
+    remote_data.base.links.add_incoming(calcjob, link_type=LinkType.CREATE, link_label='remote_folder')
+    remote_data.store()
+
+    # Verify the creator relationship
+    assert remote_data.creator is not None
+    assert remote_data.creator.pk == calcjob.pk
+    assert not calcjob.is_sealed
+
+    # Validation should fail because the creator is not sealed
+    # The validation happens when setting the source_node on the builder
+    stashcalculation = CalculationFactory('core.stash')
+    builder = stashcalculation.get_builder()
+
+    with pytest.raises(ValueError, match='The source_node is an expected output of an active calculation'):
+        builder.source_node = remote_data
+
+
+def test_source_node_validation_sealed_creator(aiida_localhost, tmp_path):
+    """Test that StashCalculation accepts source_node if its creator is sealed (finished)."""
+    from aiida.common.links import LinkType
+
+    source = tmp_path / 'source'
+    source.mkdir()
+
+    # Create a CalcJobNode (NOT sealed yet - need to add link first)
+    calcjob = orm.CalcJobNode(computer=aiida_localhost)
+    calcjob.set_options({'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}})
+    calcjob.store()
+
+    # Create RemoteData and link it to the CalcJobNode BEFORE sealing
+    remote_data = orm.RemoteData(computer=aiida_localhost, remote_path=str(source))
+    remote_data.base.links.add_incoming(calcjob, link_type=LinkType.CREATE, link_label='remote_folder')
+    remote_data.store()
+
+    # Now seal the CalcJobNode (simulates a finished job)
+    calcjob.seal()
+
+    # Verify the creator relationship
+    assert remote_data.creator is not None
+    assert remote_data.creator.pk == calcjob.pk
+    assert calcjob.is_sealed
+
+    # Validation should pass because the creator is sealed
+    stashcalculation = CalculationFactory('core.stash')
+    builder = stashcalculation.get_builder()
+    builder.source_node = remote_data  # Should not raise
+
+
+def test_source_node_validation_no_creator(aiida_localhost, tmp_path):
+    """Test that StashCalculation accepts source_node without a creator (manually created RemoteData)."""
+    source = tmp_path / 'source'
+    source.mkdir()
+
+    # Create RemoteData without linking to any CalcJobNode (no creator)
+    remote_data = orm.RemoteData(computer=aiida_localhost, remote_path=str(source))
+    remote_data.store()
+
+    # Verify no creator
+    assert remote_data.creator is None
+
+    # Validation should pass because there is no creator
+    stashcalculation = CalculationFactory('core.stash')
+    builder = stashcalculation.get_builder()
+    builder.source_node = remote_data  # Should not raise
+
+
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.requires_rmq
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes  #6915

Adds a validator to StashCalculation's source_node input that checks if the creator CalcJob is sealed. If the source_node's creator is still running (not sealed), validation fails with a clear error message explaining that stashing from a running job may skip files not yet written to the remote folder.

This addresses the issue where users might accidentally try to stash files from an in-progress calculation, which could lead to incomplete or missing data.

This is an alternative solution to https://github.com/aiidateam/aiida-core/pull/7115 as discussed/suggested by @edan-bainglass and @agoscinski 