### PR TITLE
Add typing to scheduler plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,6 @@ repos:
         src/aiida/restapi/translator/group.py|
         src/aiida/restapi/translator/nodes/.*|
         src/aiida/restapi/translator/user.py|
-        src/aiida/schedulers/plugins/direct.py|
         src/aiida/schedulers/plugins/lsf.py|
         src/aiida/schedulers/plugins/pbsbaseclasses.py|
         src/aiida/schedulers/plugins/sge.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,6 @@ repos:
         src/aiida/schedulers/plugins/lsf.py|
         src/aiida/schedulers/plugins/pbsbaseclasses.py|
         src/aiida/schedulers/plugins/sge.py|
-        src/aiida/schedulers/plugins/slurm.py|
         src/aiida/storage/psql_dos/migrations/utils/integrity.py|
         src/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py|
         src/aiida/storage/psql_dos/migrations/utils/migrate_repository.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,6 @@ repos:
         src/aiida/restapi/translator/user.py|
         src/aiida/schedulers/plugins/lsf.py|
         src/aiida/schedulers/plugins/pbsbaseclasses.py|
-        src/aiida/schedulers/plugins/sge.py|
         src/aiida/storage/psql_dos/migrations/utils/integrity.py|
         src/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py|
         src/aiida/storage/psql_dos/migrations/utils/migrate_repository.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,6 @@ repos:
         src/aiida/restapi/translator/nodes/.*|
         src/aiida/restapi/translator/user.py|
         src/aiida/schedulers/plugins/lsf.py|
-        src/aiida/schedulers/plugins/pbsbaseclasses.py|
         src/aiida/storage/psql_dos/migrations/utils/integrity.py|
         src/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py|
         src/aiida/storage/psql_dos/migrations/utils/migrate_repository.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,6 @@ repos:
         src/aiida/restapi/translator/group.py|
         src/aiida/restapi/translator/nodes/.*|
         src/aiida/restapi/translator/user.py|
-        src/aiida/schedulers/plugins/lsf.py|
         src/aiida/storage/psql_dos/migrations/utils/integrity.py|
         src/aiida/storage/psql_dos/migrations/utils/legacy_workflows.py|
         src/aiida/storage/psql_dos/migrations/utils/migrate_repository.py|

--- a/src/aiida/schedulers/datastructures.py
+++ b/src/aiida/schedulers/datastructures.py
@@ -537,6 +537,8 @@ class JobInfo(DefaultFieldsAttributeDict):
         'finish_time',
     )
 
+    # NOTE: All of these fields might be undefined, in which case they return `None`,
+    # see the definition of DefaultFieldsAttributeDict.__getitem__
     if TYPE_CHECKING:
         job_id: str
         title: str
@@ -554,7 +556,7 @@ class JobInfo(DefaultFieldsAttributeDict):
         account: str
         qos: str
         wallclock_time_seconds: int
-        requested_wallclock_time_seconds: int
+        requested_wallclock_time_seconds: int | None
         cpu_time: int
         submission_time: datetime
         dispatch_time: datetime

--- a/src/aiida/schedulers/plugins/direct.py
+++ b/src/aiida/schedulers/plugins/direct.py
@@ -13,13 +13,16 @@ from __future__ import annotations
 import re
 import typing as t
 
-import aiida.schedulers
+from typing_extensions import override
+
 from aiida.common.escaping import escape_for_bash
-from aiida.engine.processes.exit_code import ExitCode
-from aiida.schedulers import SchedulerError
+from aiida.schedulers import Scheduler, SchedulerError
 from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, NodeNumberJobResource
 
 from .bash import BashCliScheduler
+
+if t.TYPE_CHECKING:
+    from aiida.engine.processes.exit_code import ExitCode
 
 ## From the ps man page on Mac OS X 10.12
 #     state     The state is given by a sequence of characters, for example,
@@ -85,7 +88,7 @@ class DirectJobResource(NodeNumberJobResource):
 class DirectScheduler(BashCliScheduler):
     """Support for the direct execution bypassing schedulers."""
 
-    _logger = aiida.schedulers.Scheduler._logger.getChild('direct')
+    _logger = Scheduler._logger.getChild('direct')
 
     # Query only by list of jobs and not by user
     _features = {
@@ -282,6 +285,7 @@ class DirectScheduler(BashCliScheduler):
         as_dict: t.Literal[True] = True,
     ) -> dict[str, JobInfo]: ...
 
+    @override
     def get_jobs(
         self,
         jobs: list[str] | None = None,

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -97,6 +97,7 @@ _MAP_STATUS_LSF = {
 _FIELD_SEPARATOR = '|'
 
 
+# TODO: This class could be simplified if we inhereted from `ParEnvJobResource` instead
 class LsfJobResource(JobResource):
     """An implementation of JobResource for LSF, that supports
     the OPTIONAL specification of a parallel environment (a string) + the total
@@ -111,6 +112,12 @@ class LsfJobResource(JobResource):
     """
 
     _default_fields = ('parallel_env', 'tot_num_mpiprocs', 'default_mpiprocs_per_machine', 'num_machines')
+
+    if t.TYPE_CHECKING:
+        parallel_env: str
+        tot_num_mpiprocs: int
+        default_mpiprocs_per_machine: int
+        num_machined: int
 
     @classmethod
     def validate_resources(cls, **kwargs: t.Any) -> AttributeDict:
@@ -168,7 +175,7 @@ class LsfJobResource(JobResource):
 
     def get_tot_num_mpiprocs(self) -> int:
         """Return the total number of cpus of this job resource."""
-        return self.tot_num_mpiprocs  # type: ignore[no-any-return]
+        return self.tot_num_mpiprocs
 
     @classmethod
     def accepts_default_mpiprocs_per_machine(cls) -> t.Literal[False]:

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -274,8 +274,6 @@ class LsfScheduler(BashCliScheduler):
         jobnum, state, walltime, queue[=partition], user, numnodes, numcores, title
         """
 
-        # I add the environment variable SLURM_TIME_FORMAT in front to be
-        # sure to get the times in 'standard' format
         command = ['bjobs', '-noheader', f"-o '{' '.join(self._joblist_fields)} delimiter=\"{_FIELD_SEPARATOR}\"'"]
 
         if user and jobs:
@@ -322,8 +320,6 @@ class LsfScheduler(BashCliScheduler):
             lines.append('#BSUB -rn')
 
         if job_tmpl.email:
-            # If not specified, but email events are set, SLURM
-            # sends the mail to the job owner by default
             lines.append(f'#BSUB -u {job_tmpl.email}')
 
         if job_tmpl.email_on_started:

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -11,6 +11,7 @@ This has been tested on the CERN lxplus cluster (LSF 9.1.3)
 """
 
 import datetime
+import typing as t
 
 import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
@@ -19,6 +20,9 @@ from aiida.schedulers import SchedulerError, SchedulerParsingError
 from aiida.schedulers.datastructures import JobInfo, JobResource, JobState
 
 from .bash import BashCliScheduler
+
+if t.TYPE_CHECKING:
+    from aiida.engine.processes.exit_code import ExitCode
 
 # This maps LSF status codes to our own state list
 #
@@ -260,7 +264,7 @@ class LsfScheduler(BashCliScheduler):
         'name',  # job name
     ]
 
-    def _get_joblist_command(self, jobs=None, user=None):
+    def _get_joblist_command(self, jobs: list[str] | None = None, user: str | None = None) -> str:
         """The command to report full information on existing jobs.
 
         Separates the fields with the _field_separator string order:
@@ -471,7 +475,7 @@ then
 fi
 """
 
-    def _get_submit_command(self, submit_script):
+    def _get_submit_command(self, submit_script: str) -> str:
         """Return the string to execute to submit a given script.
 
         :param submit_script: the path of the submit script relative to the working
@@ -484,7 +488,7 @@ fi
 
         return submit_command
 
-    def _parse_joblist_output(self, retval, stdout, stderr):
+    def _parse_joblist_output(self, retval: int, stdout: str, stderr: str) -> list[JobInfo]:
         """Parse the queue output string, as returned by executing the
         command returned by _get_joblist_command command,
         that is here implemented as a list of lines, one for each
@@ -656,7 +660,7 @@ fi
 
         return job_list
 
-    def _parse_submit_output(self, retval, stdout, stderr):
+    def _parse_submit_output(self, retval: int, stdout: str, stderr: str) -> str | ExitCode:
         """Parse the output of the submit command, as returned by executing the
         command returned by _get_submit_command command.
 
@@ -706,13 +710,13 @@ fi
 
         return thetime
 
-    def _get_kill_command(self, jobid):
+    def _get_kill_command(self, jobid: str) -> str:
         """Return the command to kill the job with specified jobid."""
         submit_command = f'bkill {jobid}'
         self.logger.info(f'killing job {jobid}')
         return submit_command
 
-    def _parse_kill_output(self, retval, stdout, stderr):
+    def _parse_kill_output(self, retval: int, stdout: str, stderr: str) -> bool:
         """Parse the output of the kill command.
 
         :return: True if everything seems ok, False otherwise.

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -117,7 +117,7 @@ class LsfJobResource(JobResource):
         parallel_env: str
         tot_num_mpiprocs: int
         default_mpiprocs_per_machine: int
-        num_machined: int
+        num_machines: int
 
     @classmethod
     def validate_resources(cls, **kwargs: t.Any) -> AttributeDict:

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -596,14 +596,14 @@ fi
 
             this_job.queue_name = partition
 
-            psd_finish_time = self._parse_time_string(finish_time, fmt='%b %d %H:%M')
-            psd_start_time = self._parse_time_string(start_time, fmt='%b %d %H:%M')
-
             # Now get the time in seconds which has been used
             # Only if it is RUNNING; otherwise it is not meaningful,
             # and may be not set (in my test, it is set to zero)
             if this_job.job_state == JobState.RUNNING:
                 try:
+                    psd_start_time = self._parse_time_string(start_time, fmt='%b %d %H:%M')
+                    psd_finish_time = self._parse_time_string(finish_time, fmt='%b %d %H:%M')
+
                     requested_walltime = psd_finish_time - psd_start_time
                     # fix of a weird bug. Since the year is not parsed, it is assumed
                     # to always be 1900. Therefore, job submitted

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -10,6 +10,8 @@
 This has been tested on the CERN lxplus cluster (LSF 9.1.3)
 """
 
+import datetime
+
 import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
 from aiida.common.extendeddicts import AttributeDict
@@ -290,7 +292,7 @@ class LsfScheduler(BashCliScheduler):
         self.logger.debug(f'bjobs command: {comm}')
         return comm
 
-    def _get_detailed_job_info_command(self, job_id):
+    def _get_detailed_job_info_command(self, job_id: str) -> str:
         """Return the command to run to get the detailed information on a job,
         even after the job has finished.
 
@@ -683,7 +685,6 @@ fi
         """Parse a time string and returns a datetime object.
         Example format: 'Feb  2 07:39' or 'Feb  2 07:39 L'
         """
-        import datetime
 
         if string == '-':
             return None

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -10,6 +10,8 @@
 This has been tested on the CERN lxplus cluster (LSF 9.1.3)
 """
 
+from __future__ import annotations
+
 import datetime
 import re
 import string

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -17,6 +17,8 @@ import re
 import string
 import typing as t
 
+from typing_extensions import override
+
 import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
 from aiida.common.exceptions import ConfigurationError, FeatureNotAvailable
@@ -119,6 +121,7 @@ class LsfJobResource(JobResource):
         default_mpiprocs_per_machine: int
         num_machines: int
 
+    @override
     @classmethod
     def validate_resources(cls, **kwargs: t.Any) -> AttributeDict:
         """Validate the resources against the job resource class of this scheduler.

--- a/src/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/src/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
+import string
 import time
 import typing as t
 
+from aiida.common import AttributeDict, FeatureNotAvailable
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import SchedulerError, SchedulerParsingError
-from aiida.schedulers.datastructures import JobInfo, JobState, MachineInfo, NodeNumberJobResource
+from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, MachineInfo, NodeNumberJobResource
 
 from .bash import BashCliScheduler
 
@@ -75,7 +78,7 @@ class PbsJobResource(NodeNumberJobResource):
     """Class for PBS job resources."""
 
     @classmethod
-    def validate_resources(cls, **kwargs):
+    def validate_resources(cls, **kwargs: t.Any) -> AttributeDict:
         """Validate the resources against the job resource class of this scheduler.
 
         This extends the base class validator and calculates the `num_cores_per_machine` fields to pass to PBSlike
@@ -153,7 +156,6 @@ class PbsBaseClass(BashCliScheduler):
         TODO: in the case of job arrays, decide what to do (i.e., if we want
               to pass the -t options to list each subjob).
         """
-        from aiida.common.exceptions import FeatureNotAvailable
 
         command = ['qstat', '-f']
 
@@ -164,8 +166,8 @@ class PbsBaseClass(BashCliScheduler):
             command.append(f'-u{user}')
 
         if jobs:
-            if isinstance(jobs, str):
-                command.append(f'{escape_for_bash(jobs)}')
+            if isinstance(jobs, str):  # type: ignore[unreachable]
+                command.append(f'{escape_for_bash(jobs)}')  # type: ignore[unreachable]
             else:
                 try:
                     command.append(f"{' '.join(escape_for_bash(j) for j in jobs)}")
@@ -184,7 +186,7 @@ class PbsBaseClass(BashCliScheduler):
         """
         return f'tracejob -v {escape_for_bash(job_id)}'
 
-    def _get_submit_script_header(self, job_tmpl):
+    def _get_submit_script_header(self, job_tmpl: JobTemplate) -> str:
         """Return the submit script header, using the parameters from the
         job_tmpl.
 
@@ -194,9 +196,6 @@ class PbsBaseClass(BashCliScheduler):
 
         TODO: truncate the title if too long
         """
-        import re
-        import string
-
         empty_line = ''
 
         lines = []
@@ -363,7 +362,7 @@ class PbsBaseClass(BashCliScheduler):
             if retval != 0:
                 raise SchedulerError(f'Error during qstat parsing, retval={retval}\nstdout={stdout}\nstderr={stderr}')
 
-        jobdata_raw = []  # will contain raw data parsed from qstat output
+        jobdata_raw: list[dict[str, t.Any]] = []  # will contain raw data parsed from qstat output
         # Get raw data and split in lines
         for line_num, line in enumerate(stdout.split('\n'), start=1):
             # Each new job stanza starts with the string 'Job Id:': I
@@ -495,13 +494,13 @@ class PbsBaseClass(BashCliScheduler):
                     for exec_host in exec_hosts:
                         node = MachineInfo()
                         node.name, data = exec_host.split('/')
-                        data = data.split('*')
-                        if len(data) == 1:
-                            node.job_index = int(data[0])
+                        jobidx_and_ncpu = data.split('*')
+                        if len(jobidx_and_ncpu) == 1:
+                            node.job_index = int(jobidx_and_ncpu[0])
                             node.num_cpus = 1
                         elif len(data) == 2:
-                            node.job_index = int(data[0])
-                            node.num_cpus = int(data[1])
+                            node.job_index = int(jobidx_and_ncpu[0])
+                            node.num_cpus = int(jobidx_and_ncpu[1])
                         else:
                             raise ValueError(
                                 f'Wrong number of pieces: {len(data)} instead of 1 or 2 in exec_hosts: {exec_hosts}'
@@ -553,7 +552,7 @@ class PbsBaseClass(BashCliScheduler):
                 )
 
             # Double check of redundant info
-            if this_job.allocated_machines is not None and this_job.num_machines is not None:
+            if this_job.allocated_machines is not None and this_job.num_machines is not None:  # type: ignore[redundant-expr]
                 if len(set(machine.name for machine in this_job.allocated_machines)) != this_job.num_machines:
                     _LOGGER.error(
                         f'The length of the list of allocated nodes ({len(this_job.allocated_machines)}) is different '
@@ -623,7 +622,7 @@ class PbsBaseClass(BashCliScheduler):
         return job_list
 
     @staticmethod
-    def _convert_time(string):
+    def _convert_time(string: str) -> int:
         """Convert a string in the format HH:MM:SS to a number of seconds."""
         pieces = string.split(':')
         if len(pieces) != 3:
@@ -657,7 +656,7 @@ class PbsBaseClass(BashCliScheduler):
         return hours * 3600 + mins * 60 + secs
 
     @staticmethod
-    def _parse_time_string(string, fmt='%a %b %d %H:%M:%S %Y'):
+    def _parse_time_string(string: str, fmt: str = '%a %b %d %H:%M:%S %Y') -> datetime.datetime:
         """Parse a time string in the format returned from qstat -f and
         returns a datetime object.
         """

--- a/src/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/src/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -170,7 +170,7 @@ class PbsBaseClass(BashCliScheduler):
         _LOGGER.debug(f'qstat command: {comm}')
         return comm
 
-    def _get_detailed_job_info_command(self, job_id):
+    def _get_detailed_job_info_command(self, job_id: str) -> str:
         """Return the command to run to get the detailed information on a job,
         even after the job has finished.
 

--- a/src/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/src/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -498,12 +498,13 @@ class PbsBaseClass(BashCliScheduler):
                         if len(jobidx_and_ncpu) == 1:
                             node.job_index = int(jobidx_and_ncpu[0])
                             node.num_cpus = 1
-                        elif len(data) == 2:
+                        elif len(jobidx_and_ncpu) == 2:
                             node.job_index = int(jobidx_and_ncpu[0])
                             node.num_cpus = int(jobidx_and_ncpu[1])
                         else:
                             raise ValueError(
-                                f'Wrong number of pieces: {len(data)} instead of 1 or 2 in exec_hosts: {exec_hosts}'
+                                f'Wrong number of pieces: {len(jobidx_and_ncpu)} '
+                                f'instead of 1 or 2 in exec_hosts: {exec_hosts}'
                             )
                         exec_host_list.append(node)
                     this_job.allocated_machines = exec_host_list

--- a/src/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/src/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -17,6 +17,8 @@ import string
 import time
 import typing as t
 
+from typing_extensions import override
+
 from aiida.common import AttributeDict, FeatureNotAvailable
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import SchedulerError, SchedulerParsingError
@@ -77,6 +79,7 @@ _MAP_STATUS_PBS_COMMON = {
 class PbsJobResource(NodeNumberJobResource):
     """Class for PBS job resources."""
 
+    @override
     @classmethod
     def validate_resources(cls, **kwargs: t.Any) -> AttributeDict:
         """Validate the resources against the job resource class of this scheduler.

--- a/src/aiida/schedulers/plugins/sge.py
+++ b/src/aiida/schedulers/plugins/sge.py
@@ -13,6 +13,8 @@ Plugin originally written by Marco Dorigo.
 Email: marco(DOT)dorigo(AT)rub(DOT)de
 """
 
+from __future__ import annotations
+
 import datetime
 import re
 import string

--- a/src/aiida/schedulers/plugins/sge.py
+++ b/src/aiida/schedulers/plugins/sge.py
@@ -13,6 +13,10 @@ Plugin originally written by Marco Dorigo.
 Email: marco(DOT)dorigo(AT)rub(DOT)de
 """
 
+import datetime
+import re
+import string
+import time
 import xml.dom.minidom
 import xml.parsers.expat
 
@@ -131,9 +135,8 @@ class SgeScheduler(BashCliScheduler):
         return command
         # raise NotImplementedError
 
-    def _get_detailed_job_info_command(self, job_id):
-        command = f'qacct -j {escape_for_bash(job_id)}'
-        return command
+    def _get_detailed_job_info_command(self, job_id: str) -> str:
+        return f'qacct -j {escape_for_bash(job_id)}'
 
     def _get_submit_script_header(self, job_tmpl):
         """Return the submit script header, using the parameters from the
@@ -145,8 +148,6 @@ class SgeScheduler(BashCliScheduler):
 
         TODO: truncate the title if too long
         """
-        import re
-        import string
 
         lines = []
 
@@ -442,8 +443,6 @@ class SgeScheduler(BashCliScheduler):
         returns a datetime object.
         Example format: 2013-06-13T11:53:11
         """
-        import datetime
-        import time
 
         try:
             time_struct = time.strptime(string, fmt)

--- a/src/aiida/schedulers/plugins/sge.py
+++ b/src/aiida/schedulers/plugins/sge.py
@@ -17,15 +17,19 @@ import datetime
 import re
 import string
 import time
+import typing as t
 import xml.dom.minidom
 import xml.parsers.expat
 
 import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import SchedulerError, SchedulerParsingError
-from aiida.schedulers.datastructures import JobInfo, JobState, ParEnvJobResource
+from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, ParEnvJobResource
 
 from .bash import BashCliScheduler
+
+if t.TYPE_CHECKING:
+    from aiida.engine.processes.exit_code import ExitCode
 
 # 'http://www.loni.ucla.edu/twiki/bin/view/Infrastructure/GridComputing?skin=plain':
 # Jobs Status:
@@ -108,7 +112,7 @@ class SgeScheduler(BashCliScheduler):
     # The class to be used for the job resource.
     _job_resource_class = SgeJobResource
 
-    def _get_joblist_command(self, jobs=None, user=None):
+    def _get_joblist_command(self, jobs: list[str] | None = None, user: str | None = None) -> str:
         """The command to report full information on existing jobs.
 
         TODO: in the case of job arrays, decide what to do (i.e., if we want
@@ -138,7 +142,7 @@ class SgeScheduler(BashCliScheduler):
     def _get_detailed_job_info_command(self, job_id: str) -> str:
         return f'qacct -j {escape_for_bash(job_id)}'
 
-    def _get_submit_script_header(self, job_tmpl):
+    def _get_submit_script_header(self, job_tmpl: JobTemplate) -> str:
         """Return the submit script header, using the parameters from the
         job_tmpl.
 
@@ -264,7 +268,7 @@ class SgeScheduler(BashCliScheduler):
 
         return '\n'.join(lines)
 
-    def _get_submit_command(self, submit_script):
+    def _get_submit_command(self, submit_script: str) -> str:
         """Return the string to execute to submit a given script.
 
         Args:
@@ -279,7 +283,7 @@ class SgeScheduler(BashCliScheduler):
 
         return submit_command
 
-    def _parse_joblist_output(self, retval, stdout, stderr):
+    def _parse_joblist_output(self, retval: int, stdout: str, stderr: str) -> list[JobInfo]:
         if retval != 0:
             self.logger.error(f'Error in _parse_joblist_output: retval={retval}; stdout={stdout}; stderr={stderr}')
             raise SchedulerError(f'Error during joblist retrieval, retval={retval}')
@@ -301,6 +305,8 @@ class SgeScheduler(BashCliScheduler):
 
         try:
             first_child = xmldata.firstChild
+            if first_child is None:
+                raise SchedulerError
             second_childs = first_child.childNodes
             tag_names_sec = [elem.tagName for elem in second_childs if elem.nodeType == 1]
             if 'queue_info' not in tag_names_sec:
@@ -321,7 +327,7 @@ class SgeScheduler(BashCliScheduler):
             self.logger.error(f'Error in sge._parse_joblist_output: stdout={stdout}')
             raise SchedulerError('Error during xml processing, of stdout')
 
-        jobs = list(first_child.getElementsByTagName('job_list'))
+        jobs = list(first_child.getElementsByTagName('job_list'))  # type: ignore[union-attr]
         # jobs = [i for i in jobinfo.getElementsByTagName('job_list')]
         # print [i[0].childNodes[0].data for i in job_numbers if i]
         joblist = []
@@ -411,7 +417,8 @@ class SgeScheduler(BashCliScheduler):
                 try:
                     job_element = job.getElementsByTagName('slots').pop(0)
                     element_child = job_element.childNodes.pop(0)
-                    this_job.num_mpiprocs = str(element_child.data).strip()
+                    # TODO: Fix this type error (should this be int?)
+                    this_job.num_mpiprocs = str(element_child.data).strip()  # type: ignore[assignment]
                 except IndexError:
                     self.logger.warning(f"No 'slots' field for job id {this_job.job_id}")
 
@@ -419,7 +426,7 @@ class SgeScheduler(BashCliScheduler):
         # self.logger.debug("joblist final: {}".format(joblist))
         return joblist
 
-    def _parse_submit_output(self, retval, stdout, stderr):
+    def _parse_submit_output(self, retval: int, stdout: str, stderr: str) -> str | ExitCode:
         """Parse the output of the submit command, as returned by executing the
         command returned by _get_submit_command command.
 
@@ -438,7 +445,7 @@ class SgeScheduler(BashCliScheduler):
 
         return stdout.strip()
 
-    def _parse_time_string(self, string, fmt='%Y-%m-%dT%H:%M:%S'):
+    def _parse_time_string(self, string: str, fmt: str = '%Y-%m-%dT%H:%M:%S') -> datetime.datetime:
         """Parse a time string in the format returned from qstat -xml -ext and
         returns a datetime object.
         Example format: 2013-06-13T11:53:11
@@ -455,7 +462,7 @@ class SgeScheduler(BashCliScheduler):
         # http://stackoverflow.com/questions/1697815
         return datetime.datetime.fromtimestamp(time.mktime(time_struct))
 
-    def _get_kill_command(self, jobid):
+    def _get_kill_command(self, jobid: str) -> str:
         """Return the command to kill the job with specified jobid."""
         submit_command = f'qdel {jobid}'
 
@@ -463,7 +470,7 @@ class SgeScheduler(BashCliScheduler):
 
         return submit_command
 
-    def _parse_kill_output(self, retval, stdout, stderr):
+    def _parse_kill_output(self, retval: int, stdout: str, stderr: str) -> bool:
         """Parse the output of the kill command.
 
         To be implemented by the plugin.

--- a/src/aiida/schedulers/plugins/sge.py
+++ b/src/aiida/schedulers/plugins/sge.py
@@ -419,13 +419,12 @@ class SgeScheduler(BashCliScheduler):
                 try:
                     job_element = job.getElementsByTagName('slots').pop(0)
                     element_child = job_element.childNodes.pop(0)
-                    # TODO: Fix this type error (should this be int?)
-                    this_job.num_mpiprocs = str(element_child.data).strip()  # type: ignore[assignment]
+                    this_job.num_mpiprocs = int(str(element_child.data).strip())
                 except IndexError:
                     self.logger.warning(f"No 'slots' field for job id {this_job.job_id}")
 
             joblist.append(this_job)
-        # self.logger.debug("joblist final: {}".format(joblist))
+
         return joblist
 
     def _parse_submit_output(self, retval: int, stdout: str, stderr: str) -> str | ExitCode:

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -731,11 +731,12 @@ stderr='{stderr.strip()}'"""
                 raise ValueError('the `detailed_job_info` does not contain the required key `stdout`.')
 
             type_check(detailed_stdout, str)
+            assert isinstance(detailed_stdout, str)
 
             # The format of the detailed job info should be a multiline string, where the first line is the header, with
             # the labels of the projected attributes. The following line should be the values of those attributes for
             # the entire job. Any additional lines correspond to those values for any additional tasks that were run.
-            lines = detailed_stdout.splitlines()  # type: ignore[union-attr]
+            lines = detailed_stdout.splitlines()
 
             if len(lines) < 2:
                 raise ValueError('the `detailed_job_info.stdout` contained less than two lines.')

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -217,7 +217,6 @@ class SlurmScheduler(BashCliScheduler):
         if jobs:
             if isinstance(jobs, str):  # type: ignore[unreachable]
                 joblist = [jobs]  # type: ignore[unreachable]
-                joblist.append(jobs)
             else:
                 if not isinstance(jobs, (tuple, list)):
                     raise TypeError("If provided, the 'jobs' variable must be a string or a list of strings")

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -588,8 +588,7 @@ stderr='{stderr.strip()}'"""
 
             try:
                 walltime = self._convert_time(thisjob_dict['time_limit'])
-                # TODO: Fix this type ignore, _convert_time can return None
-                this_job.requested_wallclock_time_seconds = walltime  # type: ignore[assignment]
+                this_job.requested_wallclock_time_seconds = walltime
             except ValueError:
                 self.logger.warning(f'Error parsing the time limit for job id {this_job.job_id}')
 

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -568,13 +568,12 @@ stderr='{stderr.strip()}'"""
                     )
                 )
 
+            ncpus = thisjob_dict['number_cpus']
             try:
-                this_job.num_mpiprocs = int(thisjob_dict['number_cpus'])
+                this_job.num_mpiprocs = int(ncpus)
             except ValueError:
                 self.logger.warning(
-                    'The number of allocated cores is not ' 'an integer ({}) for job id {}!'.format(
-                        thisjob_dict['number_cpus'], this_job.job_id
-                    )
+                    f'The number of allocated cores is not an integer ({ncpus}) for job id {this_job.job_id}!'
                 )
 
             # ALLOCATED NODES HERE

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -10,6 +10,8 @@
 This has been tested on SLURM 14.03.7 on the CSCS.ch machines.
 """
 
+from __future__ import annotations
+
 import datetime
 import re
 import string

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -20,7 +20,6 @@ import typing as t
 
 from typing_extensions import override
 
-from aiida.common import AttributeDict
 from aiida.common.exceptions import FeatureNotAvailable
 from aiida.common.lang import type_check
 from aiida.schedulers import Scheduler, SchedulerError
@@ -29,6 +28,7 @@ from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, Node
 from .bash import BashCliScheduler
 
 if t.TYPE_CHECKING:
+    from aiida.common import AttributeDict
     from aiida.engine.processes.exit_code import ExitCode
 
 

--- a/src/aiida/schedulers/scheduler.py
+++ b/src/aiida/schedulers/scheduler.py
@@ -341,7 +341,7 @@ class Scheduler(metaclass=abc.ABCMeta):
 
         raise NotImplementedError('Unrecognized code run mode')
 
-    def _get_detailed_job_info_command(self, job_id: str) -> dict[str, t.Any]:
+    def _get_detailed_job_info_command(self, job_id: str) -> str:
         """Return the command to run to get detailed information for a given job.
 
         This is typically called after the job has finished, to retrieve the most detailed information possible about


### PR DESCRIPTION
This is a follow-up to #schedule #7136, which added typing to the parent Scheduler class. This PR adds strict typing to all the plugins. In most cases this is just copy-pasting the type-signatures from the parent class.

There are a few fixes and tweaks, which I point out in the comments inline. 