### PR TITLE
Pin mamba version to fix arm64 docker build

### DIFF
--- a/.docker/aiida-core-base/Dockerfile
+++ b/.docker/aiida-core-base/Dockerfile
@@ -134,7 +134,7 @@ RUN set -x && \
         --prefix="${CONDA_DIR}" \
         --yes \
         "${PYTHON_SPECIFIER}" \
-        mamba && \
+        mamba=2.3 && \
     rm micromamba && \
     # Pin major.minor version of python
     mamba list python | grep -oP 'python\s+\K[\d.]+' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \


### PR DESCRIPTION
The docker build on main branch is failing, please see #7169 for details.

The fix in this PR proposes to pin to a specific mamba version that is compatible with Postgresql==15. This is not the best long-term fix, but at least it gets the build going again.

I think long-term it would be good to switch from mamba to pixi. I'll write up a follow-up issue. 

Closes #7169