### PR TITLE
Fix shell escaping for OpenSSH transport to handle special chars in paths

### DIFF
--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -19,6 +19,8 @@ import abc
 import asyncio
 import logging
 import posixpath
+import re
+import subprocess
 from typing import Optional
 
 import asyncssh
@@ -29,6 +31,22 @@ from aiida.transports.transport import (
     TransportInternalError,
     has_magic,
 )
+
+
+def get_openssh_version() -> Optional[int]:
+    """Get the major version of the local OpenSSH client.
+
+    Returns the major version number (e.g., 9 for OpenSSH_9.0), or None if detection fails.
+    """
+    try:
+        result = subprocess.run(['ssh', '-V'], capture_output=True, text=True, check=False)
+        output = result.stderr + result.stdout
+        match = re.search(r'OpenSSH_(\d+)', output)
+        if match:
+            return int(match.group(1))
+    except Exception:
+        pass
+    return None
 
 
 class _AsynchronousSSHBackend(abc.ABC):
@@ -454,6 +472,18 @@ class _OpenSSH(_AsynchronousSSHBackend):
     def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
         super().__init__(machine, logger, bash_command)
 
+        # Check if the local OpenSSH client version is 9.0 or higher.
+        # OpenSSH 9.0+ changed scp to use SFTP protocol by default instead of RCP.
+        # This affects how paths are interpreted - SFTP treats paths as binary data,
+        # so shell quoting is not needed and can cause issues.
+        openssh_version = get_openssh_version()
+        if openssh_version is not None and openssh_version >= 9:
+            self.logger.debug(f'Detected OpenSSH version {openssh_version}, using SFTP mode for scp commands.')
+            self.is_openssh_9_or_higher = True
+        else:
+            self.logger.debug(f'Detected OpenSSH version {openssh_version}, using RCP mode for scp commands.')
+            self.is_openssh_9_or_higher = False
+
     async def openssh_execute(self, commands, stdin: Optional[str] = None, timeout: Optional[float] = None):
         """
         Execute a command using the _OpenSSH command line client.
@@ -482,15 +512,63 @@ class _OpenSSH(_AsynchronousSSHBackend):
 
         return process.returncode, stdout.decode(), stderr.decode()
 
-    def ssh_command_generator(self, raw_command: str):
+    def _escape_for_rcp(self, path: str) -> str:
+        """Escape special characters for scp RCP mode using backslashes.
+
+        Note: escape_for_bash() does NOT work here because scp's RCP protocol
+        expects backslash-escaped paths, not quote-wrapped strings.
+
+        :param path: The path to escape
+        :return: The escaped path with backslashes before special characters
         """
-        Generate the command to execute
-        :param raw_command: The command to execute
+
+        result = []
+        special = set(' \t\n"\'`$\\!#&*?;<>|(){}[]')
+        for char in path:
+            if char in special:
+                result.append('\\')
+            result.append(char)
+        return ''.join(result)
+
+    def _escape_for_scp(self, path: str) -> str:
+        """Prepare a path for use in scp commands.
+
+        In OpenSSH < 9.0, scp uses the RCP protocol which passes paths through
+        the remote shell. We must escape shell metacharacters with backslashes
+        to prevent shell expansion/injection.
+
+        OpenSSH 9.0+, however, uses SFTP mode by default - paths are binary data, no shell quoting needed.
         """
-        # if "'" in raw_command:
-        treated_raw_command = f'"{raw_command}"'
-        # else:
-        #     treated_raw_command = f"\'{raw_command}\'"
+
+        if self.is_openssh_9_or_higher:
+            return f'{path}'
+        else:
+            return f'{self._escape_for_rcp(path)}'
+
+    def ssh_command_generator(self, command_template: str, paths: Optional[list[str]] = None):
+        """Generate an SSH command with properly quoted paths.
+
+        :param command_template: The command template with {} placeholders for paths
+        :param paths: List of paths to be quoted and substituted into the template.
+            Each path will be safely quoted using escape_for_bash() to prevent shell injection.
+        :return: A list of command arguments for subprocess execution
+        """
+
+        if paths:
+            # Quote paths for safe shell execution using escape_for_bash.
+            # This prevents command injection via malicious filenames containing
+            # shell metacharacters like ; & | $ ` etc.
+            quoted_paths = [escape_for_bash(p) for p in paths]
+            raw_command = command_template.format(*quoted_paths)
+        else:
+            raw_command = command_template
+
+        # Double-quote for SSH; escape ", `, and $ so all variables ($!, $?, $$)
+        # are expanded only by the inner `bash `, not by the SSH shell.
+        escaped_command = raw_command.replace('$', r'\$')
+        escaped_command = escaped_command.replace('`', '\\`')
+        escaped_command = escaped_command.replace('"', '\\"')
+        treated_raw_command = f'"{escaped_command}"'
         return ['ssh', self.machine, self.bash_command + treated_raw_command]
 
     async def mkdir(self, path: str, exist_ok: bool = False, parents: bool = False):
@@ -498,7 +576,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
             if await self.path_exists(path):
                 raise FileExistsError(f'Directory already exists: {path}')
 
-        commands = self.ssh_command_generator(f"mkdir {'-p' if parents else ''} {path}")
+        commands = self.ssh_command_generator(f"mkdir {'-p' if parents else ''} {{}}", paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
@@ -509,7 +587,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
                 raise OSError(f'Failed to create directory: {path}')
 
     async def chown(self, path: str, uid: int, gid: int) -> None:
-        commands = self.ssh_command_generator(f'chown {uid}:{gid} {path}')
+        commands = self.ssh_command_generator(f'chown {uid}:{gid} {{}}', paths=[path])
 
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
@@ -519,14 +597,29 @@ class _OpenSSH(_AsynchronousSSHBackend):
     async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
         # chmod works with octal numbers, so we have to convert the mode to octal
         mode = oct(mode)[2:]  # type: ignore[assignment]
-        commands = self.ssh_command_generator(f"chmod {'-h' if not follow_symlinks else ''} {mode} {path}")
+        commands = self.ssh_command_generator(f"chmod {'-h' if not follow_symlinks else ''} {mode} {{}}", paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
             raise OSError(f'Failed to change permissions: {path}')
 
+    def _escape_for_glob(self, s):
+        """Escape dangerous shell characters while preserving glob wildcards (* ? [ ])
+        This allows safe glob expansion without command injection
+        Characters that need escaping in shell (excluding glob chars)"""
+
+        dangerous = {';', '&', '|', '$', '`', '(', ')', '<', '>', '\n', '"', "'", '\\', '!', '#', ' ', '\t'}
+        result = []
+        for c in s:
+            if c in dangerous:
+                result.append('\\' + c)
+            else:
+                result.append(c)
+        return ''.join(result)
+
     async def glob(self, path: str, ignore_nonexisting: bool = True):
-        commands = self.ssh_command_generator(f'find {path} -maxdepth 0')
+        escaped_path = self._escape_for_glob(path)
+        commands = self.ssh_command_generator(f'find {escaped_path} -maxdepth 0')
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
@@ -542,14 +635,14 @@ class _OpenSSH(_AsynchronousSSHBackend):
         No magic is allowed in source or destination.
         """
 
-        commands = self.ssh_command_generator(f'ln -s {source} {destination}')
+        commands = self.ssh_command_generator('ln -s {} {}', paths=[source, destination])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
             raise OSError(f'Failed to create symlink: {source} -> {destination}')
 
     async def path_exists(self, path: str):
-        commands = self.ssh_command_generator(f'test -e {path}')
+        commands = self.ssh_command_generator('test -e {}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if stderr:
@@ -559,35 +652,35 @@ class _OpenSSH(_AsynchronousSSHBackend):
         return returncode == 0
 
     async def rmtree(self, path: str):
-        commands = self.ssh_command_generator(f'rm -rf {path}')
+        commands = self.ssh_command_generator('rm -rf {}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
             raise OSError(f'Failed to remove path: {path}')
 
     async def rmdir(self, path: str):
-        commands = self.ssh_command_generator(f'rmdir {path}')
+        commands = self.ssh_command_generator('rmdir {}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
             raise OSError('Failed to remove directory')
 
     async def rename(self, oldpath: str, newpath: str):
-        commands = self.ssh_command_generator(f'mv {oldpath} {newpath}')
+        commands = self.ssh_command_generator('mv {} {}', paths=[oldpath, newpath])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
             raise OSError(f'Failed to rename path: {oldpath} -> {newpath}')
 
     async def remove(self, path: str):
-        commands = self.ssh_command_generator(f'rm {path}')
+        commands = self.ssh_command_generator('rm {}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
             raise OSError(f'Failed to remove path: {path}')
 
     async def listdir(self, path: str):
-        commands = self.ssh_command_generator(f'ls {path}')
+        commands = self.ssh_command_generator('ls {}', paths=[path])
         # '-d' is used prevents recursive listing of directories.
         # This is useful when 'path' includes glob patterns.
         returncode, stdout, stderr = await self.openssh_execute(commands)
@@ -596,18 +689,18 @@ class _OpenSSH(_AsynchronousSSHBackend):
         return list(stdout.strip().split())
 
     async def isdir(self, path: str):
-        commands = self.ssh_command_generator(f'test -d {path}')
+        commands = self.ssh_command_generator('test -d {}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
         return returncode == 0
 
     async def isfile(self, path: str):
-        commands = self.ssh_command_generator(f'test -f {path}')
+        commands = self.ssh_command_generator('test -f {}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
         return returncode == 0
 
     async def lstat(self, path: str):
         # order of stat matters
-        commands = self.ssh_command_generator(f"stat -c '%s %u %g %a %X %Y' {path}")
+        commands = self.ssh_command_generator("stat -c '%s %u %g %a %X %Y' {}", paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         stdout = stdout.strip()
@@ -618,12 +711,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
         return Stat(*stdout.split())
 
     async def run(self, command: str, stdin: Optional[str] = None, timeout: Optional[float] = None):
-        # Not sure if sending the entire command as a single string is a good idea
-        # This is a hack to escape the $ character in the stdin
-        command = command.replace('$', r'\$')
-        command = command.replace('\\$', r'\$')
         commands = self.ssh_command_generator(command)
-
         returncode, stdout, stderr = await self.openssh_execute(commands, stdin, timeout)
         return returncode, stdout, stderr
 
@@ -639,7 +727,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
             options.append('-r')
 
         returncode, stdout, stderr = await self.openssh_execute(
-            ['scp', *options, f'{self.machine}:{remotepath}', localpath]
+            ['scp', *options, f'{self.machine}:{self._escape_for_scp(remotepath)}', self._escape_for_scp(localpath)]
         )
         if returncode != 0:
             raise OSError({stderr})
@@ -656,7 +744,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
             options.append('-r')
 
         returncode, stdout, stderr = await self.openssh_execute(
-            ['scp', *options, localpath, f'{self.machine}:{remotepath}']
+            ['scp', *options, self._escape_for_scp(localpath), f'{self.machine}:{self._escape_for_scp(remotepath)}']
         )
         if returncode != 0:
             raise OSError({stderr})
@@ -705,7 +793,12 @@ class _OpenSSH(_AsynchronousSSHBackend):
             )
 
         returncode, stdout, stderr = await self.openssh_execute(
-            ['scp', *options, f'{self.machine}:{remotesource}', f'{self.machine}:{remotedestination}']
+            [
+                'scp',
+                *options,
+                f'{self.machine}:{self._escape_for_scp(remotesource)}',
+                f'{self.machine}:{self._escape_for_scp(remotedestination)}',
+            ]
         )
         if returncode != 0:
             raise OSError(f'Failed to copy from {remotesource} to {remotedestination} : {stderr}')

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -1,10 +1,12 @@
 import asyncio
 import os
 import stat
-from unittest.mock import MagicMock
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aiida.transports.plugins.async_backend import _OpenSSH, get_openssh_version
 from aiida.transports.plugins.ssh_async import AsyncSshTransport
 
 
@@ -83,3 +85,115 @@ class TestSemaphoreBehavior:
             max_concurrent <= max_allowed
         ), f'Semaphore should limit to {max_allowed} concurrent ops, got {max_concurrent}'
         assert max_concurrent == max_allowed, f'Expected {max_allowed} concurrent ops to verify semaphore is being used'
+
+
+def test_get_openssh_version():
+    """Test that get_openssh_version() parses version correctly."""
+    mock_result = MagicMock()
+    mock_result.stdout = ''
+
+    mock_result.stderr = 'OpenSSH_9.0p1, OpenSSL 3.0.2'
+    with patch('aiida.transports.plugins.async_backend.subprocess.run', return_value=mock_result):
+        assert get_openssh_version() == 9
+
+    mock_result.stderr = 'OpenSSH_8.9p1, OpenSSL 3.0.2'
+    with patch('aiida.transports.plugins.async_backend.subprocess.run', return_value=mock_result):
+        assert get_openssh_version() == 8
+
+    mock_result.stderr = ''
+    with patch('aiida.transports.plugins.async_backend.subprocess.run', return_value=mock_result):
+        assert get_openssh_version() is None
+
+
+class _TestOpenSSH(_OpenSSH):
+    """Minimal OpenSSH subclass for testing escape methods."""
+
+    def __init__(self):
+        self.machine = 'localhost'
+        self.bash_command = 'bash -c '
+
+
+class TestSshCommandGenerator:
+    """Tests for ssh_command_generator escaping."""
+
+    def test_escapes_shell_chars_and_paths(self):
+        """Test $, `, " escaped and paths safely quoted."""
+
+        openssh = _TestOpenSSH()
+
+        """Test command structure and that $, `, " are escaped for the outer double-quote wrapper."""
+        result = openssh.ssh_command_generator('echo $HOME `cmd` "test"')
+        assert result[:2] == ['ssh', 'localhost']
+        assert result[2].startswith('bash -c "') and result[2].endswith('"')
+        assert r'\$HOME' in result[2]
+        assert r'\`cmd\`' in result[2]
+        assert r'\"test\"' in result[2]
+
+        """Test $!, $?, $$ are escaped so they're interpreted by inner bash -c shell."""
+        result = openssh.ssh_command_generator('script.sh & echo $!; echo $?; echo $$')
+        assert r'\$!' in result[2]
+        assert r'\$?' in result[2]
+        assert r'\$\$' in result[2]
+
+        """Test paths with special chars are safely quoted via escape_for_bash."""
+        result = openssh.ssh_command_generator('cp {} {}', paths=['/path;rm -rf /', '/dst'])
+        # Semicolon should be safely quoted, not interpreted as command separator
+        assert "'/path;rm -rf /'" in result[2]
+        assert "'/dst'" in result[2]
+
+
+def test_escape_for_glob_preserves_wildcards_escapes_dangerous_chars():
+    """Test wildcards (*, ?, []) preserved while dangerous chars escaped."""
+    backend = _TestOpenSSH()
+    # Wildcards preserved, dangerous chars escaped
+    assert backend._escape_for_glob('/home/$USER/my files/[0-9]*.log') == '/home/\\$USER/my\\ files/[0-9]*.log'
+    # Command injection attempt escaped
+    assert backend._escape_for_glob('/path;rm -rf /*') == '/path\\;rm\\ -rf\\ /*'
+
+
+def test_escape_for_rcp():
+    """Test RCP mode escapes shell metacharacters."""
+    backend = _TestOpenSSH()
+    assert backend._escape_for_rcp('/path/with spaces/$VAR;cmd') == '/path/with\\ spaces/\\$VAR\\;cmd'
+
+
+def test_escape_for_scp_version_aware():
+    """Test _escape_for_scp behavior differs by OpenSSH version."""
+    backend = _TestOpenSSH()
+    path = '/path/with spaces'
+
+    # SFTP mode (OpenSSH 9+): no escaping needed
+    backend.is_openssh_9_or_higher = True
+    assert backend._escape_for_scp(path) == path
+
+    # RCP mode (OpenSSH < 9): escaping required
+    backend.is_openssh_9_or_higher = False
+    assert backend._escape_for_scp(path) == '/path/with\\ spaces'
+
+
+def test_scp_with_special_chars(tmp_path):
+    """Test scp in both SFTP and RCP modes with special characters."""
+    backend = _TestOpenSSH()
+
+    remote_dir = tmp_path / 'remote'
+    local_dir = tmp_path / 'local'
+    remote_dir.mkdir()
+    local_dir.mkdir()
+
+    special_files = ['file with spaces.txt', "file'quote.txt", 'file$dollar.txt']
+    for f in special_files:
+        (remote_dir / f).write_text(f'content of {f}')
+
+    for filename in special_files:
+        source = remote_dir / filename
+
+        # SFTP mode (default on OpenSSH 9+)
+        dest_sftp = local_dir / f'sftp_{filename}'
+        result = subprocess.run(['scp', f'localhost:{source}', str(dest_sftp)], capture_output=True, check=False)
+        assert result.returncode == 0 and dest_sftp.read_text() == f'content of {filename}'
+
+        # RCP mode (forced with -O)
+        dest_rcp = local_dir / f'rcp_{filename}'
+        escaped = backend._escape_for_rcp(str(source))
+        result = subprocess.run(['scp', '-O', f'localhost:{escaped}', str(dest_rcp)], capture_output=True, check=False)
+        assert result.returncode == 0 and dest_rcp.read_text() == f'content of {filename}'


### PR DESCRIPTION
Improve path escaping in SSH transport for special characters                                                  
                                                                                                                 
Handle shell metacharacters in filenames correctly by adding OpenSSH                                           
version detection and appropriate escaping for SSH/SCP commands.  