### PR TITLE
Switch from token-based to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    environment: release
+    permissions:
+      id-token: write
+
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
@@ -95,16 +99,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-    - name: install flit
-      run: |
-        pip install flit~=3.4
-    - name: Build and publish
-      run: |
-        flit publish
-      env:
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
-        FLIT_INDEX_URL: https://upload.pypi.org/legacy/
+    - name: Install flit
+      run: pip install flit~=3.4
+    - name: Build
+      run: flit build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
 
 
   publish-testpypi:
@@ -116,6 +116,10 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    environment: release
+    permissions:
+      id-token: write
+
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
@@ -123,13 +127,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-    - name: install flit
-      run: |
-        pip install flit~=3.4
-    - name: Build and publish
-      run: |
-        flit publish
-      env:
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.TEST_PYPI_KEY }}
-        FLIT_INDEX_URL: https://test.pypi.org/legacy/
+    - name: Install flit
+      run: pip install flit~=3.4
+    - name: Build
+      run: flit build
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Replace token-based authentication with GitHub OIDC trusted publishing for both PyPI and TestPyPI. This eliminates the need for stored API tokens in the GitHub secrets and provides better security through short-lived credentials.

This is now in addition required when doing a release. For releases to pypi it is not really necessary because the tag rules should avoid that anyone can push a tag which triggers a release, but the test release we do by a label.
<img width="1167" height="485" alt="image" src="https://github.com/user-attachments/assets/cef72ce6-3760-41bf-94e1-4278693db447" />
After approval the release action runs through. See https://github.com/aiidateam/aiida-core/actions/runs/21170102654
