### PR TITLE
Deprecate `core.ssh` transport plugin in favor of `core.ssh_async`

### DIFF
--- a/src/aiida/cmdline/params/options/commands/computer.py
+++ b/src/aiida/cmdline/params/options/commands/computer.py
@@ -15,6 +15,7 @@ import click
 from aiida.cmdline.params import options, types
 from aiida.cmdline.params.options.interactive import InteractiveOption, TemplateInteractiveOption
 from aiida.cmdline.params.options.overridable import OverridableOption
+from aiida.cmdline.utils import echo
 
 if t.TYPE_CHECKING:
     from aiida.schedulers.datastructures import JobResource
@@ -87,7 +88,19 @@ DESCRIPTION = options.DESCRIPTION.clone(
     prompt='Description', cls=InteractiveOption, help='A human-readable description of this computer.'
 )
 
-TRANSPORT = options.TRANSPORT.clone(prompt='Transport plugin', cls=InteractiveOption)
+
+def transport_callback(ctx: click.Context, param: click.Parameter, value: t.Any) -> t.Any:
+    """Callback for the transport option that shows a deprecation warning for core.ssh."""
+    if value is not None and value.name == 'core.ssh':
+        echo.echo_deprecated(
+            'The `core.ssh` transport plugin is deprecated and will be removed in v3.0. '
+            'Use `core.ssh_async` instead, which is significantly faster and provides an '
+            'easier configuration interface.'
+        )
+    return value
+
+
+TRANSPORT = options.TRANSPORT.clone(prompt='Transport plugin', cls=InteractiveOption, callback=transport_callback)
 
 SCHEDULER = options.SCHEDULER.clone(prompt='Scheduler plugin', cls=InteractiveOption)
 

--- a/src/aiida/transports/cli.py
+++ b/src/aiida/transports/cli.py
@@ -27,6 +27,12 @@ def match_comp_transport(ctx, param, computer, transport_type):
         echo.echo_critical(
             f'Computer {computer.label} has transport of type "{computer.transport_type}", not {transport_type}!'
         )
+    if transport_type == 'core.ssh':
+        echo.echo_deprecated(
+            'The `core.ssh` transport plugin is deprecated and will be removed in v3.0. '
+            'Use `core.ssh_async` instead, which is significantly faster and provides an '
+            'easier configuration interface.'
+        )
     return computer
 
 


### PR DESCRIPTION
Add deprecation warnings when selecting `core.ssh` transport during `verdi computer setup` and `verdi computer configure core.ssh`.