### PR TITLE
`Transport`: deprecate `chown` method

### DIFF
--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -201,14 +201,6 @@ class _AsynchronousSSHBackend(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def chown(self, path: str, uid: int, gid: int):
-        """Change the ownership of a file or directory.
-        :param path: The path to the file or directory
-        :param uid: The user ID to set
-        :param gid: The group ID to set
-        """
-
-    @abc.abstractmethod
     async def copy(
         self,
         remotesource: str,
@@ -356,9 +348,6 @@ class _AsyncSSH(_AsynchronousSSHBackend):
 
     async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
         await self._sftp.chmod(path, mode, follow_symlinks=follow_symlinks)
-
-    async def chown(self, path: str, uid: int, gid: int):
-        await self._sftp.chown(path, uid, gid, follow_symlinks=True)
 
     async def copy(
         self,
@@ -585,14 +574,6 @@ class _OpenSSH(_AsynchronousSSHBackend):
                     raise FileExistsError(f'Directory already exists: {path}')
             else:
                 raise OSError(f'Failed to create directory: {path}')
-
-    async def chown(self, path: str, uid: int, gid: int) -> None:
-        commands = self.ssh_command_generator(f'chown {uid}:{gid} {{}}', paths=[path])
-
-        returncode, stdout, stderr = await self.openssh_execute(commands)
-
-        if returncode != 0:
-            raise OSError(f'Failed to change ownership: {path}')
 
     async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
         # chmod works with octal numbers, so we have to convert the mode to octal

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -117,10 +117,6 @@ class LocalTransport(BlockingTransport):
 
         self._internal_dir = os.path.normpath(new_path)
 
-    def chown(self, path: TransportPath, uid, gid):
-        path = str(path)
-        os.chown(path, uid, gid)
-
     def normalize(self, path: TransportPath = '.'):
         """Normalizes path, eliminating double slashes, etc..
         :param path: path to normalize

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -774,13 +774,6 @@ class SshTransport(BlockingTransport):
         path = str(path)
         self.sftp.rmdir(path)
 
-    def chown(self, path: TransportPath, uid, gid):
-        """Change owner permissions of a file.
-
-        For now, this is not implemented for the SSH transport.
-        """
-        raise NotImplementedError
-
     def isdir(self, path: TransportPath):
         """Return True if the given path is a directory, False otherwise.
         Return False also if the path does not exist.

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -1221,28 +1221,6 @@ class AsyncSshTransport(AsyncTransport):
         else:
             raise OSError(f'Error, path {path} does not exist')
 
-    async def chown_async(self, path: TransportPath, uid: int, gid: int):
-        """Change the owner and group id of a file.
-
-        :param path: path to the file
-        :param uid: the new owner id
-        :param gid: the new group id
-
-        :type path:  :class:`Path <pathlib.Path>`, :class:`PurePosixPath <pathlib.PurePosixPath>`, or `str`
-        :type uid: int
-        :type gid: int
-
-        :raises OSError: if the path is empty
-        """
-        path = str(path)
-        if not path:
-            raise OSError('Input path is an empty argument.')
-
-        if await self.path_exists_async(path):
-            await self.async_backend.chown(path, uid, gid)
-        else:
-            raise OSError(f'Error, path {path} does not exist')
-
     async def copy_from_remote_to_remote_async(
         self,
         transportdestination: Transport,

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -304,12 +304,15 @@ class Transport(abc.ABC):
         :type mode: int
         """
 
-    @abc.abstractmethod
     def chown(self, path: TransportPath, uid: int, gid: int):
         """Change the owner (uid) and group (gid) of a file.
         As with python's os.chown function, you must pass both arguments,
         so if you only want to change one, use stat first to retrieve the
         current owner and group.
+
+        .. deprecated:: 2.7
+            This method is deprecated and will be removed in a future version.
+            It is not used internally by AiiDA and has no test coverage.
 
         :param path: path to the file to change the owner and group of
         :param uid: new owner's uid
@@ -319,6 +322,11 @@ class Transport(abc.ABC):
         :type uid: int
         :type gid: int
         """
+        warn_deprecation(
+            'The `Transport.chown` method is deprecated and will be removed. ' 'It is not used internally by AiiDA.',
+            version=3,
+        )
+        raise NotImplementedError('chown is not implemented for this transport.')
 
     @abc.abstractmethod
     def copy(self, remotesource: TransportPath, remotedestination: TransportPath, dereference=False, recursive=True):
@@ -1051,9 +1059,12 @@ class Transport(abc.ABC):
         :type mode: int
         """
 
-    @abc.abstractmethod
     async def chown_async(self, path: TransportPath, uid: int, gid: int):
         """Change the owner (uid) and group (gid) of a file.
+
+        .. deprecated:: 2.7
+            This method is deprecated and will be removed in a future version.
+            It is not used internally by AiiDA and has no test coverage.
 
         :param path: path to file
         :param uid: user id of the new owner
@@ -1063,6 +1074,12 @@ class Transport(abc.ABC):
         :type uid: int
         :type gid: int
         """
+        warn_deprecation(
+            'The `Transport.chown_async` method is deprecated and will be removed. '
+            'It is not used internally by AiiDA.',
+            version=3,
+        )
+        raise NotImplementedError('chown_async is not implemented for this transport.')
 
     @abc.abstractmethod
     async def copy_async(self, remotesource, remotedestination, dereference=False, recursive=True):


### PR DESCRIPTION
The `chown` method has never been used internally by AiiDA and has no test coverage. It was added over 10 years ago but never utilized.

This change:
- Removes `@abc.abstractmethod` from `chown` and `chown_async` in the base `Transport` class, so new transport plugins are not required to implement it
- Adds deprecation warnings to the base class implementations
- Removes all implementations from `LocalTransport`, `SshTransport`, `AsyncSshTransport`, and the async backend classes

Closes #6832