### PR TITLE
CI: change test-install schedule from nightly to weekly

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -9,7 +9,7 @@ on:
     - .github/workflows/test-install.yml
     branches-ignore: [gh-pages]
   schedule:
-  - cron: 30 02 * * *      # nightly build
+  - cron: 30 02 * * 0      # weekly build (Sunday)
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
Changes the `test-install.yml` workflow schedule from nightly to weekly (Sunday).

The purpose of `test-install.yml` is to catch regressions from upstream dependency updates. Running this nightly is excessive - a weekly schedule still provides timely detection of dependency breakages while saving CI resources.