### PR TITLE
Support 2FA with improved authentication script handling in `core.ssh_async` transport

### DIFF
--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -270,7 +270,7 @@ Using two-factor authentication (2FA) with ``core.ssh_async``
 
 Some HPC centers require two-factor authentication where you must first authenticate via an API using your credentials and a TOTP code, which then provides you with short-lived signed SSH keys for the actual connection.
 
-The ``core.ssh_async`` transport plugin provides a ``script_before`` option that runs a local script **before** each SSH connection is opened.
+The ``core.ssh_async`` transport plugin provides an ``authentication_script`` option that runs a local script before each SSH connection is opened.
 This script must be provided by the user and is responsible for obtaining fresh SSH credentials so that the subsequent connection can succeed.
 
 .. warning::
@@ -297,11 +297,12 @@ How it works
 The typical flow is:
 
 1. AiiDA needs to open an SSH connection
-2. Before connecting, AiiDA optionally runs an authentication script (``script_before``)
+2. Before connecting, AiiDA optionally runs an authentication script (``authentication_script``)
 3. Your script authenticates to the HPC center. This largely depends on the authentication mechanism of your HPC center. For example:
-   - a) It may require generating a TOTP code from a shared secret, sending your username, password, and TOTP code to the HPC center, and then receiving signed SSH keys in response.
-   - b) Your HPC center's authentication policy may strictly require you to enter credentials manually, in which case your script may prompt you to enter the required information (username, password, TOTP code, etc.) interactively.
-   - c) It may require you to authenticate via a web browser, in which case your script may open a browser for you to log in.
+
+   a. It may require generating a TOTP code from a shared secret, sending your username, password, and TOTP code to the HPC center, and then receiving signed SSH keys in response.
+   b. Your HPC center's authentication policy may strictly require you to enter credentials manually, in which case your script may prompt you to enter the required information (username, password, TOTP code, etc.) interactively.
+   c. It may require you to authenticate via a web browser, in which case your script may open a browser for you to log in.
 
 In all of the above cases, your script should ultimately enable ``ssh <my-HPC>`` to succeed without a password.
 
@@ -459,12 +460,12 @@ When configuring your computer with the ``core.ssh_async`` transport, specify th
 
    $ verdi computer configure core.ssh_async YOURCOMPUTER
    ...
-   Local script to run *before* opening connection (path) [None]: /home/YOURUSERNAME/bin/get_hpc_keys.sh
+   Local script to run before opening connection (path) [None]: /home/YOURUSERNAME/bin/get_hpc_keys.sh
    ...
 
 .. note::
 
-   - The ``script_before`` path must be **absolute** and the script must be **executable**.
+   - The ``authentication_script`` path must be **absolute** and the script must be **executable**.
    - The script runs locally before each SSH connection is opened.
    - If the script fails (non-zero exit code), the SSH connection will not be attempted and an error will be raised. AiiDA may retry later using its exponential backoff mechanism.
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -300,6 +300,8 @@ The typical flow is:
 
 In all of the above cases, your script should ultimately enable ``ssh <my-HPC>`` to succeed without a password.
 
+4. AiiDA proceeds to open the SSH connection normally.
+
 .. note::
    If your HPC center does not allow multiple connections but relies on multiplexing, you will need to reconfigure your AiiDA `Computer` to use the ``openssh`` transport backend instead of ``asyncssh``.
 
@@ -315,8 +317,6 @@ In all of the above cases, your script should ultimately enable ``ssh <my-HPC>``
    Your script may be called many times throughout the day. It is your responsibility to ensure the script is efficient and does not overload the HPC center's authentication service.
    For example, if the signed keys are valid for 24 hours, your script should check whether existing keys are still valid before requesting new ones.
 
-
-4. AiiDA proceeds to open the SSH connection normally.
 
 Example: Automated key retrieval with TOTP (case a)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -268,28 +268,21 @@ Simply copy & paste the same instructions as you have used for ``ProxyJump`` in 
 Using two-factor authentication (2FA) with ``core.ssh_async``
 =============================================================
 
-Some HPC centers require two-factor authentication where you must first authenticate via an API using your credentials and a TOTP (Time-based One-Time Password) code, which then provides you with short-lived signed SSH keys for the actual connection.
-
-The ``core.ssh_async`` transport plugin provides an ``authentication_script`` option that runs a local script before each SSH connection is opened.
-This script must be provided by the user and is responsible for obtaining fresh SSH credentials so that the subsequent connection can succeed.
-
 .. danger::
 
    Make sure that your HPC center's policies allow automated 2FA connections.
    It is your responsibility to comply with their security policies.
    We strongly recommend that you do not follow these steps if your HPC center advises against it.
 
+Some HPC centers require two-factor authentication where you must first authenticate via an API using your credentials and a TOTP (Time-based One-Time Password) code, which then provides you with short-lived signed SSH keys for the actual connection.
+
+The ``core.ssh_async`` transport plugin provides an ``authentication_script`` option that runs a local script before each SSH connection is opened.
+This script must be provided by the user and is responsible for obtaining fresh SSH credentials so that the subsequent connection can succeed.
+
 .. warning::
 
    You are responsible for securely storing your TOTP secret and any other credentials.
    Never commit secrets to version control or store them in plaintext in shared locations.
-
-.. important::
-
-   Your script will be called on each SSH connection and may run concurrently
-   from multiple daemon workers. Use ``flock`` to prevent race conditions (as shown in the example below), and
-   check certificate validity **after** acquiring the lock (another process may
-   have refreshed it while you were waiting).
 
 
 How it works
@@ -310,10 +303,18 @@ In all of the above cases, your script should ultimately enable ``ssh <my-HPC>``
 .. note::
    If your HPC center does not allow multiple connections but relies on multiplexing, you will need to reconfigure your AiiDA `Computer` to use the ``openssh`` transport backend instead of ``asyncssh``.
 
-.. warning::
+.. important::
+
+   Your script will be called on each SSH connection and may run concurrently
+   from multiple daemon workers. Use ``flock`` to prevent race conditions (as shown in the example below), and
+   check certificate validity **after** acquiring the lock (another process may
+   have refreshed it while you were waiting).
+
+.. important::
 
    Your script may be called many times throughout the day. It is your responsibility to ensure the script is efficient and does not overload the HPC center's authentication service.
    For example, if the signed keys are valid for 24 hours, your script should check whether existing keys are still valid before requesting new ones.
+
 
 4. AiiDA proceeds to open the SSH connection normally.
 


### PR DESCRIPTION
Because of 2FA, security constraints, and policy compliance—and since every HPC center handles authentication a bit differently—it makes more sense to leave authentication in the user’s hands, with a clear disclaimer in the documentation.
We include a concrete example in the docs showing what such an authentication script could look like.


