### PR TITLE
Add warning when deleting StashCalculation nodes with --clean-workdir

### DIFF
--- a/tests/cmdline/utils/test_decorators.py
+++ b/tests/cmdline/utils/test_decorators.py
@@ -44,6 +44,8 @@ def manager(monkeypatch):
         """Set a mock version of the storage backend."""
         self._profile_storage = StorageBackend()
 
+    # This ensures the Manager starts each test with unloaded storage
+    monkeypatch.setattr(manager, '_profile_storage', None)
     monkeypatch.setattr(manager.__class__, 'get_profile_storage', get_profile_storage)
     yield manager
 


### PR DESCRIPTION
When using `verdi node delete --clean-workdir` on StashCalculation nodes, the stashed data at the target basepath is not automatically cleaned up. This commit adds a warning to inform users about the paths that need manual cleanup.

Fixes:
https://github.com/aiidateam/aiida-core/issues/6781