### PR TITLE
🧪 Use `--tb=short` and add `pytest-instafail`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,7 +393,7 @@ module = [
 ]
 
 [tool.pytest.ini_options]
-addopts = '--benchmark-skip --durations=5 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append '
+addopts = '--benchmark-skip --durations=5 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append --tb=short'
 filterwarnings = [
   'ignore:.*and will be removed in NumPy 2.0.*:DeprecationWarning:ase:',
   'ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:pytz|dateutil|tqdm|aio_pika:',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,7 @@ tests = [
   'pytest-rerunfailures~=12.0',
   'pytest-benchmark~=4.0',
   'pytest-regressions~=2.2',
+  'pytest-instafail~=0.5',
   'pytest-xdist~=3.6',
   'pympler~=1.0',
   'sphinx~=7.2.0',
@@ -393,7 +394,7 @@ module = [
 ]
 
 [tool.pytest.ini_options]
-addopts = '--benchmark-skip --durations=5 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append --tb=short'
+addopts = '--benchmark-skip --durations=5 --durations-min=1 --strict-config --strict-markers -ra --cov-report xml --cov-append --tb=short --instafail'
 filterwarnings = [
   'ignore:.*and will be removed in NumPy 2.0.*:DeprecationWarning:ase:',
   'ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:pytz|dateutil|tqdm|aio_pika:',

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,7 @@ pre-commit = [
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-instafail" },
     { name = "pytest-regressions" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
@@ -183,6 +184,7 @@ tests = [
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-instafail" },
     { name = "pytest-regressions" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
@@ -260,6 +262,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = "~=0.12,<0.17" },
     { name = "pytest-benchmark", marker = "extra == 'tests'", specifier = "~=4.0" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = "~=7.0" },
+    { name = "pytest-instafail", marker = "extra == 'tests'", specifier = "~=0.5" },
     { name = "pytest-regressions", marker = "extra == 'tests'", specifier = "~=2.2" },
     { name = "pytest-rerunfailures", marker = "extra == 'tests'", specifier = "~=12.0" },
     { name = "pytest-timeout", marker = "extra == 'tests'", specifier = "~=2.0" },
@@ -5710,6 +5713,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/46/db060b291999ca048edd06d6fa9ee95945d088edc38b1172c59eeb46ec45/pytest_datadir-1.8.0.tar.gz", hash = "sha256:7a15faed76cebe87cc91941dd1920a9a38eba56a09c11e9ddf1434d28a0f78eb", size = 11848, upload-time = "2025-07-30T13:52:12.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl", hash = "sha256:5c677bc097d907ac71ca418109adc3abe34cf0bddfe6cf78aecfbabd96a15cf0", size = 6512, upload-time = "2025-07-30T13:52:11.525Z" },
+]
+
+[[package]]
+name = "pytest-instafail"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/bd/e0ba6c3cd20b9aa445f0af229f3a9582cce589f083537978a23e6f14e310/pytest-instafail-0.5.0.tar.gz", hash = "sha256:33a606f7e0c8e646dc3bfee0d5e3a4b7b78ef7c36168cfa1f3d93af7ca706c9e", size = 5849, upload-time = "2023-03-31T17:17:32.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c0/c32dc39fc172e684fdb3d30169843efb65c067be1e12689af4345731126e/pytest_instafail-0.5.0-py3-none-any.whl", hash = "sha256:6855414487e9e4bb76a118ce952c3c27d3866af15487506c4ded92eb72387819", size = 4176, upload-time = "2023-03-31T17:17:30.065Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Shorter, more readable tracebacks on test failures, and test failures immediately being shown, rather than all at the end, which requires the whole test suite on CI to run through :) 

<details>
<summary>Previous PR description on `pytest-sugar`</summary>
EDIT: just learnt about https://github.com/samuelcolvin/pytest-pretty, which might also be an option. Gotta look into it. Either way, using plain pytest is absolutely egregious for larger test runs (e.g., trying to run the whole test suite in #6977). Thoughts?

no `sugar` &rarr; ugly pytest output &rarr; sad developer :(

<img width="2256" height="646" alt="image" src="https://github.com/user-attachments/assets/25ae9714-2777-4bd5-857a-7b5d0ba68869" />

with `sugar` &rarr; beautiful pytest output &rarr; happy developer :)

<img width="2256" height="1335" alt="image" src="https://github.com/user-attachments/assets/83fa6c8a-4cc1-4e28-9761-7ca27309834e" />

(i also like tracebacks for failures being shown immediately rather than everything at the end)

Once the `pytest-sugar` plugin is installed, it will be used by default, but can also be turned off via CLI or `addopts`, for CI or if unwanted, of course.
</details>