### PR TITLE
Add orphaned database connection cleanup to `verdi process repair`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -529,16 +529,19 @@ def process_repair(manager, broker, dry_run, force):
     # Terminate unreferenced database connections that could be holding locks
     # Note: Use `type()` instead of `isinstance()` because SqliteDosBackend inherits from PsqlDosBackend
     storage = manager.get_profile_storage()
+    profile = manager.get_profile()
     if type(storage) is PsqlDosBackend:
         unreferenced = storage.get_unreferenced_connections()
         if unreferenced:
-            echo.echo_warning(f'Found {len(unreferenced)} database connection(s) that may be orphaned:')
+            echo.echo_warning(
+                f'Found {len(unreferenced)} database connection(s) for profile `{profile.name}` that may be orphaned:'
+            )
             for pid, state, port in unreferenced:
                 echo.echo(f'  PID {pid} | {state} | port {port}')
             echo.echo_warning(
-                'These may include legitimate connections from workers, Jupyter notebooks, or other processes '
-                'running under the current profile. Only terminate if you are sure no other AiiDA processes '
-                'are using this profile.'
+                f'These may include legitimate connections from workers, Jupyter notebooks, or other processes '
+                f'using profile `{profile.name}`. Only terminate if you are sure no other AiiDA processes '
+                f'are using this profile.'
             )
             if not dry_run:
                 if not force:

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -543,8 +543,9 @@ def process_repair(manager, broker, dry_run, force):
             if not dry_run:
                 if not force:
                     click.confirm('Do you want to terminate these connections?', abort=True)
-                storage.terminate_unreferenced_connections()
-                echo.echo_success(f'Terminated {len(unreferenced)} database connection(s)')
+                pids = [pid for pid, _, _ in unreferenced]
+                terminated = storage.terminate_connections(pids)
+                echo.echo_success(f'Terminated {terminated} database connection(s)')
         else:
             echo.echo_success('No unreferenced database connections found.')
 

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -508,10 +508,11 @@ def process_watch(broker, processes, most_recent_node):
 
 @verdi_process.command('repair')
 @options.DRY_RUN()
+@options.FORCE(help='Do not ask for confirmation when terminating database connections.')
 @decorators.only_if_daemon_not_running()
 @decorators.with_manager
 @decorators.with_broker
-def process_repair(manager, broker, dry_run):
+def process_repair(manager, broker, dry_run, force):
     """Automatically repair all stuck processes.
 
     N.B.: This command requires the daemon to be stopped.
@@ -523,6 +524,29 @@ def process_repair(manager, broker, dry_run):
     process is useless and should be discarded. Finally, duplicate process tasks are also problematic and are discarded.
     """
     from aiida.engine.processes.control import get_active_processes, get_process_tasks, iterate_process_tasks
+    from aiida.storage.psql_dos.backend import PsqlDosBackend
+
+    # Terminate unreferenced database connections that could be holding locks
+    # Note: Use `type()` instead of `isinstance()` because SqliteDosBackend inherits from PsqlDosBackend
+    storage = manager.get_profile_storage()
+    if type(storage) is PsqlDosBackend:
+        unreferenced = storage.get_unreferenced_connections()
+        if unreferenced:
+            echo.echo_warning(f'Found {len(unreferenced)} database connection(s) that may be orphaned:')
+            for pid, state, port in unreferenced:
+                echo.echo(f'  PID {pid} | {state} | port {port}')
+            echo.echo_warning(
+                'These may include legitimate connections from workers, Jupyter notebooks, or other processes '
+                'running under the current profile. Only terminate if you are sure no other AiiDA processes '
+                'are using this profile.'
+            )
+            if not dry_run:
+                if not force:
+                    click.confirm('Do you want to terminate these connections?', abort=True)
+                storage.terminate_unreferenced_connections()
+                echo.echo_success(f'Terminated {len(unreferenced)} database connection(s)')
+        else:
+            echo.echo_success('No unreferenced database connections found.')
 
     active_processes = get_active_processes(project='id')
     process_tasks = get_process_tasks(broker)

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -431,6 +431,58 @@ class PsqlDosBackend(StorageBackend):
                 raise KeyError(f'No setting found with key {key}')
             return setting.val
 
+    def get_unreferenced_connections(self) -> list[tuple[int, str, int]]:
+        """Return a list of database connections not associated with the current session.
+
+        These are connections owned by the current user to the current database,
+        excluding the current connection. When the daemon is not running, these
+        connections are likely orphaned zombies that could be holding locks.
+
+        :return: list of tuples (pid, state, client_port)
+        """
+        from sqlalchemy import text
+
+        session = self.get_session()
+        result = session.execute(
+            text("""
+            SELECT pid, state, client_port
+            FROM pg_stat_activity
+            WHERE usename = current_user
+            AND datname = current_database()
+            AND pid != pg_backend_pid()
+        """)
+        )
+        return [(row[0], row[1], row[2]) for row in result]
+
+    def terminate_unreferenced_connections(self) -> int:
+        """Terminate all database connections not associated with the current session.
+
+        These are connections owned by the current user to the current database,
+        excluding the current connection. When the daemon is not running, these
+        connections are likely orphaned zombies that could be holding locks.
+
+        :return: number of connections terminated
+        """
+        from sqlalchemy import text
+
+        unreferenced = self.get_unreferenced_connections()
+        count = len(unreferenced)
+
+        if count > 0:
+            session = self.get_session()
+            session.execute(
+                text("""
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE usename = current_user
+                AND datname = current_database()
+                AND pid != pg_backend_pid()
+            """)
+            )
+            session.commit()
+
+        return count
+
     def maintain(self, full: bool = False, dry_run: bool = False, **kwargs) -> None:
         from aiida.manage.profile_access import ProfileAccessManager
 

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -1109,17 +1109,17 @@ def test_process_repair_unreferenced_connections(monkeypatch, run_cli_command):
 
     terminated = []
 
-    def mock_terminate(self):
-        terminated.append(True)
-        return 1
+    def mock_terminate(self, pids):
+        terminated.extend(pids)
+        return len(pids)
 
-    monkeypatch.setattr(PsqlDosBackend, 'terminate_unreferenced_connections', mock_terminate)
+    monkeypatch.setattr(PsqlDosBackend, 'terminate_connections', mock_terminate)
 
     result = run_cli_command(cmd_process.process_repair, user_input='y', use_subprocess=False)
     assert 'Found 1 database connection(s)' in result.output
     assert 'PID 1234' in result.output
     assert 'Terminated 1 database connection(s)' in result.output
-    assert len(terminated) == 1
+    assert terminated == [1234]  # Verify the correct PID was passed
 
 
 @pytest.mark.requires_psql
@@ -1136,11 +1136,11 @@ def test_process_repair_unreferenced_connections_abort(monkeypatch, run_cli_comm
 
     terminated = []
 
-    def mock_terminate(self):
-        terminated.append(True)
-        return 1
+    def mock_terminate(self, pids):
+        terminated.extend(pids)
+        return len(pids)
 
-    monkeypatch.setattr(PsqlDosBackend, 'terminate_unreferenced_connections', mock_terminate)
+    monkeypatch.setattr(PsqlDosBackend, 'terminate_connections', mock_terminate)
 
     result = run_cli_command(cmd_process.process_repair, user_input='n', use_subprocess=False, raises=True)
     assert 'Found 1 database connection(s)' in result.output
@@ -1161,11 +1161,11 @@ def test_process_repair_unreferenced_connections_dry_run(monkeypatch, run_cli_co
 
     terminated = []
 
-    def mock_terminate(self):
-        terminated.append(True)
-        return 1
+    def mock_terminate(self, pids):
+        terminated.extend(pids)
+        return len(pids)
 
-    monkeypatch.setattr(PsqlDosBackend, 'terminate_unreferenced_connections', mock_terminate)
+    monkeypatch.setattr(PsqlDosBackend, 'terminate_connections', mock_terminate)
 
     result = run_cli_command(cmd_process.process_repair, ['--dry-run'], use_subprocess=False)
     assert 'Found 1 database connection(s)' in result.output
@@ -1187,17 +1187,17 @@ def test_process_repair_unreferenced_connections_force(monkeypatch, run_cli_comm
 
     terminated = []
 
-    def mock_terminate(self):
-        terminated.append(True)
-        return 1
+    def mock_terminate(self, pids):
+        terminated.extend(pids)
+        return len(pids)
 
-    monkeypatch.setattr(PsqlDosBackend, 'terminate_unreferenced_connections', mock_terminate)
+    monkeypatch.setattr(PsqlDosBackend, 'terminate_connections', mock_terminate)
 
     # No user_input needed with --force
     result = run_cli_command(cmd_process.process_repair, ['--force'], use_subprocess=False)
     assert 'Found 1 database connection(s)' in result.output
     assert 'Terminated 1 database connection(s)' in result.output
-    assert len(terminated) == 1
+    assert terminated == [1234]  # Verify the correct PID was passed
 
 
 @pytest.fixture

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -196,7 +196,7 @@ def test_backup(tmp_path):
         assert name in contents
 
 
-def test_get_unreferenced_connections():
+def test_get_and_terminate_unreferenced_connections():
     """Test that ``get_unreferenced_connections`` detects external database connections.
 
     This test creates a real database connection outside of the AiiDA session and verifies

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -196,7 +196,7 @@ def test_backup(tmp_path):
         assert name in contents
 
 
-def test_get_unreferenced_connections(monkeypatch):
+def test_get_unreferenced_connections():
     """Test that ``get_unreferenced_connections`` detects external database connections.
 
     This test creates a real database connection outside of the AiiDA session and verifies
@@ -235,16 +235,9 @@ def test_get_unreferenced_connections(monkeypatch):
             external_port in unreferenced_ports
         ), f'External connection port {external_port} not found in {unreferenced_ports}'
 
-        # Monkeypatch get_unreferenced_connections to return only our connection
+        # Terminate only our specific connection (not all unreferenced ones)
         # This prevents killing connections from parallel tests
-        monkeypatch.setattr(
-            storage,
-            'get_unreferenced_connections',
-            lambda: [(external_pid, 'idle in transaction', external_port)],
-        )
-
-        # Terminate unreferenced connections (only our connection due to monkeypatch)
-        count = storage.terminate_unreferenced_connections()
+        count = storage.terminate_connections([external_pid])
         assert count == 1, 'Expected exactly one connection to be terminated'
 
         # Verify the external connection was actually terminated


### PR DESCRIPTION
When AiiDA daemon workers crash or are killed without proper cleanup, their postgres connections can remain open. These connections hold locks that can block other processes indefinitely, causing workchains and calcjobs to hang.

This commit adds functionality to detect and terminate these connections as part of the `verdi process repair` command. Since `verdi process repair` requires the daemon to be stopped, any postgres connections found (other than the current session) are likely from crashed processes that should be terminated. We however cannot ensure that the no other AiiDA process is run outside of the daemon (e.g. by through directly running a process) that could hold one of the connections. Therefore we ask the user for confirmation before performing a termination of these *unreferenced* postgres connections.

Summary of changes in code:

- Add `get_unreferenced_connections()` method to `PsqlDosBackend` that queries `pg_stat_activity` to find connections owned by the current user that are not the current session
  - Add `terminate_connections(pids: list[int])` method to `PsqlDosBackend` that uses `pg_terminate_backend()` to kill the passed connections
- Update `verdi process repair` to check for and terminate unreferenced connections before proceeding with RabbitMQ repairs
- Add `--force` flag to skip confirmation prompt
- Add confirmation prompt by default to warn users that legitimate connections (workers, Jupyter notebooks, etc.) may also be terminated
