### PR TITLE
Show plugin descriptions in interactive prompt help

### DIFF
--- a/src/aiida/cmdline/params/options/interactive.py
+++ b/src/aiida/cmdline/params/options/interactive.py
@@ -153,10 +153,12 @@ class InteractiveOption(ConditionalOption):
         choices_string = []
 
         for choice in choices:
+            label = f' * {choice.value:<14}'
+            colored_label = click.style(label, fg='green')
             if choice.value and choice.help:
-                choices_string.append(f' * {choice.value:<12} {choice.help}')
+                choices_string.append(f'{colored_label} {choice.help}')
             elif choice.value:
-                choices_string.append(f' * {choice.value}')
+                choices_string.append(colored_label)
 
         if any(choices_string):
             message += '\nSelect one of:\n'

--- a/src/aiida/schedulers/plugins/pbspro.py
+++ b/src/aiida/schedulers/plugins/pbspro.py
@@ -36,11 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class PbsproScheduler(PbsBaseClass):
-    """Subclass to support the PBSPro scheduler
-    (http://www.pbsworks.com/).
-
-    I redefine only what needs to change from the base class
-    """
+    """Support for the PBSPro scheduler (http://www.pbsworks.com/)."""
 
     ## I don't need to change this from the base class
     # _job_resource_class = PbsJobResource

--- a/src/aiida/schedulers/plugins/torque.py
+++ b/src/aiida/schedulers/plugins/torque.py
@@ -31,10 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TorqueScheduler(PbsBaseClass):
-    """Subclass to support the Torque scheduler..
-
-    I redefine only what needs to change from the base class
-    """
+    """Support for the Torque scheduler."""
 
     ## I don't need to change this from the base class
     # _job_resource_class = PbsJobResource

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -64,7 +64,8 @@ def convert_to_bool(string):
 
 
 class SshTransport(BlockingTransport):
-    """Support connection, command execution and data transfer to remote computers via SSH+SFTP."""
+    """(Deprecated!) Support connection, command execution and data transfer
+    to remote computers via SSH+SFTP (using paramiko)."""
 
     # Valid keywords accepted by the connect method of paramiko.SSHClient
     # I disable 'password' and 'pkey' to avoid these data to get logged in the

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -50,7 +50,7 @@ def validate_backend(ctx, param, value: str):
 
 
 class AsyncSshTransport(AsyncTransport):
-    """Transport plugin via SSH, asynchronously."""
+    """(Recommended)  Asynchronous SSH transport plugin. Supports both OpenSSH and AsyncSSH as backends."""
 
     _DEFAULT_max_io_allowed = 8
 


### PR DESCRIPTION
Fixes https://github.com/aiidateam/aiida-core/issues/7200
              
This PR display the first line of each plugin's docstring alongside its name when users type `?` during interactive prompts (e.g.`verdi computer setup`). Plugin names are highlighted in green for readability.


Before:
<img width="1481" height="563" alt="image" src="https://github.com/user-attachments/assets/9b84827d-c8fc-4cdd-af67-e291642a237c" />



After:
<img width="1436" height="532" alt="image" src="https://github.com/user-attachments/assets/f6933ed5-1669-4902-9fe7-40193e83500c" />
