### PR TITLE
Make `AbstractRepositoryBackend.open()` properly abstract and enforce `contextmanager` contract

### DIFF
--- a/src/aiida/repository/backend/abstract.py
+++ b/src/aiida/repository/backend/abstract.py
@@ -84,7 +84,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _put_object_from_filelike(self, handle: BinaryIO) -> str:
-        pass
+        raise NotImplementedError
 
     def put_object_from_file(self, filepath: Union[str, pathlib.Path]) -> str:
         """Store a new object with contents of the file located at `filepath` on this file system.
@@ -132,8 +132,9 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :return: a dictionary with the information.
         """
 
+    @abc.abstractmethod
     @contextlib.contextmanager
-    def open(self, key: str) -> Iterator[BinaryIO]:  # type: ignore[return]
+    def open(self, key: str) -> Iterator[BinaryIO]:
         """Open a file handle to an object stored under the given key.
 
         .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
@@ -146,6 +147,8 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         """
         if not self.has_object(key):
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
+
+        raise NotImplementedError('Subclasses must implement open()')
 
     def get_object_content(self, key: str) -> bytes:
         """Return the content of a object identified by key.
@@ -168,6 +171,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if a file could not be opened.
         """
+        raise NotImplementedError
 
     def get_object_hash(self, key: str) -> str:
         """Return the SHA-256 hash of an object stored under the given key.

--- a/src/aiida/repository/backend/abstract.py
+++ b/src/aiida/repository/backend/abstract.py
@@ -147,7 +147,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         if not self.has_object(key):
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
 
-        # This method must be implemented by subclasses
+        # This method must be implemented by subclasses.
         raise NotImplementedError('Subclasses must implement open()')
 
     def get_object_content(self, key: str) -> bytes:

--- a/src/aiida/repository/backend/abstract.py
+++ b/src/aiida/repository/backend/abstract.py
@@ -133,8 +133,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    @contextlib.contextmanager
-    def open(self, key: str) -> Iterator[BinaryIO]:
+    def open(self, key: str) -> contextlib.AbstractContextManager[BinaryIO]:
         """Open a file handle to an object stored under the given key.
 
         .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
@@ -148,6 +147,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         if not self.has_object(key):
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
 
+        # This method must be implemented by subclasses.
         raise NotImplementedError('Subclasses must implement open()')
 
     def get_object_content(self, key: str) -> bytes:

--- a/src/aiida/repository/backend/abstract.py
+++ b/src/aiida/repository/backend/abstract.py
@@ -167,7 +167,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if a file could not be opened.
         """
-        raise NotImplementedError
+        pass
 
     def get_object_hash(self, key: str) -> str:
         """Return the SHA-256 hash of an object stored under the given key.

--- a/src/aiida/repository/backend/abstract.py
+++ b/src/aiida/repository/backend/abstract.py
@@ -84,7 +84,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _put_object_from_filelike(self, handle: BinaryIO) -> str:
-        raise NotImplementedError
+        pass
 
     def put_object_from_file(self, filepath: Union[str, pathlib.Path]) -> str:
         """Store a new object with contents of the file located at `filepath` on this file system.
@@ -144,11 +144,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
-        if not self.has_object(key):
-            raise FileNotFoundError(f'object with key `{key}` does not exist.')
-
-        # This method must be implemented by subclasses.
-        raise NotImplementedError('Subclasses must implement open()')
+        pass
 
     def get_object_content(self, key: str) -> bytes:
         """Return the content of a object identified by key.

--- a/src/aiida/repository/backend/abstract.py
+++ b/src/aiida/repository/backend/abstract.py
@@ -147,7 +147,7 @@ class AbstractRepositoryBackend(metaclass=abc.ABCMeta):
         if not self.has_object(key):
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
 
-        # This method must be implemented by subclasses.
+        # This method must be implemented by subclasses
         raise NotImplementedError('Subclasses must implement open()')
 
     def get_object_content(self, key: str) -> bytes:

--- a/src/aiida/repository/backend/disk_object_store.py
+++ b/src/aiida/repository/backend/disk_object_store.py
@@ -106,18 +106,12 @@ class DiskObjectStoreRepositoryBackend(AbstractRepositoryBackend):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
-        from disk_objectstore.exceptions import NotExistent
 
-        # enforce abstract contract
-        if not isinstance(key, str):
-            raise TypeError('key must be a string')
-
+        if not self.has_object(key):
+            raise FileNotFoundError(f'object with key `{key}` does not exist.')
         with self._container as container:
-            try:
-                with container.get_object_stream(key) as handle:
-                    yield t.cast(t.BinaryIO, handle)
-            except NotExistent:
-                raise FileNotFoundError(f'object with key `{key}` does not exist.')
+            with container.get_object_stream(key) as handle:
+                yield t.cast(t.BinaryIO, handle)
 
     def iter_object_streams(self, keys: t.Iterable[str]) -> t.Iterator[t.Tuple[str, t.BinaryIO]]:
         with self._container.get_objects_stream_and_meta(keys) as triplets:  # type: ignore[arg-type]

--- a/src/aiida/repository/backend/disk_object_store.py
+++ b/src/aiida/repository/backend/disk_object_store.py
@@ -106,11 +106,18 @@ class DiskObjectStoreRepositoryBackend(AbstractRepositoryBackend):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
-        super().open(key)
+        from disk_objectstore.exceptions import NotExistent
+
+        # enforce abstract contract
+        if not isinstance(key, str):
+            raise TypeError('key must be a string')
 
         with self._container as container:
-            with container.get_object_stream(key) as handle:
-                yield handle  # type: ignore[misc]
+            try:
+                with container.get_object_stream(key) as handle:
+                    yield t.cast(t.BinaryIO, handle)
+            except NotExistent:
+                raise FileNotFoundError(f'object with key `{key}` does not exist.')
 
     def iter_object_streams(self, keys: t.Iterable[str]) -> t.Iterator[t.Tuple[str, t.BinaryIO]]:
         with self._container.get_objects_stream_and_meta(keys) as triplets:  # type: ignore[arg-type]

--- a/src/aiida/repository/backend/sandbox.py
+++ b/src/aiida/repository/backend/sandbox.py
@@ -104,10 +104,17 @@ class SandboxRepositoryBackend(AbstractRepositoryBackend):
 
     @contextlib.contextmanager
     def open(self, key: str) -> t.Iterator[t.BinaryIO]:
-        super().open(key)
+        """Open a file handle to an object stored under the given key."""
 
-        with self.sandbox.open(key, mode='rb') as handle:
-            yield handle
+        # enforce abstract contract
+        if not isinstance(key, str):
+            raise TypeError('key must be a string')
+
+        try:
+            with self.sandbox.open(key, mode='rb') as handle:
+                yield handle
+        except FileNotFoundError:
+            raise FileNotFoundError(f'object with key `{key}` does not exist.')
 
     def iter_object_streams(self, keys: t.Iterable[str]) -> t.Iterator[tuple[str, t.BinaryIO]]:
         for key in keys:

--- a/src/aiida/repository/backend/sandbox.py
+++ b/src/aiida/repository/backend/sandbox.py
@@ -106,15 +106,11 @@ class SandboxRepositoryBackend(AbstractRepositoryBackend):
     def open(self, key: str) -> t.Iterator[t.BinaryIO]:
         """Open a file handle to an object stored under the given key."""
 
-        # enforce abstract contract
-        if not isinstance(key, str):
-            raise TypeError('key must be a string')
-
-        try:
-            with self.sandbox.open(key, mode='rb') as handle:
-                yield handle
-        except FileNotFoundError:
+        if not self.has_object(key):
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
+
+        with self.sandbox.open(key, mode='rb') as handle:
+            yield handle
 
     def iter_object_streams(self, keys: t.Iterable[str]) -> t.Iterator[tuple[str, t.BinaryIO]]:
         for key in keys:

--- a/src/aiida/repository/repository.py
+++ b/src/aiida/repository/repository.py
@@ -150,14 +150,6 @@ class Repository:
         if path_obj.is_absolute():
             raise TypeError(f'path `{path_obj}` is not a relative path.')
 
-        # reject Windows absolute paths
-        if path_obj.anchor:
-            raise TypeError(f'path `{path_obj}` is not a relative path.')
-
-        # reject parent traversal
-        if '..' in path_obj.parts:
-            raise TypeError(f'path `{path_obj}` cannot contain parent traversal (`..`).')
-
         return path_obj
 
     @property

--- a/src/aiida/repository/repository.py
+++ b/src/aiida/repository/repository.py
@@ -138,16 +138,27 @@ class Repository:
         if path is None:
             return pathlib.PurePath()
 
+        # convert str to PurePath
         if isinstance(path, str):
-            path = pathlib.PurePath(path)
-
-        if not isinstance(path, pathlib.PurePath):
+            path_obj = pathlib.PurePath(path)
+        elif isinstance(path, pathlib.PurePath):
+            path_obj = path
+        else:
             raise TypeError('path is not of type `str` nor `pathlib.PurePath`.')
 
-        if path.is_absolute():
-            raise TypeError(f'path `{path}` is not a relative path.')
+        # reject absolute paths
+        if path_obj.is_absolute():
+            raise TypeError(f'path `{path_obj}` is not a relative path.')
 
-        return path
+        # reject Windows absolute paths
+        if path_obj.anchor:
+            raise TypeError(f'path `{path_obj}` is not a relative path.')
+
+        # reject parent traversal
+        if '..' in path_obj.parts:
+            raise TypeError(f'path `{path_obj}` cannot contain parent traversal (`..`).')
+
+        return path_obj
 
     @property
     def backend(self) -> AbstractRepositoryBackend:

--- a/src/aiida/storage/psql_dos/migrations/utils/utils.py
+++ b/src/aiida/storage/psql_dos/migrations/utils/utils.py
@@ -8,6 +8,7 @@
 ###########################################################################
 """Various utils that should be used during migrations and migrations tests because the AiiDA ORM cannot be used."""
 
+import contextlib
 import datetime
 import functools
 import io
@@ -15,7 +16,7 @@ import json
 import os
 import pathlib
 import re
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, Iterator, List, Optional, Union
 
 import numpy
 from disk_objectstore import Container
@@ -127,6 +128,10 @@ class NoopRepositoryBackend(AbstractRepositoryBackend):
 
     def get_info(self, detailed: bool = False, **kwargs) -> dict:
         raise NotImplementedError
+
+    @contextlib.contextmanager
+    def open(self, key: str) -> Iterator[io.BufferedIOBase]:
+        raise NotImplementedError()
 
 
 def migrate_legacy_repository(profile, shard=None):

--- a/tests/repository/backend/test_abstract.py
+++ b/tests/repository/backend/test_abstract.py
@@ -1,5 +1,6 @@
 """Tests for the :mod:`aiida.repository.backend.abstract` module."""
 
+import contextlib
 import io
 import tempfile
 from typing import BinaryIO, Iterable, List, Optional
@@ -50,6 +51,12 @@ class RepositoryBackend(AbstractRepositoryBackend):
 
     def get_info(self, detailed: bool = False, **kwargs) -> dict:
         raise NotImplementedError
+
+    def open(self, key: str) -> contextlib.AbstractContextManager[BinaryIO]:
+        """Minimal implementation required because open() is now abstract."""
+        if not self.has_object(key):
+            raise FileNotFoundError(f'object with key `{key}` does not exist.')
+        return contextlib.nullcontext(io.BytesIO(b'test'))
 
 
 @pytest.fixture(scope='function')

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -113,6 +113,14 @@ def test_pre_process_path():
     assert Repository._pre_process_path(pathlib.Path('relative')) == pathlib.Path('relative')
     assert Repository._pre_process_path(pathlib.Path('relative/nested')) == pathlib.Path('relative/nested')
 
+    # reject windows absolute paths
+    with pytest.raises(TypeError, match=r'path `.*` is not a relative path.'):
+        Repository._pre_process_path(path=pathlib.PureWindowsPath('C:/absolute/path'))
+
+    # reject parent traversal
+    with pytest.raises(TypeError, match=r'cannot contain parent traversal'):
+        Repository._pre_process_path(path='../evil')
+
 
 def test_create_directory_raises(repository):
     """Test the ``Repository.create_directory`` method when it is supposed to raise."""

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -117,10 +117,6 @@ def test_pre_process_path():
     with pytest.raises(TypeError, match=r'path `.*` is not a relative path.'):
         Repository._pre_process_path(path=pathlib.PureWindowsPath('C:/absolute/path'))
 
-    # reject parent traversal
-    with pytest.raises(TypeError, match=r'cannot contain parent traversal'):
-        Repository._pre_process_path(path='../evil')
-
 
 def test_create_directory_raises(repository):
     """Test the ``Repository.create_directory`` method when it is supposed to raise."""

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -113,10 +113,6 @@ def test_pre_process_path():
     assert Repository._pre_process_path(pathlib.Path('relative')) == pathlib.Path('relative')
     assert Repository._pre_process_path(pathlib.Path('relative/nested')) == pathlib.Path('relative/nested')
 
-    # reject windows absolute paths
-    with pytest.raises(TypeError, match=r'path `.*` is not a relative path.'):
-        Repository._pre_process_path(path=pathlib.PureWindowsPath('C:/absolute/path'))
-
 
 def test_create_directory_raises(repository):
     """Test the ``Repository.create_directory`` method when it is supposed to raise."""


### PR DESCRIPTION
Fixes #7198 
Previously, `open()` was not abstract and could silently return None if subclasses did not override it causing confusing runtime errors when used in `get_object_content()` or `get_object_hash()`

This change:

• Marks `open()` as an abstract method  
• Uses `AbstractContextManager[BinaryIO]` as the correct return type  
• Enforces correct subclass implementation  
• Ensures compatibility with `mypy` and `contextmanager` usage  

This makes the interface contract explicit and prevents subtle subclassing bugs
