### PR TITLE
Fix ResourceWarning from unclosed TextIOWrapper

### DIFF
--- a/src/aiida/orm/nodes/repository.py
+++ b/src/aiida/orm/nodes/repository.py
@@ -212,18 +212,7 @@ class NodeRepository:
 
         with self._repository.open(path) as handle:
             if 'b' not in mode:
-                # Note: do not yield directly the text_wrapper, but give it a variable name.
-                #
-                # In fact, if this is not done and the caller does a
-                # `with ...repo.open():` (rather than
-                #  `with ...repo.open() as something:`),
-                # then one gets (at least in python 3.11) a
-                # then the following warning is triggered
-                # `ResourceWarning: unclosed file <_io.TextIOWrapper...>`
-                # (even if the underlying file is closed).
-                # See more discussion in #7181.
-                text_wrapper = io.TextIOWrapper(handle, encoding='utf-8')
-                yield text_wrapper
+                yield io.TextIOWrapper(handle, encoding='utf-8')
             else:
                 yield handle
 

--- a/src/aiida/orm/nodes/repository.py
+++ b/src/aiida/orm/nodes/repository.py
@@ -212,7 +212,8 @@ class NodeRepository:
 
         with self._repository.open(path) as handle:
             if 'b' not in mode:
-                yield io.TextIOWrapper(handle, encoding='utf-8')
+                with io.TextIOWrapper(handle, encoding='utf-8') as text_stream:
+                    yield text_stream
             else:
                 yield handle
 


### PR DESCRIPTION
It turns out that the original fix for #7181 was just papering over the real issue. Here we fix the `ResourceWarning` properly by closing the TextIOWrapper object (using the `with` statement).

Closes #7181 