### PR TITLE
🧪 CI: Upload `coverage.xml` as artifact

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -85,7 +85,7 @@ jobs:
 
     - name: Upload coverage artifact
       if: matrix.python-version == '3.13'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-xml
         path: coverage.xml

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -88,6 +88,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: coverage-xml
+        include-hidden-files: true
         path: |
           coverage.xml
           .coverage

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -87,7 +87,7 @@ jobs:
       if: matrix.python-version == '3.13'
       uses: actions/upload-artifact@v6
       with:
-        name: coverage-xml
+        name: coverage
         include-hidden-files: true
         path: |
           coverage.xml

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -88,7 +88,9 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: coverage-xml
-        path: coverage.xml
+        path: |
+          coverage.xml
+          .coverage
         retention-days: 30
 
   tests-minimum-requirements:

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -83,6 +83,14 @@ jobs:
         files: ./coverage.xml
         fail_ci_if_error: false  # don't fail job, if coverage upload fails
 
+    - name: Upload coverage artifact
+      if: matrix.python-version == '3.13'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-xml
+        path: coverage.xml
+        retention-days: 30
+
   tests-minimum-requirements:
     name: test minimum reqs (${{ matrix.python-version }}, ${{ matrix.database-backend }})
     runs-on: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,6 +308,7 @@ omit = [
   "src/aiida/tools/_dumping/**/*"
 ]
 patch = ['subprocess']
+relative_files = true
 
 [tool.flit.module]
 name = 'aiida'


### PR DESCRIPTION
Currently, we do generate `codecov.xml` when running the full test suite via CI. However, we only upload it to the codecov webpage (outside of GHA), and, when the GH runner finishes, all the data is cleaned up. With this PR, we upload `codecov.xml` explicitly to GHA artifacts. This allows easily fetching the file at a later stage via the GH web UI or `gh` CLI tool.

Personally, I use coverage gutters in IDEs to easily identify uncovered code paths in my PRs, or run tests with coverage only on the files changed in a PR (also planning to look into `pytest-pytestmon`, but that's a different story). So I do deem it useful to have easy access to the full coverage of the code, but did not find a simple way to obtain it rather than re-running the test suite locally myself, or using a rather complicated vibe-coded script to fetch it via codecov API. As we already have it on every PR, why throw it away? :) 

As an open source project, artifact storage is free, and a small XML file is negligible in practice, so I don't really see a downside to this.