### PR TITLE
Fix missing return of exit code 0 in `inspect_process` when not paused

### DIFF
--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -402,10 +402,7 @@ class BaseRestartWorkChain(WorkChain):
 
             self.report(template.format(self.ctx.process_name, node.pk))
 
-            if last_report.exit_code.status != 0:
-                return last_report.exit_code
-
-            if pause_process:
+            if last_report.exit_code.status == 0 and pause_process:
                 self.report(
                     'Resetting the iteration counter(s) and pausing for inspection. You can resume execution using '
                     f'`verdi process play {self.node.pk}`, or kill the work chain using '
@@ -413,8 +410,9 @@ class BaseRestartWorkChain(WorkChain):
                 )
                 self.ctx.iteration = 0
                 self.pause(f"Paused for user inspection, see: 'verdi process report {self.node.pk}'")
+                return None
 
-            return None
+            return last_report.exit_code
 
         # Otherwise the process was successful and no handler returned anything so we consider the work done
         self.ctx.is_finished = True

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -221,7 +221,8 @@ def test_global_max_iterations(generate_work_chain, generate_calculation_node, m
             process.ctx.children.append(generate_calculation_node(exit_status=1))
             process.ctx.iteration += 1
             result = process.inspect_process()
-            assert result is None  # No exit code
+            assert isinstance(result, engine.ExitCode)
+            assert result.status == 0
 
     # One more trigger - `max_iterations` is reached
     process.ctx.children.append(generate_calculation_node(exit_status=1))


### PR DESCRIPTION
When pausing on failure was introduced 24e840cd03665025f0f2708c5fd04e43957a7d2c inspect_process should return None when being paused. However, in case the process is not paused we should continue returning exit code 0.