### PR TITLE
Fix dict-style access for lazy builder namespaces

### DIFF
--- a/src/aiida/engine/processes/builder.py
+++ b/src/aiida/engine/processes/builder.py
@@ -57,7 +57,7 @@ class ProcessBuilderNamespace(MutableMapping):
         """
         self._port_namespace = port_namespace
         self._valid_fields = []
-        self._data = {}
+        self._data: dict[str, Any] = {}
 
         dynamic_properties = {}
 
@@ -69,17 +69,18 @@ class ProcessBuilderNamespace(MutableMapping):
             self._valid_fields.append(name)
 
             if isinstance(port, PortNamespace):
-                self._data[name] = ProcessBuilderNamespace(port)
 
-                def fgetter(self, name=name):
-                    return self._data.get(name)
+                def fgetter(self, name=name, port=port, default=None):
+                    if name not in self._data:
+                        self._data[name] = ProcessBuilderNamespace(port)
+                    return self._data[name]
             elif port.has_default():
 
-                def fgetter(self, name=name, default=port.default):  # type: ignore[misc]
+                def fgetter(self, name=name, port=None, default=port.default):
                     return self._data.get(name, default)
             else:
 
-                def fgetter(self, name=name):
+                def fgetter(self, name=name, port=None, default=None):
                     return self._data.get(name, None)
 
             def fsetter(self, value, name=name):
@@ -147,6 +148,10 @@ class ProcessBuilderNamespace(MutableMapping):
         return len(self._data)
 
     def __getitem__(self, item):
+        if item not in self._data and item in self._valid_fields:
+            port = self._port_namespace.get(item)
+            if isinstance(port, PortNamespace):
+                self._data[item] = ProcessBuilderNamespace(port)
         return self._data[item]
 
     def __setitem__(self, item, value):
@@ -218,6 +223,12 @@ class ProcessBuilderNamespace(MutableMapping):
         """
         if prune:
             return prune_mapping(dict(self))
+
+        # Materialize all lazy namespaces so the full port structure is visible
+        for field in self._valid_fields:
+            value = getattr(self, field)
+            if isinstance(value, ProcessBuilderNamespace):
+                value._inputs(prune=False)
 
         return dict(self)
 

--- a/src/aiida/engine/processes/builder.py
+++ b/src/aiida/engine/processes/builder.py
@@ -69,26 +69,18 @@ class ProcessBuilderNamespace(MutableMapping):
             self._valid_fields.append(name)
 
             if isinstance(port, PortNamespace):
-                # Only add the nested namespace to _data if populate_defaults is True.
-                # This prevents empty namespaces from appearing in the builder when they
-                # have no values set and populate_defaults=False.
-                if port.populate_defaults:
-                    self._data[name] = ProcessBuilderNamespace(port)
+                self._data[name] = ProcessBuilderNamespace(port)
 
-                def fgetter(self, name=name, port=port, default=None):
-                    # Lazily create the ProcessBuilderNamespace if it doesn't exist yet.
-                    # This allows accessing nested namespaces that have populate_defaults=False.
-                    if name not in self._data:
-                        self._data[name] = ProcessBuilderNamespace(port)
+                def fgetter(self, name=name):
                     return self._data.get(name)
             elif port.has_default():
 
-                def fgetter(self, name=name, port=None, default=port.default):
+                def fgetter(self, name=name, default=port.default):  # type: ignore[misc]
                     return self._data.get(name, default)
             else:
 
-                def fgetter(self, name=name, port=None, default=None):
-                    return self._data.get(name, default)
+                def fgetter(self, name=name):
+                    return self._data.get(name, None)
 
             def fsetter(self, value, name=name):
                 self._data[name] = value

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -276,7 +276,6 @@ class CalcJob(Process):
             'monitors',
             valid_type=orm.Dict,
             required=False,
-            populate_defaults=False,
             validator=validate_monitors,
             help='Add monitoring functions that can inspect output files while the job is running and decide to '
             'prematurely terminate the job.',

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -142,6 +142,31 @@ def test_builder_inputs():
     assert builder._inputs(prune=True) == {'namespace': {'nested': {'bird': []}}}
 
 
+def test_builder_lazy_namespaces():
+    """Test that dict-style access lazily creates namespaces, including through nested levels."""
+    # Dict-style access creates the namespace
+    builder = LazyProcessNamespace.get_builder()
+    _ = builder['namespace']
+    assert 'namespace' in dict(builder)
+
+    # Nested dict-style access where both parent and child are absent
+    builder = LazyProcessNamespace.get_builder()
+    _ = builder['namespace']['nested']
+    assert 'nested' in dict(builder['namespace'])
+
+    # Setting a value through nested dict-style access
+    builder = LazyProcessNamespace.get_builder()
+    builder['namespace']['nested']['bird'] = 'robin'
+    assert builder._inputs(prune=True) == {'namespace': {'nested': {'bird': 'robin'}}}
+
+    # Invalid keys raise KeyError at any nesting level
+    builder = LazyProcessNamespace.get_builder()
+    with pytest.raises(KeyError):
+        builder['nonexistent']
+    with pytest.raises(KeyError):
+        builder['namespace']['nonexistent']
+
+
 @pytest.mark.parametrize(
     'process_class',
     [
@@ -182,6 +207,7 @@ def test_dynamic_setters(example_inputs):
     builder.name_spaced = example_inputs['name_spaced']
     builder.boolean = example_inputs['boolean']
     builder.dict = example_inputs['dict']
+    builder.metadata = example_inputs['metadata']
     assert builder == example_inputs
 
 

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -51,16 +51,6 @@ class LazyProcessNamespace(Process):
         spec.input('namespace.c', non_db=True)
 
 
-class PopulateDefaultsProcess(Process):
-    """Process with namespaces using populate_defaults=False to test lazy namespace creation."""
-
-    @classmethod
-    def define(cls, spec):
-        super().define(spec)
-        spec.input_namespace('optional_ns', non_db=True, required=False, populate_defaults=False)
-        spec.input('optional_ns.value', valid_type=str, non_db=True, required=False)
-
-
 class SimpleProcessNamespace(Process):
     """Process with basic nested namespaces to test "pruning" of empty nested namespaces from the builder."""
 
@@ -150,27 +140,6 @@ def test_builder_inputs():
     builder.namespace.nested.bird = []
     assert builder._inputs(prune=False) == {'namespace': {'nested': {'bird': []}}, 'metadata': {}}
     assert builder._inputs(prune=True) == {'namespace': {'nested': {'bird': []}}}
-
-
-def test_builder_populate_defaults_false():
-    """Test that namespaces with populate_defaults=False are not added to builder until accessed."""
-    # An empty builder should not have the namespace with populate_defaults=False
-    builder = PopulateDefaultsProcess.get_builder()
-    assert 'optional_ns' not in dict(builder)
-    # Note that the 'metadata' dict does not contain 'options' here, as that is added in the
-    # CalcJob interface, while here we are testing on a `Process` only
-    assert builder._inputs(prune=False) == {'metadata': {}}
-
-    # Accessing the namespace should create it (lazy creation)
-    _ = builder.optional_ns
-    assert 'optional_ns' in dict(builder)
-    # But with prune=True, it should be removed since it's empty
-    assert builder._inputs(prune=True) == {}
-
-    # Setting a value in the namespace should keep it
-    builder = PopulateDefaultsProcess.get_builder()
-    builder.optional_ns.value = 'test'
-    assert builder._inputs(prune=True) == {'optional_ns': {'value': 'test'}}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
After #7143, dict-style access (`builder['metadata']['options']['stash']`) surprisingly broke for namespaces with unset values and `populate_defaults=False`, while attribute access (`builder.stash`) works fine. This PR makes both consistent.

```
  >>> from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
  >>> from aiida.common.datastructures import StashMode

  >>> ArithmeticAddCalculation.get_builder()['metadata']['options']['stash']
  {}

  >>> ArithmeticAddCalculation.get_builder()['metadata']['options']['NonExistance']
  KeyError: 'NonExistance'

  >>> builder = ArithmeticAddCalculation.get_builder()
  >>> builder['metadata']['options']['stash']['stash_mode'] = StashMode.COPY.value
  >>> builder
  {'metadata': {'options': {'stash': {'stash_mode': 'copy'}}}}
```
