### PR TITLE
Use same pre-commit settings in release workflow as in pre-commit workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Install aiida-core and pre-commit
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: '3.9'
+        python-version: '3.11'
         extras: pre-commit
-        from-lock: 'true'
+        from-lock: 'false'
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Install aiida-core and pre-commit
       uses: ./.github/actions/install-aiida-core
       with:
-        python-version: '3.11'
+        python-version: '3.9'
         extras: pre-commit
-        from-lock: 'false'
+        from-lock: 'true'
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         python-version: '3.11'
         extras: pre-commit
-        from-lock: 'false'
+        from-lock: 'true'
 
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -17,7 +17,6 @@ remote HPC resources and codes, thanks to its flexible plugin interface
 and workflow engine for the automation of complex sequences of simulations.
 
 More information at http://www.aiida.net
-Some change to trigger CI?
 """
 
 from aiida.common.log import configure_logging

--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -17,6 +17,7 @@ remote HPC resources and codes, thanks to its flexible plugin interface
 and workflow engine for the automation of complex sequences of simulations.
 
 More information at http://www.aiida.net
+Some change to trigger CI?
 """
 
 from aiida.common.log import configure_logging


### PR DESCRIPTION
Changes the python version in release workflow to the same version as in pre-commit workflow 3.9. In this case the pretty-format-toml hook does result in different indentation in the formatting.

The fix does not work (see action run https://github.com/aiidateam/aiida-core/actions/runs/22674636384/job/65727720684). The CI errors must be because we do not use the uv.lock file for this pre-commit job (while for the other github workflow we do). The click errors I can understand, as far as I remember they did a breaking change with a minor release, so that mypy hits makes sense. I don't understand the autodoc error. In this case there is also no good solution. To make the CI happy we can use the same uv lock file but ideally formatting is independent of versioning.