### PR TITLE
Add python 3.14 as classifier to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'Topic :: Scientific/Engineering'
 ]
 # NOTE: When updating versions of some packages, such as requests or paramiko,


### PR DESCRIPTION
After a discussion in #7240 we decided to add a classifier.

EDIT: You are right, I should at least run the our production test suite on py3.14 before merging.