### PR TITLE
 Deprecate Node.base.attributes.all in favor of get_dict()

### DIFF
--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -288,7 +288,7 @@ def echo_node_dict(nodes: list[Node], keys: list, fmt: str, identifier: str, raw
             id_value = node.uuid  # type: ignore[assignment]
 
         if use_attrs:
-            node_dict = node.base.attributes.all
+            node_dict = node.base.attributes.get_dict()
             dict_name = 'attributes'
         else:
             node_dict = node.base.extras.all

--- a/src/aiida/orm/nodes/attributes.py
+++ b/src/aiida/orm/nodes/attributes.py
@@ -40,24 +40,31 @@ class NodeAttributes:
 
     @property
     def all(self) -> Dict[str, Any]:
-        """Return the complete attributes dictionary.
+        """Return a deep copy of the complete attributes dictionary.
 
-        .. warning:: While the entity is unstored, this will return references of the attributes on the database model,
-            meaning that changes on the returned values (if they are mutable themselves, e.g. a list or dictionary) will
-            automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-            attributes will be a deep copy and mutations of the database attributes will have to go through the
-            appropriate set methods. Therefore, once stored, retrieving a deep copy can be a heavy operation. If you
-            only need the keys or some values, use the iterators `keys` and `items`, or the
-            getters `get` and `get_many` instead.
+        .. deprecated:: 3.0
+            Use :meth:`get_dict` instead.
 
         :return: the attributes as a dictionary
         """
-        attributes = self._backend_node.attributes
+        from aiida.common.warnings import warn_deprecation
 
-        if self._node.is_stored:
-            attributes = copy.deepcopy(attributes)
+        warn_deprecation(
+            'The `all` property is deprecated. Please use the `get_dict()` method instead.',
+            version=3
+        )
+        return self.get_dict()
 
-        return attributes
+    def get_dict(self) -> Dict[str, Any]:
+        """Return a deep copy of the complete attributes dictionary.
+
+        This method will always return a deep copy, ensuring that modifications 
+        to the returned dictionary do not implicitly modify the node's attributes.
+        Use `set` or `set_many` to modify attributes.
+
+        :return: the attributes as a dictionary
+        """
+        return copy.deepcopy(self._backend_node.attributes)
 
     def get(self, key: str, default=_NO_DEFAULT) -> Any:
         """Return the value of an attribute.

--- a/src/aiida/orm/nodes/data/data.py
+++ b/src/aiida/orm/nodes/data/data.py
@@ -77,7 +77,7 @@ class Data(Node):
 
         backend_clone = self.backend_entity.clone()
         clone = from_backend_entity(self.__class__, backend_clone)
-        clone.base.attributes.reset(copy.deepcopy(self.base.attributes.all))
+        clone.base.attributes.reset(copy.deepcopy(self.base.attributes.get_dict()))
         clone.base.repository._clone(self.base.repository)
 
         return clone

--- a/src/aiida/orm/nodes/data/dict.py
+++ b/src/aiida/orm/nodes/data/dict.py
@@ -134,7 +134,7 @@ class Dict(Data):
 
         :return: dictionary
         """
-        return dict(self.base.attributes.all)
+        return dict(self.base.attributes.get_dict())
 
     def keys(self):
         """Iterator of valid keys stored in the Dict object.
@@ -155,7 +155,7 @@ class Dict(Data):
 
         :return: The dictionary content.
         """
-        return self.base.attributes.all
+        return self.base.attributes.get_dict()
 
     @property
     def dict(self):

--- a/src/aiida/orm/nodes/data/enum.py
+++ b/src/aiida/orm/nodes/data/enum.py
@@ -119,6 +119,6 @@ class EnumData(Data):
             except (ImportError, ValueError):
                 return False
         elif isinstance(other, EnumData):
-            return self.base.attributes.all == other.base.attributes.all
+            return self.base.attributes.get_dict() == other.base.attributes.get_dict()
 
         return False

--- a/src/aiida/orm/nodes/data/jsonable.py
+++ b/src/aiida/orm/nodes/data/jsonable.py
@@ -121,7 +121,7 @@ class JsonableData(Data):
         try:
             return self._obj
         except AttributeError:
-            attributes = self.base.attributes.all
+            attributes = self.base.attributes.get_dict()
             class_name = attributes.pop('@class')
             module_name = attributes.pop('@module')
 

--- a/src/aiida/orm/nodes/data/structure.py
+++ b/src/aiida/orm/nodes/data/structure.py
@@ -1307,7 +1307,9 @@ class StructureData(Data):
             raise ValueError(f'A kind with the same name ({kind.name}) already exists.')
 
         # If here, no exceptions have been raised, so I add the site.
-        self.base.attributes.all.setdefault('kinds', []).append(new_kind.get_raw())
+        kinds = self.base.attributes.get('kinds', [])
+        kinds.append(new_kind.get_raw())
+        self.base.attributes.set('kinds', kinds)
         # Note, this is a dict (with integer keys) so it allows for empty spots!
         if self._internal_kind_tags is None:
             self._internal_kind_tags = {}
@@ -1334,7 +1336,9 @@ class StructureData(Data):
             )
 
         # If here, no exceptions have been raised, so I add the site.
-        self.base.attributes.all.setdefault('sites', []).append(new_site.get_raw())
+        sites = self.base.attributes.get('sites', [])
+        sites.append(new_site.get_raw())
+        self.base.attributes.set('sites', sites)
 
     def append_atom(self, **kwargs):
         """Append an atom to the Structure, taking care of creating the

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -241,7 +241,7 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             None,
             description='The node attributes',
             is_attribute=False,
-            orm_to_model=lambda node, _: node.base.attributes.all,  # type: ignore[attr-defined]
+            orm_to_model=lambda node, _: node.base.attributes.get_dict(),  # type: ignore[attr-defined]
             is_subscriptable=True,
             exclude_from_cli=True,
             exclude_to_orm=True,
@@ -640,7 +640,7 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
         # Make sure to reinitialize the repository instance of the clone to that of the source node.
         self.base.repository._copy(cache_node.base.repository)
 
-        for key, value in cache_node.base.attributes.all.items():
+        for key, value in cache_node.base.attributes.get_dict().items():
             if key != Sealable.SEALED_KEY:
                 self.base.attributes.set(key, value)
 

--- a/src/aiida/restapi/translator/nodes/node.py
+++ b/src/aiida/restapi/translator/nodes/node.py
@@ -242,7 +242,7 @@ class NodeTranslator(BaseTranslator):
         if self._content_type == 'attributes':
             # Get all attrs if attributes_filter is None
             if self._attributes_filter is None:
-                data = {self._content_type: node.base.attributes.all}
+                data = {self._content_type: node.base.attributes.get_dict()}
             # Get all attrs contained in attributes_filter
             else:
                 attrs = {}

--- a/src/aiida/tools/_dumping/executors/process.py
+++ b/src/aiida/tools/_dumping/executors/process.py
@@ -448,7 +448,7 @@ class NodeMetadataWriter:
                 node_dict['Computer data'] = computer_dict
 
         if self.config.include_attributes:
-            node_attributes = process_node.base.attributes.all
+            node_attributes = process_node.base.attributes.get_dict()
             if node_attributes:
                 node_dict['Node attributes'] = node_attributes
 

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -435,7 +435,7 @@ def test_code_export(run_cli_command, aiida_code_installed, tmp_path, file_regre
         cmd_code.code_create, ['core.code.installed', '--non-interactive', '--config', filepath, '--label', new_label]
     )
     new_code = load_code(new_label)
-    assert code.base.attributes.all == new_code.base.attributes.all
+    assert code.base.attributes.get_dict() == new_code.base.attributes.get_dict()
     assert isinstance(new_code, InstalledCode)
 
 

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -137,11 +137,11 @@ class TestNodeAttributesExtras:
         self.node = Data()
 
     def test_attributes(self):
-        """Test the `Node.base.attributes.all` property."""
+        """Test the `Node.base.attributes.get_dict` method."""
         original_attribute = {'nested': {'a': 1}}
 
         self.node.base.attributes.set('key', original_attribute)
-        node_attributes = self.node.base.attributes.all
+        node_attributes = self.node.base.attributes.get_dict()
         assert node_attributes['key'] == original_attribute
         node_attributes['key']['nested']['a'] = 2
 
@@ -149,11 +149,17 @@ class TestNodeAttributesExtras:
 
         # Now store the node and verify that `attributes` then returns a deep copy
         self.node.store()
-        node_attributes = self.node.base.attributes.all
+        node_attributes = self.node.base.attributes.get_dict()
 
         # We change the returned node attributes but the original attribute should remain unchanged
         node_attributes['key']['nested']['a'] = 3
         assert original_attribute['nested']['a'] == 2
+
+    def test_attributes_all_deprecated(self):
+        """Test the deprecated `Node.base.attributes.all` property."""
+        from aiida.common.warnings import AiidaDeprecationWarning
+        with pytest.warns(AiidaDeprecationWarning):
+            _ = self.node.base.attributes.all
 
     def test_get_attribute(self):
         """Test the `Node.get_attribute` method."""
@@ -232,9 +238,9 @@ class TestNodeAttributesExtras:
         attributes_illegal = {'attribute.illegal': 'value', 'attribute_four': 'value'}
 
         self.node.base.attributes.set_many(attributes_before)
-        assert self.node.base.attributes.all == attributes_before
+        assert self.node.base.attributes.get_dict() == attributes_before
         self.node.base.attributes.reset(attributes_after)
-        assert self.node.base.attributes.all == attributes_after
+        assert self.node.base.attributes.get_dict() == attributes_after
 
         with pytest.raises(exceptions.ValidationError):
             self.node.base.attributes.reset(attributes_illegal)
@@ -267,10 +273,10 @@ class TestNodeAttributesExtras:
         """Test the `Node.clear_attributes` method."""
         attributes = {'attribute_one': 'value', 'attribute_two': 'value'}
         self.node.base.attributes.set_many(attributes)
-        assert self.node.base.attributes.all == attributes
+        assert self.node.base.attributes.get_dict() == attributes
 
         self.node.base.attributes.clear()
-        assert self.node.base.attributes.all == {}
+        assert self.node.base.attributes.get_dict() == {}
 
         # Repeat for stored node
         self.node.store()
@@ -1024,7 +1030,7 @@ class TestNodeCaching:
         """Test that subclasses get different hashes even if they contain the same attributes."""
         node_int = Int(5).store()
         node_data = Data()
-        node_data.base.attributes.set_many(node_int.base.attributes.all)
+        node_data.base.attributes.set_many(node_int.base.attributes.get_dict())
         node_data.store()
         assert node_int.base.caching.get_hash() != node_data.base.caching.get_hash()
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -342,7 +342,7 @@ class TestNodeBasic:
         }
 
         # Now I check if I can retrieve them, before the storage
-        assert a.base.attributes.all == target_attrs
+        assert a.base.attributes.get_dict() == target_attrs
 
         # And now I try to delete the keys
         a.base.attributes.delete('k1')
@@ -355,7 +355,7 @@ class TestNodeBasic:
         a.base.attributes.delete('k8')
         a.base.attributes.delete('k9')
 
-        assert a.base.attributes.all == {}
+        assert a.base.attributes.get_dict() == {}
 
     def test_get_attrs_after_storing(self):
         a = orm.Data()
@@ -384,7 +384,7 @@ class TestNodeBasic:
         }
 
         # Now I check if I can retrieve them, before the storage
-        assert a.base.attributes.all == target_attrs
+        assert a.base.attributes.get_dict() == target_attrs
 
     def test_store_object(self):
         """Trying to set objects as attributes should fail, because they are not json-serializable."""
@@ -427,7 +427,7 @@ class TestNodeBasic:
         b_expected_attributes['new'] = 'cvb'
 
         # I check before storing that the attributes are ok
-        assert b.base.attributes.all == b_expected_attributes
+        assert b.base.attributes.get_dict() == b_expected_attributes
         # Note that during copy, I do not copy the extras!
         assert b.base.extras.all == {}
 
@@ -438,11 +438,11 @@ class TestNodeBasic:
         b_expected_extras = {'meta': 'textofext', '_aiida_hash': AnyValue()}
 
         # Now I check that the attributes of the original node have not changed
-        assert a.base.attributes.all == attrs_to_set
+        assert a.base.attributes.get_dict() == attrs_to_set
 
         # I check then on the 'b' copy
         assert b.base.extras.all == b_expected_extras
-        assert b.base.attributes.all == b_expected_attributes
+        assert b.base.attributes.get_dict() == b_expected_attributes
 
     def test_files(self):
         a = orm.Data()
@@ -777,7 +777,7 @@ class TestNodeBasic:
         assert set(list(a.base.extras.keys())) == set(all_extras.keys())
         assert set(list(a.base.attributes.keys())) == set(attrs_to_set.keys())
 
-        assert a.base.attributes.all == attrs_to_set
+        assert a.base.attributes.get_dict() == attrs_to_set
 
         assert a.base.extras.all == all_extras
 

--- a/tests/tools/archive/test_complex.py
+++ b/tests/tools/archive/test_complex.py
@@ -175,13 +175,13 @@ def get_hash_from_db_content(grouplabel):
     hash_ = make_hash(
         [
             (
-                item['param']['*'].base.attributes.all,
+                item['param']['*'].base.attributes.get_dict(),
                 item['param']['*'].uuid,
                 item['param']['*'].label,
                 item['param']['*'].description,
                 item['calc']['*'].uuid,
-                item['calc']['*'].base.attributes.all,
-                item['array']['*'].base.attributes.all,
+                item['calc']['*'].base.attributes.get_dict(),
+                item['array']['*'].base.attributes.get_dict(),
                 [item['array']['*'].get_array(name).tolist() for name in item['array']['*'].get_arraynames()],
                 item['array']['*'].uuid,
                 item['group']['*'].uuid,

--- a/tests/tools/archive/test_specific_import.py
+++ b/tests/tools/archive/test_specific_import.py
@@ -105,8 +105,8 @@ def test_cycle_structure_data(aiida_profile_clean, aiida_localhost, tmp_path):
     # Verify that orm.CalculationNodes have non-empty attribute dictionaries
     builder = orm.QueryBuilder().append(orm.CalculationNode)
     for [calculation] in builder.iterall():
-        assert isinstance(calculation.base.attributes.all, dict)
-        assert len(calculation.base.attributes.all) != 0
+        assert isinstance(calculation.base.attributes.get_dict(), dict)
+        assert len(calculation.base.attributes.get_dict()) != 0
 
     # Verify that the structure data maintained its label, cell and kinds
     builder = orm.QueryBuilder().append(orm.StructureData)

--- a/tests/tools/groups/test_paths.py
+++ b/tests/tools/groups/test_paths.py
@@ -134,7 +134,7 @@ def test_walk_nodes():
     node.store()
     group.add_nodes(node)
     group_path = GroupPath()
-    assert [(r.group_path.path, r.node.base.attributes.all) for r in group_path.walk_nodes()] == [
+    assert [(r.group_path.path, r.node.base.attributes.get_dict()) for r in group_path.walk_nodes()] == [
         ('a', {'i': 1, 'j': 2})
     ]
 


### PR DESCRIPTION
## Description
Fixes #6393.
As discussed in the issue, the `attributes.all` property returns a deep copy of the node attributes when stored. This leads to user-unfriendly behavior where users might try to mutate the dictionary via `node.base.attributes.all['key'] = value`, which fails silently because they are only mutating a copy.
To resolve this and make the copy semantics explicit, this PR:
1. **Introduces** a new [get_dict()](cci:1://file:///e:/AiiDA/src/aiida/orm/nodes/attributes.py:57:4-66:59) method on [NodeAttributes](cci:2://file:///e:/AiiDA/src/aiida/orm/nodes/attributes.py:21:0-188:51) that consistently returns a [deepcopy](cci:1://file:///e:/AiiDA/src/aiida/orm/nodes/data/data.py:63:4-68:27) of the attributes dictionary.
2. **Deprecates** the existing `.all` property (it now emits an `AiidaDeprecationWarning` for v3 and delegates to [get_dict()](cci:1://file:///e:/AiiDA/src/aiida/orm/nodes/attributes.py:57:4-66:59)).
3. **Replaces** all internal usages of `.attributes.all` across the `aiida-core` repository (`src/` and `tests/`) with `.attributes.get_dict()` to prevent AiiDA internals from triggering the deprecation warning.
4. **Fixes** an implicit mutation bug in [structure.py](cci:7://file:///e:/AiiDA/src/aiida/orm/nodes/data/structure.py:0:0-0:0) (`append_name` and [append_kind](cci:1://file:///e:/AiiDA/src/aiida/orm/nodes/data/structure.py:1291:4-1316:97)) by explicitly using `.get()`, appending to the list, and then using `.set()` instead of relying on in-place mutations of `.all`.
## Tests
- Updated existing tests to use [get_dict()](cci:1://file:///e:/AiiDA/src/aiida/orm/nodes/attributes.py:57:4-66:59).
- Added [test_attributes_all_deprecated](cci:1://file:///e:/AiiDA/tests/orm/nodes/test_node.py:157:4-161:45) in [tests/orm/nodes/test_node.py](cci:7://file:///e:/AiiDA/tests/orm/nodes/test_node.py:0:0-0:0) to verify that the `AiidaDeprecationWarning` is successfully emitted.