### PR TITLE
Fix resource leaks in storage, runner and broker

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -45,6 +45,13 @@ class RabbitmqBroker(Broker):
             self._communicator.close()
             self._communicator = None
 
+    def __del__(self):
+        if self._communicator is not None:
+            import warnings
+
+            warnings.warn(f'RabbitmqBroker was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
+            self.close()
+
     def iterate_tasks(self):
         """Return an iterator over the tasks in the launch queue."""
         for task in self.get_communicator().task_queue(get_launch_queue_name(self._prefix)):

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -119,6 +119,7 @@ def verdi_status(print_traceback, no_rmq):
     else:
         message = str(storage_backend)
         print_status(ServiceStatus.UP, 'storage', message)
+        storage_backend.close()
 
     if no_rmq:
         warn_deprecation(

--- a/src/aiida/cmdline/commands/cmd_storage.py
+++ b/src/aiida/cmdline/commands/cmd_storage.py
@@ -50,7 +50,7 @@ def storage_version():
         echo.echo_critical(f'Failed to determine the storage version: {exception}')
 
     try:
-        profile.storage_cls(profile)
+        storage = profile.storage_cls(profile)
     except (CorruptStorage, UnreachableStorage) as exception:
         echo.echo_error(f'The storage cannot be reached or is corrupt: {exception}')
         sys.exit(3)
@@ -60,6 +60,8 @@ def storage_version():
             'Run `verdi storage migrate` to migrate the storage.'
         )
         sys.exit(4)
+    else:
+        storage.close()
 
 
 @verdi_storage.command('migrate')

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -34,7 +34,8 @@ async def shutdown_worker(runner: Runner) -> None:
 
     await asyncio.gather(*tasks, return_exceptions=True)
 
-    runner.close()
+    # Close every open connection
+    get_manager().reset_profile()
 
     LOGGER.info('Daemon worker stopped')
 
@@ -74,6 +75,6 @@ def start_daemon_worker(foreground: bool = False, profile_name: Union[str, None]
         runner.start()
     except SystemError as exception:
         LOGGER.info('Received a SystemError: %s', exception)
-        runner.close()
+        manager.reset_profile()
 
     LOGGER.info('Daemon worker started')

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -595,11 +595,17 @@ class Config:
                     )
                 else:
                     storage = storage_cls(profile)
-                    storage.delete()
+                    try:
+                        storage.delete()
+                    finally:
+                        storage.close()
                     LOGGER.report(f'Data storage deleted, configuration was: {profile.storage_config}')
             else:
                 storage = storage_cls(profile)
-                storage.delete()
+                try:
+                    storage.delete()
+                finally:
+                    storage.close()
                 LOGGER.report(f'Data storage deleted, configuration was: {profile.storage_config}')
         else:
             LOGGER.report(f'Data storage not deleted, configuration is: {profile.storage_config}')

--- a/src/aiida/orm/implementation/storage_backend.py
+++ b/src/aiida/orm/implementation/storage_backend.py
@@ -135,6 +135,18 @@ class StorageBackend(abc.ABC):
     def close(self) -> None:
         """Close the storage access."""
 
+    def __del__(self):
+        try:
+            closed = self.is_closed
+        except AttributeError:
+            # covers cases where the backend implementation is not yet initialized but object is deleted
+            return
+        if not closed:
+            import warnings
+
+            warnings.warn(f'StorageBackend was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
+            self.close()
+
     @property
     @abc.abstractmethod
     def is_closed(self) -> bool:

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Test data-related verdi commands."""
 
-import asyncio
 import io
 import os
 import subprocess as sp
@@ -240,12 +239,8 @@ class TestVerdiDataBands(DummyVerdiDataListable):
     @pytest.fixture(autouse=True)
     def init_profile(self, aiida_profile_clean, run_cli_command):
         """Initialize the profile."""
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
         self.pks = self.create_structure_bands()
         self.cli_runner = run_cli_command
-        yield
-        self.loop.close()
 
     @staticmethod
     def create_structure_bands():

--- a/tests/cmdline/commands/test_setup.py
+++ b/tests/cmdline/commands/test_setup.py
@@ -110,7 +110,10 @@ class TestVerdiSetup:
 
         # Check that the repository UUID was stored in the database
         backend = profile.storage_cls(profile)
-        assert backend.get_global_variable('repository|uuid') == backend.get_repository().uuid
+        try:
+            assert backend.get_global_variable('repository|uuid') == backend.get_repository().uuid
+        finally:
+            backend.close()
 
     def test_quicksetup_default_user(self, tmp_path):
         """Test `verdi quicksetup` and ensure that user details (apart from the email) are optional."""
@@ -280,7 +283,10 @@ repository: {tmp_path}"""
 
         # Check that the repository UUID was stored in the database
         backend = profile.storage_cls(profile)
-        assert backend.get_global_variable('repository|uuid') == backend.get_repository().uuid
+        try:
+            assert backend.get_global_variable('repository|uuid') == backend.get_repository().uuid
+        finally:
+            backend.close()
 
     def test_setup_profile_uuid(self):
         """Test ``verdi setup`` explicitly defining the ``--profile-uuid`` option.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -500,7 +500,7 @@ def manager():
     """Get the ``Manager`` instance of the currently loaded profile."""
     manager = get_manager()
 
-    yield get_manager()
+    yield manager
 
     # close connections
     manager.reset_profile()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -498,8 +498,12 @@ def config_with_profile(config_with_profile_factory):
 @pytest.fixture
 def manager():
     """Get the ``Manager`` instance of the currently loaded profile."""
+    manager = get_manager()
 
-    return get_manager()
+    yield get_manager()
+
+    # close connections
+    manager.reset_profile()
 
 
 @pytest.fixture

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Module to test process runners."""
 
-import asyncio
 import threading
 
 import plumpy
@@ -24,8 +23,9 @@ from aiida.orm import Int, Str, WorkflowNode
 @pytest.fixture
 def runner():
     """Construct and return a `Runner`."""
-    loop = asyncio.new_event_loop()
-    return get_manager().create_runner(poll_interval=0.5, loop=loop)
+    manager = get_manager()
+    yield manager.create_runner(poll_interval=0.5)
+    manager.reset_runner()
 
 
 class Proc(Process):

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -23,9 +23,9 @@ from aiida.orm import Int, Str, WorkflowNode
 @pytest.fixture
 def runner():
     """Construct and return a `Runner`."""
-    manager = get_manager()
-    yield manager.create_runner(poll_interval=0.5)
-    manager.reset_runner()
+    runner = get_manager().create_runner(poll_interval=0.5)
+    yield runner
+    runner.close()
 
 
 class Proc(Process):

--- a/tests/storage/sqlite/test_archive.py
+++ b/tests/storage/sqlite/test_archive.py
@@ -28,6 +28,7 @@ def test_basic(tmp_path):
 
     # export to archive
     create_archive(None, backend=backend1, filename=filename)
+    backend1.close()
 
     # create a new temporary backend and import
     profile2 = SqliteTempBackend.create_profile(filepath=str(tmp_path / 'repo2'))
@@ -45,3 +46,5 @@ def test_basic(tmp_path):
     # check that we can retrieve the repository data
     node = orm.QueryBuilder(backend=backend2).append(orm.SinglefileData).first(flat=True)
     assert node.get_content() == text_data
+
+    backend2.close()


### PR DESCRIPTION
Need to check this. I assume this can keep up psql connections alive after the worker died.

EDIT: I checked the CI log for the warnings that are now emitted on `__del__` of the resources storage, runner and broker. By temporary storing the traceback where the object was initialized in the object itself and printing it on deletion if not closed, one could identify the places where these objects are not released.