### PR TITLE
🐛 `verdi status`: close broker connection after check

### DIFF
--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -139,6 +139,8 @@ def verdi_status(print_traceback, no_rmq):
             exit_code = ExitCode.CRITICAL
         else:
             print_status(ServiceStatus.UP, 'broker', broker)
+        finally:
+            broker.close()
     else:
         print_status(
             ServiceStatus.WARNING,


### PR DESCRIPTION
The `verdi status` command connects to RabbitMQ to check if it is reachable, but
never disconnects properly afterwards. Instead, the connection is dropped abruptly
when the process exits, causing RabbitMQ to log a warning:

    client unexpectedly closed TCP connection

While harmless, this warning can be a red herring when debugging other RabbitMQ
issues. Here we explicitly close the connection after the check, whether it
succeeded or failed.