### PR TITLE
✨ Add Code-level scheduler cmds & mpirun params

### DIFF
--- a/docs/source/howto/tricks_real_world_runs.rst
+++ b/docs/source/howto/tricks_real_world_runs.rst
@@ -10,7 +10,13 @@ Setting runtime configuration of a calculation job
 ==================================================
 
 When submitting a job, you can provide specific instructions which should be put in the job submission script (e.g. for the Slurm scheduler).
-They can be provided via the ``metadata.options`` dictionary of the calculation job.
+These can be configured at multiple levels, and are **additive** — they get concatenated during submission, not overridden:
+
+- **Computer level**: applies to *all* jobs on this machine (e.g. ``module load gcc``). Set during ``verdi computer setup``.
+- **Code level**: applies to all jobs using *this specific code* (e.g. ``#SBATCH --uenv=quantumespresso/...``). Set during ``verdi code create``.
+- **CalcJob level**: applies to *this specific job* only (e.g. one-off overrides). Set via the ``metadata.options`` dictionary of the calculation job.
+
+During submission, values from all three levels are joined together (computer first, then code, then CalcJob).
 
 In particular, you can provide:
 
@@ -61,7 +67,9 @@ In case you are submitting a ``PwBaseWorkChain``, these options should be set un
 Custom scheduler directives (e.g. extra ``#SBATCH``)
 ----------------------------------------------------
 
-Use ``custom_scheduler_commands`` to inject raw scheduler lines near the top of the submit script (before any non-scheduler command):
+Use ``custom_scheduler_commands`` to inject raw scheduler lines near the top of the submit script (before any non-scheduler command).
+
+**On a per-job basis** via ``metadata.options``:
 
 .. code-block:: python
 
@@ -71,16 +79,34 @@ Use ``custom_scheduler_commands`` to inject raw scheduler lines near the top of 
 	#SBATCH --hint=nomultithread
 	""".strip()
 
+**On the code** (applies to all jobs using this code):
+
+.. code-block:: yaml
+
+	# In the code YAML configuration:
+	custom_scheduler_commands: |
+	    #SBATCH --uenv=quantumespresso/v7.3.1:v1
+	    #SBATCH --view=default
+
+This is particularly useful for CSCS Alps ``uenv`` images or similar setups where the scheduler must be told to mount a specific environment before the job starts.
+
 Notes:
 
 - Keep the lines valid for your scheduler (Slurm here; adapt to PBS/LSF/etc.).
 - Use this when a directive is not covered by a dedicated option.
+- Code-level and CalcJob-level values are concatenated (code first, then CalcJob).
 
 
 Prepend/append shell code to the job script
 -------------------------------------------
 
-Use ``prepend_text`` to add shell commands immediately before launching the code, and ``append_text`` for commands executed right after the code finishes:
+Use ``prepend_text`` to add shell commands immediately before launching the code, and ``append_text`` for commands executed right after the code finishes.
+
+``prepend_text`` can be set at three levels (all are concatenated in the submission script):
+
+- **Computer**: set during ``verdi computer setup`` — applies to all jobs on this machine (e.g. ``module load gcc``)
+- **Code**: set during ``verdi code create`` — applies to all jobs using this code (e.g. ``uenv start quantumespresso/v7.3.1:v1``)
+- **CalcJob**: set via ``metadata.options`` — applies to this specific job only
 
 .. code-block:: python
 
@@ -105,7 +131,9 @@ Use ``prepend_text`` to add shell commands immediately before launching the code
 Extra parameters to mpirun (or equivalent)
 ------------------------------------------
 
-Set ``mpirun_extra_params`` to pass flags to the MPI launcher in addition to the computer's configured ``mpirun_command``:
+Set ``mpirun_extra_params`` to pass flags to the MPI launcher in addition to the computer's configured ``mpirun_command``.
+
+**On a per-job basis** via ``metadata.options``:
 
 .. code-block:: python
 
@@ -114,8 +142,17 @@ Set ``mpirun_extra_params`` to pass flags to the MPI launcher in addition to the
 		 '--bind-to', 'core', '--map-by', 'socket:PE=2',
 	]
 
+**On the code** (applies to all jobs using this code):
+
+.. code-block:: yaml
+
+	# In the code YAML configuration:
+	mpirun_extra_params:
+	    - '--uenv=quantumespresso/v7.3.1:v1'
+	    - '--view=default'
+
 .. note::
-	``mpirun_extra_params`` is a list/tuple of strings; AiiDA will join them with spaces. Keep launcher-specific flags consistent with your cluster (OpenMPI, MPICH, srun, etc.).
+	``mpirun_extra_params`` is a list of strings; AiiDA will join them with spaces. Code-level and CalcJob-level values are concatenated (code first, then CalcJob). Keep launcher-specific flags consistent with your cluster (OpenMPI, MPICH, srun, etc.).
 
 
 Full list of metadata available

--- a/docs/source/howto/tricks_real_world_runs.rst
+++ b/docs/source/howto/tricks_real_world_runs.rst
@@ -24,7 +24,7 @@ In particular, you can provide:
 - prepend text to the job script (e.g. if you need to load specific modules or set specific environment variables which are not already specified in the computer/code setup)
 - additional mpirun parameters (e.g. if you need to bind processes to cores, etc.)
 
-The full list of available options can be found in the `AiiDA CalcJob options documentation <https://aiida--7048.org.readthedocs.build/projects/aiida-core/en/7048/topics/calculations/usage.html#options>`__.
+For a complete overview of which options are available at which level and how they are merged, see :ref:`topics:calculations:usage:calcjobs:scheduler-and-runtime-options`.
 
 
 Basic pattern
@@ -94,7 +94,8 @@ Notes:
 
 - Keep the lines valid for your scheduler (Slurm here; adapt to PBS/LSF/etc.).
 - Use this when a directive is not covered by a dedicated option.
-- Code-level and CalcJob-level values are concatenated (code first, then CalcJob).
+- Can also be set at the **Computer** level (during ``verdi computer setup``) for directives that apply to all jobs on that machine.
+- All three levels are concatenated (Computer first, then Code, then CalcJob).
 
 
 Prepend/append shell code to the job script
@@ -118,7 +119,17 @@ Use ``prepend_text`` to add shell commands immediately before launching the code
 	echo "Run finished on $(hostname) at $(date)"
 	""".strip()
 
-.. tip:: for simple environment variables you can also use ``environment_variables`` (AiiDA will export them for you):
+Environment variables
+---------------------
+
+Use ``environment_variables`` to set environment variables that AiiDA will export for you in the submit script.
+This can be set at three levels (all are merged, with more specific levels overriding):
+
+- **Computer**: set during ``verdi computer setup`` — applies to all jobs on this machine
+- **Code**: set during ``verdi code create`` — applies to all jobs using this code
+- **CalcJob**: set via ``metadata.options`` — applies to this specific job only
+
+**On a per-job basis** via ``metadata.options``:
 
 .. code-block:: python
 
@@ -126,6 +137,17 @@ Use ``prepend_text`` to add shell commands immediately before launching the code
 		 'OMP_NUM_THREADS': '1',
 	}
 
+**On the code** (applies to all jobs using this code):
+
+.. code-block:: yaml
+
+	# In the code YAML configuration:
+	environment_variables:
+	    OMP_NUM_THREADS: '1'
+	    LD_LIBRARY_PATH: '/opt/lib'
+
+.. note::
+	``environment_variables`` is a dictionary of strings. Computer-level, code-level, and CalcJob-level values are merged (later levels override earlier ones for the same key).
 
 
 Extra parameters to mpirun (or equivalent)
@@ -176,7 +198,7 @@ Here is the full list of options that can be set in ``builder.metadata``.
       - additional_retrieve_list (list | tuple | None): Relative file paths to retrieve in addition to what the plugin specifies.
       - append_text (str): Text appended to the scheduler-job script just after the code execution.
       - custom_scheduler_commands (str): Raw scheduler directives inserted before any non-scheduler command (e.g. extra ``#SBATCH`` lines).
-      - environment_variables (dict): Environment variables to export for this calculation.
+      - environment_variables (dict): Environment variables to export for this calculation. Merged with computer-level and code-level values (CalcJob overrides Code overrides Computer).
       - environment_variables_double_quotes (bool): If True, use double quotes instead of single quotes to escape ``environment_variables``.
       - import_sys_environment (bool): If True, the submission script will load the system environment variables.
       - input_filename (str): Name of the main input file written to the remote working directory.

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -986,6 +986,95 @@ Best Practices and Considerations
 
    - **Error handling**: In case of custom stashing, it's your sole responsibility to manage the failures and log errors.
 
+.. _topics:calculations:usage:calcjobs:scheduler-and-runtime-options:
+
+Scheduler and runtime options
+-----------------------------
+
+Several options that control the submission script can be set at up to three levels: **Computer**, **Code**, and **CalcJob**.
+During submission, AiiDA merges them automatically — text options are concatenated (Computer first, then Code, then CalcJob), while dictionary options are merged (later levels override earlier ones for the same key).
+
+The table below shows where each option can be set and how values from different levels are combined.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 12 12 12 34
+
+   * - Option
+     - Computer
+     - Code
+     - CalcJob
+     - Merging strategy
+   * - ``prepend_text``
+     - yes
+     - yes
+     - yes
+     - Concatenated (Computer → Code → CalcJob)
+   * - ``append_text``
+     - yes
+     - yes
+     - yes
+     - Concatenated (CalcJob → Code → Computer)
+   * - ``custom_scheduler_commands``
+     - yes
+     - yes
+     - yes
+     - Concatenated (Computer → Code → CalcJob)
+   * - ``environment_variables``
+     - yes
+     - yes
+     - yes
+     - Dict merge (Computer → Code → CalcJob, later overrides same key)
+   * - ``mpirun_extra_params``
+     -
+     - yes
+     - yes
+     - Concatenated (Code → CalcJob)
+   * - ``with_mpi``
+     -
+     - yes
+     - yes (``withmpi``)
+     - Must agree if set at multiple levels; error on conflict
+   * - ``use_double_quotes``
+     - yes
+     - yes
+     -
+     - Per code-info
+   * - ``mpirun_command``
+     - yes
+     -
+     -
+     - —
+   * - ``default_mpiprocs_per_machine``
+     - yes
+     -
+     -
+     - Fallback for ``resources``
+   * - ``default_memory_per_machine``
+     - yes
+     -
+     -
+     - Fallback for ``resources``
+   * - ``resources``
+     -
+     -
+     - yes
+     - —
+   * - ``queue_name``, ``account``, ``qos``
+     -
+     -
+     - yes
+     - —
+   * - ``max_wallclock_seconds``, ``max_memory_kb``
+     -
+     -
+     - yes
+     - —
+
+Options that appear only at the CalcJob level (``resources``, ``queue_name``, ``max_wallclock_seconds``, etc.) are job-specific and do not support layered configuration.
+
+For practical examples of how to use these options, see :ref:`how-to:real-world-tricks`.
+
 .. _topics:calculations:usage:calcjobs:options:
 
 Options

--- a/src/aiida/cmdline/__init__.py
+++ b/src/aiida/cmdline/__init__.py
@@ -30,6 +30,7 @@ __all__ = (
     'GroupParamType',
     'HostnameType',
     'IdentifierParamType',
+    'JSONDictParamType',
     'LabelStringType',
     'LazyChoice',
     'MpirunCommandParamType',

--- a/src/aiida/cmdline/commands/cmd_code.py
+++ b/src/aiida/cmdline/commands/cmd_code.py
@@ -147,8 +147,16 @@ def setup_code(ctx, non_interactive, **kwargs):
 
 @verdi_code.command('test')
 @arguments.CODE(callback=set_code_builder)
+@click.option(
+    '--run-prepend-text',
+    is_flag=True,
+    default=False,
+    help="Execute the computer's and code's prepend text on the remote computer before checking the executable. "
+    'This is useful when the executable only becomes available after running setup commands '
+    '(e.g. `module load ...` or `uenv start ...`).',
+)
 @with_dbenv()
-def code_test(code):
+def code_test(code, run_prepend_text):
     """Run tests for the given code to check whether it is usable.
 
     For remote codes the following checks are performed:
@@ -160,7 +168,7 @@ def code_test(code):
 
     if isinstance(code, InstalledCode):
         try:
-            code.validate_filepath_executable()
+            code.validate_filepath_executable(run_prepend_text=run_prepend_text)
         except exceptions.ValidationError as exception:
             echo.echo_critical(f'validation failed: {exception}')
 

--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -284,8 +284,10 @@ def set_computer_builder(ctx, param, value):
 @options_computer.MPI_PROCS_PER_MACHINE()
 @options_computer.DEFAULT_MEMORY_PER_MACHINE()
 @options_computer.USE_DOUBLE_QUOTES()
+@options_computer.CUSTOM_SCHEDULER_COMMANDS()
 @options_computer.PREPEND_TEXT()
 @options_computer.APPEND_TEXT()
+@options_computer.ENVIRONMENT_VARIABLES()
 @options.NON_INTERACTIVE()
 @options.CONFIG_FILE()
 @click.pass_context
@@ -337,8 +339,12 @@ def computer_setup(ctx, non_interactive, **kwargs):
 @options_computer.DEFAULT_MEMORY_PER_MACHINE(
     contextual_default=partial(get_parameter_default, 'default_memory_per_machine')
 )
+@options_computer.CUSTOM_SCHEDULER_COMMANDS(
+    contextual_default=partial(get_parameter_default, 'custom_scheduler_commands')
+)
 @options_computer.PREPEND_TEXT(contextual_default=partial(get_parameter_default, 'prepend_text'))
 @options_computer.APPEND_TEXT(contextual_default=partial(get_parameter_default, 'append_text'))
+@options_computer.ENVIRONMENT_VARIABLES(contextual_default=partial(get_parameter_default, 'environment_variables'))
 @options.NON_INTERACTIVE()
 @click.pass_context
 @with_dbenv()
@@ -490,8 +496,10 @@ def computer_show(computer):
         ['Mpirun command', ' '.join(computer.get_mpirun_command())],
         ['Default #procs/machine', computer.get_default_mpiprocs_per_machine()],
         ['Default memory (kB)/machine', computer.get_default_memory_per_machine()],
+        ['Custom scheduler commands', computer.get_custom_scheduler_commands()],
         ['Prepend text', computer.get_prepend_text()],
         ['Append text', computer.get_append_text()],
+        ['Environment variables', computer.get_environment_variables()],
     ]
     echo_tabulate(table)
 
@@ -790,8 +798,10 @@ def computer_export_setup(computer, output_file, overwrite, sort):
         'mpiprocs_per_machine': computer.get_default_mpiprocs_per_machine(),
         'default_memory_per_machine': computer.get_default_memory_per_machine(),
         'use_double_quotes': computer.get_use_double_quotes(),
+        'custom_scheduler_commands': computer.get_custom_scheduler_commands(),
         'prepend_text': computer.get_prepend_text(),
         'append_text': computer.get_append_text(),
+        'environment_variables': computer.get_environment_variables(),
     }
 
     if output_file is None:

--- a/src/aiida/cmdline/groups/dynamic.py
+++ b/src/aiida/cmdline/groups/dynamic.py
@@ -176,12 +176,17 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
 
             default = field_info.default_factory if field_info.default is PydanticUndefined else field_info.default
 
+            # Check if the type is a list or tuple (e.g. list[str], tuple[str, ...]) which should be handled as
+            # Click ``multiple=True`` options, allowing the option to be specified multiple times on the CLI.
+            origin = t.get_origin(field_info.annotation)
+            is_multiple = origin in (list, tuple)
+
             # If the annotation has the ``__args__`` attribute it is an instance of a type from ``typing`` and the real
             # type can be gotten from the arguments. For example it could be ``typing.Union[str, None]`` calling
             # ``typing.Union[str, None].__args__`` will return the tuple ``(str, NoneType)``. So to get the real type,
             # we simply remove all ``NoneType`` and the remaining type should be the type of the option.
             if hasattr(field_info.annotation, '__args__'):
-                args = list(filter(lambda e: e is not type(None), field_info.annotation.__args__))
+                args = list(filter(lambda e: e is not type(None) and e is not Ellipsis, field_info.annotation.__args__))
                 # Click parameters only support specifying a single type, so we default to the first one even if the
                 # pydantic model defines multiple.
                 field_type = args[0]
@@ -196,6 +201,10 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
                 'default': default,
                 'help': field_info.description,
             }
+
+            if is_multiple:
+                options_spec[key]['multiple'] = True
+
             for metadata in field_info.metadata:
                 for metadata_key, metadata_value in metadata.items():
                     if metadata_key in ('priority', 'short_name', 'option_cls'):

--- a/src/aiida/cmdline/groups/dynamic.py
+++ b/src/aiida/cmdline/groups/dynamic.py
@@ -178,8 +178,10 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
 
             # Check if the type is a list or tuple (e.g. list[str], tuple[str, ...]) which should be handled as
             # Click ``multiple=True`` options, allowing the option to be specified multiple times on the CLI.
+            # Dict types (e.g. dict[str, str]) are handled with a custom JSON-based Click ParamType.
             origin = t.get_origin(field_info.annotation)
             is_multiple = origin in (list, tuple)
+            is_dict = origin is dict
 
             # If the annotation has the ``__args__`` attribute it is an instance of a type from ``typing`` and the real
             # type can be gotten from the arguments. For example it could be ``typing.Union[str, None]`` calling
@@ -204,6 +206,11 @@ class DynamicEntryPointCommandGroup(VerdiCommandGroup):
 
             if is_multiple:
                 options_spec[key]['multiple'] = True
+
+            if is_dict:
+                from aiida.cmdline.params.types import JSONDictParamType
+
+                options_spec[key]['type'] = JSONDictParamType()
 
             for metadata in field_info.metadata:
                 for metadata_key, metadata_value in metadata.items():

--- a/src/aiida/cmdline/params/__init__.py
+++ b/src/aiida/cmdline/params/__init__.py
@@ -27,6 +27,7 @@ __all__ = (
     'GroupParamType',
     'HostnameType',
     'IdentifierParamType',
+    'JSONDictParamType',
     'LabelStringType',
     'LazyChoice',
     'MpirunCommandParamType',

--- a/src/aiida/cmdline/params/options/commands/computer.py
+++ b/src/aiida/cmdline/params/options/commands/computer.py
@@ -164,6 +164,32 @@ USE_DOUBLE_QUOTES = OverridableOption(
     'escaped with single or double quotes.',
 )
 
+CUSTOM_SCHEDULER_COMMANDS = OverridableOption(
+    '--custom-scheduler-commands',
+    cls=TemplateInteractiveOption,
+    prompt='Custom scheduler commands',
+    type=click.STRING,
+    default='',
+    help='Custom scheduler commands to add to the submission script header for all jobs on this computer '
+    '(e.g. extra #SBATCH lines).',
+    extension='.bash',
+    header='CUSTOM_SCHEDULER_COMMANDS: if there are any scheduler-specific commands that should be added '
+    'to the submission script header for all jobs on this computer, type that between the equal signs below '
+    'and save the file.',
+    footer='All lines that start with `#=` will be ignored.',
+)
+
+ENVIRONMENT_VARIABLES = OverridableOption(
+    '--environment-variables',
+    cls=InteractiveOption,
+    prompt='Environment variables (JSON)',
+    type=types.JSONDictParamType(),
+    default={},
+    required=False,
+    help='Environment variables to set for all jobs on this computer, as a JSON object '
+    '(e.g. \'{"OMP_NUM_THREADS": "1"}\').',
+)
+
 PREPEND_TEXT = OverridableOption(
     '--prepend-text',
     cls=TemplateInteractiveOption,

--- a/src/aiida/cmdline/params/types/__init__.py
+++ b/src/aiida/cmdline/params/types/__init__.py
@@ -43,6 +43,7 @@ __all__ = (
     'GroupParamType',
     'HostnameType',
     'IdentifierParamType',
+    'JSONDictParamType',
     'LabelStringType',
     'LazyChoice',
     'MpirunCommandParamType',

--- a/src/aiida/cmdline/params/types/strings.py
+++ b/src/aiida/cmdline/params/types/strings.py
@@ -16,7 +16,42 @@ import typing as t
 import click
 from click.types import StringParamType
 
-__all__ = ('EmailType', 'EntryPointType', 'HostnameType', 'LabelStringType', 'NonEmptyStringParamType')
+__all__ = (
+    'EmailType',
+    'EntryPointType',
+    'HostnameType',
+    'JSONDictParamType',
+    'LabelStringType',
+    'NonEmptyStringParamType',
+)
+
+
+class JSONDictParamType(click.ParamType):
+    """Click parameter type that accepts a JSON object string or a Python dict.
+
+    On the CLI, pass a JSON string: ``--option '{"KEY": "VALUE"}'``.
+    From a YAML config file, the value is already parsed as a dict and passed through.
+    """
+
+    name = 'JSON_DICT'
+
+    def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None) -> dict[str, str]:
+        import json
+
+        if isinstance(value, dict):
+            return value
+        if value is None:
+            return {}
+        try:
+            result = json.loads(value)
+        except (json.JSONDecodeError, TypeError) as exc:
+            self.fail(f'Invalid JSON: {exc}', param, ctx)
+        if not isinstance(result, dict):
+            self.fail(f'Expected a JSON object, got {type(result).__name__}', param, ctx)
+        return result
+
+    def __repr__(self) -> str:
+        return 'JSON_DICT'
 
 
 class NonEmptyStringParamType(StringParamType):

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -1078,7 +1078,8 @@ class CalcJob(Process):
                     with_mpi = False
 
             if with_mpi:
-                prepend_cmdline_params = code.get_prepend_cmdline_params(mpi_args, extra_mpirun_params)
+                all_extra_mpirun_params = list(code.mpirun_extra_params) + list(extra_mpirun_params or [])
+                prepend_cmdline_params = code.get_prepend_cmdline_params(mpi_args, all_extra_mpirun_params or None)
             else:
                 prepend_cmdline_params = code.get_prepend_cmdline_params()
 
@@ -1121,7 +1122,10 @@ class CalcJob(Process):
 
         ########################################################################
 
-        custom_sched_commands = self.node.get_option('custom_scheduler_commands')
+        custom_sched_commands_parts = [code.custom_scheduler_commands for code in codes] + [
+            self.node.get_option('custom_scheduler_commands')
+        ]
+        custom_sched_commands = '\n'.join(part for part in custom_sched_commands_parts if part)
         if custom_sched_commands:
             job_tmpl.custom_scheduler_commands = custom_sched_commands
 

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -1122,16 +1122,23 @@ class CalcJob(Process):
 
         ########################################################################
 
-        custom_sched_commands_parts = [code.custom_scheduler_commands for code in codes] + [
-            self.node.get_option('custom_scheduler_commands')
-        ]
+        custom_sched_commands_parts = (
+            [computer.get_custom_scheduler_commands()]
+            + [code.custom_scheduler_commands for code in codes]
+            + [self.node.get_option('custom_scheduler_commands')]
+        )
         custom_sched_commands = '\n'.join(part for part in custom_sched_commands_parts if part)
         if custom_sched_commands:
             job_tmpl.custom_scheduler_commands = custom_sched_commands
 
         job_tmpl.import_sys_environment = self.node.get_option('import_sys_environment')
 
-        job_tmpl.job_environment = self.node.get_option('environment_variables')
+        # Merge environment variables: Computer → Code(s) → CalcJob (later values override)
+        merged_env = dict(computer.get_environment_variables())
+        for code in codes:
+            merged_env.update(code.environment_variables)
+        merged_env.update(self.node.get_option('environment_variables') or {})
+        job_tmpl.job_environment = merged_env
         job_tmpl.environment_variables_double_quotes = self.node.get_option('environment_variables_double_quotes')
 
         queue_name = self.node.get_option('queue_name')

--- a/src/aiida/orm/computers.py
+++ b/src/aiida/orm/computers.py
@@ -412,6 +412,20 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
                 raise AttributeError(f"'{name}' property not found")
             return args[0]
 
+    def get_custom_scheduler_commands(self) -> str:
+        """Return the custom scheduler commands for this computer.
+
+        :returns: Custom scheduler commands to add to the submission script header for all jobs on this computer.
+        """
+        return self.get_property('custom_scheduler_commands', '')
+
+    def set_custom_scheduler_commands(self, val: str) -> None:
+        """Set the custom scheduler commands for this computer.
+
+        :param val: Custom scheduler commands (e.g. extra ``#SBATCH`` lines).
+        """
+        self.set_property('custom_scheduler_commands', str(val))
+
     def get_prepend_text(self) -> str:
         return self.get_property('prepend_text', '')
 
@@ -423,6 +437,24 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
 
     def set_append_text(self, val: str) -> None:
         self.set_property('append_text', str(val))
+
+    def get_environment_variables(self) -> dict:
+        """Return the environment variables for this computer.
+
+        :returns: Dictionary of environment variables to set for all jobs on this computer.
+        """
+        return self.get_property('environment_variables', {})
+
+    def set_environment_variables(self, val: dict) -> None:
+        """Set the environment variables for this computer.
+
+        :param val: Dictionary of environment variables (keys and values must be strings).
+        """
+        if not isinstance(val, dict):
+            raise TypeError('environment_variables must be a dictionary')
+        if any(not isinstance(k, str) or not isinstance(v, str) for k, v in val.items()):
+            raise TypeError('environment_variables keys and values must all be strings')
+        self.set_property('environment_variables', val)
 
     def get_use_double_quotes(self) -> bool:
         """Return whether the command line parameters of this computer should be escaped with double quotes.

--- a/src/aiida/orm/nodes/data/code/abstract.py
+++ b/src/aiida/orm/nodes/data/code/abstract.py
@@ -38,6 +38,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
     _KEY_ATTRIBUTE_DEFAULT_CALC_JOB_PLUGIN: str = 'input_plugin'
     _KEY_ATTRIBUTE_APPEND_TEXT: str = 'append_text'
     _KEY_ATTRIBUTE_CUSTOM_SCHEDULER_COMMANDS: str = 'custom_scheduler_commands'
+    _KEY_ATTRIBUTE_ENVIRONMENT_VARIABLES: str = 'environment_variables'
     _KEY_ATTRIBUTE_MPIRUN_EXTRA_PARAMS: str = 'mpirun_extra_params'
     _KEY_ATTRIBUTE_PREPEND_TEXT: str = 'prepend_text'
     _KEY_ATTRIBUTE_USE_DOUBLE_QUOTES: str = 'use_double_quotes'
@@ -117,6 +118,12 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
                 footer='All lines that start with `#=`: will be ignored.',
             ),
         )
+        environment_variables: t.Dict[str, str] = MetadataField(
+            {},
+            title='Environment variables',
+            description='Environment variables to set for all jobs using this code '
+            '(e.g. {"OMP_NUM_THREADS": "1", "LD_LIBRARY_PATH": "/opt/lib"}).',
+        )
         mpirun_extra_params: t.List[str] = MetadataField(
             [],
             title='Extra mpirun params',
@@ -131,6 +138,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         append_text: str = '',
         prepend_text: str = '',
         custom_scheduler_commands: str = '',
+        environment_variables: dict[str, str] | None = None,
         mpirun_extra_params: list[str] | tuple[str, ...] = (),
         use_double_quotes: bool = False,
         with_mpi: bool | None = None,
@@ -144,6 +152,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         :param append_text: The text that should be appended to the run line in the job script.
         :param prepend_text: The text that should be prepended to the run line in the job script.
         :param custom_scheduler_commands: Custom scheduler commands to add to the submission script header.
+        :param environment_variables: Environment variables to set for all jobs using this code.
         :param mpirun_extra_params: Extra parameters to pass to the mpirun command.
         :param use_double_quotes: Whether the command line invocation of this code should be escaped with double quotes.
         :param with_mpi: Whether the command should be run as an MPI program.
@@ -156,6 +165,7 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         self.append_text = append_text
         self.prepend_text = prepend_text
         self.custom_scheduler_commands = custom_scheduler_commands
+        self.environment_variables = environment_variables or {}
         self.mpirun_extra_params = mpirun_extra_params
         self.use_double_quotes = use_double_quotes
         self.with_mpi = with_mpi
@@ -313,6 +323,22 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         """
         type_check(value, str, allow_none=True)
         self.base.attributes.set(self._KEY_ATTRIBUTE_CUSTOM_SCHEDULER_COMMANDS, value)
+
+    @property
+    def environment_variables(self) -> dict[str, str]:
+        """Return the environment variables for this code.
+
+        :return: The environment variables to set for all jobs using this code.
+        """
+        return self.base.attributes.get(self._KEY_ATTRIBUTE_ENVIRONMENT_VARIABLES, {})
+
+    @environment_variables.setter
+    def environment_variables(self, value: dict[str, str]) -> None:
+        """Set the environment variables for this code.
+
+        :param value: The environment variables to set for all jobs using this code.
+        """
+        self.base.attributes.set(self._KEY_ATTRIBUTE_ENVIRONMENT_VARIABLES, value)
 
     @property
     def mpirun_extra_params(self) -> list[str]:

--- a/src/aiida/orm/nodes/data/code/abstract.py
+++ b/src/aiida/orm/nodes/data/code/abstract.py
@@ -37,6 +37,8 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
     # Should become ``default_calc_job_plugin`` once ``Code`` is dropped in ``aiida-core==3.0``
     _KEY_ATTRIBUTE_DEFAULT_CALC_JOB_PLUGIN: str = 'input_plugin'
     _KEY_ATTRIBUTE_APPEND_TEXT: str = 'append_text'
+    _KEY_ATTRIBUTE_CUSTOM_SCHEDULER_COMMANDS: str = 'custom_scheduler_commands'
+    _KEY_ATTRIBUTE_MPIRUN_EXTRA_PARAMS: str = 'mpirun_extra_params'
     _KEY_ATTRIBUTE_PREPEND_TEXT: str = 'prepend_text'
     _KEY_ATTRIBUTE_USE_DOUBLE_QUOTES: str = 'use_double_quotes'
     _KEY_ATTRIBUTE_WITH_MPI: str = 'with_mpi'
@@ -101,12 +103,35 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
                 footer='All lines that start with `#=`: will be ignored.',
             ),
         )
+        custom_scheduler_commands: str = MetadataField(
+            '',
+            title='Custom scheduler commands',
+            description='Custom scheduler commands to be added to the submission script header '
+            'for all submit scripts for this code (e.g. "#SBATCH --uenv=...").',
+            option_cls=functools.partial(
+                TemplateInteractiveOption,
+                extension='.bash',
+                header='CUSTOM_SCHEDULER_COMMANDS: if there is any scheduler-specific commands that should be added '
+                'to the submission script header for this code, type that between the equal signs below '
+                'and save the file.',
+                footer='All lines that start with `#=`: will be ignored.',
+            ),
+        )
+        mpirun_extra_params: t.List[str] = MetadataField(
+            [],
+            title='Extra mpirun params',
+            description='Extra parameters to be passed to the mpirun command for this code '
+            '(e.g. "--uenv=... --view=default").',
+            orm_to_model=lambda node, _: list(t.cast('AbstractCode', node).mpirun_extra_params),
+        )
 
     def __init__(
         self,
         default_calc_job_plugin: str | None = None,
         append_text: str = '',
         prepend_text: str = '',
+        custom_scheduler_commands: str = '',
+        mpirun_extra_params: list[str] | tuple[str, ...] = (),
         use_double_quotes: bool = False,
         with_mpi: bool | None = None,
         is_hidden: bool = False,
@@ -118,6 +143,8 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         :param default_calc_job_plugin: The entry point name of the default ``CalcJob`` plugin to use.
         :param append_text: The text that should be appended to the run line in the job script.
         :param prepend_text: The text that should be prepended to the run line in the job script.
+        :param custom_scheduler_commands: Custom scheduler commands to add to the submission script header.
+        :param mpirun_extra_params: Extra parameters to pass to the mpirun command.
         :param use_double_quotes: Whether the command line invocation of this code should be escaped with double quotes.
         :param with_mpi: Whether the command should be run as an MPI program.
         :param wrap_cmdline_params: Whether to wrap the executable and all its command line parameters into quotes to
@@ -128,6 +155,8 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         self.default_calc_job_plugin = default_calc_job_plugin
         self.append_text = append_text
         self.prepend_text = prepend_text
+        self.custom_scheduler_commands = custom_scheduler_commands
+        self.mpirun_extra_params = mpirun_extra_params
         self.use_double_quotes = use_double_quotes
         self.with_mpi = with_mpi
         self.wrap_cmdline_params = wrap_cmdline_params
@@ -267,6 +296,41 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         """
         type_check(value, str, allow_none=True)
         self.base.attributes.set(self._KEY_ATTRIBUTE_PREPEND_TEXT, value)
+
+    @property
+    def custom_scheduler_commands(self) -> str:
+        """Return the custom scheduler commands for this code.
+
+        :return: The custom scheduler commands to add to the submission script header.
+        """
+        return self.base.attributes.get(self._KEY_ATTRIBUTE_CUSTOM_SCHEDULER_COMMANDS, '')
+
+    @custom_scheduler_commands.setter
+    def custom_scheduler_commands(self, value: str) -> None:
+        """Set the custom scheduler commands for this code.
+
+        :param value: The custom scheduler commands to add to the submission script header.
+        """
+        type_check(value, str, allow_none=True)
+        self.base.attributes.set(self._KEY_ATTRIBUTE_CUSTOM_SCHEDULER_COMMANDS, value)
+
+    @property
+    def mpirun_extra_params(self) -> list[str]:
+        """Return the extra mpirun parameters for this code.
+
+        :return: The extra parameters to pass to the mpirun command.
+        """
+        return list(self.base.attributes.get(self._KEY_ATTRIBUTE_MPIRUN_EXTRA_PARAMS, []))
+
+    @mpirun_extra_params.setter
+    def mpirun_extra_params(self, value: tuple[str, ...] | list[str]) -> None:
+        """Set the extra mpirun parameters for this code.
+
+        :param value: The extra parameters to pass to the mpirun command.
+        """
+        if any(not isinstance(p, str) for p in value):
+            raise TypeError('`mpirun_extra_params` must be a tuple or list of strings.')
+        self.base.attributes.set(self._KEY_ATTRIBUTE_MPIRUN_EXTRA_PARAMS, list(value))
 
     @property
     def use_double_quotes(self) -> bool:

--- a/src/aiida/orm/nodes/data/code/installed.py
+++ b/src/aiida/orm/nodes/data/code/installed.py
@@ -101,7 +101,7 @@ class InstalledCode(Code):
         except TypeError as exception:
             raise exceptions.ValidationError('The `filepath_executable` is not set.') from exception
 
-    def validate_filepath_executable(self):
+    def validate_filepath_executable(self, run_prepend_text: bool = False):
         """Validate the ``filepath_executable`` attribute.
 
         Checks whether the executable exists on the remote computer if a transport can be opened to it. This method
@@ -110,6 +110,9 @@ class InstalledCode(Code):
 
         .. note:: If the ``filepath_executable`` is not an absolute path, the check is skipped.
 
+        :param run_prepend_text: If ``True``, execute the computer's and code's ``prepend_text`` on the remote computer
+            before checking the executable. This is useful when the executable only becomes available after running
+            setup commands (e.g. ``uenv start ...``).
         :raises `~aiida.common.exceptions.ValidationError`: if no transport could be opened or if the defined executable
             does not exist on the remote computer.
         """
@@ -119,13 +122,33 @@ class InstalledCode(Code):
         try:
             with override_log_level():  # Temporarily suppress noisy logging
                 with self.computer.get_transport() as transport:
-                    file_exists = transport.isfile(str(self.filepath_executable))
-                    if file_exists:
-                        mode = transport.get_mode(str(self.filepath_executable))
-                        # `format(mode, 'b')` with default permissions
-                        # gives 110110100, representing rw-rw-r--
-                        # Check on index 2 if user has execute
-                        user_has_execute = format(mode, 'b')[2] == '1'
+                    if run_prepend_text:
+                        prepend_parts = [self.computer.get_prepend_text(), self.prepend_text]
+                        prepend_text = '\n\n'.join(part for part in prepend_parts if part)
+                    else:
+                        prepend_text = ''
+
+                    if prepend_text:
+                        filepath = str(self.filepath_executable)
+                        retval, stdout, stderr = transport.exec_command_wait(
+                            f'{prepend_text}\n'
+                            f'if [ -f {filepath} ]; then\n'
+                            f'  if [ -x {filepath} ]; then echo "OK"; else echo "NOT_EXECUTABLE"; fi\n'
+                            f'else\n'
+                            f'  echo "NOT_FOUND"\n'
+                            f'fi'
+                        )
+                        result = stdout.strip()
+                        file_exists = result != 'NOT_FOUND'
+                        user_has_execute = result == 'OK'
+                    else:
+                        file_exists = transport.isfile(str(self.filepath_executable))
+                        if file_exists:
+                            mode = transport.get_mode(str(self.filepath_executable))
+                            # `format(mode, 'b')` with default permissions
+                            # gives 110110100, representing rw-rw-r--
+                            # Check on index 2 if user has execute
+                            user_has_execute = format(mode, 'b')[2] == '1'
 
         except Exception as exception:
             raise exceptions.ValidationError(

--- a/src/aiida/orm/utils/builders/computer.py
+++ b/src/aiida/orm/utils/builders/computer.py
@@ -42,6 +42,8 @@ class ComputerBuilder:
         spec['scheduler'] = computer.scheduler_type
         spec['transport'] = computer.transport_type
         spec['use_double_quotes'] = computer.get_use_double_quotes()
+        spec['custom_scheduler_commands'] = computer.get_custom_scheduler_commands()
+        spec['environment_variables'] = computer.get_environment_variables()
         spec['prepend_text'] = computer.get_prepend_text()
         spec['append_text'] = computer.get_append_text()
         spec['work_dir'] = computer.get_workdir()
@@ -84,6 +86,16 @@ class ComputerBuilder:
         computer.scheduler_type = self._get_and_count('scheduler', used)
         computer.transport_type = self._get_and_count('transport', used)
         computer.set_use_double_quotes(self._get_and_count('use_double_quotes', used))
+        custom_scheduler_commands = self._get('custom_scheduler_commands')
+        if custom_scheduler_commands is not None:
+            used.add('custom_scheduler_commands')
+            if custom_scheduler_commands:
+                computer.set_custom_scheduler_commands(custom_scheduler_commands)
+        environment_variables = self._get('environment_variables')
+        if environment_variables is not None:
+            used.add('environment_variables')
+            if environment_variables:
+                computer.set_environment_variables(environment_variables)
         computer.set_prepend_text(self._get_and_count('prepend_text', used))
         computer.set_append_text(self._get_and_count('append_text', used))
         computer.set_workdir(self._get_and_count('work_dir', used))

--- a/tests/cmdline/commands/test_code/test_code_export___no_sort_.yml
+++ b/tests/cmdline/commands/test_code/test_code_export___no_sort_.yml
@@ -7,5 +7,6 @@ with_mpi: null
 prepend_text: "module load something\n    some command"
 append_text: ''
 custom_scheduler_commands: ''
+environment_variables: {}
 mpirun_extra_params: []
 filepath_executable: /bin/cat

--- a/tests/cmdline/commands/test_code/test_code_export___no_sort_.yml
+++ b/tests/cmdline/commands/test_code/test_code_export___no_sort_.yml
@@ -6,4 +6,6 @@ use_double_quotes: false
 with_mpi: null
 prepend_text: "module load something\n    some command"
 append_text: ''
+custom_scheduler_commands: ''
+mpirun_extra_params: []
 filepath_executable: /bin/cat

--- a/tests/cmdline/commands/test_code/test_code_export___sort_.yml
+++ b/tests/cmdline/commands/test_code/test_code_export___sort_.yml
@@ -1,9 +1,11 @@
 append_text: ''
 computer: localhost
+custom_scheduler_commands: ''
 default_calc_job_plugin: core.arithmetic.add
 description: ''
 filepath_executable: /bin/cat
 label: code
+mpirun_extra_params: []
 prepend_text: "module load something\n    some command"
 use_double_quotes: false
 with_mpi: null

--- a/tests/cmdline/commands/test_code/test_code_export___sort_.yml
+++ b/tests/cmdline/commands/test_code/test_code_export___sort_.yml
@@ -3,6 +3,7 @@ computer: localhost
 custom_scheduler_commands: ''
 default_calc_job_plugin: core.arithmetic.add
 description: ''
+environment_variables: {}
 filepath_executable: /bin/cat
 label: code
 mpirun_extra_params: []

--- a/tests/cmdline/commands/test_code/test_code_show_containerized.txt
+++ b/tests/cmdline/commands/test_code/test_code_show_containerized.txt
@@ -9,6 +9,8 @@ Escape using double quotes    False
 Run with MPI
 Prepend script                text to prepend
 Append script                 text to append
+Custom scheduler commands
+Extra mpirun params           []
 Filepath executable           /usr/bin/bash
 Engine command                singularity exec --bind $PWD:$PWD {image_name}
 Image name                    ubuntu

--- a/tests/cmdline/commands/test_code/test_code_show_containerized.txt
+++ b/tests/cmdline/commands/test_code/test_code_show_containerized.txt
@@ -10,6 +10,7 @@ Run with MPI
 Prepend script                text to prepend
 Append script                 text to append
 Custom scheduler commands
+Environment variables         {}
 Extra mpirun params           []
 Filepath executable           /usr/bin/bash
 Engine command                singularity exec --bind $PWD:$PWD {image_name}

--- a/tests/cmdline/commands/test_code/test_code_show_installed.txt
+++ b/tests/cmdline/commands/test_code/test_code_show_installed.txt
@@ -9,4 +9,6 @@ Escape using double quotes  False
 Run with MPI
 Prepend script              text to prepend
 Append script               text to append
+Custom scheduler commands
+Extra mpirun params         []
 Filepath executable         /remote/abs/path

--- a/tests/cmdline/commands/test_code/test_code_show_installed.txt
+++ b/tests/cmdline/commands/test_code/test_code_show_installed.txt
@@ -10,5 +10,6 @@ Run with MPI
 Prepend script              text to prepend
 Append script               text to append
 Custom scheduler commands
+Environment variables       {}
 Extra mpirun params         []
 Filepath executable         /remote/abs/path

--- a/tests/cmdline/commands/test_code/test_code_show_portable.txt
+++ b/tests/cmdline/commands/test_code/test_code_show_portable.txt
@@ -8,4 +8,6 @@ Escape using double quotes  False
 Run with MPI
 Prepend script              text to prepend
 Append script               text to append
+Custom scheduler commands
+Extra mpirun params         []
 Filepath executable         bash

--- a/tests/cmdline/commands/test_code/test_code_show_portable.txt
+++ b/tests/cmdline/commands/test_code/test_code_show_portable.txt
@@ -9,5 +9,6 @@ Run with MPI
 Prepend script              text to prepend
 Append script               text to append
 Custom scheduler commands
+Environment variables       {}
 Extra mpirun params         []
 Filepath executable         bash

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -145,6 +145,7 @@ def test_mixed(run_cli_command):
     non_interactive_options_dict['scheduler'] = options_dict.pop('scheduler')
 
     options_dict['use-login-shell'] = 'y'
+    options_dict['environment-variables'] = '{}'
     # In any case, these would be managed by the visual editor
     user_input = '\n'.join(generate_setup_options_interactive(options_dict))
     options = generate_setup_options(non_interactive_options_dict)
@@ -889,7 +890,7 @@ def test_computer_duplicate_interactive(run_cli_command, aiida_localhost, non_in
     """Test 'verdi computer duplicate' in interactive mode."""
     label = 'computer_duplicate_interactive'
     computer = aiida_localhost
-    user_input = f'{label}\n\n\n\n\n\n\n\n\n\n'
+    user_input = f'{label}\n\n\n\n\n\n\n\n\n\n\n'
     result = run_cli_command(computer_duplicate, [str(computer.pk)], user_input=user_input)
     assert result.exception is None, result.output
 
@@ -904,6 +905,7 @@ def test_computer_duplicate_interactive(run_cli_command, aiida_localhost, non_in
     assert new_computer.get_default_mpiprocs_per_machine() == computer.get_default_mpiprocs_per_machine()
     assert new_computer.get_prepend_text() == computer.get_prepend_text()
     assert new_computer.get_append_text() == computer.get_append_text()
+    assert new_computer.get_environment_variables() == computer.get_environment_variables()
 
 
 @pytest.mark.parametrize('non_interactive_editor', ('vim -cwq',), indirect=True)
@@ -940,6 +942,7 @@ def test_direct_interactive(run_cli_command, non_interactive_editor):
     options_dict.pop('prepend-text')
     options_dict.pop('append-text')
     options_dict['use-login-shell'] = 'y'
+    options_dict['environment-variables'] = '{}'
     user_input = '\n'.join(generate_setup_options_interactive(options_dict))
 
     result = run_cli_command(computer_setup, user_input=user_input)

--- a/tests/cmdline/commands/test_computer/test_computer_export_setup___no_sort_.yaml
+++ b/tests/cmdline/commands/test_computer/test_computer_export_setup___no_sort_.yaml
@@ -9,5 +9,7 @@ mpirun_command: mpirun
 mpiprocs_per_machine: 8
 default_memory_per_machine: 100000
 use_double_quotes: false
+custom_scheduler_commands: ''
 prepend_text: ''
 append_text: ''
+environment_variables: {}

--- a/tests/cmdline/commands/test_computer/test_computer_export_setup___sort_.yaml
+++ b/tests/cmdline/commands/test_computer/test_computer_export_setup___sort_.yaml
@@ -1,6 +1,8 @@
 append_text: ''
+custom_scheduler_commands: ''
 default_memory_per_machine: 100000
 description: Test Computer
+environment_variables: {}
 hostname: localhost
 label: test_computer_export_setup--sort
 mpiprocs_per_machine: 8

--- a/tests/orm/data/code/test_portable.py
+++ b/tests/orm/data/code/test_portable.py
@@ -156,6 +156,7 @@ with_mpi: null
 prepend_text: ''
 append_text: ''
 custom_scheduler_commands: ''
+environment_variables: {{}}
 mpirun_extra_params: []
 filepath_executable: bash
 filepath_files: {tmp_path}/some-label

--- a/tests/orm/data/code/test_portable.py
+++ b/tests/orm/data/code/test_portable.py
@@ -155,6 +155,8 @@ use_double_quotes: false
 with_mpi: null
 prepend_text: ''
 append_text: ''
+custom_scheduler_commands: ''
+mpirun_extra_params: []
 filepath_executable: bash
 filepath_files: {tmp_path}/some-label
 """

--- a/tests/orm/test_fields/fields_aiida.data.core.code.Code.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.Code.yml
@@ -3,14 +3,19 @@ attributes: QbDictField('attributes', dtype=typing.Dict[str, typing.Any] | None,
   is_subscriptable=True)
 computer: QbNumericField('computer', dtype=int | None, is_attribute=False)
 ctime: QbNumericField('ctime', dtype=datetime.datetime | None, is_attribute=False)
+custom_scheduler_commands: QbStrField('custom_scheduler_commands', dtype=<class 'str'>,
+  is_attribute=True)
 default_calc_job_plugin: QbStrField('default_calc_job_plugin', dtype=str | None, is_attribute=True)
 description: QbStrField('description', dtype=<class 'str'>, is_attribute=True)
+environment_variables: QbDictField('environment_variables', dtype=typing.Dict[str,
+  str], is_attribute=True)
 extras: QbDictField('extras', dtype=typing.Dict[str, typing.Any] | None, is_attribute=False,
   is_subscriptable=True)
 input_plugin: QbStrField('input_plugin', dtype=str | None, is_attribute=True)
 is_local: QbField('is_local', dtype=bool | None, is_attribute=True)
 label: QbStrField('label', dtype=<class 'str'>, is_attribute=True)
 local_executable: QbStrField('local_executable', dtype=str | None, is_attribute=True)
+mpirun_extra_params: QbArrayField('mpirun_extra_params', dtype=typing.List[str], is_attribute=True)
 mtime: QbNumericField('mtime', dtype=datetime.datetime | None, is_attribute=False)
 node_type: QbStrField('node_type', dtype=str | None, is_attribute=False)
 pk: QbNumericField('pk', dtype=int | None, is_attribute=False)

--- a/tests/orm/test_fields/fields_aiida.data.core.code.abstract.AbstractCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.abstract.AbstractCode.yml
@@ -3,11 +3,16 @@ attributes: QbDictField('attributes', dtype=typing.Dict[str, typing.Any] | None,
   is_subscriptable=True)
 computer: QbNumericField('computer', dtype=int | None, is_attribute=False)
 ctime: QbNumericField('ctime', dtype=datetime.datetime | None, is_attribute=False)
+custom_scheduler_commands: QbStrField('custom_scheduler_commands', dtype=<class 'str'>,
+  is_attribute=True)
 default_calc_job_plugin: QbStrField('default_calc_job_plugin', dtype=str | None, is_attribute=True)
 description: QbStrField('description', dtype=<class 'str'>, is_attribute=True)
+environment_variables: QbDictField('environment_variables', dtype=typing.Dict[str,
+  str], is_attribute=True)
 extras: QbDictField('extras', dtype=typing.Dict[str, typing.Any] | None, is_attribute=False,
   is_subscriptable=True)
 label: QbStrField('label', dtype=<class 'str'>, is_attribute=True)
+mpirun_extra_params: QbArrayField('mpirun_extra_params', dtype=typing.List[str], is_attribute=True)
 mtime: QbNumericField('mtime', dtype=datetime.datetime | None, is_attribute=False)
 node_type: QbStrField('node_type', dtype=str | None, is_attribute=False)
 pk: QbNumericField('pk', dtype=int | None, is_attribute=False)

--- a/tests/orm/test_fields/fields_aiida.data.core.code.containerized.ContainerizedCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.containerized.ContainerizedCode.yml
@@ -3,14 +3,19 @@ attributes: QbDictField('attributes', dtype=typing.Dict[str, typing.Any] | None,
   is_subscriptable=True)
 computer: QbStrField('computer', dtype=<class 'str'>, is_attribute=True)
 ctime: QbNumericField('ctime', dtype=datetime.datetime | None, is_attribute=False)
+custom_scheduler_commands: QbStrField('custom_scheduler_commands', dtype=<class 'str'>,
+  is_attribute=True)
 default_calc_job_plugin: QbStrField('default_calc_job_plugin', dtype=str | None, is_attribute=True)
 description: QbStrField('description', dtype=<class 'str'>, is_attribute=True)
 engine_command: QbStrField('engine_command', dtype=<class 'str'>, is_attribute=True)
+environment_variables: QbDictField('environment_variables', dtype=typing.Dict[str,
+  str], is_attribute=True)
 extras: QbDictField('extras', dtype=typing.Dict[str, typing.Any] | None, is_attribute=False,
   is_subscriptable=True)
 filepath_executable: QbStrField('filepath_executable', dtype=<class 'str'>, is_attribute=True)
 image_name: QbStrField('image_name', dtype=<class 'str'>, is_attribute=True)
 label: QbStrField('label', dtype=<class 'str'>, is_attribute=True)
+mpirun_extra_params: QbArrayField('mpirun_extra_params', dtype=typing.List[str], is_attribute=True)
 mtime: QbNumericField('mtime', dtype=datetime.datetime | None, is_attribute=False)
 node_type: QbStrField('node_type', dtype=str | None, is_attribute=False)
 pk: QbNumericField('pk', dtype=int | None, is_attribute=False)

--- a/tests/orm/test_fields/fields_aiida.data.core.code.installed.InstalledCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.installed.InstalledCode.yml
@@ -3,12 +3,17 @@ attributes: QbDictField('attributes', dtype=typing.Dict[str, typing.Any] | None,
   is_subscriptable=True)
 computer: QbStrField('computer', dtype=<class 'str'>, is_attribute=True)
 ctime: QbNumericField('ctime', dtype=datetime.datetime | None, is_attribute=False)
+custom_scheduler_commands: QbStrField('custom_scheduler_commands', dtype=<class 'str'>,
+  is_attribute=True)
 default_calc_job_plugin: QbStrField('default_calc_job_plugin', dtype=str | None, is_attribute=True)
 description: QbStrField('description', dtype=<class 'str'>, is_attribute=True)
+environment_variables: QbDictField('environment_variables', dtype=typing.Dict[str,
+  str], is_attribute=True)
 extras: QbDictField('extras', dtype=typing.Dict[str, typing.Any] | None, is_attribute=False,
   is_subscriptable=True)
 filepath_executable: QbStrField('filepath_executable', dtype=<class 'str'>, is_attribute=True)
 label: QbStrField('label', dtype=<class 'str'>, is_attribute=True)
+mpirun_extra_params: QbArrayField('mpirun_extra_params', dtype=typing.List[str], is_attribute=True)
 mtime: QbNumericField('mtime', dtype=datetime.datetime | None, is_attribute=False)
 node_type: QbStrField('node_type', dtype=str | None, is_attribute=False)
 pk: QbNumericField('pk', dtype=int | None, is_attribute=False)

--- a/tests/orm/test_fields/fields_aiida.data.core.code.portable.PortableCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.portable.PortableCode.yml
@@ -3,13 +3,18 @@ attributes: QbDictField('attributes', dtype=typing.Dict[str, typing.Any] | None,
   is_subscriptable=True)
 computer: QbNumericField('computer', dtype=int | None, is_attribute=False)
 ctime: QbNumericField('ctime', dtype=datetime.datetime | None, is_attribute=False)
+custom_scheduler_commands: QbStrField('custom_scheduler_commands', dtype=<class 'str'>,
+  is_attribute=True)
 default_calc_job_plugin: QbStrField('default_calc_job_plugin', dtype=str | None, is_attribute=True)
 description: QbStrField('description', dtype=<class 'str'>, is_attribute=True)
+environment_variables: QbDictField('environment_variables', dtype=typing.Dict[str,
+  str], is_attribute=True)
 extras: QbDictField('extras', dtype=typing.Dict[str, typing.Any] | None, is_attribute=False,
   is_subscriptable=True)
 filepath_executable: QbStrField('filepath_executable', dtype=<class 'str'>, is_attribute=True)
 filepath_files: QbStrField('filepath_files', dtype=<class 'str'>, is_attribute=False)
 label: QbStrField('label', dtype=<class 'str'>, is_attribute=True)
+mpirun_extra_params: QbArrayField('mpirun_extra_params', dtype=typing.List[str], is_attribute=True)
 mtime: QbNumericField('mtime', dtype=datetime.datetime | None, is_attribute=False)
 node_type: QbStrField('node_type', dtype=str | None, is_attribute=False)
 pk: QbNumericField('pk', dtype=int | None, is_attribute=False)


### PR DESCRIPTION
NOTE: Possibly split up into multiple PRs

Rendered modified docs pages:
https://aiida--7272.org.readthedocs.build/projects/aiida-core/en/7272/howto/tricks_real_world_runs.html
https://aiida--7272.org.readthedocs.build/projects/aiida-core/en/7272/topics/calculations/usage.html#scheduler-and-runtime-options

See commit msg:

```md
Add `custom_scheduler_commands` and `mpirun_extra_params` as code-level
properties on `AbstractCode`, allowing codes to carry scheduler
directives (e.g. `#SBATCH --uenv=...`) and extra mpirun parameters (e.g.
`--uenv=... --view=default`) that are automatically included in every
submission script using that code. These are merged with the existing
CalcJob-level `metadata.options` values during presubmit (code-level
first, then CalcJob-level).

Also adds a `--run-prepend-text` flag to `verdi code test` that executes
the computer's and code's prepend text on the remote machine before
checking whether the executable exists. This fixes the case where the
executable only becomes available after running setup commands (e.g.
`module load ...` or `uenv start` mounting a squashfs filesystem). Note
that only prepend
text can be executed at this stage — `custom_scheduler_commands` are
scheduler directives (e.g. `#SBATCH` lines) that are processed by the
scheduler, not the shell, and `mpirun_extra_params` are flags passed to
the MPI launcher, not standalone commands. Neither can be meaningfully
simulated in an SSH session.
```

Both new fields are fully integrated into `verdi code create`, `verdi code show`, and `verdi code export`/import, so YAML round-trips work correctly.

This was originally motivated by the CSCS Alps `uenv` infrastructure, where different codes require different user environments that must be specified either as scheduler directives, prepend text, or mpirun flags. Without code-level support, users had to set these on every individual calculation, which is error-prone and prevents static configuration via YAML files (e.g. for AiiDAlab or code registries).