### PR TITLE
pre-commit: Do not autoformat uv.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
   hooks:
   - id: pretty-format-toml
     args: [--autofix]
+    exclude: uv.lock
   - id: pretty-format-yaml
     args: [--autofix]
     exclude: >-


### PR DESCRIPTION
pre-commit (correctly) started to identify uv.lock as using TOML format, which meant that suddenly it is being autoformatted by our pretty-toml hook.
Since uv.lock file is autogenerated by uv and must not be manually edited, it should not be touched by a random non-uv tool. Let's exclude it from the pretty-format, it is quite pretty as it is!

See #7273 for a more detailed writeup.

Closes #7273 
