### PR TITLE
🔧 Add docs build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ pip-wheel-metadata
 docs/build
 docs/source/reference/apidoc
 _sandbox
+_build/
+docs/html/
+docs/jupyter_execute/
+sphinx.log
 
 pplot_out/
 
@@ -46,3 +50,5 @@ docker-bake.override.json
 
 # benchmark
 .benchmarks/
+
+#

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+__pycache__/
 *.pyc
+*.pyo
 *~
 *.swp
 *.project
@@ -13,24 +15,33 @@
 
 /venv*/
 /.idea/
+*.egg
 *.egg-info
 .eggs
 .vscode
+pyrightconfig.json
+stubs/
 .tox
 Pipfile
 
 .aiida
+
+# Linter/type-checker caches
+.mypy_cache/
+.ruff_cache/
 
 # files created by coverage
 .cache
 .pytest_cache
 .coverage
 coverage.xml
+htmlcov/
 
 # Files created by RPN tests
 **/polish_workchains/polish*
 
 # Build files
+build/
 dist/
 pip-wheel-metadata
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,3 @@ docker-bake.override.json
 
 # benchmark
 .benchmarks/
-
-#


### PR DESCRIPTION
When using the command as it is in CI. Of course, one could use `git clean -fd` afterwards, or specify a different folder for the build, but, either way, I think it's a natural approach to just copy-paste what we run for the docs build in CI, and that should not pollute the repo...