### PR TITLE
Fix test_shutdown_worker leaving stale callback that breaks later tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,12 +55,6 @@ class TestDbBackend(Enum):
     PSQL = 'psql'
 
 
-@pytest.fixture(autouse=True)
-def _reset_runner(request):
-    yield
-    get_manager().reset_runner()
-
-
 def pytest_collection_modifyitems(items, config):
     """Automatically generate markers for certain tests.
 

--- a/tests/engine/daemon/test_worker.py
+++ b/tests/engine/daemon/test_worker.py
@@ -16,17 +16,12 @@ from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
 
 @pytest.mark.requires_rmq
-@pytest.mark.asyncio
-async def test_shutdown_worker(manager):
+def test_shutdown_worker(manager):
     """Test the ``shutdown_worker`` method."""
     runner = manager.get_runner()
-    await shutdown_worker(runner)
-
-    try:
-        assert runner.is_closed()
-    finally:
-        # Reset the runner of the manager, because once closed it cannot be reused by other tests.
-        manager._runner = None
+    runner.loop.create_task(shutdown_worker(runner))
+    runner.loop.run_forever()
+    assert runner.is_closed()
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -15,15 +15,18 @@ import pytest
 
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from aiida.engine import Process, launch
-from aiida.manage import get_manager
 from aiida.manage.caching import enable_caching
 from aiida.orm import Int, Str, WorkflowNode
 
 
 @pytest.fixture
-def runner():
-    """Construct and return a `Runner`."""
-    runner = get_manager().create_runner(poll_interval=0.5)
+def runner(manager):
+    """Construct and return a ``Runner``.
+
+    This fixture depends on ``manager`` so that the manager teardown resets the global profile state after the test,
+    clearing any shared runner state before later tests run.
+    """
+    runner = manager.create_runner(poll_interval=0.5)
     yield runner
     runner.close()
 


### PR DESCRIPTION
So in the end it is really a minor issue with a lot of complexity. It only affects the tests. This fix requires first #7268 to be merged because it relies on some fixes that release resources in the test (the manager fixture).

### Root cause
test_shutdown_worker was an async test (@pytest.mark.asyncio), so pytest-asyncio ran it via loop.run_until_complete(). Inside the test, shutdown_worker() calls runner.close() -> loop.stop(). Calling loop.stop() from within loop.run_until_complete() leaves a stale _run_until_complete_cb in the event loop's ready queue. This callback calls loop.stop() when it fires, which poisons the next run_until_complete() call on the same loop with: RuntimeError: Event loop stopped before Future completed

### Why the next test is affected
The event_loop fixture in conftest.py returns manager.get_runner().loop. After test_shutdown_worker, this loop still has the stale callback. When a later test (e.g. test_calc_job_node_get_builder_restart) calls run_until_complete() on the same loop, the stale callback fires loop.stop() prematurely.

### Why the _reset_runner autouse fixture masked the issue
The _reset_runner fixture called manager.reset_runner() after every test, which called runner.close() -> loop.close(). This closed the loop entirely, so get_or_create_event_loop() created a fresh loop for the next test without the stale callback. Removing this fixture exposed the underlying bug.


### Why run_forever fixes it
In the real daemon, start_daemon_worker() uses loop.run_forever(), not loop.run_until_complete(). run_forever() does not add a _run_until_complete_cb, so loop.stop() cleanly exits the loop with no stale callbacks. The fix changes the test to use the same pattern: schedule shutdown_worker as a task, then call run_forever(). This mirrors production behavior and avoids the stale callback.

### Minimal example to reproduce
```python
"""Minimal example demonstrating how loop.stop() inside run_until_complete()
leaves a stale _run_until_complete_cb that breaks subsequent calls.

This is the root cause of the intermittent CI failure:
  RuntimeError: Event loop stopped before Future completed
"""
import asyncio


# === Working: loop.stop() inside run_forever() ===
# This is how the real daemon works. No stale callback.

loop = asyncio.new_event_loop()

async def shutdown_via_run_forever():
    await asyncio.sleep(0)
    loop.stop()  # cleanly exits run_forever()

loop.create_task(shutdown_via_run_forever())
loop.run_forever()
print(f"After run_forever + loop.stop(): _ready has {len(loop._ready)} stale items")
loop.close()


# === Broken: loop.stop() inside run_until_complete() ===
# This is what the async test did via pytest-asyncio.
# run_until_complete() adds _run_until_complete_cb to the task.
# When loop.stop() exits the loop early, that callback is never
# processed and stays in _ready.

loop = asyncio.new_event_loop()

async def shutdown_via_run_until_complete():
    await asyncio.sleep(0)
    loop.stop()  # exits run_until_complete() early

loop.run_until_complete(shutdown_via_run_until_complete())

n_stale = len(loop._ready)
print(f"After run_until_complete + loop.stop(): _ready has {n_stale} stale items")
for h in loop._ready:
    cb = getattr(h, '_callback', None)
    print(f"  stale callback: {getattr(cb, '__name__', repr(cb))}")


# === The stale callback poisons the next run_until_complete() ===

async def innocent_coroutine():
    await asyncio.sleep(0)  # yield so the stale callback fires first
    return 42

try:
    result = loop.run_until_complete(innocent_coroutine())
    print(f"Next call succeeded: {result}")
except RuntimeError as e:
    print(f"Next call FAILED: {e}")

loop.close()
```