### PR TITLE
Revert lazy init of builder namespaces

### DIFF
--- a/src/aiida/engine/processes/builder.py
+++ b/src/aiida/engine/processes/builder.py
@@ -57,7 +57,7 @@ class ProcessBuilderNamespace(MutableMapping):
         """
         self._port_namespace = port_namespace
         self._valid_fields = []
-        self._data: dict[str, Any] = {}
+        self._data = {}
 
         dynamic_properties = {}
 
@@ -69,18 +69,17 @@ class ProcessBuilderNamespace(MutableMapping):
             self._valid_fields.append(name)
 
             if isinstance(port, PortNamespace):
+                self._data[name] = ProcessBuilderNamespace(port)
 
-                def fgetter(self, name=name, port=port, default=None):
-                    if name not in self._data:
-                        self._data[name] = ProcessBuilderNamespace(port)
-                    return self._data[name]
+                def fgetter(self, name=name):
+                    return self._data.get(name)
             elif port.has_default():
 
-                def fgetter(self, name=name, port=None, default=port.default):
+                def fgetter(self, name=name, default=port.default):  # type: ignore[misc]
                     return self._data.get(name, default)
             else:
 
-                def fgetter(self, name=name, port=None, default=None):
+                def fgetter(self, name=name):
                     return self._data.get(name, None)
 
             def fsetter(self, value, name=name):
@@ -148,10 +147,6 @@ class ProcessBuilderNamespace(MutableMapping):
         return len(self._data)
 
     def __getitem__(self, item):
-        if item not in self._data and item in self._valid_fields:
-            port = self._port_namespace.get(item)
-            if isinstance(port, PortNamespace):
-                self._data[item] = ProcessBuilderNamespace(port)
         return self._data[item]
 
     def __setitem__(self, item, value):
@@ -223,12 +218,6 @@ class ProcessBuilderNamespace(MutableMapping):
         """
         if prune:
             return prune_mapping(dict(self))
-
-        # Materialize all lazy namespaces so the full port structure is visible
-        for field in self._valid_fields:
-            value = getattr(self, field)
-            if isinstance(value, ProcessBuilderNamespace):
-                value._inputs(prune=False)
 
         return dict(self)
 

--- a/tests/engine/processes/test_builder.py
+++ b/tests/engine/processes/test_builder.py
@@ -142,31 +142,6 @@ def test_builder_inputs():
     assert builder._inputs(prune=True) == {'namespace': {'nested': {'bird': []}}}
 
 
-def test_builder_lazy_namespaces():
-    """Test that dict-style access lazily creates namespaces, including through nested levels."""
-    # Dict-style access creates the namespace
-    builder = LazyProcessNamespace.get_builder()
-    _ = builder['namespace']
-    assert 'namespace' in dict(builder)
-
-    # Nested dict-style access where both parent and child are absent
-    builder = LazyProcessNamespace.get_builder()
-    _ = builder['namespace']['nested']
-    assert 'nested' in dict(builder['namespace'])
-
-    # Setting a value through nested dict-style access
-    builder = LazyProcessNamespace.get_builder()
-    builder['namespace']['nested']['bird'] = 'robin'
-    assert builder._inputs(prune=True) == {'namespace': {'nested': {'bird': 'robin'}}}
-
-    # Invalid keys raise KeyError at any nesting level
-    builder = LazyProcessNamespace.get_builder()
-    with pytest.raises(KeyError):
-        builder['nonexistent']
-    with pytest.raises(KeyError):
-        builder['namespace']['nonexistent']
-
-
 @pytest.mark.parametrize(
     'process_class',
     [
@@ -207,7 +182,6 @@ def test_dynamic_setters(example_inputs):
     builder.name_spaced = example_inputs['name_spaced']
     builder.boolean = example_inputs['boolean']
     builder.dict = example_inputs['dict']
-    builder.metadata = example_inputs['metadata']
     assert builder == example_inputs
 
 


### PR DESCRIPTION
This reverts commit e68883eb2957ccc03f72840a5c078a70ed0a0288.

Due to the builder's usage in aiidalab we have to revert the change. A proper solution require breaking the API.

I link the original issue here: 
https://github.com/aiidateam/aiida-core/issues/6994