### PR TITLE
Fix flaky test_unload_profile by properly removing scoped session

### DIFF
--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -9,7 +9,6 @@
 """SqlAlchemy implementation of `aiida.orm.implementation.backends.Backend`."""
 
 import functools
-import gc
 import pathlib
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager, nullcontext
@@ -185,12 +184,8 @@ class PsqlDosBackend(StorageBackend):
         if engine is not None:
             engine.dispose()  # type: ignore[union-attr]
         self._session_factory.expunge_all()
-        self._session_factory.close()
+        self._session_factory.remove()
         self._session_factory = None
-
-        # Without this, sqlalchemy keeps a weakref to a session
-        # in sqlalchemy.orm.session._sessions
-        gc.collect()
 
     def _clear(self) -> None:
         from aiida.storage.psql_dos.models.settings import DbSetting

--- a/src/aiida/storage/psql_dos/orm/querybuilder/joiner.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/joiner.py
@@ -9,6 +9,7 @@
 # ruff: noqa: N802
 """A module containing the logic for creating joined queries."""
 
+import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Protocol, Type
 
@@ -55,6 +56,8 @@ class _EntityMapper(Protocol):
     @property
     def table_groups_nodes(self) -> Type[Table]: ...
 
+    def build_filters(self, alias: AliasedClass, filter_spec: Dict[str, Any]) -> Optional[ColumnElement[bool]]: ...
+
 
 @dataclass
 class JoinReturn:
@@ -73,11 +76,9 @@ class SqlaJoiner:
     def __init__(
         self,
         entity_mapper: _EntityMapper,
-        filter_builder: Callable[[AliasedClass, FilterType], Optional[ColumnElement[bool]]],
     ):
         """Initialise the class"""
-        self._entities = entity_mapper
-        self._build_filters = filter_builder
+        self._entities = weakref.proxy(entity_mapper)
 
     def get_join_func(self, entity_key: str, relationship: str) -> JoinFuncType:
         """Return the function to join two entities"""
@@ -398,7 +399,7 @@ class SqlaJoiner:
         node1 = aliased(self._entities.Node)
 
         link_filters = link1.type.in_((LinkType.CREATE.value, LinkType.INPUT_CALC.value))  # follow input / create links
-        in_recursive_filters = self._build_filters(node1, filter_dict)
+        in_recursive_filters = self._entities.build_filters(node1, filter_dict)
         if in_recursive_filters is None:
             filters = link_filters
         else:
@@ -465,7 +466,7 @@ class SqlaJoiner:
         node1 = aliased(self._entities.Node)
 
         link_filters = link1.type.in_((LinkType.CREATE.value, LinkType.INPUT_CALC.value))  # follow input / create links
-        in_recursive_filters = self._build_filters(node1, filter_dict)
+        in_recursive_filters = self._entities.build_filters(node1, filter_dict)
         if in_recursive_filters is None:
             filters = link_filters
         else:

--- a/src/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -94,7 +94,7 @@ class SqlaQueryBuilder(BackendQueryBuilder):
     def __init__(self, backend):
         super().__init__(backend)
 
-        self._joiner = SqlaJoiner(self, self.build_filters)
+        self._joiner = SqlaJoiner(self)
 
         # Set conversions between the field names in the database and used by the `QueryBuilder`
         # table -> field -> field

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -584,18 +584,6 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
             # these specific formats, because ``matplotlib`` used in the others _also_ calls ``subprocess.check_output``
             monkeypatch.setattr(sp, 'check_output', mock_check_output)
 
-        if fmt in ['mpl_pos']:
-            # This has to be mocked because ``plot_positions_xyz`` imports ``matplotlib.pyplot`` and for some completely
-            # unknown reason, causes ``tests/storage/psql_dos/test_backend.py::test_unload_profile`` to fail. For some
-            # reason, merely importing ``matplotlib`` (even here directly in the test) will cause that test to claim
-            # that there still is something holding on to a reference of an sqlalchemy session that it keeps track of
-            # in the ``sqlalchemy.orm.session._sessions`` weak ref dictionary. Since it is impossible to figure out why
-            # the hell importing matplotlib would interact with sqlalchemy sessions, the function that does the import
-            # is simply mocked out for now.
-            from aiida.orm.nodes.data.array import trajectory
-
-            monkeypatch.setattr(trajectory, 'plot_positions_XYZ', lambda *args, **kwargs: None)
-
         run_cli_command(cmd_trajectory.trajectory_show, options, use_subprocess=False)
 
 

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -157,24 +157,20 @@ def test_unload_profile():
 
     This is a regression test for #5506.
     """
-    import gc
-
     from sqlalchemy.orm.session import _sessions
-
-    # Run the garbage collector to ensure any lingering unrelated sessions do not cause the test to fail.
-    gc.collect()
-
-    # Just running the test suite itself should have opened at least one session
-    current_sessions = len(_sessions)
-    assert current_sessions != 0, str(_sessions)
 
     manager = get_manager()
     profile_name = manager.get_profile().name
 
+    # Ensure at least one session exists by accessing the storage
+    manager.get_profile_storage().get_session()
+
+    current_sessions = len(_sessions)
+    assert current_sessions != 0, f'Expected at least one session, got: {_sessions}'
+
     try:
         manager.unload_profile()
-        # After unloading, the session should have been cleared, so we should have one less
-        assert len(_sessions) == current_sessions - 1, str(_sessions)
+        assert len(_sessions) == current_sessions - 1, f'Expected {current_sessions - 1} sessions, got: {_sessions}'
     finally:
         manager.load_profile(profile_name)
 


### PR DESCRIPTION
Fixes flaky test, e.g. in https://github.com/agoscinski/aiida-core/actions/runs/22924322496/job/66530719671
```
FAILED tests/storage/psql_dos/test_backend.py::test_unload_profile - AssertionError: <WeakValueDictionary at 0x7f74710caea0>
assert 1 == (1 - 1)
 +  where 1 = len(<WeakValueDictionary at 0x7f74710caea0>)
= 1 failed, 3422 passed, 54 skipped, 1 xfailed, 42 warnings in 1338.81s (0:22:18) =
```

## Commit 1: Missing remove in storage backend

The test_unload_profile test checks that SQLAlchemy's internal _sessions WeakValueDictionary shrinks after unloading the profile. This test was flaky for two reasons:

1. The backend close() method called scoped_session.close() but not scoped_session.remove(). close() releases the database connection and resets the session state, but the session object remains registered in the scoped_session's thread-local registry. Since _sessions is a WeakValueDictionary, entries are only removed when all strong references to the session are gone. The thread-local registry held a strong reference, preventing cleanup. Adding remove() explicitly clears the session from the thread-local registry, which drops the last strong reference and lets the WeakValueDictionary entry be collected immediately.

   This removes the gc.collect() workaround in close() that was previously needed to trigger cleanup of the weak reference. With remove(), the reference is dropped deterministically.

2. The test assumed that previous tests had already created at least one session (assert current_sessions != 0). When run in isolation, no sessions exist and the test fails at the first assertion. Fix by explicitly creating a session via get_session() before checking counts.

   The gc.collect() in the test is also removed. It was needed to clean up sessions leaked by earlier tests whose close() didn't call remove(), so sessions lingered in the WeakValueDictionary until GC collected them. Now that close() calls remove(), sessions from previous tests are already gone deterministically.


### Script reproducing the error, showing that remove really removes it

```python
"""Reproduce the scoped_session leak in SQLAlchemy's _sessions WeakValueDictionary.

Demonstrates that scoped_session.close() does NOT remove the session from
SQLAlchemy's global _sessions registry, while scoped_session.remove() does.

This is the root cause of the flaky test_unload_profile test.
"""
from sqlalchemy import create_engine
from sqlalchemy.orm import scoped_session, sessionmaker
from sqlalchemy.orm.session import _sessions


engine = create_engine('sqlite://')

# === Without remove(): session lingers in _sessions ===
print('--- close() without remove() ---')
before = len(_sessions)
factory = scoped_session(sessionmaker(bind=engine))
factory()  # creates and registers session in _sessions
print(f'After creating session: {len(_sessions) - before} new entries in _sessions')

factory.expunge_all()
factory.close()
after_close = len(_sessions)
print(f'After close(): {after_close - before} entries remain (expected 0, session leaked!)')

# === With remove(): session is cleaned up ===
print('\n--- close() + remove() ---')
before = len(_sessions)
factory2 = scoped_session(sessionmaker(bind=engine))
factory2()
print(f'After creating session: {len(_sessions) - before} new entries in _sessions')

factory2.expunge_all()
factory2.close()
factory2.remove()
after_remove = len(_sessions)
print(f'After close() + remove(): {after_remove - before} entries remain (cleaned up!)')

engine.dispose()
```

## Commit 2: Cyclic ownership between SqlaQueryBuilder and SqlaJoiner

Read second commit message.

## Commit 3: Remove unnecessary monkeypatching of the trajectory

Covers what is described in the comment https://github.com/aiidateam/aiida-core/pull/7281#issuecomment-4112954499