### PR TITLE
🐛 `ProcessBuilder`: use `__str__` instead of `__repr__`

### DIFF
--- a/src/aiida/engine/processes/builder.py
+++ b/src/aiida/engine/processes/builder.py
@@ -237,8 +237,8 @@ class ProcessBuilder(ProcessBuilderNamespace):
         """Return the process class for which this builder is constructed."""
         return self._process_class
 
-    def __repr__(self) -> str:
-        """Return a string representation showing the process class and its current inputs."""
+    def __str__(self) -> str:
+        """Return a readable string showing the process class and its current inputs."""
         import yaml
 
         return (
@@ -248,4 +248,4 @@ class ProcessBuilder(ProcessBuilderNamespace):
 
     def _repr_pretty_(self, p, _) -> None:
         """Pretty representation hook for IPython and Jupyter environments."""
-        p.text(repr(self))
+        p.text(str(self))


### PR DESCRIPTION
`__repr__` is meant to return an unambiguous, developer-facing string that ideally allows reconstructing the object. `__str__` is the appropriate hook for a human-readable, end-user-facing representation. Here we replace the incorrect choice of `__repr__` made in c79d22a5f8 by `__str__`.