### PR TITLE
Fix verdi status message when no daemon is available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,6 +364,7 @@ disallow_untyped_defs = true
 module = [
   'aiida.cmdline.groups.*',
   'aiida.cmdline.params.*',
+  'aiida.cmdline.commands.cmd_status',
   'aiida.common.*',
   'aiida.repository.*',
   'aiida.schedulers.*',

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """`verdi status` command."""
 
+from __future__ import annotations
+
 import enum
 import sys
 

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -156,7 +156,7 @@ def verdi_status(print_traceback, no_rmq):
         print_status(
             ServiceStatus.WARNING,
             'daemon',
-            'No broker defined for this profile: daemon is not available. See {URL_NO_BROKER}',
+            'No broker defined for this profile: daemon is not available.',
         )
     except DaemonNotRunningException as exception:
         print_status(ServiceStatus.WARNING, 'daemon', str(exception))

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -55,7 +55,7 @@ STATUS_SYMBOLS = {
 @verdi.command('status')
 @options.PRINT_TRACEBACK()
 @click.option('--no-rmq', is_flag=True, help='Do not check RabbitMQ status')
-def verdi_status(print_traceback, no_rmq):
+def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     """Print status of AiiDA services."""
     from aiida import __version__
     from aiida.common.docs import URL_NO_BROKER
@@ -68,7 +68,7 @@ def verdi_status(print_traceback, no_rmq):
     configure_directory = AiiDAConfigDir.get()
 
     print_status(ServiceStatus.UP, 'version', f'AiiDA v{__version__}')
-    print_status(ServiceStatus.UP, 'config', configure_directory)
+    print_status(ServiceStatus.UP, 'config', str(configure_directory))
 
     manager = get_manager()
 
@@ -133,20 +133,20 @@ def verdi_status(print_traceback, no_rmq):
 
     if broker:
         try:
-            broker.get_communicator()
+            broker.get_communicator()  # type: ignore[no-untyped-call]
         except Exception as exc:
             message = f'Unable to connect to broker: {broker}'
             print_status(ServiceStatus.ERROR, 'broker', message, exception=exc, print_traceback=print_traceback)
             exit_code = ExitCode.CRITICAL
         else:
-            print_status(ServiceStatus.UP, 'broker', broker)
+            print_status(ServiceStatus.UP, 'broker', str(broker))
         finally:
-            broker.close()
+            broker.close()  # type: ignore[no-untyped-call]
     else:
         print_status(
             ServiceStatus.WARNING,
             'broker',
-            f'No broker defined for this profile: certain functionality not available. See {URL_NO_BROKER}',
+            ('No broker defined for this profile: certain functionality not available.', f'See {URL_NO_BROKER}'),
         )
 
     # Getting the daemon status
@@ -174,7 +174,13 @@ def verdi_status(print_traceback, no_rmq):
         sys.exit(exit_code)
 
 
-def print_status(status, service, msg='', exception=None, print_traceback=False):
+def print_status(
+    status: ServiceStatus,
+    service: str,
+    msg: str | tuple[str, ...] = '',
+    exception: Exception | None = None,
+    print_traceback: bool = False,
+) -> None:
     """Print status message.
 
     Includes colored indicator.
@@ -185,7 +191,13 @@ def print_status(status, service, msg='', exception=None, print_traceback=False)
     """
     symbol = STATUS_SYMBOLS[status]
     echo.echo(f" {symbol['string']} ", fg=symbol['color'], nl=False)
-    echo.echo(f"{service + ':':12s} {msg}")
+    echo.echo(f"{service + ':':12s} ", nl=False)
+    if isinstance(msg, tuple):
+        echo.echo(msg[0])
+        for s in msg[1:]:
+            echo.echo(f"{'':15s} {s}")
+    else:
+        echo.echo(msg)
 
     if exception is not None:
         echo.echo_error(f'{type(exception).__name__}: {exception}')

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -148,7 +148,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         print_status(
             ServiceStatus.WARNING,
             'broker',
-            ('No broker defined for this profile: certain functionality not available.', f'See {URL_NO_BROKER}'),
+            f'No broker defined for this profile: certain functionality not available.\nSee {URL_NO_BROKER}',
         )
 
     # Getting the daemon status
@@ -179,7 +179,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
 def print_status(
     status: ServiceStatus,
     service: str,
-    msg: str | tuple[str, ...] = '',
+    msg: str = '',
     exception: Exception | None = None,
     print_traceback: bool = False,
 ) -> None:
@@ -194,12 +194,10 @@ def print_status(
     symbol = STATUS_SYMBOLS[status]
     echo.echo(f" {symbol['string']} ", fg=symbol['color'], nl=False)
     echo.echo(f"{service + ':':12s} ", nl=False)
-    if isinstance(msg, tuple):
-        echo.echo(msg[0])
-        for s in msg[1:]:
-            echo.echo(f"{'':15s} {s}")
-    else:
-        echo.echo(msg)
+    lines = msg.split('\n')
+    echo.echo(lines[0])
+    for line in lines[1:]:
+        echo.echo(f"{'':15s} {line}")
 
     if exception is not None:
         echo.echo_error(f'{type(exception).__name__}: {exception}')


### PR DESCRIPTION
IMO It's not neccessary to print the same URL to the docs twice in a row (both for broker and daemon).
(also the string was missing the f-string prefix so the URL was not printed correctly).

Here's how it looks now for a presto profile.

```console
❯ verdi status
 ✔ version:     AiiDA v2.8.0.post0
 ✔ config:      /home/hollas/.aiida
 ✔ profile:     presto
 ✔ storage:     SqliteDosStorage[/home/hollas/.aiida/repository/sqlite_dos_56fe4774efe64338883c991cf09b0555]: open,
 ⏺ broker:      No broker defined for this profile: certain functionality not available. See https://aiida-core.readthedocs.io/en/stable/installation/guide_quick.html#quick-install-limitations
 ⏺ daemon:      No broker defined for this profile: daemon is not available.
```

(I think it would be nicer to print the URL on a new line, but that would require bit more work due to the way things are printed currently)