### PR TITLE
Fix: avoid importing and calling close in __del__ during Python shutdown

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import functools
+import sys
 import typing as t
+import warnings
 from collections.abc import Iterator
 
 from aiida.brokers.broker import Broker
@@ -49,10 +51,9 @@ class RabbitmqBroker(Broker):
 
     def __del__(self) -> None:
         if self._communicator is not None:
-            import warnings
-
             warnings.warn(f'RabbitmqBroker was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
-            self.close()
+            if not sys.is_finalizing():
+                self.close()
 
     def iterate_tasks(self) -> Iterator[t.Any]:
         """Return an iterator over the tasks in the launch queue."""

--- a/src/aiida/orm/implementation/storage_backend.py
+++ b/src/aiida/orm/implementation/storage_backend.py
@@ -11,6 +11,8 @@
 from __future__ import annotations
 
 import abc
+import sys
+import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ContextManager, List, Optional, TypeVar, Union
 
@@ -142,10 +144,9 @@ class StorageBackend(abc.ABC):
             # covers cases where the backend implementation is not yet initialized but object is deleted
             return
         if not closed:
-            import warnings
-
             warnings.warn(f'StorageBackend was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
-            self.close()
+            if not sys.is_finalizing():
+                self.close()
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
Fixing issue #7309

Two related fixes to prevent 'Exception ignored in __del__' errors during Python shutdown:

1. Move 'import warnings' to module level in RabbitmqBroker and StorageBackend to avoid ImportError when sys.meta_path is None during shutdown.

2. Guard __del__ with sys.is_finalizing() to skip the close() call during Python shutdown when asyncio/kiwipy event loop infrastructure is already torn down, preventing AttributeError in pytray's await_ method.

During shutdown:
- sys.meta_path becomes None, making imports unavailable
- Module globals are set to None before garbage collection
- asyncio.run_coroutine_threadsafe() fails with AttributeError

By deferring the import and skipping close during finalization, we avoid both issues since the process is exiting anyway.

TODO:
- [ ]  There is some filterwarning somewhere in the database module that needs to be removed, otherwise the warning is always filtered out.

Upcoming changes:
- [ ] ResourceWarnings are ignored by default one needs to use `PYTHONDEVMODE`. This not a bug but a design consideration, it would be good if these warnings are logged somewhere but not showing them to the user makes sense. this requires some upcoming changes in the logger system
