### PR TITLE
🐛 OpenSSH backend: ignore benign path check warnings

### DIFF
--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -627,9 +627,10 @@ class _OpenSSH(_AsynchronousSSHBackend):
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if stderr:
-            # this should not happen, but just in case for debugging
-            self.logger.debug(f'Unexpected stderr: {stderr}')
-            raise OSError(stderr)
+            self.logger.debug(f'Stderr from `test -e {path}`: {stderr}')
+
+        if returncode not in (0, 1):
+            raise OSError(f'Failed to check whether path exists: {path} (exit code {returncode}): {stderr}')
         return returncode == 0
 
     async def rmtree(self, path: str):

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -629,9 +629,10 @@ class _OpenSSH(_AsynchronousSSHBackend):
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if stderr:
-            # this should not happen, but just in case for debugging
-            self.logger.debug(f'Unexpected stderr: {stderr}')
-            raise OSError(stderr)
+            self.logger.debug(f'Stderr from `test -e {path}`: {stderr}')
+
+        if returncode not in (0, 1):
+            raise OSError(f'Failed to check whether path exists: {path} (exit code {returncode}): {stderr}')
         return returncode == 0
 
     async def rmtree(self, path: str):

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -62,10 +62,12 @@ class AsyncSshTransport(AsyncTransport):
             'host',
             {
                 'type': str,
-                'prompt': "Host as in 'ssh <HOST>' (needs to be a password-less setup in your ssh config)",
+                'prompt': "Host as in 'ssh <HOST>' (needs a password-less setup, with the host key in known_hosts)",
                 'help': (
                     'Password-less host-setup to connect, as in command `ssh <HOST>`.'
                     ' You need to have a `Host <HOST>` entry defined in your `~/.ssh/config` file.'
+                    ' The remote host key must also already be present in your `~/.ssh/known_hosts` file;'
+                    ' connect once manually (e.g. run `ssh <HOST>`) to add it, otherwise the connection could fail.'
                     " Note, if not provided, we will use the 'hostname' that was set by you during setup."
                 ),
                 'non_interactive_default': True,

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -177,6 +177,36 @@ class _TestOpenSSH(_OpenSSH):
     def __init__(self):
         self.machine = 'localhost'
         self.bash_command = 'bash -c '
+        self.logger = MagicMock()
+
+
+class TestOpenSSHPathExists:
+    """Tests for `_OpenSSH.path_exists` handling of stderr and return codes."""
+
+    @pytest.mark.parametrize(
+        'returncode, expected',
+        [
+            (0, True),
+            (1, False),
+        ],
+    )
+    def test_path_exists_ignores_stderr_for_expected_return_codes(self, returncode, expected):
+        backend = _TestOpenSSH()
+        backend.openssh_execute = AsyncMock(return_value=(returncode, '', "Warning: host key added to known hosts"))
+
+        assert asyncio.run(backend.path_exists('/remote/path')) is expected
+        backend.logger.debug.assert_called_once_with(
+            'Stderr from `test -e /remote/path`: Warning: host key added to known hosts'
+        )
+
+    def test_path_exists_raises_for_unexpected_return_codes(self):
+        backend = _TestOpenSSH()
+        backend.openssh_execute = AsyncMock(return_value=(2, '', 'some actual ssh failure'))
+
+        with pytest.raises(OSError, match='Failed to check whether path exists: /remote/path'):
+            asyncio.run(backend.path_exists('/remote/path'))
+
+        backend.logger.debug.assert_called_once_with('Stderr from `test -e /remote/path`: some actual ssh failure')
 
 
 class TestSshCommandGenerator:

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -177,36 +177,15 @@ class _TestOpenSSH(_OpenSSH):
     def __init__(self):
         self.machine = 'localhost'
         self.bash_command = 'bash -c '
-        self.logger = MagicMock()
 
 
-class TestOpenSSHPathExists:
-    """Tests for `_OpenSSH.path_exists` handling of stderr and return codes."""
+def test_openssh_path_exists_raises_on_unexpected_return_code():
+    """`_OpenSSH.path_exists` raises on a return code other than 0/1 (255 = SSH connection failure)."""
+    backend = _TestOpenSSH()
+    backend.openssh_execute = AsyncMock(return_value=(255, '', ''))
 
-    @pytest.mark.parametrize(
-        'returncode, expected',
-        [
-            (0, True),
-            (1, False),
-        ],
-    )
-    def test_path_exists_ignores_stderr_for_expected_return_codes(self, returncode, expected):
-        backend = _TestOpenSSH()
-        backend.openssh_execute = AsyncMock(return_value=(returncode, '', "Warning: host key added to known hosts"))
-
-        assert asyncio.run(backend.path_exists('/remote/path')) is expected
-        backend.logger.debug.assert_called_once_with(
-            'Stderr from `test -e /remote/path`: Warning: host key added to known hosts'
-        )
-
-    def test_path_exists_raises_for_unexpected_return_codes(self):
-        backend = _TestOpenSSH()
-        backend.openssh_execute = AsyncMock(return_value=(2, '', 'some actual ssh failure'))
-
-        with pytest.raises(OSError, match='Failed to check whether path exists: /remote/path'):
-            asyncio.run(backend.path_exists('/remote/path'))
-
-        backend.logger.debug.assert_called_once_with('Stderr from `test -e /remote/path`: some actual ssh failure')
+    with pytest.raises(OSError, match='Failed to check whether path exists'):
+        asyncio.run(backend.path_exists('/remote/path'))
 
 
 class TestSshCommandGenerator:


### PR DESCRIPTION
Fixes #7311

`_OpenSSH.path_exists` now treats the `test -e` return code as the source of truth: `0` means the path exists, `1` means it does not. Any stderr from those expected outcomes is logged for debugging instead of being raised, which avoids failing on harmless OpenSSH host-key warnings. Unexpected return codes still raise with the stderr context.

Validation:
- `pytest tests/transports/test_asyncssh_plugin.py -k path_exists`
- `python3 -m compileall -q src/aiida/transports/plugins/async_backend.py tests/transports/test_asyncssh_plugin.py`
- `ruff check --ignore PLC0415,RUF059 src/aiida/transports/plugins/async_backend.py tests/transports/test_asyncssh_plugin.py`