### PR TITLE
👌 `Scheduler.get_jobs`: fix `as_dict` overload

### DIFF
--- a/src/aiida/schedulers/plugins/bash.py
+++ b/src/aiida/schedulers/plugins/bash.py
@@ -48,7 +48,8 @@ class BashCliScheduler(Scheduler, metaclass=abc.ABCMeta):
         self,
         jobs: list[str] | None = None,
         user: str | None = None,
-        as_dict: t.Literal[True] = True,
+        *,
+        as_dict: t.Literal[True],
     ) -> dict[str, JobInfo]: ...
 
     def get_jobs(

--- a/src/aiida/schedulers/plugins/bash.py
+++ b/src/aiida/schedulers/plugins/bash.py
@@ -48,8 +48,7 @@ class BashCliScheduler(Scheduler, metaclass=abc.ABCMeta):
         self,
         jobs: list[str] | None = None,
         user: str | None = None,
-        *,
-        as_dict: t.Literal[True],
+        as_dict: t.Literal[True] = ...,
     ) -> dict[str, JobInfo]: ...
 
     def get_jobs(

--- a/src/aiida/schedulers/plugins/direct.py
+++ b/src/aiida/schedulers/plugins/direct.py
@@ -282,8 +282,7 @@ class DirectScheduler(BashCliScheduler):
         self,
         jobs: list[str] | None = None,
         user: str | None = None,
-        *,
-        as_dict: t.Literal[True],
+        as_dict: t.Literal[True] = ...,
     ) -> dict[str, JobInfo]: ...
 
     @override

--- a/src/aiida/schedulers/plugins/direct.py
+++ b/src/aiida/schedulers/plugins/direct.py
@@ -282,7 +282,8 @@ class DirectScheduler(BashCliScheduler):
         self,
         jobs: list[str] | None = None,
         user: str | None = None,
-        as_dict: t.Literal[True] = True,
+        *,
+        as_dict: t.Literal[True],
     ) -> dict[str, JobInfo]: ...
 
     @override

--- a/src/aiida/schedulers/scheduler.py
+++ b/src/aiida/schedulers/scheduler.py
@@ -147,8 +147,7 @@ class Scheduler(metaclass=abc.ABCMeta):
         self,
         jobs: list[str] | None = None,
         user: str | None = None,
-        *,
-        as_dict: t.Literal[True],
+        as_dict: t.Literal[True] = ...,
     ) -> dict[str, JobInfo]: ...
 
     @abc.abstractmethod

--- a/src/aiida/schedulers/scheduler.py
+++ b/src/aiida/schedulers/scheduler.py
@@ -147,7 +147,8 @@ class Scheduler(metaclass=abc.ABCMeta):
         self,
         jobs: list[str] | None = None,
         user: str | None = None,
-        as_dict: t.Literal[True] = True,
+        *,
+        as_dict: t.Literal[True],
     ) -> dict[str, JobInfo]: ...
 
     @abc.abstractmethod


### PR DESCRIPTION
Fixes #7296

The overload returning a dictionary no longer declares `as_dict: Literal[True] = True`. Instead, `as_dict` is required as a keyword-only literal while `jobs` and `user` remain positional-compatible with the runtime implementation.

Validation:
- `python3 -m compileall -q src/aiida/schedulers/scheduler.py src/aiida/schedulers/plugins/bash.py src/aiida/schedulers/plugins/direct.py`
- `ruff check --ignore PLC0415 src/aiida/schedulers/scheduler.py src/aiida/schedulers/plugins/bash.py src/aiida/schedulers/plugins/direct.py`
- `mypy --config-file=pyproject.toml --follow-imports=skip --disable-error-code=misc --disable-error-code=untyped-decorator src/aiida/schedulers/scheduler.py src/aiida/schedulers/plugins/bash.py src/aiida/schedulers/plugins/direct.py`