### PR TITLE
✨ Add --clean-workdir to verdi group delete

### DIFF
--- a/src/aiida/cmdline/commands/cmd_group.py
+++ b/src/aiida/cmdline/commands/cmd_group.py
@@ -178,12 +178,19 @@ def group_move_nodes(source_group, target_group, force, nodes, all_entries):
 @click.option(
     '--delete-nodes', is_flag=True, default=False, help='Delete all nodes in the group along with the group itself.'
 )
+@click.option(
+    '--clean-workdir',
+    is_flag=True,
+    default=False,
+    help='With `--delete-nodes`, also clean remote work directories of deleted calculation jobs.',
+)
 @options.graph_traversal_rules(GraphTraversalRules.DELETE.value)
 @options.DRY_RUN()
 @with_dbenv()
 def group_delete(
     groups,
     delete_nodes,
+    clean_workdir,
     dry_run,
     force,
     all_users,
@@ -205,6 +212,9 @@ def group_delete(
     filters_provided = any(
         [all_users or user or past_days or startswith or endswith or contains or node or type_string]
     )
+
+    if clean_workdir and not delete_nodes:
+        echo.echo_critical('The `--clean-workdir` option can only be used together with `--delete-nodes`.')
 
     if groups and filters_provided:
         echo.echo_critical('Cannot specify both GROUPS and any of the other filters.')
@@ -298,6 +308,22 @@ def group_delete(
         group_str = str(group)
 
         if delete_nodes:
+            if clean_workdir:
+                from aiida.cmdline.commands.cmd_node import _clean_workdirs
+                from aiida.manage import get_manager
+                from aiida.tools.graph.graph_traversers import get_nodes_delete
+
+                backend = get_manager().get_profile_storage()
+                node_pks = (
+                    orm.QueryBuilder(backend=backend)
+                    .append(orm.Group, filters={'id': group.pk}, tag='group')
+                    .append(orm.Node, with_group='group', project='id')
+                    .all(flat=True)
+                )
+                pks_set_to_delete = get_nodes_delete(
+                    node_pks, get_links=False, backend=backend, **traversal_rules
+                )['nodes']
+                _clean_workdirs(pks_set_to_delete, dry_run=dry_run, force=force)
 
             def _dry_run_callback(pks):
                 if not pks or force:

--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -367,6 +367,46 @@ def _warn_about_stash_nodes(pks_to_delete: set[int]) -> None:
     echo.echo_warning('Consider manually removing these paths from the remote computer.')
 
 
+def _clean_workdirs(pks_set_to_delete: set[int], dry_run: bool, force: bool) -> None:
+    """Clean the remote work directories for the ``CalcJobNode`` instances in a deletion set."""
+    from aiida.orm import CalcJobNode, QueryBuilder
+    from aiida.orm.utils.remote import clean_mapping_remote_paths, get_calcjob_remote_paths
+
+    qb = QueryBuilder()
+    qb.append(CalcJobNode, filters={'id': {'in': pks_set_to_delete}}, project='id')
+    calcjobs_pks = [result[0] for result in qb.all()]
+
+    if not calcjobs_pks:
+        echo.echo_report('--clean-workdir ignored. No CalcJobNode associated with the given node, found.')
+        return
+
+    path_mapping = get_calcjob_remote_paths(
+        calcjobs_pks,
+        only_not_cleaned=True,
+    )
+
+    if not path_mapping:
+        echo.echo_report('--clean-workdir ignored. CalcJobNode work directories are already cleaned.')
+        return
+
+    _warn_about_stash_nodes(pks_set_to_delete)
+
+    descendant_pks = [remote_folder.pk for paths in path_mapping.values() for remote_folder in paths]
+
+    if not force and not dry_run:
+        echo.echo_warning(f'YOU ARE ABOUT TO CLEAN {len(descendant_pks)} REMOTE DIRECTORIES! THIS CANNOT BE UNDONE!')
+        echo.echo_info(
+            'Remote directories of nodes with the following pks would be cleaned: '
+            + ' '.join(map(str, descendant_pks))
+        )
+        click.confirm('Shall I continue?', abort=True)
+
+    if dry_run:
+        echo.echo_report('Remote folders of these node are marked for deletion: ' + ' '.join(map(str, descendant_pks)))
+    else:
+        clean_mapping_remote_paths(path_mapping)
+
+
 @verdi_node.command('delete')
 @click.argument('identifier', nargs=-1, metavar='NODES')
 @options.DRY_RUN()
@@ -411,8 +451,6 @@ def node_delete(identifier, dry_run, force, clean_workdir, **traversal_rules):
 
     if clean_workdir:
         from aiida.manage import get_manager
-        from aiida.orm import CalcJobNode, QueryBuilder
-        from aiida.orm.utils.remote import clean_mapping_remote_paths, get_calcjob_remote_paths
         from aiida.tools.graph.graph_traversers import get_nodes_delete
 
         backend = get_manager().get_profile_storage()
@@ -421,45 +459,7 @@ def node_delete(identifier, dry_run, force, clean_workdir, **traversal_rules):
             pks, get_links=False, missing_callback=lambda missing_pks: None, backend=backend, **traversal_rules
         )['nodes']
 
-        qb = QueryBuilder()
-        qb.append(CalcJobNode, filters={'id': {'in': pks_set_to_delete}}, project='id')
-        calcjobs_pks = [result[0] for result in qb.all()]
-
-        if not calcjobs_pks:
-            echo.echo_report('--clean-workdir ignored. No CalcJobNode associated with the given node, found.')
-            _perform_delete()
-            return
-
-        path_mapping = get_calcjob_remote_paths(
-            calcjobs_pks,
-            only_not_cleaned=True,
-        )
-
-        if not path_mapping:
-            echo.echo_report('--clean-workdir ignored. CalcJobNode work directories are already cleaned.')
-            _perform_delete()
-            return
-
-        _warn_about_stash_nodes(pks_set_to_delete)
-
-        descendant_pks = [remote_folder.pk for paths in path_mapping.values() for remote_folder in paths]
-
-        if not force and not dry_run:
-            echo.echo_warning(
-                f'YOU ARE ABOUT TO CLEAN {len(descendant_pks)} REMOTE DIRECTORIES! ' 'THIS CANNOT BE UNDONE!'
-            )
-            echo.echo_info(
-                'Remote directories of nodes with the following pks would be cleaned: '
-                + ' '.join(map(str, descendant_pks))
-            )
-            click.confirm('Shall I continue?', abort=True)
-
-        if dry_run:
-            echo.echo_report(
-                'Remote folders of these node are marked for deletion: ' + ' '.join(map(str, descendant_pks))
-            )
-        else:
-            clean_mapping_remote_paths(path_mapping)
+        _clean_workdirs(pks_set_to_delete, dry_run=dry_run, force=force)
 
     _perform_delete()
 

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -324,6 +324,45 @@ class TestVerdiGroup:
             orm.load_group(label='group_test_delete_15')
         assert 'do_not_delete_group' not in result.output
 
+    def test_delete_clean_workdir_requires_delete_nodes(self, run_cli_command):
+        """Test that ``--clean-workdir`` is only accepted together with ``--delete-nodes``."""
+        result = run_cli_command(cmd_group.group_delete, ['--force', '--clean-workdir', 'dummygroup1'], raises=True)
+
+        assert 'The `--clean-workdir` option can only be used together with `--delete-nodes`.' in result.output
+
+    def test_delete_clean_workdir(self, run_cli_command, aiida_localhost, tmp_path):
+        """Test deleting a group can also clean remote work directories of contained calcjobs."""
+        from aiida.common.links import LinkType
+
+        workdir = tmp_path / 'workdir'
+        workdir.mkdir()
+        (workdir / 'output.txt').write_text('content')
+
+        calcjob = orm.CalcJobNode(computer=aiida_localhost)
+        calcjob.set_remote_workdir(str(workdir))
+        calcjob.store()
+
+        remote = orm.RemoteData(remote_path=str(workdir), computer=aiida_localhost)
+        remote.base.links.add_incoming(calcjob, LinkType.CREATE, link_label='remote_folder')
+        remote.store()
+
+        group = orm.Group(label='group_test_clean_workdir').store()
+        group.add_nodes(calcjob)
+        calcjob_pk = calcjob.pk
+        remote_pk = remote.pk
+
+        result = run_cli_command(
+            cmd_group.group_delete,
+            ['--force', '--delete-nodes', '--clean-workdir', group.label],
+        )
+
+        assert 'remote folders cleaned' in result.output
+        assert not workdir.exists()
+        with pytest.raises(exceptions.NotExistent):
+            orm.load_node(calcjob_pk)
+        with pytest.raises(exceptions.NotExistent):
+            orm.load_node(remote_pk)
+
     def test_show(self, run_cli_command):
         """Test `verdi group show` command."""
         result = run_cli_command(cmd_group.group_show, ['dummygroup1'], use_subprocess=True)


### PR DESCRIPTION
Fixes #7299

This adds `--clean-workdir` to `verdi group delete` when used together with `--delete-nodes`. The implementation reuses the existing node deletion cleanup flow so the same dry-run, confirmation, already-cleaned, and stash-warning behavior is shared.

Validation:
- `pytest tests/cmdline/commands/test_group.py -k "delete_clean_workdir or test_delete"`
- `pytest tests/cmdline/commands/test_node.py -k node_delete` with the local venv bin directory on `PATH` for subprocess-based cases
- `python3 -m compileall -q src/aiida/cmdline/commands/cmd_node.py src/aiida/cmdline/commands/cmd_group.py tests/cmdline/commands/test_group.py`
- `ruff check --ignore PLC0415 src/aiida/cmdline/commands/cmd_node.py src/aiida/cmdline/commands/cmd_group.py tests/cmdline/commands/test_group.py`