### PR TITLE
✨ `engine.submit`: Add `timeout` parameter

### DIFF
--- a/src/aiida/engine/__init__.py
+++ b/src/aiida/engine/__init__.py
@@ -50,6 +50,7 @@ __all__ = (
     'ProcessHandlerReport',
     'ProcessSpec',
     'ProcessState',
+    'ProcessTimeoutError',
     'Runner',
     'ToContext',
     'WithNonDb',

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -86,6 +86,7 @@ def submit(
     *,
     wait: bool = False,
     wait_interval: int = 5,
+    timeout: int | None = None,
     **kwargs: t.Any,
 ) -> ProcessNode:
     """Submit the process with the supplied inputs to the daemon immediately returning control to the interpreter.
@@ -100,8 +101,11 @@ def submit(
     :param wait: when set to ``True``, the submission will be blocking and wait for the process to complete at which
         point the function returns the calculation node.
     :param wait_interval: the number of seconds to wait between checking the state of the process when ``wait=True``.
+    :param timeout: optional timeout in seconds when ``wait=True``. If the process does not terminate within this time,
+        a ``TimeoutError`` is raised. If ``None`` (default), waits indefinitely.
     :param kwargs: inputs to be passed to the process. This is an alternative to the positional ``inputs`` argument.
     :return: the calculation node of the process
+    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds.
     """
     from aiida.common.docs import URL_NO_BROKER
 
@@ -147,7 +151,13 @@ def submit(
     if not wait:
         return node
 
+    start_time = time.monotonic()
+
     while not node.is_terminated:
+        if timeout is not None and (time.monotonic() - start_time) >= timeout:
+            msg = f'Process<{node.pk}> did not terminate within {timeout} seconds.'
+            raise TimeoutError(msg)
+
         LOGGER.report(
             f'Process<{node.pk}> has not yet terminated, current state is `{node.process_state}`. '
             f'Waiting for {wait_interval} seconds.'

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -88,8 +88,8 @@ def submit(
     inputs: dict[str, t.Any] | None = None,
     *,
     wait: bool = False,
-    wait_interval: int = 5,
-    timeout: int | None = None,
+    wait_interval: float = 5,
+    timeout: float | None = None,
     **kwargs: t.Any,
 ) -> ProcessNode:
     """Submit the process with the supplied inputs to the daemon immediately returning control to the interpreter.
@@ -104,13 +104,21 @@ def submit(
     :param wait: when set to ``True``, the submission will be blocking and wait for the process to complete at which
         point the function returns the calculation node.
     :param wait_interval: the number of seconds to wait between checking the state of the process when ``wait=True``.
-    :param timeout: optional timeout in seconds when ``wait=True``. If the process does not terminate within this time,
-        a ``TimeoutError`` is raised. If ``None`` (default), waits indefinitely.
+    :param timeout: optional maximum number of seconds to wait for the process to terminate, only used when
+        ``wait=True``. Must be a positive number. If the process does not terminate within this time, a
+        ``TimeoutError`` is raised; note that the process itself keeps running on the daemon. If ``None`` (default),
+        waits indefinitely.
     :param kwargs: inputs to be passed to the process. This is an alternative to the positional ``inputs`` argument.
     :return: the calculation node of the process
-    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds.
+    :raises ValueError: if ``timeout`` is not a positive number.
+    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds; the process
+        continues running on the daemon.
     """
     from aiida.common.docs import URL_NO_BROKER
+
+    if timeout is not None and timeout <= 0:
+        msg = f'`timeout` must be a positive number of seconds, but got {timeout}.'
+        raise ValueError(msg)
 
     inputs = prepare_inputs(inputs, **kwargs)
 
@@ -176,18 +184,40 @@ def submit(
     if not wait:
         return node
 
+    return _wait_for_process_termination(node, wait_interval=wait_interval, timeout=timeout)
+
+
+def _wait_for_process_termination(node: ProcessNode, wait_interval: float, timeout: float | None = None) -> ProcessNode:
+    """Block until ``node`` reaches a terminal state, polling its state every ``wait_interval`` seconds.
+
+    :param node: the process node to wait for.
+    :param wait_interval: the number of seconds to wait between checks of the process state.
+    :param timeout: optional maximum number of seconds to wait. If the process does not terminate within this time, a
+        ``TimeoutError`` is raised; the process itself keeps running on the daemon. If ``None``, waits indefinitely.
+        Assumed to be ``None`` or a positive number (validated by the caller).
+    :return: the ``node``, once it has reached a terminal state.
+    :raises TimeoutError: if ``timeout`` is set and the process does not terminate within it.
+    """
     start_time = time.monotonic()
 
     while not node.is_terminated:
-        if timeout is not None and (time.monotonic() - start_time) >= timeout:
-            msg = f'Process<{node.pk}> did not terminate within {timeout} seconds.'
+        elapsed = time.monotonic() - start_time
+
+        if timeout is not None and elapsed >= timeout:
+            msg = (
+                f'Process<{node.pk}> did not terminate within {timeout} seconds. It is still running on the daemon; '
+                f'use `verdi process status {node.pk}` to monitor it or `verdi process kill {node.pk}` to stop it.'
+            )
             raise TimeoutError(msg)
 
+        # Never sleep past the deadline, so the timeout fires on time rather than overshooting by up to
+        # ``wait_interval`` (relevant when ``timeout`` is smaller than, or not a multiple of, ``wait_interval``).
+        wait = wait_interval if timeout is None else min(wait_interval, timeout - elapsed)
         LOGGER.report(
             f'Process<{node.pk}> has not yet terminated, current state is `{node.process_state}`. '
-            f'Waiting for {wait_interval} seconds.'
+            f'Waiting for {wait:g} seconds.'
         )
-        time.sleep(wait_interval)
+        time.sleep(wait)
 
     return node
 

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -106,13 +106,13 @@ def submit(
     :param wait_interval: the number of seconds to wait between checking the state of the process when ``wait=True``.
     :param timeout: optional maximum number of seconds to wait for the process to terminate, only used when
         ``wait=True``. Must be a positive number. If the process does not terminate within this time, a
-        ``TimeoutError`` is raised; note that the process itself keeps running on the daemon. If ``None`` (default),
-        waits indefinitely.
+        ``TimeoutError`` is raised. The timeout only stops waiting; the process itself is not cancelled and keeps
+        being processed by the daemon. If ``None`` (default), waits indefinitely.
     :param kwargs: inputs to be passed to the process. This is an alternative to the positional ``inputs`` argument.
     :return: the calculation node of the process
     :raises ValueError: if ``timeout`` is not a positive number.
-    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds; the process
-        continues running on the daemon.
+    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds. The timeout
+        only stops waiting; the process is not cancelled and keeps being processed by the daemon.
     """
     from aiida.common.docs import URL_NO_BROKER
 
@@ -193,8 +193,8 @@ def _wait_for_process_termination(node: ProcessNode, wait_interval: float, timeo
     :param node: the process node to wait for.
     :param wait_interval: the number of seconds to wait between checks of the process state.
     :param timeout: optional maximum number of seconds to wait. If the process does not terminate within this time, a
-        ``TimeoutError`` is raised; the process itself keeps running on the daemon. If ``None``, waits indefinitely.
-        Assumed to be ``None`` or a positive number (validated by the caller).
+        ``TimeoutError`` is raised; the process is not cancelled and keeps being processed by the daemon. If ``None``,
+        waits indefinitely. Assumed to be ``None`` or a positive number (validated by the caller).
     :return: the ``node``, once it has reached a terminal state.
     :raises TimeoutError: if ``timeout`` is set and the process does not terminate within it.
     """
@@ -205,8 +205,10 @@ def _wait_for_process_termination(node: ProcessNode, wait_interval: float, timeo
 
         if timeout is not None and elapsed >= timeout:
             msg = (
-                f'Process<{node.pk}> did not terminate within {timeout} seconds. It is still running on the daemon; '
-                f'use `verdi process status {node.pk}` to monitor it or `verdi process kill {node.pk}` to stop it.'
+                f'Process<{node.pk}> did not terminate within the {timeout}s timeout '
+                f'(current state: `{node.process_state}`). The timeout only stopped waiting; the process was not '
+                f'cancelled and keeps being processed by the daemon. Use `verdi process status {node.pk}` to '
+                f'monitor it or `verdi process kill {node.pk}` to stop it.'
             )
             raise TimeoutError(msg)
 

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -25,12 +25,25 @@ from .processes.process import Process
 from .runners import ResultAndPk
 from .utils import instantiate_process, is_process_scoped, prepare_inputs
 
-__all__ = ('await_processes', 'run', 'run_get_node', 'run_get_pk', 'submit')
+__all__ = ('ProcessTimeoutError', 'await_processes', 'run', 'run_get_node', 'run_get_pk', 'submit')
 
 TYPE_RUN_PROCESS = Process | type[Process] | ProcessBuilder
 # run can also be process function, but it is not clear what type this should be
 TYPE_SUBMIT_PROCESS = Process | type[Process] | ProcessBuilder
 LOGGER = AIIDA_LOGGER.getChild('engine.launch')
+
+
+class ProcessTimeoutError(TimeoutError):
+    """Raised when a blocking wait (``submit(wait=True, timeout=...)``) exceeds its ``timeout``.
+
+    Subclasses the built-in :class:`TimeoutError`, so existing ``except TimeoutError`` handlers keep working. The wait
+    timing out does not cancel the process; it keeps being processed by the daemon. The process node is attached as
+    :attr:`node` so a caller that catches this can keep monitoring the process without parsing the message.
+    """
+
+    def __init__(self, message: str, node: ProcessNode) -> None:
+        super().__init__(message)
+        self.node = node
 
 
 def run(process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None, **kwargs: t.Any) -> dict[str, t.Any]:
@@ -111,8 +124,9 @@ def submit(
     :param kwargs: inputs to be passed to the process. This is an alternative to the positional ``inputs`` argument.
     :return: the calculation node of the process
     :raises ValueError: if ``timeout`` is not a positive number.
-    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds. The timeout
-        only stops waiting; the process is not cancelled and keeps being processed by the daemon.
+    :raises ProcessTimeoutError: subclass of ``TimeoutError``, if ``wait=True`` and the process does not terminate
+        within ``timeout`` seconds. The timeout only stops waiting; the process is not cancelled, keeps being processed
+        by the daemon, and is available as the exception's ``node`` attribute.
     """
     from aiida.common.docs import URL_NO_BROKER
 
@@ -196,7 +210,7 @@ def _wait_for_process_termination(node: ProcessNode, wait_interval: float, timeo
         ``TimeoutError`` is raised; the process is not cancelled and keeps being processed by the daemon. If ``None``,
         waits indefinitely. Assumed to be ``None`` or a positive number (validated by the caller).
     :return: the ``node``, once it has reached a terminal state.
-    :raises TimeoutError: if ``timeout`` is set and the process does not terminate within it.
+    :raises ProcessTimeoutError: if ``timeout`` is set and the process does not terminate within it.
     """
     start_time = time.monotonic()
 
@@ -210,7 +224,7 @@ def _wait_for_process_termination(node: ProcessNode, wait_interval: float, timeo
                 f'cancelled and keeps being processed by the daemon. Use `verdi process status {node.pk}` to '
                 f'monitor it or `verdi process kill {node.pk}` to stop it.'
             )
-            raise TimeoutError(msg)
+            raise ProcessTimeoutError(msg, node)
 
         # Never sleep past the deadline, so the timeout fires on time rather than overshooting by up to
         # ``wait_interval`` (relevant when ``timeout`` is smaller than, or not a multiple of, ``wait_interval``).

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -89,6 +89,7 @@ def submit(
     *,
     wait: bool = False,
     wait_interval: int = 5,
+    timeout: int | None = None,
     **kwargs: t.Any,
 ) -> ProcessNode:
     """Submit the process with the supplied inputs to the daemon immediately returning control to the interpreter.
@@ -103,8 +104,11 @@ def submit(
     :param wait: when set to ``True``, the submission will be blocking and wait for the process to complete at which
         point the function returns the calculation node.
     :param wait_interval: the number of seconds to wait between checking the state of the process when ``wait=True``.
+    :param timeout: optional timeout in seconds when ``wait=True``. If the process does not terminate within this time,
+        a ``TimeoutError`` is raised. If ``None`` (default), waits indefinitely.
     :param kwargs: inputs to be passed to the process. This is an alternative to the positional ``inputs`` argument.
     :return: the calculation node of the process
+    :raises TimeoutError: if ``wait=True`` and the process does not terminate within ``timeout`` seconds.
     """
     from aiida.common.docs import URL_NO_BROKER
 
@@ -172,7 +176,13 @@ def submit(
     if not wait:
         return node
 
+    start_time = time.monotonic()
+
     while not node.is_terminated:
+        if timeout is not None and (time.monotonic() - start_time) >= timeout:
+            msg = f'Process<{node.pk}> did not terminate within {timeout} seconds.'
+            raise TimeoutError(msg)
+
         LOGGER.report(
             f'Process<{node.pk}> has not yet terminated, current state is `{node.process_state}`. '
             f'Waiting for {wait_interval} seconds.'

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -12,6 +12,7 @@ import os
 import shutil
 
 import pytest
+
 from aiida import orm
 from aiida.common import exceptions
 from aiida.engine import CalcJob, Process, WorkChain, calcfunction, launch

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -87,6 +87,25 @@ def test_submit_wait(arithmetic_add_builder):
     assert node.is_finished_ok, node.exit_code
 
 
+@pytest.mark.usefixtures('started_daemon_client')
+def test_submit_wait_with_timeout(arithmetic_add_builder):
+    """Test ``submit`` with ``wait=True`` and a generous ``timeout`` that the process finishes within."""
+    node = launch.submit(arithmetic_add_builder, wait=True, wait_interval=0.1, timeout=60)
+    assert node.is_finished, node.process_state
+    assert node.is_finished_ok, node.exit_code
+
+
+@pytest.mark.usefixtures('started_daemon_client')
+def test_submit_wait_timeout_raises(arithmetic_add_builder):
+    """Test ``submit`` with ``wait=True`` and ``timeout=0`` raises ``TimeoutError``.
+
+    Using ``timeout=0`` forces the timeout check to fire on the first iteration of the wait loop, before
+    the daemon can possibly finish the process. This keeps the test deterministic (no timing dependency).
+    """
+    with pytest.raises(TimeoutError, match=r'Process<\d+> did not terminate within 0 seconds'):
+        launch.submit(arithmetic_add_builder, wait=True, wait_interval=0.1, timeout=0)
+
+
 def test_submit_no_broker(arithmetic_add_builder, monkeypatch, manager):
     """Test that ``submit`` raises ``InvalidOperation`` if the runner does not have a controller.
 

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -12,7 +12,6 @@ import os
 import shutil
 
 import pytest
-
 from aiida import orm
 from aiida.common import exceptions
 from aiida.engine import CalcJob, Process, WorkChain, calcfunction, launch
@@ -95,15 +94,41 @@ def test_submit_wait_with_timeout(arithmetic_add_builder):
     assert node.is_finished_ok, node.exit_code
 
 
-@pytest.mark.usefixtures('started_daemon_client')
-def test_submit_wait_timeout_raises(arithmetic_add_builder):
-    """Test ``submit`` with ``wait=True`` and ``timeout=0`` raises ``TimeoutError``.
+@pytest.mark.parametrize('timeout', [0, -1, -0.5])
+def test_submit_invalid_timeout(timeout):
+    """Test that ``submit`` rejects a non-positive ``timeout`` up front, before the process is submitted."""
+    with pytest.raises(ValueError, match=r'`timeout` must be a positive number'):
+        launch.submit(ArithmeticAddCalculation, wait=True, timeout=timeout)
 
-    Using ``timeout=0`` forces the timeout check to fire on the first iteration of the wait loop, before
-    the daemon can possibly finish the process. This keeps the test deterministic (no timing dependency).
+
+class _NeverTerminatingNode:
+    """Minimal ``ProcessNode`` stand-in that never terminates, to drive the wait loop without a daemon."""
+
+    pk = 1
+    process_state = 'running'
+
+    @property
+    def is_terminated(self) -> bool:
+        return False
+
+
+def test_wait_for_process_termination_timeout(monkeypatch):
+    """Test that the wait loop raises ``TimeoutError`` at the deadline, without overshooting by ``wait_interval``.
+
+    ``time.monotonic`` and ``time.sleep`` are replaced by a virtual clock so the test is fast and fully deterministic
+    (no dependency on real elapsed time). With ``wait_interval=2`` and ``timeout=5`` the loop must fire at exactly
+    ``5`` and not overshoot to ``6``.
     """
-    with pytest.raises(TimeoutError, match=r'Process<\d+> did not terminate within 0 seconds'):
-        launch.submit(arithmetic_add_builder, wait=True, wait_interval=0.1, timeout=0)
+    clock = {'now': 0.0}
+    monkeypatch.setattr(launch.time, 'monotonic', lambda: clock['now'])
+    monkeypatch.setattr(launch.time, 'sleep', lambda seconds: clock.__setitem__('now', clock['now'] + seconds))
+
+    with pytest.raises(
+        TimeoutError, match=r'Process<1> did not terminate within 5 seconds\. It is still running on the daemon'
+    ):
+        launch._wait_for_process_termination(_NeverTerminatingNode(), wait_interval=2, timeout=5)
+
+    assert clock['now'] == pytest.approx(5.0), 'timeout should fire exactly at the deadline, not overshoot'
 
 
 def test_submit_no_broker(arithmetic_add_builder, monkeypatch, manager):

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -12,7 +12,6 @@ import os
 import shutil
 
 import pytest
-
 from aiida import orm
 from aiida.common import exceptions
 from aiida.engine import CalcJob, Process, WorkChain, calcfunction, launch
@@ -124,9 +123,7 @@ def test_wait_for_process_termination_timeout(monkeypatch):
     monkeypatch.setattr(launch.time, 'monotonic', lambda: clock['now'])
     monkeypatch.setattr(launch.time, 'sleep', lambda seconds: clock.__setitem__('now', clock['now'] + seconds))
 
-    with pytest.raises(
-        TimeoutError, match=r'Process<1> did not terminate within 5 seconds\. It is still running on the daemon'
-    ):
+    with pytest.raises(TimeoutError, match=r'Process<1> did not terminate within the 5s timeout.*was not cancelled'):
         launch._wait_for_process_termination(_NeverTerminatingNode(), wait_interval=2, timeout=5)
 
     assert clock['now'] == pytest.approx(5.0), 'timeout should fire exactly at the deadline, not overshoot'

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -124,9 +124,14 @@ def test_wait_for_process_termination_timeout(monkeypatch):
     monkeypatch.setattr(launch.time, 'monotonic', lambda: clock['now'])
     monkeypatch.setattr(launch.time, 'sleep', lambda seconds: clock.__setitem__('now', clock['now'] + seconds))
 
-    with pytest.raises(TimeoutError, match=r'Process<1> did not terminate within the 5s timeout.*was not cancelled'):
-        launch._wait_for_process_termination(_NeverTerminatingNode(), wait_interval=2, timeout=5)
+    node = _NeverTerminatingNode()
+    with pytest.raises(
+        launch.ProcessTimeoutError, match=r'Process<1> did not terminate within the 5s timeout.*was not cancelled'
+    ) as excinfo:
+        launch._wait_for_process_termination(node, wait_interval=2, timeout=5)
 
+    assert isinstance(excinfo.value, TimeoutError), '`ProcessTimeoutError` must remain catchable as `TimeoutError`'
+    assert excinfo.value.node is node, 'the timed-out process node should be attached to the exception'
     assert clock['now'] == pytest.approx(5.0), 'timeout should fire exactly at the deadline, not overshoot'
 
 


### PR DESCRIPTION
`submit(wait=True)` polls until the process terminates, with no way to bound that wait, so a process that never terminates hangs the caller forever. This adds an optional `timeout` (seconds) that bounds it, raising `ProcessTimeoutError`. Opt-in and backwards compatible: the default `timeout=None` keeps current behaviour, and `timeout` has no effect without `wait=True`.

It bounds the wait, not the process: nothing is cancelled, the daemon keeps processing it. `ProcessTimeoutError` subclasses `TimeoutError` and carries the still-running `node`; its message points at `verdi process status`/`kill`. (`wait=True` overlaps with `run`, but it is pre-existing API and runs on the daemon rather than in-process; this PR only bounds its wait.)

Uses `time.monotonic()`, rejects a non-positive `timeout` with `ValueError`, clamps the last sleep to the deadline so it fires on time instead of overshooting by up to `wait_interval`, and types `timeout`/`wait_interval` as `float`.

Also unblocks [#7261](https://github.com/aiidateam/aiida-core/pull/7261): `engine.submit(wg)` can only replace `wg.submit(wait=True, timeout=...)` once `engine.submit` supports `timeout`. Extracted from that PR so it can be reviewed on its own.