### PR TITLE
fix: escape workdir in SSH exec_command to prevent shell injection

### DIFF
--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -1418,7 +1418,7 @@ class SshTransport(BlockingTransport):
         channel.set_combine_stderr(combine_stderr)
 
         if workdir is not None:
-            command_to_execute = f'cd {workdir} &&  ( {command} )'
+            command_to_execute = f'cd {escape_for_bash(workdir)} &&  ( {command} )'
         elif (cwd := self.getcwd()) is not None:
             escaped_folder = escape_for_bash(cwd)
             command_to_execute = f'cd {escaped_folder} && ( {command} )'


### PR DESCRIPTION
## Summary

`SshTransport.exec_command` constructs a shell command:

```python
if workdir is not None:
    command_to_execute = f'cd {workdir} &&  ( {command} )'
elif (cwd := self.getcwd()) is not None:
    escaped_folder = escape_for_bash(cwd)
    command_to_execute = f'cd {escaped_folder} && ( {command} )'
```

The `getcwd()` fallback already calls `escape_for_bash`, but the explicit `workdir` branch does not. A workdir value containing shell metacharacters (e.g. a path with spaces or `$(...)`) could break out of the `cd` argument and inject arbitrary commands over SSH.

## Change

Apply `escape_for_bash` (already imported from `aiida.common.escaping`) to `workdir` in the same way it is applied to `cwd`:

```python
command_to_execute = f'cd {escape_for_bash(workdir)} &&  ( {command} )'
```

## Test plan

- [ ] Run existing SSH transport tests (`tests/transports/test_ssh.py`)
- [ ] Confirm workdirs with spaces are correctly quoted in the remote command

🤖 Generated with [Claude Code](https://claude.com/claude-code)