### PR TITLE
✨ Add daemon version drift warning

### DIFF
--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -111,6 +111,7 @@ def status(ctx, all_profiles, timeout):
     from tabulate import tabulate
 
     from aiida.cmdline.utils.common import format_local_time
+    from aiida.cmdline.utils.daemon import get_daemon_package_drift_lines
     from aiida.engine.daemon.client import DaemonException, get_daemon_client
     from aiida.manage.manager import get_manager
 
@@ -151,8 +152,8 @@ def status(ctx, all_profiles, timeout):
 
         start_time = format_local_time(daemon_response['info']['create_time'])
 
-        # Build broker status line for managed brokers (e.g., ZMQ)
-        broker_line = ''
+        # Build broker status lines for managed brokers (e.g., ZMQ)
+        broker_lines: list[str] = []
         broker = get_manager().get_broker()
         from aiida.brokers.zmq.broker import ZmqBroker
 
@@ -163,20 +164,25 @@ def status(ctx, all_profiles, timeout):
                     broker_pid = status_info.get('pid', '?')
                     pending = status_info.get('pending_tasks', 0)
                     processing = status_info.get('processing_tasks', 0)
-                    broker_line = (
-                        f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]\n'
-                        f'Broker directory: {broker.base_path}\n'
+                    broker_lines.append(
+                        f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]'
                     )
+                    broker_lines.append(f'Broker directory: {broker.base_path}')
             else:
-                broker_line = 'Broker is NOT running\n'
+                broker_lines.append('Broker is NOT running')
 
-        echo.echo(
-            f'Daemon is running as PID {daemon_response["info"]["pid"]} since {start_time}\n'
-            f'{broker_line}'
-            f'Active workers [{len(workers)}]:\n{workers_info}\n'
-            f'Log file: {client.daemon_log_file}\n'
-            'Use `verdi daemon [incr | decr] [num]` to increase / decrease the number of workers'
-        )
+        lines = [
+            f'Daemon is running as PID {daemon_response["info"]["pid"]} since {start_time}',
+            *broker_lines,
+            f'Active workers [{len(workers)}]:',
+            workers_info,
+            f'Log file: {client.daemon_log_file}',
+        ]
+
+        lines.extend(get_daemon_package_drift_lines(client))
+
+        lines.append('Use `verdi daemon [incr | decr] [num]` to increase / decrease the number of workers')
+        echo.echo('\n'.join(lines))
 
     if not all(daemons_running):
         sys.exit(3)

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -60,6 +60,7 @@ STATUS_SYMBOLS = {
 def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     """Print status of AiiDA services."""
     from aiida import __version__
+    from aiida.cmdline.utils.daemon import get_daemon_package_drift_lines
     from aiida.common.docs import URL_NO_BROKER
     from aiida.common.exceptions import ConfigurationError
     from aiida.engine.daemon.client import DaemonException, DaemonNotRunningException
@@ -133,9 +134,9 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     # Getting the daemon and broker status
     broker = manager.get_broker()
 
-    if broker:
-        from aiida.brokers.zmq.broker import ZmqBroker
+    from aiida.brokers.zmq.broker import ZmqBroker
 
+    if broker:
         # For RabbitMQ: verify broker connectivity as a separate status line
         # For ZMQ: broker info is shown alongside the daemon status below
         if not isinstance(broker, ZmqBroker):
@@ -156,43 +157,50 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
             'broker',
             f'No broker defined for this profile: certain functionality not available.\nSee {URL_NO_BROKER}',
         )
+
+    # Getting the daemon status
+    try:
+        daemon_client = manager.get_daemon_client()
+        status = daemon_client.get_status()
+    except ConfigurationError:
         print_status(
             ServiceStatus.WARNING,
             'daemon',
             f'No broker defined for this profile: daemon is not available. See {URL_NO_BROKER}',
         )
+    except DaemonNotRunningException as exception:
+        print_status(ServiceStatus.WARNING, 'daemon', str(exception))
+    except DaemonException as exception:
+        print_status(ServiceStatus.ERROR, 'daemon', str(exception))
+    except Exception as exception:
+        message = 'Error getting daemon status'
+        print_status(ServiceStatus.ERROR, 'daemon', message, exception=exception, print_traceback=print_traceback)
+        exit_code = ExitCode.CRITICAL
     else:
-        try:
-            daemon_status = manager.get_daemon_client().get_status()
-        except ConfigurationError:
-            print_status(
-                ServiceStatus.WARNING,
-                'daemon',
-                f'No broker defined for this profile: daemon is not available. See {URL_NO_BROKER}',
-            )
-        except DaemonNotRunningException as exception:
-            print_status(ServiceStatus.WARNING, 'daemon', str(exception))
-        except DaemonException as exception:
-            print_status(ServiceStatus.ERROR, 'daemon', str(exception))
-        except Exception as exception:
-            message = 'Error getting daemon status'
-            print_status(ServiceStatus.ERROR, 'daemon', message, exception=exception, print_traceback=print_traceback)
-            exit_code = ExitCode.CRITICAL
-        else:
-            daemon_msg = f'Daemon is running with PID {daemon_status["pid"]}'
-            # Append broker info for managed brokers (e.g., ZMQ)
+        daemon_status = ServiceStatus.UP
+        daemon_msg = f'Daemon is running with PID {status["pid"]}'
+        # Append broker info for managed brokers (e.g., ZMQ)
 
-            if isinstance(broker, ZmqBroker):
-                if broker.is_running:
-                    status_info = broker.get_service_status()
-                    if status_info:
-                        broker_pid = status_info.get('pid', '?')
-                        pending = status_info.get('pending_tasks', 0)
-                        processing = status_info.get('processing_tasks', 0)
-                        daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
-                else:
-                    daemon_msg += ', Broker is NOT running'
-            print_status(ServiceStatus.UP, 'daemon', daemon_msg)
+        if broker and isinstance(broker, ZmqBroker):
+            if broker.is_running:
+                status_info = broker.get_service_status()
+                if status_info:
+                    broker_pid = status_info.get('pid', '?')
+                    pending = status_info.get('pending_tasks', 0)
+                    processing = status_info.get('processing_tasks', 0)
+                    daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
+            else:
+                daemon_msg += ', Broker is NOT running'
+
+        daemon_lines = [daemon_msg]
+
+        # Check for package mismatches
+        drift_lines = get_daemon_package_drift_lines(daemon_client)
+        if drift_lines:
+            daemon_status = ServiceStatus.WARNING
+            daemon_lines.extend(drift_lines)
+
+        print_status(daemon_status, 'daemon', '\n'.join(daemon_lines))
 
     # Note: click does not forward return values to the exit code, see https://github.com/pallets/click/issues/747
     if exit_code != ExitCode.SUCCESS:

--- a/src/aiida/cmdline/utils/daemon.py
+++ b/src/aiida/cmdline/utils/daemon.py
@@ -1,0 +1,102 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Utilities for daemon-related CLI output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aiida.engine.daemon.client import DaemonClient, PackageVersionInfo, PackageVersionSnapshot
+
+
+def format_package_version_info(version_info: PackageVersionInfo) -> str:
+    """Return a human-readable string for package version information."""
+    version = version_info['version']
+    editable_path = version_info.get('editable_path')
+
+    if editable_path is not None:
+        return f'{version} @ {editable_path}'
+
+    return version
+
+
+def package_versions_match(daemon_version: PackageVersionInfo, current_version: PackageVersionInfo) -> bool:
+    """Return whether daemon and current package version information match."""
+    if daemon_version['version'] != current_version['version']:
+        return False
+
+    daemon_path = daemon_version.get('editable_path')
+    current_path = current_version.get('editable_path')
+
+    if daemon_path is None and current_path is None:
+        return True
+
+    if daemon_path is None or current_path is None:
+        return False
+
+    return daemon_path == current_path
+
+
+def format_package_state_change_lines(
+    daemon_versions: PackageVersionSnapshot, current_versions: PackageVersionSnapshot
+) -> list[str]:
+    """Return formatted package-state mismatch lines."""
+    changed: list[str] = []
+    added: list[str] = []
+    removed: list[str] = []
+
+    for package in sorted(set(daemon_versions) | set(current_versions)):
+        daemon_version = daemon_versions.get(package)
+        current_version = current_versions.get(package)
+
+        if daemon_version is not None and current_version is not None:
+            if package_versions_match(daemon_version, current_version):
+                continue
+            changed.append(
+                f'{package} ({format_package_version_info(daemon_version)} '
+                f'-> {format_package_version_info(current_version)})'
+            )
+        elif current_version is not None:
+            added.append(f'{package} ({format_package_version_info(current_version)})')
+        elif daemon_version is not None:
+            removed.append(f'{package} ({format_package_version_info(daemon_version)})')
+
+    lines: list[str] = []
+    if changed:
+        lines.append(f'Changed packages: {", ".join(changed)}')
+    if added:
+        lines.append(f'Added packages: {", ".join(added)}')
+    if removed:
+        lines.append(f'Removed packages: {", ".join(removed)}')
+    return lines
+
+
+_DRIFT_WARNING = (
+    'The daemon was started with different package versions than currently installed. '
+    'Running processes may use the old versions and behave unexpectedly. '
+    'Run `verdi daemon restart` to pick up the new versions.'
+)
+
+
+def get_daemon_package_drift_lines(client: DaemonClient) -> list[str]:
+    """Return drift warning lines, or an empty list if package state matches."""
+    from aiida.engine.daemon.client import DaemonClient as _DaemonClient
+
+    daemon_versions = client.get_daemon_package_snapshot()
+    if daemon_versions is None:
+        return []
+    current_versions = _DaemonClient.get_package_version_snapshot()
+    validated = _DaemonClient._validate_package_version_snapshot(current_versions)
+    if validated is None:
+        return []
+    change_lines = format_package_state_change_lines(daemon_versions, validated)
+    if not change_lines:
+        return []
+    return [_DRIFT_WARNING, *change_lines]

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import contextlib
 import enum
+import json
 import os
 import pathlib
 import shutil
@@ -21,6 +22,8 @@ import sys
 import tempfile
 import time
 import typing as t
+import urllib.parse
+import urllib.request
 from typing import TYPE_CHECKING
 
 import psutil
@@ -42,6 +45,116 @@ VERDI_BIN = shutil.which('verdi')
 VIRTUALENV = os.environ.get('VIRTUAL_ENV', None)
 
 __all__ = ('DaemonClient', 'get_daemon_client')
+
+
+class _PackageVersionInfoRequired(t.TypedDict):
+    """Required fields for structured version information of an installed package."""
+
+    version: str
+
+
+class PackageVersionInfo(_PackageVersionInfoRequired, total=False):
+    """Structured version information for an installed package."""
+
+    editable_path: str
+
+
+PackageVersionSnapshot: t.TypeAlias = dict[str, PackageVersionInfo]
+
+
+class _VcsInfo(t.TypedDict, total=False):
+    """VCS metadata from ``direct_url.json`` (PEP 610)."""
+
+    vcs: str
+    commit_id: str
+    requested_revision: str
+
+
+class _DirInfo(t.TypedDict, total=False):
+    """Directory metadata from ``direct_url.json`` (PEP 610)."""
+
+    editable: bool
+
+
+class _DirectUrlData(t.TypedDict, total=False):
+    """Parsed ``direct_url.json`` structure per PEP 610."""
+
+    url: str
+    vcs_info: _VcsInfo
+    dir_info: _DirInfo
+
+
+def _get_dist_direct_url_data(dist: t.Any) -> _DirectUrlData | None:
+    """Return the parsed ``direct_url.json`` metadata for a distribution, if available."""
+    try:
+        text = dist.read_text('direct_url.json')
+        if text is None:
+            return None
+
+        return json.loads(text)
+    except (AttributeError, TypeError, json.JSONDecodeError) as exc:
+        LOGGER.debug('Failed to determine direct URL metadata for %s: %s', getattr(dist, 'name', '?'), exc)
+        return None
+
+
+def _get_editable_path_from_direct_url_data(data: _DirectUrlData | None) -> str | None:
+    """Return the normalized editable install path recorded in parsed direct URL metadata, if available."""
+    if data is None:
+        return None
+
+    dir_info = data.get('dir_info')
+    if not dir_info or not dir_info.get('editable'):
+        return None
+
+    url = data.get('url')
+    if not isinstance(url, str):
+        return None
+
+    # Only handle file:// URLs with empty or localhost netloc (per PEP 610)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != 'file' or parsed.netloc not in ('', 'localhost'):
+        return None
+
+    # url2pathname already percent-decodes on POSIX, so unquote is not needed
+    path = pathlib.Path(urllib.request.url2pathname(parsed.path))
+
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def _get_dist_editable_path(dist: t.Any, direct_url_data: _DirectUrlData | None = None) -> str | None:
+    """Return the normalized editable install path recorded in the distribution metadata, if available."""
+    if direct_url_data is None:
+        direct_url_data = _get_dist_direct_url_data(dist)
+
+    return _get_editable_path_from_direct_url_data(direct_url_data)
+
+
+def _get_commit_hash_from_direct_url_data(data: _DirectUrlData | None) -> str | None:
+    """Return the git commit hash recorded in parsed direct URL metadata, if available."""
+    if data is None:
+        return None
+
+    vcs_info = data.get('vcs_info')
+    if not vcs_info or vcs_info.get('vcs') != 'git':
+        return None
+
+    commit_id = vcs_info.get('commit_id')
+    return commit_id if isinstance(commit_id, str) else None
+
+
+def _get_dist_commit_hash(dist: t.Any, direct_url_data: _DirectUrlData | None = None) -> str | None:
+    """Return the git commit hash recorded in the distribution metadata, if available.
+
+    This only supports VCS installs where pip recorded ``vcs_info.commit_id`` in
+    ``direct_url.json`` metadata.
+    """
+    if direct_url_data is None:
+        direct_url_data = _get_dist_direct_url_data(dist)
+
+    return _get_commit_hash_from_direct_url_data(direct_url_data)
 
 
 class ControllerProtocol(enum.Enum):
@@ -201,6 +314,13 @@ class DaemonClient:
     @property
     def daemon_pid_file(self) -> str:
         return self._config.filepaths(self.profile)['daemon']['pid']
+
+    @property
+    def daemon_package_snapshot_file(self) -> str:
+        try:
+            return self._config.filepaths(self.profile)['daemon']['package_snapshot']
+        except KeyError as exc:
+            raise ConfigurationError('daemon package snapshot file path is not configured') from exc
 
     def get_circus_port(self) -> int:
         """Retrieve the port for the circus controller, which should be written to the circus port file.
@@ -508,6 +628,82 @@ class DaemonClient:
         command = {'command': 'dstats', 'properties': {}}
         return self.call_client(command, timeout=timeout)
 
+    @staticmethod
+    def get_package_version_snapshot() -> PackageVersionSnapshot:
+        """Return version information for installed packages that provide ``aiida.*`` entry points.
+
+        For packages installed from a git repository through a VCS URL, the
+        version string includes the recorded commit hash from the distribution
+        metadata. Editable installs from a local path record their normalized
+        source path.
+        """
+        from aiida.plugins.entry_point import ENTRY_POINT_GROUP_PREFIX, eps
+
+        versions: PackageVersionSnapshot = {}
+        for ep in eps():
+            if ep.group.startswith(ENTRY_POINT_GROUP_PREFIX) and ep.dist:
+                if ep.dist.name not in versions:
+                    version_info: PackageVersionInfo = {'version': ep.dist.version}
+                    direct_url_data = _get_dist_direct_url_data(ep.dist)
+                    commit = _get_dist_commit_hash(ep.dist, direct_url_data)
+                    editable_path = _get_dist_editable_path(ep.dist, direct_url_data)
+
+                    if commit:
+                        version_info['version'] = f'{ep.dist.version}+{commit[:8]}'
+
+                    if editable_path:
+                        version_info['editable_path'] = editable_path
+
+                    versions[ep.dist.name] = version_info
+        return versions
+
+    @staticmethod
+    def _validate_package_version_snapshot(snapshot: t.Any) -> PackageVersionSnapshot | None:
+        """Validate a structured package version snapshot."""
+        if not isinstance(snapshot, dict):
+            LOGGER.warning('Daemon package snapshot file has unexpected format; ignoring.')
+            return None
+
+        validated: PackageVersionSnapshot = {}
+
+        for package, value in snapshot.items():
+            if not isinstance(package, str) or not isinstance(value, dict):
+                LOGGER.warning('Daemon package snapshot file has unexpected format; ignoring.')
+                return None
+
+            version = value.get('version')
+            if not isinstance(version, str):
+                LOGGER.warning('Daemon package snapshot file has unexpected format; ignoring.')
+                return None
+
+            package_info: PackageVersionInfo = {'version': version}
+            editable_path = value.get('editable_path')
+            if isinstance(editable_path, str):
+                package_info['editable_path'] = editable_path
+
+            validated[package] = package_info
+
+        return validated
+
+    def _write_version_file(self) -> None:
+        """Write the current package version snapshot to the daemon version file."""
+        version_info = self.get_package_version_snapshot()
+        try:
+            pathlib.Path(self.daemon_package_snapshot_file).write_text(json.dumps(version_info), encoding='utf8')
+        except ConfigurationError:
+            LOGGER.debug('Cannot write daemon version file: version file path is not configured.')
+        except OSError as exc:
+            LOGGER.warning('Failed to write daemon version file: %s', exc)
+
+    def get_daemon_package_snapshot(self) -> PackageVersionSnapshot | None:
+        """Return version info recorded at daemon startup, or None if unavailable."""
+        try:
+            data = json.loads(pathlib.Path(self.daemon_package_snapshot_file).read_text(encoding='utf8'))
+        except (ConfigurationError, OSError, json.JSONDecodeError):
+            return None
+
+        return self._validate_package_version_snapshot(data)
+
     def increase_workers(self, number: int, timeout: int | None = None) -> dict[str, t.Any]:
         """Increase the number of workers.
 
@@ -556,6 +752,7 @@ class DaemonClient:
             raise DaemonException(f'The daemon failed to start with error:\n{exception.stdout.decode()}') from exception
 
         if not wait:
+            self._write_version_file()
             return
 
         self._await_condition(
@@ -563,6 +760,8 @@ class DaemonClient:
             DaemonTimeoutException(f'The daemon failed to start or is unresponsive after {timeout} seconds.'),
             timeout=timeout,
         )
+
+        self._write_version_file()
 
     def restart_daemon(self, wait: bool = True, timeout: int | None = None) -> dict[str, t.Any]:
         """Restart the daemon.
@@ -576,7 +775,10 @@ class DaemonClient:
         :raises DaemonException: If the connection to the daemon failed for any other reason.
         """
         command = {'command': 'restart', 'properties': {'name': self.daemon_name, 'waiting': wait}}
-        return self.call_client(command, timeout=timeout)
+        response = self.call_client(command, timeout=timeout)
+        if response.get('status') == 'ok':
+            self._write_version_file()
+        return response
 
     def stop_daemon(self, wait: bool = True, timeout: int | None = None) -> dict[str, t.Any]:
         """Stop the daemon.
@@ -596,6 +798,14 @@ class DaemonClient:
 
         if self._ENDPOINT_PROTOCOL == ControllerProtocol.IPC:
             self.delete_circus_socket_directory()
+
+        # Best-effort cleanup of version file
+        try:
+            pathlib.Path(self.daemon_package_snapshot_file).unlink(missing_ok=True)
+        except ConfigurationError:
+            LOGGER.debug('Cannot remove daemon version file: version file path is not configured.')
+        except OSError as exc:
+            LOGGER.debug('Failed to remove daemon version file: %s', exc)
 
         return response
 

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -888,5 +888,6 @@ class Config:
             'daemon': {
                 'log': str(daemon_log_dir / f'aiida-{profile.name}.log'),
                 'pid': str(daemon_dir / f'aiida-{profile.name}.pid'),
+                'package_snapshot': str(daemon_dir / f'aiida-{profile.name}.package_snapshot'),
             },
         }

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -215,3 +215,20 @@ def test_daemon_status_worker_timeout(run_cli_command):
     assert 'Active workers [1]:' in result.output
     assert '4990  -        -        -' in result.output
     assert 'Use `verdi daemon [incr | decr] [num]`' in result.output
+
+
+@patch.object(DaemonClient, 'get_status', lambda self, timeout=None: {'status': 'running'})
+@patch.object(DaemonClient, 'get_daemon_info', get_daemon_info)
+@patch.object(DaemonClient, 'get_worker_info', get_worker_info)
+@patch.object(DaemonClient, 'get_daemon_package_snapshot', lambda self: {'aiida-core': {'version': '2.8.0.post0'}})
+@patch.object(
+    DaemonClient,
+    'get_package_version_snapshot',
+    lambda: {'aiida-core': {'version': '2.8.0.post0'}, 'aiida-plugin': {'version': '1.2.3'}},
+)
+@patch('aiida.cmdline.utils.common.format_local_time', format_local_time)
+def test_daemon_status_package_state_warning(run_cli_command):
+    """Test `verdi daemon status` includes package-state mismatch warnings."""
+    result = run_cli_command(cmd_daemon.status)
+    assert 'different package versions' in result.output
+    assert 'Added packages: aiida-plugin (1.2.3)' in result.output

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -14,6 +14,7 @@ from aiida import __version__, get_profile
 from aiida.cmdline.commands import cmd_status
 from aiida.cmdline.utils.echo import ExitCode
 from aiida.common.warnings import AiidaDeprecationWarning
+from aiida.engine.daemon.client import DaemonClient
 from aiida.storage.psql_dos import migrator
 
 
@@ -130,3 +131,120 @@ def test_sqlite_version(run_cli_command, monkeypatch):
         monkeypatch.setattr('aiida.storage.sqlite_zip.backend.validate_sqlite_version', mock_)
         result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
         assert mock_.call_count == 0
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_version_mismatch_warning(run_cli_command, monkeypatch, tmp_path):
+    """Test that ``verdi status`` warns about version mismatches."""
+    daemon_path = tmp_path / 'old-checkout'
+    current_path = tmp_path / 'new-checkout'
+
+    monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
+    monkeypatch.setattr(
+        DaemonClient,
+        'get_daemon_package_snapshot',
+        lambda self: {'aiida-core': {'version': '2.8.0.post0', 'editable_path': str(daemon_path)}},
+    )
+    monkeypatch.setattr(
+        DaemonClient,
+        'get_package_version_snapshot',
+        staticmethod(lambda: {'aiida-core': {'version': '2.8.0.post0', 'editable_path': str(current_path)}}),
+    )
+
+    result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+    assert 'different package versions' in result.output
+    assert 'Changed packages:' in result.output
+    assert 'aiida-core' in result.output
+    assert result.output.count('daemon:') == 1
+    assert str(daemon_path) in result.output
+    assert str(current_path) in result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+@pytest.mark.parametrize(
+    ('daemon_versions', 'current_versions', 'expected_section', 'expected_change'),
+    [
+        (
+            {'aiida-core': {'version': '2.8.0.post0'}},
+            {'aiida-core': {'version': '2.8.0.post0'}, 'aiida-plugin': {'version': '1.2.3'}},
+            'Added packages:',
+            'aiida-plugin (1.2.3)',
+        ),
+        (
+            {'aiida-core': {'version': '2.8.0.post0'}, 'aiida-plugin': {'version': '1.2.3'}},
+            {'aiida-core': {'version': '2.8.0.post0'}},
+            'Removed packages:',
+            'aiida-plugin (1.2.3)',
+        ),
+    ],
+)
+def test_version_mismatch_warning_for_added_or_removed_plugin(
+    run_cli_command, monkeypatch, daemon_versions, current_versions, expected_section, expected_change
+):
+    """Test that ``verdi status`` warns when plugins were added or removed since daemon startup."""
+    monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
+    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: daemon_versions)
+    monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: current_versions))
+
+    result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+    assert 'different package versions' in result.output
+    assert expected_section in result.output
+    assert expected_change in result.output
+    assert result.output.count('daemon:') == 1
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+@pytest.mark.parametrize(
+    ('use_editable_path',),
+    [(True,), (False,)],
+)
+def test_no_warning_when_versions_match(run_cli_command, monkeypatch, tmp_path, use_editable_path):
+    """Test that ``verdi status`` shows no warning when versions match."""
+    pkg_info: dict = {'version': '2.8.0.post0'}
+    if use_editable_path:
+        pkg_info['editable_path'] = str(tmp_path / 'aiida-core')
+
+    monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
+    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: {'aiida-core': pkg_info})
+    monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: {'aiida-core': pkg_info}))
+
+    result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+    assert 'different package versions' not in result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+@pytest.mark.parametrize(
+    ('daemon_has_path', 'current_has_path'),
+    [(True, False), (False, True)],
+)
+def test_warning_when_editable_install_state_changes(
+    run_cli_command, monkeypatch, tmp_path, daemon_has_path, current_has_path
+):
+    """Test that ``verdi status`` warns when editable-install state changes without a version change."""
+    editable_path = str(tmp_path / 'aiida-core')
+    daemon_info: dict = {'version': '2.8.0.post0'}
+    current_info: dict = {'version': '2.8.0.post0'}
+    if daemon_has_path:
+        daemon_info['editable_path'] = editable_path
+    if current_has_path:
+        current_info['editable_path'] = editable_path
+
+    monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
+    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: {'aiida-core': daemon_info})
+    monkeypatch.setattr(
+        DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: {'aiida-core': current_info})
+    )
+
+    result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+    assert 'different package versions' in result.output
+    assert 'Changed packages:' in result.output
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_no_warning_when_version_file_missing(run_cli_command, monkeypatch):
+    """Test that ``verdi status`` shows no warning when version file is missing."""
+    monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
+    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: None)
+
+    result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+    assert 'different package versions' not in result.output

--- a/tests/cmdline/utils/test_daemon.py
+++ b/tests/cmdline/utils/test_daemon.py
@@ -1,0 +1,116 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Unit tests for ``aiida.cmdline.utils.daemon`` formatter helpers."""
+
+import pytest
+
+from aiida.cmdline.utils.daemon import (
+    format_package_state_change_lines,
+    format_package_version_info,
+)
+
+
+@pytest.mark.parametrize(
+    ('version_info', 'expected'),
+    [
+        pytest.param({'version': '2.8.0.post0'}, '2.8.0.post0', id='plain'),
+        pytest.param(
+            {'version': '2.8.0.post0', 'editable_path': None},
+            '2.8.0.post0',
+            id='editable-none-treated-as-absent',
+        ),
+    ],
+)
+def test_format_package_version_info_no_path(version_info, expected):
+    """``format_package_version_info`` with no editable path returns the bare version."""
+    assert format_package_version_info(version_info) == expected
+
+
+def test_format_package_version_info_with_editable_path(tmp_path):
+    """``format_package_version_info`` formats as ``'<version> @ <path>'``."""
+    info = {'version': '2.8.0.post0', 'editable_path': str(tmp_path)}
+    expected = f'2.8.0.post0 @ {tmp_path}'
+    assert format_package_version_info(info) == expected
+
+
+@pytest.mark.parametrize(
+    ('daemon', 'current', 'expected'),
+    [
+        pytest.param({}, {}, [], id='both-empty'),
+        pytest.param(
+            {'aiida-core': {'version': '2.8.0'}},
+            {'aiida-core': {'version': '2.8.0'}},
+            [],
+            id='unchanged',
+        ),
+        pytest.param(
+            {},
+            {'aiida-plugin': {'version': '1.2.3'}},
+            ['Added packages: aiida-plugin (1.2.3)'],
+            id='added',
+        ),
+        pytest.param(
+            {'aiida-plugin': {'version': '1.2.3'}},
+            {},
+            ['Removed packages: aiida-plugin (1.2.3)'],
+            id='removed',
+        ),
+        pytest.param(
+            {'aiida-core': {'version': '2.8.0'}},
+            {'aiida-core': {'version': '2.8.1'}},
+            ['Changed packages: aiida-core (2.8.0 -> 2.8.1)'],
+            id='changed-version',
+        ),
+        pytest.param(
+            {'a': {'version': '1'}, 'b': {'version': '2'}},
+            {'a': {'version': '1.1'}, 'c': {'version': '3'}},
+            [
+                'Changed packages: a (1 -> 1.1)',
+                'Added packages: c (3)',
+                'Removed packages: b (2)',
+            ],
+            id='mixed-section-order',
+        ),
+        pytest.param(
+            {},
+            {'b-pkg': {'version': '1'}, 'a-pkg': {'version': '2'}},
+            ['Added packages: a-pkg (2), b-pkg (1)'],
+            id='multiple-added-alphabetical',
+        ),
+    ],
+)
+def test_format_package_state_change_lines(daemon, current, expected):
+    """Pin the categorisation, ordering, and formatting contract."""
+    assert format_package_state_change_lines(daemon, current) == expected
+
+
+def test_format_package_state_change_lines_editable_path_changed(tmp_path):
+    """A change in editable path alone (same version) is reported as Changed."""
+    old = tmp_path / 'old'
+    new = tmp_path / 'new'
+    daemon = {'aiida-core': {'version': '2.8.0', 'editable_path': str(old)}}
+    current = {'aiida-core': {'version': '2.8.0', 'editable_path': str(new)}}
+    expected = [f'Changed packages: aiida-core (2.8.0 @ {old} -> 2.8.0 @ {new})']
+    assert format_package_state_change_lines(daemon, current) == expected
+
+
+def test_format_package_state_change_lines_editable_path_appears(tmp_path):
+    """Package gaining an editable path shows up as Changed."""
+    daemon = {'aiida-core': {'version': '2.8.0'}}
+    current = {'aiida-core': {'version': '2.8.0', 'editable_path': str(tmp_path)}}
+    expected = [f'Changed packages: aiida-core (2.8.0 -> 2.8.0 @ {tmp_path})']
+    assert format_package_state_change_lines(daemon, current) == expected
+
+
+def test_format_package_state_change_lines_editable_path_disappears(tmp_path):
+    """Package losing its editable path shows up as Changed."""
+    daemon = {'aiida-core': {'version': '2.8.0', 'editable_path': str(tmp_path)}}
+    current = {'aiida-core': {'version': '2.8.0'}}
+    expected = [f'Changed packages: aiida-core (2.8.0 @ {tmp_path} -> 2.8.0)']
+    assert format_package_state_change_lines(daemon, current) == expected

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Unit tests for the `DaemonClient` class."""
 
+import json
+import pathlib
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +19,8 @@ from aiida.engine.daemon.client import (
     DaemonClient,
     DaemonNotRunningException,
     DaemonTimeoutException,
+    _get_dist_commit_hash,
+    _get_dist_editable_path,
     get_daemon_client,
 )
 
@@ -101,3 +105,284 @@ def test_get_status_timeout(stopped_daemon_client):
     """Test ``DaemonClient.get_status`` output when the circus daemon process cannot be reached."""
     with pytest.raises(DaemonTimeoutException, match='Connection to the daemon timed out.'):
         stopped_daemon_client.get_status()
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+class TestDaemonVersionInfo:
+    """Tests for the daemon version info methods."""
+
+    @staticmethod
+    def test_get_package_version_snapshot():
+        """Test that ``get_package_version_snapshot`` returns at least ``aiida-core``."""
+        from importlib.metadata import version as metadata_version
+
+        versions = DaemonClient.get_package_version_snapshot()
+        assert 'aiida-core' in versions
+        assert versions['aiida-core']['version'].startswith(metadata_version('aiida-core'))
+
+    @staticmethod
+    def test_get_daemon_package_snapshot_no_file(stopped_daemon_client):
+        """Test that ``get_daemon_package_snapshot`` returns None when no version file exists."""
+        assert stopped_daemon_client.get_daemon_package_snapshot() is None
+
+    @staticmethod
+    def test_daemon_package_snapshot_file_missing_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``daemon_package_snapshot_file`` raises ``ConfigurationError`` when the filepath is missing."""
+        from aiida.common.exceptions import ConfigurationError
+
+        filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
+        monkeypatch.setattr(
+            stopped_daemon_client._config, 'filepaths', lambda profile: {'daemon': {'pid': filepaths['daemon']['pid']}}
+        )
+
+        with pytest.raises(ConfigurationError, match='daemon package snapshot file path is not configured'):
+            _ = stopped_daemon_client.daemon_package_snapshot_file
+
+    @staticmethod
+    def test_get_daemon_package_snapshot_missing_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``get_daemon_package_snapshot`` returns None when the filepath is missing."""
+        filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
+        modified_filepaths = dict(filepaths)
+        modified_filepaths['daemon'] = dict(filepaths['daemon'])
+        modified_filepaths['daemon'].pop('package_snapshot', None)
+        monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
+
+        assert stopped_daemon_client.get_daemon_package_snapshot() is None
+
+    @staticmethod
+    def test_get_daemon_package_snapshot_corrupt_file(stopped_daemon_client):
+        """Test that ``get_daemon_package_snapshot`` returns None for corrupt version file."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.write_text('not valid json {{{', encoding='utf8')
+        assert stopped_daemon_client.get_daemon_package_snapshot() is None
+
+    @staticmethod
+    def test_daemon_version_info_roundtrip(stopped_daemon_client):
+        """Test that version info can be written and read back."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        expected = {
+            'aiida-core': {'version': '2.6.0', 'editable_path': '/tmp/aiida-core'},
+            'some-plugin': {'version': '1.0.0'},
+        }
+        version_file.write_text(json.dumps(expected), encoding='utf8')
+        assert stopped_daemon_client.get_daemon_package_snapshot() == expected
+
+    @staticmethod
+    def test_get_dist_commit_hash_vcs_install():
+        """Test that ``_get_dist_commit_hash`` extracts commit_id from VCS install metadata."""
+        from unittest.mock import MagicMock
+
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {
+                'url': 'https://github.com/aiidateam/aiida-core',
+                'vcs_info': {'vcs': 'git', 'commit_id': 'abcdef1234567890', 'requested_revision': 'main'},
+            }
+        )
+        assert _get_dist_commit_hash(dist) == 'abcdef1234567890'
+
+    @staticmethod
+    def test_get_dist_commit_hash_no_direct_url():
+        """Test that ``_get_dist_commit_hash`` returns None when direct_url.json is absent."""
+        from unittest.mock import MagicMock
+
+        dist = MagicMock()
+        dist.read_text.return_value = None
+        assert _get_dist_commit_hash(dist) is None
+
+    @staticmethod
+    def test_get_dist_commit_hash_editable_install():
+        """Test that ``_get_dist_commit_hash`` ignores editable installs from local directories."""
+        from unittest.mock import MagicMock
+
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {
+                'url': 'file:///tmp/aiida-core',
+                'dir_info': {'editable': True},
+            }
+        )
+        assert _get_dist_commit_hash(dist) is None
+
+    @staticmethod
+    def test_get_dist_editable_path():
+        """Test that ``_get_dist_editable_path`` extracts a normalized local path for editable installs."""
+        import tempfile
+        from unittest.mock import MagicMock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist = MagicMock()
+            dist.read_text.return_value = json.dumps(
+                {'url': pathlib.Path(tmpdir).as_uri(), 'dir_info': {'editable': True}}
+            )
+            assert _get_dist_editable_path(dist) == str(pathlib.Path(tmpdir).resolve())
+
+    @staticmethod
+    def test_get_package_version_snapshot_includes_editable_path():
+        """Test that editable local installs record their source path in the package snapshot."""
+        import tempfile
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist = MagicMock()
+            dist.name = 'aiida-core'
+            dist.version = '2.8.0.post0'
+            dist.read_text.return_value = json.dumps(
+                {'url': pathlib.Path(tmpdir).as_uri(), 'dir_info': {'editable': True}}
+            )
+            entry_point = SimpleNamespace(group='aiida.transports', dist=dist)
+
+            with patch('aiida.plugins.entry_point.eps', return_value=[entry_point]):
+                versions = DaemonClient.get_package_version_snapshot()
+
+            assert versions == {
+                'aiida-core': {'version': '2.8.0.post0', 'editable_path': str(pathlib.Path(tmpdir).resolve())}
+            }
+
+    @staticmethod
+    def test_get_package_version_snapshot_parses_direct_url_once():
+        """Test that ``get_package_version_snapshot`` reads ``direct_url.json`` at most once per distribution."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        dist = MagicMock()
+        dist.name = 'aiida-core'
+        dist.version = '2.8.0.post0'
+        dist.read_text.return_value = json.dumps({'url': 'https://github.com/aiidateam/aiida-core'})
+        entry_point = SimpleNamespace(group='aiida.transports', dist=dist)
+
+        with patch('aiida.plugins.entry_point.eps', return_value=[entry_point]):
+            DaemonClient.get_package_version_snapshot()
+
+        dist.read_text.assert_called_once_with('direct_url.json')
+
+    @staticmethod
+    def test_stop_daemon_cleans_version_file(stopped_daemon_client):
+        """Test that ``stop_daemon`` removes the version file."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.write_text('{"aiida-core": "2.6.0"}', encoding='utf8')
+        assert version_file.exists()
+
+        with (
+            patch.object(DaemonClient, 'call_client', return_value={}),
+            patch.object(DaemonClient, 'delete_circus_socket_directory'),
+        ):
+            stopped_daemon_client.stop_daemon()
+
+        assert not version_file.exists()
+
+    @staticmethod
+    def test_stop_daemon_missing_version_file_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``stop_daemon`` ignores a missing version-file configuration."""
+        filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
+        modified_filepaths = dict(filepaths)
+        modified_filepaths['daemon'] = dict(filepaths['daemon'])
+        modified_filepaths['daemon'].pop('package_snapshot', None)
+        monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
+
+        with (
+            patch.object(DaemonClient, 'call_client', return_value={}),
+            patch.object(DaemonClient, 'delete_circus_socket_directory'),
+        ):
+            assert stopped_daemon_client.stop_daemon() == {}
+
+    @staticmethod
+    def test_start_daemon_writes_version_file(stopped_daemon_client):
+        """Test that ``start_daemon`` writes the version file after a successful spawn."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.unlink(missing_ok=True)
+
+        with (
+            patch('aiida.engine.daemon.client.subprocess.check_output', return_value=b''),
+            patch.object(DaemonClient, '_await_condition'),
+            patch.object(DaemonClient, '_clean_potentially_stale_pid_file'),
+            patch.object(
+                DaemonClient, 'get_package_version_snapshot', return_value={'aiida-core': {'version': '2.6.0'}}
+            ),
+        ):
+            stopped_daemon_client.start_daemon()
+
+        assert version_file.exists()
+        assert json.loads(version_file.read_text(encoding='utf8')) == {'aiida-core': {'version': '2.6.0'}}
+
+    @staticmethod
+    def test_start_daemon_no_version_file_on_await_failure(stopped_daemon_client):
+        """Test that ``start_daemon`` does not write the version file if ``_await_condition`` fails."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.unlink(missing_ok=True)
+
+        with (
+            patch('aiida.engine.daemon.client.subprocess.check_output', return_value=b''),
+            patch.object(
+                DaemonClient,
+                '_await_condition',
+                side_effect=DaemonTimeoutException('timed out'),
+            ),
+            patch.object(DaemonClient, '_clean_potentially_stale_pid_file'),
+            patch.object(
+                DaemonClient, 'get_package_version_snapshot', return_value={'aiida-core': {'version': '2.6.0'}}
+            ),
+        ):
+            with pytest.raises(DaemonTimeoutException):
+                stopped_daemon_client.start_daemon()
+
+        assert not version_file.exists()
+
+    @staticmethod
+    def test_start_daemon_missing_version_file_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``start_daemon`` ignores a missing version-file configuration."""
+        filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
+        modified_filepaths = dict(filepaths)
+        modified_filepaths['daemon'] = dict(filepaths['daemon'])
+        modified_filepaths['daemon'].pop('package_snapshot', None)
+        monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
+
+        with (
+            patch('aiida.engine.daemon.client.subprocess.check_output', return_value=b''),
+            patch.object(DaemonClient, '_await_condition'),
+            patch.object(DaemonClient, '_clean_potentially_stale_pid_file'),
+            patch.object(
+                DaemonClient, 'get_package_version_snapshot', return_value={'aiida-core': {'version': '2.6.0'}}
+            ),
+        ):
+            stopped_daemon_client.start_daemon()
+
+    @staticmethod
+    def test_restart_daemon_writes_version_file(stopped_daemon_client):
+        """Test that ``restart_daemon`` updates the version file after a successful restart."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.write_text('{"aiida-core": {"version": "1.0.0"}}', encoding='utf8')
+
+        with (
+            patch.object(DaemonClient, 'call_client', return_value={'status': 'ok'}),
+            patch.object(
+                DaemonClient, 'get_package_version_snapshot', return_value={'aiida-core': {'version': '2.6.0'}}
+            ),
+        ):
+            stopped_daemon_client.restart_daemon()
+
+        assert json.loads(version_file.read_text(encoding='utf8')) == {'aiida-core': {'version': '2.6.0'}}
+
+    @staticmethod
+    def test_restart_daemon_missing_version_file_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``restart_daemon`` ignores a missing version-file configuration."""
+        filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
+        modified_filepaths = dict(filepaths)
+        modified_filepaths['daemon'] = dict(filepaths['daemon'])
+        modified_filepaths['daemon'].pop('package_snapshot', None)
+        monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
+
+        with (
+            patch.object(DaemonClient, 'call_client', return_value={'status': 'ok'}),
+            patch.object(
+                DaemonClient, 'get_package_version_snapshot', return_value={'aiida-core': {'version': '2.6.0'}}
+            ),
+        ):
+            assert stopped_daemon_client.restart_daemon() == {'status': 'ok'}

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -225,6 +225,15 @@ def test_basic_properties(config_with_profile):
     assert isinstance(config.dictionary, dict)
 
 
+def test_filepaths_includes_package_snapshot(config_with_profile):
+    """Test that ``filepaths`` returns a ``package_snapshot`` entry for the daemon."""
+    config = config_with_profile
+    profile = config.get_profile(config.default_profile_name)
+    filepaths = config.filepaths(profile)
+    assert 'package_snapshot' in filepaths['daemon']
+    assert filepaths['daemon']['package_snapshot'].endswith('.package_snapshot')
+
+
 def test_setting_versions(config_with_profile):
     """Test the version setters."""
     config = config_with_profile


### PR DESCRIPTION
Record installed package versions when the daemon starts or restarts in a file, and warn in `verdi status` and `verdi daemon status` if current versions differ from those the daemon was started with. This helps catch subtle bugs caused by upgrading aiida-core or plugins without restarting the daemon.

After playing with different possibilities I only used the information that is available in `direct_url.json` that follows the specification from https://packaging.python.org/en/latest/specifications/direct-url-data-structure/ so the approach is robust. In contrast `pip freeze` does for example retrieves more information by for example in case of a editable mode install checking the local directory for the git hash. This allows to also detect local changes in the editable installation but would introduce extra logic that tries to retrieve the HEAD hash from the directory. I don't think this feature is worth the complexity.

In the examples below you see that I added a fish-like compression of the directory `~/c/a/w/f/new-checkout` I am not sure if this is the best way, but including the whole directory is quite verbose and I kind of like the way fish does it.

Note that there can be still a change in the aiida-core dependencies and this will not be tracked. To detect this it would require a comparison of the complete dependency tree which would make verdi status way too slow.

Note that by using `ep.dist.version` local changes in `aiida.__version__` are not detected for an editable installation (only when newly pip installed). I think that also is consistent with the philosophy that we do not track local changes in editable mode.

Below the agent summary, its quite comprehensive I would say.

---

## Description

This PR adds daemon package-state tracking and surfaces a warning in
both `verdi status` and `verdi daemon status` when the currently
installed AiiDA packages no longer match the package state the daemon
was started with.

The goal is to make daemon/environment drift visible before it turns
into confusing runtime behavior after:
- upgrading `aiida-core`
- upgrading or uninstalling an AiiDA plugin
- switching editable checkouts

The warning compares the package snapshot recorded at daemon startup
against the current package snapshot.

What is tracked:
- installed package version
- VCS commit hash when it is present in package metadata
- editable install source path for local editable installs

For editable installs, this PR intentionally compares normalized source
paths, not the checkout's current git `HEAD`. Editable checkouts can
change without a commit change, and package metadata for local
editables does not reliably expose VCS commit information.

## Examples

Version or editable-path mismatch:

```console
$ verdi status
✔ version:     AiiDA v2.8.0.post1
✔ config:      /path/to/.aiida
✔ profile:     presto-2
✔ storage:     SqliteDosStorage[/path/to/repository]: open,
✔ broker:      RabbitMQ ...
⏺ daemon:      Daemon is running with PID 13669
               The daemon is running with mismatching package state. Restart the daemon with `verdi daemon restart`.
               Changed packages: aiida-core (2.8.0.post0 @ ~/c/a/w/f/old-checkout -> 2.8.0.post0 @ ~/c/a/w/f/new-checkout)
```

Plugin removed after daemon start:

```console
$ verdi status
✔ version:     AiiDA v2.8.0.post1
✔ config:      /path/to/.aiida
✔ profile:     presto-2
✔ storage:     SqliteDosStorage[/path/to/repository]: open,
✔ broker:      RabbitMQ ...
⏺ daemon:      Daemon is running with PID 13669
               The daemon is running with mismatching package state. Restart the daemon with `verdi daemon restart`.
               Removed packages: aiida-quantumespresso (4.12.1)
```

Plugin added after daemon start:

```console
$ verdi status
...
⏺ daemon:      Daemon is running with PID 12345
               The daemon is running with mismatching package state. Restart the daemon with `verdi daemon restart`.
               Added packages: aiida-plugin (1.2.3)
```

The same mismatch is also surfaced through `verdi daemon status`:

```console
$ verdi daemon status
Profile: presto-2
Daemon is running as PID 13669 since 2026-04-22 08:30:30
Active workers [1]:
  PID    MEM %    CPU %  started
-----  -------  -------  -------------------
13670     0.42        0  2026-04-22 08:30:30
Log file: /path/to/aiida-presto-2.log
The daemon is running with mismatching package state. Restart the daemon with `verdi daemon restart`.
Changed packages: aiida-core (2.8.0.post0 @ ~/c/a/w/f/old-checkout -> 2.8.0.post0 @ ~/c/a/w/f/new-checkout)
Use `verdi daemon [incr | decr] [num]` to increase / decrease the number of workers
```

## Implementation Notes

- add a daemon version-info file in the profile daemon filepaths
- write the package snapshot on daemon start/restart
- remove the snapshot on daemon stop
- read VCS commit hashes from `direct_url.json` / distribution origin
  metadata when available
- record normalized editable paths for local editable installs
- validate the stored snapshot format before using it
- share package-drift formatting between `verdi status` and
  `verdi daemon status`
- keep `verdi status` output to a single `daemon:` line block