### PR TITLE
🐛 Stop daemon before `verdi profile delete`

### DIFF
--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -40,19 +40,22 @@ def verdi_daemon():
     """Inspect and manage the daemon."""
 
 
-def execute_client_command(command: str, daemon_not_running_ok: bool = False, **kwargs) -> dict[str, t.Any] | None:
+def execute_client_command(
+    command: str, daemon_not_running_ok: bool = False, profile_name: str | None = None, **kwargs
+) -> dict[str, t.Any] | None:
     """Execute a command of the :class:`aiida.engine.daemon.client.DaemonClient` and echo whether it failed or not.
 
-    :param command: The name of hte method.
+    :param command: The name of the method.
     :param daemon_not_running_ok: If ``True``, the command raising an exception because the daemon was not running is
         not treated as a failure.
+    :param profile_name: Optional profile name. If not provided, the current profile is used.
     :param kwargs: Keyword arguments that are passed to the client method.
     """
     from aiida.common.exceptions import ConfigurationError
     from aiida.engine.daemon.client import DaemonException, DaemonNotRunningException, get_daemon_client
 
     try:
-        client = get_daemon_client()
+        client = get_daemon_client(profile_name)
     except ConfigurationError:
         echo.echo('WARNING', fg=echo.COLORS['warning'], bold=True)
         return None
@@ -216,7 +219,9 @@ def stop(ctx, no_wait, all_profiles, timeout):
         echo.echo('Profile: ', fg=echo.COLORS['report'], bold=True, nl=False)
         echo.echo(f'{profile.name}', bold=True)
         echo.echo('Stopping the daemon... ', nl=False)
-        execute_client_command('stop_daemon', daemon_not_running_ok=True, wait=not no_wait, timeout=timeout)
+        execute_client_command(
+            'stop_daemon', daemon_not_running_ok=True, profile_name=profile.name, wait=not no_wait, timeout=timeout
+        )
 
 
 @verdi_daemon.command()

--- a/src/aiida/common/log.py
+++ b/src/aiida/common/log.py
@@ -96,7 +96,7 @@ def get_logging_config() -> dict[str, t.Any]:
             'aiida': {
                 'handlers': ['console'],
                 'level': lambda: get_config_option('logging.aiida_loglevel'),
-                'propagate': True,
+                'propagate': False,
             },
             'verdi': {
                 'handlers': ['cli'],

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -68,15 +68,27 @@ class DaemonStalePidException(DaemonException):
 
 
 def get_daemon_client(profile_name: str | None = None) -> 'DaemonClient':
-    """Return the daemon client for the given profile or the current profile if not specified.
+    """Return the daemon client for the given profile or the currently loaded profile if not specified.
 
-    :param profile_name: Optional profile name to load.
+    :param profile_name: Optional profile name.
     :return: The daemon client.
 
     :raises aiida.common.MissingConfigurationError: if the configuration file cannot be found.
     :raises aiida.common.ProfileConfigurationError: if the given profile does not exist.
+    :raises aiida.common.ConfigurationError: if no profile is loaded and ``profile_name`` is not specified.
     """
-    profile = get_manager().load_profile(profile_name)
+    manager = get_manager()
+
+    if profile_name is None:
+        profile = manager.get_profile()
+
+        if profile is None:
+            raise ConfigurationError(
+                'Could not determine the current profile. Consider loading a profile using `aiida.load_profile()`.'
+            )
+    else:
+        profile = get_config().get_profile(profile_name)
+
     return DaemonClient(profile)
 
 

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -41,20 +41,23 @@ async def shutdown_worker(runner: Runner) -> None:
 
 
 def start_daemon_worker(foreground: bool = False, profile_name: Union[str, None] = None) -> None:
-    """Start a daemon worker for the currently configured profile.
+    """Start a daemon worker for the given profile or the currently configured profile.
 
     :param foreground: If true, the logging will be configured to write to stdout, otherwise it will be configured to
         write to the daemon log file.
+    :param profile_name: Optional profile name.
     """
+    manager = get_manager()
+    profile = manager.load_profile(profile_name)
 
     daemon_client = get_daemon_client(profile_name)
     configure_logging(with_orm=True, daemon=not foreground, daemon_log_file=daemon_client.daemon_log_file)
 
-    LOGGER.debug(f'sys.executable: {sys.executable}')
-    LOGGER.debug(f'sys.path: {sys.path}')
+    LOGGER.debug('Loaded profile %s', profile.name)
+    LOGGER.debug('sys.executable: %s', sys.executable)
+    LOGGER.debug('sys.path: %s', sys.path)
 
     try:
-        manager = get_manager()
         runner = manager.create_daemon_runner()
         manager.set_runner(runner)
     except Exception:

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -572,10 +572,59 @@ class Config:
 
         :param delete_storage: Whether to delete the storage with all its data or not.
         """
+        from aiida.engine.daemon.client import (
+            DaemonException,
+            DaemonNotRunningException,
+            DaemonStalePidException,
+            DaemonTimeoutException,
+            get_daemon_client,
+        )
         from aiida.plugins import StorageFactory
 
         profile = self.get_profile(name)
         is_default_profile: bool = profile.name == self.default_profile_name
+
+        if profile.process_control_backend is not None:
+            client = get_daemon_client(profile.name)
+            try:
+                client.stop_daemon(wait=True, timeout=5)
+                LOGGER.report('Daemon for profile `%s` stopped.', profile.name)
+            except DaemonTimeoutException:
+                daemon_pid = client.get_daemon_pid()
+                if daemon_pid is None:
+                    LOGGER.warning(
+                        'Timed out while contacting the daemon for profile `%s`. The daemon may still be running.',
+                        profile.name,
+                    )
+                else:
+                    LOGGER.warning(
+                        'Timed out while contacting the daemon for profile `%s`. '
+                        'The daemon with PID `%s` may still be running.',
+                        profile.name,
+                        daemon_pid,
+                    )
+            except DaemonNotRunningException:
+                pass
+            except DaemonStalePidException as exception:
+                LOGGER.debug('Stale daemon PID file detected for profile `%s`: %s', profile.name, exception)
+            except DaemonException as exception:
+                daemon_pid = client.get_daemon_pid()
+                if daemon_pid is None:
+                    LOGGER.warning(
+                        'Failed to stop the daemon for profile `%s`: %s. ' 'The daemon may still be running.',
+                        profile.name,
+                        exception,
+                    )
+                else:
+                    LOGGER.warning(
+                        'Failed to stop the daemon for profile `%s`: %s. '
+                        'The daemon with PID `%s` may still be running.',
+                        profile.name,
+                        exception,
+                        daemon_pid,
+                    )
+        else:
+            LOGGER.debug('Profile `%s` has no broker configured, skipping daemon shutdown.', profile.name)
         if delete_storage:
             storage_cls = StorageFactory(profile.storage_backend)
             if profile.storage_backend == 'core.sqlite_zip':

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -15,7 +15,7 @@ import pytest
 
 from aiida import get_profile
 from aiida.cmdline.commands import cmd_daemon
-from aiida.engine.daemon.client import DaemonClient
+from aiida.engine.daemon.client import DaemonClient, DaemonTimeoutException
 
 pytestmark = pytest.mark.requires_rmq
 
@@ -99,6 +99,11 @@ def test_daemon_start_number_config(run_cli_command, stopped_daemon_client, isol
 def test_daemon_stop(run_cli_command, started_daemon_client):
     """Test ``verdi daemon stop``."""
     result = run_cli_command(cmd_daemon.stop)
+
+    started_daemon_client._await_condition(
+        lambda: not started_daemon_client.is_daemon_running,
+        DaemonTimeoutException('The daemon failed to stop.'),
+    )
 
     assert 'Stopping the daemon' in result.output
     assert not started_daemon_client.is_daemon_running

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -96,6 +96,14 @@ def test_daemon_start_number_config(run_cli_command, stopped_daemon_client, isol
     assert len(worker_response['info']) == number
 
 
+def test_daemon_stop(run_cli_command, started_daemon_client):
+    """Test ``verdi daemon stop``."""
+    result = run_cli_command(cmd_daemon.stop)
+
+    assert 'Stopping the daemon' in result.output
+    assert not started_daemon_client.is_daemon_running
+
+
 def test_foreground_multiple_workers(run_cli_command):
     """Test `verdi daemon start` in foreground with more than one worker will fail."""
     run_cli_command(cmd_daemon.start, ['--foreground', str(4)], raises=True)
@@ -248,3 +256,25 @@ def test_daemon_status_worker_timeout(run_cli_command):
     result = run_cli_command(cmd_daemon.status)
     for literal in literals:
         assert literal in result.output
+
+
+def test_execute_client_command_profile_name(monkeypatch):
+    """Test that ``execute_client_command`` passes ``profile_name`` to ``get_daemon_client``."""
+    received_profile_names = []
+
+    def mock_get_daemon_client(profile_name=None):
+        received_profile_names.append(profile_name)
+
+        class MockClient:
+            def stop_daemon(self, **kwargs):
+                return None
+
+        return MockClient()
+
+    monkeypatch.setattr('aiida.engine.daemon.client.get_daemon_client', mock_get_daemon_client)
+
+    cmd_daemon.execute_client_command('stop_daemon', profile_name='test-profile')
+    assert received_profile_names == ['test-profile']
+
+    cmd_daemon.execute_client_command('stop_daemon')
+    assert received_profile_names == ['test-profile', None]

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -15,6 +15,7 @@ from pgtest.pgtest import PGTest
 
 from aiida import orm
 from aiida.cmdline.commands import cmd_profile, cmd_verdi
+from aiida.engine.daemon.client import DaemonException, DaemonStalePidException, DaemonTimeoutException
 from aiida.manage import configuration
 from aiida.plugins import StorageFactory
 from aiida.tools.archive.create import create_archive
@@ -164,6 +165,78 @@ def test_delete_force(run_cli_command, mock_profiles, pg_test_cluster):
         cmd_profile.profile_delete, ['--force', profile_list[0]], use_subprocess=False, raises=True
     )
     assert 'When the `-f/--force` flag is used either `--delete-data` or `--keep-data`' in result.output
+
+
+def test_delete_stops_running_daemon(run_cli_command, mock_profiles, pg_test_cluster, monkeypatch):
+    """Test that ``verdi profile delete`` stops the daemon if it is running."""
+    from aiida.engine.daemon.client import DaemonClient
+
+    kwargs = {'database_port': pg_test_cluster.dsn['port']}
+    profile_list = mock_profiles(**kwargs)
+    daemon_kwargs = {}
+
+    def stop_daemon(self, **kwargs):
+        daemon_kwargs.update(kwargs)
+        return {'status': 'ok'}
+
+    monkeypatch.setattr(DaemonClient, 'stop_daemon', stop_daemon)
+
+    result = run_cli_command(
+        cmd_profile.profile_delete,
+        ['--force', '--keep-data', profile_list[0]],
+        use_subprocess=False,
+    )
+
+    assert daemon_kwargs == {'wait': True, 'timeout': 5}
+    assert f'Daemon for profile `{profile_list[0]}` stopped.' in result.output
+    assert f'`{profile_list[0]}` was deleted' in result.output
+
+
+@pytest.mark.parametrize(
+    ('exception_cls', 'message'),
+    [
+        (DaemonTimeoutException, 'Connection to the daemon timed out.'),
+        (DaemonException, 'Connection failed.'),
+        (DaemonStalePidException, 'Stale PID file.'),
+    ],
+)
+def test_delete_proceeds_on_daemon_stop_exception(
+    run_cli_command, mock_profiles, pg_test_cluster, monkeypatch, exception_cls, message
+):
+    """Test that ``verdi profile delete`` proceeds when stopping the daemon raises a non-fatal exception."""
+    from aiida.engine.daemon.client import DaemonClient
+
+    kwargs = {'database_port': pg_test_cluster.dsn['port']}
+    profile_list = mock_profiles(**kwargs)
+
+    def stop_daemon_raise(self, **kwargs):
+        raise exception_cls(message)
+
+    monkeypatch.setattr(DaemonClient, 'stop_daemon', stop_daemon_raise)
+
+    result = run_cli_command(
+        cmd_profile.profile_delete,
+        ['--force', '--keep-data', profile_list[0]],
+        use_subprocess=False,
+    )
+
+    assert f'`{profile_list[0]}` was deleted' in result.output
+    config = configuration.get_config()
+    assert profile_list[0] not in config.profile_names
+
+
+def test_delete_no_broker(run_cli_command, mock_profiles, pg_test_cluster):
+    """Test that ``verdi profile delete`` proceeds if no broker is configured."""
+    kwargs = {'database_port': pg_test_cluster.dsn['port'], 'process_control_backend': None}
+    profile_list = mock_profiles(**kwargs)
+
+    result = run_cli_command(
+        cmd_profile.profile_delete,
+        ['--force', '--keep-data', profile_list[0]],
+        use_subprocess=False,
+    )
+
+    assert f'`{profile_list[0]}` was deleted' in result.output
 
 
 @pytest.mark.parametrize('entry_point', ('core.sqlite_dos', 'core.sqlite_zip'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import logging
 import os
 import pathlib
 import subprocess
@@ -116,6 +117,51 @@ def pytest_addoption(parser):
         help=f'Database backend to be used for tests {tuple(db.value for db in TestDbBackend)}',
         type=db_backend_type,
     )
+
+
+@pytest.fixture(autouse=True)
+def capture_aiida_and_verdi_logs(request, monkeypatch):
+    """Forward AiiDA and verdi log records to ``caplog`` despite ``propagate=False``.
+
+    The production logging configuration disables propagation for the top-level ``aiida`` and ``verdi`` loggers.
+    For tests that use ``caplog``, attach the pytest log capture handler directly to those loggers and re-attach it
+    after any logging reconfiguration so existing ``caplog``-based assertions keep observing their records.
+    """
+    if 'caplog' not in request.fixturenames:
+        yield
+        return
+
+    from aiida.common import log as common_log
+
+    caplog = request.getfixturevalue('caplog')
+
+    def attach_handler() -> None:
+        for logger_name in ('aiida', 'verdi'):
+            logger = logging.getLogger(logger_name)
+            if caplog.handler not in logger.handlers:
+                logger.addHandler(caplog.handler)
+
+    original_configure_logging = common_log.configure_logging
+
+    def configure_logging(*args, **kwargs):
+        result = original_configure_logging(*args, **kwargs)
+        attach_handler()
+        return result
+
+    monkeypatch.setattr(common_log, 'configure_logging', configure_logging)
+    monkeypatch.setattr('aiida.configure_logging', configure_logging, raising=False)
+    monkeypatch.setattr('aiida.engine.daemon.worker.configure_logging', configure_logging, raising=False)
+    monkeypatch.setattr('aiida.cmdline.params.options.main.configure_logging', configure_logging, raising=False)
+
+    attach_handler()
+
+    try:
+        yield
+    finally:
+        for logger_name in ('aiida', 'verdi'):
+            logger = logging.getLogger(logger_name)
+            if caplog.handler in logger.handlers:
+                logger.removeHandler(caplog.handler)
 
 
 @pytest.fixture(scope='session')

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -43,6 +43,48 @@ def test_ipc_socket_file_length_limit():
     assert len(stats_endpoint) <= zmq.IPC_PATH_MAX_LEN
 
 
+def test_get_daemon_client_non_default_profile(profile_factory, empty_config):
+    """Test that ``get_daemon_client`` returns a client for the requested profile, not the default."""
+    profile_default = profile_factory('default-profile')
+    profile_other = profile_factory('other-profile')
+    empty_config.add_profile(profile_default)
+    empty_config.add_profile(profile_other)
+    empty_config.set_default_profile('default-profile', overwrite=True).store()
+
+    client = get_daemon_client('other-profile')
+    assert client.profile.name == 'other-profile'
+
+
+def test_get_daemon_client_does_not_switch_profile(empty_config, profile_factory):
+    """Test that ``get_daemon_client`` does not switch the loaded profile."""
+    from aiida.manage import get_manager
+
+    profile_default = profile_factory(
+        'default',
+        storage_backend='core.sqlite_dos',
+        process_control_backend='rabbitmq',
+        repository_dirpath=empty_config.dirpath,
+    )
+    profile_other = profile_factory(
+        'other',
+        storage_backend='core.sqlite_dos',
+        process_control_backend='rabbitmq',
+        repository_dirpath=empty_config.dirpath,
+    )
+
+    empty_config.add_profile(profile_default)
+    empty_config.add_profile(profile_other)
+    empty_config.set_default_profile(profile_default.name, overwrite=True)
+    empty_config.store()
+
+    manager = get_manager()
+    manager.load_profile(profile_other.name, allow_switch=True)
+
+    assert manager.get_profile().name == profile_other.name
+    assert get_daemon_client(profile_default.name).profile.name == profile_default.name
+    assert manager.get_profile().name == profile_other.name
+
+
 def test_get_status_daemon_not_running(stopped_daemon_client):
     """Test ``DaemonClient.get_status`` output when the daemon is not running."""
     with pytest.raises(DaemonNotRunningException, match='The daemon is not running.'):

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -16,6 +16,8 @@ import uuid
 import pytest
 
 from aiida.common import exceptions
+from aiida.common.log import LOG_LEVEL_REPORT
+from aiida.engine.daemon.client import DaemonException, DaemonTimeoutException
 from aiida.manage.configuration import Profile, settings
 from aiida.manage.configuration.config import Config
 from aiida.manage.configuration.migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
@@ -420,8 +422,12 @@ def test_store(config_with_profile):
         assert config.dictionary == config_recreated.dictionary
 
 
-def test_delete_profile(config_with_profile, profile_factory):
+def test_delete_profile(config_with_profile, profile_factory, monkeypatch, caplog):
     """Test the ``delete_profile`` method."""
+    import logging
+
+    from aiida.engine.daemon.client import DaemonClient
+
     config = config_with_profile
     profile_name = 'to-be-deleted'
     profile = profile_factory(name=profile_name)
@@ -432,12 +438,61 @@ def test_delete_profile(config_with_profile, profile_factory):
     # Write the contents to disk so that the to-be-deleted profile is in the config file on disk
     config.store()
 
-    config.delete_profile(profile_name, delete_storage=False)
+    monkeypatch.setattr(DaemonClient, 'stop_daemon', lambda self, **kwargs: {'status': 'ok'})
+
+    logger = logging.getLogger('aiida.manage.configuration.config')
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(LOG_LEVEL_REPORT, logger='aiida.manage.configuration.config'):
+            config.delete_profile(profile_name, delete_storage=False)
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    assert any(f'Daemon for profile `{profile_name}` stopped.' in record.message for record in caplog.records)
     assert profile_name not in config.profile_names
 
     # Now reload the config from disk to make sure the changes after deletion were persisted to disk
     config_on_disk = Config.from_file(config.filepath)
     assert profile_name not in config_on_disk.profile_names
+
+
+@pytest.mark.parametrize(
+    ('profile_name', 'exception_cls', 'message'),
+    [
+        ('to-be-deleted-timeout', DaemonTimeoutException, 'Connection to the daemon timed out.'),
+        ('to-be-deleted-failure', DaemonException, 'Connection failed.'),
+    ],
+)
+def test_delete_profile_warns_with_daemon_pid(
+    config_with_profile, profile_factory, monkeypatch, caplog, profile_name, exception_cls, message
+):
+    """Test that ``delete_profile`` warns if daemon shutdown does not complete cleanly."""
+    import logging
+
+    from aiida.engine.daemon.client import DaemonClient
+
+    config = config_with_profile
+    profile = profile_factory(name=profile_name)
+
+    config.add_profile(profile)
+    config.store()
+
+    def stop_daemon_raise(self, **kwargs):
+        raise exception_cls(message)
+
+    monkeypatch.setattr(DaemonClient, 'stop_daemon', stop_daemon_raise)
+    monkeypatch.setattr(DaemonClient, 'get_daemon_pid', lambda self: 1234)
+
+    logger = logging.getLogger('aiida.manage.configuration.config')
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger='aiida.manage.configuration.config'):
+            config.delete_profile(profile_name, delete_storage=False)
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    assert any('The daemon with PID `1234` may still be running.' in record.message for record in caplog.records)
+    assert profile_name not in config.profile_names
 
 
 @pytest.mark.parametrize(
@@ -479,8 +534,13 @@ def test_delete_profile_sqlite_zip(
 
     caplog.clear()
 
-    with caplog.at_level(logging.INFO):
-        config.delete_profile(profile_name, delete_storage=delete_storage)
+    logger = logging.getLogger('aiida.manage.configuration.config')
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(LOG_LEVEL_REPORT, logger='aiida.manage.configuration.config'):
+            config.delete_profile(profile_name, delete_storage=delete_storage)
+    finally:
+        logger.removeHandler(caplog.handler)
 
     # Verify file handling
     if delete_storage and file_exists:


### PR DESCRIPTION
`verdi profile delete` now gracefully stops any running daemon for a profile before removing it. This prevents orphaned Circus arbiter and worker processes, stale PID files, and broken connections to deleted storage backends.

Stale PID files and race conditions (daemon stops between check and stop call) are handled gracefully. If the daemon cannot be stopped, deletion is aborted to avoid corrupting a live daemon's state.

A docstring warning is added to `Config.delete_profile()` to alert programmatic callers that they must stop the daemon themselves.

I wanted to reuse the code of `execute_client_command` in the profile deletion cmd and realized that there is no arg to pass the profile but it requires a profile to actually stop the daemon because of the `--all` option. That was a bug I fixed in the first commit to then move on in the second commit stopping the daemon on a profile delete.


Commit 069bcba was added because of flaky CI I had see run https://github.com/agoscinski/aiida-core/actions/runs/24631414651/job/72019360201