### PR TITLE
🐛 Avoid importing and calling close in `__del__` during shutdown

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import functools
+import sys
 import typing as t
+import warnings
 from collections.abc import Iterator
 
 from aiida.brokers.broker import Broker
@@ -49,10 +51,9 @@ class RabbitmqBroker(Broker):
 
     def __del__(self) -> None:
         if self._communicator is not None:
-            import warnings
-
             warnings.warn(f'RabbitmqBroker was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
-            self.close()
+            if not sys.is_finalizing():
+                self.close()
 
     def iterate_tasks(self) -> Iterator[t.Any]:
         """Return an iterator over the tasks in the launch queue."""

--- a/src/aiida/orm/implementation/storage_backend.py
+++ b/src/aiida/orm/implementation/storage_backend.py
@@ -11,6 +11,8 @@
 from __future__ import annotations
 
 import abc
+import sys
+import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ContextManager, List, Optional, TypeVar, Union
 
@@ -142,10 +144,9 @@ class StorageBackend(abc.ABC):
             # covers cases where the backend implementation is not yet initialized but object is deleted
             return
         if not closed:
-            import warnings
-
             warnings.warn(f'StorageBackend was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
-            self.close()
+            if not sys.is_finalizing():
+                self.close()
 
     @property
     @abc.abstractmethod

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -8,9 +8,9 @@
 ###########################################################################
 """Tests for the `aiida.brokers.rabbitmq` module."""
 
-import gc
 import pathlib
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -37,25 +37,31 @@ def test_str_method(monkeypatch, manager):
     assert 'RabbitMQ @' in str(broker)
 
 
-def test_del_closes_communicator_when_not_finalizing(aiida_profile):
-    """Test `__del__` closes the communicator when Python is not finalizing."""
-
-    class DummyCommunicator:
-        def __init__(self):
-            self.closed = False
-
-        def close(self):
-            self.closed = True
-
-    communicator = DummyCommunicator()
+def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch):
+    """Test `__del__` closes the broker when Python is not finalizing."""
     broker = RabbitmqBroker(aiida_profile)
-    broker._communicator = communicator
+    broker._communicator = MagicMock()
+    close = MagicMock()
+    monkeypatch.setattr(broker, 'close', close)
 
     with pytest.warns(ResourceWarning, match='RabbitmqBroker was not closed explicitly'):
-        del broker
-        gc.collect()
+        broker.__del__()
 
-    assert communicator.closed is True
+    close.assert_called_once_with()
+
+
+def test_del_skips_close_when_finalizing(aiida_profile, monkeypatch):
+    """Test ``__del__`` skips close when Python is finalizing."""
+    broker = RabbitmqBroker(aiida_profile)
+    broker._communicator = MagicMock()
+    close = MagicMock()
+    monkeypatch.setattr(broker, 'close', close)
+    monkeypatch.setattr('sys.is_finalizing', lambda: True)
+
+    with pytest.warns(ResourceWarning, match='RabbitmqBroker was not closed explicitly'):
+        broker.__del__()
+
+    close.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -8,6 +8,7 @@
 ###########################################################################
 """Tests for the `aiida.brokers.rabbitmq` module."""
 
+import gc
 import pathlib
 import uuid
 
@@ -16,7 +17,7 @@ import requests
 from kiwipy.rmq import RmqThreadCommunicator
 from packaging.version import parse
 
-from aiida.brokers.rabbitmq import client, utils
+from aiida.brokers.rabbitmq import RabbitmqBroker, client, utils
 from aiida.engine.processes import ProcessState, control
 from aiida.orm import Int
 
@@ -34,6 +35,27 @@ def test_str_method(monkeypatch, manager):
 
     monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
     assert 'RabbitMQ @' in str(broker)
+
+
+def test_del_closes_communicator_when_not_finalizing(aiida_profile):
+    """Test `__del__` closes the communicator when Python is not finalizing."""
+
+    class DummyCommunicator:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    communicator = DummyCommunicator()
+    broker = RabbitmqBroker(aiida_profile)
+    broker._communicator = communicator
+
+    with pytest.warns(ResourceWarning, match='RabbitmqBroker was not closed explicitly'):
+        del broker
+        gc.collect()
+
+    assert communicator.closed is True
 
 
 @pytest.mark.parametrize(

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -10,10 +10,10 @@
 
 from __future__ import annotations
 
-import gc
 import json
 import pathlib
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,7 +21,6 @@ from aiida import orm
 from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.orm.entities import EntityTypes
-from aiida.orm.implementation.storage_backend import StorageBackend
 
 
 class TestBackend:
@@ -170,30 +169,29 @@ class TestBackend:
         assert len(group.nodes) == 0
 
 
-def test_del_closes_backend_when_not_finalizing():
+def test_del_closes_backend_when_not_finalizing(aiida_profile, monkeypatch):
     """Test ``__del__`` closes the backend when Python is not finalizing."""
-
-    class DummyStorageBackend:
-        __del__ = StorageBackend.__del__
-
-        def __init__(self, state):
-            self._state = state
-
-        def close(self):
-            self._state['closed'] = True
-
-        @property
-        def is_closed(self):
-            return self._state['closed']
-
-    state = {'closed': False}
-    backend = DummyStorageBackend(state)
+    backend = aiida_profile.storage_cls(aiida_profile)
+    close = MagicMock()
+    monkeypatch.setattr(backend, 'close', close)
 
     with pytest.warns(ResourceWarning, match='StorageBackend was not closed explicitly'):
-        del backend
-        gc.collect()
+        backend.__del__()
 
-    assert state['closed'] is True
+    close.assert_called_once_with()
+
+
+def test_del_skips_close_when_finalizing(aiida_profile, monkeypatch):
+    """Test ``__del__`` skips close when Python is finalizing."""
+    backend = aiida_profile.storage_cls(aiida_profile)
+    close = MagicMock()
+    monkeypatch.setattr(backend, 'close', close)
+    monkeypatch.setattr('sys.is_finalizing', lambda: True)
+
+    with pytest.warns(ResourceWarning, match='StorageBackend was not closed explicitly'):
+        backend.__del__()
+
+    close.assert_not_called()
 
 
 def test_backup_not_implemented(aiida_config, backend, monkeypatch, tmp_path):

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import gc
 import json
 import pathlib
 import uuid
@@ -20,6 +21,7 @@ from aiida import orm
 from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.orm.entities import EntityTypes
+from aiida.orm.implementation.storage_backend import StorageBackend
 
 
 class TestBackend:
@@ -166,6 +168,32 @@ class TestBackend:
             orm.Node.collection.get(id=node_pk)
         assert len(calc_node.base.links.get_outgoing().all()) == 0
         assert len(group.nodes) == 0
+
+
+def test_del_closes_backend_when_not_finalizing():
+    """Test ``__del__`` closes the backend when Python is not finalizing."""
+
+    class DummyStorageBackend:
+        __del__ = StorageBackend.__del__
+
+        def __init__(self, state):
+            self._state = state
+
+        def close(self):
+            self._state['closed'] = True
+
+        @property
+        def is_closed(self):
+            return self._state['closed']
+
+    state = {'closed': False}
+    backend = DummyStorageBackend(state)
+
+    with pytest.warns(ResourceWarning, match='StorageBackend was not closed explicitly'):
+        del backend
+        gc.collect()
+
+    assert state['closed'] is True
 
 
 def test_backup_not_implemented(aiida_config, backend, monkeypatch, tmp_path):


### PR DESCRIPTION
Two related fixes to prevent 'Exception ignored in __del__' errors during Python shutdown:

1. Move 'import warnings' to module level in `RabbitmqBroker` and `StorageBackend` to avoid `ImportError` when `sys.meta_path` is `None` during shutdown.

2. Guard `__del__` with `sys.is_finalizing()` to skip the `close()` call during Python shutdown when asyncio/kiwipy event loop infrastructure is already torn down, preventing `AttributeError` in pytray's `await_` method.

During shutdown:
- `sys.meta_path` becomes `None`, making imports unavailable
- Module globals are set to `None` before garbage collection
- `asyncio.run_coroutine_threadsafe()` fails with `AttributeError`

By deferring the import and skipping close during finalization, we avoid both issues since the process is exiting anyway.

Fixes #7309

---

### Further changes in the future

When doing the overhaul of the logging system in #7323  I will change the warning to using the logger system so it is properly tracked. ResourceWarnings are only shown when a certain env is on or python is run in developer mode. Both is not really useful for us. The logger system only works however when not finalizing. So we cannot track places where resources were not close during a python shutdown, which is fine.