### PR TITLE
Fix flaky tests in `test_group.py::test_show_limit` and `test_statistics.py::test_count_consistency`

### DIFF
--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -340,15 +340,21 @@ class TestVerdiGroup:
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_show_limit(self, run_cli_command):
         """Test `--limit` option of the `verdi group show` command."""
+        import re
+
         label = 'test_group_limit'
         nodes = [orm.Data().store(), orm.Data().store()]
         group = orm.Group(label=label).store()
         group.add_nodes(nodes)
 
+        def _pk_in_output(pk, output):
+            """Check if a PK is preceded by whitespace or string start and followed by whitespace."""
+            return bool(re.search(rf'(^|\s){pk}\s', output))
+
         # Default should include all nodes in the output
         result = run_cli_command(cmd_group.group_show, [label], use_subprocess=True)
         for node in nodes:
-            assert str(node.pk) in result.output
+            assert _pk_in_output(node.pk, result.output)
 
         # Repeat test with `limit=1`, use also the `--raw` option to only display nodes
         result = run_cli_command(
@@ -358,14 +364,20 @@ class TestVerdiGroup:
         # The current `verdi group show` does not support ordering so we cannot rely on that for now to test if only
         # one of the nodes is shown
         assert len(result.output.strip().split('\n')) == 1
-        assert str(nodes[0].pk) in result.output or str(nodes[1].pk) in result.output
+        assert _pk_in_output(nodes[0].pk, result.output) or _pk_in_output(
+            nodes[1].pk, result.output
+        ), f'Neither found PK {nodes[0].pk} nor {nodes[1].pk} in expression {result.output!r}'
 
         # Repeat test with `limit=1` but without the `--raw` flag as it has a different code path that is affected
         result = run_cli_command(cmd_group.group_show, [label, '--limit', '1'], use_subprocess=True)
 
         # Check that one, and only one pk appears in the output
-        assert str(nodes[0].pk) in result.output or str(nodes[1].pk) in result.output
-        assert not (str(nodes[0].pk) in result.output and str(nodes[1].pk) in result.output)
+        assert _pk_in_output(nodes[0].pk, result.output) or _pk_in_output(
+            nodes[1].pk, result.output
+        ), f'Neither found PK {nodes[0].pk} nor PK {nodes[1].pk} in expression {result.output!r}'
+        assert not (
+            _pk_in_output(nodes[0].pk, result.output) and _pk_in_output(nodes[1].pk, result.output)
+        ), f'Found both PKs {nodes[0].pk} and {nodes[1].pk} (but only one is allowed) in expression {result.output!r}'
 
     def test_description(self, run_cli_command):
         """Test `verdi group description` command."""

--- a/tests/restapi/test_statistics.py
+++ b/tests/restapi/test_statistics.py
@@ -33,7 +33,7 @@ def linearize_namespace(tree_namespace, linear_namespace=None):
     return linear_namespace
 
 
-@pytest.mark.usefixtures('populate_restapi_database')
+@pytest.mark.usefixtures('aiida_profile_clean', 'populate_restapi_database')
 def test_count_consistency(restapi_server, server_url):
     """Test the consistency in values between full_type_count and statistics"""
     server = restapi_server()


### PR DESCRIPTION
Fix flaky tests:
- `tests/cmdline/commands/test_group.py` 
```
FAILED tests/cmdline/commands/test_group.py::TestVerdiGroup::test_show_limit - AssertionError: assert not ('1' in '-----------------  ----------------\nGroup label        test_group_limit\nGroup type_string  core\nGroup description ...n-----------------  ----------------\n# Nodes:\n  PK  Type    Created\n----  ------  ---------\n   1  Data    2s ago\n' and '2' in '-----------------  ----------------\nGroup label        test_group_limit\nGroup type_string  core\nGroup description ...n-----------------  ----------------\n# Nodes:\n  PK  Type    Created\n----  ------  ---------\n   1  Data    2s ago\n')
 +  where '1' = str(1)
 +    where 1 = <Data: uuid: 925fbc25-a48f-4009-94ca-1a67f4036496 (pk: 1)>.pk
 +  and   '-----------------  ----------------\nGroup label        test_group_limit\nGroup type_string  core\nGroup description ...n-----------------  ----------------\n# Nodes:\n  PK  Type    Created\n----  ------  ---------\n   1  Data    2s ago\n' = CliResult(stderr_bytes=b'', stdout_bytes=b'-----------------  ----------------\nGroup label        test_group_limit\nG...   Created\n----  ------  ---------\n   1  Data    2s ago\n', exc_info=(None, None, None), exception=None, exit_code=0).output
 +  and   '2' = str(2)
 +    where 2 = <Data: uuid: c2d5c8d0-b339-4187-bfbd-84d41bd17832 (pk: 2)>.pk
 +  and   '-----------------  ----------------\nGroup label        test_group_limit\nGroup type_string  core\nGroup description ...n-----------------  ----------------\n# Nodes:\n  PK  Type    Created\n----  ------  ---------\n   1  Data    2s ago\n' = CliResult(stderr_bytes=b'', stdout_bytes=b'-----------------  ----------------\nGroup label        test_group_limit\nG...   Created\n----  ------  ---------\n   1  Data    2s ago\n', exc_info=(None, None, None), exception=None, exit_code=0).output
```
Because of the 2s the test identifies it as PK.
- `tests/restapi/test_statistics.py`, sometimes they are executed in a different order and thereby the database is populated returning a different result. I don't have an error msg available right now. I can provide it if someone wants to see it, but cleaning the database seems also not like an unreasonable thing to do.