### PR TITLE
🐛 Fix RabbitMQ config probe cleanup

### DIFF
--- a/src/aiida/brokers/rabbitmq/defaults.py
+++ b/src/aiida/brokers/rabbitmq/defaults.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import typing as t
 
@@ -40,23 +41,50 @@ def detect_rabbitmq_config(
     :raises ConnectionError: If the connection failed with the provided connection parameters
     :returns: The connection parameters if the RabbitMQ server was successfully connected to, or ``None`` otherwise.
     """
-    from kiwipy.rmq.threadcomms import connect
+    import aio_pika
+
+    from .utils import get_rmq_url
+
+    async def probe_rabbitmq_connection(url: str) -> None:
+        """Open and close a temporary RabbitMQ connection."""
+        connection = await aio_pika.connect_robust(url=url)
+        await connection.close()
+
+    protocol = protocol or os.getenv('AIIDA_BROKER_PROTOCOL', BROKER_DEFAULTS['protocol'])
+    username = username or os.getenv('AIIDA_BROKER_USERNAME', BROKER_DEFAULTS['username'])
+    password = password or os.getenv('AIIDA_BROKER_PASSWORD', BROKER_DEFAULTS['password'])
+    host = host or os.getenv('AIIDA_BROKER_HOST', BROKER_DEFAULTS['host'])
+    port = port or int(os.getenv('AIIDA_BROKER_PORT', BROKER_DEFAULTS['port']))
+    virtual_host = virtual_host or os.getenv('AIIDA_BROKER_VIRTUAL_HOST', BROKER_DEFAULTS['virtual_host'])
 
     connection_params = {
-        'protocol': protocol or os.getenv('AIIDA_BROKER_PROTOCOL', BROKER_DEFAULTS['protocol']),
-        'username': username or os.getenv('AIIDA_BROKER_USERNAME', BROKER_DEFAULTS['username']),
-        'password': password or os.getenv('AIIDA_BROKER_PASSWORD', BROKER_DEFAULTS['password']),
-        'host': host or os.getenv('AIIDA_BROKER_HOST', BROKER_DEFAULTS['host']),
-        'port': port or int(os.getenv('AIIDA_BROKER_PORT', BROKER_DEFAULTS['port'])),
-        'virtual_host': virtual_host or os.getenv('AIIDA_BROKER_VIRTUAL_HOST', BROKER_DEFAULTS['virtual_host']),
+        'protocol': protocol,
+        'username': username,
+        'password': password,
+        'host': host,
+        'port': port,
+        'virtual_host': virtual_host,
     }
+    url = get_rmq_url(
+        protocol=protocol,
+        username=username,
+        password=password,
+        host=host,
+        port=str(port),
+        virtual_host=virtual_host,
+    )
 
     LOGGER.info(f'Attempting to connect to RabbitMQ with parameters: {connection_params}')
 
     try:
-        connect(connection_params=connection_params)
+        # Use a direct temporary connection instead of a ``kiwipy`` communicator.
+        # The communicator stack can leave ``aio_pika`` connection objects to be garbage-collected after the event
+        # loop has already been closed, which then surfaces as an unraisable ``Connection.__del__`` exception in the
+        # test suite.
+        asyncio.run(probe_rabbitmq_connection(url))
     except ConnectionError:
-        raise ConnectionError(f'Failed to connect with following connection parameters: {connection_params}')
+        msg = f'Failed to connect with following connection parameters: {connection_params}'
+        raise ConnectionError(msg)
 
     # The profile configuration expects the keys of the broker config to be prefixed with ``broker_``.
     return {f'broker_{key}': value for key, value in connection_params.items()}

--- a/tests/brokers/test_rabbitmq_defaults.py
+++ b/tests/brokers/test_rabbitmq_defaults.py
@@ -1,0 +1,64 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for :mod:`aiida.brokers.rabbitmq.defaults`."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
+
+
+class FakeConnection:
+    """Fake RabbitMQ connection."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        """Close the connection."""
+        self.closed = True
+
+
+def test_detect_rabbitmq_config_closes_connection(monkeypatch):
+    """Test ``detect_rabbitmq_config`` closes the temporary connection."""
+    connection = FakeConnection()
+
+    async def connect_robust(*args, **kwargs):
+        return connection
+
+    import aio_pika
+
+    monkeypatch.setattr(aio_pika, 'connect_robust', connect_robust)
+
+    result = detect_rabbitmq_config(protocol='amqp', username='guest', password='guest', host='127.0.0.1', port=5672)
+
+    assert result == {
+        'broker_protocol': 'amqp',
+        'broker_username': 'guest',
+        'broker_password': 'guest',
+        'broker_host': '127.0.0.1',
+        'broker_port': 5672,
+        'broker_virtual_host': '',
+    }
+    assert connection.closed is True
+
+
+def test_detect_rabbitmq_config_wraps_connection_error(monkeypatch):
+    """Test ``detect_rabbitmq_config`` wraps connection errors consistently."""
+
+    async def connect_robust(*args, **kwargs):
+        raise ConnectionError('failed to connect')
+
+    import aio_pika
+
+    monkeypatch.setattr(aio_pika, 'connect_robust', connect_robust)
+
+    with pytest.raises(ConnectionError, match='Failed to connect with following connection parameters'):
+        detect_rabbitmq_config(host='127.0.0.1', port=5672)


### PR DESCRIPTION
Maybe you have seen the event loop is closed error in the CI. I think it pops up in every PR. This should fix it.

TODO: I need to check why kiwipy connect does not work, this might be a bug in kiwipy.

---

## Summary

Fix a RabbitMQ connection cleanup issue in `detect_rabbitmq_config()` that was causing intermittent `Event loop is closed` warnings in CI.

The previous implementation used `kiwipy.rmq.threadcomms.connect()` to probe whether RabbitMQ was reachable.
Even though this was only meant as a connectivity check, it could leave `aio_pika` connection objects to be finalized later, after the event loop had already been closed. Pytest would then report this as an unraisable exception.

This PR changes the probe to use a short-lived direct `aio_pika.connect_robust()` connection that is opened and explicitly closed immediately. That avoids creating the heavier communicator stack for a simple connectivity check and fixes the CI warning.

## Tests

Add regression tests for `detect_rabbitmq_config()` to verify that:
- the temporary connection is closed on success
- connection errors are still wrapped with the existing error message

## Notes for review

We first tried keeping the existing `kiwipy.rmq.threadcomms.connect(...)` probe and explicitly closing the communicator, but the CI warning still remained. Since `detect_rabbitmq_config()` only needs a simple connectivity check, using a short-lived direct `aio_pika.connect_robust()` connection is a better fit and avoids the heavier communicator stack that appears to leave `aio_pika` objects behind until after loop shutdown.