### PR TITLE
📚 Document workflow tools entry points

### DIFF
--- a/docs/source/howto/plugins_develop.rst
+++ b/docs/source/howto/plugins_develop.rst
@@ -117,6 +117,11 @@ Adding a new entry point consists of the following steps:
 
 Your new entry point should now show up in ``verdi plugin list aiida.calculations``.
 
+For ``CalcJob`` and ``WorkChain`` plugins, you can also register optional helper classes in the ``aiida.tools.calculations`` and ``aiida.tools.workflows`` entry point groups.
+Use the same entry point name as the corresponding process plugin.
+AiiDA exposes these helper classes on ``CalcJobNode.tools`` and ``WorkChainNode.tools``.
+If no matching tools entry point is registered, these properties fall back to the base ``CalculationTools`` or ``WorkflowTools`` implementation.
+
 .. note::
 
     Taking a package with the name ``aiida-diff`` as example, what does ``pip install aiida-diff`` do?

--- a/docs/source/howto/plugins_develop.rst
+++ b/docs/source/howto/plugins_develop.rst
@@ -117,6 +117,8 @@ Adding a new entry point consists of the following steps:
 
 Your new entry point should now show up in ``verdi plugin list aiida.calculations``.
 
+For ``CalcJob`` and ``WorkChain`` plugins, you can also register optional helper classes in the :ref:`aiida.tools.calculations <topics:plugins:entrypointgroups:aiida.tools.calculations>` and :ref:`aiida.tools.workflows <topics:plugins:entrypointgroups:aiida.tools.workflows>` entry point groups.
+
 .. note::
 
     Taking a package with the name ``aiida-diff`` as example, what does ``pip install aiida-diff`` do?

--- a/docs/source/howto/plugins_develop.rst
+++ b/docs/source/howto/plugins_develop.rst
@@ -173,7 +173,7 @@ The profile (and configuration directory in which it is hosted) is only temporar
 This ensures that any production profiles on the system are not affected by the tests.
 
 Other fixtures have to be explicitly used in a test to be of use.
-They usually allow creating some resources that are required by the test, such as a ``Code`` node:
+They usually allow creating some resources that are required by the test, such as a ``Code`` node::
 
     def test_calculation(aiida_code_installed):
         """Test running a calculation using a ``CalcJob`` plugin."""

--- a/docs/source/topics/plugins.rst
+++ b/docs/source/topics/plugins.rst
@@ -9,7 +9,7 @@ Plugins
 What a plugin can do
 ====================
 
-* Add a new class to AiiDA's :ref:`entry point groups <topics:plugins:entrypointgroups>`, including:: calculations, parsers, workflows, data types, verdi commands, schedulers, transports and importers/exporters from external databases.
+* Add a new class to AiiDA's :ref:`entry point groups <topics:plugins:entrypointgroups>`, including calculations, parsers, workflows, calculation tools, workflow tools, data types, verdi commands, schedulers, transports and importers/exporters from external databases.
   This typically involves subclassing the respective base class AiiDA provides for that purpose.
 * Install new commandline and/or GUI executables
 * Depend on, and build on top of any number of other plugins (as long as their requirements do not clash)
@@ -192,6 +192,47 @@ Usage::
    Therefore one cannot load these workflows with the ``WorkflowFactory``.
    The only way to run these, is to store their source code in the ``aiida/workflows/user`` directory and use normal python imports to load the classes.
 
+``aiida.tools.calculations``
+----------------------------
+
+Package helper classes for ``CalcJobNode`` instances as follows:
+
+Spec::
+
+   [project.entry-points."aiida.tools.calculations"]
+   "mycode.mycode" = "aiida_mycode.tools.calculations:MycodeCalculationTools"
+
+``aiida_mycode/tools/calculations.py``::
+
+   from aiida.tools.calculations import CalculationTools
+
+   class MycodeCalculationTools(CalculationTools):
+      ...
+
+If a ``CalcJobNode`` has the process type ``aiida.calculations:mycode.mycode``, AiiDA will load the matching helper class through ``node.tools``.
+The tools entry point name should match the calculation entry point name.
+If no matching tools entry point is registered, ``node.tools`` falls back to the base :py:class:`~aiida.tools.calculations.base.CalculationTools` implementation.
+
+``aiida.tools.workflows``
+-------------------------
+
+Package helper classes for ``WorkChainNode`` instances as follows:
+
+Spec::
+
+   [project.entry-points."aiida.tools.workflows"]
+   "mycode.mywf" = "aiida_mycode.tools.workflows:MyWorkflowTools"
+
+``aiida_mycode/tools/workflows.py``::
+
+   from aiida.tools.workflows import WorkflowTools
+
+   class MyWorkflowTools(WorkflowTools):
+      ...
+
+If a ``WorkChainNode`` has the process type ``aiida.workflows:mycode.mywf``, AiiDA will load the matching helper class through ``node.tools``.
+The tools entry point name should match the workflow entry point name.
+If no matching tools entry point is registered, ``node.tools`` falls back to the base :py:class:`~aiida.tools.workflows.base.WorkflowTools` implementation.
 
 ``aiida.cmdline``
 -----------------

--- a/docs/source/topics/plugins.rst
+++ b/docs/source/topics/plugins.rst
@@ -9,7 +9,7 @@ Plugins
 What a plugin can do
 ====================
 
-* Add a new class to AiiDA's :ref:`entry point groups <topics:plugins:entrypointgroups>`, including:: calculations, parsers, workflows, data types, verdi commands, schedulers, transports and importers/exporters from external databases.
+* Add a new class to AiiDA's :ref:`entry point groups <topics:plugins:entrypointgroups>`, including calculations, parsers, workflows, calculation tools, workflow tools, data types, verdi commands, schedulers, transports and importers/exporters from external databases.
   This typically involves subclassing the respective base class AiiDA provides for that purpose.
 * Install new commandline and/or GUI executables
 * Depend on, and build on top of any number of other plugins (as long as their requirements do not clash)
@@ -192,6 +192,49 @@ Usage::
    Therefore one cannot load these workflows with the ``WorkflowFactory``.
    The only way to run these, is to store their source code in the ``aiida/workflows/user`` directory and use normal python imports to load the classes.
 
+.. _topics:plugins:entrypointgroups:aiida.tools.calculations:
+
+``aiida.tools.calculations``
+----------------------------
+
+Plugins can ship helper methods for post-processing or analysing ``CalcJobNode`` outputs by registering a :py:class:`~aiida.tools.calculations.base.CalculationTools` subclass here.
+AiiDA automatically loads the right tools class based on the node's process type, so after loading a node users can call ``node.tools`` to access the plugin-specific helpers.
+The entry point name should match the corresponding ``aiida.calculations`` entry point.
+
+Spec::
+
+   [project.entry-points."aiida.tools.calculations"]
+   "mycode.mycode" = "aiida_mycode.tools.calculations:MycodeCalculationTools"
+
+``aiida_mycode/tools/calculations.py``::
+
+   from aiida.tools.calculations import CalculationTools
+
+   class MycodeCalculationTools(CalculationTools):
+      ...
+
+.. _topics:plugins:entrypointgroups:aiida.tools.workflows:
+
+``aiida.tools.workflows``
+-------------------------
+
+.. versionadded:: 2.9
+
+Plugins can ship helper methods for post-processing or analysing ``WorkChainNode`` outputs by registering a :py:class:`~aiida.tools.workflows.base.WorkflowTools` subclass here.
+AiiDA automatically loads the right tools class based on the node's process type, so after loading a node users can call ``node.tools`` to access the plugin-specific helpers.
+The entry point name should match the corresponding ``aiida.workflows`` entry point.
+
+Spec::
+
+   [project.entry-points."aiida.tools.workflows"]
+   "mycode.mywf" = "aiida_mycode.tools.workflows:MyWorkflowTools"
+
+``aiida_mycode/tools/workflows.py``::
+
+   from aiida.tools.workflows import WorkflowTools
+
+   class MyWorkflowTools(WorkflowTools):
+      ...
 
 ``aiida.cmdline``
 -----------------


### PR DESCRIPTION
Document the new `aiida.tools.workflows` entry point group and explain how matching helper classes are exposed through `WorkChainNode.tools`.

Also document the parallel calculation tools entry point group in the plugin entry point overview and plugin development guide for consistency.