### PR TITLE
🧪 Enable memory leak tests on Python 3.14

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,6 +1,7 @@
 name: test-install
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - environment.yml

--- a/tests/engine/test_memory_leaks.py
+++ b/tests/engine/test_memory_leaks.py
@@ -8,8 +8,6 @@
 ###########################################################################
 """Utilities for testing memory leakage."""
 
-import sys
-
 import pytest
 
 from aiida import orm
@@ -44,7 +42,6 @@ def check_memory_leaks():
     assert not process_instances, f'Memory leak: process instances remain in memory: {process_instances}'
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
 @pytest.mark.usefixtures('aiida_profile', 'check_memory_leaks')
 def test_leak_run_process():
     """Test whether running a dummy process leaks memory."""
@@ -52,7 +49,6 @@ def test_leak_run_process():
     run_finished_ok(test_processes.DummyProcess, **inputs)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
 @pytest.mark.usefixtures('aiida_profile', 'check_memory_leaks')
 def test_leak_local_calcjob(aiida_code_installed):
     """Test whether running a local CalcJob leaks memory."""
@@ -64,7 +60,6 @@ def test_leak_local_calcjob(aiida_code_installed):
     run_finished_ok(ArithmeticAddCalculation, **inputs)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Garbage collecting hangs on Python 3.12')
 @pytest.mark.usefixtures('aiida_profile', 'check_memory_leaks')
 def test_leak_ssh_calcjob(aiida_computer_ssh):
     """Test whether running a CalcJob over SSH leaks memory.


### PR DESCRIPTION
Remove the skip markers from the engine memory leak tests. These were added when `pympler.muppy.get_objects` caused the suite to hang on Python 3.12.