### PR TITLE
🧪 Isolate all-entries process control tests

### DIFF
--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -41,10 +41,15 @@ def test_pause_processes(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
-def test_pause_processes_all_entries(submit_and_await):
-    """Test :func:`aiida.engine.processes.control.pause_processes` with ``all_entries=True``."""
+def test_pause_processes_all_entries(submit_and_await, monkeypatch):
+    """Test :func:`aiida.engine.processes.control.pause_processes` with ``all_entries=True``.
+
+    Patch ``get_active_processes`` to keep the test isolated from other concurrently running tests.
+    """
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
     assert not node.paused
+
+    monkeypatch.setattr(control, 'get_active_processes', lambda paused=False, project='*': [node])
 
     control.pause_processes(all_entries=True, timeout=float('inf'))
     assert node.paused
@@ -64,13 +69,18 @@ def test_play_processes(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
-def test_play_processes_all_entries(submit_and_await):
-    """Test :func:`aiida.engine.processes.control.play_processes` with ``all_entries=True``."""
+def test_play_processes_all_entries(submit_and_await, monkeypatch):
+    """Test :func:`aiida.engine.processes.control.play_processes` with ``all_entries=True``.
+
+    Patch ``get_active_processes`` to keep the test isolated from other concurrently running tests.
+    """
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
     assert not node.paused
 
     control.pause_processes([node], timeout=float('inf'))
     assert node.paused
+
+    monkeypatch.setattr(control, 'get_active_processes', lambda paused=False, project='*': [node] if paused else [])
 
     control.play_processes(all_entries=True, timeout=float('inf'))
     assert not node.paused
@@ -88,9 +98,14 @@ def test_kill_processes(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
-def test_kill_processes_all_entries(submit_and_await):
-    """Test :func:`aiida.engine.processes.control.kill_processes` with ``all_entries=True``."""
+def test_kill_processes_all_entries(submit_and_await, monkeypatch):
+    """Test :func:`aiida.engine.processes.control.kill_processes` with ``all_entries=True``.
+
+    Patch ``get_active_processes`` to keep the test isolated from other concurrently running tests.
+    """
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
+
+    monkeypatch.setattr(control, 'get_active_processes', lambda paused=False, project='*': [node])
 
     control.kill_processes(all_entries=True, timeout=float('inf'))
     assert node.is_terminated


### PR DESCRIPTION
I did not have time to look at it. I just make PRs once I see something flaky so I do not forget about it and will review them later. Will mark them as ready when I checked it.

---

I checked the failing GitHub Actions job for PR #7322 https://github.com/aiidateam/aiida-core/actions/runs/24705782159/job/72258651163

- Workflow job: `test minimum reqs (3.10, sqlite)`
- Failing test: `tests/engine/processes/test_control.py::test_play_processes_all_entries`

Failure
```
_______________________ test_play_processes_all_entries ________________________
[gw1] linux -- Python 3.10.20 /home/runner/work/aiida-core/aiida-core/.venv/bin/python3
tests/engine/processes/test_control.py:69: in test_play_processes_all_entries
    node = submit_and_await(WaitProcess, ProcessState.WAITING)
src/aiida/tools/pytest_fixtures/daemon.py:136: in factory
    node = submit(submittable, **kwargs)
src/aiida/engine/launch.py:128: in submit
    process_inited = instantiate_process(runner, process, **inputs)
src/aiida/engine/utils.py:88: in instantiate_process
    process = process_class(runner=runner, inputs=inputs)
.venv/lib/python3.10/site-packages/plumpy/base/state_machine.py:205: in __call__
    inst.transition_to(inst.create_initial_state())
.venv/lib/python3.10/site-packages/plumpy/base/state_machine.py:357: in transition_to
    self.transition_failed(initial_state_label, label, *sys.exc_info()[1:])
.venv/lib/python3.10/site-packages/plumpy/processes.py:1092: in transition_failed
    raise exception.with_traceback(trace)
.venv/lib/python3.10/site-packages/plumpy/base/state_machine.py:343: in transition_to
    self._enter_next_state(new_state)
.venv/lib/python3.10/site-packages/plumpy/base/state_machine.py:414: in _enter_next_state
    self._fire_state_event(StateEventHook.ENTERED_STATE, last_state)
.venv/lib/python3.10/site-packages/plumpy/base/state_machine.py:311: in _fire_state_event
    callback(self, hook, state)
.venv/lib/python3.10/site-packages/plumpy/processes.py:358: in <lambda>
    state_machine.StateEventHook.ENTERED_STATE: lambda _s, _h, from_state: self.on_entered(
src/aiida/engine/processes/process.py:485: in on_entered
    self.node.set_process_state(self._state.LABEL)  # type: ignore[arg-type]
src/aiida/orm/nodes/process/process.py:340: in set_process_state
    return self.base.attributes.set(self.PROCESS_STATE_KEY, state)
src/aiida/orm/nodes/attributes.py:118: in set
    self._node._check_mutability_attributes([key])
src/aiida/orm/utils/mixins.py:218: in _check_mutability_attributes
    raise exceptions.ModificationNotAllowed('attributes of a sealed node are immutable')
E   aiida.common.exceptions.ModificationNotAllowed: attributes of a sealed node are immutable
```

## Failure summary

The failure in CI was:

```text
aiida.common.exceptions.ModificationNotAllowed: attributes of a sealed node are immutable
```

This happened while the test was still trying to submit and initialize a `WaitProcess`.

## Root cause

The `all_entries=True` tests in `tests/engine/processes/test_control.py` were operating on the real global set of active processes.
When the full suite runs with `pytest -n auto`, those tests can interfere with processes created by other tests that are running at the same time.

That makes these tests flaky under parallel execution.

## Implemented fix

I isolated the three `all_entries=True` tests by monkeypatching `control.get_active_processes()` so each test only acts on the process node it created itself:

- `test_pause_processes_all_entries`
- `test_play_processes_all_entries`
- `test_kill_processes_all_entries`

This keeps coverage of the `all_entries=True` code path, but removes cross-test interference from shared daemon/process state.

## Validation

I ran:

```bash
pixi run -e tests-env pytest tests/engine/processes/test_control.py -q
```

and also repeated parallel stress runs:

```bash
for i in $(seq 1 10); do
  pixi run -e tests-env pytest tests/engine/processes/test_control.py -n 4 -q
 done
```

All runs passed.

## Commit

```text
07be04058  🧪 Isolate all-entries control tests
```

## Suggested PR comment

I checked the f ailing minimum-requirements job for PR #7322. The failure was in `tests/engine/processes/test_control.py::test_play_processes_all_entries`, not in the production code changed by the PR.

The issue is that the `all_entries=True` process control tests were querying the real global set of active processes.
Under `pytest -n auto`, that can include processes from other concurrently running tests, causing cross-test interference and flaky failures.

I fixed this by monkeypatching `control.get_active_processes()` in the `all_entries=True` tests so each test only acts on the node it created itself. This preserves coverage of the `all_entries=True` branch while making the tests isolated and stable under parallel execution.
