### PR TITLE
🧪 Stabilize calcjob monitor tests

### DIFF
--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -25,7 +25,7 @@ from aiida.common import CalcJobState, LinkType, StashMode, exceptions
 from aiida.common.datastructures import FileCopyOperation
 from aiida.engine import CalcJob, CalcJobImporter, ExitCode, Process, launch
 from aiida.engine.processes.calcjobs.calcjob import validate_monitors, validate_stash_options
-from aiida.engine.processes.calcjobs.monitors import CalcJobMonitorAction, CalcJobMonitorResult
+from aiida.engine.processes.calcjobs.monitors import CalcJobMonitorAction, CalcJobMonitorResult, CalcJobMonitors
 from aiida.engine.processes.ports import PortNamespace
 from aiida.engine.utils import instantiate_process
 from aiida.plugins import CalculationFactory, ParserFactory
@@ -1298,28 +1298,52 @@ def test_monitor_result_action_disable_all(get_calcjob_builder, entry_points):
 
 
 def monitor_disable_self(node, transport, **kwargs):
-    """Monitor that will disable itself."""
+    """Monitor that will disable itself and record how often it was called."""
+    node.base.extras.set('disable_self_calls', node.base.extras.get('disable_self_calls', 0) + 1)
     return CalcJobMonitorResult(action=CalcJobMonitorAction.DISABLE_SELF, message='Disable self.')
 
 
-@pytest.mark.usefixtures('override_logging')
-def test_monitor_result_action_disable_self(get_calcjob_builder, entry_points, caplog):
+def monitor_record_kill(node, transport, **kwargs):
+    """Monitor that records how often it was called and requests the job to be killed."""
+    node.base.extras.set('record_kill_calls', node.base.extras.get('record_kill_calls', 0) + 1)
+    return CalcJobMonitorResult(message='Kill monitor called.')
+
+
+def test_monitor_result_action_disable_self(entry_points, generate_calcjob_node):
     """Test the ``action`` attr of :class:`aiida.engine.processes.calcjobs.monitors.CalcJobMonitorResult`.
 
-    If set to ``CalcJobMonitorAction.DISABLE_SELF``, the calculation should continue running and the monitor should not
-    be invoked anymore, but any other monitor should continue to be called.
+    If set to ``CalcJobMonitorAction.DISABLE_SELF``, the monitor should be invoked once, disable itself and allow other
+    monitors to continue running.
 
-    The ``override_logging`` fixture is necessary to set the logging level to ``DEBUG`` because the monitor message is
-    logged at the ``INFO`` level and so without this change, it would not be captured.
+    This test processes the same collection of monitors twice. The first pass should return the ``disable_self``
+    monitor. After disabling it, the second pass should skip it and execute the next monitor instead.
     """
     entry_points.add(monitor_disable_self, group='aiida.calculations.monitors', name='core.disable_self')
+    entry_points.add(monitor_record_kill, group='aiida.calculations.monitors', name='core.record_kill')
 
-    builder = get_calcjob_builder()
-    builder.metadata.options.sleep = 1
-    builder.monitors = {'disable_self': orm.Dict({'entry_point': 'core.disable_self'})}
-    _, node = launch.run_get_node(builder)
-    assert node.is_finished_ok
-    assert len([record for record in caplog.records if 'Disable self.' in record.message]) == 1
+    node = generate_calcjob_node()
+    monitors = CalcJobMonitors(
+        {
+            'disable_self': orm.Dict({'entry_point': 'core.disable_self', 'priority': 100}),
+            'record_kill': orm.Dict({'entry_point': 'core.record_kill', 'priority': 0}),
+        }
+    )
+
+    monitor_result = monitors.process(node, None)
+    assert monitor_result is not None
+    assert monitor_result.action == CalcJobMonitorAction.DISABLE_SELF
+    assert monitor_result.key == 'disable_self'
+    assert node.base.extras.get('disable_self_calls') == 1
+    assert 'record_kill_calls' not in node.base.extras.all
+
+    monitors.monitors[monitor_result.key].disabled = True
+
+    monitor_result = monitors.process(node, None)
+    assert monitor_result is not None
+    assert monitor_result.action == CalcJobMonitorAction.KILL
+    assert monitor_result.key == 'record_kill'
+    assert node.base.extras.get('disable_self_calls') == 1
+    assert node.base.extras.get('record_kill_calls') == 1
 
 
 def test_submit_return_exit_code(get_calcjob_builder, monkeypatch):

--- a/tests/engine/processes/calcjobs/test_monitors.py
+++ b/tests/engine/processes/calcjobs/test_monitors.py
@@ -198,7 +198,9 @@ def test_calc_job_monitors_process_poll_interval_integrated(entry_points, aiida_
     builder.x = Int(1)
     builder.y = Int(1)
     builder.monitors = {'always_kill': Dict({'entry_point': 'core.emit_warning', 'minimum_poll_interval': 5})}
-    builder.metadata = {'options': {'sleep': 1, 'resources': {'num_machines': 1}}}
+    # Keep the job running long enough for the monitor to be invoked at least once, but shorter than the monitor
+    # ``minimum_poll_interval`` so that a second invocation is skipped deterministically.
+    builder.metadata = {'options': {'sleep': 3, 'resources': {'num_machines': 1}}}
 
     _, node = run_get_node(builder)
     assert node.is_finished_ok


### PR DESCRIPTION
Need to still review this PR

---

## Summary

Fix flaky CalcJob monitor tests in the presto suite.

The `test_monitor_result_action_disable_self` regression test previously relied on a short-lived `CalcJob` being monitored before the scheduler marked it as finished. On slower or more contended CI workers this could race, causing the monitor to never run and the assertion on captured log records to fail. This change rewrites that test to exercise the `DISABLE_SELF` behavior deterministically by processing the monitor collection twice and asserting that the first monitor disables itself before the next monitor is selected.

The integrated `minimum_poll_interval` monitor test had the same timing sensitivity. It now keeps the job alive long enough for one monitor pass to happen reliably while still remaining shorter than the configured poll interval, so a second invocation is still skipped.

## CI failure reproduced from

- https://github.com/aiidateam/aiida-core/actions/runs/24720548599/job/72308029572?pr=7326

```
tests/engine/processes/calcjobs/test_calc_job.py:1322: in test_monitor_result_action_disable_self
    assert len([record for record in caplog.records if 'Disable self.' in record.message]) == 1
E   assert 0 == 1
E    +  where 0 = len([])
```