### PR TITLE
Fix: Remove glob character escaping for SCP RCP protocol

### DIFF
--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -507,12 +507,16 @@ class _OpenSSH(_AsynchronousSSHBackend):
         Note: escape_for_bash() does NOT work here because scp's RCP protocol
         expects backslash-escaped paths, not quote-wrapped strings.
 
+        Important: We do NOT escape glob characters (*, ?, []) because the RCP
+        protocol passes these to the remote shell for glob expansion. Escaping
+        them would prevent proper file pattern matching.
+
         :param path: The path to escape
         :return: The escaped path with backslashes before special characters
         """
 
         result = []
-        special = set(' \t\n"\'`$\\!#&*?;<>|(){}[]')
+        special = set(' \t\n"\'`$\\!#&;<>|(){}')
         for char in path:
             if char in special:
                 result.append('\\')
@@ -522,11 +526,20 @@ class _OpenSSH(_AsynchronousSSHBackend):
     def _escape_for_scp(self, path: str) -> str:
         """Prepare a path for use in scp commands.
 
-        In OpenSSH < 9.0, scp uses the RCP protocol which passes paths through
-        the remote shell. We must escape shell metacharacters with backslashes
-        to prevent shell expansion/injection.
+        Version-specific behavior:
 
-        OpenSSH 9.0+, however, uses SFTP mode by default - paths are binary data, no shell quoting needed.
+        - OpenSSH 9.0+ (SFTP mode):
+          Uses SFTP protocol where paths are treated as binary data.
+          No escaping needed - glob characters are not expanded.
+          Direct return of the path.
+
+        - OpenSSH < 9.0 (RCP mode):
+          Uses RCP protocol where paths are passed to remote shell.
+          Must escape shell metacharacters to prevent injection,
+          but MUST preserve glob characters (*, ?, []) for proper
+          file pattern matching.
+
+        Version detection is based on `is_openssh_9_or_higher` flag set in __init__.
         """
 
         if self.is_openssh_9_or_higher:

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -502,17 +502,16 @@ class _OpenSSH(_AsynchronousSSHBackend):
         return process.returncode, stdout.decode(), stderr.decode()
 
     def _escape_for_rcp(self, path: str) -> str:
-        """Escape special characters for scp RCP mode using backslashes.
+        """Backslash-escape shell metacharacters for scp's RCP protocol.
 
-        Note: escape_for_bash() does NOT work here because scp's RCP protocol
-        expects backslash-escaped paths, not quote-wrapped strings.
+        Glob characters (``*``, ``?``, ``[``, ``]``) are deliberately left
+        unescaped so the remote shell expands them; the trade-off is that
+        filenames containing literal glob characters cannot be addressed
+        in RCP mode. :func:`escape_for_bash` is unsuitable here because it
+        quote-wraps rather than backslash-escapes.
 
-        Important: We do NOT escape glob characters (*, ?, []) because the RCP
-        protocol passes these to the remote shell for glob expansion. Escaping
-        them would prevent proper file pattern matching.
-
-        :param path: The path to escape
-        :return: The escaped path with backslashes before special characters
+        :param path: The path to escape.
+        :return: The escaped path.
         """
 
         result = []
@@ -526,20 +525,13 @@ class _OpenSSH(_AsynchronousSSHBackend):
     def _escape_for_scp(self, path: str) -> str:
         """Prepare a path for use in scp commands.
 
-        Version-specific behavior:
-
-        - OpenSSH 9.0+ (SFTP mode):
-          Uses SFTP protocol where paths are treated as binary data.
-          No escaping needed - glob characters are not expanded.
-          Direct return of the path.
-
-        - OpenSSH < 9.0 (RCP mode):
-          Uses RCP protocol where paths are passed to remote shell.
-          Must escape shell metacharacters to prevent injection,
-          but MUST preserve glob characters (*, ?, []) for proper
-          file pattern matching.
-
-        Version detection is based on `is_openssh_9_or_higher` flag set in __init__.
+        OpenSSH >= 9.0 uses SFTP mode: paths are sent as binary, no
+        escaping needed. OpenSSH < 9.0 uses RCP mode: paths are interpreted
+        by a shell on both ends (scp itself shells out internally for local
+        paths), so shell metacharacters are backslash-escaped via
+        :meth:`_escape_for_rcp` while glob characters are deliberately
+        preserved for pattern matching. Mode is selected via
+        :attr:`is_openssh_9_or_higher`.
         """
 
         if self.is_openssh_9_or_higher:

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -218,9 +218,11 @@ def test_escape_for_glob_preserves_wildcards_escapes_dangerous_chars():
 
 
 def test_escape_for_rcp():
-    """Test RCP mode escapes shell metacharacters."""
+    """Test RCP mode escapes shell metacharacters but preserves globs."""
     backend = _TestOpenSSH()
     assert backend._escape_for_rcp('/path/with spaces/$VAR;cmd') == '/path/with\\ spaces/\\$VAR\\;cmd'
+    # Glob characters pass through so the remote shell can expand them.
+    assert backend._escape_for_rcp('/dir/*.[ch]') == '/dir/*.[ch]'
 
 
 def test_escape_for_scp_version_aware():


### PR DESCRIPTION
Problem:
- When using OpenSSH < 9.0, scp uses the RCP protocol
- RCP protocol passes paths to remote shell for glob expansion
- Escaping glob characters (*, ?, []) breaks file pattern matching
- This causes SCP to fail with returncode=1 when copying files with glob paths

Solution:
- Remove ALL glob characters from the special character escape set in _escape_for_rcp()
- Glob characters should be passed to remote shell for proper expansion
- All three glob metacharacters are preserved:
  * (asterisk) - matches any sequence of characters ? (question mark) - matches any single character [] (square brackets) - matches character classes/ranges

Changes:
1. Modified _escape_for_rcp() to not escape glob characters (*, ?, [])
2. Updated docstring in _escape_for_rcp() to explain why glob chars are preserved
3. Enhanced docstring in _escape_for_scp() to clearly document version-specific behavior:
   - OpenSSH 9.0+ uses SFTP mode (no escaping needed)
   - OpenSSH < 9.0 uses RCP mode (preserve glob chars for shell expansion)

Testing:
- Verified on OpenSSH 8.9 (Ubuntu 22.04)
- Successfully copies remote files with glob patterns (*.txt, etc.)
- OpenSSH 9.0+ unaffected (uses SFTP protocol)

Compatibility:
- Fully compatible with both OpenSSH < 9.0 and >= 9.0
- Version detection is based on is_openssh_9_or_higher flag