### PR TITLE
✨ Add `verdi bug-report` command

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -32,6 +32,26 @@ Below is a list with all available subcommands.
       version  Print the current version of an archive's schema.
 
 
+.. _reference:command-line:verdi-bug-report:
+
+``verdi bug-report``
+--------------------
+
+.. code:: console
+
+    Usage:  [OPTIONS]
+
+      Create a zip file with diagnostic information for bug reports.
+
+      Bundles profile configuration, service status, and log files into a zip archive that can
+      be attached to a GitHub issue.
+
+    Options:
+      -o, --output PATH  Output zip file path or directory where to put the zip. Defaults to
+                         aiida-bug-report-<timestamp>.zip in current directory.
+      --help             Show this message and exit.
+
+
 .. _reference:command-line:verdi-calcjob:
 
 ``verdi calcjob``

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -6,12 +6,16 @@ import abc
 import typing as t
 from dataclasses import dataclass
 
+JsonPrimitive = str | int | float | bool | None
+JsonValue = JsonPrimitive | list['JsonValue'] | dict[str, 'JsonValue']
+BrokerServiceStatus = dict[str, JsonValue]
+
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
     from aiida.manage.configuration.profile import Profile
 
-# We intentionally do not expose BrokerConfigField to public API, because we might change it later
+# We intentionally do not expose all entities to public API, because we might change it later
 __all__ = ('Broker',)
 
 
@@ -67,6 +71,10 @@ class Broker(abc.ABC):
     @abc.abstractmethod
     def iterate_tasks(self) -> Iterator[t.Any]:
         """Return an iterator over the tasks in the launch queue."""
+
+    @abc.abstractmethod
+    def get_service_status(self) -> BrokerServiceStatus | None:
+        """Return service status information for the broker, if available."""
 
     @abc.abstractmethod
     def close(self) -> None:

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -73,6 +73,10 @@ class Broker(abc.ABC):
         """Return an iterator over the tasks in the launch queue."""
 
     @abc.abstractmethod
+    def is_service_reachable(self) -> bool:
+        """Return whether the broker service is reachable from this client."""
+
+    @abc.abstractmethod
     def get_service_status(self) -> BrokerServiceStatus | None:
         """Return service status information for the broker, if available."""
 

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -7,7 +7,7 @@ import sys
 import typing as t
 from collections.abc import Iterator
 
-from aiida.brokers.broker import Broker, BrokerConfigField
+from aiida.brokers.broker import Broker, BrokerConfigField, BrokerServiceStatus, JsonValue
 from aiida.brokers.rabbitmq import defaults
 from aiida.common.log import AIIDA_LOGGER
 from aiida.manage.configuration import get_config_option
@@ -97,6 +97,14 @@ class RabbitmqBroker(Broker):
             return f'RabbitMQ v{self.get_rabbitmq_version()} @ {url}'
         except ConnectionError:
             return f'RabbitMQ @ {url} <Connection failed>'
+
+    def get_service_status(self) -> BrokerServiceStatus | None:
+        """Return status information reported by the RabbitMQ server."""
+        properties = self.get_communicator().server_properties
+        return {
+            key: t.cast(JsonValue, value.decode('utf-8') if isinstance(value, bytes) else value)
+            for key, value in properties.items()
+        }
 
     def close(self) -> None:
         """Close the broker."""

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -106,7 +106,7 @@ class RabbitmqBroker(Broker):
             for key, value in properties.items()
         }
 
-    def is_service_running(self) -> bool:
+    def is_service_reachable(self) -> bool:
         """Return whether the RabbitMQ service is reachable."""
         had_communicator = self._communicator is not None
 

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -106,6 +106,20 @@ class RabbitmqBroker(Broker):
             for key, value in properties.items()
         }
 
+    def is_service_running(self) -> bool:
+        """Return whether the RabbitMQ service is reachable."""
+        had_communicator = self._communicator is not None
+
+        try:
+            self.get_communicator()
+        except Exception:
+            return False
+        finally:
+            if not had_communicator:
+                self.close()
+
+        return True
+
     def close(self) -> None:
         """Close the broker."""
         if self._communicator is not None:

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -91,10 +91,12 @@ class RabbitmqBroker(Broker):
         self._prefix = f'aiida-{self._profile.uuid}'
 
     def __str__(self) -> str:
+        url = self.get_url(safe=True)
+
         try:
-            return f'RabbitMQ v{self.get_rabbitmq_version()} @ {self.get_url()}'
+            return f'RabbitMQ v{self.get_rabbitmq_version()} @ {url}'
         except ConnectionError:
-            return f'RabbitMQ @ {self.get_url()} <Connection failed>'
+            return f'RabbitMQ @ {url} <Connection failed>'
 
     def close(self) -> None:
         """Close the broker."""
@@ -156,15 +158,38 @@ class RabbitmqBroker(Broker):
 
         return version, True
 
-    def get_url(self) -> str:
-        """Return the RMQ url for this profile."""
+    def get_url(self, safe: bool = False) -> str:
+        """Return the RMQ url for this profile.
+
+        :param safe: If ``True``, redact embedded credentials in the returned URL.
+        """
+        from urllib.parse import urlsplit, urlunsplit
+
         from .utils import get_rmq_url
 
         kwargs = {
             key[7:]: val for key, val in self._profile.process_control_config.items() if key.startswith('broker_')
         }
         additional_kwargs = kwargs.pop('parameters', {})
-        return get_rmq_url(**kwargs, **additional_kwargs)
+        url = get_rmq_url(**kwargs, **additional_kwargs)
+
+        if not safe:
+            return url
+
+        parsed = urlsplit(url)
+
+        if parsed.hostname is None:
+            return url
+
+        netloc = parsed.hostname
+
+        if parsed.username is not None:
+            netloc = f'{parsed.username}:***@{netloc}'
+
+        if parsed.port is not None:
+            netloc = f'{netloc}:{parsed.port}'
+
+        return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
 
     def is_rabbitmq_version_supported(self) -> bool:
         """Return whether the version of RabbitMQ configured for the current profile is supported.

--- a/src/aiida/brokers/rabbitmq/utils.py
+++ b/src/aiida/brokers/rabbitmq/utils.py
@@ -33,15 +33,15 @@ def get_rmq_url(
     :param kwargs: remaining keyword arguments that will be encoded as query parameters.
     :returns: the connection URL string.
     """
-    from urllib.parse import urlencode, urlunparse
+    from urllib.parse import quote, urlencode, urlunparse
 
     if 'heartbeat' not in kwargs:
         kwargs['heartbeat'] = defaults.BROKER_DEFAULTS.heartbeat
 
     scheme = protocol or defaults.BROKER_DEFAULTS.protocol
     netloc = '{username}:{password}@{host}:{port}'.format(
-        username=username or defaults.BROKER_DEFAULTS.username,
-        password=password or defaults.BROKER_DEFAULTS.password,
+        username=quote(username or defaults.BROKER_DEFAULTS.username, safe=''),
+        password=quote(password or defaults.BROKER_DEFAULTS.password, safe=''),
         host=host or defaults.BROKER_DEFAULTS.host,
         port=port or defaults.BROKER_DEFAULTS.port,
     )

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import psutil
 
-from aiida.brokers.broker import Broker, BrokerConfigField
+from aiida.brokers.broker import Broker, BrokerConfigField, BrokerServiceStatus
 from aiida.common.exceptions import ConfigurationError
 from aiida.common.log import AIIDA_LOGGER
 
@@ -138,12 +138,12 @@ class ZeromqBroker(Broker):
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             return False
 
-    def get_service_status(self) -> dict[str, t.Any] | None:
+    def get_service_status(self) -> BrokerServiceStatus | None:
         """Read the ZeromqBrokerService status from its status file."""
         if not self._service_status_file.exists():
             return None
         try:
-            return json.loads(self._service_status_file.read_text())  # type: ignore[no-any-return]
+            return t.cast(BrokerServiceStatus, json.loads(self._service_status_file.read_text()))
         except (json.JSONDecodeError, OSError):
             return None
 

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -76,7 +76,7 @@ class ZeromqBroker(Broker):
         self._storage_path = layout.storage_path
 
     def __str__(self) -> str:
-        if self.is_service_running():
+        if self.is_service_reachable():
             status = self.get_service_status()
             pid = status.get('pid', '?') if status else '?'
             return f'ZeroMQ Broker (PID {pid}) @ {self._service_dir}'
@@ -127,7 +127,7 @@ class ZeromqBroker(Broker):
         except (ValueError, OSError):
             return None
 
-    def is_service_running(self) -> bool:
+    def is_service_reachable(self) -> bool:
         """Check if the ZeromqBrokerService process is running."""
         pid = self._get_service_pid()
         if pid is None:

--- a/src/aiida/cmdline/commands/__init__.py
+++ b/src/aiida/cmdline/commands/__init__.py
@@ -14,6 +14,7 @@ The commands need to be imported here for them to be registered with the top-lev
 
 from aiida.cmdline.commands import (
     cmd_archive,
+    cmd_bug_report,
     cmd_calcjob,
     cmd_code,
     cmd_computer,

--- a/src/aiida/cmdline/commands/cmd_bug_report.py
+++ b/src/aiida/cmdline/commands/cmd_bug_report.py
@@ -1,0 +1,311 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""`verdi bug-report` command."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import platform
+import sys
+import zipfile
+from datetime import datetime
+from typing import Any
+
+import click
+
+from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.utils import echo
+from aiida.common.log import AIIDA_LOGGER
+
+SENSITIVE_KEY_FRAGMENTS = ('password', 'passphrase', 'secret', 'token')
+SENSITIVE_CONFIG_KEYS = ('AIIDADB_PASS',)
+REDACTED_VALUE = '***'
+
+# Maximum number of bytes included per log file; longer logs are truncated to their tail
+MAX_LOG_BYTES = 1024 * 1024
+
+LOGGER = AIIDA_LOGGER.getChild('cmdline.commands.bug_report')
+
+
+def _format_exception(exception: Exception) -> str:
+    """Return a stable string representation for an exception."""
+    return f'{type(exception).__name__}: {exception}'
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return whether the key likely contains a sensitive value."""
+    lowercase = key.lower()
+    return key in SENSITIVE_CONFIG_KEYS or any(fragment in lowercase for fragment in SENSITIVE_KEY_FRAGMENTS)
+
+
+def _redact_sensitive_values(value: Any) -> Any:
+    """Redact values that are likely to contain secrets."""
+    if isinstance(value, dict):
+        redacted = {}
+
+        for key, subvalue in value.items():
+            if _is_sensitive_key(key) and subvalue is not None:
+                redacted[key] = REDACTED_VALUE
+            else:
+                redacted[key] = _redact_sensitive_values(subvalue)
+
+        return redacted
+
+    if isinstance(value, list):
+        return [_redact_sensitive_values(subvalue) for subvalue in value]
+
+    return value
+
+
+def _check_storage() -> dict[str, Any]:
+    """Return storage connection information."""
+    from aiida.manage import get_manager
+
+    manager = get_manager()
+    storage_loaded = manager.profile_storage_loaded
+
+    try:
+        storage = manager.get_profile_storage()
+        status = str(storage)
+        connected = True
+    except Exception as exception:
+        connected = False
+        status = _format_exception(exception)
+    finally:
+        if not storage_loaded:
+            try:
+                manager.reset_profile_storage()
+            except Exception as exception:
+                LOGGER.warning(f'Failed to reset storage while collecting bug report diagnostics: {exception}')
+
+    return {'connected': connected, 'status': status}
+
+
+def _check_broker() -> dict[str, Any]:
+    """Return broker connection information for the current profile."""
+    from aiida.manage import get_manager
+
+    manager = get_manager()
+    # There is no public accessor to determine whether the manager already cached a broker instance. We need to know
+    # this to avoid resetting a broker that was already loaded before running diagnostics, so use the private cache
+    # attribute here and only reset brokers that this check caused to be loaded.
+    broker_loaded = manager._broker is not None
+    status: dict[str, Any] | str | None = None
+
+    try:
+        broker = manager.get_broker()
+
+        if broker is None:
+            return {'connected': False, 'status': 'No broker configured for this profile.'}
+
+        status = broker.get_service_status()
+        connected = status is not None
+    except Exception as exception:
+        connected = False
+        status = _format_exception(exception)
+    finally:
+        if not broker_loaded:
+            try:
+                manager.reset_broker()
+            except Exception as exception:
+                LOGGER.warning(f'Failed to reset broker while collecting bug report diagnostics: {exception}')
+
+    return {'connected': connected, 'status': status}
+
+
+def _check_daemon() -> dict[str, Any]:
+    """Return daemon connection information for the current profile."""
+    from aiida.manage import get_manager
+
+    try:
+        status = get_manager().get_daemon_client().get_status()
+    except Exception as exception:
+        return {'connected': False, 'status': _format_exception(exception)}
+
+    return {'connected': True, 'status': status}
+
+
+def _collect_python_info() -> dict[str, Any]:
+    """Return structured information on the Python interpreter."""
+    return {
+        'version': platform.python_version(),
+        'major': sys.version_info.major,
+        'minor': sys.version_info.minor,
+        'micro': sys.version_info.micro,
+        'implementation': platform.python_implementation(),
+        'compiler': platform.python_compiler(),
+        'build': list(platform.python_build()),
+        'executable': sys.executable,
+    }
+
+
+def _get_config_data() -> dict[str, Any] | None:
+    """Return the contents of the AiiDA configuration file with secrets redacted."""
+    from aiida.manage.configuration import get_config
+    from aiida.manage.configuration.settings import DEFAULT_CONFIG_FILE_NAME
+
+    filepath = pathlib.Path(get_config().dirpath) / DEFAULT_CONFIG_FILE_NAME
+
+    if not filepath.exists():
+        return None
+
+    return _redact_sensitive_values(json.loads(filepath.read_text(encoding='utf-8')))
+
+
+def _collect_diagnostics() -> dict[str, Any]:
+    """Collect structured diagnostic information for the bug report."""
+    import aiida
+    from aiida.manage import get_manager
+
+    manager = get_manager()
+    profile = manager.get_profile()
+
+    services = {
+        'storage': _check_storage(),
+        'broker': _check_broker(),
+        'daemon': _check_daemon(),
+    }
+
+    config = None
+    config_error = None
+
+    try:
+        config = _get_config_data()
+    except Exception as exception:
+        config_error = _format_exception(exception)
+
+    diagnostics = {
+        'generated_at': datetime.now().astimezone().isoformat(),
+        'aiida_version': aiida.__version__,
+        'python': _collect_python_info(),
+        'platform': {
+            'platform': platform.platform(),
+            'system': platform.system(),
+            'release': platform.release(),
+            'machine': platform.machine(),
+        },
+        'profile': {'name': profile.name} if profile is not None else None,
+        'config': config,
+        'services': services,
+    }
+
+    if config_error is not None:
+        diagnostics['config_error'] = config_error
+
+    return diagnostics
+
+
+def _get_log_files() -> list[pathlib.Path]:
+    """Return the log files to include."""
+    from aiida.manage import get_manager
+    from aiida.manage.configuration import get_config
+
+    profile = get_manager().get_profile()
+
+    if profile is None:
+        return []
+
+    filepaths = get_config().filepaths(profile)
+    files = []
+
+    log_filepaths = [
+        filepaths['profile']['log'],
+        filepaths['circus']['log'],
+        filepaths['daemon']['log'],
+        filepaths['zmq_broker_service']['log'],
+    ]
+
+    for log_filepath in log_filepaths:
+        path = pathlib.Path(log_filepath)
+        if path.exists():
+            files.append(path)
+
+    return files
+
+
+def _read_log_tail(filepath: pathlib.Path, max_bytes: int = MAX_LOG_BYTES) -> bytes:
+    """Return the contents of the log file, truncated to the last ``max_bytes`` bytes."""
+    size = filepath.stat().st_size
+
+    with filepath.open('rb') as handle:
+        if size <= max_bytes:
+            return handle.read()
+
+        header = f'... (truncated from {size} bytes)\n'.encode('utf-8')
+
+        if len(header) >= max_bytes:
+            return header[:max_bytes]
+
+        payload_bytes = max_bytes - len(header)
+        handle.seek(size - payload_bytes)
+        data = handle.read(payload_bytes)
+        return header + data.decode('utf-8', errors='ignore').encode('utf-8')
+
+
+@verdi.command('bug-report')
+@click.option(
+    '-o',
+    '--output',
+    type=click.Path(dir_okay=True, file_okay=True, writable=True, path_type=pathlib.Path),
+    default=None,
+    help=(
+        'Output zip file path or directory where to put the zip. Defaults to '
+        'aiida-bug-report-<timestamp>.zip in current directory.'
+    ),
+)
+def verdi_bug_report(output: str | None) -> None:
+    """Create a zip file with diagnostic information for bug reports.
+
+    Bundles profile configuration, service status, and log files into a
+    zip archive that can be attached to a GitHub issue.
+    """
+    if output is None:
+        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S-%f')
+        output = f'aiida-bug-report-{timestamp}.zip'
+
+    output_path = pathlib.Path(output)
+
+    if output_path.exists() and output_path.is_dir():
+        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S-%f')
+        output_path = output_path / f'aiida-bug-report-{timestamp}.zip'
+
+    if output_path.exists():
+        echo.echo_critical(f'Output file `{output_path}` already exists.')
+
+    echo.echo('Collecting diagnostic information...')
+
+    diagnostics = _collect_diagnostics()
+    log_files = _get_log_files()
+
+    contents: list[tuple[str, int]] = []
+
+    try:
+        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr('diagnostics.json', json.dumps(diagnostics, indent=2, sort_keys=True, default=str))
+            for filepath in log_files:
+                data = _read_log_tail(filepath)
+                zf.writestr(filepath.name, data)
+                contents.append((filepath.name, len(data)))
+    except OSError as exception:
+        if output_path.exists():
+            try:
+                output_path.unlink()
+            except OSError:
+                pass
+        echo.echo_critical(f'Failed to write bug report to `{output_path}`: {exception}')
+
+    echo.echo_success(f'Bug report written to: {output_path}')
+    echo.echo_info('Contents:')
+    echo.echo('  diagnostics.json')
+    for archive_name, num_bytes in contents:
+        echo.echo(f'  {archive_name} ({num_bytes} bytes)')
+    echo.echo('')
+    echo.echo('Attach this file to your post at Discourse:')
+    echo.echo('https://aiida.discourse.group')

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -158,7 +158,7 @@ def status(ctx, all_profiles, timeout):
         from aiida.brokers.zeromq.broker import ZeromqBroker
 
         if isinstance(broker, ZeromqBroker):
-            if broker.is_service_running():
+            if broker.is_service_reachable():
                 status_info = broker.get_service_status()
                 if status_info:
                     broker_pid = status_info.get('pid', '?')

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -182,7 +182,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         # Append broker info for managed brokers (e.g., ZeroMQ)
 
         if broker and isinstance(broker, ZeromqBroker):
-            if broker.is_service_running():
+            if broker.is_service_reachable():
                 status_info = broker.get_service_status()
                 if status_info:
                     broker_pid = status_info.get('pid', '?')

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -985,7 +985,7 @@ class DaemonClient:
             except Exception:
                 LOGGER.warning('Could not load the broker instance while preparing daemon watchers.', exc_info=True)
                 broker_instance = None
-            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_service_running():
+            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_service_reachable():
                 # prepare zmq broker service profile directory
                 pathlib.Path(self.zmq_broker_service_dir).mkdir(parents=True, exist_ok=True)
 

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -55,7 +55,7 @@ def test_get_service_status(monkeypatch, manager):
     assert broker.get_service_status() == {'product': 'RabbitMQ', 'version': '3.12.0'}
 
 
-def test_is_service_running(monkeypatch, manager):
+def test_is_service_reachable(monkeypatch, manager):
     """Test RabbitMQ service reachability checks open and close a fresh communicator."""
     broker = manager.get_broker()
     communicator = MagicMock()
@@ -63,11 +63,11 @@ def test_is_service_running(monkeypatch, manager):
     monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
     monkeypatch.setattr(broker, 'close', close)
 
-    assert broker.is_service_running() is True
+    assert broker.is_service_reachable() is True
     close.assert_called_once_with()
 
 
-def test_is_service_running_false(monkeypatch, manager):
+def test_is_service_reachable_false(monkeypatch, manager):
     """Test RabbitMQ service reachability returns false on connection errors."""
     broker = manager.get_broker()
     close = MagicMock()
@@ -78,7 +78,7 @@ def test_is_service_running_false(monkeypatch, manager):
     monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
     monkeypatch.setattr(broker, 'close', close)
 
-    assert broker.is_service_running() is False
+    assert broker.is_service_reachable() is False
     close.assert_called_once_with()
 
 

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -11,6 +11,7 @@
 import logging
 import pathlib
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -133,6 +134,28 @@ def test_get_rmq_url(args, kwargs, expected):
     else:
         with pytest.raises(expected):
             utils.get_rmq_url(*args, **kwargs)
+
+
+def test_get_rmq_url_quotes_credentials():
+    """Test RabbitMQ URLs quote reserved characters in credentials."""
+    url = utils.get_rmq_url(username='user/name', password='pass?word#fragment')
+
+    assert url.startswith('amqp://user%2Fname:pass%3Fword%23fragment@127.0.0.1:5672?')
+
+
+def test_get_url_safe_quotes_then_redacts_credentials():
+    """Test safe broker URLs redact credentials after quoting reserved characters."""
+    profile = SimpleNamespace(
+        uuid='uuid',
+        is_test_profile=False,
+        process_control_config={
+            'broker_username': 'user/name',
+            'broker_password': 'pass?word#fragment',
+        },
+    )
+    broker = RabbitmqBroker(profile)
+
+    assert broker.get_url(safe=True).startswith('amqp://user%2Fname:***@127.0.0.1:5672?')
 
 
 @pytest.mark.parametrize('url', ('amqp://guest:guest@127.0.0.1:5672',))

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -32,10 +32,17 @@ def test_str_method(monkeypatch, manager):
         raise ConnectionError
 
     broker = manager.get_broker()
-    assert 'RabbitMQ v' in str(broker)
+    unsafe_url = broker.get_url()
+    broker_string = str(broker)
+    assert 'RabbitMQ v' in broker_string
+    assert ':***@' in broker_string
+    assert unsafe_url not in broker_string
 
     monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
-    assert 'RabbitMQ @' in str(broker)
+    broker_string = str(broker)
+    assert 'RabbitMQ @' in broker_string
+    assert ':***@' in broker_string
+    assert unsafe_url not in broker_string
 
 
 def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch, caplog):

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -46,6 +46,15 @@ def test_str_method(monkeypatch, manager):
     assert unsafe_url not in broker_string
 
 
+def test_get_service_status(monkeypatch, manager):
+    """Test RabbitMQ service status is derived from server properties."""
+    broker = manager.get_broker()
+    communicator = MagicMock(server_properties={'product': b'RabbitMQ', 'version': '3.12.0'})
+    monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
+
+    assert broker.get_service_status() == {'product': 'RabbitMQ', 'version': '3.12.0'}
+
+
 def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch, caplog):
     """Test `__del__` closes the broker when Python is not finalizing."""
     broker = RabbitmqBroker(aiida_profile)

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -55,6 +55,33 @@ def test_get_service_status(monkeypatch, manager):
     assert broker.get_service_status() == {'product': 'RabbitMQ', 'version': '3.12.0'}
 
 
+def test_is_service_running(monkeypatch, manager):
+    """Test RabbitMQ service reachability checks open and close a fresh communicator."""
+    broker = manager.get_broker()
+    communicator = MagicMock()
+    close = MagicMock()
+    monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
+    monkeypatch.setattr(broker, 'close', close)
+
+    assert broker.is_service_running() is True
+    close.assert_called_once_with()
+
+
+def test_is_service_running_false(monkeypatch, manager):
+    """Test RabbitMQ service reachability returns false on connection errors."""
+    broker = manager.get_broker()
+    close = MagicMock()
+
+    def raise_connection_error():
+        raise ConnectionError
+
+    monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
+    monkeypatch.setattr(broker, 'close', close)
+
+    assert broker.is_service_running() is False
+    close.assert_called_once_with()
+
+
 def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch, caplog):
     """Test `__del__` closes the broker when Python is not finalizing."""
     broker = RabbitmqBroker(aiida_profile)

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -55,7 +55,7 @@ class TestZeromqBrokerStatusQueries:
 
     def test_is_running_no_pid_file(self, zeromq_broker):
         """Test is_running returns False when no PID file exists."""
-        assert not zeromq_broker.is_service_running()
+        assert not zeromq_broker.is_service_reachable()
 
     def test_get_service_status_no_file(self, zeromq_broker):
         """Test get_service_status returns None when no status file exists."""
@@ -86,7 +86,7 @@ class TestZeromqBrokerStatusQueries:
         pid_file.write_text('aiida-zeromq-broker 12345')
 
         with patch('aiida.brokers.zeromq.broker.psutil.Process', side_effect=psutil.NoSuchProcess(pid=12345)):
-            assert not zeromq_broker.is_service_running()
+            assert not zeromq_broker.is_service_reachable()
 
     def test_get_service_status_valid(self, zeromq_broker):
         """Test get_service_status with valid JSON."""
@@ -224,7 +224,7 @@ class TestZeromqBrokerIntegration:
 
     def test_broker_lifecycle(self, zeromq_broker_with_server):
         """Test the zeromq_broker lifecycle."""
-        assert zeromq_broker_with_server.is_service_running()
+        assert zeromq_broker_with_server.is_service_reachable()
 
         status = zeromq_broker_with_server.get_service_status()
         assert status is not None

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -1,0 +1,475 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for ``verdi bug-report``."""
+
+import json
+import pathlib
+import sys
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+import aiida
+from aiida.brokers.zeromq.broker import ZeromqBroker
+from aiida.cmdline.commands import cmd_bug_report
+
+
+class DummyStorageBackend:
+    """Dummy storage backend."""
+
+    def __init__(self, _profile):
+        self.closed = False
+
+    def __str__(self):
+        return 'DummyStorageBackend'
+
+    def close(self):
+        self.closed = True
+
+
+class DummyBroker:
+    """Dummy broker."""
+
+    def __init__(self):
+        self.closed = False
+
+    def get_communicator(self):
+        return object()
+
+    def get_service_status(self):
+        return {'product': 'RabbitMQ', 'version': '3.12.0'}
+
+    def close(self):
+        self.closed = True
+
+
+class BrokenStorageBackend:
+    """Broken storage backend."""
+
+    def __init__(self, _profile):
+        raise RuntimeError('storage unavailable')
+
+
+class BrokenStorageStringBackend(DummyStorageBackend):
+    """Storage backend whose string conversion fails."""
+
+    def __str__(self):
+        raise RuntimeError('storage string unavailable')
+
+
+class BrokenStorageCloseBackend(DummyStorageBackend):
+    """Storage backend whose close operation fails."""
+
+    def close(self):
+        raise RuntimeError('storage close unavailable')
+
+
+def _make_zeromq_broker(service_dir: pathlib.Path, is_running: bool, status: dict | None) -> ZeromqBroker:
+    """Create a ``ZeromqBroker`` instance without invoking its constructor."""
+    broker = ZeromqBroker.__new__(ZeromqBroker)
+    broker._service_dir = service_dir
+    broker.is_service_running = lambda: is_running
+    broker.get_service_status = lambda: status
+    return broker
+
+
+def _patch_manager(monkeypatch, profile, broker, get_daemon_client):
+    """Patch the global manager used by ``cmd_bug_report``."""
+    manager = SimpleNamespace(
+        _broker=None,
+        profile_storage_loaded=False,
+        get_profile=lambda: profile,
+        get_profile_storage=lambda: profile.storage_cls(profile),
+        reset_profile_storage=lambda: None,
+        get_broker=lambda: broker,
+        reset_broker=lambda: None,
+        get_daemon_client=get_daemon_client,
+    )
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+
+def _get_daemon_client_ok():
+    """Return a daemon client with a running daemon status."""
+    return SimpleNamespace(get_status=lambda: {'pid': 1234})
+
+
+def _get_daemon_client_error():
+    """Raise an error for an unavailable daemon client."""
+    raise RuntimeError('daemon unavailable')
+
+
+def _make_filepaths(dirpath: pathlib.Path) -> dict:
+    """Return a profile filepaths dictionary rooted in the given directory."""
+    return {
+        'profile': {'log': str(dirpath / 'profile.log')},
+        'daemon': {'log': str(dirpath / 'daemon.log')},
+        'circus': {'log': str(dirpath / 'circus.log')},
+        'zmq_broker_service': {'dir': str(dirpath / 'broker'), 'log': str(dirpath / 'broker' / 'broker.log')},
+    }
+
+
+def _patch_config(monkeypatch, dirpath):
+    """Patch the global config used by ``cmd_bug_report``."""
+    monkeypatch.setattr(
+        'aiida.manage.configuration.get_config',
+        lambda: SimpleNamespace(
+            dirpath=str(dirpath),
+            filepaths=lambda _profile: _make_filepaths(dirpath),
+        ),
+    )
+
+
+def test_collect_diagnostics(monkeypatch, tmp_path):
+    """Test ``_collect_diagnostics`` returns structured JSON-serializable data."""
+    profile = SimpleNamespace(name='default', storage_cls=DummyStorageBackend)
+    config_data = {
+        'profiles': {
+            'default': {
+                'storage': {'backend': 'core.sqlite_dos', 'config': {'database_password': 'secret'}},
+                'process_control': {'config': {'broker_password': 'guest'}},
+                'AIIDADB_PASS': 'legacy-secret',
+            }
+        }
+    }
+    (tmp_path / 'config.json').write_text(json.dumps(config_data), encoding='utf-8')
+
+    monkeypatch.setattr(aiida, '__version__', '1.2.3')
+    _patch_manager(monkeypatch, profile, DummyBroker(), _get_daemon_client_ok)
+    _patch_config(monkeypatch, tmp_path)
+
+    diagnostics = cmd_bug_report._collect_diagnostics()
+
+    assert diagnostics['aiida_version'] == '1.2.3'
+    assert diagnostics['profile'] == {'name': 'default'}
+    assert diagnostics['config']['profiles']['default']['storage']['config']['database_password'] == '***'
+    assert diagnostics['config']['profiles']['default']['process_control']['config']['broker_password'] == '***'
+    assert diagnostics['config']['profiles']['default']['AIIDADB_PASS'] == '***'
+    assert {key: diagnostics['python'][key] for key in ('major', 'minor', 'micro')} == {
+        'major': sys.version_info.major,
+        'minor': sys.version_info.minor,
+        'micro': sys.version_info.micro,
+    }
+    for key in ('version', 'implementation', 'compiler', 'executable'):
+        assert diagnostics['python'][key]
+    assert isinstance(diagnostics['python']['build'], list)
+
+
+@pytest.mark.parametrize(
+    ('storage_cls', 'broker_cls', 'get_daemon_client', 'expected_services'),
+    [
+        pytest.param(
+            DummyStorageBackend,
+            DummyBroker,
+            _get_daemon_client_ok,
+            {
+                'storage': {'connected': True, 'status': 'DummyStorageBackend'},
+                'broker': {'connected': True, 'status': {'product': 'RabbitMQ', 'version': '3.12.0'}},
+                'daemon': {'connected': True, 'status': {'pid': 1234}},
+            },
+            id='connected',
+        ),
+        pytest.param(
+            BrokenStorageBackend,
+            None,
+            _get_daemon_client_error,
+            {
+                'storage': {'connected': False, 'status': 'RuntimeError: storage unavailable'},
+                'broker': {'connected': False, 'status': 'No broker configured for this profile.'},
+                'daemon': {'connected': False, 'status': 'RuntimeError: daemon unavailable'},
+            },
+            id='not-connected',
+        ),
+    ],
+)
+def test_collect_diagnostics_services(
+    monkeypatch, tmp_path, storage_cls, broker_cls, get_daemon_client, expected_services
+):
+    """Test ``_collect_diagnostics`` reports service connection information."""
+    profile = SimpleNamespace(name='default', dictionary={}, storage_cls=storage_cls)
+    broker = broker_cls() if broker_cls is not None else None
+    (tmp_path / 'config.json').write_text('{}', encoding='utf-8')
+    _patch_manager(monkeypatch, profile, broker, get_daemon_client)
+    _patch_config(monkeypatch, tmp_path)
+
+    diagnostics = cmd_bug_report._collect_diagnostics()
+
+    assert diagnostics['services'] == expected_services
+
+
+@pytest.mark.parametrize(
+    ('is_running', 'status'),
+    [
+        (True, {'pid': 4321, 'pending_tasks': 0}),
+        (False, None),
+    ],
+)
+def test_check_broker_zeromq_status(monkeypatch, tmp_path, is_running, status):
+    """Test ``_check_broker`` reports the ZeroMQ broker service status payload."""
+    broker = _make_zeromq_broker(tmp_path, is_running=is_running, status=status)
+    manager = SimpleNamespace(_broker=None, get_broker=lambda: broker, reset_broker=lambda: None)
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    result = cmd_bug_report._check_broker()
+
+    assert result['connected'] is (status is not None)
+    assert result['status'] == status
+
+
+def test_get_config_data(monkeypatch, tmp_path):
+    """Test ``_get_config_data`` returns the contents of ``config.json`` with secrets redacted."""
+    config_data = {
+        'profiles': {
+            'default': {
+                'test_profile': False,
+                'storage': {'config': {'database_password': 'secret'}},
+                'process_control': {'config': {'broker_password': 'guest'}},
+                'AIIDADB_PASS': 'legacy-secret',
+            }
+        }
+    }
+    (tmp_path / 'config.json').write_text(json.dumps(config_data), encoding='utf-8')
+
+    _patch_config(monkeypatch, tmp_path)
+
+    assert cmd_bug_report._get_config_data() == {
+        'profiles': {
+            'default': {
+                'test_profile': False,
+                'storage': {'config': {'database_password': '***'}},
+                'process_control': {'config': {'broker_password': '***'}},
+                'AIIDADB_PASS': '***',
+            }
+        }
+    }
+
+
+def test_collect_diagnostics_invalid_config(monkeypatch, tmp_path):
+    """Test invalid config data does not abort diagnostics collection."""
+    profile = SimpleNamespace(name='default', storage_cls=DummyStorageBackend)
+    (tmp_path / 'config.json').write_bytes(b'\x80')
+
+    _patch_manager(monkeypatch, profile, DummyBroker(), _get_daemon_client_ok)
+    _patch_config(monkeypatch, tmp_path)
+
+    diagnostics = cmd_bug_report._collect_diagnostics()
+
+    assert diagnostics['config'] is None
+    assert (
+        diagnostics['config_error']
+        == "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte"
+    )
+
+
+def test_get_log_files(monkeypatch, tmp_path):
+    """Test ``_get_log_files`` returns the existing log files from the profile filepaths."""
+    profile_log = tmp_path / 'profile.log'
+    profile_log.write_text('profile', encoding='utf-8')
+
+    daemon_log = tmp_path / 'daemon.log'
+    daemon_log.write_text('daemon', encoding='utf-8')
+
+    circus_log = tmp_path / 'circus.log'
+    circus_log.write_text('circus', encoding='utf-8')
+
+    broker_log = tmp_path / 'broker' / 'broker.log'
+    broker_log.parent.mkdir()
+    broker_log.write_text('broker', encoding='utf-8')
+
+    profile = SimpleNamespace(name='default')
+    manager = SimpleNamespace(get_profile=lambda: profile)
+
+    _patch_config(monkeypatch, tmp_path)
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    assert cmd_bug_report._get_log_files() == [profile_log, circus_log, daemon_log, broker_log]
+
+
+def test_get_log_files_skips_missing(monkeypatch, tmp_path):
+    """Test ``_get_log_files`` skips log files that do not exist."""
+    daemon_log = tmp_path / 'daemon.log'
+    daemon_log.write_text('daemon', encoding='utf-8')
+
+    profile = SimpleNamespace(name='default')
+    manager = SimpleNamespace(get_profile=lambda: profile)
+
+    _patch_config(monkeypatch, tmp_path)
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    assert cmd_bug_report._get_log_files() == [daemon_log]
+
+
+def test_read_log_tail(tmp_path):
+    """Test ``_read_log_tail`` truncates long log files to their tail."""
+    log_file = tmp_path / 'test.log'
+    log_file.write_bytes(b'a' * 10 + b'b' * 30)
+
+    assert cmd_bug_report._read_log_tail(log_file, max_bytes=100) == b'a' * 10 + b'b' * 30
+
+    truncated = cmd_bug_report._read_log_tail(log_file, max_bytes=35)
+    assert truncated == b'... (truncated from 40 bytes)\n' + b'b' * 5
+    assert len(truncated) <= 35
+
+
+def test_read_log_tail_handles_partial_utf8(tmp_path):
+    """Test ``_read_log_tail`` drops incomplete UTF-8 bytes at the truncation boundary."""
+    log_file = tmp_path / 'test.log'
+    log_file.write_bytes(b'a' * 30 + '🙂'.encode('utf-8') + b'b' * 2)
+
+    truncated = cmd_bug_report._read_log_tail(log_file, max_bytes=34)
+
+    assert truncated == b'... (truncated from 36 bytes)\n' + b'b' * 2
+
+
+def test_check_storage_failure_after_instantiation(monkeypatch):
+    """Test storage string conversion failures are reported instead of escaping."""
+    profile = SimpleNamespace(storage_cls=BrokenStorageStringBackend)
+
+    def reset_profile_storage():
+        return None
+
+    manager = SimpleNamespace(
+        profile_storage_loaded=False,
+        get_profile_storage=lambda: profile.storage_cls(profile),
+        reset_profile_storage=reset_profile_storage,
+    )
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    assert cmd_bug_report._check_storage() == {
+        'connected': False,
+        'status': 'RuntimeError: storage string unavailable',
+    }
+
+
+def test_check_storage_close_failure_is_logged(monkeypatch, caplog):
+    """Test storage reset failures are logged without changing the connection result."""
+    profile = SimpleNamespace(storage_cls=DummyStorageBackend)
+    manager = SimpleNamespace(
+        profile_storage_loaded=False,
+        get_profile_storage=lambda: profile.storage_cls(profile),
+        reset_profile_storage=lambda: (_ for _ in ()).throw(RuntimeError('storage close unavailable')),
+    )
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    result = cmd_bug_report._check_storage()
+
+    assert result == {'connected': True, 'status': 'DummyStorageBackend'}
+    assert 'Failed to reset storage while collecting bug report diagnostics' in caplog.text
+
+
+def test_check_broker_reset_failure_is_logged(monkeypatch, caplog):
+    """Test broker reset failures are logged without changing the connection result."""
+    broker = DummyBroker()
+    manager = SimpleNamespace(
+        _broker=None,
+        get_broker=lambda: broker,
+        reset_broker=lambda: (_ for _ in ()).throw(RuntimeError('broker close unavailable')),
+    )
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    result = cmd_bug_report._check_broker()
+
+    assert result == {'connected': True, 'status': {'product': 'RabbitMQ', 'version': '3.12.0'}}
+    assert 'Failed to reset broker while collecting bug report diagnostics' in caplog.text
+
+
+def test_check_broker_does_not_reset_preloaded_broker(monkeypatch):
+    """Test preloaded broker is not reset by the diagnostics check."""
+    broker = DummyBroker()
+    reset_called = False
+
+    def reset_broker():
+        nonlocal reset_called
+        reset_called = True
+
+    manager = SimpleNamespace(_broker=broker, get_broker=lambda: broker, reset_broker=reset_broker)
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    result = cmd_bug_report._check_broker()
+
+    assert result == {'connected': True, 'status': {'product': 'RabbitMQ', 'version': '3.12.0'}}
+    assert reset_called is False
+    assert broker.closed is False
+
+
+def test_check_storage_does_not_reset_preloaded_storage(monkeypatch):
+    """Test preloaded storage is not reset by the diagnostics check."""
+    storage = DummyStorageBackend(None)
+    reset_called = False
+
+    def reset_profile_storage():
+        nonlocal reset_called
+        reset_called = True
+
+    manager = SimpleNamespace(
+        profile_storage_loaded=True,
+        get_profile_storage=lambda: storage,
+        reset_profile_storage=reset_profile_storage,
+    )
+    monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
+
+    result = cmd_bug_report._check_storage()
+
+    assert result == {'connected': True, 'status': 'DummyStorageBackend'}
+    assert reset_called is False
+    assert storage.closed is False
+
+
+def test_bug_report_command(run_cli_command, tmp_path):
+    """Test the ``verdi bug-report`` command creates a zip file with diagnostics."""
+    output = tmp_path / 'report.zip'
+    result = run_cli_command(cmd_bug_report.verdi_bug_report, ['-o', str(output)], use_subprocess=False)
+
+    assert output.exists()
+    assert 'Bug report written to' in result.output
+
+    with zipfile.ZipFile(output) as zf:
+        assert 'diagnostics.json' in zf.namelist()
+        diagnostics = json.loads(zf.read('diagnostics.json'))
+
+    assert diagnostics['aiida_version'] == aiida.__version__
+    assert diagnostics['profile'] is not None
+    assert diagnostics['services']['storage']['connected'] is True
+
+
+def test_bug_report_command_default_output(run_cli_command, monkeypatch, tmp_path):
+    """Test ``verdi bug-report`` uses a timestamped default output filename."""
+    monkeypatch.chdir(tmp_path)
+
+    result = run_cli_command(cmd_bug_report.verdi_bug_report, use_subprocess=False)
+
+    output_files = list(tmp_path.glob('aiida-bug-report-*.zip'))
+
+    assert len(output_files) == 1
+    assert output_files[0].name != 'aiida-bug-report-{timestamp}.zip'
+    assert 'Bug report written to' in result.output
+
+
+def test_bug_report_command_output_directory(run_cli_command, tmp_path):
+    """Test ``verdi bug-report`` writes into a target output directory."""
+    output_directory = tmp_path / 'reports'
+    output_directory.mkdir()
+
+    result = run_cli_command(cmd_bug_report.verdi_bug_report, ['-o', str(output_directory)], use_subprocess=False)
+
+    output_files = list(output_directory.glob('aiida-bug-report-*.zip'))
+
+    assert len(output_files) == 1
+    assert 'Bug report written to' in result.output
+
+
+def test_bug_report_command_rejects_existing_output(run_cli_command, tmp_path):
+    """Test ``verdi bug-report`` fails rather than overwriting an existing archive."""
+    output = tmp_path / 'report.zip'
+    output.write_text('existing', encoding='utf-8')
+
+    result = run_cli_command(cmd_bug_report.verdi_bug_report, ['-o', str(output)], raises=True, use_subprocess=False)
+
+    assert 'already exists' in result.output
+    assert output.read_text(encoding='utf-8') == 'existing'

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -75,7 +75,7 @@ def _make_zeromq_broker(service_dir: pathlib.Path, is_running: bool, status: dic
     """Create a ``ZeromqBroker`` instance without invoking its constructor."""
     broker = ZeromqBroker.__new__(ZeromqBroker)
     broker._service_dir = service_dir
-    broker.is_service_running = lambda: is_running
+    broker.is_service_reachable = lambda: is_running
     broker.get_service_status = lambda: status
     return broker
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def zeromq_broker(tmp_path):
 @contextmanager
 def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0):
     """Run a ZeroMQ broker service subprocess for the duration of a context."""
-    if zeromq_broker.is_service_running():
+    if zeromq_broker.is_service_reachable():
         raise ValueError('Broker server already running')
 
     zeromq_broker.service_dir.mkdir(parents=True, exist_ok=True)
@@ -122,7 +122,7 @@ def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0
             if process.poll() is not None:
                 msg = f'ZeroMQ broker exited before becoming ready with code {process.returncode}'
                 raise RuntimeError(msg)
-            if zeromq_broker.is_service_running():
+            if zeromq_broker.is_service_reachable():
                 break
             time.sleep(0.1)
         else:


### PR DESCRIPTION
Bundle diagnostic information for bug reports, including AiiDA and Python versions, platform details, profile configuration, service status for storage, broker, and daemon, and the tails of the daemon and circus log files. The command `verdi bug-report` creates a zip with logfiles (daemon, broker, client)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `verdi bug-report` to create diagnostic ZIP archives containing system details, service status, redacted configuration data, and relevant logs.
  * Broker status checks now report service reachability and provide additional service information.
  * Broker URLs displayed in status information now conceal embedded credentials.

* **Documentation**
  * Added command-line reference documentation for `verdi bug-report`, including output options and usage details.

* **Bug Fixes**
  * Improved daemon and status reporting to accurately reflect broker connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->