### PR TITLE
🐛 Fix flaky `test_fallback_calculation_tools_on_loading_error`

### DIFF
--- a/tests/tools/calculations/test_base.py
+++ b/tests/tools/calculations/test_base.py
@@ -65,12 +65,14 @@ def test_fallback_calculation_tools_on_loading_error(monkeypatch, generate_calcj
     """Test fallback tools when the calculation tools entry point fails to load."""
     from aiida.plugins import entry_point as entry_point_module
 
+    # Create the node before monkeypatching, otherwise the patch also breaks
+    # ``StorageFactory`` which calls ``load_entry_point`` during node creation.
+    node = generate_calcjob_node(entry_point=f'aiida.calculations:{CALCULATION_ENTRY_POINT_NAME}')
+
     def raise_loading_entry_point_error(*_, **__):
         raise LoadingEntryPointError('broken tools entry point')
 
     monkeypatch.setattr(entry_point_module, 'load_entry_point', raise_loading_entry_point_error)
-
-    node = generate_calcjob_node(entry_point=f'aiida.calculations:{CALCULATION_ENTRY_POINT_NAME}')
 
     assert isinstance(node.tools, CalculationTools)
     assert f'could not load the calculation tools entry point {CALCULATION_ENTRY_POINT_NAME}' in caplog.text


### PR DESCRIPTION
Create the node before monkeypatching `load_entry_point`, otherwise the patch also breaks `StorageFactory` during node creation when the storage is not yet cached.

Stumbled on this in CI run https://github.com/aiidateam/aiida-core/actions/runs/24989801388/job/73172225190?pr=7284
```
tests/tools/calculations/test_base.py F

_______________ test_fallback_calculation_tools_on_loading_error _______________
[gw1] linux -- Python 3.10.20 /home/runner/work/aiida-core/aiida-core/.venv/bin/python3
tests/tools/calculations/test_base.py:73: in test_fallback_calculation_tools_on_loading_error
    node = generate_calcjob_node(entry_point=f'aiida.calculations:{CALCULATION_ENTRY_POINT_NAME}')
tests/conftest.py:383: in _generate_calcjob_node
    calcjob_node = CalcJobNode(process_type=entry_point)
src/aiida/orm/nodes/node.py:295: in __init__
    backend = backend or get_manager().get_profile_storage()
src/aiida/manage/manager.py:339: in get_profile_storage
    storage_cls = profile.storage_cls
src/aiida/manage/configuration/profile.py:124: in storage_cls
    return StorageFactory(self.storage_backend)
src/aiida/plugins/factories.py:400: in StorageFactory
    entry_point = BaseFactory(entry_point_group, entry_point_name, load=load)
src/aiida/plugins/factories.py:75: in BaseFactory
    return load_entry_point(group, name)
tests/tools/calculations/test_base.py:69: in raise_loading_entry_point_error
    raise LoadingEntryPointError('broken tools entry point')
E   aiida.common.exceptions.LoadingEntryPointError: broken tools entry point
```