### PR TITLE
🐛 Fix RabbitMQ probe cleanup on Python 3.14

### DIFF
--- a/src/aiida/brokers/rabbitmq/defaults.py
+++ b/src/aiida/brokers/rabbitmq/defaults.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import typing as t
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 
 from aio_pika.connection import make_url
 from aio_pika.robust_connection import RobustConnection
@@ -32,6 +33,21 @@ BROKER_DEFAULTS = AttributeDict(
 )
 
 
+@contextmanager
+def _suppress_rabbitmq_probe_logging() -> t.Iterator[None]:
+    """Suppress expected RabbitMQ probe logs for missing brokers."""
+    logger_names = ('aiormq.connection', 'aio_pika.robust_connection')
+    levels = {name: logging.getLogger(name).level for name in logger_names}
+
+    try:
+        for name in logger_names:
+            logging.getLogger(name).setLevel(logging.CRITICAL + 1)
+        yield
+    finally:
+        for name, level in levels.items():
+            logging.getLogger(name).setLevel(level)
+
+
 def _probe_rabbitmq_connection(connection_params: dict[str, t.Any]) -> None:
     """Validate RabbitMQ connection parameters in an isolated event loop."""
 
@@ -54,7 +70,8 @@ def _probe_rabbitmq_connection(connection_params: dict[str, t.Any]) -> None:
             with suppress(Exception):
                 await connection.close()
 
-    asyncio.run(connect())
+    with _suppress_rabbitmq_probe_logging():
+        asyncio.run(connect())
 
 
 def detect_rabbitmq_config(

--- a/src/aiida/brokers/rabbitmq/defaults.py
+++ b/src/aiida/brokers/rabbitmq/defaults.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import typing as t
+from contextlib import suppress
+
+from aio_pika.connection import make_url
+from aio_pika.robust_connection import RobustConnection
 
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.log import AIIDA_LOGGER
@@ -27,6 +32,31 @@ BROKER_DEFAULTS = AttributeDict(
 )
 
 
+def _probe_rabbitmq_connection(connection_params: dict[str, t.Any]) -> None:
+    """Validate RabbitMQ connection parameters in an isolated event loop."""
+
+    async def connect() -> None:
+        connection = RobustConnection(
+            make_url(
+                host=connection_params['host'],
+                port=connection_params['port'],
+                login=connection_params['username'],
+                password=connection_params['password'],
+                virtualhost=connection_params['virtual_host'],
+                ssl=connection_params['protocol'] == 'amqps',
+            ),
+            loop=asyncio.get_running_loop(),
+        )
+
+        try:
+            await connection.connect()
+        finally:
+            with suppress(Exception):
+                await connection.close()
+
+    asyncio.run(connect())
+
+
 def detect_rabbitmq_config(
     protocol: str | None = None,
     username: str | None = None,
@@ -38,10 +68,8 @@ def detect_rabbitmq_config(
     """Try to connect to a RabbitMQ server with the default connection parameters.
 
     :raises ConnectionError: If the connection failed with the provided connection parameters
-    :returns: The connection parameters if the RabbitMQ server was successfully connected to, or ``None`` otherwise.
+    :returns: The connection parameters with keys prefixed with ``broker_``.
     """
-    from kiwipy.rmq.threadcomms import connect
-
     connection_params = {
         'protocol': protocol or os.getenv('AIIDA_BROKER_PROTOCOL', BROKER_DEFAULTS['protocol']),
         'username': username or os.getenv('AIIDA_BROKER_USERNAME', BROKER_DEFAULTS['username']),
@@ -54,9 +82,10 @@ def detect_rabbitmq_config(
     LOGGER.info(f'Attempting to connect to RabbitMQ with parameters: {connection_params}')
 
     try:
-        connect(connection_params=connection_params)
-    except ConnectionError:
-        raise ConnectionError(f'Failed to connect with following connection parameters: {connection_params}')
+        _probe_rabbitmq_connection(connection_params)
+    except Exception as exception:
+        msg = f'Failed to connect with following connection parameters: {connection_params}'
+        raise ConnectionError(msg) from exception
 
     # The profile configuration expects the keys of the broker config to be prefixed with ``broker_``.
     return {f'broker_{key}': value for key, value in connection_params.items()}

--- a/src/aiida/brokers/rabbitmq/defaults.py
+++ b/src/aiida/brokers/rabbitmq/defaults.py
@@ -8,9 +8,6 @@ import os
 import typing as t
 from contextlib import contextmanager, suppress
 
-from aio_pika.connection import make_url
-from aio_pika.robust_connection import RobustConnection
-
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.log import AIIDA_LOGGER
 
@@ -50,6 +47,8 @@ def _suppress_rabbitmq_probe_logging() -> t.Iterator[None]:
 
 def _probe_rabbitmq_connection(connection_params: dict[str, t.Any]) -> None:
     """Validate RabbitMQ connection parameters in an isolated event loop."""
+    from aio_pika.connection import make_url
+    from aio_pika.robust_connection import RobustConnection
 
     async def connect() -> None:
         connection = RobustConnection(

--- a/tests/brokers/test_rabbitmq_defaults.py
+++ b/tests/brokers/test_rabbitmq_defaults.py
@@ -67,6 +67,7 @@ def test_detect_rabbitmq_config_failed_probe_does_not_emit_cleanup_warning():
     result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, check=False)
 
     assert result.returncode == 0, result.stderr
+    assert 'error when creating transport' not in result.stderr
     assert 'Exception ignored while calling deallocator' not in result.stderr
     assert "coroutine 'RobustConnection.close' was never awaited" not in result.stderr
 

--- a/tests/brokers/test_rabbitmq_defaults.py
+++ b/tests/brokers/test_rabbitmq_defaults.py
@@ -90,8 +90,8 @@ def test_probe_rabbitmq_connection_closes_connection_on_failure(monkeypatch):
         async def close(self):
             self.closed = True
 
-    monkeypatch.setattr(defaults, 'make_url', lambda **kwargs: kwargs)
-    monkeypatch.setattr(defaults, 'RobustConnection', DummyConnection)
+    monkeypatch.setattr('aio_pika.connection.make_url', lambda **kwargs: kwargs)
+    monkeypatch.setattr('aio_pika.robust_connection.RobustConnection', DummyConnection)
 
     with pytest.raises(RuntimeError, match='failed to connect'):
         defaults._probe_rabbitmq_connection(

--- a/tests/brokers/test_rabbitmq_defaults.py
+++ b/tests/brokers/test_rabbitmq_defaults.py
@@ -1,0 +1,108 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for :mod:`aiida.brokers.rabbitmq.defaults`."""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from aiida.brokers.rabbitmq import defaults
+
+
+@pytest.fixture
+def connection_params():
+    """Return RabbitMQ connection parameters for tests."""
+    return {
+        'protocol': 'amqps',
+        'username': 'user',
+        'password': 'password',
+        'host': 'host',
+        'port': 1234,
+        'virtual_host': 'virtual-host',
+    }
+
+
+def test_detect_rabbitmq_config(monkeypatch, connection_params):
+    """Test ``detect_rabbitmq_config`` returns the broker configuration on success."""
+    captured = {}
+    monkeypatch.setattr(defaults, '_probe_rabbitmq_connection', lambda params: captured.setdefault('params', params))
+
+    result = defaults.detect_rabbitmq_config(**connection_params)
+
+    assert captured['params'] == connection_params
+    assert result == {f'broker_{key}': value for key, value in connection_params.items()}
+
+
+def test_detect_rabbitmq_config_raises_connection_error(monkeypatch):
+    """Test ``detect_rabbitmq_config`` raises ``ConnectionError`` on failure."""
+
+    def probe(_):
+        raise RuntimeError('failed to connect')
+
+    monkeypatch.setattr(defaults, '_probe_rabbitmq_connection', probe)
+
+    with pytest.raises(ConnectionError, match='Failed to connect with following connection parameters'):
+        defaults.detect_rabbitmq_config()
+
+
+def test_detect_rabbitmq_config_failed_probe_does_not_emit_cleanup_warning():
+    """Test failed probes do not emit asyncio cleanup warnings on interpreter shutdown."""
+    code = textwrap.dedent("""
+        from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
+
+        try:
+            detect_rabbitmq_config(host='127.0.0.1', port=1)
+        except ConnectionError:
+            pass
+        """)
+
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert 'Exception ignored while calling deallocator' not in result.stderr
+    assert "coroutine 'RobustConnection.close' was never awaited" not in result.stderr
+
+
+def test_probe_rabbitmq_connection_closes_connection_on_failure(monkeypatch):
+    """Test ``_probe_rabbitmq_connection`` closes the connection if connecting fails."""
+    connection = None
+
+    class DummyConnection:
+        def __init__(self, url, loop):
+            nonlocal connection
+            self.url = url
+            self.loop = loop
+            self.closed = False
+            connection = self
+
+        async def connect(self):
+            raise RuntimeError('failed to connect')
+
+        async def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(defaults, 'make_url', lambda **kwargs: kwargs)
+    monkeypatch.setattr(defaults, 'RobustConnection', DummyConnection)
+
+    with pytest.raises(RuntimeError, match='failed to connect'):
+        defaults._probe_rabbitmq_connection(
+            {
+                'protocol': 'amqp',
+                'username': 'guest',
+                'password': 'guest',
+                'host': '127.0.0.1',
+                'port': 5672,
+                'virtual_host': '',
+            }
+        )
+
+    assert connection is not None
+    assert connection.closed is True


### PR DESCRIPTION
Should fix issues when trying to connect to RMQ. This fix is not related to ZMQ but the problem became more pressing because in verdi presto we first try to connect to RMQ and if its not available  
```
❮ verdi presto
Report: Option `--use-postgres` not enabled: configuring the profile to use SQLite.
error when creating transport: <AMQPConnectionError: (61, "Connect call failed ('127.0.0.1', 5672)")>
Report: RabbitMQ server not found: falling back to ZMQ broker.
Warning: The ZMQ broker is a new feature. If you experience issues, recreate the profile with `verdi presto --no-broker`.
Exception ignored while calling deallocator <function Connection.__del__ at 0x105a44ca0>:
Traceback (most recent call last):
  File "/Users/mbercx/.aiida_venvs/qe-test/lib/python3.14/site-packages/aio_pika/connection.py", line 215, in __del__
    asyncio.ensure_future(self.close())
  File "/Users/mbercx/.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/asyncio/tasks.py", line 730, in ensure_future
    loop = events.get_event_loop()
  File "/Users/mbercx/.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'.
/Users/mbercx/.aiida_venvs/qe-test/lib/python3.14/site-packages/alembic/operations/base.py:27: RuntimeWarning: coroutine 'RobustConnection.close' was never awaited
  from . import batch
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Report: Initialising the storage backend.
Report: Migrating to the head of the main branch
Report: Storage initialisation completed.
Success: Created new profile `presto`.
Success: Configured the localhost as a computer.
```

First commit fixes the `RobustConnection.close`. Second commit surpresses the `error when creating transport: <AMQPConnectionError: (61, "Connect call failed ('127.0.0.1', 5672)")>`

This PR replaces probably PR #7328 but need to verify.

---

Probe RabbitMQ connection parameters in an isolated event loop and close the temporary aio-pika connection explicitly, even when the connection attempt fails.

This avoids the Python 3.14 cleanup warning emitted by aio-pika's Connection.__del__ when verdi presto falls back from a failed RabbitMQ probe to the ZMQ broker.

Add regression coverage for the failed probe path and verify that it no longer emits the ignored deallocator exception or unawaited coroutine warning.