### PR TITLE
🐛 Fix local launchers without live broker

### DIFF
--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -43,7 +43,8 @@ def run(process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None, **kwa
     if isinstance(process, Process):
         runner = process.runner
     else:
-        runner = manager.get_manager().get_runner()
+        # Note: it is safe to create new local runner here without but the explanation can be found in issue #7353
+        runner = manager.get_manager().create_runner(communicator=None)
 
     return runner.run(process, inputs, **kwargs)
 
@@ -60,7 +61,8 @@ def run_get_node(
     if isinstance(process, Process):
         runner = process.runner
     else:
-        runner = manager.get_manager().get_runner()
+        # Note: it is safe to create new local runner here without but the explanation can be found in issue #7353
+        runner = manager.get_manager().create_runner(communicator=None)
 
     return runner.run_get_node(process, inputs, **kwargs)
 
@@ -75,7 +77,8 @@ def run_get_pk(process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None
     if isinstance(process, Process):
         runner = process.runner
     else:
-        runner = manager.get_manager().get_runner()
+        # Note: it is safe to create new local runner here without but the explanation can be found in issue #7353
+        runner = manager.get_manager().create_runner(communicator=None)
 
     return runner.run_get_pk(process, inputs, **kwargs)
 

--- a/src/aiida/engine/processes/functions.py
+++ b/src/aiida/engine/processes/functions.py
@@ -153,7 +153,15 @@ def process_function(node_class: t.Type['ProcessNode']) -> t.Callable[[FunctionT
             :return: tuple of the outputs of the process and the process node
             """
             manager = get_manager()
-            runner = manager.get_runner()
+            # If called from inside a running process (e.g. a workchain calling a calcfunction), reuse that
+            # process's runner. Otherwise create a new runner without eagerly connecting to the broker since
+            # function processes run locally and don't need a broker connection.
+            # Note: it is safe to create new local runner here without but the explanation can be found in issue #7353
+            current = Process.current()
+            if isinstance(current, Process):
+                runner = current.runner
+            else:
+                runner = manager.create_runner(communicator=None)
             inputs = process_class.create_inputs(*args, **kwargs)
 
             # Remove all the known inputs from the kwargs
@@ -168,7 +176,7 @@ def process_function(node_class: t.Type['ProcessNode']) -> t.Callable[[FunctionT
 
             # Only add handlers for interrupt signal to kill the process if we are in a local and not a daemon runner.
             # Without this check, running process functions in a daemon worker would be killed if the daemon is shutdown
-            current_runner = manager.get_runner()
+            current_runner = runner
             original_handler = None
             kill_signal = signal.SIGINT
 

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -102,6 +102,35 @@ def test_submit_no_broker(arithmetic_add_builder, monkeypatch, manager):
         launch.submit(arithmetic_add_builder)
 
 
+def test_run_launchers_without_live_broker(aiida_config_tmp, aiida_profile_factory, config_sqlite_dos):
+    """Test local launchers work even if the configured broker is not running.
+
+    Regression test for ``launch.run*`` eagerly loading the profile communicator through the global runner. A RMQ
+    profile is used here because the bug is exposed reliably when no broker service has been started.
+    """
+    from aiida.manage import get_manager
+
+    with aiida_profile_factory(
+        aiida_config_tmp,
+        storage_backend='core.sqlite_dos',
+        storage_config=config_sqlite_dos(),
+        broker_backend='core.rabbitmq',
+        broker_config={},
+    ):
+        assert get_manager().get_broker() is not None
+
+        result = launch.run(add, term_a=orm.Int(1), term_b=orm.Int(2))
+        assert result == 3
+
+        result, node = launch.run_get_node(add, term_a=orm.Int(1), term_b=orm.Int(2))
+        assert result == 3
+        assert isinstance(node, orm.CalcFunctionNode)
+
+        result, pk = launch.run_get_pk(add, term_a=orm.Int(1), term_b=orm.Int(2))
+        assert result == 3
+        assert isinstance(pk, int)
+
+
 def test_await_processes_invalid():
     """Test :func:`aiida.engine.launch.await_processes` for invalid inputs."""
     with pytest.raises(TypeError):


### PR DESCRIPTION
I went through so many different solutions and I think a proper fix requires to touch plumpy. This is the best fix I could get without touching plumpy.

---

Allow `run*` launcher functions to work without an alive broker when a broker is configured in the profile. This already worked when no broker was configured. The issue existed with RMQ but only became apparent with the ZMQ broker because its lifetime is bound to the daemon, whereas RMQ is an independent process.
    
The root cause is that the communicator is eagerly initialized whenever a broker is configured in the profile, even for `run*` launchers that execute locally. By passing `communicator=None` to `create_runner`, the code follows the same path as when no broker is configured.
    
These runners are intentionally not cached on the manager so they don't conflict with the global runner that `submit` needs with a communicator attached. The downside is that the runner's resources (primarily the asyncio event loop) are never explicitly freed. We accept this because `plumpy.get_or_create_event_loop` already keeps a single global event loop alive, so only one loop is retained after a `run*` call. Closing the loop is not safe because it may be shared, and not closing it avoids leaking implementation details from the runner into the launcher. A proper fix would require changes in plumpy.
