### PR TITLE
🐛 Raise error on unavailable ZMQ broker in submit launches

### DIFF
--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -118,7 +118,12 @@ def submit(
     # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
     # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
     # for if `remote_folder` is present in the inputs, which means we are importing an already completed calculation.
-    if inputs.get('metadata', {}).get('dry_run', False) or 'remote_folder' in inputs:
+    # Builder inputs need to be merged so that detection works for ``submit(builder)`` too.
+    if isinstance(process, ProcessBuilder):
+        merged_inputs = {**inputs, **process._inputs(prune=True)}
+    else:
+        merged_inputs = inputs
+    if (merged_inputs.get('metadata') or {}).get('dry_run', False) or 'remote_folder' in merged_inputs:
         _, node = run_get_node(process, inputs)
         return node
 
@@ -127,10 +132,13 @@ def submit(
 
     if profile is not None and profile.process_control_backend == 'core.zmq':
         daemon_client = current_manager.get_daemon_client()
+        # Note: ``is_daemon_running`` only checks for a PID file, so a stale PID from a crashed daemon will let this
+        # check pass.
         if not daemon_client.is_daemon_running:
             msg = (
-                'Cannot submit because the daemon and thus the ZMQ broker is not running. '
-                'Start the daemon with `verdi daemon start` and try again.'
+                'Cannot submit because the daemon is not running. The ZMQ broker is bundled into the daemon for this '
+                'profile, so submission requires `verdi daemon start`. To run the process locally without the daemon '
+                'instead, use `aiida.engine.run` (or `run_get_node`).'
             )
             raise InvalidOperation(msg)
 

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -115,6 +115,13 @@ def submit(
     if is_process_scoped() and not isinstance(Process.current(), FunctionProcess):
         raise InvalidOperation('Cannot use top-level `submit` from within another process, use `self.submit` instead')
 
+    # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
+    # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
+    # for if `remote_folder` is present in the inputs, which means we are importing an already completed calculation.
+    if inputs.get('metadata', {}).get('dry_run', False) or 'remote_folder' in inputs:
+        _, node = run_get_node(process, inputs)
+        return node
+
     current_manager = manager.get_manager()
     profile = current_manager.get_profile()
 
@@ -141,13 +148,6 @@ def submit(
     assert runner.persister is not None, 'runner does not have a persister'
 
     process_inited = instantiate_process(runner, process, **inputs)
-
-    # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
-    # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
-    # for if `remote_folder` is present in the inputs, which means we are importing an already completed calculation.
-    if process_inited.metadata.get('dry_run', False) or 'remote_folder' in inputs:
-        _, node = run_get_node(process_inited)
-        return node
 
     if not process_inited.metadata.store_provenance:
         raise InvalidOperation('cannot submit a process with `store_provenance=False`')

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -115,7 +115,19 @@ def submit(
     if is_process_scoped() and not isinstance(Process.current(), FunctionProcess):
         raise InvalidOperation('Cannot use top-level `submit` from within another process, use `self.submit` instead')
 
-    runner = manager.get_manager().get_runner()
+    current_manager = manager.get_manager()
+    profile = current_manager.get_profile()
+
+    if profile is not None and profile.process_control_backend == 'core.zmq':
+        daemon_client = current_manager.get_daemon_client()
+        if not daemon_client.is_daemon_running:
+            msg = (
+                'Cannot submit because the daemon and thus the ZMQ broker is not running. '
+                'Start the daemon with `verdi daemon start` and try again.'
+            )
+            raise InvalidOperation(msg)
+
+    runner = current_manager.get_runner()
 
     if runner.controller is None:
         raise InvalidOperation(

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -120,7 +120,7 @@ def test_submit_without_daemon(aiida_config_tmp, aiida_profile_factory, config_s
 
         with pytest.raises(
             exceptions.InvalidOperation,
-            match=r'Cannot submit because the daemon and thus the ZMQ broker is not running\..*',
+            match=r'Cannot submit because the daemon is not running\.',
         ):
             launch.submit(AddWorkChain, term_a=orm.Int(1), term_b=orm.Int(2))
 
@@ -310,6 +310,32 @@ class TestLaunchersDryRun:
 
         node = launch.submit(ArithmeticAddCalculation, **inputs)
         assert isinstance(node, orm.CalcJobNode)
+
+    def test_submit_builder_dry_run(self):
+        """Regression test: ``submit`` with a ``ProcessBuilder`` carrying ``metadata.dry_run=True``.
+
+        Builder inputs are merged into ``inputs`` only inside ``instantiate_process``, so the early dry-run detection in
+        ``submit`` must merge them itself; otherwise the call falls through to the real submit path.
+        """
+        import pathlib
+
+        builder = ArithmeticAddCalculation.get_builder()
+        builder.code = self.code
+        builder.x = orm.Int(1)
+        builder.y = orm.Int(1)
+        builder.metadata = {
+            'dry_run': True,
+            'options': {'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}},
+        }
+        node = launch.submit(builder)
+        assert isinstance(node, orm.CalcJobNode)
+        # ``dry_run_info`` is set only by ``CalcJob._perform_dry_run``; a real submit would have queued the calc for the
+        # daemon, returning a non-terminated node and no ``dry_run_info``.
+        assert isinstance(node.dry_run_info, dict)
+        assert node.is_terminated
+        folder = pathlib.Path(node.dry_run_info['folder'])
+        assert folder.is_dir()
+        assert (folder / node.dry_run_info['script_filename']).is_file()
 
     def test_launchers_dry_run_no_provenance(self):
         """Test the launchers in `dry_run` mode with `store_provenance=False`."""

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -102,6 +102,29 @@ def test_submit_no_broker(arithmetic_add_builder, monkeypatch, manager):
         launch.submit(arithmetic_add_builder)
 
 
+def test_submit_without_daemon(aiida_config_tmp, aiida_profile_factory, config_sqlite_dos):
+    """Test ``submit`` raises a meaningful error if the daemon is not running.
+
+    A ZMQ profile is used here because the daemon check is specific to the ZMQ broker.
+    """
+    from aiida.manage import get_manager
+
+    with aiida_profile_factory(
+        aiida_config_tmp,
+        storage_backend='core.sqlite_dos',
+        storage_config=config_sqlite_dos(),
+        broker_backend='core.zmq',
+        broker_config={},
+    ):
+        assert not get_manager().get_daemon_client().is_daemon_running
+
+        with pytest.raises(
+            exceptions.InvalidOperation,
+            match=r'Cannot submit because the daemon and thus the ZMQ broker is not running\..*',
+        ):
+            launch.submit(AddWorkChain, term_a=orm.Int(1), term_b=orm.Int(2))
+
+
 def test_run_launchers_without_live_broker(aiida_config_tmp, aiida_profile_factory, config_sqlite_dos):
     """Test local launchers work even if the configured broker is not running.
 

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -441,7 +441,7 @@ def test_run_launchers():
     assert isinstance(node, orm.CalcFunctionNode)
 
 
-@pytest.mark.requires_broker
+@pytest.mark.requires_rmq
 def test_submit_launchers():
     """Verify that submit to daemon works."""
     # Process function can be submitted and will be run by a daemon worker as long as the function is importable

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -443,7 +443,13 @@ def test_run_launchers():
 
 @pytest.mark.requires_rmq
 def test_submit_launchers():
-    """Verify that submit to daemon works."""
+    """Verify that submit to daemon works.
+
+    Marked ``requires_rmq`` (not ``requires_broker``) because under the ``core.zmq`` profile the broker is bundled into
+    the daemon, so ``aiida.engine.launch.submit`` raises ``InvalidOperation`` when the daemon is not up — which a CI
+    run with only the broker started would trip. The ZMQ submit-of-process-function path is exercised by the daemon
+    system tests under ``.github/system_tests/test_daemon.py``.
+    """
     # Process function can be submitted and will be run by a daemon worker as long as the function is importable
     # Note that the actual running is not tested here but is done so in `.github/system_tests/test_daemon.py`.
     node = submit(add_multiply, x=orm.Int(1), y=orm.Int(2), z=orm.Int(3))


### PR DESCRIPTION
Raises an error when a user submits but has not the daemon running with the ZMQ broker. With RMQ we start the broker once and also mostly before the profile creation, then it works for all profiles. With ZMQ we put the broker process into the daemon start so it is here needed to run the daemon when submitting jobs to receive the sent task. We only raise the error for ZMQ because I don't want to break behavior for RMQ and it is an issue that mainly appears with ZMQ because of the one-broker-per-profile design.

Note that we needed to move the code for dry run up because this is run locally and does not require a broker. So it should not error out when there is not daemon.

**General note about the design why ZMQ is in the daemon**:

It is important to note that the ZMQ broker is per profile and not global. Here I had the option to imitate the one broker for all profiles design as RMQ does it but then we would need to separately manage the broker with some CLI commands `verdi broker [start|stop|restart]`. The other option was to make put the broker per profile like the daemon and thus I can bind the broker management to the daemon's management. Because the whole point about introducing the ZMQ broker was the usability aspect, I opted for the second option. The only downside I see is that we are more resource heavy because we spaw a ZMQ broker process for each profile, but we have the same problem already with the daemon and it seemed to be never to become a real resource issue.