### PR TITLE
🐛 Handle `IntegrityError` in `aiida_computer` fixture

### DIFF
--- a/src/aiida/tools/pytest_fixtures/orm.py
+++ b/src/aiida/tools/pytest_fixtures/orm.py
@@ -96,29 +96,38 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
 
         label = label or f'test-computer-{uuid.uuid4().hex}'
 
-        try:
-            computer = Computer.collection.get(
-                label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
-            )
-        except NotExistent:
-            computer = Computer(
+        def _build() -> 'Computer':
+            return Computer(
                 label=label,
                 hostname=hostname,
                 workdir=str(tmp_path),
                 transport_type=transport_type,
                 scheduler_type=scheduler_type,
             )
+
+        try:
+            computer = Computer.collection.get(
+                label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
+            )
+        except NotExistent:
+            computer = _build()
             try:
                 computer.store()
             except IntegrityError:
-                # A computer with this label was concurrently created by another fixture call,
-                # e.g. after ``aiida_profile_clean`` wiped the database mid-session.
-                computer = Computer.collection.get(
-                    label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
-                )
-            else:
-                computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
-                computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)
+                # Another xdist worker concurrently re-created this computer after
+                # ``aiida_profile_clean`` reset the shared database. Re-querying is
+                # safe because the ``psql_dos`` storage backend rolls back our failed
+                # transaction before raising (see ``psql_dos/orm/utils.py``).
+                try:
+                    computer = Computer.collection.get(
+                        label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
+                    )
+                except NotExistent:
+                    # Row no longer present (rare): rebuild and store fresh.
+                    computer = _build()
+                    computer.store()
+            computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
+            computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)
 
         if configuration_kwargs:
             computer.configure(**configuration_kwargs)

--- a/src/aiida/tools/pytest_fixtures/orm.py
+++ b/src/aiida/tools/pytest_fixtures/orm.py
@@ -91,7 +91,9 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
     ) -> 'Computer':
         import uuid
 
-        from aiida.common.exceptions import NotExistent
+        from sqlalchemy.exc import IntegrityError as SqlaIntegrityError
+
+        from aiida.common.exceptions import IntegrityError, NotExistent
         from aiida.orm import Computer
 
         label = label or f'test-computer-{uuid.uuid4().hex}'
@@ -108,9 +110,15 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
                 transport_type=transport_type,
                 scheduler_type=scheduler_type,
             )
-            computer.store()
-            computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
-            computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)
+            try:
+                computer.store()
+            except (IntegrityError, SqlaIntegrityError):
+                # A computer with this label was concurrently created by another fixture call,
+                # e.g. after ``aiida_profile_clean`` wiped the database mid-session.
+                computer = Computer.collection.get(label=label)
+            else:
+                computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
+                computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)
 
         if configuration_kwargs:
             computer.configure(**configuration_kwargs)

--- a/src/aiida/tools/pytest_fixtures/orm.py
+++ b/src/aiida/tools/pytest_fixtures/orm.py
@@ -91,8 +91,6 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
     ) -> 'Computer':
         import uuid
 
-        from sqlalchemy.exc import IntegrityError as SqlaIntegrityError
-
         from aiida.common.exceptions import IntegrityError, NotExistent
         from aiida.orm import Computer
 
@@ -112,10 +110,12 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
             )
             try:
                 computer.store()
-            except (IntegrityError, SqlaIntegrityError):
+            except IntegrityError:
                 # A computer with this label was concurrently created by another fixture call,
                 # e.g. after ``aiida_profile_clean`` wiped the database mid-session.
-                computer = Computer.collection.get(label=label)
+                computer = Computer.collection.get(
+                    label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
+                )
             else:
                 computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
                 computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)

--- a/tests/tools/pytest_fixtures/test_orm.py
+++ b/tests/tools/pytest_fixtures/test_orm.py
@@ -50,40 +50,62 @@ def test_aiida_computer_fixtures(fixture_name, transport_cls, transport_type, re
     assert not computer_unconfigured.is_configured
 
 
+@pytest.mark.parametrize(
+    'fallback_get_misses',
+    [False, True],
+    ids=['fallback_get_succeeds', 'fallback_get_misses_rebuilds'],
+)
 @pytest.mark.usefixtures('aiida_profile_clean')
-def test_aiida_computer_integrity_error_fallback(aiida_computer):
-    """Test that ``aiida_computer`` falls back to ``get()`` on ``IntegrityError``.
+def test_aiida_computer_integrity_error_recovery(aiida_computer, fallback_get_misses):
+    """Cover both branches of the ``IntegrityError`` recovery path under xdist races.
 
-    Simulates the TOCTOU race under xdist where ``get()`` raises ``NotExistent``
-    but ``store()`` fails because another worker already created the computer.
+    In both cases, the first ``get()`` misses (as if ``aiida_profile_clean`` wiped
+    the DB) and ``store()`` fails with ``IntegrityError`` (another worker re-created
+    the computer). The two branches differ in what the fallback ``get()`` sees:
+
+    - ``fallback_get_succeeds``: it finds the racing worker's row and returns it.
+    - ``fallback_get_misses_rebuilds``: it raises ``NotExistent`` again (rare),
+      so the fixture rebuilds and stores fresh.
     """
     from unittest.mock import patch
 
     from aiida.common.exceptions import IntegrityError, NotExistent
 
-    # First, create and store the computer normally.
-    label = f'test-integrity-{uuid.uuid4().hex}'
-    computer = aiida_computer(label=label)
+    label = f'test-recovery-{uuid.uuid4().hex}'
 
-    # Simulate the race: the first get() misses (as if DB was just wiped by
-    # another worker's aiida_profile_clean), store() fails with IntegrityError
-    # (another worker re-created the computer first), and the fallback get()
-    # inside the except block finds the computer.
-    original_get = Computer.collection.get
+    pre_existing = aiida_computer(label=label) if not fallback_get_misses else None
 
-    collection = Computer.collection
+    if fallback_get_misses:
+        get_side_effect = [
+            NotExistent('First get: DB was just cleaned'),
+            NotExistent('Second get: racing worker row vanished'),
+        ]
+    else:
+        get_side_effect = [NotExistent('First get: DB was just cleaned'), pre_existing]
+
+    original_store = Computer.store
+    store_calls = {'n': 0}
+
+    def store_side_effect(self):
+        store_calls['n'] += 1
+        if store_calls['n'] == 1:
+            raise IntegrityError('UNIQUE constraint failed')
+        return original_store(self)
+
     with (
-        patch.object(
-            type(collection),
-            'get',
-            side_effect=[NotExistent('Simulated race: DB was just cleaned'), original_get(label=label)],
-        ),
-        patch.object(Computer, 'store', side_effect=IntegrityError('UNIQUE constraint failed')),
+        patch.object(type(Computer.collection), 'get', side_effect=get_side_effect),
+        patch.object(Computer, 'store', autospec=True, side_effect=store_side_effect),
     ):
-        fallback_computer = aiida_computer(label=label)
+        recovered = aiida_computer(label=label)
 
-    assert fallback_computer.pk == computer.pk
-    assert fallback_computer.uuid == computer.uuid
+    assert recovered.is_stored
+    assert recovered.label == label
+    if fallback_get_misses:
+        assert store_calls['n'] == 2  # rebuild path: first store failed, second persisted
+    else:
+        assert pre_existing is not None
+        assert recovered.pk == pre_existing.pk
+        assert store_calls['n'] == 1  # fallback path: only the failing store ran
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/pytest_fixtures/test_orm.py
+++ b/tests/tools/pytest_fixtures/test_orm.py
@@ -50,6 +50,42 @@ def test_aiida_computer_fixtures(fixture_name, transport_cls, transport_type, re
     assert not computer_unconfigured.is_configured
 
 
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_aiida_computer_integrity_error_fallback(aiida_computer):
+    """Test that ``aiida_computer`` falls back to ``get()`` on ``IntegrityError``.
+
+    Simulates the TOCTOU race under xdist where ``get()`` raises ``NotExistent``
+    but ``store()`` fails because another worker already created the computer.
+    """
+    from unittest.mock import patch
+
+    from aiida.common.exceptions import IntegrityError, NotExistent
+
+    # First, create and store the computer normally.
+    label = f'test-integrity-{uuid.uuid4().hex}'
+    computer = aiida_computer(label=label)
+
+    # Simulate the race: the first get() misses (as if DB was just wiped by
+    # another worker's aiida_profile_clean), store() fails with IntegrityError
+    # (another worker re-created the computer first), and the fallback get()
+    # inside the except block finds the computer.
+    original_get = Computer.collection.get
+
+    collection = Computer.collection
+    with (
+        patch.object(
+            type(collection),
+            'get',
+            side_effect=[NotExistent('Simulated race: DB was just cleaned'), original_get(label=label)],
+        ),
+        patch.object(Computer, 'store', side_effect=IntegrityError('UNIQUE constraint failed')),
+    ):
+        fallback_computer = aiida_computer(label=label)
+
+    assert fallback_computer.pk == computer.pk
+    assert fallback_computer.uuid == computer.uuid
+
+
 @pytest.mark.parametrize(
     'backend, backend_class',
     [

--- a/tests/tools/pytest_fixtures/test_orm.py
+++ b/tests/tools/pytest_fixtures/test_orm.py
@@ -1,9 +1,11 @@
 """Tests for the :mod:`aiida.tools.pytest_fixtures.orm` module."""
 
 import uuid
+from unittest.mock import patch
 
 import pytest
 
+from aiida.common.exceptions import IntegrityError, NotExistent
 from aiida.orm import Computer
 from aiida.transports import AsyncTransport, BlockingTransport
 from aiida.transports.plugins.async_backend import _AsyncSSH, _OpenSSH
@@ -50,39 +52,45 @@ def test_aiida_computer_fixtures(fixture_name, transport_cls, transport_type, re
     assert not computer_unconfigured.is_configured
 
 
-@pytest.mark.parametrize(
-    'fallback_get_misses',
-    [False, True],
-    ids=['fallback_get_succeeds', 'fallback_get_misses_rebuilds'],
-)
 @pytest.mark.usefixtures('aiida_profile_clean')
-def test_aiida_computer_integrity_error_recovery(aiida_computer, fallback_get_misses):
-    """Cover both branches of the ``IntegrityError`` recovery path under xdist races.
+def test_aiida_computer_integrity_error_fallback(aiida_computer):
+    """The fallback ``get()`` returns the racing worker's row.
 
-    In both cases, the first ``get()`` misses (as if ``aiida_profile_clean`` wiped
-    the DB) and ``store()`` fails with ``IntegrityError`` (another worker re-created
-    the computer). The two branches differ in what the fallback ``get()`` sees:
-
-    - ``fallback_get_succeeds``: it finds the racing worker's row and returns it.
-    - ``fallback_get_misses_rebuilds``: it raises ``NotExistent`` again (rare),
-      so the fixture rebuilds and stores fresh.
+    Simulates the xdist race where a row exists in the shared DB but our session
+    can't see it on the first ``get()`` (as if ``aiida_profile_clean`` just wiped
+    things from this worker's POV); ``store()`` then fails with ``IntegrityError``
+    on the UNIQUE label constraint, and the fallback ``get()`` finds the row.
     """
-    from unittest.mock import patch
+    label = f'test-fallback-{uuid.uuid4().hex}'
+    existing = aiida_computer(label=label)
 
-    from aiida.common.exceptions import IntegrityError, NotExistent
+    with (
+        patch.object(
+            type(Computer.collection),
+            'get',
+            side_effect=[NotExistent('First get: DB was just cleaned'), existing],
+        ),
+        patch.object(Computer, 'store', side_effect=IntegrityError('UNIQUE constraint failed')),
+    ):
+        recovered = aiida_computer(label=label)
 
-    label = f'test-recovery-{uuid.uuid4().hex}'
+    assert recovered.pk == existing.pk
+    assert recovered.uuid == existing.uuid
 
-    pre_existing = aiida_computer(label=label) if not fallback_get_misses else None
 
-    if fallback_get_misses:
-        get_side_effect = [
-            NotExistent('First get: DB was just cleaned'),
-            NotExistent('Second get: racing worker row vanished'),
-        ]
-    else:
-        get_side_effect = [NotExistent('First get: DB was just cleaned'), pre_existing]
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_aiida_computer_integrity_error_rebuild(aiida_computer):
+    """The fallback ``get()`` also misses, so the fixture rebuilds and stores fresh.
 
+    Rare follow-up to the fallback case: ``store()`` raised ``IntegrityError`` (so
+    the racing worker's row should be there), but by the time we re-query it has
+    already vanished. The fixture must then build a new ``Computer`` and store it.
+    """
+    label = f'test-rebuild-{uuid.uuid4().hex}'
+
+    # store() fails the first time (simulating the race) and persists for real on
+    # the second call (the rebuild). ``autospec=True`` is required so the mock
+    # passes ``self`` to ``store_side_effect``, which we need to call through.
     original_store = Computer.store
     store_calls = {'n': 0}
 
@@ -93,19 +101,21 @@ def test_aiida_computer_integrity_error_recovery(aiida_computer, fallback_get_mi
         return original_store(self)
 
     with (
-        patch.object(type(Computer.collection), 'get', side_effect=get_side_effect),
+        patch.object(
+            type(Computer.collection),
+            'get',
+            side_effect=[
+                NotExistent('First get: DB was just cleaned'),
+                NotExistent('Second get: racing worker row vanished'),
+            ],
+        ),
         patch.object(Computer, 'store', autospec=True, side_effect=store_side_effect),
     ):
         recovered = aiida_computer(label=label)
 
     assert recovered.is_stored
     assert recovered.label == label
-    if fallback_get_misses:
-        assert store_calls['n'] == 2  # rebuild path: first store failed, second persisted
-    else:
-        assert pre_existing is not None
-        assert recovered.pk == pre_existing.pk
-        assert store_calls['n'] == 1  # fallback path: only the failing store ran
+    assert store_calls['n'] == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Tried to fix issue #7347 here but this is just a tmp helper fix. This seems to fix category 1 problem but its more a bandaid than a real fix.

---

When `aiida_profile_clean` resets the database mid-session, subsequent calls to the `aiida_computer` fixture can hit a TOCTOU race: `get()` finds no matching computer, but `store()` fails with an IntegrityError because another fixture call already recreated it. Catch the error and fall back to `get()` by label.