### PR TITLE
✨ Auto-start daemon in `verdi presto`

### DIFF
--- a/.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh
+++ b/.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh
@@ -18,14 +18,17 @@ verdi config set warnings.development_version False
 # If the environment variable `SETUP_DEFAULT_AIIDA_PROFILE` is not set, set it to `true`.
 if [[ ${SETUP_DEFAULT_AIIDA_PROFILE:-true} == true ]] && ! verdi profile show ${AIIDA_PROFILE_NAME} &> /dev/null; then
 
-    # Create AiiDA profile.
+    # Create AiiDA profile. Use --no-daemon-autostart because the Docker
+    # container manages the daemon lifecycle separately via s6-overlay
+    # (aiida-daemon-start runs after this script and run-before-daemon-start).
     verdi presto \
         --verbosity info \
         --profile-name "${AIIDA_PROFILE_NAME:-default}" \
         --email "${AIIDA_USER_EMAIL:-aiida@localhost}" \
         --use-postgres \
         --postgres-hostname "${AIIDA_POSTGRES_HOSTNAME:-localhost}" \
-        --postgres-password "${AIIDA_POSTGRES_PASSWORD:-password}"
+        --postgres-password "${AIIDA_POSTGRES_PASSWORD:-password}" \
+        --no-daemon-autostart
 
     # Setup and configure local computer.
     computer_name=localhost

--- a/.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh
+++ b/.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh
@@ -18,17 +18,17 @@ verdi config set warnings.development_version False
 # If the environment variable `SETUP_DEFAULT_AIIDA_PROFILE` is not set, set it to `true`.
 if [[ ${SETUP_DEFAULT_AIIDA_PROFILE:-true} == true ]] && ! verdi profile show ${AIIDA_PROFILE_NAME} &> /dev/null; then
 
-    # Create AiiDA profile. Use --no-daemon-autostart because the Docker
-    # container manages the daemon lifecycle separately via s6-overlay
-    # (aiida-daemon-start runs after this script and run-before-daemon-start).
-    verdi presto \
+    # Create AiiDA profile. Set AIIDA_NO_DAEMON_AUTOSTART because the
+    # Docker container manages the daemon lifecycle separately via
+    # s6-overlay (aiida-daemon-start runs after this script and
+    # run-before-daemon-start).
+    AIIDA_NO_DAEMON_AUTOSTART=1 verdi presto \
         --verbosity info \
         --profile-name "${AIIDA_PROFILE_NAME:-default}" \
         --email "${AIIDA_USER_EMAIL:-aiida@localhost}" \
         --use-postgres \
         --postgres-hostname "${AIIDA_POSTGRES_HOSTNAME:-localhost}" \
-        --postgres-password "${AIIDA_POSTGRES_PASSWORD:-password}" \
-        --no-daemon-autostart
+        --postgres-password "${AIIDA_POSTGRES_PASSWORD:-password}"
 
     # Setup and configure local computer.
     computer_name=localhost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Behavior changes
+
+**`verdi presto`: auto-starts the daemon** ([#7351](https://github.com/aiidateam/aiida-core/pull/7351))
+
+`verdi presto` now starts the daemon automatically after creating the profile, when a broker is configured.
+Scripts that previously ran `verdi daemon start` after `verdi presto` continue to work; the daemon-start invocation is idempotent.
+
 ## v2.8.0 - 2026-03-16
 
 This release brings important improvements to the `BaseRestartWorkChain`, the engine, stashing, typing coverage, and dependency updates.

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -319,7 +319,8 @@ Below is a list with all available subcommands.
       * Create a default user for the profile (email can be configured through the `--email` option)
       * Set up the localhost as a `Computer` and configure it
       * Set a number of configuration options with sensible defaults
-      * Start the daemon (unless `--no-broker` or `--no-daemon-autostart` is specified)
+      * Start the daemon (unless `--no-broker` is specified or the
+        `AIIDA_NO_DAEMON_AUTOSTART` environment variable is set)
 
       By default the command creates a profile that uses SQLite for the database. For the
       message broker, it automatically checks for RabbitMQ running on localhost. If found, it
@@ -357,8 +358,6 @@ Below is a list with all available subcommands.
                                       means the daemon cannot be started and processes cannot
                                       be submitted. Useful for profiles used only for data
                                       exploration and querying.
-      --no-daemon-autostart           When toggled on, the daemon is not started automatically
-                                      after setting up the profile.
       --postgres-hostname TEXT        The hostname of the PostgreSQL server.
       --postgres-port INTEGER         The port of the PostgreSQL server.
       --postgres-username TEXT        The username of the PostgreSQL user that is authorized

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -319,8 +319,7 @@ Below is a list with all available subcommands.
       * Create a default user for the profile (email can be configured through the `--email` option)
       * Set up the localhost as a `Computer` and configure it
       * Set a number of configuration options with sensible defaults
-      * Start the daemon (unless `--no-broker` is specified or the
-        `AIIDA_NO_DAEMON_AUTOSTART` environment variable is set)
+      * Start the daemon (unless `--no-broker` is specified)
 
       By default the command creates a profile that uses SQLite for the database. For the
       message broker, it automatically checks for RabbitMQ running on localhost. If found, it

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -319,6 +319,7 @@ Below is a list with all available subcommands.
       * Create a default user for the profile (email can be configured through the `--email` option)
       * Set up the localhost as a `Computer` and configure it
       * Set a number of configuration options with sensible defaults
+      * Start the daemon (unless `--no-broker` or `--no-daemon-autostart` is specified)
 
       By default the command creates a profile that uses SQLite for the database. For the
       message broker, it automatically checks for RabbitMQ running on localhost. If found, it
@@ -356,6 +357,8 @@ Below is a list with all available subcommands.
                                       means the daemon cannot be started and processes cannot
                                       be submitted. Useful for profiles used only for data
                                       exploration and querying.
+      --no-daemon-autostart           When toggled on, the daemon is not started automatically
+                                      after setting up the profile.
       --postgres-hostname TEXT        The hostname of the PostgreSQL server.
       --postgres-port INTEGER         The port of the PostgreSQL server.
       --postgres-username TEXT        The username of the PostgreSQL user that is authorized

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -298,13 +298,14 @@ def verdi_presto(
     echo.echo_success('Configured the localhost as a computer.')
 
     if broker_backend is not None and not no_daemon_autostart:
-        from aiida.engine.daemon.client import get_daemon_client
+        from aiida.common.exceptions import ConfigurationError
+        from aiida.engine.daemon.client import DaemonException, get_daemon_client
 
         echo.echo('Starting the daemon... ', nl=False)
         try:
             client = get_daemon_client(profile.name)
             client.start_daemon()
-        except Exception as exception:
+        except (DaemonException, ConfigurationError) as exception:
             echo.echo('FAILED', fg=echo.COLORS['error'], bold=True)
             echo.echo_warning(f'Failed to start the daemon: {exception}')
             echo.echo_report('You can start it manually with `verdi daemon start`.')

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -139,6 +139,11 @@ def detect_postgres_config(
     help='When toggled on, no message broker is configured. This means the daemon cannot be started and processes '
     'cannot be submitted. Useful for profiles used only for data exploration and querying.',
 )
+@click.option(
+    '--no-daemon-autostart',
+    is_flag=True,
+    help='When toggled on, the daemon is not started automatically after setting up the profile.',
+)
 @click.option('--postgres-hostname', type=str, default='localhost', help='The hostname of the PostgreSQL server.')
 @click.option('--postgres-port', type=int, default=5432, help='The port of the PostgreSQL server.')
 @click.option(
@@ -162,6 +167,7 @@ def verdi_presto(
     use_postgres,
     use_zmq,
     no_broker,
+    no_daemon_autostart,
     postgres_hostname,
     postgres_port,
     postgres_username,
@@ -183,6 +189,7 @@ def verdi_presto(
     * Create a default user for the profile (email can be configured through the `--email` option)
     * Set up the localhost as a `Computer` and configure it
     * Set a number of configuration options with sensible defaults
+    * Start the daemon (unless `--no-broker` or `--no-daemon-autostart` is specified)
 
     By default the command creates a profile that uses SQLite for the database. For the message broker, it automatically
     checks for RabbitMQ running on localhost. If found, it configures RabbitMQ as the broker. Otherwise, it falls back
@@ -289,3 +296,17 @@ def verdi_presto(
     computer.set_default_mpiprocs_per_machine(1)
 
     echo.echo_success('Configured the localhost as a computer.')
+
+    if broker_backend is not None and not no_daemon_autostart:
+        from aiida.engine.daemon.client import get_daemon_client
+
+        echo.echo('Starting the daemon... ', nl=False)
+        try:
+            client = get_daemon_client(profile.name)
+            client.start_daemon()
+        except Exception as exception:
+            echo.echo('FAILED', fg=echo.COLORS['error'], bold=True)
+            echo.echo_warning(f'Failed to start the daemon: {exception}')
+            echo.echo_report('You can start it manually with `verdi daemon start`.')
+        else:
+            echo.echo('OK', fg=echo.COLORS['success'], bold=True)

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -184,8 +184,7 @@ def verdi_presto(
     * Create a default user for the profile (email can be configured through the `--email` option)
     * Set up the localhost as a `Computer` and configure it
     * Set a number of configuration options with sensible defaults
-    * Start the daemon (unless `--no-broker` is specified or the
-      `AIIDA_NO_DAEMON_AUTOSTART` environment variable is set)
+    * Start the daemon (unless `--no-broker` is specified)
 
     By default the command creates a profile that uses SQLite for the database. For the message broker, it automatically
     checks for RabbitMQ running on localhost. If found, it configures RabbitMQ as the broker. Otherwise, it falls back
@@ -293,7 +292,9 @@ def verdi_presto(
 
     echo.echo_success('Configured the localhost as a computer.')
 
-    if broker_backend is not None and not os.environ.get('AIIDA_NO_DAEMON_AUTOSTART'):
+    # `AIIDA_NO_DAEMON_AUTOSTART` is an internal escape hatch for the Docker init script (see
+    # `.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh`); deliberately undocumented in `--help`.
+    if broker_backend is not None and os.environ.get('AIIDA_NO_DAEMON_AUTOSTART') != '1':
         from aiida.common.exceptions import ConfigurationError
         from aiida.engine.daemon.client import DaemonException, get_daemon_client
 

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import typing as t
@@ -139,11 +140,6 @@ def detect_postgres_config(
     help='When toggled on, no message broker is configured. This means the daemon cannot be started and processes '
     'cannot be submitted. Useful for profiles used only for data exploration and querying.',
 )
-@click.option(
-    '--no-daemon-autostart',
-    is_flag=True,
-    help='When toggled on, the daemon is not started automatically after setting up the profile.',
-)
 @click.option('--postgres-hostname', type=str, default='localhost', help='The hostname of the PostgreSQL server.')
 @click.option('--postgres-port', type=int, default=5432, help='The port of the PostgreSQL server.')
 @click.option(
@@ -167,7 +163,6 @@ def verdi_presto(
     use_postgres,
     use_zmq,
     no_broker,
-    no_daemon_autostart,
     postgres_hostname,
     postgres_port,
     postgres_username,
@@ -189,7 +184,8 @@ def verdi_presto(
     * Create a default user for the profile (email can be configured through the `--email` option)
     * Set up the localhost as a `Computer` and configure it
     * Set a number of configuration options with sensible defaults
-    * Start the daemon (unless `--no-broker` or `--no-daemon-autostart` is specified)
+    * Start the daemon (unless `--no-broker` is specified or the
+      `AIIDA_NO_DAEMON_AUTOSTART` environment variable is set)
 
     By default the command creates a profile that uses SQLite for the database. For the message broker, it automatically
     checks for RabbitMQ running on localhost. If found, it configures RabbitMQ as the broker. Otherwise, it falls back
@@ -297,7 +293,7 @@ def verdi_presto(
 
     echo.echo_success('Configured the localhost as a computer.')
 
-    if broker_backend is not None and not no_daemon_autostart:
+    if broker_backend is not None and not os.environ.get('AIIDA_NO_DAEMON_AUTOSTART'):
         from aiida.common.exceptions import ConfigurationError
         from aiida.engine.daemon.client import DaemonException, get_daemon_client
 

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -41,8 +41,8 @@ def test_get_default_presto_profile_name(monkeypatch, profile_names, expected):
     assert get_default_presto_profile_name() == expected
 
 
-@pytest.mark.usefixtures('empty_config')
-def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch, mock_daemon_client):
+@pytest.mark.usefixtures('empty_config', 'mock_daemon_client')
+def test_presto_without_rmq(run_cli_command, monkeypatch):
     """Test the ``verdi presto`` without RabbitMQ falls back to ZMQ."""
     from aiida.brokers.rabbitmq import defaults
 
@@ -63,8 +63,8 @@ def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch, mock_dae
         assert profile.process_control_backend == 'core.zmq'
 
 
-@pytest.mark.usefixtures('empty_config')
-def test_presto(run_cli_command, mock_daemon_client):
+@pytest.mark.usefixtures('empty_config', 'mock_daemon_client')
+def test_presto(run_cli_command):
     """Test that ``verdi presto`` configures a broker (RabbitMQ if available, otherwise ZMQ)."""
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile `presto`.' in result.output
@@ -78,8 +78,8 @@ def test_presto(run_cli_command, mock_daemon_client):
 
 
 @pytest.mark.requires_psql
-@pytest.mark.usefixtures('empty_config')
-def test_presto_use_postgres(run_cli_command, manager, mock_daemon_client):
+@pytest.mark.usefixtures('empty_config', 'mock_daemon_client')
+def test_presto_use_postgres(run_cli_command, manager):
     """Test the ``verdi presto`` with the ``--use-postgres`` flag."""
     result = run_cli_command(verdi_presto, ['--non-interactive', '--use-postgres'])
     assert 'Created new profile `presto`.' in result.output
@@ -100,8 +100,8 @@ def test_presto_use_postgres_fail(run_cli_command):
     assert 'Failed to connect to the PostgreSQL server' in result.output
 
 
-@pytest.mark.usefixtures('empty_config')
-def test_presto_overdose(run_cli_command, config_with_profile_factory, mock_daemon_client):
+@pytest.mark.usefixtures('empty_config', 'mock_daemon_client')
+def test_presto_overdose(run_cli_command, config_with_profile_factory):
     """Test that ``verdi presto`` still works for users that have over 10 presto profiles."""
     config_with_profile_factory(name='presto-10')
     result = run_cli_command(verdi_presto)
@@ -113,7 +113,7 @@ def test_presto_starts_daemon(run_cli_command, mock_daemon_client):
     """Test that ``verdi presto`` auto-starts the daemon."""
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Starting the daemon' in result.output
-    mock_daemon_client.start_daemon.assert_called_once()
+    mock_daemon_client.start_daemon.assert_called_once_with()
 
 
 @pytest.mark.usefixtures('empty_config')
@@ -126,21 +126,26 @@ def test_presto_no_daemon_autostart(run_cli_command, mock_daemon_client):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto_daemon_start_failure(run_cli_command, monkeypatch):
+def test_presto_no_broker_skips_daemon(run_cli_command, mock_daemon_client):
+    """Test that ``verdi presto --no-broker`` skips the daemon auto-start (no broker means no daemon)."""
+    result = run_cli_command(verdi_presto, ['--non-interactive', '--no-broker'])
+    assert 'Created new profile' in result.output
+    assert 'Starting the daemon' not in result.output
+    mock_daemon_client.start_daemon.assert_not_called()
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_presto_daemon_start_failure(run_cli_command, mock_daemon_client):
     """Test that ``verdi presto`` handles daemon start failure gracefully."""
-    from aiida.engine.daemon import client as daemon_client_mod
+    from aiida.engine.daemon.client import DaemonException
 
-    def mock_get_daemon_client(*args, **kwargs):
-        mock = MagicMock()
-        mock.start_daemon.side_effect = RuntimeError('Could not start daemon')
-        return mock
-
-    monkeypatch.setattr(daemon_client_mod, 'get_daemon_client', mock_get_daemon_client)
+    mock_daemon_client.start_daemon.side_effect = DaemonException('Could not start daemon')
 
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile' in result.output
     assert 'FAILED' in result.output
     assert 'Could not start daemon' in result.output
+    assert 'verdi daemon start' in result.output
 
 
 @pytest.mark.requires_psql

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -117,9 +117,10 @@ def test_presto_starts_daemon(run_cli_command, mock_daemon_client):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto_no_daemon_autostart(run_cli_command, mock_daemon_client):
-    """Test that ``verdi presto --no-daemon-autostart`` does not start the daemon."""
-    result = run_cli_command(verdi_presto, ['--non-interactive', '--no-daemon-autostart'])
+def test_presto_no_daemon_autostart_env(run_cli_command, mock_daemon_client, monkeypatch):
+    """Test that setting ``AIIDA_NO_DAEMON_AUTOSTART`` skips the daemon auto-start."""
+    monkeypatch.setenv('AIIDA_NO_DAEMON_AUTOSTART', '1')
+    result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile' in result.output
     assert 'Starting the daemon' not in result.output
     mock_daemon_client.start_daemon.assert_not_called()

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -118,12 +118,27 @@ def test_presto_starts_daemon(run_cli_command, mock_daemon_client):
 
 @pytest.mark.usefixtures('empty_config')
 def test_presto_no_daemon_autostart_env(run_cli_command, mock_daemon_client, monkeypatch):
-    """Test that setting ``AIIDA_NO_DAEMON_AUTOSTART`` skips the daemon auto-start."""
+    """Test that ``AIIDA_NO_DAEMON_AUTOSTART=1`` skips the daemon auto-start."""
     monkeypatch.setenv('AIIDA_NO_DAEMON_AUTOSTART', '1')
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile' in result.output
     assert 'Starting the daemon' not in result.output
     mock_daemon_client.start_daemon.assert_not_called()
+
+
+@pytest.mark.parametrize('value', ('0', 'true', 'false', '', 'banana'))
+@pytest.mark.usefixtures('empty_config')
+def test_presto_daemon_autostart_env_non_one(run_cli_command, mock_daemon_client, monkeypatch, value):
+    """Test that anything other than the literal string ``1`` does not skip the daemon.
+
+    Only ``AIIDA_NO_DAEMON_AUTOSTART=1`` is recognized; any other value (including ``0``, ``true``,
+    typos, or empty string) falls through to "start the daemon" so a misspelled or unrecognized
+    value doesn't silently disable the daemon.
+    """
+    monkeypatch.setenv('AIIDA_NO_DAEMON_AUTOSTART', value)
+    result = run_cli_command(verdi_presto, ['--non-interactive'])
+    assert 'Starting the daemon' in result.output
+    mock_daemon_client.start_daemon.assert_called_once_with()
 
 
 @pytest.mark.usefixtures('empty_config')

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -1,6 +1,7 @@
 """Tests for ``verdi presto``."""
 
 import textwrap
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -8,6 +9,16 @@ from aiida.cmdline.commands.cmd_presto import get_default_presto_profile_name, v
 from aiida.manage.configuration import profile_context
 from aiida.manage.configuration.config import Config
 from aiida.orm import Computer
+
+
+@pytest.fixture()
+def mock_daemon_client(monkeypatch):
+    """Mock the daemon client so the daemon is not actually started during tests."""
+    from aiida.engine.daemon import client as daemon_client_mod
+
+    mock_client = MagicMock()
+    monkeypatch.setattr(daemon_client_mod, 'get_daemon_client', lambda *args, **kwargs: mock_client)
+    return mock_client
 
 
 @pytest.mark.parametrize(
@@ -31,7 +42,7 @@ def test_get_default_presto_profile_name(monkeypatch, profile_names, expected):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
+def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch, mock_daemon_client):
     """Test the ``verdi presto`` without RabbitMQ falls back to ZMQ."""
     from aiida.brokers.rabbitmq import defaults
 
@@ -53,7 +64,7 @@ def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto(run_cli_command):
+def test_presto(run_cli_command, mock_daemon_client):
     """Test that ``verdi presto`` configures a broker (RabbitMQ if available, otherwise ZMQ)."""
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile `presto`.' in result.output
@@ -68,7 +79,7 @@ def test_presto(run_cli_command):
 
 @pytest.mark.requires_psql
 @pytest.mark.usefixtures('empty_config')
-def test_presto_use_postgres(run_cli_command, manager):
+def test_presto_use_postgres(run_cli_command, manager, mock_daemon_client):
     """Test the ``verdi presto`` with the ``--use-postgres`` flag."""
     result = run_cli_command(verdi_presto, ['--non-interactive', '--use-postgres'])
     assert 'Created new profile `presto`.' in result.output
@@ -90,11 +101,46 @@ def test_presto_use_postgres_fail(run_cli_command):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto_overdose(run_cli_command, config_with_profile_factory):
+def test_presto_overdose(run_cli_command, config_with_profile_factory, mock_daemon_client):
     """Test that ``verdi presto`` still works for users that have over 10 presto profiles."""
     config_with_profile_factory(name='presto-10')
     result = run_cli_command(verdi_presto)
     assert 'Created new profile `presto-11`.' in result.output
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_presto_starts_daemon(run_cli_command, mock_daemon_client):
+    """Test that ``verdi presto`` auto-starts the daemon."""
+    result = run_cli_command(verdi_presto, ['--non-interactive'])
+    assert 'Starting the daemon' in result.output
+    mock_daemon_client.start_daemon.assert_called_once()
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_presto_no_daemon_autostart(run_cli_command, mock_daemon_client):
+    """Test that ``verdi presto --no-daemon-autostart`` does not start the daemon."""
+    result = run_cli_command(verdi_presto, ['--non-interactive', '--no-daemon-autostart'])
+    assert 'Created new profile' in result.output
+    assert 'Starting the daemon' not in result.output
+    mock_daemon_client.start_daemon.assert_not_called()
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_presto_daemon_start_failure(run_cli_command, monkeypatch):
+    """Test that ``verdi presto`` handles daemon start failure gracefully."""
+    from aiida.engine.daemon import client as daemon_client_mod
+
+    def mock_get_daemon_client(*args, **kwargs):
+        mock = MagicMock()
+        mock.start_daemon.side_effect = RuntimeError('Could not start daemon')
+        return mock
+
+    monkeypatch.setattr(daemon_client_mod, 'get_daemon_client', mock_get_daemon_client)
+
+    result = run_cli_command(verdi_presto, ['--non-interactive'])
+    assert 'Created new profile' in result.output
+    assert 'FAILED' in result.output
+    assert 'Could not start daemon' in result.output
 
 
 @pytest.mark.requires_psql


### PR DESCRIPTION
I would have preferred to not add an option `--no-daemon-autostart` but the docker image needs to be flexible for different environments and automatically detect and initialize the aiida profile according to them which would have resulted in copying the auto-configuration from `verdi presto` into the CI.

---

When a broker is configured, `verdi presto` now automatically starts the daemon after profile setup. If the daemon fails to start, a warning is shown without failing the command.
    
Add `--no-daemon-autostart` flag to skip the daemon auto-start. This is needed in the Docker container where s6-overlay manages the daemon lifecycle separately (the editable install in `run-before-daemon-start` must complete before the daemon starts).
