### PR TITLE
🐛 Fix ZMQ broker lifecycle bugs causing xdist worker crashes

### DIFF
--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -205,6 +205,15 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
             if threading.current_thread() is not self._loop_thread:
                 self._loop_thread.join(timeout=LOOP_JOIN_TIMEOUT)
 
+                if self._loop_thread.is_alive():
+                    _LOGGER.warning('ZMQ loop thread did not join in time, terminating ZMQ context')
+                    # Force-terminate the ZMQ context to unblock the poll loop.
+                    # This causes recv_multipart to raise ZMQError, exiting the thread.
+                    if self._context is not None:
+                        self._context.term()
+                        self._context = None
+                    self._loop_thread.join(timeout=LOOP_JOIN_TIMEOUT)
+
         self._loop = None
         self._loop_thread = None
 

--- a/src/aiida/brokers/zmq/service.py
+++ b/src/aiida/brokers/zmq/service.py
@@ -93,9 +93,6 @@ class ZmqBrokerService:
         self._write_status(self._server.get_status())
 
     def stop(self) -> None:
-        if not self._running:
-            return
-
         self._running = False
 
         if self._server:

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -224,7 +224,6 @@ class Manager:
                 self._broker.close()
             except futures.TimeoutError as exception:
                 self.logger.warning(f'Call to close the broker timed out: {exception}')
-            self._broker.close()
 
         self._broker = None
         self._process_controller = None


### PR DESCRIPTION
---

## Summary

- Fix `ZmqBrokerService.stop()` silently skipping server cleanup when `_running` is already `False`, leaking ZMQ sockets and contexts that crash xdist workers
- Fix `Manager.reset_broker()` calling `broker.close()` twice — the uncaught second call crashes the process if the first times out
- Force-terminate the ZMQ context when the communicator's background thread doesn't join within the timeout, preventing orphaned threads with open sockets

## Details

The main fix is in `ZmqBrokerService.stop()`. The method had an early `if not self._running: return` guard that skipped all cleanup. `test_run_forever_with_early_stop` (and any code that sets `_running = False` before calling `stop()`) would leave the ZMQ server's ROUTER socket bound and its context alive. On xdist workers, this leaked server interfered with subsequent tests, causing random worker crashes with no Python traceback.

The other two fixes harden the broker shutdown path: removing a double `close()` in `Manager.reset_broker()` that could raise uncaught after a timeout, and force-terminating the ZMQ context to unblock a stuck poll loop thread.

Fixes #7347