### PR TITLE
🐛 ZMQ broker: send immediate task acknowledgment

### DIFF
--- a/docs/source/internals/broker.rst
+++ b/docs/source/internals/broker.rst
@@ -137,8 +137,10 @@ Message types
      - worker → broker
      - Negative acknowledgment. Broker requeues the task for redelivery.
    * - ``TASK_RESPONSE``
-     - worker → broker → client
-     - Return the result of a completed task. Broker forwards to original sender.
+     - broker → client
+     - Immediate acknowledgment that the task was persisted to the queue
+       (matches RabbitMQ publisher-confirm semantics).
+       The worker's eventual result is not forwarded back to the sender.
    * - ``RPC``
      - client → broker → recipient
      - Remote procedure call to a named recipient. Broker routes by subscriber ID.
@@ -173,6 +175,7 @@ The protocol maps AMQP concepts to ZMQ message types:
 
     AMQP concept              ZMQ broker equivalent
     ────────────────────────  ──────────────────────────────────
+    publisher confirm         TASK_RESPONSE (immediate broker ack)
     basic.ack                 TASK_ACK
     basic.nack                TASK_NACK
     consumer with prefetch    TASK dispatch to available workers
@@ -209,24 +212,27 @@ Message flow: task submission
           │  task_send(task)            │                      │
           │──── TASK ──────────────────────────────────────────▶│
           │                             │          push to PersistentQueue
+          │◀──── TASK_RESPONSE (ack) ──────────────────────────│  immediate
           │                             │                      │
           │                             │◀─── TASK ────────────│  dispatch
           │                             │                      │
           │                             │  (process runs...)   │
           │                             │                      │
           │                             │──── TASK_ACK ───────▶│  ack: remove from queue
-          │                             │──── TASK_RESPONSE ──▶│
-          │                             │                      │
-          │◀────────────── TASK_RESPONSE (forwarded) ──────────│
           │                             │                      │
 
 Key details:
 
+- The broker sends an **immediate** ``TASK_RESPONSE`` back to the sender as soon as the task
+  is persisted to the queue on disk.  This matches RabbitMQ's publisher-confirm semantics:
+  the caller's ``Future`` resolves without waiting for a worker to process the task.
+  Without this, ``task_send`` would block until ``broker.task_timeout`` when no workers are connected
+  (e.g. during ``verdi process repair``).
 - The broker persists the task to disk **before** dispatching it.
   If the broker crashes, tasks are recovered from disk on restart.
 - Workers delay the ACK until the task Future resolves (see :ref:`deferred ACK <internal_architecture:broker:deferred_ack>` below).
   If a worker dies before ACK'ing, the broker detects the disconnect (via ZMTP heartbeats + PING probing) and requeues the task.
-- If ``no_reply=True``, no TASK_RESPONSE is sent.
+- If ``no_reply=True``, no ``TASK_RESPONSE`` is sent (fire-and-forget, used by ``submit()``).
 
 
 Task dispatch strategy

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -85,8 +85,7 @@ class ZmqBrokerServer:
         # rpc_subscribers: identifier -> client_identity (bytes)
         self._rpc_subscribers: dict[str, bytes] = {}
 
-        # Pending responses: correlation_id -> (client_identity, timestamp)
-        self._pending_task_responses: dict[str, tuple[bytes, float]] = {}
+        # Pending RPC responses: correlation_id -> (client_identity, timestamp)
         self._pending_rpc_responses: dict[str, tuple[bytes, float]] = {}
 
         # Task-worker assignments: task_id -> worker_identity
@@ -283,6 +282,14 @@ class ZmqBrokerServer:
         """Handle incoming task message.
 
         Queue the task and try to dispatch to an available worker.
+
+        When the sender expects a reply (``no_reply=False``), an immediate
+        acknowledgment response is sent back as soon as the task is persisted
+        to disk.  This mirrors RabbitMQ's publisher-confirm behaviour: the
+        caller learns that the broker accepted the task without having to wait
+        for a worker to process it.  The worker's eventual result (if any) is
+        *not* forwarded back to the original sender — callers like
+        ``continue_process`` only need the confirmation, not the outcome.
         """
         task_id = msg['id']
         sender = msg.get('sender', '')
@@ -299,9 +306,15 @@ class ZmqBrokerServer:
         }
         self._task_queue.push(task_id, task_data)
 
-        # Track pending response if reply expected
+        # Send an immediate acknowledgment to the sender so its Future
+        # resolves without waiting for a worker (matches RabbitMQ semantics).
         if not no_reply:
-            self._pending_task_responses[task_id] = (identity, time.time())
+            response = {
+                'type': MessageType.TASK_RESPONSE.value,
+                'task_id': task_id,
+                'result': True,
+            }
+            self._send_to_client(identity, response)
 
         # Try to dispatch immediately
         self._dispatch_pending_tasks()
@@ -309,23 +322,11 @@ class ZmqBrokerServer:
     def _handle_task_response(self, identity: bytes, msg: dict[str, Any]) -> None:
         """Handle task response from worker.
 
-        Route the response back to the original task sender.
+        Since the broker already sends an immediate acknowledgment when a task
+        is queued, the worker's result response is simply logged and discarded.
         """
-        task_id = msg.get('task_id')
-        if not task_id:
-            _LOGGER.warning('Task response missing task_id')
-            return
-
-        # Find original sender
-        pending = self._pending_task_responses.pop(task_id, None)
-        if not pending:
-            _LOGGER.warning('No pending response for task: %s', task_id)
-            return
-
-        original_sender, _ = pending
-
-        # Forward response to original sender
-        self._send_to_client(original_sender, msg)
+        task_id = msg.get('task_id', '?')
+        _LOGGER.debug('Received task response for %s (discarded — sender already acknowledged)', task_id)
 
     def _handle_task_ack(self, identity: bytes, msg: dict[str, Any]) -> None:
         """Handle task acknowledgment from worker."""
@@ -602,7 +603,6 @@ class ZmqBrokerServer:
             'task_subscribers': len(self._task_subscribers),
             'rpc_subscribers': len(self._rpc_subscribers),
             'available_workers': len(self._available_workers),
-            'pending_task_responses': len(self._pending_task_responses),
             'pending_rpc_responses': len(self._pending_rpc_responses),
         }
 

--- a/tests/brokers/test_zmq_communicator.py
+++ b/tests/brokers/test_zmq_communicator.py
@@ -173,20 +173,23 @@ class TestZmqCommunicatorRoundTrip:
         stop_zmq_broker(broker)
 
     def test_task_round_trip(self, sender_and_worker):
-        """Test full task send -> subscribe -> handle -> response cycle."""
+        """Test task send gets immediate broker acknowledgment.
+
+        The broker sends an immediate TASK_RESPONSE when the task is queued
+        (matching RabbitMQ publisher-confirm semantics).  The worker processes
+        the task independently.
+        """
         _, sender, worker = sender_and_worker
 
-        def handle_task(comm, body):
-            return body.get('x', 0) * 2
-
-        worker.add_task_subscriber(handle_task, identifier='worker')
+        worker.add_task_subscriber(lambda comm, body: body.get('x', 0) * 2, identifier='worker')
         time.sleep(0.5)
 
         future = sender.task_send({'x': 21})
         assert future is not None
 
+        # The sender's Future resolves with the broker's acceptance, not the worker's result
         result = future.result(timeout=5.0)
-        assert result.result() == 42
+        assert result.result() is True
 
     def test_rpc_round_trip(self, sender_and_worker):
         """Test full RPC send -> subscribe -> handle -> response cycle."""
@@ -221,7 +224,7 @@ class TestZmqCommunicatorRoundTrip:
         assert received[0] == ('ping', 'test.ping')
 
     def test_task_with_deferred_future(self, sender_and_worker):
-        """Test task handler returning a Future (deferred ACK path)."""
+        """Test task send with deferred handler gets immediate broker ack."""
         _, sender, worker = sender_and_worker
 
         def handle_task(comm, body):
@@ -233,8 +236,9 @@ class TestZmqCommunicatorRoundTrip:
         time.sleep(0.5)
 
         future = sender.task_send({'val': 5})
+        # Sender gets immediate broker acknowledgment, not the worker's deferred result
         result = future.result(timeout=5.0)
-        assert result.result() == 105
+        assert result.result() is True
 
     def test_rpc_with_deferred_future(self, sender_and_worker):
         """Test RPC handler returning a Future."""

--- a/tests/brokers/test_zmq_server.py
+++ b/tests/brokers/test_zmq_server.py
@@ -99,7 +99,8 @@ class TestZmqBrokerServerMessageHandling:
     # --- Task handling ---
 
     def test_handle_task_no_reply(self, server):
-        """Test _handle_task queues a task with no_reply=True."""
+        """Test _handle_task queues a task with no_reply=True (no ack sent)."""
+        server._send_to_client = MagicMock()
         msg = {
             'type': MessageType.TASK.value,
             'id': 'task-001',
@@ -110,10 +111,12 @@ class TestZmqBrokerServerMessageHandling:
         server._handle_task(b'worker-1', msg)
 
         assert server._task_queue.size() == 1
-        assert 'task-001' not in server._pending_task_responses
+        # no_reply=True means no immediate acknowledgment sent
+        server._send_to_client.assert_not_called()
 
     def test_handle_task_with_reply(self, server):
-        """Test _handle_task tracks pending response when reply expected."""
+        """Test _handle_task sends immediate acknowledgment when reply expected."""
+        server._send_to_client = MagicMock()
         msg = {
             'type': MessageType.TASK.value,
             'id': 'task-002',
@@ -122,37 +125,23 @@ class TestZmqBrokerServerMessageHandling:
             'no_reply': False,
         }
         server._handle_task(b'client-1', msg)
-        assert 'task-002' in server._pending_task_responses
 
-    def test_handle_task_response(self, server):
-        """Test _handle_task_response routes to original sender."""
-        original_sender = b'sender-1'
-        server._pending_task_responses['task-100'] = (original_sender, time.time())
-        server._send_to_client = MagicMock()
+        # Broker sends immediate TASK_RESPONSE acknowledgment
+        server._send_to_client.assert_called_once()
+        ack_msg = server._send_to_client.call_args[0][1]
+        assert ack_msg['type'] == MessageType.TASK_RESPONSE.value
+        assert ack_msg['task_id'] == 'task-002'
+        assert ack_msg['result'] is True
 
+    def test_handle_task_response_discarded(self, server):
+        """Test _handle_task_response discards worker responses (sender already acked)."""
         msg = {
             'type': MessageType.TASK_RESPONSE.value,
             'task_id': 'task-100',
             'result': 'done',
         }
+        # Should not raise — worker responses are simply logged and discarded
         server._handle_task_response(b'worker-1', msg)
-
-        server._send_to_client.assert_called_once_with(original_sender, msg)
-        assert 'task-100' not in server._pending_task_responses
-
-    def test_handle_task_response_missing_task_id(self, server):
-        """Test _handle_task_response with missing task_id is a no-op."""
-        server._send_to_client = MagicMock()
-        msg = {'type': MessageType.TASK_RESPONSE.value}
-        server._handle_task_response(b'worker', msg)
-        server._send_to_client.assert_not_called()
-
-    def test_handle_task_response_no_pending(self, server):
-        """Test _handle_task_response with unknown task is a no-op."""
-        server._send_to_client = MagicMock()
-        msg = {'type': MessageType.TASK_RESPONSE.value, 'task_id': 'unknown'}
-        server._handle_task_response(b'worker', msg)
-        server._send_to_client.assert_not_called()
 
     def test_handle_task_ack(self, server):
         """Test _handle_task_ack removes task and marks worker available."""


### PR DESCRIPTION
This is super hard to understand because it is going through plumpy and kiwipy logic. Basically we immediately send an ACK on submission of a task to not let the client wait for the response (so you can spam responses). I thought I implemented it the way RMQ does it but apparently not. Because I assigned the broker to the daemon lifetime (and thus worker lifetime) this got unnoticed. 

---

When a task is received, the broker now sends an immediate TASK_RESPONSE back to the sender as soon as the task is persisted to the queue on disk.  This matches RabbitMQ's publisher-confirm semantics: the caller's Future resolves without waiting for a worker to process the task.

Previously, the sender's Future would only resolve when a worker sent its result back, causing timeouts when no workers were connected (e.g. during `verdi process repair` with the daemon stopped).

Update the internal architecture docs to reflect that the broker now sends an immediate TASK_RESPONSE when a task is queued (matching RabbitMQ publisher-confirm semantics), rather than forwarding the worker's result back to the sender.