### PR TITLE
🧪 Fix flaky `test_await_processes` log assertion

### DIFF
--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -156,8 +156,7 @@ def test_await_processes(aiida_code_installed, caplog):
     assert not node.is_terminated
     launch.await_processes([node])
     assert node.is_terminated
-    assert len(caplog.records) > 0
-    assert 'out of 1 processes terminated.' in caplog.records[0].message
+    assert any('out of 1 processes terminated.' in record.message for record in caplog.records)
 
 
 @pytest.mark.requires_broker


### PR DESCRIPTION
> FAILED tests/engine/test_launch.py::test_await_processes - assert 'out of 1 processes terminated.' in "Executing <Task pending name='Task-1401' coro=<LoopScheduler.await_submit.<locals>.coro() running at /home/runner/wor...res.py:392] created at /opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/asyncio/tasks.py:636> took 0.393 seconds"


https://github.com/aiidateam/aiida-core/actions/runs/25174875760/job/73804111070

---

The test assumed the expected log message was the first captured record, but under load an asyncio slow-task warning can appear first. Check any record instead of hardcoding index 0.