### PR TITLE
♻️ `Broker`: polymorphic process revival

### DIFF
--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -31,6 +31,23 @@ class Broker(abc.ABC):
     def iterate_tasks(self) -> Iterator[t.Any]:
         """Return an iterator over the tasks in the launch queue."""
 
+    def revive_process(self, pid: int) -> None:
+        """Re-enqueue a continuation task for an active process that has no task in the broker.
+
+        Used by ``verdi process repair`` to recover zombie processes (active in the database but
+        without a corresponding task on the broker). The required state depends on the
+        implementation: a broker whose lifecycle is managed by the daemon needs the daemon
+        stopped, while a broker that runs as an independent service only needs to be reachable.
+
+        Implementations are optional. The default raises :class:`NotImplementedError` so that
+        third-party brokers remain instantiable; they can opt in by overriding this method.
+
+        :param pid: The pk of the process to revive.
+        :raises NotImplementedError: If the broker does not support process revival.
+        """
+        msg = f'`{type(self).__name__}` does not implement `revive_process` (cannot revive process `{pid}`)'
+        raise NotImplementedError(msg)
+
     @abc.abstractmethod
     def close(self) -> None:
         """Close the broker."""

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -60,6 +60,17 @@ class RabbitmqBroker(Broker):
         for task in self.get_communicator().task_queue(get_launch_queue_name(self._prefix)):
             yield task
 
+    def revive_process(self, pid: int) -> None:
+        """Re-enqueue a continuation task for a zombie process via the live RabbitMQ broker.
+
+        Requires the RabbitMQ server to be reachable. The daemon may be in any state — RabbitMQ
+        runs as an independent service, not managed by the daemon, unlike the ZMQ broker.
+        """
+        from plumpy.process_comms import RemoteProcessThreadController
+
+        controller = RemoteProcessThreadController(self.get_communicator())
+        controller.continue_process(pid)
+
     def get_communicator(self) -> 'RmqThreadCommunicator':
         if self._communicator is None:
             self._communicator = self._create_communicator()

--- a/src/aiida/brokers/zmq/broker.py
+++ b/src/aiida/brokers/zmq/broker.py
@@ -6,7 +6,9 @@ import json
 import shutil
 import time
 import typing as t
+import uuid
 from contextlib import contextmanager
+from functools import cached_property
 from pathlib import Path
 
 import psutil
@@ -44,6 +46,7 @@ class ZmqBroker(Broker):
         self._communicator: ZmqCommunicator | None = None
         self._broker_dir = broker_dir
         self._storage_path = broker_dir / 'storage'
+        self._queue_path = self._storage_path / 'tasks'
         self._service_pid_file = broker_dir / 'broker.pid'
         self._service_status_file = broker_dir / 'broker.status'
         self._service_sockets_file = broker_dir / 'broker.sockets'
@@ -168,14 +171,36 @@ class ZmqBroker(Broker):
 
         return self._communicator
 
+    @cached_property
+    def _queue(self) -> PersistentQueue:
+        """Lazily-instantiated persistent queue.
+
+        Cached so that crash-recovery (run by :meth:`PersistentQueue._load`) happens once per
+        broker instance and the in-memory pending deque stays consistent across
+        :meth:`iterate_tasks` and :meth:`revive_process`.
+        """
+        return PersistentQueue(self._queue_path)
+
     def iterate_tasks(self) -> t.Iterator['ZmqIncomingTask']:
-        queue_path = self._storage_path / 'tasks'
-        if not queue_path.exists():
+        if not self._queue_path.exists():
             return
 
-        queue = PersistentQueue(queue_path)
-        for task_id, task_data in queue.get_all_pending():
-            yield ZmqIncomingTask(task_id, task_data, queue)
+        for task_id, task_data in self._queue.get_all_pending():
+            yield ZmqIncomingTask(task_id, task_data, self._queue)
+
+    def revive_process(self, pid: int) -> None:
+        """Re-enqueue a continuation task for a zombie process.
+
+        Writes the task directly to the persistent queue on disk. The ZMQ broker is a subprocess
+        managed by the daemon (via circus), and ``verdi process repair`` requires the daemon to
+        be stopped, so a live broker is not available; the task will be picked up when the broker
+        is next started.
+        """
+        from plumpy.process_comms import create_continue_body
+
+        task_id = uuid.uuid4().hex
+        body = create_continue_body(pid=pid, nowait=True)
+        self._queue.push(task_id, {'body': body, 'no_reply': True})
 
     def close(self) -> None:
         if self._communicator is not None:

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -600,33 +600,9 @@ def process_repair(manager, broker, dry_run, force):
             echo.echo_report(f'Acknowledged task `{pid}`')
 
     # Revive zombie processes that no longer have a process task
-    zombies = set_active_processes.difference(set_process_tasks)
-    if zombies:
-        from aiida.brokers.zmq.broker import ZmqBroker
-
-        if isinstance(broker, ZmqBroker):
-            # For ZMQ, the broker runs inside the daemon (which must be stopped for repair).
-            # Write revival tasks directly to the persistent queue on disk — the broker will
-            # pick them up when the daemon is restarted.  This avoids starting a temporary
-            # broker process and the timing issues that come with it.
-            import uuid
-
-            from plumpy.process_comms import create_continue_body
-
-            from aiida.brokers.zmq.queue import PersistentQueue
-
-            queue_path = broker.storage_path / 'tasks'
-            queue = PersistentQueue(queue_path)
-            for pid in zombies:
-                task_id = uuid.uuid4().hex
-                body = create_continue_body(pid=pid, nowait=True)
-                queue.push(task_id, {'body': body, 'no_reply': True})
-                echo.echo_report(f'Revived process `{pid}`')
-        else:
-            process_controller = manager.get_process_controller()
-            for pid in zombies:
-                process_controller.continue_process(pid)
-                echo.echo_report(f'Revived process `{pid}`')
+    for pid in set_active_processes.difference(set_process_tasks):
+        broker.revive_process(pid)
+        echo.echo_report(f'Revived process `{pid}`')
 
 
 @verdi_process.command('dump')

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -10,7 +10,7 @@
 
 import pathlib
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -35,6 +35,19 @@ def test_str_method(monkeypatch, manager):
 
     monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
     assert 'RabbitMQ @' in str(broker)
+
+
+def test_revive_process_uses_remote_controller(aiida_profile):
+    """``revive_process`` should delegate to ``RemoteProcessThreadController.continue_process``."""
+    broker = RabbitmqBroker(aiida_profile)
+    communicator = MagicMock()
+    broker._communicator = communicator
+
+    with patch('plumpy.process_comms.RemoteProcessThreadController') as controller_cls:
+        broker.revive_process(42)
+
+    controller_cls.assert_called_once_with(communicator)
+    controller_cls.return_value.continue_process.assert_called_once_with(42)
 
 
 def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch):

--- a/tests/brokers/test_zmq_broker.py
+++ b/tests/brokers/test_zmq_broker.py
@@ -253,6 +253,47 @@ class TestZmqBrokerTasks:
         assert len(tasks) == 2
         assert all(isinstance(t, ZmqIncomingTask) for t in tasks)
 
+    def test_revive_process_writes_continue_task(self, tmp_path):
+        """``revive_process`` should push a continue task to the persistent queue."""
+        broker = _create_broker_with_base_path(tmp_path)
+
+        broker.revive_process(42)
+
+        queue = PersistentQueue(tmp_path / 'storage' / 'tasks')
+        pending = queue.get_all_pending()
+        assert len(pending) == 1
+
+        _, task_data = pending[0]
+        assert task_data['no_reply'] is True
+        # plumpy.create_continue_body shape: {'task': 'continue', 'args': {'pid': 42, 'nowait': True, 'tag': None}}
+        assert task_data['body']['args']['pid'] == 42
+        assert task_data['body']['args']['nowait'] is True
+
+    def test_revive_process_multiple_pids(self, tmp_path):
+        """Reviving multiple PIDs should produce one task per PID with unique task ids."""
+        broker = _create_broker_with_base_path(tmp_path)
+
+        for pid in (1, 2, 3):
+            broker.revive_process(pid)
+
+        queue = PersistentQueue(tmp_path / 'storage' / 'tasks')
+        pending = queue.get_all_pending()
+        assert len(pending) == 3
+        assert len({task_id for task_id, _ in pending}) == 3
+        assert {task_data['body']['args']['pid'] for _, task_data in pending} == {1, 2, 3}
+
+    def test_revive_then_iterate_round_trip(self, tmp_path):
+        """A revived task must be visible to ``iterate_tasks`` (producer/consumer schema check)."""
+        broker = _create_broker_with_base_path(tmp_path)
+
+        broker.revive_process(7)
+
+        tasks = list(broker.iterate_tasks())
+        assert len(tasks) == 1
+        body = tasks[0].body
+        assert body is not None
+        assert body['args']['pid'] == 7
+
 
 class TestZmqIncomingTask:
     """Tests for ZmqIncomingTask."""


### PR DESCRIPTION
Copy of commit msg here:
```
`verdi process repair` previously branched on `isinstance(broker,
ZmqBroker)` to choose between writing tasks directly to the
PersistentQueue (ZMQ) and calling a `RemoteProcessThreadController`
(RabbitMQ). Move both paths behind a polymorphic
`Broker.revive_process(pid)` method so the CLI is broker-agnostic and
third-party brokers can plug in their own strategy.

The default raises `NotImplementedError` rather than being abstract, so
existing out-of-tree `Broker` subclasses remain instantiable; they opt
in by overriding.
```