### PR TITLE
🐛 `aiida_localhost`: suffix label with xdist-worker id

### DIFF
--- a/src/aiida/tools/pytest_fixtures/orm.py
+++ b/src/aiida/tools/pytest_fixtures/orm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 import typing as t
 
@@ -105,6 +106,14 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
                 scheduler_type=scheduler_type,
             )
 
+        # Atomic get-or-create using UNIQUE as the serializer (try get → on miss, store → on UNIQUE
+        # violation, re-query). A user-space lock (``threading.Lock``, ``filelock``, etc.) would be
+        # redundant with the DB-level UNIQUE check and wouldn't address the actual flakiness — a
+        # single-thread session-cache stale read after ``aiida_profile_clean``, not a concurrent-
+        # write race. The cleanest alternative would be ``INSERT ... ON CONFLICT DO NOTHING
+        # RETURNING`` (one atomic round-trip, no exception handling), but that's dialect-specific
+        # and bypasses ``Computer(...).store()``'s AiiDA-side defaults — not worth it for a test
+        # fixture.
         try:
             computer = Computer.collection.get(
                 label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
@@ -114,10 +123,23 @@ def aiida_computer(tmp_path) -> t.Callable[[], 'Computer']:
             try:
                 computer.store()
             except IntegrityError:
-                # Another xdist worker concurrently re-created this computer after
-                # ``aiida_profile_clean`` reset the shared database. Re-querying is
-                # safe because the ``psql_dos`` storage backend rolls back our failed
-                # transaction before raising (see ``psql_dos/orm/utils.py``).
+                # The row exists at the DB level (UNIQUE fired) but the preceding ``get()`` raised
+                # ``NotExistent``. This typically happens after ``aiida_profile_clean`` has reset
+                # session state mid-test, or when a row committed by an earlier test in the same
+                # worker is not visible to the current session's cache. The follow-up ``get()``
+                # re-issues the query against fresh state and is safe: the storage layer rolls back
+                # our failed transaction before raising (the shared ``ModelWrapper.save()`` in
+                # ``psql_dos/orm/utils.py``, used by both ``psql_dos`` and the ``sqlite_*`` backends).
+                #
+                # No retry loop or EBM: by the time ``IntegrityError`` fires, the conflicting row
+                # is already committed at the DB level, and a fresh ``get()`` against a rolled-
+                # back transaction will almost always see it. The ``NotExistent`` fallback below
+                # covers the rare cases where the re-query still misses — session-cache state
+                # hiding the committed row, a test manually calling ``reset_storage()`` between
+                # the two queries, or edge cases we haven't anticipated. Kept (not removed as
+                # dead code) to avoid re-introducing flakiness if any of those surface. Loop-
+                # with-backoff is for genuinely transient errors (SQLite ``database is locked``,
+                # connection-pool exhaustion), not races already pinned down by commit.
                 try:
                     computer = Computer.collection.get(
                         label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
@@ -269,6 +291,12 @@ def aiida_computer_ssh_async(aiida_computer) -> t.Callable[[], 'Computer']:
 def aiida_localhost(aiida_computer_local) -> 'Computer':
     """Return a :class:`aiida.orm.computers.Computer` instance representing localhost with ``core.local`` transport.
 
+    The computer's label is suffixed with the pytest-xdist worker id (e.g. ``localhost-gw0``,
+    or just ``localhost-master`` when not running under xdist). This keeps the fixture's row
+    distinct from any literal-``'localhost'`` Computer that ``verdi presto`` or other code
+    paths may create in the same profile, avoiding UNIQUE-constraint collisions on
+    ``Computer.label``.
+
     Usage::
 
         def test(aiida_localhost):
@@ -276,7 +304,8 @@ def aiida_localhost(aiida_computer_local) -> 'Computer':
 
     :return: The computer.
     """
-    return aiida_computer_local(label='localhost')
+    worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+    return aiida_computer_local(label=f'localhost-{worker_id}')
 
 
 @pytest.fixture

--- a/tests/calculations/test_stash.py
+++ b/tests/calculations/test_stash.py
@@ -109,7 +109,7 @@ def test_code_vs_stash_mode_conflict(stash_mode, fixture_sandbox, aiida_localhos
     code = orm.InstalledCode(
         label='dummy_code',
         default_calc_job_plugin='core.stash',
-        computer=orm.load_computer(label='localhost'),
+        computer=aiida_localhost,
         filepath_executable='/doesnot/exist/script.sh',
     )
 
@@ -252,7 +252,7 @@ done
     code = orm.InstalledCode(
         label='test_code',
         default_calc_job_plugin='core.stash',
-        computer=orm.load_computer(label='localhost'),
+        computer=aiida_localhost,
         filepath_executable=str(executable),
     )
     code.store()

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -192,7 +192,7 @@ def test_code_delete_one_force(run_cli_command, code):
         load_code('code')
 
 
-def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, hostname) -> str:
+def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, computer_label, hostname) -> str:
     """Normalize dynamic values in CLI output for stable regression testing.
 
     Args:
@@ -200,6 +200,9 @@ def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, hostnam
         code_pk: The actual PK to be replaced with placeholder
         code_uuid: The actual UUID to be replaced with placeholder
         computer_pk: Optional computer PK to be replaced with placeholder
+        computer_label: Optional suffixed ``aiida_localhost`` label whose worker-id suffix should be
+            stripped (e.g. ``localhost-gw1`` -> ``localhost``), so the golden file can carry the
+            user-facing label without an xdist artefact
         hostname: Optional hostname to be replaced with placeholder
 
     Returns:
@@ -218,6 +221,13 @@ def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, hostnam
 
     # Replace UUID first (before PK, as PK digits might appear in UUID)
     normalized = normalized.replace(code_uuid, '<UUID>')
+
+    # Strip the worker-id suffix from the ``aiida_localhost`` label so the golden file shows the
+    # user-facing ``localhost`` rather than ``localhost-gw1``. Done before hostname substitution
+    # because the suffixed label contains the hostname as a substring (matching ``localhost``
+    # first would leave a dangling ``-gw1``).
+    if computer_label and computer_label.startswith(f'{hostname}-'):
+        normalized = normalized.replace(computer_label, hostname)
 
     # Replace hostname if provided
     if hostname:
@@ -290,6 +300,7 @@ def test_code_show(run_cli_command, aiida_localhost, tmp_path, bash_path, aiida_
         code_pk=code.pk,
         code_uuid=code.uuid,
         computer_pk=computer.pk if computer else None,
+        computer_label=computer.label if computer else None,
         hostname=computer.hostname if computer else None,
     )
 
@@ -410,7 +421,7 @@ def test_code_duplicate_ignore(run_cli_command, aiida_code_installed, non_intera
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('sort_option', ('--sort', '--no-sort'))
-def test_code_export(run_cli_command, aiida_code_installed, tmp_path, file_regression, sort_option):
+def test_code_export(run_cli_command, aiida_code_installed, aiida_localhost, tmp_path, file_regression, sort_option):
     """Test export the code setup to str."""
     prepend_text = 'module load something\n    some command'
     code = aiida_code_installed(
@@ -424,8 +435,10 @@ def test_code_export(run_cli_command, aiida_code_installed, tmp_path, file_regre
     options = [str(code.pk), str(filepath), sort_option]
     result = run_cli_command(cmd_code.export, options)
     assert str(filepath) in result.output, 'Filename should be in terminal output but was not found.'
-    # file regression check
-    content = filepath.read_text()
+    # file regression check; strip the worker-id suffix from the computer label so the golden
+    # file carries the user-facing ``localhost`` rather than ``localhost-gw1`` (see
+    # ``aiida_localhost`` fixture).
+    content = filepath.read_text().replace(aiida_localhost.label, aiida_localhost.hostname)
     file_regression.check(content, extension='.yml')
 
     # round trip test by create code from the config file
@@ -481,7 +494,7 @@ def test_code_export_overwrite(run_cli_command, aiida_code_installed, tmp_path):
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.usefixtures('chdir_tmp_path')
-def test_code_export_default_filename(run_cli_command, aiida_code_installed):
+def test_code_export_default_filename(run_cli_command, aiida_code_installed, aiida_localhost):
     """Test default filename being created if no argument passed."""
 
     prepend_text = 'module load something\n    some command'
@@ -495,7 +508,7 @@ def test_code_export_default_filename(run_cli_command, aiida_code_installed):
     options = [str(code.pk)]
     run_cli_command(cmd_code.export, options)
 
-    assert pathlib.Path('code@localhost.yaml').is_file()
+    assert pathlib.Path(f'code@{aiida_localhost.label}.yaml').is_file()
 
 
 @pytest.mark.parametrize('non_interactive_editor', ('vim -cwq',), indirect=True)

--- a/tests/orm/nodes/data/test_remote.py
+++ b/tests/orm/nodes/data/test_remote.py
@@ -18,14 +18,16 @@ from aiida.orm import RemoteData
 
 
 @pytest.fixture
-def remote_data_factory(tmp_path, aiida_computer_local, aiida_computer_ssh):
+def remote_data_factory(tmp_path, aiida_localhost, aiida_computer_ssh):
     """Factory fixture to create RemoteData instances."""
 
     def _create_remote_data(mode: str, content: str | bytes = b'some content'):
         if mode == 'local':
-            computer = aiida_computer_local(label='localhost')
+            computer = aiida_localhost
         elif mode == 'ssh':
-            computer = aiida_computer_ssh(label='localhost-ssh')
+            # Let ``aiida_computer_ssh`` auto-generate a UUID label, so concurrent xdist workers
+            # (or repeated calls within the same session) cannot collide on ``Computer.label``.
+            computer = aiida_computer_ssh()
         else:
             raise ValueError(f'Unknown mode: {mode}')
 

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -17,24 +17,18 @@ import pytest
 
 from aiida.common import LinkType, exceptions, timezone
 from aiida.manage import get_manager
-from aiida.orm import CalculationNode, Computer, Data, Int, Log, Node, User, WorkflowNode, load_node
+from aiida.orm import CalculationNode, Data, Int, Log, Node, User, WorkflowNode, load_node
 from aiida.orm.utils.links import LinkTriple
 
 
 class TestNode:
     """Tests for generic node functionality."""
 
-    def setup_method(self):
-        """Setup for methods."""
+    @pytest.fixture(autouse=True)
+    def _setup(self, aiida_localhost):
+        """Class setup, autouse so it runs before each test method."""
         self.user = User.collection.get_default()
-        _, self.computer = Computer.collection.get_or_create(
-            label='localhost',
-            description='localhost computer set up by test manager',
-            hostname='localhost',
-            transport_type='core.local',
-            scheduler_type='core.direct',
-        )
-        self.computer.store()
+        self.computer = aiida_localhost
 
     def test_instantiate_with_user(self):
         """Test a Node can be instantiated with a specific user."""

--- a/tests/tools/pytest_fixtures/test_orm.py
+++ b/tests/tools/pytest_fixtures/test_orm.py
@@ -16,8 +16,45 @@ pytest_plugins = ['aiida.tools.pytest_fixtures']
 
 
 def test_aiida_localhost(aiida_localhost):
-    """Test the ``aiida_localhost`` fixture."""
-    assert aiida_localhost.label == 'localhost'
+    """Test the ``aiida_localhost`` fixture.
+
+    The label is suffixed with the pytest-xdist worker id to avoid collisions with literal
+    ``'localhost'`` Computers created by other tests or commands (e.g. ``verdi presto``).
+    """
+    # Assert at the contract level (the suffix exists) rather than coupling to the specific
+    # worker-id value, which depends on ``PYTEST_XDIST_WORKER`` at runtime.
+    assert aiida_localhost.label.startswith('localhost-')
+    assert aiida_localhost.hostname == 'localhost'
+    assert aiida_localhost.transport_type == 'core.local'
+    assert aiida_localhost.scheduler_type == 'core.direct'
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_aiida_localhost_no_literal_collision(request):
+    """The fixture's Computer must coexist with a pre-existing literal ``'localhost'`` Computer.
+
+    ``verdi presto`` and other code paths create a Computer with the literal ``'localhost'``
+    label in the same profile. This is the actual #7347 failure
+    order: the literal row is inserted first, then ``aiida_localhost`` is requested. Worker-
+    suffixing the fixture's label makes its row distinct from any literal-label row already in
+    the database, so no UNIQUE-constraint collision can fire.
+    """
+    Computer(
+        label='localhost',
+        hostname='localhost',
+        transport_type='core.ssh',
+        scheduler_type='core.direct',
+        workdir='/tmp',
+    ).store()
+
+    # Defer the fixture's creation until *after* the literal-``'localhost'`` row exists, mirroring
+    # the actual #7347 failure order. If we depended on ``aiida_localhost`` via the test signature,
+    # pytest would evaluate it before the test body runs and the literal row would not yet be
+    # present — we'd be testing the wrong direction of the race.
+    aiida_localhost = request.getfixturevalue('aiida_localhost')
+
+    assert aiida_localhost.label != 'localhost'
+    assert aiida_localhost.transport_type == 'core.local'
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -205,7 +205,7 @@ class TestVisGraph:
 
         expected = {
             'State: running" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]',
-            '@localhost" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]',
+            f'@{self.computer.label}" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]',
             'Exit Code: 200" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]',
             f'N{nodes.fd1.pk} [label="FolderData ({nodes.fd1.pk})" color=lightgray fillcolor=white penwidth=2 '
             'shape=ellipse style=filled]',
@@ -262,7 +262,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=rectangle style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @localhost" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
+                    @{computer_label}" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -276,7 +276,7 @@ class TestVisGraph:
                 N{rd1} -> N{calcf1} [color="#000000" style=solid]
                 N{calcf1} -> N{fd1} [color="#000000" style=solid]
                 N{calcf1} -> N{pd3} [color="#000000" style=solid]
-        }}""".format(**{k: v.pk for k, v in nodes.items()})
+        }}""".format(computer_label=self.computer.label, **{k: v.pk for k, v in nodes.items()})
 
         # dedent before comparison
         assert sorted([line.strip() for line in graph.graphviz.source.splitlines()]) == sorted(
@@ -301,7 +301,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=polygon sides=6 style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @localhost" pencolor=black shape=rectangle]
+                    @{computer_label}" pencolor=black shape=rectangle]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" pencolor=black shape=rectangle]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -315,7 +315,7 @@ class TestVisGraph:
                 N{rd1} -> N{calcf1} [color="#000000" style=solid]
                 N{calcf1} -> N{fd1} [color="#000000" style=solid]
                 N{calcf1} -> N{pd3} [color="#000000" style=solid]
-        }}""".format(**{k: v.pk for k, v in nodes.items()})
+        }}""".format(computer_label=self.computer.label, **{k: v.pk for k, v in nodes.items()})
 
         # dedent before comparison
         assert sorted([line.strip() for line in graph.graphviz.source.splitlines()]) == sorted(


### PR DESCRIPTION
commit msg:
```
🐛 `aiida_localhost`: suffix label with xdist-worker id

Fixes the `UNIQUE constraint failed: db_dbcomputer.label` flake on
`tests-presto` and friends (#7347, Category 1). The `aiida_localhost`
fixture's row and a literal-`'localhost'` row created by another code
path (notably `verdi presto`) ended up in the same profile, and one
of two adjacent statements in the fixture's get-or-create — the four-
field `Computer.collection.get` followed by `Computer(...).store()` —
saw inconsistent state and tripped the single-column UNIQUE on
`Computer.label`. Tracing didn't pin the exact within-worker mechanism
(likely a SQLAlchemy session-cache stale read after `aiida_profile_-
clean` reset state); xdist surfaces it more often by widening the test
ordering space.

Fix: suffix the fixture's label with the pytest-xdist worker id
(`localhost-gw0`, ..., or `localhost-master` outside xdist). The
fixture row and any literal-label row coexist under different names,
so UNIQUE cannot fire regardless of the timing or cache state. The
literal `'localhost'` label remains the production contract for
`verdi presto` and is untouched. `'master'` matches xdist's own
`worker_id` fixture convention.

Eight tests asserted against the literal `'localhost'` form and broke;
they are parameterized on `aiida_localhost.label` so the comparison is
exact and stable across workers. `test_code.py`'s
`_normalize_code_show_output` strips the worker-id suffix from the
fixture's label before the hostname substitution (the suffixed label
contains the hostname as a substring), so the four affected golden
files keep the user-facing literal `localhost`. The three graphviz
tests in `test_graph.py` build their expected strings off
`self.computer.label`.

Audit other test sites that bypassed the fixture and created or loaded
a literal-`'localhost'` Computer directly, switching them to depend on
`aiida_localhost`: `tests/calculations/test_stash.py`,
`tests/orm/nodes/data/test_remote.py`'s factory, and the `TestNode`
class in `tests/orm/nodes/test_node.py` (`setup_method` becomes a
pytest autouse fixture). Literal-`'localhost'` sites in
`test_presto.py` and the fixture's own non-collision regression test
are intentional. Production code paths that own the literal-
`'localhost'` contract (`verdi presto`, `prepare_localhost`,
`stash`/`unstash`) are deliberately untouched.

Drive-by: document `aiida_computer`'s `IntegrityError` recovery —
why catch-and-retry-`get()` rather than loop-with-backoff, why a
defensive `NotExistent` fallback is kept, and why a user-space lock
or `INSERT ... ON CONFLICT` would not be a better fit here.

Addresses Category 1 of #7347 only. Category 2 (worker crashes from
`reset_storage()` mid-test) needs per-worker profile isolation, not a
label fix, and is left for follow-up.
```