### PR TITLE
🧪 `ci-code`: unique coverage artifact per broker

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -88,7 +88,7 @@ jobs:
       if: matrix.python-version == '3.14'
       uses: actions/upload-artifact@v7
       with:
-        name: coverage
+        name: coverage-${{ matrix.broker-backend }}
         include-hidden-files: true
         path: |
           coverage.xml


### PR DESCRIPTION
The two py3.14 matrix variants (rmq, zmq) both upload an artifact named `coverage`, which collides under `upload-artifact@v4+`.