### PR TITLE
Docker: publish a `latest` tag for stable releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,6 +76,7 @@ jobs:
           type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
           type=edge,enable={{is_default_branch}}
           type=raw,value=aiida-${{ steps.get-version.outputs.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
+          type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && !contains(github.ref_name, 'rc') }}
           type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           type=raw,value=postgresql-${{ env.PGSQL_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,6 +65,18 @@ jobs:
         tag="${{ github.ref_name }}"
         echo "AIIDA_VERSION=${tag#v}" >> $GITHUB_OUTPUT
 
+    - id: get-latest-tag
+      if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+      continue-on-error: true # never let the `latest` logic block the real release tags
+      env:
+        TAG: ${{ github.ref_name }}
+      run: |
+        # `latest` only if this tag is the highest final release: metadata-action sees this tag alone,
+        # so without comparing we would tag `latest` on the most recently pushed tag, not the highest.
+        highest=$(git ls-remote --tags --refs origin | sed 's|.*refs/tags/||' |
+          { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
+        echo "IS_LATEST=$([[ -n "$highest" && "$TAG" == "$highest" ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
@@ -76,7 +88,7 @@ jobs:
           type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
           type=edge,enable={{is_default_branch}}
           type=raw,value=aiida-${{ steps.get-version.outputs.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
-          type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && !contains(github.ref_name, 'rc') }}
+          type=raw,value=latest,enable=${{ steps.get-latest-tag.outputs.IS_LATEST == 'true' }}
           type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           type=raw,value=postgresql-${{ env.PGSQL_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,23 +59,40 @@ jobs:
         vars=$(cat build.json | jq -c '[.variable | to_entries[] | {"key": .key, "value": .value.default}] | from_entries')
         echo "vars=$vars" | tee -a "${GITHUB_OUTPUT}"
 
+    - id: tag-check
+      # Single source of truth for "this build is a version tag" (v-prefixed). The
+      # version-gated steps and tag rules below reference this instead of each
+      # re-deriving the same condition. Computed as a GitHub expression so no ref
+      # name is interpolated into the shell.
+      run: echo "IS_VERSION_TAG=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}" >> "$GITHUB_OUTPUT"
+
     - id: get-version
-      if: ${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
-      run: |
-        tag="${{ github.ref_name }}"
-        echo "AIIDA_VERSION=${tag#v}" >> $GITHUB_OUTPUT
+      if: ${{ steps.tag-check.outputs.IS_VERSION_TAG == 'true' }}
+      env:
+        TAG: ${{ github.ref_name }}
+      run: echo "AIIDA_VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
 
     - id: get-latest-tag
-      if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+      if: ${{ steps.tag-check.outputs.IS_VERSION_TAG == 'true' }}
       continue-on-error: true # never let the `latest` logic block the real release tags
       env:
         TAG: ${{ github.ref_name }}
       run: |
-        # `latest` only if this tag is the highest final release: metadata-action sees this tag alone,
-        # so without comparing we would tag `latest` on the most recently pushed tag, not the highest.
-        highest=$(git ls-remote --tags --refs origin | sed 's|.*refs/tags/||' |
-          { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
-        echo "IS_LATEST=$([[ -n "$highest" && "$TAG" == "$highest" ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+        # `latest` only if this tag is the highest final release. metadata-action sees
+        # only the tag being built, so we compare against the remote's tags ourselves;
+        # otherwise `latest` would follow the most recently pushed tag, not the highest.
+        remote_tags=$(git ls-remote --tags --refs origin | sed 's|.*refs/tags/||')
+        # Keep final releases only (vX.Y.Z, no rc/pre/... suffix); `|| true` so "no match" is empty, not an error.
+        release_tags=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' <<<"$remote_tags" || true)
+        highest=$(sort -V <<<"$release_tags" | tail -n1)
+        if [[ -n "$highest" && "$TAG" == "$highest" ]]; then
+          is_latest=true
+        else
+          is_latest=false
+        fi
+        # Surface the decision in the run summary so a skipped `latest` is never a mystery.
+        echo "latest tag: this release $TAG, highest final on origin ${highest:-none}, IS_LATEST=$is_latest" >> "$GITHUB_STEP_SUMMARY"
+        echo "IS_LATEST=$is_latest" >> "$GITHUB_OUTPUT"
 
     - name: Docker meta
       id: meta
@@ -87,10 +104,10 @@ jobs:
           type=ref,event=pr
           type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
           type=edge,enable={{is_default_branch}}
-          type=raw,value=aiida-${{ steps.get-version.outputs.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
+          type=raw,value=aiida-${{ steps.get-version.outputs.AIIDA_VERSION }},enable=${{ steps.tag-check.outputs.IS_VERSION_TAG == 'true' }}
           type=raw,value=latest,enable=${{ steps.get-latest-tag.outputs.IS_LATEST == 'true' }}
-          type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
-          type=raw,value=postgresql-${{ env.PGSQL_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+          type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ steps.tag-check.outputs.IS_VERSION_TAG == 'true' }}
+          type=raw,value=postgresql-${{ env.PGSQL_VERSION }},enable=${{ steps.tag-check.outputs.IS_VERSION_TAG == 'true' }}
           type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1
 
     - name: Determine source image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,10 +60,6 @@ jobs:
         echo "vars=$vars" | tee -a "${GITHUB_OUTPUT}"
 
     - id: tag-check
-      # Single source of truth for "this build is a version tag" (v-prefixed). The
-      # version-gated steps and tag rules below reference this instead of each
-      # re-deriving the same condition. Computed as a GitHub expression so no ref
-      # name is interpolated into the shell.
       run: echo "IS_VERSION_TAG=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}" >> "$GITHUB_OUTPUT"
 
     - id: get-version
@@ -78,11 +74,7 @@ jobs:
       env:
         TAG: ${{ github.ref_name }}
       run: |
-        # `latest` only if this tag is the highest final release. metadata-action sees
-        # only the tag being built, so we compare against the remote's tags ourselves;
-        # otherwise `latest` would follow the most recently pushed tag, not the highest.
         remote_tags=$(git ls-remote --tags --refs origin | sed 's|.*refs/tags/||')
-        # Keep final releases only (vX.Y.Z, no rc/pre/... suffix); `|| true` so "no match" is empty, not an error.
         release_tags=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' <<<"$remote_tags" || true)
         highest=$(sort -V <<<"$release_tags" | tail -n1)
         if [[ -n "$highest" && "$TAG" == "$highest" ]]; then
@@ -90,7 +82,6 @@ jobs:
         else
           is_latest=false
         fi
-        # Surface the decision in the run summary so a skipped `latest` is never a mystery.
         echo "latest tag: this release $TAG, highest final on origin ${highest:-none}, IS_LATEST=$is_latest" >> "$GITHUB_STEP_SUMMARY"
         echo "IS_LATEST=$is_latest" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The container images on ghcr.io no longer get a `latest` tag.
`:latest` has been frozen since June 2024 — it still points at an aiida-core 2.5.x image written by an older workflow.

This breaks anything that pulls `:latest`. In particular the `aiida-registry`  install checks run inside `aiida-core-with-services:latest` and pin `aiida-core` to whatever that image ships, so every plugin that requires `aiida-core >= 2.7` currently fails to install (e.g. [aiida-firecrest)](https://aiida.net/plugin-registry/aiida-firecrest/)

This PR adds a `type=raw` rule that tags `latest` on stable release tags, using the same condition as the `aiida-<version>` tag plus a `!contains(ref_name, 'rc')` guard so release candidates don't move `latest`.

Note this only takes effect on the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker image builds now automatically publish a `latest` tag for stable version releases, excluding release-candidate tags.
  * The workflow checks whether the current `v*` tag is the newest matching final-release tag before enabling `latest`, ensuring consumers pull the most recent non-release-candidate image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->