### PR TITLE
Factor out the mutable fields of `BaseNodeModel` as `MutableNodeFields`

### DIFF
--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -218,7 +218,7 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
 
     identity_field = 'uuid'
 
-    class BaseNodeModel(OrmModel):
+    class MutableNodeFields(OrmModel):
         label: str = OrmMetadataField(
             '',
             description='The node label',
@@ -236,6 +236,8 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             may_be_large=True,
             examples=[{'extra_key': 'extra_value'}],
         )
+
+    class BaseNodeModel(MutableNodeFields):
         node_type: str = OrmMetadataField(description='The type of the node.')
 
     class AttributesModel(OrmModel):


### PR DESCRIPTION
Found this useful while working on the REST API's nodes PUT endpoint ([here](https://github.com/aiidateam/aiida-restapi/pull/126)).