### PR TITLE
Update tested  RabbitMQ versions in nightly test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,7 +114,10 @@ jobs:
       matrix:
         # Currently supported RMQ versions per:
         # https://www.rabbitmq.com/docs/which-erlang#compatibility-matrix
-        rabbitmq-version: ['3.11', '4.2']
+        # Version 3.10 is currently used by AiiDAlab.
+        # Version 4.3 broke aiida-core, so the latest supported is 4.2:
+        # https://github.com/aiidateam/aiida-core/issues/7375
+        rabbitmq-version: ['3.10', '4.2']
 
     services:
       rabbitmq:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         # Currently supported RMQ versions per:
         # https://www.rabbitmq.com/docs/which-erlang#compatibility-matrix
-        rabbitmq-version: ['3.11', '3.12', '3.13', '4.0', '4.3']
+        rabbitmq-version: ['3.11', '4.2']
 
     services:
       rabbitmq:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         # Currently supported RMQ versions per:
         # https://www.rabbitmq.com/docs/which-erlang#compatibility-matrix
-        rabbitmq-version: ['3.11', '3.12', '3.13', '4.0', latest]
+        rabbitmq-version: ['3.11', '3.12', '3.13', '4.0', '4.3']
 
     services:
       rabbitmq:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         # Currently supported RMQ versions per:
         # https://www.rabbitmq.com/docs/which-erlang#compatibility-matrix
-        rabbitmq-version: ['3.11', '3.12', '3.13', '4.0']
+        rabbitmq-version: ['3.11', '3.12', '3.13', '4.0', latest]
 
     services:
       rabbitmq:


### PR DESCRIPTION
~~We should be testing the latest RabbitMQ version in nightly tests~~

We cannot test RMQ latest because version 4.3 broke AiiDA, see #7375 

So we test with 4.2 as the latest supported. I've set the minimum tested version to 3.10 since that's the version we currently use in AiiDAlab.

I've removed testing versions in between since we've never seen issues specific to these specific versions so it seems like an overkill to test all of them. 