### PR TITLE
🐛 `_AsyncSSH`: honor `StrictHostKeyChecking no`

### DIFF
--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -231,7 +231,20 @@ class _AsyncSSH(_AsynchronousSSHBackend):
         super().__init__(machine, logger, bash_command)
 
     async def open(self):
-        self._conn = await asyncssh.connect(self.machine)
+        # asyncssh reads ~/.ssh/config and resolves ``known_hosts`` from the
+        # ``UserKnownHostsFile`` directive.  When the config says
+        # ``UserKnownHostsFile /dev/null`` (common with ``StrictHostKeyChecking
+        # no``), asyncssh resolves this to an empty list ``[]``.  An empty list
+        # means "verify against nothing", which always fails with
+        # ``HostKeyNotVerifiable``.  Passing ``known_hosts=None`` instead tells
+        # asyncssh to skip host-key verification entirely, which is the
+        # behaviour the user intended with ``StrictHostKeyChecking no``.
+        opts = asyncssh.SSHClientConnectionOptions(host=self.machine)
+        connect_kwargs: dict = {}
+        if opts.known_hosts is not None and not opts.known_hosts:
+            connect_kwargs['known_hosts'] = None
+
+        self._conn = await asyncssh.connect(self.machine, **connect_kwargs)
         self._sftp = await self._conn.start_sftp_client()
 
     async def close(self):


### PR DESCRIPTION
This came up while working on Module 4 (remote submission) of the new tutorial modules in #7205. The tutorial uses a SLURM container reachable over SSH with `StrictHostKeyChecking no` and `UserKnownHostsFile /dev/null` in `~/.ssh/config`, which is a common setup for ephemeral hosts and CI environments. The asyncssh backend failed to connect with `HostKeyNotVerifiable`, while the openssh backend worked fine.

The root cause: `asyncssh.connect()` reads the SSH config and resolves `UserKnownHostsFile /dev/null` into `known_hosts=[]` (empty list). In asyncssh's semantics, an empty list means "verify the host key against no known hosts", which always fails. The intended semantics of `StrictHostKeyChecking no` is to skip verification entirely, which requires `known_hosts=None`.

The fix detects the empty-list case before calling `asyncssh.connect()` and passes `known_hosts=None` explicitly, aligning the asyncssh backend's behavior with what the user configured in their SSH config.