### PR TITLE
🐛 `Comment.set_user`: fix broken user reassignment

### DIFF
--- a/src/aiida/orm/comments.py
+++ b/src/aiida/orm/comments.py
@@ -165,8 +165,7 @@ class Comment(entities.Entity['BackendComment', CommentCollection]):
         return entities.from_backend_entity(User, self._backend_entity.user)
 
     def set_user(self, value: 'User') -> None:
-        # mypy error: Property "user" defined in "BackendComment" is read-only
-        self._backend_entity.user = value.backend_entity  # type: ignore[misc]
+        return self._backend_entity.set_user(value.backend_entity)
 
     @property
     def content(self) -> str:

--- a/src/aiida/storage/psql_dos/orm/comments.py
+++ b/src/aiida/storage/psql_dos/orm/comments.py
@@ -85,7 +85,8 @@ class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):
         return self.backend.users.ENTITY_CLASS.from_dbmodel(self.model.user, self.backend)
 
     def set_user(self, value):
-        self.model.user = value
+        lang.type_check(value, self.USER_CLASS)
+        self.model.user = value.bare_model
 
     @property
     def content(self):

--- a/tests/orm/test_comments.py
+++ b/tests/orm/test_comments.py
@@ -60,13 +60,21 @@ def test_comment_user(node, default_user):
     assert comment.user.uuid == default_user.uuid
 
 
-@pytest.mark.xfail
 def test_comment_set_user(node, default_user):
+    """Test setting the user of a Comment.
+
+    Regression test for https://github.com/aiidateam/aiida-core/issues/7027: ``set_user`` used to assign to the
+    read-only ``user`` property of the backend entity, raising an ``AttributeError``.
+    """
     new_user = orm.User(email='meeseeks.look@me').store()
     comment = Comment(node, default_user, 'Look at me!').store()
     assert comment.user.uuid == default_user.uuid
+
     comment.set_user(new_user)
     assert comment.user.uuid == new_user.uuid
+
+    # The change should be persisted, so reloading the comment from the backend should reflect the new user.
+    assert Comment.collection.get(id=comment.pk).user.uuid == new_user.uuid
 
 
 def test_comment_collection_get(create_comment):


### PR DESCRIPTION
## Fixes #7027

### Problem

`Comment.set_user` is completely broken: calling it always raises an `AttributeError`, as reported in #7027 and captured by the `xfail`-marked `tests/orm/test_comments.py::test_comment_set_user`.

```python
comment.set_user(new_user)
# AttributeError: property 'user' of 'SqliteComment' object has no setter
```

### Root cause

There are two layered bugs:

1. **Front-end** (`aiida.orm.comments.Comment.set_user`) assigned to the *read-only* `user` property of the backend entity:

   ```python
   self._backend_entity.user = value.backend_entity  # type: ignore[misc]
   ```

   The `BackendComment` interface already declares a dedicated `set_user` method for this (alongside `set_content`/`set_mtime`), but it was not being used. This is also what the `# type: ignore[misc]` added in #6704 was papering over.

2. **Backend** (`SqlaComment.set_user`, shared by the PostgreSQL and SQLite storage backends) assigned the `BackendUser` *wrapper* to the SQLAlchemy relationship instead of the underlying model:

   ```python
   self.model.user = value  # should be value.bare_model
   ```

   So even once the front-end was routed through it, it would raise `'SqliteUser' object has no attribute '_sa_instance_state'`.

### Fix

- `Comment.set_user` now delegates to the backend `set_user` method, mirroring the sibling `set_content`/`set_mtime` setters (and removing the obsolete `# type: ignore`).
- `SqlaComment.set_user` unwraps the user to its `bare_model` and validates the type, mirroring the class constructor.

Both backends share `SqlaComment`, so the fix applies to PostgreSQL and SQLite alike.

### Tests

The previously `xfail`-marked `test_comment_set_user` is unmarked (so it is now enforced under `xfail_strict`) and extended to assert that the new user is persisted, by reloading the comment from the backend. The full `tests/orm/test_comments.py` suite passes locally, and `pre-commit` (ruff, mypy) is clean.