### PR TITLE
Leave `Data.ReadModel.node_type` as `str`

### DIFF
--- a/src/aiida/orm/nodes/data/data.py
+++ b/src/aiida/orm/nodes/data/data.py
@@ -354,3 +354,13 @@ class Data(Node):
         valid_format_names = [i[len(exporter_prefix) :] for i in method_names if i.startswith(exporter_prefix)]
         valid_formats = {k: getattr(self, exporter_prefix + k) for k in valid_format_names}
         return valid_formats
+
+    @classmethod
+    def _get_patched_node_type_field(cls):
+        node_type_field = super()._get_patched_node_type_field()
+        if cls.__name__ == 'Data':
+            # `Data` is not to be used directly! It is only ever used when a subclass
+            # from an uninstalled plugin regresses to `Data`, in which case, the node
+            # type should not be validated against a `Literal`, only as a `str`.
+            return (str, node_type_field[1])
+        return node_type_field

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -1075,6 +1075,12 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
         cls.AttributesModel.model_rebuild(force=True)
 
     @classmethod
+    def _get_patched_node_type_field(cls):
+        """Return a copy of the `node_type` field cast as the literal type for this class."""
+        node_type_field = deepcopy(cls.BaseNodeModel.model_fields['node_type'])
+        return (Literal[cls.class_node_type], node_type_field)
+
+    @classmethod
     def _patch_read_model(cls):
         """Patch `ReadModel` by wiring the subclass-specific `attributes` model.
 
@@ -1107,9 +1113,8 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             }
 
         attributes_field = deepcopy(cls.ReadModel.model_fields['attributes'])
-        node_type_field = deepcopy(cls.BaseNodeModel.model_fields['node_type'])
-        model_fields['node_type'] = (Literal[cls.class_node_type], node_type_field)
         model_fields['attributes'] = (cls.AttributesModel, attributes_field)
+        model_fields['node_type'] = cls._get_patched_node_type_field()
 
         ReadModel = cast(  # noqa: N806
             type[Node.ReadModel],
@@ -1130,23 +1135,28 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
         """Patch `ConstructorModel` by synthesizing it from `BaseNodeModel` and `ConstructorArgsModel`."""
         if not cls.supports_constructor_model:
             return
-        node_type_field = deepcopy(cls.BaseNodeModel.model_fields['node_type'])
+
         args_field = OrmMetadataField(
             description='The constructor arguments.',
             write_only=True,
         )
+        model_fields: dict[str, Any] = {
+            'args': (cls.ConstructorArgsModel, args_field),
+            'node_type': cls._get_patched_node_type_field(),
+        }
+
         ConstructorModel = cast(  # noqa: N806
             type[Node.BaseNodeModel],
             pdt.create_model(
                 'ConstructorModel',
                 __base__=cls.BaseNodeModel,
                 __module__=cls.__module__,
-                node_type=(Literal[cls.class_node_type], node_type_field),
-                args=(cls.ConstructorArgsModel, args_field),
+                **model_fields,
             ),
         )
         ConstructorModel.__qualname__ = f'{cls.__name__}.ConstructorModel'
         ConstructorModel.model_rebuild(force=True)
+
         cls._ConstructorModel = ConstructorModel
 
     @classmethod


### PR DESCRIPTION
**tl;dr** - converting `Data.ReadModel.node_type` from `str` to `Literal['data.Data.']` fails validation for regressed nodes. In principle, `Data` should never be used directly! This PR leaves its `node_type` field as `str`.

### Full context

I encountered an issue in Pydantic when working on the REST API. When fetching a `UpfData` node, I pick it up from the DB and try to serialize it. However, it was picked up as `Data`, because I didn't have aiida-pseudo installed. This is the built-in AiiDA ORM regression mechanism. But `Data`'s `ReadModel` defines `node_type` as `Literal['data.Data.']` (for reference, this is auto-wired for all nodes in `Node.__init_subclass__`). But the incoming true `node_type` is `data.pseudo.upf.UpfData.`, which fails validation against `Data`'s literal.

This PR resolves this by the above realization - `Data` is never to be used directly! It only ever comes into play in the regression case. By skipping the `str`-to-`Literal` conversion for `Data`, we allow any `node_type` to pass through `Data`'s model.