### PR TITLE
Skip unconfigured computers during remote cleanup

### DIFF
--- a/src/aiida/orm/utils/remote.py
+++ b/src/aiida/orm/utils/remote.py
@@ -69,8 +69,8 @@ def clean_mapping_remote_paths(path_mapping, silent=False):
         except NotExistent:
             if not silent:
                 echo.echo_warning(
-                    f'Skipping {len(paths)} remote folders on {computer.label}: '
-                    f'computer is not configured for user {user.email}'
+                    f'Skipping {len(paths)} remote folders on `{computer.label}`: '
+                    f'computer is not configured for user `{user.email}`'
                 )
             continue
 

--- a/src/aiida/orm/utils/remote.py
+++ b/src/aiida/orm/utils/remote.py
@@ -53,7 +53,7 @@ def clean_mapping_remote_paths(path_mapping, silent=False):
     :param path_mapping: a dictionary where the keys are the computer UUIDs and the values are lists of remote folders
         It's designed to accept the output of `get_calcjob_remote_paths`
     :param transport: the transport to use to clean the remote folders
-    :param silent: if True, the `echo` output will be suppressed
+    :param silent: if True, the success message output will be suppressed
     """
 
     user = orm.User.collection.get_default()
@@ -67,11 +67,10 @@ def clean_mapping_remote_paths(path_mapping, silent=False):
         try:
             authinfo = orm.AuthInfo.collection.get(dbcomputer_id=computer.pk, aiidauser_id=user.pk)
         except NotExistent:
-            if not silent:
-                echo.echo_warning(
-                    f'Skipping {len(paths)} remote folders on `{computer.label}`: '
-                    f'computer is not configured for user `{user.email}`'
-                )
+            echo.echo_warning(
+                f'Skipping {len(paths)} remote folders on `{computer.label}`: '
+                f'computer is not configured for user `{user.email}`'
+            )
             continue
 
         transport = authinfo.get_transport()

--- a/src/aiida/orm/utils/remote.py
+++ b/src/aiida/orm/utils/remote.py
@@ -15,6 +15,7 @@ import typing as t
 
 from aiida import orm
 from aiida.cmdline.utils import echo
+from aiida.common.exceptions import NotExistent
 from aiida.orm.nodes.data.remote.base import RemoteData
 
 if t.TYPE_CHECKING:
@@ -63,7 +64,17 @@ def clean_mapping_remote_paths(path_mapping, silent=False):
     for computer_uuid, paths in path_mapping.items():
         counter = 0
         computer = orm.load_computer(uuid=computer_uuid)
-        transport = orm.AuthInfo.collection.get(dbcomputer_id=computer.pk, aiidauser_id=user.pk).get_transport()
+        try:
+            authinfo = orm.AuthInfo.collection.get(dbcomputer_id=computer.pk, aiidauser_id=user.pk)
+        except NotExistent:
+            if not silent:
+                echo.echo_warning(
+                    f'Skipping {len(paths)} remote folders on {computer.label}: '
+                    f'computer is not configured for user {user.email}'
+                )
+            continue
+
+        transport = authinfo.get_transport()
 
         with transport:
             for remote_folder in paths:

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -8,40 +8,55 @@
 ###########################################################################
 """Tests for remote utilities."""
 
+from unittest.mock import Mock
+
+import pytest
+
 from aiida import orm
+from aiida.orm.nodes.data.remote.base import RemoteData
 from aiida.orm.utils import remote
 
 
-class UncleanableRemoteFolder:
-    """Remote folder that should not be cleaned."""
-
-    def _clean(self, **kwargs):
-        raise AssertionError('Unconfigured computers should be skipped.')
-
-
-def test_clean_mapping_remote_paths_skips_unconfigured_computer(aiida_profile_clean, tmp_path, monkeypatch):
-    """Test that remote cleanup skips computers without AuthInfo."""
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkeypatch):
+    """Unconfigured computers are skipped with a warning; configured ones in the same call are still cleaned."""
     user = orm.User.collection.get_default()
-    computer = orm.Computer(
+
+    unconfigured = orm.Computer(
         label='unconfigured-computer',
         hostname='localhost',
         transport_type='core.local',
         scheduler_type='core.direct',
-        workdir=str(tmp_path),
+        workdir=str(tmp_path / 'unconfigured'),
     ).store()
 
-    warnings = []
-    monkeypatch.setattr(remote.echo, 'echo_warning', warnings.append)
+    configured = orm.Computer(
+        label='configured-computer',
+        hostname='localhost',
+        transport_type='core.local',
+        scheduler_type='core.direct',
+        workdir=str(tmp_path / 'configured'),
+    ).store()
+    configured.configure(user=user)
+
+    folder_unconfigured = Mock(spec=RemoteData)
+    folder_configured = Mock(spec=RemoteData)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(remote.echo, 'echo_warning', lambda message, **kwargs: warnings.append(message))
+    monkeypatch.setattr(remote.echo, 'echo_success', lambda *args, **kwargs: None)
 
     remote.clean_mapping_remote_paths(
         {
-            computer.uuid: [
-                UncleanableRemoteFolder(),
-                UncleanableRemoteFolder(),
-            ]
+            unconfigured.uuid: [folder_unconfigured],
+            configured.uuid: [folder_configured],
         }
     )
 
+    folder_unconfigured._clean.assert_not_called()
+    folder_configured._clean.assert_called_once()
+
     assert warnings == [
-        f'Skipping 2 remote folders on {computer.label}: computer is not configured for user {user.email}'
+        f'Skipping 1 remote folders on `{unconfigured.label}`: '
+        f'computer is not configured for user `{user.email}`'
     ]

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -58,5 +58,5 @@ def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkey
     folder_configured._clean.assert_called_once()
 
     assert warnings == [
-        f'Skipping 1 remote folders on `{unconfigured.label}`: ' f'computer is not configured for user `{user.email}`',
+        f'Skipping 1 remote folders on `{unconfigured.label}`: ' f'computer is not configured for user `{user.email}`'
     ]

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -1,0 +1,47 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for remote utilities."""
+
+from aiida import orm
+from aiida.orm.utils import remote
+
+
+class UncleanableRemoteFolder:
+    """Remote folder that should not be cleaned."""
+
+    def _clean(self, **kwargs):
+        raise AssertionError('Unconfigured computers should be skipped.')
+
+
+def test_clean_mapping_remote_paths_skips_unconfigured_computer(aiida_profile_clean, tmp_path, monkeypatch):
+    """Test that remote cleanup skips computers without AuthInfo."""
+    user = orm.User.collection.get_default()
+    computer = orm.Computer(
+        label='unconfigured-computer',
+        hostname='localhost',
+        transport_type='core.local',
+        scheduler_type='core.direct',
+        workdir=str(tmp_path),
+    ).store()
+
+    warnings = []
+    monkeypatch.setattr(remote.echo, 'echo_warning', warnings.append)
+
+    remote.clean_mapping_remote_paths(
+        {
+            computer.uuid: [
+                UncleanableRemoteFolder(),
+                UncleanableRemoteFolder(),
+            ]
+        }
+    )
+
+    assert warnings == [
+        f'Skipping 2 remote folders on {computer.label}: computer is not configured for user {user.email}'
+    ]

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -50,7 +50,8 @@ def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkey
         {
             unconfigured.uuid: [folder_unconfigured],
             configured.uuid: [folder_configured],
-        }
+        },
+        silent=True,
     )
 
     folder_unconfigured._clean.assert_not_called()

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -8,7 +8,7 @@
 ###########################################################################
 """Tests for remote utilities."""
 
-from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
@@ -39,23 +39,24 @@ def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkey
     ).store()
     configured.configure(user=user)
 
-    folder_unconfigured = Mock(spec=RemoteData)
-    folder_configured = Mock(spec=RemoteData)
+    folder_unconfigured = RemoteData(remote_path=str(tmp_path / 'unconfigured-folder'), computer=unconfigured)
+    folder_configured = RemoteData(remote_path=str(tmp_path / 'configured-folder'), computer=configured)
 
     warnings: list[str] = []
     monkeypatch.setattr(remote.echo, 'echo_warning', lambda message, **kwargs: warnings.append(message))
     monkeypatch.setattr(remote.echo, 'echo_success', lambda *args, **kwargs: None)
 
-    remote.clean_mapping_remote_paths(
-        {
-            unconfigured.uuid: [folder_unconfigured],
-            configured.uuid: [folder_configured],
-        },
-        silent=True,
-    )
+    with patch.object(RemoteData, '_clean', autospec=True) as mock_clean:
+        remote.clean_mapping_remote_paths(
+            {
+                unconfigured.uuid: [folder_unconfigured],
+                configured.uuid: [folder_configured],
+            },
+            silent=True,
+        )
 
-    folder_unconfigured._clean.assert_not_called()
-    folder_configured._clean.assert_called_once()
+    mock_clean.assert_called_once()
+    assert mock_clean.call_args.args[0] is folder_configured
 
     assert warnings == [
         f'Skipping 1 remote folders on `{unconfigured.label}`: ' f'computer is not configured for user `{user.email}`'

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -59,5 +59,5 @@ def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkey
 
     assert warnings == [
         f'Skipping 1 remote folders on `{unconfigured.label}`: '
-        f'computer is not configured for user `{user.email}`'
+        f'computer is not configured for user `{user.email}`',
     ]

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -58,6 +58,5 @@ def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkey
     folder_configured._clean.assert_called_once()
 
     assert warnings == [
-        f'Skipping 1 remote folders on `{unconfigured.label}`: '
-        f'computer is not configured for user `{user.email}`',
+        f'Skipping 1 remote folders on `{unconfigured.label}`: ' f'computer is not configured for user `{user.email}`',
     ]


### PR DESCRIPTION
This PR updates clean_mapping_remote_paths to skip computers that do not have AuthInfo configured for the current user. Instead of raising NotExistent, the cleanup now emits one warning per unconfigured computer and continues.

Tested with:

python -m pytest tests/orm/utils/test_remote.py
python -m compileall src/aiida/orm/utils/remote.py tests/orm/utils/test_remote.py