### PR TITLE
Fallback to `ProcessNode` if missing entrypoint

### DIFF
--- a/src/aiida/orm/utils/node.py
+++ b/src/aiida/orm/utils/node.py
@@ -47,8 +47,7 @@ def load_node_class(type_string):
     if base_path.startswith('node.'):
         base_path = base_path.removeprefix('node.')
 
-    # Data nodes are the only ones with sub classes that are still external, so if the plugin is not available
-    # we fall back on the base node type
+    # If the Data plugin is not available we fall back on the base Data class
     if base_path.startswith('data.'):
         entry_point_name = base_path.removeprefix('data.')
         try:
@@ -56,6 +55,7 @@ def load_node_class(type_string):
         except exceptions.MissingEntryPointError:
             return Data
 
+    # If the Process plugin is not available we fall back on the base ProcessNode class
     if base_path.startswith('process'):
         try:
             return load_entry_point('aiida.node', base_path)

--- a/src/aiida/orm/utils/node.py
+++ b/src/aiida/orm/utils/node.py
@@ -28,7 +28,7 @@ def load_node_class(type_string):
     :param type_string: the `type` string of the node
     :return: a sub class of `Node`
     """
-    from aiida.orm import Data, Node
+    from aiida.orm import Data, Node, ProcessNode
     from aiida.plugins.entry_point import load_entry_point
 
     if type_string == '':
@@ -57,7 +57,10 @@ def load_node_class(type_string):
             return Data
 
     if base_path.startswith('process'):
-        return load_entry_point('aiida.node', base_path)
+        try:
+            return load_entry_point('aiida.node', base_path)
+        except exceptions.MissingEntryPointError:
+            return ProcessNode
 
     # At this point we really have an anomalous type string. At some point, storing nodes with unresolvable type strings
     # was allowed, for example by creating a sub class in a shell and then storing an instance. Attempting to load the

--- a/tests/orm/utils/test_node.py
+++ b/tests/orm/utils/test_node.py
@@ -11,7 +11,7 @@
 import pytest
 
 from aiida.common import exceptions
-from aiida.orm import Data
+from aiida.orm import Data, ProcessNode
 from aiida.orm.utils.node import (
     get_type_string_from_class,
     is_valid_node_type_string,
@@ -32,6 +32,10 @@ def test_load_node_class_fallback():
     # Test invalid type string without trailing dot.
     with pytest.raises(exceptions.DbContentError, match='invalid'):
         load_node_class('data.dict')
+
+    # Test process plugin fallback
+    loaded_class = load_node_class('process.some.non.existing.plugin.')
+    assert loaded_class == ProcessNode
 
 
 def test_load_node_class_with_node_prefix():


### PR DESCRIPTION
For `Data` nodes, if the associated plugin is not installed in the environment, we regress the node to the root `Data` class. Here we do the same for processes, regressing to `ProcessNode` if the plugin is missing. As of this commit, this is limited to the `WorkGraph` package.