### PR TITLE
🔧 Switch `main` version marker to `2.9.0.dev0`

### DIFF
--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -27,7 +27,7 @@ __copyright__ = (
     'For further information please visit http://www.aiida.net/. All rights reserved.'
 )
 __license__ = 'MIT license, see LICENSE.txt file.'
-__version__ = '2.8.0.post0'
+__version__ = '2.9.0.dev0'
 __authors__ = 'The AiiDA team.'
 __paper__ = (
     'S. P. Huber et al., "AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and '

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -529,12 +529,12 @@ class Manager:
         return runner
 
     def check_version(self):
-        """Check the currently installed version of ``aiida-core`` and warn if it is a post release development version.
+        """Check the currently installed version of ``aiida-core`` and warn if it is a development version.
 
-        The ``aiida-core`` package maintains the protocol that the ``main`` branch will use a post release version
-        number. This means it will always append `.post0` to the version of the latest release. This should mean that if
-        this protocol is maintained properly, this method will print a warning if the currently installed version is a
-        post release development branch and not an actual release.
+        The ``aiida-core`` package maintains the protocol that the ``main`` branch carries a development version number,
+        appending `.dev0` to the version of the next anticipated release. Support branches that backport fixes on top of
+        a release use a post release number, appending `.post0`. This method prints a warning whenever the currently
+        installed version is such a development or post release and not an actual release.
         """
         from packaging.version import parse
 
@@ -546,8 +546,8 @@ class Manager:
         show_warning = self._profile.get_option('warnings.development_version')
         version = parse(__version__)
 
-        if version.is_postrelease and show_warning:
-            echo.echo_warning(f'You are currently using a post release development version of AiiDA: {version}')
+        if (version.is_prerelease or version.is_postrelease) and show_warning:
+            echo.echo_warning(f'You are currently using a development version of AiiDA: {version}')
             echo.echo_warning('Be aware that this is not recommended for production and is not officially supported.')
             echo.echo_warning('Databases used with this version may not be compatible with future releases of AiiDA')
             echo.echo_warning('as you might not be able to automatically migrate your data.\n')

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -41,16 +41,17 @@ def test_check_version_release(monkeypatch, capsys, isolated_config):
     assert not captured.out
 
 
+@pytest.mark.parametrize('version', ('1.0.0.dev0', '1.0.0.post0'))
 @pytest.mark.parametrize('suppress_warning', (True, False))
 @pytest.mark.usefixtures('isolated_config')
-def test_check_version_development(monkeypatch, suppress_warning):
-    """Test that ``Manager.check_version`` prints a warning for a post release development version.
+def test_check_version_development(monkeypatch, suppress_warning, version):
+    """Test that ``Manager.check_version`` prints a warning for a development or post release version.
 
-    The warning can be suppressed by setting the option ``warnings.development_version`` to ``False``.
+    The ``main`` branch carries a ``.dev0`` version and support branches a ``.post0`` version; both should trigger the
+    warning. It can be suppressed by setting the option ``warnings.development_version`` to ``False``.
     """
     from unittest.mock import MagicMock
 
-    version = '1.0.0.post0'
     monkeypatch.setattr(aiida, '__version__', version)
 
     manager = get_manager()
@@ -66,7 +67,7 @@ def test_check_version_development(monkeypatch, suppress_warning):
     else:
         mock_warning.assert_called()
         first_call_msg = mock_warning.call_args_list[0][0][0]
-        assert f'You are currently using a post release development version of AiiDA: {version}' in first_call_msg
+        assert f'You are currently using a development version of AiiDA: {version}' in first_call_msg
 
 
 def test_profile_context(config_with_profile, profile_factory):


### PR DESCRIPTION
Following the discussion in #7365 let's switch to a more standard behaviour.
