### PR TITLE
Simplify RTD config

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -32,7 +32,7 @@ runs:
   - name: Set up uv
     uses: astral-sh/setup-uv@v6
     with:
-      version: 0.9.8
+      version: 0.11.21
       python-version: ${{ inputs.python-version }}
       activate-environment: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
       )$
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.8
+  rev: 0.11.21
   hooks:
     # Check and update the uv lockfile
   - id: uv-lock

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,33 +1,27 @@
 version: 2
 
-# Important: we need to disable all unneeded formats.
-# Note that HTML and JSON are always built: https://docs.readthedocs.io/en/latest/yaml-config.html#formats
-# Especially, the 'htmlzip' format takes a LOT of memory and causes the build to fail - see our issue #1472:
-# https://github.com/aiidateam/aiida-core/issues/1472
-formats: []
-
 build:
   apt_packages:
   - graphviz
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: '3.11'
-  jobs:
-    # Use uv to speed up the build
-    # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
-    pre_create_environment:
-    - asdf plugin add uv
-    - asdf install uv 0.9.8
-    - asdf global uv 0.9.8
-    create_environment:
-    # Create a virtual environment in '.venv/' folder
-    # which is picked up automatically by `uv sync` and `uv run` commands below
-    - uv venv
-    install:
-    - uv sync --extra docs --extra tests --extra rest --extra atomic_tools
-    build:
-      html:
-      - uv run sphinx-build -T -W --keep-going -b html -d _build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html -w sphinx.log || (cat sphinx.log && exit 1)
+    python: '3.12'
+
+python:
+  install:
+  - method: uv
+    command: sync
+    path: .
+    extras:
+    - docs
+    - tests
+    - rest
+    - atomic_tools
+
+sphinx:
+  builder: html
+  fail_on_warning: true
+  configuration: docs/source/conf.py
 
 search:
   ranking:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -587,5 +587,4 @@ commands = molecule {posargs:test}
 # NOTE: When you bump the minimum uv version, you might also need to change it in:
 # .pre-commit-config.yaml
 # .github/actions/install-aiida-core/action.yml
-# .readthedocs.yml
 required-version = ">=0.8.4"


### PR DESCRIPTION
ReadTheDocs now supports uv installer natively, so we can simplify the configuration a little bit, per: 
https://docs.readthedocs.com/platform/stable/config-file/v2.html#uv