### PR TITLE
Leave `ProcessNode.ReadModel.node_type` as `str`

### DIFF
--- a/src/aiida/orm/nodes/data/data.py
+++ b/src/aiida/orm/nodes/data/data.py
@@ -354,13 +354,3 @@ class Data(Node):
         valid_format_names = [i[len(exporter_prefix) :] for i in method_names if i.startswith(exporter_prefix)]
         valid_formats = {k: getattr(self, exporter_prefix + k) for k in valid_format_names}
         return valid_formats
-
-    @classmethod
-    def _get_patched_node_type_field(cls):
-        node_type_field = super()._get_patched_node_type_field()
-        if cls.__name__ == 'Data':
-            # `Data` is not to be used directly! It is only ever used when a subclass
-            # from an uninstalled plugin regresses to `Data`, in which case, the node
-            # type should not be validated against a `Literal`, only as a `str`.
-            return (str, node_type_field[1])
-        return node_type_field

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -1083,8 +1083,7 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             # a subclass from a plugin regresses due to the plugin not being installed, in which
             # case, the node type should not be validated against a `Literal`, only as a `str`.
             return str, node_type_field
-        else:
-            return Literal[cls.class_node_type], node_type_field
+        return Literal[cls.class_node_type], node_type_field
 
     @classmethod
     def _patch_read_model(cls):

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -1078,7 +1078,13 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
     def _get_patched_node_type_field(cls):
         """Return a copy of the `node_type` field cast as the literal type for this class."""
         node_type_field = deepcopy(cls.BaseNodeModel.model_fields['node_type'])
-        return (Literal[cls.class_node_type], node_type_field)
+        if cls.__name__ in ('Data', 'ProcessNode'):
+            # `Data` and `ProcessNode` are not to be used directly! They do, however, surface when
+            # a subclass from a plugin regresses due to the plugin not being installed, in which
+            # case, the node type should not be validated against a `Literal`, only as a `str`.
+            return str, node_type_field
+        else:
+            return Literal[cls.class_node_type], node_type_field
 
     @classmethod
     def _patch_read_model(cls):


### PR DESCRIPTION
Applying #7384 fix also to `ProcessNode`, which was added as fallback for missing processes in #7386.