### PR TITLE
👌 Warn on mismatch of Python binary of daemon

### DIFF
--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -111,7 +111,7 @@ def status(ctx, all_profiles, timeout):
     from tabulate import tabulate
 
     from aiida.cmdline.utils.common import format_local_time
-    from aiida.cmdline.utils.daemon import get_daemon_package_drift_lines
+    from aiida.cmdline.utils.daemon import validate_daemon_version
     from aiida.engine.daemon.client import DaemonException, get_daemon_client
     from aiida.manage.manager import get_manager
 
@@ -179,7 +179,9 @@ def status(ctx, all_profiles, timeout):
             f'Log file: {client.daemon_log_file}',
         ]
 
-        lines.extend(get_daemon_package_drift_lines(client))
+        drift_error = validate_daemon_version(client)
+        if drift_error is not None:
+            lines.append(drift_error)
 
         lines.append('Use `verdi daemon [incr | decr] [num]` to increase / decrease the number of workers')
         echo.echo('\n'.join(lines))

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -111,7 +111,7 @@ def status(ctx, all_profiles, timeout):
     from tabulate import tabulate
 
     from aiida.cmdline.utils.common import format_local_time
-    from aiida.cmdline.utils.daemon import validate_daemon_version
+    from aiida.cmdline.utils.daemon import validate_daemon_env
     from aiida.engine.daemon.client import DaemonException, get_daemon_client
     from aiida.manage.manager import get_manager
 
@@ -179,7 +179,7 @@ def status(ctx, all_profiles, timeout):
             f'Log file: {client.daemon_log_file}',
         ]
 
-        drift_error = validate_daemon_version(client)
+        drift_error = validate_daemon_env(client)
         if drift_error is not None:
             lines.append(drift_error)
 

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -60,7 +60,7 @@ STATUS_SYMBOLS = {
 def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     """Print status of AiiDA services."""
     from aiida import __version__
-    from aiida.cmdline.utils.daemon import validate_daemon_version
+    from aiida.cmdline.utils.daemon import validate_daemon_env
     from aiida.common.docs import URL_NO_BROKER
     from aiida.common.exceptions import ConfigurationError
     from aiida.engine.daemon.client import DaemonException, DaemonNotRunningException
@@ -195,7 +195,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         daemon_lines = [daemon_msg]
 
         # Check for package mismatches
-        drift_error = validate_daemon_version(daemon_client)
+        drift_error = validate_daemon_env(daemon_client)
         if drift_error is not None:
             daemon_status = ServiceStatus.WARNING
             daemon_lines.append(drift_error)

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -60,7 +60,7 @@ STATUS_SYMBOLS = {
 def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     """Print status of AiiDA services."""
     from aiida import __version__
-    from aiida.cmdline.utils.daemon import get_daemon_package_drift_lines
+    from aiida.cmdline.utils.daemon import validate_daemon_version
     from aiida.common.docs import URL_NO_BROKER
     from aiida.common.exceptions import ConfigurationError
     from aiida.engine.daemon.client import DaemonException, DaemonNotRunningException
@@ -195,10 +195,10 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         daemon_lines = [daemon_msg]
 
         # Check for package mismatches
-        drift_lines = get_daemon_package_drift_lines(daemon_client)
-        if drift_lines:
+        drift_error = validate_daemon_version(daemon_client)
+        if drift_error is not None:
             daemon_status = ServiceStatus.WARNING
-            daemon_lines.extend(drift_lines)
+            daemon_lines.append(drift_error)
 
         print_status(daemon_status, 'daemon', '\n'.join(daemon_lines))
 

--- a/src/aiida/cmdline/utils/daemon.py
+++ b/src/aiida/cmdline/utils/daemon.py
@@ -14,7 +14,7 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from aiida.engine.daemon.client import DaemonClient, PackageVersionInfo, PackageVersionSnapshot
+    from aiida.engine.daemon.client import DaemonClient, DaemonVersionInfo, PackageVersionInfo, PackageVersionSnapshot
 
 
 def format_package_version_info(version_info: PackageVersionInfo) -> str:
@@ -79,36 +79,28 @@ def format_package_state_change_lines(
     return lines
 
 
-def validate_python_binary(client: DaemonClient) -> str | None:
+def validate_python_binary(version_info: DaemonVersionInfo) -> str | None:
     """Return an error message if the daemon's Python binary differs from the current one, or None if they match."""
-    daemon_binary = client.get_daemon_python_binary()
-    if daemon_binary is None:
-        return None
-
-    current_binary = sys.executable
-    if daemon_binary == current_binary:
+    if version_info['python_binary'] == sys.executable:
         return None
 
     return (
         'The daemon is running with a different Python binary than the current one. '
         'Run `verdi daemon restart` to use the current Python binary.\n'
-        f'Daemon: {daemon_binary}\n'
-        f'Current: {current_binary}'
+        f'Daemon: {version_info["python_binary"]}\n'
+        f'Current: {sys.executable}'
     )
 
 
-def validate_package_versions(client: DaemonClient) -> str | None:
+def validate_package_versions(version_info: DaemonVersionInfo) -> str | None:
     """Return an error message if daemon and current package versions differ, or None if they match."""
-    from aiida.engine.daemon.client import DaemonClient as _DaemonClient
+    from aiida.engine.daemon.client import DaemonClient
 
-    daemon_versions = client.get_daemon_package_snapshot()
-    if daemon_versions is None:
-        return None
-    current_versions = _DaemonClient.get_package_version_snapshot()
-    validated = _DaemonClient._validate_package_version_snapshot(current_versions)
+    current_versions = DaemonClient.get_package_version_snapshot()
+    validated = DaemonClient._validate_package_version_snapshot(current_versions)
     if validated is None:
         return None
-    change_lines = format_package_state_change_lines(daemon_versions, validated)
+    change_lines = format_package_state_change_lines(version_info['packages'], validated)
     if not change_lines:
         return None
 
@@ -122,7 +114,11 @@ def validate_package_versions(client: DaemonClient) -> str | None:
 
 def validate_daemon_version(client: DaemonClient) -> str | None:
     """Return an error message if the daemon environment differs from the current one, or None if they match."""
-    if (error := validate_python_binary(client)) is not None:
+    version_info = client.get_daemon_version_info()
+    if version_info is None:
+        return None
+
+    if (error := validate_python_binary(version_info)) is not None:
         return error
 
-    return validate_package_versions(client)
+    return validate_package_versions(version_info)

--- a/src/aiida/cmdline/utils/daemon.py
+++ b/src/aiida/cmdline/utils/daemon.py
@@ -79,45 +79,50 @@ def format_package_state_change_lines(
     return lines
 
 
-_DRIFT_WARNING = (
-    'The daemon was started with different package versions than currently installed. '
-    'Running processes may use the old versions and behave unexpectedly. '
-    'Run `verdi daemon restart` to pick up the new versions.'
-)
-
-_BINARY_DRIFT_WARNING = (
-    'The daemon is running with a different Python binary than the current one. '
-    'Run `verdi daemon restart` to use the current Python binary.'
-)
-
-
-def get_daemon_python_binary_drift_lines(client: DaemonClient) -> list[str]:
-    """Return Python binary mismatch warning lines, or an empty list if they match."""
+def validate_python_binary(client: DaemonClient) -> str | None:
+    """Return an error message if the daemon's Python binary differs from the current one, or None if they match."""
     daemon_binary = client.get_daemon_python_binary()
     if daemon_binary is None:
-        return []
+        return None
 
     current_binary = sys.executable
     if daemon_binary == current_binary:
-        return []
+        return None
 
-    return [_BINARY_DRIFT_WARNING, f'Daemon: {daemon_binary}', f'Current: {current_binary}']
+    return (
+        'The daemon is running with a different Python binary than the current one. '
+        'Run `verdi daemon restart` to use the current Python binary.\n'
+        f'Daemon: {daemon_binary}\n'
+        f'Current: {current_binary}'
+    )
 
 
-def get_daemon_package_drift_lines(client: DaemonClient) -> list[str]:
-    """Return drift warning lines, or an empty list if package state matches."""
+def validate_package_versions(client: DaemonClient) -> str | None:
+    """Return an error message if daemon and current package versions differ, or None if they match."""
     from aiida.engine.daemon.client import DaemonClient as _DaemonClient
-
-    lines = get_daemon_python_binary_drift_lines(client)
 
     daemon_versions = client.get_daemon_package_snapshot()
     if daemon_versions is None:
-        return lines
+        return None
     current_versions = _DaemonClient.get_package_version_snapshot()
     validated = _DaemonClient._validate_package_version_snapshot(current_versions)
     if validated is None:
-        return lines
+        return None
     change_lines = format_package_state_change_lines(daemon_versions, validated)
     if not change_lines:
-        return lines
-    return [*lines, _DRIFT_WARNING, *change_lines]
+        return None
+
+    header = (
+        'The daemon was started with different package versions than currently installed. '
+        'Running processes may use the old versions and behave unexpectedly. '
+        'Run `verdi daemon restart` to pick up the new versions.'
+    )
+    return '\n'.join([header, *change_lines])
+
+
+def validate_daemon_version(client: DaemonClient) -> str | None:
+    """Return an error message if the daemon environment differs from the current one, or None if they match."""
+    if (error := validate_python_binary(client)) is not None:
+        return error
+
+    return validate_package_versions(client)

--- a/src/aiida/cmdline/utils/daemon.py
+++ b/src/aiida/cmdline/utils/daemon.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -84,19 +85,39 @@ _DRIFT_WARNING = (
     'Run `verdi daemon restart` to pick up the new versions.'
 )
 
+_BINARY_DRIFT_WARNING = (
+    'The daemon is running with a different Python binary than the current one. '
+    'Run `verdi daemon restart` to use the current Python binary.'
+)
+
+
+def get_daemon_python_binary_drift_lines(client: DaemonClient) -> list[str]:
+    """Return Python binary mismatch warning lines, or an empty list if they match."""
+    daemon_binary = client.get_daemon_python_binary()
+    if daemon_binary is None:
+        return []
+
+    current_binary = sys.executable
+    if daemon_binary == current_binary:
+        return []
+
+    return [_BINARY_DRIFT_WARNING, f'Daemon: {daemon_binary}', f'Current: {current_binary}']
+
 
 def get_daemon_package_drift_lines(client: DaemonClient) -> list[str]:
     """Return drift warning lines, or an empty list if package state matches."""
     from aiida.engine.daemon.client import DaemonClient as _DaemonClient
 
+    lines = get_daemon_python_binary_drift_lines(client)
+
     daemon_versions = client.get_daemon_package_snapshot()
     if daemon_versions is None:
-        return []
+        return lines
     current_versions = _DaemonClient.get_package_version_snapshot()
     validated = _DaemonClient._validate_package_version_snapshot(current_versions)
     if validated is None:
-        return []
+        return lines
     change_lines = format_package_state_change_lines(daemon_versions, validated)
     if not change_lines:
-        return []
-    return [_DRIFT_WARNING, *change_lines]
+        return lines
+    return [*lines, _DRIFT_WARNING, *change_lines]

--- a/src/aiida/cmdline/utils/daemon.py
+++ b/src/aiida/cmdline/utils/daemon.py
@@ -14,7 +14,7 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from aiida.engine.daemon.client import DaemonClient, DaemonVersionInfo, PackageVersionInfo, PackageVersionSnapshot
+    from aiida.engine.daemon.client import DaemonClient, DaemonEnvInfo, PackageVersionInfo, PackageVersionSnapshot
 
 
 def format_package_version_info(version_info: PackageVersionInfo) -> str:
@@ -28,13 +28,13 @@ def format_package_version_info(version_info: PackageVersionInfo) -> str:
     return version
 
 
-def package_versions_match(daemon_version: PackageVersionInfo, current_version: PackageVersionInfo) -> bool:
+def package_versions_match(package_version: PackageVersionInfo, current_package_version: PackageVersionInfo) -> bool:
     """Return whether daemon and current package version information match."""
-    if daemon_version['version'] != current_version['version']:
+    if package_version['version'] != current_package_version['version']:
         return False
 
-    daemon_path = daemon_version.get('editable_path')
-    current_path = current_version.get('editable_path')
+    daemon_path = package_version.get('editable_path')
+    current_path = current_package_version.get('editable_path')
 
     if daemon_path is None and current_path is None:
         return True
@@ -46,28 +46,28 @@ def package_versions_match(daemon_version: PackageVersionInfo, current_version: 
 
 
 def format_package_state_change_lines(
-    daemon_versions: PackageVersionSnapshot, current_versions: PackageVersionSnapshot
+    daemon_packages: PackageVersionSnapshot, current_packages: PackageVersionSnapshot
 ) -> list[str]:
     """Return formatted package-state mismatch lines."""
     changed: list[str] = []
     added: list[str] = []
     removed: list[str] = []
 
-    for package in sorted(set(daemon_versions) | set(current_versions)):
-        daemon_version = daemon_versions.get(package)
-        current_version = current_versions.get(package)
+    for package in sorted(set(daemon_packages) | set(current_packages)):
+        package_version = daemon_packages.get(package)
+        current_package_version = current_packages.get(package)
 
-        if daemon_version is not None and current_version is not None:
-            if package_versions_match(daemon_version, current_version):
+        if package_version is not None and current_package_version is not None:
+            if package_versions_match(package_version, current_package_version):
                 continue
             changed.append(
-                f'{package} ({format_package_version_info(daemon_version)} '
-                f'-> {format_package_version_info(current_version)})'
+                f'{package} ({format_package_version_info(package_version)} '
+                f'-> {format_package_version_info(current_package_version)})'
             )
-        elif current_version is not None:
-            added.append(f'{package} ({format_package_version_info(current_version)})')
-        elif daemon_version is not None:
-            removed.append(f'{package} ({format_package_version_info(daemon_version)})')
+        elif current_package_version is not None:
+            added.append(f'{package} ({format_package_version_info(current_package_version)})')
+        elif package_version is not None:
+            removed.append(f'{package} ({format_package_version_info(package_version)})')
 
     lines: list[str] = []
     if changed:
@@ -79,28 +79,28 @@ def format_package_state_change_lines(
     return lines
 
 
-def validate_python_binary(version_info: DaemonVersionInfo) -> str | None:
+def validate_python_binary(env_info: DaemonEnvInfo) -> str | None:
     """Return an error message if the daemon's Python binary differs from the current one, or None if they match."""
-    if version_info['python_binary'] == sys.executable:
+    if env_info['python_binary'] == sys.executable:
         return None
 
     return (
         'The daemon is running with a different Python binary than the current one. '
         'Run `verdi daemon restart` to use the current Python binary.\n'
-        f'Daemon: {version_info["python_binary"]}\n'
+        f'Daemon: {env_info["python_binary"]}\n'
         f'Current: {sys.executable}'
     )
 
 
-def validate_package_versions(version_info: DaemonVersionInfo) -> str | None:
+def validate_package_versions(env_info: DaemonEnvInfo) -> str | None:
     """Return an error message if daemon and current package versions differ, or None if they match."""
     from aiida.engine.daemon.client import DaemonClient
 
-    current_versions = DaemonClient.get_package_version_snapshot()
-    validated = DaemonClient._validate_package_version_snapshot(current_versions)
+    current_packages = DaemonClient.get_package_version_snapshot()
+    validated = DaemonClient._validate_package_version_snapshot(current_packages)
     if validated is None:
         return None
-    change_lines = format_package_state_change_lines(version_info['packages'], validated)
+    change_lines = format_package_state_change_lines(env_info['packages'], validated)
     if not change_lines:
         return None
 
@@ -112,13 +112,13 @@ def validate_package_versions(version_info: DaemonVersionInfo) -> str | None:
     return '\n'.join([header, *change_lines])
 
 
-def validate_daemon_version(client: DaemonClient) -> str | None:
+def validate_daemon_env(client: DaemonClient) -> str | None:
     """Return an error message if the daemon environment differs from the current one, or None if they match."""
-    version_info = client.get_daemon_version_info()
-    if version_info is None:
+    env_info = client.get_daemon_env_info()
+    if env_info is None:
         return None
 
-    if (error := validate_python_binary(version_info)) is not None:
+    if (error := validate_python_binary(env_info)) is not None:
         return error
 
-    return validate_package_versions(version_info)
+    return validate_package_versions(env_info)

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -62,7 +62,7 @@ class PackageVersionInfo(_PackageVersionInfoRequired, total=False):
 PackageVersionSnapshot: t.TypeAlias = dict[str, PackageVersionInfo]
 
 
-class DaemonVersionInfo(t.TypedDict):
+class _DaemonVersionInfo(t.TypedDict):
     """Content written to the daemon version file."""
 
     packages: PackageVersionSnapshot
@@ -694,7 +694,7 @@ class DaemonClient:
 
     def _write_version_file(self) -> None:
         """Write the current package version snapshot to the daemon version file."""
-        version_info: DaemonVersionInfo = {
+        version_info: _DaemonVersionInfo = {
             'packages': self.get_package_version_snapshot(),
             'python_binary': sys.executable,
         }
@@ -705,7 +705,7 @@ class DaemonClient:
         except OSError as exc:
             LOGGER.warning('Failed to write daemon version file: %s', exc)
 
-    def _read_version_file(self) -> DaemonVersionInfo | None:
+    def _read_version_file(self) -> _DaemonVersionInfo | None:
         """Read and validate the daemon version file, or return None if unavailable or invalid."""
         try:
             data = json.loads(pathlib.Path(self.daemon_package_snapshot_file).read_text(encoding='utf8'))
@@ -723,7 +723,7 @@ class DaemonClient:
         if not isinstance(python_binary, str):
             return None
 
-        return DaemonVersionInfo(packages=packages, python_binary=python_binary)
+        return _DaemonVersionInfo(packages=packages, python_binary=python_binary)
 
     def get_daemon_package_snapshot(self) -> PackageVersionSnapshot | None:
         """Return version info recorded at daemon startup, or None if unavailable."""

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -62,6 +62,13 @@ class PackageVersionInfo(_PackageVersionInfoRequired, total=False):
 PackageVersionSnapshot: t.TypeAlias = dict[str, PackageVersionInfo]
 
 
+class DaemonVersionInfo(t.TypedDict):
+    """Content written to the daemon version file."""
+
+    packages: PackageVersionSnapshot
+    python_binary: str
+
+
 class _VcsInfo(t.TypedDict, total=False):
     """VCS metadata from ``direct_url.json`` (PEP 610)."""
 
@@ -687,7 +694,10 @@ class DaemonClient:
 
     def _write_version_file(self) -> None:
         """Write the current package version snapshot to the daemon version file."""
-        version_info = self.get_package_version_snapshot()
+        version_info: DaemonVersionInfo = {
+            'packages': self.get_package_version_snapshot(),
+            'python_binary': sys.executable,
+        }
         try:
             pathlib.Path(self.daemon_package_snapshot_file).write_text(json.dumps(version_info), encoding='utf8')
         except ConfigurationError:
@@ -695,14 +705,35 @@ class DaemonClient:
         except OSError as exc:
             LOGGER.warning('Failed to write daemon version file: %s', exc)
 
-    def get_daemon_package_snapshot(self) -> PackageVersionSnapshot | None:
-        """Return version info recorded at daemon startup, or None if unavailable."""
+    def _read_version_file(self) -> DaemonVersionInfo | None:
+        """Read and validate the daemon version file, or return None if unavailable or invalid."""
         try:
             data = json.loads(pathlib.Path(self.daemon_package_snapshot_file).read_text(encoding='utf8'))
         except (ConfigurationError, OSError, json.JSONDecodeError):
             return None
 
-        return self._validate_package_version_snapshot(data)
+        if not isinstance(data, dict):
+            return None
+
+        packages = self._validate_package_version_snapshot(data.get('packages'))
+        if packages is None:
+            return None
+
+        python_binary = data.get('python_binary')
+        if not isinstance(python_binary, str):
+            return None
+
+        return DaemonVersionInfo(packages=packages, python_binary=python_binary)
+
+    def get_daemon_package_snapshot(self) -> PackageVersionSnapshot | None:
+        """Return version info recorded at daemon startup, or None if unavailable."""
+        version_file = self._read_version_file()
+        return version_file['packages'] if version_file is not None else None
+
+    def get_daemon_python_binary(self) -> str | None:
+        """Return the Python binary path recorded at daemon startup, or None if unavailable."""
+        version_file = self._read_version_file()
+        return version_file['python_binary'] if version_file is not None else None
 
     def increase_workers(self, number: int, timeout: int | None = None) -> dict[str, t.Any]:
         """Increase the number of workers.

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -62,7 +62,7 @@ class PackageVersionInfo(_PackageVersionInfoRequired, total=False):
 PackageVersionSnapshot: t.TypeAlias = dict[str, PackageVersionInfo]
 
 
-class _DaemonVersionInfo(t.TypedDict):
+class DaemonVersionInfo(t.TypedDict):
     """Content written to the daemon version file."""
 
     packages: PackageVersionSnapshot
@@ -694,7 +694,7 @@ class DaemonClient:
 
     def _write_version_file(self) -> None:
         """Write the current package version snapshot to the daemon version file."""
-        version_info: _DaemonVersionInfo = {
+        version_info: DaemonVersionInfo = {
             'packages': self.get_package_version_snapshot(),
             'python_binary': sys.executable,
         }
@@ -705,7 +705,7 @@ class DaemonClient:
         except OSError as exc:
             LOGGER.warning('Failed to write daemon version file: %s', exc)
 
-    def _read_version_file(self) -> _DaemonVersionInfo | None:
+    def get_daemon_version_info(self) -> DaemonVersionInfo | None:
         """Read and validate the daemon version file, or return None if unavailable or invalid."""
         try:
             data = json.loads(pathlib.Path(self.daemon_package_snapshot_file).read_text(encoding='utf8'))
@@ -723,17 +723,7 @@ class DaemonClient:
         if not isinstance(python_binary, str):
             return None
 
-        return _DaemonVersionInfo(packages=packages, python_binary=python_binary)
-
-    def get_daemon_package_snapshot(self) -> PackageVersionSnapshot | None:
-        """Return version info recorded at daemon startup, or None if unavailable."""
-        version_file = self._read_version_file()
-        return version_file['packages'] if version_file is not None else None
-
-    def get_daemon_python_binary(self) -> str | None:
-        """Return the Python binary path recorded at daemon startup, or None if unavailable."""
-        version_file = self._read_version_file()
-        return version_file['python_binary'] if version_file is not None else None
+        return DaemonVersionInfo(packages=packages, python_binary=python_binary)
 
     def increase_workers(self, number: int, timeout: int | None = None) -> dict[str, t.Any]:
         """Increase the number of workers.

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -62,7 +62,7 @@ class PackageVersionInfo(_PackageVersionInfoRequired, total=False):
 PackageVersionSnapshot: t.TypeAlias = dict[str, PackageVersionInfo]
 
 
-class DaemonVersionInfo(t.TypedDict):
+class DaemonEnvInfo(t.TypedDict):
     """Content written to the daemon version file."""
 
     packages: PackageVersionSnapshot
@@ -323,11 +323,11 @@ class DaemonClient:
         return self._config.filepaths(self.profile)['daemon']['pid']
 
     @property
-    def daemon_package_snapshot_file(self) -> str:
+    def daemon_env_info_file(self) -> str:
         try:
-            return self._config.filepaths(self.profile)['daemon']['package_snapshot']
+            return self._config.filepaths(self.profile)['daemon']['daemon_env_info']
         except KeyError as exc:
-            raise ConfigurationError('daemon package snapshot file path is not configured') from exc
+            raise ConfigurationError('daemon env info file path is not configured') from exc
 
     def get_circus_port(self) -> int:
         """Retrieve the port for the circus controller, which should be written to the circus port file.
@@ -668,19 +668,19 @@ class DaemonClient:
     def _validate_package_version_snapshot(snapshot: t.Any) -> PackageVersionSnapshot | None:
         """Validate a structured package version snapshot."""
         if not isinstance(snapshot, dict):
-            LOGGER.warning('Daemon package snapshot file has unexpected format; ignoring.')
+            LOGGER.warning('Daemon env info file has unexpected format; ignoring.')
             return None
 
         validated: PackageVersionSnapshot = {}
 
         for package, value in snapshot.items():
             if not isinstance(package, str) or not isinstance(value, dict):
-                LOGGER.warning('Daemon package snapshot file has unexpected format; ignoring.')
+                LOGGER.warning('Daemon env info file has unexpected format; ignoring.')
                 return None
 
             version = value.get('version')
             if not isinstance(version, str):
-                LOGGER.warning('Daemon package snapshot file has unexpected format; ignoring.')
+                LOGGER.warning('Daemon env info file has unexpected format; ignoring.')
                 return None
 
             package_info: PackageVersionInfo = {'version': version}
@@ -694,21 +694,21 @@ class DaemonClient:
 
     def _write_version_file(self) -> None:
         """Write the current package version snapshot to the daemon version file."""
-        version_info: DaemonVersionInfo = {
+        env_info: DaemonEnvInfo = {
             'packages': self.get_package_version_snapshot(),
             'python_binary': sys.executable,
         }
         try:
-            pathlib.Path(self.daemon_package_snapshot_file).write_text(json.dumps(version_info), encoding='utf8')
+            pathlib.Path(self.daemon_env_info_file).write_text(json.dumps(env_info), encoding='utf8')
         except ConfigurationError:
             LOGGER.debug('Cannot write daemon version file: version file path is not configured.')
         except OSError as exc:
             LOGGER.warning('Failed to write daemon version file: %s', exc)
 
-    def get_daemon_version_info(self) -> DaemonVersionInfo | None:
+    def get_daemon_env_info(self) -> DaemonEnvInfo | None:
         """Read and validate the daemon version file, or return None if unavailable or invalid."""
         try:
-            data = json.loads(pathlib.Path(self.daemon_package_snapshot_file).read_text(encoding='utf8'))
+            data = json.loads(pathlib.Path(self.daemon_env_info_file).read_text(encoding='utf8'))
         except (ConfigurationError, OSError, json.JSONDecodeError):
             return None
 
@@ -723,7 +723,7 @@ class DaemonClient:
         if not isinstance(python_binary, str):
             return None
 
-        return DaemonVersionInfo(packages=packages, python_binary=python_binary)
+        return DaemonEnvInfo(packages=packages, python_binary=python_binary)
 
     def increase_workers(self, number: int, timeout: int | None = None) -> dict[str, t.Any]:
         """Increase the number of workers.
@@ -822,7 +822,7 @@ class DaemonClient:
 
         # Best-effort cleanup of version file
         try:
-            pathlib.Path(self.daemon_package_snapshot_file).unlink(missing_ok=True)
+            pathlib.Path(self.daemon_env_info_file).unlink(missing_ok=True)
         except ConfigurationError:
             LOGGER.debug('Cannot remove daemon version file: version file path is not configured.')
         except OSError as exc:

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -888,6 +888,6 @@ class Config:
             'daemon': {
                 'log': str(daemon_log_dir / f'aiida-{profile.name}.log'),
                 'pid': str(daemon_dir / f'aiida-{profile.name}.pid'),
-                'package_snapshot': str(daemon_dir / f'aiida-{profile.name}.package_snapshot'),
+                'daemon_env_info': str(daemon_dir / f'aiida-{profile.name}-env-info.json'),
             },
         }

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -8,6 +8,7 @@
 ###########################################################################
 """Tests for ``verdi daemon``."""
 
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -220,7 +221,11 @@ def test_daemon_status_worker_timeout(run_cli_command):
 @patch.object(DaemonClient, 'get_status', lambda self, timeout=None: {'status': 'running'})
 @patch.object(DaemonClient, 'get_daemon_info', get_daemon_info)
 @patch.object(DaemonClient, 'get_worker_info', get_worker_info)
-@patch.object(DaemonClient, 'get_daemon_package_snapshot', lambda self: {'aiida-core': {'version': '2.8.0.post0'}})
+@patch.object(
+    DaemonClient,
+    'get_daemon_version_info',
+    lambda self: {'packages': {'aiida-core': {'version': '2.8.0.post0'}}, 'python_binary': sys.executable},
+)
 @patch.object(
     DaemonClient,
     'get_package_version_snapshot',

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -223,7 +223,7 @@ def test_daemon_status_worker_timeout(run_cli_command):
 @patch.object(DaemonClient, 'get_worker_info', get_worker_info)
 @patch.object(
     DaemonClient,
-    'get_daemon_version_info',
+    'get_daemon_env_info',
     lambda self: {'packages': {'aiida-core': {'version': '2.8.0.post0'}}, 'python_binary': sys.executable},
 )
 @patch.object(

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Tests for `verdi status`."""
 
+import sys
+
 import pytest
 
 from aiida import __version__, get_profile
@@ -142,8 +144,11 @@ def test_version_mismatch_warning(run_cli_command, monkeypatch, tmp_path):
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
     monkeypatch.setattr(
         DaemonClient,
-        'get_daemon_package_snapshot',
-        lambda self: {'aiida-core': {'version': '2.8.0.post0', 'editable_path': str(daemon_path)}},
+        'get_daemon_version_info',
+        lambda self: {
+            'packages': {'aiida-core': {'version': '2.8.0.post0', 'editable_path': str(daemon_path)}},
+            'python_binary': sys.executable,
+        },
     )
     monkeypatch.setattr(
         DaemonClient,
@@ -183,7 +188,11 @@ def test_version_mismatch_warning_for_added_or_removed_plugin(
 ):
     """Test that ``verdi status`` warns when plugins were added or removed since daemon startup."""
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
-    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: daemon_versions)
+    monkeypatch.setattr(
+        DaemonClient,
+        'get_daemon_version_info',
+        lambda self: {'packages': daemon_versions, 'python_binary': sys.executable},
+    )
     monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: current_versions))
 
     result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
@@ -205,7 +214,11 @@ def test_no_warning_when_versions_match(run_cli_command, monkeypatch, tmp_path, 
         pkg_info['editable_path'] = str(tmp_path / 'aiida-core')
 
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
-    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: {'aiida-core': pkg_info})
+    monkeypatch.setattr(
+        DaemonClient,
+        'get_daemon_version_info',
+        lambda self: {'packages': {'aiida-core': pkg_info}, 'python_binary': sys.executable},
+    )
     monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: {'aiida-core': pkg_info}))
 
     result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
@@ -230,7 +243,11 @@ def test_warning_when_editable_install_state_changes(
         current_info['editable_path'] = editable_path
 
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
-    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: {'aiida-core': daemon_info})
+    monkeypatch.setattr(
+        DaemonClient,
+        'get_daemon_version_info',
+        lambda self: {'packages': {'aiida-core': daemon_info}, 'python_binary': sys.executable},
+    )
     monkeypatch.setattr(
         DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: {'aiida-core': current_info})
     )
@@ -244,7 +261,7 @@ def test_warning_when_editable_install_state_changes(
 def test_no_warning_when_version_file_missing(run_cli_command, monkeypatch):
     """Test that ``verdi status`` shows no warning when version file is missing."""
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
-    monkeypatch.setattr(DaemonClient, 'get_daemon_package_snapshot', lambda self: None)
+    monkeypatch.setattr(DaemonClient, 'get_daemon_version_info', lambda self: None)
 
     result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
     assert 'different package versions' not in result.output

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -144,7 +144,7 @@ def test_version_mismatch_warning(run_cli_command, monkeypatch, tmp_path):
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
     monkeypatch.setattr(
         DaemonClient,
-        'get_daemon_version_info',
+        'get_daemon_env_info',
         lambda self: {
             'packages': {'aiida-core': {'version': '2.8.0.post0', 'editable_path': str(daemon_path)}},
             'python_binary': sys.executable,
@@ -167,7 +167,7 @@ def test_version_mismatch_warning(run_cli_command, monkeypatch, tmp_path):
 
 @pytest.mark.usefixtures('stopped_daemon_client')
 @pytest.mark.parametrize(
-    ('daemon_versions', 'current_versions', 'expected_section', 'expected_change'),
+    ('daemon_packages', 'current_packages', 'expected_section', 'expected_change'),
     [
         (
             {'aiida-core': {'version': '2.8.0.post0'}},
@@ -184,16 +184,16 @@ def test_version_mismatch_warning(run_cli_command, monkeypatch, tmp_path):
     ],
 )
 def test_version_mismatch_warning_for_added_or_removed_plugin(
-    run_cli_command, monkeypatch, daemon_versions, current_versions, expected_section, expected_change
+    run_cli_command, monkeypatch, daemon_packages, current_packages, expected_section, expected_change
 ):
     """Test that ``verdi status`` warns when plugins were added or removed since daemon startup."""
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
     monkeypatch.setattr(
         DaemonClient,
-        'get_daemon_version_info',
-        lambda self: {'packages': daemon_versions, 'python_binary': sys.executable},
+        'get_daemon_env_info',
+        lambda self: {'packages': daemon_packages, 'python_binary': sys.executable},
     )
-    monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: current_versions))
+    monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: current_packages))
 
     result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
     assert 'different package versions' in result.output
@@ -216,7 +216,7 @@ def test_no_warning_when_versions_match(run_cli_command, monkeypatch, tmp_path, 
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
     monkeypatch.setattr(
         DaemonClient,
-        'get_daemon_version_info',
+        'get_daemon_env_info',
         lambda self: {'packages': {'aiida-core': pkg_info}, 'python_binary': sys.executable},
     )
     monkeypatch.setattr(DaemonClient, 'get_package_version_snapshot', staticmethod(lambda: {'aiida-core': pkg_info}))
@@ -245,7 +245,7 @@ def test_warning_when_editable_install_state_changes(
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
     monkeypatch.setattr(
         DaemonClient,
-        'get_daemon_version_info',
+        'get_daemon_env_info',
         lambda self: {'packages': {'aiida-core': daemon_info}, 'python_binary': sys.executable},
     )
     monkeypatch.setattr(
@@ -261,7 +261,7 @@ def test_warning_when_editable_install_state_changes(
 def test_no_warning_when_version_file_missing(run_cli_command, monkeypatch):
     """Test that ``verdi status`` shows no warning when version file is missing."""
     monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
-    monkeypatch.setattr(DaemonClient, 'get_daemon_version_info', lambda self: None)
+    monkeypatch.setattr(DaemonClient, 'get_daemon_env_info', lambda self: None)
 
     result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
     assert 'different package versions' not in result.output

--- a/tests/cmdline/utils/test_daemon.py
+++ b/tests/cmdline/utils/test_daemon.py
@@ -8,7 +8,7 @@
 ###########################################################################
 """Unit tests for ``aiida.cmdline.utils.daemon`` formatter helpers."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -119,29 +119,20 @@ def test_format_package_state_change_lines_editable_path_disappears(tmp_path):
     assert format_package_state_change_lines(daemon, current) == expected
 
 
-def test_validate_python_binary_no_binary():
-    """No error when daemon binary is not recorded."""
-    client = MagicMock()
-    client.get_daemon_python_binary.return_value = None
-    assert validate_python_binary(client) is None
-
-
 def test_validate_python_binary_match():
     """No error when binaries match."""
-    client = MagicMock()
-    client.get_daemon_python_binary.return_value = '/usr/bin/python3'
+    version_info = {'packages': {}, 'python_binary': '/usr/bin/python3'}
     with patch('aiida.cmdline.utils.daemon.sys') as mock_sys:
         mock_sys.executable = '/usr/bin/python3'
-        assert validate_python_binary(client) is None
+        assert validate_python_binary(version_info) is None
 
 
 def test_validate_python_binary_mismatch():
     """Error message is returned when binaries differ."""
-    client = MagicMock()
-    client.get_daemon_python_binary.return_value = '/old/venv/bin/python'
+    version_info = {'packages': {}, 'python_binary': '/old/venv/bin/python'}
     with patch('aiida.cmdline.utils.daemon.sys') as mock_sys:
         mock_sys.executable = '/new/venv/bin/python'
-        error = validate_python_binary(client)
+        error = validate_python_binary(version_info)
     assert 'different Python binary' in error
     assert '/old/venv/bin/python' in error
     assert '/new/venv/bin/python' in error

--- a/tests/cmdline/utils/test_daemon.py
+++ b/tests/cmdline/utils/test_daemon.py
@@ -8,11 +8,14 @@
 ###########################################################################
 """Unit tests for ``aiida.cmdline.utils.daemon`` formatter helpers."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from aiida.cmdline.utils.daemon import (
     format_package_state_change_lines,
     format_package_version_info,
+    get_daemon_python_binary_drift_lines,
 )
 
 
@@ -114,3 +117,32 @@ def test_format_package_state_change_lines_editable_path_disappears(tmp_path):
     current = {'aiida-core': {'version': '2.8.0'}}
     expected = [f'Changed packages: aiida-core (2.8.0 @ {tmp_path} -> 2.8.0)']
     assert format_package_state_change_lines(daemon, current) == expected
+
+
+def test_get_daemon_python_binary_drift_lines_no_binary():
+    """No drift lines when daemon binary is not recorded."""
+    client = MagicMock()
+    client.get_daemon_python_binary.return_value = None
+    assert get_daemon_python_binary_drift_lines(client) == []
+
+
+def test_get_daemon_python_binary_drift_lines_match():
+    """No drift lines when binaries match."""
+    client = MagicMock()
+    client.get_daemon_python_binary.return_value = '/usr/bin/python3'
+    with patch('aiida.cmdline.utils.daemon.sys') as mock_sys:
+        mock_sys.executable = '/usr/bin/python3'
+        assert get_daemon_python_binary_drift_lines(client) == []
+
+
+def test_get_daemon_python_binary_drift_lines_mismatch():
+    """Drift lines are returned when binaries differ."""
+    client = MagicMock()
+    client.get_daemon_python_binary.return_value = '/old/venv/bin/python'
+    with patch('aiida.cmdline.utils.daemon.sys') as mock_sys:
+        mock_sys.executable = '/new/venv/bin/python'
+        lines = get_daemon_python_binary_drift_lines(client)
+    assert len(lines) == 3
+    assert 'different Python binary' in lines[0]
+    assert '/old/venv/bin/python' in lines[1]
+    assert '/new/venv/bin/python' in lines[2]

--- a/tests/cmdline/utils/test_daemon.py
+++ b/tests/cmdline/utils/test_daemon.py
@@ -15,7 +15,7 @@ import pytest
 from aiida.cmdline.utils.daemon import (
     format_package_state_change_lines,
     format_package_version_info,
-    get_daemon_python_binary_drift_lines,
+    validate_python_binary,
 )
 
 
@@ -119,30 +119,29 @@ def test_format_package_state_change_lines_editable_path_disappears(tmp_path):
     assert format_package_state_change_lines(daemon, current) == expected
 
 
-def test_get_daemon_python_binary_drift_lines_no_binary():
-    """No drift lines when daemon binary is not recorded."""
+def test_validate_python_binary_no_binary():
+    """No error when daemon binary is not recorded."""
     client = MagicMock()
     client.get_daemon_python_binary.return_value = None
-    assert get_daemon_python_binary_drift_lines(client) == []
+    assert validate_python_binary(client) is None
 
 
-def test_get_daemon_python_binary_drift_lines_match():
-    """No drift lines when binaries match."""
+def test_validate_python_binary_match():
+    """No error when binaries match."""
     client = MagicMock()
     client.get_daemon_python_binary.return_value = '/usr/bin/python3'
     with patch('aiida.cmdline.utils.daemon.sys') as mock_sys:
         mock_sys.executable = '/usr/bin/python3'
-        assert get_daemon_python_binary_drift_lines(client) == []
+        assert validate_python_binary(client) is None
 
 
-def test_get_daemon_python_binary_drift_lines_mismatch():
-    """Drift lines are returned when binaries differ."""
+def test_validate_python_binary_mismatch():
+    """Error message is returned when binaries differ."""
     client = MagicMock()
     client.get_daemon_python_binary.return_value = '/old/venv/bin/python'
     with patch('aiida.cmdline.utils.daemon.sys') as mock_sys:
         mock_sys.executable = '/new/venv/bin/python'
-        lines = get_daemon_python_binary_drift_lines(client)
-    assert len(lines) == 3
-    assert 'different Python binary' in lines[0]
-    assert '/old/venv/bin/python' in lines[1]
-    assert '/new/venv/bin/python' in lines[2]
+        error = validate_python_binary(client)
+    assert 'different Python binary' in error
+    assert '/old/venv/bin/python' in error
+    assert '/new/venv/bin/python' in error

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -121,9 +121,9 @@ class TestDaemonVersionInfo:
         assert versions['aiida-core']['version'].startswith(metadata_version('aiida-core'))
 
     @staticmethod
-    def test_get_daemon_package_snapshot_no_file(stopped_daemon_client):
-        """Test that ``get_daemon_package_snapshot`` returns None when no version file exists."""
-        assert stopped_daemon_client.get_daemon_package_snapshot() is None
+    def test_get_daemon_version_info_no_file(stopped_daemon_client):
+        """Test that ``get_daemon_version_info`` returns None when no version file exists."""
+        assert stopped_daemon_client.get_daemon_version_info() is None
 
     @staticmethod
     def test_daemon_package_snapshot_file_missing_configuration(stopped_daemon_client, monkeypatch):
@@ -139,23 +139,23 @@ class TestDaemonVersionInfo:
             _ = stopped_daemon_client.daemon_package_snapshot_file
 
     @staticmethod
-    def test_get_daemon_package_snapshot_missing_configuration(stopped_daemon_client, monkeypatch):
-        """Test that ``get_daemon_package_snapshot`` returns None when the filepath is missing."""
+    def test_get_daemon_version_info_missing_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``get_daemon_version_info`` returns None when the filepath is missing."""
         filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
         modified_filepaths = dict(filepaths)
         modified_filepaths['daemon'] = dict(filepaths['daemon'])
         modified_filepaths['daemon'].pop('package_snapshot', None)
         monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
 
-        assert stopped_daemon_client.get_daemon_package_snapshot() is None
+        assert stopped_daemon_client.get_daemon_version_info() is None
 
     @staticmethod
-    def test_get_daemon_package_snapshot_corrupt_file(stopped_daemon_client):
-        """Test that ``get_daemon_package_snapshot`` returns None for corrupt version file."""
+    def test_get_daemon_version_info_corrupt_file(stopped_daemon_client):
+        """Test that ``get_daemon_version_info`` returns None for corrupt version file."""
         version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         version_file.write_text('not valid json {{{', encoding='utf8')
-        assert stopped_daemon_client.get_daemon_package_snapshot() is None
+        assert stopped_daemon_client.get_daemon_version_info() is None
 
     @staticmethod
     def test_daemon_version_info_roundtrip(stopped_daemon_client):
@@ -168,8 +168,9 @@ class TestDaemonVersionInfo:
         }
         snapshot = {'packages': packages, 'python_binary': '/usr/bin/python3'}
         version_file.write_text(json.dumps(snapshot), encoding='utf8')
-        assert stopped_daemon_client.get_daemon_package_snapshot() == packages
-        assert stopped_daemon_client.get_daemon_python_binary() == '/usr/bin/python3'
+        info = stopped_daemon_client.get_daemon_version_info()
+        assert info['packages'] == packages
+        assert info['python_binary'] == '/usr/bin/python3'
 
     @staticmethod
     def test_get_dist_commit_hash_vcs_install():

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -108,8 +108,8 @@ def test_get_status_timeout(stopped_daemon_client):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-class TestDaemonVersionInfo:
-    """Tests for the daemon version info methods."""
+class TestDaemonEnvInfo:
+    """Tests for the daemon env info methods."""
 
     @staticmethod
     def test_get_package_version_snapshot():
@@ -121,13 +121,13 @@ class TestDaemonVersionInfo:
         assert versions['aiida-core']['version'].startswith(metadata_version('aiida-core'))
 
     @staticmethod
-    def test_get_daemon_version_info_no_file(stopped_daemon_client):
-        """Test that ``get_daemon_version_info`` returns None when no version file exists."""
-        assert stopped_daemon_client.get_daemon_version_info() is None
+    def test_get_daemon_env_info_no_file(stopped_daemon_client):
+        """Test that ``get_daemon_env_info`` returns None when no version file exists."""
+        assert stopped_daemon_client.get_daemon_env_info() is None
 
     @staticmethod
-    def test_daemon_package_snapshot_file_missing_configuration(stopped_daemon_client, monkeypatch):
-        """Test that ``daemon_package_snapshot_file`` raises ``ConfigurationError`` when the filepath is missing."""
+    def test_daemon_env_info_file_missing_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``daemon_env_info_file`` raises ``ConfigurationError`` when the filepath is missing."""
         from aiida.common.exceptions import ConfigurationError
 
         filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
@@ -135,32 +135,32 @@ class TestDaemonVersionInfo:
             stopped_daemon_client._config, 'filepaths', lambda profile: {'daemon': {'pid': filepaths['daemon']['pid']}}
         )
 
-        with pytest.raises(ConfigurationError, match='daemon package snapshot file path is not configured'):
-            _ = stopped_daemon_client.daemon_package_snapshot_file
+        with pytest.raises(ConfigurationError, match='daemon env info file path is not configured'):
+            _ = stopped_daemon_client.daemon_env_info_file
 
     @staticmethod
-    def test_get_daemon_version_info_missing_configuration(stopped_daemon_client, monkeypatch):
-        """Test that ``get_daemon_version_info`` returns None when the filepath is missing."""
+    def test_get_daemon_env_info_missing_configuration(stopped_daemon_client, monkeypatch):
+        """Test that ``get_daemon_env_info`` returns None when the filepath is missing."""
         filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
         modified_filepaths = dict(filepaths)
         modified_filepaths['daemon'] = dict(filepaths['daemon'])
-        modified_filepaths['daemon'].pop('package_snapshot', None)
+        modified_filepaths['daemon'].pop('daemon_env_info', None)
         monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
 
-        assert stopped_daemon_client.get_daemon_version_info() is None
+        assert stopped_daemon_client.get_daemon_env_info() is None
 
     @staticmethod
-    def test_get_daemon_version_info_corrupt_file(stopped_daemon_client):
-        """Test that ``get_daemon_version_info`` returns None for corrupt version file."""
-        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+    def test_get_daemon_env_info_corrupt_file(stopped_daemon_client):
+        """Test that ``get_daemon_env_info`` returns None for corrupt version file."""
+        version_file = pathlib.Path(stopped_daemon_client.daemon_env_info_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         version_file.write_text('not valid json {{{', encoding='utf8')
-        assert stopped_daemon_client.get_daemon_version_info() is None
+        assert stopped_daemon_client.get_daemon_env_info() is None
 
     @staticmethod
-    def test_daemon_version_info_roundtrip(stopped_daemon_client):
+    def test_daemon_env_info_roundtrip(stopped_daemon_client):
         """Test that version info can be written and read back."""
-        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file = pathlib.Path(stopped_daemon_client.daemon_env_info_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         packages = {
             'aiida-core': {'version': '2.6.0', 'editable_path': '/tmp/aiida-core'},
@@ -168,7 +168,7 @@ class TestDaemonVersionInfo:
         }
         snapshot = {'packages': packages, 'python_binary': '/usr/bin/python3'}
         version_file.write_text(json.dumps(snapshot), encoding='utf8')
-        info = stopped_daemon_client.get_daemon_version_info()
+        info = stopped_daemon_client.get_daemon_env_info()
         assert info['packages'] == packages
         assert info['python_binary'] == '/usr/bin/python3'
 
@@ -265,7 +265,7 @@ class TestDaemonVersionInfo:
     @staticmethod
     def test_stop_daemon_cleans_version_file(stopped_daemon_client):
         """Test that ``stop_daemon`` removes the version file."""
-        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file = pathlib.Path(stopped_daemon_client.daemon_env_info_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         version_file.write_text('{"aiida-core": "2.6.0"}', encoding='utf8')
         assert version_file.exists()
@@ -284,7 +284,7 @@ class TestDaemonVersionInfo:
         filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
         modified_filepaths = dict(filepaths)
         modified_filepaths['daemon'] = dict(filepaths['daemon'])
-        modified_filepaths['daemon'].pop('package_snapshot', None)
+        modified_filepaths['daemon'].pop('daemon_env_info', None)
         monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
 
         with (
@@ -296,7 +296,7 @@ class TestDaemonVersionInfo:
     @staticmethod
     def test_start_daemon_writes_version_file(stopped_daemon_client):
         """Test that ``start_daemon`` writes the version file after a successful spawn."""
-        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file = pathlib.Path(stopped_daemon_client.daemon_env_info_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         version_file.unlink(missing_ok=True)
 
@@ -318,7 +318,7 @@ class TestDaemonVersionInfo:
     @staticmethod
     def test_start_daemon_no_version_file_on_await_failure(stopped_daemon_client):
         """Test that ``start_daemon`` does not write the version file if ``_await_condition`` fails."""
-        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file = pathlib.Path(stopped_daemon_client.daemon_env_info_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         version_file.unlink(missing_ok=True)
 
@@ -345,7 +345,7 @@ class TestDaemonVersionInfo:
         filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
         modified_filepaths = dict(filepaths)
         modified_filepaths['daemon'] = dict(filepaths['daemon'])
-        modified_filepaths['daemon'].pop('package_snapshot', None)
+        modified_filepaths['daemon'].pop('daemon_env_info', None)
         monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
 
         with (
@@ -361,7 +361,7 @@ class TestDaemonVersionInfo:
     @staticmethod
     def test_restart_daemon_writes_version_file(stopped_daemon_client):
         """Test that ``restart_daemon`` updates the version file after a successful restart."""
-        version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
+        version_file = pathlib.Path(stopped_daemon_client.daemon_env_info_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
         version_file.write_text('{"aiida-core": {"version": "1.0.0"}}', encoding='utf8')
 
@@ -383,7 +383,7 @@ class TestDaemonVersionInfo:
         filepaths = stopped_daemon_client._config.filepaths(stopped_daemon_client.profile)
         modified_filepaths = dict(filepaths)
         modified_filepaths['daemon'] = dict(filepaths['daemon'])
-        modified_filepaths['daemon'].pop('package_snapshot', None)
+        modified_filepaths['daemon'].pop('daemon_env_info', None)
         monkeypatch.setattr(stopped_daemon_client._config, 'filepaths', lambda profile: modified_filepaths)
 
         with (

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -162,12 +162,14 @@ class TestDaemonVersionInfo:
         """Test that version info can be written and read back."""
         version_file = pathlib.Path(stopped_daemon_client.daemon_package_snapshot_file)
         version_file.parent.mkdir(parents=True, exist_ok=True)
-        expected = {
+        packages = {
             'aiida-core': {'version': '2.6.0', 'editable_path': '/tmp/aiida-core'},
             'some-plugin': {'version': '1.0.0'},
         }
-        version_file.write_text(json.dumps(expected), encoding='utf8')
-        assert stopped_daemon_client.get_daemon_package_snapshot() == expected
+        snapshot = {'packages': packages, 'python_binary': '/usr/bin/python3'}
+        version_file.write_text(json.dumps(snapshot), encoding='utf8')
+        assert stopped_daemon_client.get_daemon_package_snapshot() == packages
+        assert stopped_daemon_client.get_daemon_python_binary() == '/usr/bin/python3'
 
     @staticmethod
     def test_get_dist_commit_hash_vcs_install():
@@ -308,7 +310,9 @@ class TestDaemonVersionInfo:
             stopped_daemon_client.start_daemon()
 
         assert version_file.exists()
-        assert json.loads(version_file.read_text(encoding='utf8')) == {'aiida-core': {'version': '2.6.0'}}
+        written = json.loads(version_file.read_text(encoding='utf8'))
+        assert written['packages'] == {'aiida-core': {'version': '2.6.0'}}
+        assert 'python_binary' in written
 
     @staticmethod
     def test_start_daemon_no_version_file_on_await_failure(stopped_daemon_client):
@@ -368,7 +372,9 @@ class TestDaemonVersionInfo:
         ):
             stopped_daemon_client.restart_daemon()
 
-        assert json.loads(version_file.read_text(encoding='utf8')) == {'aiida-core': {'version': '2.6.0'}}
+        written = json.loads(version_file.read_text(encoding='utf8'))
+        assert written['packages'] == {'aiida-core': {'version': '2.6.0'}}
+        assert 'python_binary' in written
 
     @staticmethod
     def test_restart_daemon_missing_version_file_configuration(stopped_daemon_client, monkeypatch):

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -225,13 +225,13 @@ def test_basic_properties(config_with_profile):
     assert isinstance(config.dictionary, dict)
 
 
-def test_filepaths_includes_package_snapshot(config_with_profile):
-    """Test that ``filepaths`` returns a ``package_snapshot`` entry for the daemon."""
+def test_filepaths_includes_daemon_env_info(config_with_profile):
+    """Test that ``filepaths`` returns a ``daemon_env_info`` entry for the daemon."""
     config = config_with_profile
     profile = config.get_profile(config.default_profile_name)
     filepaths = config.filepaths(profile)
-    assert 'package_snapshot' in filepaths['daemon']
-    assert filepaths['daemon']['package_snapshot'].endswith('.package_snapshot')
+    assert 'daemon_env_info' in filepaths['daemon']
+    assert filepaths['daemon']['daemon_env_info'].endswith('-env-info.json')
 
 
 def test_setting_versions(config_with_profile):


### PR DESCRIPTION
Issues is described in #7408. The fix puts the python binary path using `sys.executable` into the daemon version file to detect a mismatch/drift or even a deletion.

I also refactored in the second commit of the how the function that performed the validation worked. I don't think it was good design to have getter function that main perform a validation task. I moved to a pattern where the validation function returns a string with the error message. I think using exceptions instead of string return with raise would just end up in a lot of boilerplate without much usage as long as we don't use the validation in other context where raising makes sense.

To reduce 2 reads for binary and package info into 1 read of daemon version file, I refactored in the public API of the DaemonClient a bit in the third commit. Its not part of our public API but the changes only affects new functions that have not been released yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `verdi status` and `verdi daemon status` now check both the daemon’s Python executable and its package versions, and show a unified `verdi daemon restart` instruction when mismatches are found.

* **Bug Fixes**
  * Improved status output for daemon environment problems: missing or invalid daemon environment info now results in a single clearer warning message rather than noisy drift-style output.

* **Tests**
  * Updated and added coverage to mock the new daemon environment validation behavior, including Python-binary mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->