### PR TITLE
👌 Replace ResourceWarning with logging in __del__

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import functools
 import sys
 import typing as t
-import warnings
 from collections.abc import Iterator
 
 from aiida.brokers.broker import Broker
@@ -51,7 +50,7 @@ class RabbitmqBroker(Broker):
 
     def __del__(self) -> None:
         if self._communicator is not None:
-            warnings.warn(f'RabbitmqBroker was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
+            LOGGER.warning(f'RabbitmqBroker {self!r} was not closed explicitly.')
             if not sys.is_finalizing():
                 self.close()
 

--- a/src/aiida/cmdline/utils/log.py
+++ b/src/aiida/cmdline/utils/log.py
@@ -1,6 +1,7 @@
 """Utilities for logging in the command line interface context."""
 
 import logging
+import sys
 
 import click
 
@@ -10,7 +11,9 @@ from .echo import COLORS
 class CliHandler(logging.Handler):
     """Handler for writing to the console using click."""
 
-    def emit(self, record):
+    # Capture `sys` as a default since module globals may be cleared during interpreter shutdown.
+    # See https://stackoverflow.com/questions/67902926/python-importerror-in-del-how-to-solve-this
+    def emit(self, record, _sys=sys):
         """Emit log record via click.
 
         Can make use of special attributes 'nl' (whether to add newline) and 'err' (whether to print to stderr), which
@@ -37,6 +40,21 @@ class CliHandler(logging.Handler):
             msg = self.format(record)
             click.echo(msg, err=err, nl=nl)
         except Exception:
+            # if errored out and python finalizes, click resources have been
+            # most likely destructed so we emit with minimal formatting
+            if _sys.is_finalizing():
+                try:
+                    msg = record.getMessage()
+                    if prefix:
+                        msg = f'{record.levelname.capitalize()}: {msg}'
+                    stream = _sys.__stderr__ if err else _sys.__stdout__
+                    if stream is not None:
+                        stream.write(f'{msg}\n' if nl else msg)
+                        stream.flush()
+                except Exception:
+                    pass
+                return
+
             self.handleError(record)
 
 

--- a/src/aiida/orm/implementation/storage_backend.py
+++ b/src/aiida/orm/implementation/storage_backend.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import abc
 import sys
-import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ContextManager, List, Optional, TypeVar, Union
+
+from aiida.common.log import AIIDA_LOGGER
 
 if TYPE_CHECKING:
     from disk_objectstore.backup_utils import BackupManager
@@ -36,6 +37,8 @@ if TYPE_CHECKING:
     from aiida.repository.backend.abstract import AbstractRepositoryBackend
 
 __all__ = ('StorageBackend',)
+
+LOGGER = AIIDA_LOGGER.getChild('orm.implementation.storage_backend')
 
 TransactionType = TypeVar('TransactionType')
 
@@ -137,14 +140,15 @@ class StorageBackend(abc.ABC):
     def close(self) -> None:
         """Close the storage access."""
 
-    def __del__(self):
+    def __del__(self) -> None:
         try:
             closed = self.is_closed
         except AttributeError:
             # covers cases where the backend implementation is not yet initialized but object is deleted
             return
+
         if not closed:
-            warnings.warn(f'StorageBackend was not closed explicitly: {self!r}', ResourceWarning, stacklevel=1)
+            LOGGER.warning(f'StorageBackend {self!r} was not closed explicitly.')
             if not sys.is_finalizing():
                 self.close()
 

--- a/src/aiida/orm/utils/log.py
+++ b/src/aiida/orm/utils/log.py
@@ -9,12 +9,19 @@
 """Module for logging methods/classes that need the ORM."""
 
 import logging
+import sys
 
 
 class DBLogHandler(logging.Handler):
     """A custom db log handler for writing logs tot he database"""
 
-    def emit(self, record):
+    # Capture `sys` as a default since module globals may be cleared during interpreter shutdown.
+    # See https://stackoverflow.com/questions/67902926/python-importerror-in-del-how-to-solve-this
+    def emit(self, record, _sys=sys):
+        # when we finalize we do not have any guarantee on database resources being alive, therefore we omit logging
+        if _sys.is_finalizing():
+            return
+
         if record.exc_info:
             # We do this because if there is exc_info this will put an appropriate string in exc_text.
             # See:

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -8,6 +8,7 @@
 ###########################################################################
 """Tests for the `aiida.brokers.rabbitmq` module."""
 
+import logging
 import pathlib
 import uuid
 from unittest.mock import MagicMock
@@ -37,29 +38,45 @@ def test_str_method(monkeypatch, manager):
     assert 'RabbitMQ @' in str(broker)
 
 
-def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch):
+def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch, caplog):
     """Test `__del__` closes the broker when Python is not finalizing."""
     broker = RabbitmqBroker(aiida_profile)
     broker._communicator = MagicMock()
     close = MagicMock()
     monkeypatch.setattr(broker, 'close', close)
 
-    with pytest.warns(ResourceWarning, match='RabbitmqBroker was not closed explicitly'):
+    with caplog.at_level(logging.WARNING, logger='aiida.broker.rabbitmq'):
         broker.__del__()
+
+    # Note: we do an in assert because it might be that a broker instance of a
+    # previous test got deleted during the log capture
+    assert (
+        'aiida.broker.rabbitmq',
+        logging.WARNING,
+        f'RabbitmqBroker {broker!r} was not closed explicitly.',
+    ) in caplog.record_tuples
 
     close.assert_called_once_with()
 
 
-def test_del_skips_close_when_finalizing(aiida_profile, monkeypatch):
-    """Test ``__del__`` skips close when Python is finalizing."""
+def test_del_logs_but_skips_close_when_finalizing(aiida_profile, monkeypatch, caplog):
+    """Test ``__del__`` logs but skips close when Python is finalizing."""
     broker = RabbitmqBroker(aiida_profile)
-    broker._communicator = MagicMock()
     close = MagicMock()
+    broker._communicator = MagicMock()
     monkeypatch.setattr(broker, 'close', close)
     monkeypatch.setattr('sys.is_finalizing', lambda: True)
 
-    with pytest.warns(ResourceWarning, match='RabbitmqBroker was not closed explicitly'):
+    with caplog.at_level(logging.WARNING, logger='aiida.broker.rabbitmq'):
         broker.__del__()
+
+    # Note: we do an in assert because it might be that a broker instance of a
+    # previous test got deleted during the log capture
+    assert (
+        'aiida.broker.rabbitmq',
+        logging.WARNING,
+        f'RabbitmqBroker {broker!r} was not closed explicitly.',
+    ) in caplog.record_tuples
 
     close.assert_not_called()
 

--- a/tests/cmdline/utils/test_log.py
+++ b/tests/cmdline/utils/test_log.py
@@ -9,6 +9,7 @@
 """Tests for the :mod:`aiida.cmdline.utils.log` module."""
 
 import logging
+from io import StringIO
 
 from aiida.cmdline.utils import log
 
@@ -53,3 +54,18 @@ def test_cli_formatter_prefix():
     record = logging.LogRecord('name', logging.INFO, 'pathname', 0, 'Some %s', ('value',), None)
     record.prefix = True
     assert log.CliFormatter().format(record) == '\x1b[34m\x1b[1mInfo\x1b[0m: Some value'
+
+
+def test_cli_handler_emit_when_globals_are_finalized(monkeypatch):
+    """Test ``CliHandler.emit`` falls back to a plain stream write during finalization."""
+    record = logging.LogRecord('name', logging.WARNING, 'pathname', 0, 'Some %s', ('value',), None)
+    handler = log.CliHandler()
+    stream = StringIO()
+    monkeypatch.setattr(log.sys, 'is_finalizing', lambda: True)
+    monkeypatch.setattr(log.sys, '__stdout__', stream)
+    monkeypatch.setattr(log, 'sys', None)
+    monkeypatch.setattr(log, 'click', None)
+
+    handler.emit(record)
+
+    assert stream.getvalue() == 'Warning: Some value\n'

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import pathlib
 import uuid
 from unittest.mock import MagicMock
@@ -21,6 +22,7 @@ from aiida import orm
 from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.orm.entities import EntityTypes
+from aiida.orm.implementation import storage_backend as storage_backend_module
 
 
 class TestBackend:
@@ -169,27 +171,43 @@ class TestBackend:
         assert len(group.nodes) == 0
 
 
-def test_del_closes_backend_when_not_finalizing(aiida_profile, monkeypatch):
+def test_del_closes_backend_when_not_finalizing(aiida_profile, monkeypatch, caplog):
     """Test ``__del__`` closes the backend when Python is not finalizing."""
     backend = aiida_profile.storage_cls(aiida_profile)
     close = MagicMock()
     monkeypatch.setattr(backend, 'close', close)
 
-    with pytest.warns(ResourceWarning, match='StorageBackend was not closed explicitly'):
+    with caplog.at_level(logging.WARNING, logger=storage_backend_module.LOGGER.name):
         backend.__del__()
+
+    # Note: we do an ``in`` assert because it might be that a backend instance of a
+    # previous test got deleted during the log capture
+    assert (
+        storage_backend_module.LOGGER.name,
+        logging.WARNING,
+        f'StorageBackend {backend!r} was not closed explicitly.',
+    ) in caplog.record_tuples
 
     close.assert_called_once_with()
 
 
-def test_del_skips_close_when_finalizing(aiida_profile, monkeypatch):
-    """Test ``__del__`` skips close when Python is finalizing."""
+def test_del_logs_but_skips_close_when_finalizing(aiida_profile, monkeypatch, caplog):
+    """Test ``__del__`` logs but skips close when Python is finalizing."""
     backend = aiida_profile.storage_cls(aiida_profile)
     close = MagicMock()
     monkeypatch.setattr(backend, 'close', close)
     monkeypatch.setattr('sys.is_finalizing', lambda: True)
 
-    with pytest.warns(ResourceWarning, match='StorageBackend was not closed explicitly'):
+    with caplog.at_level(logging.WARNING, logger=storage_backend_module.LOGGER.name):
         backend.__del__()
+
+    # Note: we do an ``in`` assert because it might be that a backend instance of a
+    # previous test got deleted during the log capture
+    assert (
+        storage_backend_module.LOGGER.name,
+        logging.WARNING,
+        f'StorageBackend {backend!r} was not closed explicitly.',
+    ) in caplog.record_tuples
 
     close.assert_not_called()
 


### PR DESCRIPTION
Replace `warnings.warn(ResourceWarning)` with `LOGGER.info` in `RabbitmqBroker.__del__` and `StorageBackend.__del__` so that unclosed-resource messages go through the logging system instead of the warnings machinery.

Harden `CliHandler.emit`, `CliFormatter.format`, and `DBLogHandler.emit` against interpreter-shutdown scenarios where module globals may already be cleared. We cannot use clicks utility but have to write to stdout and stderr by ourselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Open brokers and backends that aren’t explicitly closed now emit warning logs instead of `ResourceWarning` during shutdown.
  * Improved shutdown safety for logging: CLI and ORM-related logging detect interpreter finalization and avoid persisting ORM output, using a minimal console fallback when needed.
* **Tests**
  * Updated broker and backend tests to assert emitted warning log messages, including scenarios where cleanup actions are intentionally skipped during interpreter finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->