### PR TITLE
👌 `traverse_graph`: report progress per iteration

### DIFF
--- a/src/aiida/common/progress_reporter.py
+++ b/src/aiida/common/progress_reporter.py
@@ -51,10 +51,10 @@ class ProgressReporterAbstract:
 
     """
 
-    def __init__(self, *, total: int, desc: Optional[str] = None, **kwargs: Any):
+    def __init__(self, *, total: Optional[int], desc: Optional[str] = None, **kwargs: Any):
         """Initialise the progress reporting contextmanager.
 
-        :param total: The number of expected iterations.
+        :param total: The number of expected iterations, or None if unknown in advance.
         :param desc: A description of the process
 
         """
@@ -63,7 +63,7 @@ class ProgressReporterAbstract:
         self._increment: int = 0
 
     @property
-    def total(self) -> int:
+    def total(self) -> Optional[int]:
         """Return the total iterations expected."""
         return self._total
 
@@ -186,7 +186,16 @@ def set_progress_bar_tqdm(
     """
     from tqdm import tqdm
 
-    set_progress_reporter(tqdm, bar_format=bar_format, leave=leave, **kwargs)
+    class TqdmProgressReporter(tqdm):  # type: ignore[type-arg]
+        def __init__(self, *args: Any, **kwargs: Any):
+            # A bar format with a percentage is meaningless when the total is unknown; fall back
+            # to tqdm's native counter display (`123it [00:01, 12.3it/s]`) in that case. Only an
+            # explicit `total=None` counts: an absent total is derived from the iterable by tqdm.
+            if 'total' in kwargs and kwargs['total'] is None:
+                kwargs['bar_format'] = None
+            super().__init__(*args, **kwargs)
+
+    set_progress_reporter(TqdmProgressReporter, bar_format=bar_format, leave=leave, **kwargs)
 
 
 def create_callback(progress_reporter: ProgressReporterAbstract | tqdm[Any]) -> Callable[[str, Any], None]:

--- a/src/aiida/common/progress_reporter.py
+++ b/src/aiida/common/progress_reporter.py
@@ -52,10 +52,10 @@ class ProgressReporterAbstract:
 
     """
 
-    def __init__(self, *, total: int, desc: str | None = None, **kwargs: Any):
+    def __init__(self, *, total: int | None, desc: str | None = None, **kwargs: Any):
         """Initialise the progress reporting contextmanager.
 
-        :param total: The number of expected iterations.
+        :param total: The number of expected iterations, or None if unknown in advance.
         :param desc: A description of the process
 
         """
@@ -64,8 +64,8 @@ class ProgressReporterAbstract:
         self._increment: int = 0
 
     @property
-    def total(self) -> int:
-        """Return the total iterations expected."""
+    def total(self) -> int | None:
+        """Return the total iterations expected, or None if not known in advance."""
         return self._total
 
     @property
@@ -177,7 +177,8 @@ def set_progress_bar_tqdm(bar_format: str | None = TQDM_BAR_FORMAT, leave: bool 
 
     See :func:`~aiida.common.progress_reporter.set_progress_reporter` for details.
 
-    :param bar_format: Specify a custom bar string format.
+    :param bar_format: Specify a custom bar string format. Pass ``bar_format=None`` when creating a
+        bar with ``total=None``, since this format's percentage would sit frozen at 0%.
     :param leave: If True, keeps all traces of the progressbar upon termination of iteration.
             If `None`, will leave only if `position` is `0`.
     :param kwargs: pass to the tqdm init

--- a/src/aiida/tools/graph/age_rules.py
+++ b/src/aiida/tools/graph/age_rules.py
@@ -19,7 +19,7 @@ from aiida.common.lang import type_check
 from aiida.tools.graph.age_entities import Basket
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from aiida.orm import QueryBuilder
     from aiida.orm.implementation.querybuilder import QueryDictType
@@ -362,13 +362,28 @@ class RuleSequence(Operation):
     the first (see RuleSetWalkers and RuleSaveWalkers).
     """
 
-    def __init__(self, rules: Iterable[Operation], max_iterations: int = 1):
+    def __init__(
+        self,
+        rules: Iterable[Operation],
+        max_iterations: int = 1,
+        callback: Callable[[int, Basket], None] | None = None,
+    ):
+        """Initialization method
+
+        :param rules: the rules to apply in order on each iteration.
+        :param max_iterations: maximum number of iterations to perform.
+        :param callback: called after each iteration with the number of iterations done so far and the
+            basket of all entities visited so far, e.g. to report progress of long traversals. The basket
+            is the live internal accumulator and must be treated as read-only; mutating or retaining it
+            corrupts the traversal state.
+        """
         for rule in rules:
             if not isinstance(rule, Operation):
                 raise TypeError('rule has to be an instance of Operation-subclass')
         self._rules = rules
         self._accumulator_set: Basket | None = None
         self._visits_set: Basket | None = None
+        self._callback = callback
         super().__init__(max_iterations, track_edges=False)
 
     def run(self, operational_set: Basket) -> Basket:
@@ -402,6 +417,9 @@ class RuleSequence(Operation):
             # I set the operational set to all results that have not been visited yet.
             operational_set = new_results - self._accumulator_set
             self._accumulator_set += new_results
+
+            if self._callback is not None:
+                self._callback(self._iterations_done, self._visits_set)
 
         return self._visits_set.copy()
 

--- a/src/aiida/tools/graph/age_rules.py
+++ b/src/aiida/tools/graph/age_rules.py
@@ -377,6 +377,9 @@ class RuleSequence(Operation):
             is the live internal accumulator and must be treated as read-only; mutating or retaining it
             corrupts the traversal state.
         """
+        # Materialize before validating: run() iterates the rules once per iteration, so a
+        # generator input would otherwise be consumed by the validation loop already.
+        rules = list(rules)
         for rule in rules:
             if not isinstance(rule, Operation):
                 raise TypeError('rule has to be an instance of Operation-subclass')

--- a/src/aiida/tools/graph/age_rules.py
+++ b/src/aiida/tools/graph/age_rules.py
@@ -19,7 +19,7 @@ from aiida.common.lang import type_check
 from aiida.tools.graph.age_entities import Basket
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from aiida.orm import QueryBuilder
     from aiida.orm.implementation.querybuilder import QueryDictType
@@ -361,13 +361,25 @@ class RuleSequence(Operation):
     the first (see RuleSetWalkers and RuleSaveWalkers).
     """
 
-    def __init__(self, rules: Iterable[Operation], max_iterations: int = 1):
+    def __init__(
+        self,
+        rules: Iterable[Operation],
+        max_iterations: int = 1,
+        *,
+        iteration_callback: Callable[[int, int], None] | None = None,
+    ):
+        """:param rules: the rules to apply in order on each iteration.
+        :param max_iterations: maximum number of iterations to perform.
+        :param iteration_callback: called after each iteration with the number of iterations done so
+            far and the number of nodes visited so far, e.g. to report progress of long traversals.
+        """
         for rule in rules:
             if not isinstance(rule, Operation):
                 raise TypeError('rule has to be an instance of Operation-subclass')
         self._rules = rules
         self._accumulator_set: Basket | None = None
         self._visits_set: Basket | None = None
+        self._iteration_callback = iteration_callback
         super().__init__(max_iterations, track_edges=False)
 
     def run(self, operational_set: Basket) -> Basket:
@@ -401,6 +413,9 @@ class RuleSequence(Operation):
             # I set the operational set to all results that have not been visited yet.
             operational_set = new_results - self._accumulator_set
             self._accumulator_set += new_results
+
+            if self._iteration_callback is not None:
+                self._iteration_callback(self._iterations_done, len(self._visits_set.nodes.keyset))
 
         return self._visits_set.copy()
 

--- a/src/aiida/tools/graph/graph_traversers.py
+++ b/src/aiida/tools/graph/graph_traversers.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional,
 from aiida import orm
 from aiida.common import exceptions
 from aiida.common.links import GraphTraversalRules, LinkType
+from aiida.common.progress_reporter import get_progress_reporter
 from aiida.tools.graph.age_entities import Basket
 from aiida.tools.graph.age_rules import RuleSaveWalkers, RuleSequence, RuleSetWalkers, UpdateRule
 
@@ -282,9 +283,18 @@ def traverse_graph(
         rule_incoming = UpdateRule(query_incoming, max_iterations=1, track_edges=get_links)
         rules += [rule_incoming]
 
-    rulesequence = RuleSequence(rules, max_iterations=max_iterations)
+    # The total number of nodes to traverse is unknown upfront, so the progress bar is a plain
+    # counter of the nodes visited, updated after each traversal iteration.
+    with get_progress_reporter()(total=None, desc='Traversing provenance graph') as progress:
 
-    results = rulesequence.run(basket)
+        def update_progress(iterations_done: int, visits: Basket) -> None:
+            # refresh=False: the throttled update() below redraws anyway; an unconditional refresh
+            # per iteration would flood non-TTY output (e.g. CI logs) with one redraw per level.
+            progress.set_description_str(f'Traversing provenance graph: iteration {iterations_done}', refresh=False)
+            progress.update(len(visits.nodes.keyset) - progress.n)
+
+        rulesequence = RuleSequence(rules, max_iterations=max_iterations, callback=update_progress)
+        results = rulesequence.run(basket)
 
     output: TraverseGraphOutput = {}
     output['nodes'] = results.nodes.keyset

--- a/src/aiida/tools/graph/graph_traversers.py
+++ b/src/aiida/tools/graph/graph_traversers.py
@@ -18,6 +18,7 @@ from typing_extensions import TypedDict
 from aiida import orm
 from aiida.common import exceptions
 from aiida.common.links import GraphTraversalRules, LinkType
+from aiida.common.progress_reporter import get_progress_reporter
 from aiida.tools.graph.age_entities import Basket
 from aiida.tools.graph.age_rules import RuleSaveWalkers, RuleSequence, RuleSetWalkers, UpdateRule
 
@@ -281,9 +282,24 @@ def traverse_graph(
         rule_incoming = UpdateRule(query_incoming, max_iterations=1, track_edges=get_links)
         rules += [rule_incoming]
 
-    rulesequence = RuleSequence(rules, max_iterations=max_iterations)
+    # Without a total the project bar format's percentage sits frozen at 0%, so `bar_format=None`
+    # falls back to tqdm's plain counter. `unit` is set because tqdm's default renders the count as
+    # `251000it`, which beside a description ending in "(iteration 3)" reads as a count of iterations.
+    description = 'Traversing provenance graph'
+    with get_progress_reporter()(total=None, desc=description, unit=' nodes', bar_format=None) as progress:
+        # The starting nodes already count as visited. `update` alone is throttled and the next
+        # tick is the long first query itself, so the description write is what forces the redraw.
+        progress.update(len(basket.nodes.keyset))
+        progress.set_description_str(description, refresh=True)
 
-    results = rulesequence.run(basket)
+        def update_progress(iterations_done: int, nodes_visited: int) -> None:
+            # refresh=False: the throttled `update` below redraws anyway, and refreshing here on
+            # every level would flood non-TTY output such as CI logs.
+            progress.set_description_str(f'{description} (iteration {iterations_done})', refresh=False)
+            progress.update(nodes_visited - progress.n)
+
+        rulesequence = RuleSequence(rules, max_iterations=max_iterations, iteration_callback=update_progress)
+        results = rulesequence.run(basket)
 
     return TraverseGraphOutput(
         nodes=results.nodes.keyset,

--- a/tests/tools/graph/test_graph_traversers.py
+++ b/tests/tools/graph/test_graph_traversers.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Tests for aiida.tools.graph.graph_traversers"""
 
+from typing import ClassVar
+
 import pytest
 
 from aiida.common.links import LinkType
@@ -422,7 +424,7 @@ def recording_progress_reporter():
     """Install a progress reporter that records its instances and description updates."""
 
     class RecordingReporter(ProgressReporterAbstract):
-        instances: list['RecordingReporter'] = []
+        instances: ClassVar[list['RecordingReporter']] = []
 
         def __init__(self, **kwargs):
             super().__init__(**kwargs)

--- a/tests/tools/graph/test_graph_traversers.py
+++ b/tests/tools/graph/test_graph_traversers.py
@@ -11,6 +11,7 @@
 import pytest
 
 from aiida.common.links import LinkType
+from aiida.common.progress_reporter import ProgressReporterAbstract, set_progress_reporter
 from aiida.tools.graph.graph_traversers import get_nodes_delete, traverse_graph
 
 
@@ -414,3 +415,50 @@ class TestTraverseGraph:
 
         with pytest.raises(ValueError):
             _ = get_nodes_delete([nodes_dict['data_o'].pk], create_backward=False)
+
+
+@pytest.fixture
+def recording_progress_reporter():
+    """Install a progress reporter that records its instances and description updates."""
+
+    class RecordingReporter(ProgressReporterAbstract):
+        instances: list['RecordingReporter'] = []
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.descriptions: list[str | None] = []
+            RecordingReporter.instances.append(self)
+
+        def set_description_str(self, text=None, refresh=True):
+            super().set_description_str(text, refresh)
+            self.descriptions.append(text)
+
+    set_progress_reporter(RecordingReporter)
+    try:
+        yield RecordingReporter
+    finally:
+        set_progress_reporter(None)
+
+
+class TestTraversalProgress:
+    """Tests for progress reporting during graph traversal."""
+
+    def test_progress_reported_per_iteration(self, recording_progress_reporter):
+        """Each traversal iteration must update the progress reporter, counting the nodes visited so far."""
+        nodes_dict = create_minimal_graph()
+
+        result = traverse_graph(
+            [nodes_dict['data_i'].pk],
+            links_forward=[LinkType.INPUT_CALC, LinkType.CREATE],
+        )
+
+        # Three iterations: data_i -> calc_0, calc_0 -> data_o, data_o -> nothing new
+        assert result['nodes'] == {nodes_dict['data_i'].pk, nodes_dict['calc_0'].pk, nodes_dict['data_o'].pk}
+        (reporter,) = recording_progress_reporter.instances
+        assert reporter.n == len(result['nodes'])
+        assert reporter.descriptions == [f'Traversing provenance graph: iteration {i}' for i in (1, 2, 3)]
+
+    def test_progress_skipped_for_empty_start(self, recording_progress_reporter):
+        """No progress reporter should be created when there is nothing to traverse."""
+        traverse_graph([], links_forward=[LinkType.CREATE])
+        assert recording_progress_reporter.instances == []

--- a/tests/tools/graph/test_graph_traversers.py
+++ b/tests/tools/graph/test_graph_traversers.py
@@ -11,6 +11,7 @@
 import pytest
 
 from aiida.common.links import LinkType
+from aiida.common.progress_reporter import ProgressReporterAbstract, set_progress_reporter
 from aiida.tools.graph.graph_traversers import get_nodes_delete, traverse_graph
 
 
@@ -414,3 +415,63 @@ class TestTraverseGraph:
 
         with pytest.raises(ValueError):
             _ = get_nodes_delete([nodes_dict['data_o'].pk], create_backward=False)
+
+
+@pytest.fixture
+def reporter_events():
+    """Install a progress reporter that logs every call it receives, and yield the log."""
+    events: list[tuple] = []
+
+    class Recorder(ProgressReporterAbstract):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            events.append(('init', kwargs))
+
+        def set_description_str(self, text=None, refresh=True):
+            super().set_description_str(text, refresh)
+            events.append(('desc', text))
+
+        def update(self, n=1):
+            super().update(n)
+            events.append(('count', self.n))
+
+    set_progress_reporter(Recorder)
+    try:
+        yield events
+    finally:
+        set_progress_reporter(None)
+
+
+class TestTraversalProgress:
+    """Tests for progress reporting during graph traversal."""
+
+    def test_progress_reported_per_iteration(self, reporter_events):
+        """Each traversal iteration must update the progress reporter, counting the nodes visited so far."""
+        nodes_dict = create_minimal_graph()
+
+        result = traverse_graph(
+            [nodes_dict['data_i'].pk],
+            links_forward=[LinkType.INPUT_CALC, LinkType.CREATE],
+        )
+
+        # Three iterations: data_i -> calc_0, calc_0 -> data_o, data_o -> nothing new
+        assert result['nodes'] == {nodes_dict['data_i'].pk, nodes_dict['calc_0'].pk, nodes_dict['data_o'].pk}
+        # `unit` is named so the count cannot be misread as the iteration number beside it, and
+        # `bar_format` is dropped because the project format's percentage would sit frozen at 0%.
+        # The seeded count lands before the first query, followed by its forced redraw.
+        assert reporter_events == [
+            ('init', {'total': None, 'desc': 'Traversing provenance graph', 'unit': ' nodes', 'bar_format': None}),
+            ('count', 1),
+            ('desc', 'Traversing provenance graph'),
+            ('desc', 'Traversing provenance graph (iteration 1)'),
+            ('count', 2),
+            ('desc', 'Traversing provenance graph (iteration 2)'),
+            ('count', 3),
+            ('desc', 'Traversing provenance graph (iteration 3)'),
+            ('count', 3),
+        ]
+
+    def test_progress_skipped_for_empty_start(self, reporter_events):
+        """No progress reporter should be created when there is nothing to traverse."""
+        traverse_graph([], links_forward=[LinkType.CREATE])
+        assert reporter_events == []


### PR DESCRIPTION
Exporting a large database looks like a hang at 14%: the traversal is one opaque step of the "Collecting entities" bar. `RuleSequence` now takes an `iteration_callback`, which `traverse_graph` uses to drive its own bar counting nodes visited.

The total is unknown upfront, so `ProgressReporterAbstract` accepts `total=None` and the bar drops the project format, whose percentage would otherwise sit frozen at 0%. `total: int` never described `tqdm`, a reporter the module documents as valid and which has always accepted `None`. That widens public API, so this is a minor release rather than a patch. A custom reporter dividing by `total` needs to handle it.

The counter is seeded with the starting nodes, which already count as visited, so a wide, shallow graph shows its 35k immediately instead of `0` while the first query runs. Ticking *inside* that query needs batched progress in `QueryRule._load_results`, a follow-up.

<details>
<summary>Dogfooded on a real 535k-node profile</summary>

An mc3d profile: 535,005 nodes, 1,257,350 links, exporting its 35,240 workchains. The traversal step alone takes ~75 s with the outer bar stuck at 14%, exactly as reported:

```
Collecting entities: Computers:  14% 1/7 [01:15<07:34, 75.81s/it]
```

Before, that window produced no output at all:

```
[   12.25s] starting set: 35240 workchain nodes
[  152.52s] done
```

After, the count appears immediately and moves per level:

```
[   19.34s]   counter -> 35240
[   42.12s]   desc    -> Traversing provenance graph (iteration 1)
[   94.27s]   counter -> 535005
```

```
Traversing provenance graph (iteration 3): 535005 nodes [01:14, 7169.38 nodes/s]
```

(Differing totals are run-to-run variance, not a speedup.)

</details>