### PR TITLE
Add shallow nested dictionary copy utility

### DIFF
--- a/src/aiida/orm/__init__.py
+++ b/src/aiida/orm/__init__.py
@@ -119,6 +119,7 @@ __all__ = (
     'load_node',
     'load_node_class',
     'pycifrw_from_cif',
+    'shallow_copy_nested_dict',
     'to_aiida_type',
     'validate_link',
 )

--- a/src/aiida/orm/utils/__init__.py
+++ b/src/aiida/orm/utils/__init__.py
@@ -13,6 +13,7 @@
 # fmt: off
 
 from .calcjob import *
+from .collections import *
 from .links import *
 from .loaders import *
 from .managers import *
@@ -41,6 +42,7 @@ __all__ = (
     'load_group',
     'load_node',
     'load_node_class',
+    'shallow_copy_nested_dict',
     'validate_link',
 )
 

--- a/src/aiida/orm/utils/collections.py
+++ b/src/aiida/orm/utils/collections.py
@@ -1,0 +1,27 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Utilities for collections of ORM objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ('shallow_copy_nested_dict',)
+
+
+def shallow_copy_nested_dict(dictionary: dict[Any, Any]) -> dict[Any, Any]:
+    """Return a recursive shallow copy of a nested dictionary.
+
+    Nested dictionaries are copied recursively, while all non-dictionary values are kept by reference. This is useful
+    for dictionaries containing ORM nodes, where ``copy.deepcopy`` would invoke node-specific copy behavior.
+    """
+    return {
+        key: shallow_copy_nested_dict(value) if isinstance(value, dict) else value
+        for key, value in dictionary.items()
+    }

--- a/tests/orm/utils/test_collections.py
+++ b/tests/orm/utils/test_collections.py
@@ -1,0 +1,42 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the :mod:`aiida.orm.utils.collections` module."""
+
+from aiida import orm
+from aiida.orm.utils.collections import shallow_copy_nested_dict
+
+
+def test_shallow_copy_nested_dict():
+    """Test nested dictionaries are copied recursively while leaf values are preserved."""
+    node = orm.Int(1)
+    numbers = [1, 2, 3]
+    original = {
+        'metadata': {
+            'options': {
+                'resources': {
+                    'num_machines': 1,
+                },
+            },
+            'node': node,
+        },
+        'numbers': numbers,
+    }
+
+    copied = shallow_copy_nested_dict(original)
+
+    assert copied is not original
+    assert copied['metadata'] is not original['metadata']
+    assert copied['metadata']['options'] is not original['metadata']['options']
+    assert copied['metadata']['options']['resources'] is not original['metadata']['options']['resources']
+    assert copied['metadata']['node'] is node
+    assert copied['numbers'] is numbers
+
+    copied['metadata']['options']['resources']['num_machines'] = 2
+
+    assert original['metadata']['options']['resources']['num_machines'] == 1


### PR DESCRIPTION
## Summary

Add `aiida.orm.utils.shallow_copy_nested_dict` to recursively copy nested dictionary containers while preserving leaf objects by reference.

This gives callers an explicit alternative to `copy.deepcopy` for input dictionaries containing ORM nodes, where deepcopy may invoke node-specific copy behavior.

Closes #7418.

@edan-bainglass I still did not test this, but if this is what you had in mind I will do all tests and propose it for review.

## Validation

- Syntax-checked the new utility, test, and generated exports with Python 3.10.
- Ran a direct behavior smoke test without installing this checkout.
- Did not run pytest in this AiiDAlab image because `/usr/bin/python3.10` does not have pytest installed.
