### PR TITLE
🧪 Reap ZMQ broker service subprocess in test helpers

### DIFF
--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 import time
 import typing as t
 from contextlib import contextmanager
@@ -148,14 +147,6 @@ class ZeromqBroker(Broker):
             return json.loads(self._service_status_file.read_text())  # type: ignore[no-any-return]
         except (json.JSONDecodeError, OSError):
             return None
-
-    def _cleanup_stale_service_files(self) -> None:
-        self._service_pid_file.unlink(missing_ok=True)
-        self._service_status_file.unlink(missing_ok=True)
-        sockets_path = self._get_sockets_path()
-        if sockets_path is not None and sockets_path.exists():
-            shutil.rmtree(sockets_path, ignore_errors=True)
-        self._service_sockets_file.unlink(missing_ok=True)
 
     # --- Communicator ---
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -18,7 +18,6 @@ import pytest
 from aiida.brokers.zeromq.broker import ZeromqBroker, ZeromqIncomingTask
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from aiida.brokers.zeromq.queue import PersistentQueue
-from tests.conftest import start_zeromq_broker, stop_zeromq_broker
 
 
 def test_get_default_config():
@@ -56,57 +55,11 @@ class TestZeromqBrokerStatusQueries:
         """Test endpoints return None when sockets file doesn't exist."""
         assert zeromq_broker.router_endpoint is None
 
-    def test_start_stop_cycle(self, zeromq_broker):
-        """Test querying a running zeromq_broker service."""
-        start_zeromq_broker(zeromq_broker)
-
-        try:
-            assert zeromq_broker.is_running
-            assert zeromq_broker.get_service_pid() is not None
-            assert zeromq_broker.router_endpoint is not None
-        finally:
-            stop_zeromq_broker(zeromq_broker)
-
-        assert not zeromq_broker.is_running
-
-    def test_start_already_running(self, zeromq_broker):
-        """Test starting when already running is idempotent."""
-        start_zeromq_broker(zeromq_broker)
-
-        try:
-            start_zeromq_broker(zeromq_broker)  # idempotent
-            assert zeromq_broker.is_running
-        finally:
-            stop_zeromq_broker(zeromq_broker)
-
-    def test_stop_not_running(self, zeromq_broker):
-        """Test stopping when not running is a no-op."""
-        stop_zeromq_broker(zeromq_broker)  # Should not raise
-
-    def test_restart(self, zeromq_broker):
-        """Test restarting the zeromq_broker service."""
-        start_zeromq_broker(zeromq_broker)
-
-        try:
-            old_pid = zeromq_broker.get_service_pid()
-            stop_zeromq_broker(zeromq_broker)
-            start_zeromq_broker(zeromq_broker)
-            assert zeromq_broker.is_running
-
-            new_pid = zeromq_broker.get_service_pid()
-            assert new_pid != old_pid
-        finally:
-            stop_zeromq_broker(zeromq_broker)
-
-    def test_str_running(self, zeromq_broker):
+    def test_str_running(self, zeromq_broker_server):
         """Test __str__ when running."""
-        start_zeromq_broker(zeromq_broker)
-        try:
-            s = str(zeromq_broker)
-            assert 'ZeroMQ Broker' in s
-            assert 'PID' in s
-        finally:
-            stop_zeromq_broker(zeromq_broker)
+        s = str(zeromq_broker_server)
+        assert 'ZeroMQ Broker' in s
+        assert 'PID' in s
 
     def test_str_not_running(self, zeromq_broker):
         """Test __str__ when not running."""
@@ -169,43 +122,23 @@ class TestZeromqBrokerStatusQueries:
         status_file.write_text('{INVALID JSON')
         assert zeromq_broker.get_service_status() is None
 
-    def test_cleanup_stale_service_files(self, zeromq_broker):
-        """Test _cleanup_stale_service_files removes all stale files."""
-
-        service_dir = zeromq_broker.service_dir
-        (service_dir / 'broker.pid').write_text('aiida-zeromq-broker 1')
-        (service_dir / 'broker.status').write_text('{}')
-        sockets_dir = service_dir / 'test_sockets'
-        sockets_dir.mkdir()
-        (service_dir / 'broker.sockets').write_text(str(sockets_dir))
-
-        zeromq_broker._cleanup_stale_service_files()
-
-        assert not (service_dir / 'broker.pid').exists()
-        assert not (service_dir / 'broker.status').exists()
-        assert not (service_dir / 'broker.sockets').exists()
-        assert not sockets_dir.exists()
-
 
 class TestZeromqBrokerCommunicator:
     """Tests for ZeromqBroker communicator management."""
 
-    def test_get_communicator_and_close(self, zeromq_broker):
+    def test_get_communicator_and_close(self, zeromq_broker_server):
         """Test get_communicator and close."""
-        start_zeromq_broker(zeromq_broker)
-
         try:
             with patch('aiida.manage.configuration.get_config_option', return_value=None):
-                comm = zeromq_broker.get_communicator(wait_for_broker=5.0)
+                comm = zeromq_broker_server.get_communicator(wait_for_broker=5.0)
                 assert comm is not None
                 assert not comm.is_closed()
 
                 # Second call returns cached instance
-                comm2 = zeromq_broker.get_communicator()
+                comm2 = zeromq_broker_server.get_communicator()
                 assert comm2 is comm
         finally:
-            zeromq_broker.close()
-            stop_zeromq_broker(zeromq_broker)
+            zeromq_broker_server.close()
 
     def test_get_communicator_timeout(self, zeromq_broker):
         """Test get_communicator raises on timeout when zeromq_broker not running."""
@@ -259,27 +192,18 @@ class TestZeromqIncomingTask:
 class TestZeromqBrokerIntegration:
     """Integration tests for the ZeroMQ zeromq_broker with AiiDA."""
 
-    @pytest.fixture
-    def zeromq_broker(self, zeromq_broker):
-        """Create a ZeroMQ zeromq_broker for testing."""
-        start_zeromq_broker(zeromq_broker)
-
-        yield zeromq_broker
-
-        stop_zeromq_broker(zeromq_broker)
-
-    def test_broker_lifecycle(self, zeromq_broker):
+    def test_broker_lifecycle(self, zeromq_broker_server):
         """Test the zeromq_broker lifecycle."""
-        assert zeromq_broker.is_running
+        assert zeromq_broker_server.is_running
 
-        status = zeromq_broker.get_service_status()
+        status = zeromq_broker_server.get_service_status()
         assert status is not None
         assert 'pid' in status
 
-    def test_communicator_connection(self, zeromq_broker):
+    def test_communicator_connection(self, zeromq_broker_server):
         """Test connecting a communicator to the zeromq_broker."""
         communicator = ZeromqCommunicator(
-            router_endpoint=zeromq_broker.router_endpoint,
+            router_endpoint=zeromq_broker_server.router_endpoint,
         )
         communicator.start()
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -18,6 +18,25 @@ import pytest
 from aiida.brokers.zeromq.broker import ZeromqBroker, ZeromqIncomingTask
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from aiida.brokers.zeromq.queue import PersistentQueue
+from tests.conftest import _run_zeromq_broker_server
+
+
+@pytest.fixture(scope='module')
+def zeromq_broker_with_server(tmp_path_factory):
+    """Create a ZMQ broker instance with a ZMQ server running in the background."""
+    service_dir = tmp_path_factory.mktemp('zeromq-broker')
+    profile = MagicMock()
+    profile.process_control_config = {'supervised_by_daemon': True}
+    profile.name = 'test-profile'
+    config = MagicMock()
+    config.filepaths.return_value = {
+        'zmq_broker_service': {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
+    }
+
+    with patch('aiida.manage.configuration.get_config', return_value=config):
+        broker = ZeromqBroker(profile)
+        with _run_zeromq_broker_server(broker):
+            yield broker
 
 
 def test_get_default_config():
@@ -55,9 +74,9 @@ class TestZeromqBrokerStatusQueries:
         """Test endpoints return None when sockets file doesn't exist."""
         assert zeromq_broker.router_endpoint is None
 
-    def test_str_running(self, zeromq_broker_server):
+    def test_str_running(self, zeromq_broker_with_server):
         """Test __str__ when running."""
-        s = str(zeromq_broker_server)
+        s = str(zeromq_broker_with_server)
         assert 'ZeroMQ Broker' in s
         assert 'PID' in s
 
@@ -126,19 +145,19 @@ class TestZeromqBrokerStatusQueries:
 class TestZeromqBrokerCommunicator:
     """Tests for ZeromqBroker communicator management."""
 
-    def test_get_communicator_and_close(self, zeromq_broker_server):
+    def test_get_communicator_and_close(self, zeromq_broker_with_server):
         """Test get_communicator and close."""
         try:
             with patch('aiida.manage.configuration.get_config_option', return_value=None):
-                comm = zeromq_broker_server.get_communicator(wait_for_broker=5.0)
+                comm = zeromq_broker_with_server.get_communicator(wait_for_broker=5.0)
                 assert comm is not None
                 assert not comm.is_closed()
 
                 # Second call returns cached instance
-                comm2 = zeromq_broker_server.get_communicator()
+                comm2 = zeromq_broker_with_server.get_communicator()
                 assert comm2 is comm
         finally:
-            zeromq_broker_server.close()
+            zeromq_broker_with_server.close()
 
     def test_get_communicator_timeout(self, zeromq_broker):
         """Test get_communicator raises on timeout when zeromq_broker not running."""
@@ -192,18 +211,18 @@ class TestZeromqIncomingTask:
 class TestZeromqBrokerIntegration:
     """Integration tests for the ZeroMQ zeromq_broker with AiiDA."""
 
-    def test_broker_lifecycle(self, zeromq_broker_server):
+    def test_broker_lifecycle(self, zeromq_broker_with_server):
         """Test the zeromq_broker lifecycle."""
-        assert zeromq_broker_server.is_running
+        assert zeromq_broker_with_server.is_running
 
-        status = zeromq_broker_server.get_service_status()
+        status = zeromq_broker_with_server.get_service_status()
         assert status is not None
         assert 'pid' in status
 
-    def test_communicator_connection(self, zeromq_broker_server):
+    def test_communicator_connection(self, zeromq_broker_with_server):
         """Test connecting a communicator to the zeromq_broker."""
         communicator = ZeromqCommunicator(
-            router_endpoint=zeromq_broker_server.router_endpoint,
+            router_endpoint=zeromq_broker_with_server.router_endpoint,
         )
         communicator.start()
 

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -12,19 +12,40 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
 
 import kiwipy
 import pytest
 
+from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
+from tests.conftest import _run_zeromq_broker_server
+
+
+@pytest.fixture(scope='module')
+def zeromq_broker_with_server(tmp_path_factory):
+    """Create a ZMQ broker instance with a ZMQ server running in the background."""
+    service_dir = tmp_path_factory.mktemp('zeromq-broker')
+    profile = MagicMock()
+    profile.process_control_config = {'supervised_by_daemon': True}
+    profile.name = 'test-profile'
+    config = MagicMock()
+    config.filepaths.return_value = {
+        'zmq_broker_service': {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
+    }
+
+    with patch('aiida.manage.configuration.get_config', return_value=config):
+        broker = ZeromqBroker(profile)
+        with _run_zeromq_broker_server(broker):
+            yield broker
 
 
 class TestZeromqCommunicatorLifecycle:
     """Tests for communicator initialization and lifecycle."""
 
-    def test_init(self, zeromq_broker_server):
+    def test_init(self, zeromq_broker_with_server):
         """Test communicator initialization."""
-        communicator = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint)
+        communicator = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint)
         communicator.start()
 
         try:
@@ -34,16 +55,16 @@ class TestZeromqCommunicatorLifecycle:
 
         assert communicator.is_closed() is True
 
-    def test_context_manager(self, zeromq_broker_server):
+    def test_context_manager(self, zeromq_broker_with_server):
         """Test communicator as context manager."""
-        with ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint) as communicator:
+        with ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint) as communicator:
             assert communicator.is_closed() is False
 
         assert communicator.is_closed() is True
 
-    def test_close_idempotent(self, zeromq_broker_server):
+    def test_close_idempotent(self, zeromq_broker_with_server):
         """Test close is idempotent."""
-        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint)
+        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint)
         comm.start()
         comm.close()
         comm.close()  # should not raise
@@ -60,11 +81,11 @@ class TestZeromqCommunicatorMessaging:
     """Tests for communicator messaging operations with a real zeromq_broker."""
 
     @pytest.fixture
-    def zeromq_broker_and_comm(self, zeromq_broker_server):
-        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint)
+    def zeromq_broker_and_comm(self, zeromq_broker_with_server):
+        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint)
         comm.start()
 
-        yield zeromq_broker_server, comm
+        yield zeromq_broker_with_server, comm
 
         comm.close()
 
@@ -125,14 +146,14 @@ class TestZeromqCommunicatorRoundTrip:
     """Integration tests for full task, RPC, and broadcast round-trips."""
 
     @pytest.fixture
-    def sender_and_worker(self, zeromq_broker_server):
-        sender = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint, client_id='sender')
+    def sender_and_worker(self, zeromq_broker_with_server):
+        sender = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint, client_id='sender')
         sender.start()
 
-        worker = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint, client_id='worker')
+        worker = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint, client_id='worker')
         worker.start()
 
-        yield zeromq_broker_server, sender, worker
+        yield zeromq_broker_with_server, sender, worker
 
         worker.close()
         sender.close()

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -17,53 +17,37 @@ import kiwipy
 import pytest
 
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
-from tests.conftest import start_zeromq_broker, stop_zeromq_broker
 
 
 class TestZeromqCommunicatorLifecycle:
     """Tests for communicator initialization and lifecycle."""
 
-    def test_init(self, zeromq_broker):
+    def test_init(self, zeromq_broker_server):
         """Test communicator initialization."""
-        start_zeromq_broker(zeromq_broker)
+        communicator = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint)
+        communicator.start()
 
         try:
-            communicator = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint)
-            communicator.start()
-
-            try:
-                assert communicator.is_closed() is False
-            finally:
-                communicator.close()
-
-            assert communicator.is_closed() is True
+            assert communicator.is_closed() is False
         finally:
-            stop_zeromq_broker(zeromq_broker)
+            communicator.close()
 
-    def test_context_manager(self, zeromq_broker):
+        assert communicator.is_closed() is True
+
+    def test_context_manager(self, zeromq_broker_server):
         """Test communicator as context manager."""
-        start_zeromq_broker(zeromq_broker)
+        with ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint) as communicator:
+            assert communicator.is_closed() is False
 
-        try:
-            with ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint) as communicator:
-                assert communicator.is_closed() is False
+        assert communicator.is_closed() is True
 
-            assert communicator.is_closed() is True
-        finally:
-            stop_zeromq_broker(zeromq_broker)
-
-    def test_close_idempotent(self, zeromq_broker):
+    def test_close_idempotent(self, zeromq_broker_server):
         """Test close is idempotent."""
-        start_zeromq_broker(zeromq_broker)
-
-        try:
-            comm = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint)
-            comm.start()
-            comm.close()
-            comm.close()  # should not raise
-            assert comm.is_closed()
-        finally:
-            stop_zeromq_broker(zeromq_broker)
+        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint)
+        comm.start()
+        comm.close()
+        comm.close()  # should not raise
+        assert comm.is_closed()
 
     def test_ensure_open_raises_when_closed(self):
         """Test _ensure_open raises when communicator is closed."""
@@ -76,16 +60,13 @@ class TestZeromqCommunicatorMessaging:
     """Tests for communicator messaging operations with a real zeromq_broker."""
 
     @pytest.fixture
-    def zeromq_broker_and_comm(self, zeromq_broker):
-        start_zeromq_broker(zeromq_broker)
-
-        comm = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint)
+    def zeromq_broker_and_comm(self, zeromq_broker_server):
+        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint)
         comm.start()
 
-        yield zeromq_broker, comm
+        yield zeromq_broker_server, comm
 
         comm.close()
-        stop_zeromq_broker(zeromq_broker)
 
     def test_task_send_no_reply(self, zeromq_broker_and_comm):
         """Test task_send with no_reply=True returns None."""
@@ -144,20 +125,17 @@ class TestZeromqCommunicatorRoundTrip:
     """Integration tests for full task, RPC, and broadcast round-trips."""
 
     @pytest.fixture
-    def sender_and_worker(self, zeromq_broker):
-        start_zeromq_broker(zeromq_broker)
-
-        sender = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint, client_id='sender')
+    def sender_and_worker(self, zeromq_broker_server):
+        sender = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint, client_id='sender')
         sender.start()
 
-        worker = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint, client_id='worker')
+        worker = ZeromqCommunicator(router_endpoint=zeromq_broker_server.router_endpoint, client_id='worker')
         worker.start()
 
-        yield zeromq_broker, sender, worker
+        yield zeromq_broker_server, sender, worker
 
         worker.close()
         sender.close()
-        stop_zeromq_broker(zeromq_broker)
 
     def test_task_round_trip(self, sender_and_worker):
         """Test task send gets immediate zeromq_broker acknowledgment.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ import time
 import types
 import typing as t
 import warnings
+from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -82,18 +83,22 @@ def zeromq_broker(tmp_path):
         yield ZeromqBroker(profile)
 
 
-def start_zeromq_broker(broker, timeout: float = 10.0):
-    """Start a ZeroMQ broker service subprocess for testing.
+@pytest.fixture
+def zeromq_broker_server(zeromq_broker):
+    with _run_zeromq_broker_server(zeromq_broker) as started_broker:
+        yield started_broker
 
-    :param broker: A ``ZeromqBroker`` instance (has ``service_dir``, ``is_running``, etc.)
-    """
-    broker.service_dir.mkdir(parents=True, exist_ok=True)
 
-    if broker.is_running:
+@contextmanager
+def _run_zeromq_broker_server(zeromq_broker, timeout: float = 10.0):
+    """Run a ZeroMQ broker service subprocess for the duration of a context."""
+    zeromq_broker.service_dir.mkdir(parents=True, exist_ok=True)
+
+    if zeromq_broker.check_is_service_running():
         return
 
     subprocess.Popen(
-        [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--service-dir', str(broker.service_dir)],
+        [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--service-dir', str(zeromq_broker.service_dir)],
         start_new_session=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -101,34 +106,29 @@ def start_zeromq_broker(broker, timeout: float = 10.0):
     )
 
     start_time = time.time()
-    while time.time() - start_time < timeout:
-        if broker.is_running:
-            return
+    while time.time() - start_time < 10:
+        if zeromq_broker.is_running:
+            yield
         time.sleep(0.1)
 
-    raise TimeoutError(f'ZeroMQ broker did not start within {timeout}s')
+    if not zeromq_broker.is_running:
+        raise TimeoutError(f'ZeroMQ broker did not start within {timeout}s')
 
-
-def stop_zeromq_broker(broker, timeout: float = 5.0):
-    """Stop a ZeroMQ broker service subprocess for testing.
-
-    :param broker: A ``ZeromqBroker`` instance
-    """
-    pid = broker.get_service_pid()
-    if pid is None or not broker.is_running:
-        broker._cleanup_stale_service_files()
+    pid = zeromq_broker.get_service_pid()
+    if pid is None or not zeromq_broker.is_running:
+        zeromq_broker._cleanup_stale_service_files()
         return
 
     try:
         os.kill(pid, signal.SIGINT)
     except OSError:
-        broker._cleanup_stale_service_files()
+        zeromq_broker._cleanup_stale_service_files()
         return
 
     start_time = time.time()
     while time.time() - start_time < timeout:
-        if not broker.is_running:
-            broker._cleanup_stale_service_files()
+        if not zeromq_broker.is_running:
+            zeromq_broker._cleanup_stale_service_files()
             return
         time.sleep(0.1)
 
@@ -136,7 +136,7 @@ def stop_zeromq_broker(broker, timeout: float = 5.0):
         os.kill(pid, signal.SIGKILL)
     except OSError:
         pass
-    broker._cleanup_stale_service_files()
+    zeromq_broker._cleanup_stale_service_files()
 
 
 def pytest_collection_modifyitems(items, config):
@@ -333,12 +333,9 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
     ) as profile:
         # Start ZeroMQ broker service if needed (tests don't use circus)
         broker_instance = get_manager().get_broker()
-        if broker_instance is not None and hasattr(broker_instance, 'is_running'):
-            start_zeromq_broker(broker_instance)
-            try:
+        if isinstance(broker_instance, ZeromqBroker):
+            with _run_zeromq_broker_server(broker_instance):
                 yield profile
-            finally:
-                stop_zeromq_broker(broker_instance)
         else:
             yield profile
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,14 +83,8 @@ def zeromq_broker(tmp_path):
         yield ZeromqBroker(profile)
 
 
-@pytest.fixture
-def zeromq_broker_server(zeromq_broker):
-    with _run_zeromq_broker_server(zeromq_broker) as started_broker:
-        yield started_broker
-
-
 @contextmanager
-def _run_zeromq_broker_server(zeromq_broker, timeout: float = 10.0):
+def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0):
     """Run a ZeroMQ broker service subprocess for the duration of a context."""
     if zeromq_broker.is_running:
         raise ValueError('Broker server already running')
@@ -115,7 +109,7 @@ def _run_zeromq_broker_server(zeromq_broker, timeout: float = 10.0):
                 break
             time.sleep(0.1)
         else:
-            msg = f'ZeroMQ broker did not start within {timeout}s'
+            msg = f'ZeroMQ broker did not become ready within {timeout}s'
             raise TimeoutError(msg)
 
         yield process

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,12 +92,12 @@ def zeromq_broker_server(zeromq_broker):
 @contextmanager
 def _run_zeromq_broker_server(zeromq_broker, timeout: float = 10.0):
     """Run a ZeroMQ broker service subprocess for the duration of a context."""
+    if zeromq_broker.is_running:
+        raise ValueError('Broker server already running')
+
     zeromq_broker.service_dir.mkdir(parents=True, exist_ok=True)
 
-    if zeromq_broker.check_is_service_running():
-        return
-
-    subprocess.Popen(
+    process = subprocess.Popen(
         [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--service-dir', str(zeromq_broker.service_dir)],
         start_new_session=True,
         stdout=subprocess.DEVNULL,
@@ -105,38 +105,31 @@ def _run_zeromq_broker_server(zeromq_broker, timeout: float = 10.0):
         stdin=subprocess.DEVNULL,
     )
 
-    start_time = time.time()
-    while time.time() - start_time < 10:
-        if zeromq_broker.is_running:
-            yield
-        time.sleep(0.1)
-
-    if not zeromq_broker.is_running:
-        raise TimeoutError(f'ZeroMQ broker did not start within {timeout}s')
-
-    pid = zeromq_broker.get_service_pid()
-    if pid is None or not zeromq_broker.is_running:
-        zeromq_broker._cleanup_stale_service_files()
-        return
-
     try:
-        os.kill(pid, signal.SIGINT)
-    except OSError:
-        zeromq_broker._cleanup_stale_service_files()
-        return
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if process.poll() is not None:
+                msg = f'ZeroMQ broker exited before becoming ready with code {process.returncode}'
+                raise RuntimeError(msg)
+            if zeromq_broker.is_running:
+                break
+            time.sleep(0.1)
+        else:
+            msg = f'ZeroMQ broker did not start within {timeout}s'
+            raise TimeoutError(msg)
 
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        if not zeromq_broker.is_running:
+        yield process
+    finally:
+        try:
+            if process.poll() is None:
+                process.send_signal(signal.SIGINT)
+                try:
+                    process.wait(timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+        finally:
             zeromq_broker._cleanup_stale_service_files()
-            return
-        time.sleep(0.1)
-
-    try:
-        os.kill(pid, signal.SIGKILL)
-    except OSError:
-        pass
-    zeromq_broker._cleanup_stale_service_files()
 
 
 def pytest_collection_modifyitems(items, config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ import dataclasses
 import logging
 import os
 import pathlib
+import shutil
 import signal
 import subprocess
 import sys
@@ -123,7 +124,7 @@ def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0
                     process.kill()
                     process.wait()
         finally:
-            zeromq_broker._cleanup_stale_service_files()
+            shutil.rmtree(zeromq_broker.service_dir, ignore_errors=True)
 
 
 def pytest_collection_modifyitems(items, config):


### PR DESCRIPTION
The start_zmq_broker helper discarded the Popen object of the broker service it spawned. CPython emits 'ResourceWarning: subprocess is still running' when a Popen is garbage collected without having been waited on, and the killed service lingered as a zombie since stop_zmq_broker only signalled it via os.kill without reaping it.

Keep the Popen handle on the broker instance and wait() on it in stop_zmq_broker (and on startup timeout), so the process is reaped and the warning no longer fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted ZeroMQ broker stale-artifact handling so it no longer removes persisted broker service artifacts (e.g., PID/status files and related persisted socket/service directories).

* **Tests**
  * Refreshed ZeroMQ test setup to use a single shared, long-running module-scoped broker and reuse its router endpoint.
  * Replaced per-test start/stop helpers with a unified server context manager that manages readiness and shutdown escalation.
  * Updated communicator and integration tests to construct from the shared endpoint, verify running status (including PID), and removed obsolete stale-cleanup and lifecycle-specific coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->