### PR TITLE
👌 Improve communication to user when schema version is higher

### DIFF
--- a/docs/source/reference/configuration_schema.rst
+++ b/docs/source/reference/configuration_schema.rst
@@ -1,0 +1,29 @@
+Configuration schema compatibility
+==================================
+
+The AiiDA configuration file is stored in ``<AIIDA_PATH>/.aiida/config.json``.
+
+Whenever AiiDA accesses the configuration file, it automatically upgrades the configuration file for the newest schema version compatible with the current AiiDA version.
+
+If an older AiiDA installation cannot read the configuration anymore, run ``verdi config downgrade <SCHEMA_VERSION>`` with the newer installation before switching back.
+
+The table below summarizes the released ``aiida-core`` version series and the configuration schema versions they write and read.
+
+.. list-table:: Configuration schema compatibility by ``aiida-core`` version
+   :header-rows: 1
+
+   * - ``aiida-core`` version series
+     - Compatible schema version(s)
+   * - 1.0 - 1.3
+     - 3
+   * - 1.4 - 1.5
+     - 3 - 4
+   * - 1.6
+     - 5
+   * - 2.0
+     - 8
+   * - 2.1 - 2.8
+     - 9
+
+Schema versions 6 and 7 were only used by development snapshots.
+They were not part of a stable ``aiida-core`` release series.

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,6 +6,7 @@ Reference
    :maxdepth: 1
 
    command_line
+   configuration_schema
    api/index
    rest_api
    cheatsheet

--- a/src/aiida/common/docs.py
+++ b/src/aiida/common/docs.py
@@ -2,3 +2,4 @@
 
 URL_BASE = 'https://aiida-core.readthedocs.io/en/stable'
 URL_NO_BROKER = f'{URL_BASE}/installation/guide_quick.html#quick-install-limitations'
+URL_CONFIG_SCHEMA_COMPATIBILITY = f'{URL_BASE}/reference/configuration_schema.html'

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -295,6 +295,7 @@ class Config:
             config.store()
         else:
             migrated = False
+            current_version = config.get(cls.KEY_VERSION, {}).get(cls.KEY_VERSION_CURRENT, 0)
 
             # If the configuration file needs to be migrated first create a specific backup so it can easily be reverted
             if config_needs_migrating(config, filepath):
@@ -306,6 +307,9 @@ class Config:
             config = Config(filepath, check_and_migrate_config(config))
 
             if migrated:
+                echo.echo_report(
+                    f'configuration file `{filepath}` migrated from v{current_version} to v{config.version}'
+                )
                 config.store()
 
         return config

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -11,6 +11,7 @@
 from typing import Any, Dict, Iterable, Optional, Protocol, Type
 
 from aiida.common import exceptions
+from aiida.common.docs import URL_CONFIG_SCHEMA_COMPATIBILITY
 from aiida.common.log import AIIDA_LOGGER
 
 __all__ = (
@@ -503,10 +504,13 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
 
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         filepath = filepath if filepath else ''
-        raise exceptions.ConfigurationVersionError(
-            f'The configuration file has version {current_version} '
-            f'which is not compatible with the current version {CURRENT_CONFIG_VERSION}: {filepath}\n'
-            'Use a newer version of AiiDA to downgrade this configuration.'
+        msg = (
+            f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
+            f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
+            'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
+            f' at least version {CURRENT_CONFIG_VERSION} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
+            f' to rewrite it for an older version. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
         )
+        raise exceptions.ConfigurationVersionError(msg)
 
     return CURRENT_CONFIG_VERSION > current_version

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -15,9 +15,15 @@ import uuid
 
 import pytest
 
-from aiida.common.exceptions import ConfigurationError
+from aiida.common.exceptions import ConfigurationError, ConfigurationVersionError
 from aiida.manage.configuration.migrations import check_and_migrate_config
-from aiida.manage.configuration.migrations.migrations import MIGRATIONS, Initial, downgrade_config, upgrade_config
+from aiida.manage.configuration.migrations.migrations import (
+    CURRENT_CONFIG_VERSION,
+    MIGRATIONS,
+    Initial,
+    downgrade_config,
+    upgrade_config,
+)
 
 
 class CircularMigration(Initial):
@@ -62,6 +68,16 @@ def test_downgrade_path_fail(load_config_sample):
     # circular dependency
     with pytest.raises(ConfigurationError):
         downgrade_config(config_initial, 4, migrations=[CircularMigration])
+
+
+def test_config_needs_migrating_incompatible_version():
+    """An incompatible configuration version should raise with downgrade guidance."""
+    config = {
+        'CONFIG_VERSION': {'CURRENT': CURRENT_CONFIG_VERSION + 1, 'OLDEST_COMPATIBLE': CURRENT_CONFIG_VERSION + 1}
+    }
+
+    with pytest.raises(ConfigurationVersionError, match=r'verdi config downgrade'):
+        check_and_migrate_config(config, filepath='/tmp/config.json')
 
 
 def test_migrate_full(load_config_sample, monkeypatch):

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -12,6 +12,7 @@ import json
 import os
 import pathlib
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -166,11 +167,13 @@ def compare_config_in_memory_and_on_disk(config, filepath):
     assert in_memory == on_disk
 
 
-def test_from_file(tmp_path):
+def test_from_file(tmp_path, monkeypatch):
     """Test the `Config.from_file` class method.
 
     Regression test for #3790: make sure configuration is written to disk after it is loaded and migrated.
     """
+    mock_report = MagicMock()
+    monkeypatch.setattr('aiida.cmdline.utils.echo.echo_report', mock_report)
     # If the config file does not exist, a completely new file is created with a migrated config
     filepath_nonexisting = tmp_path / 'config_nonexisting.json'
     config = Config.from_file(filepath_nonexisting)
@@ -195,6 +198,10 @@ def test_from_file(tmp_path):
 
         config = Config.from_file(handle.name)
         compare_config_in_memory_and_on_disk(config, handle.name)
+
+    mock_report.assert_called_once_with(
+        f'configuration file `{handle.name}` migrated from v0 to v{CURRENT_CONFIG_VERSION}'
+    )
 
 
 def test_from_file_no_migrate(config_with_profile):


### PR DESCRIPTION
Because we update the config schema in v2.9 and the communication to the user about the config schema is not great, it can cause problems when changing the aiida version getting a schema version error. Leaving the user without any help to fix the problem. To improve the messages at least already for v2.8, we put these message upgrades in place.

Reporting to the user that the configuration file upgraded will probably most of the time go silently into the daemon log but I don't want to create a lot of extra logic to ensure the user is informed. There is another small problem that when the user is informed about the config change, the CLI formatting has not been loaded yet. The config contains the logging options so it makes sense that the logging hasn't been configured yet. Effectively the `REPORT: ` is only missing in the message. I think that is okay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Configuration schema compatibility” reference page covering config location, automatic schema upgrades on access, and a manual downgrade workflow for newer schemas.
  * Included a compatibility table mapping `aiida-core` version series to compatible configuration schema versions, noting dev-only schema versions.
  * Linked the new page in the reference navigation.
* **Bug Fixes**
  * Improved configuration migration output to report the source and resulting schema versions.
  * Enhanced “config too new” error messaging with clearer downgrade guidance and an inline reference link.
* **Tests**
  * Updated/added tests to verify the improved migration and incompatibility messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->