### PR TITLE
✨ Report daemon restart for config options

### DIFF
--- a/src/aiida/cmdline/commands/cmd_config.py
+++ b/src/aiida/cmdline/commands/cmd_config.py
@@ -134,6 +134,7 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
     import typing
 
     from aiida.common.exceptions import ConfigurationError
+    from aiida.manage.configuration.options import get_option
 
     if typing.TYPE_CHECKING:
         from aiida.manage.configuration import Profile
@@ -167,14 +168,13 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
         value = [value]
 
     # Warn about deprecated option names
-    option_name = option.name
     if option.deprecated_by:
-        option_name = option.deprecated_by
         echo.echo_warning(f'`{option.name}` is deprecated using `{option.deprecated_by}` instead.')
+        option = get_option(option.deprecated_by)
 
     # Set the specified option
     try:
-        value = config.set_option(option_name, value, scope=scope)
+        value = config.set_option(option.name, value, scope=scope)
     except ConfigurationError as error:
         echo.echo_critical(str(error))
 
@@ -184,10 +184,13 @@ def verdi_config_set(ctx, option, value, globally, append, remove):
     # a logger level is lowered as well.
     from aiida.common.log import validate_handler
 
-    if warning := validate_handler(config, option_name, scope):
+    if warning := validate_handler(config, option.name, scope):
         echo.echo_warning(warning)
 
-    echo.echo_success(f"'{option_name}' set to {value} {scope_text}")
+    echo.echo_success(f"'{option.name}' set to {value} {scope_text}")
+
+    if option.requires_daemon_restart:
+        echo.echo_report('Run `verdi daemon restart` for this change to take effect.')
 
 
 @verdi_config.command('unset')
@@ -213,6 +216,9 @@ def verdi_config_unset(ctx, option, globally):
     config.unset_option(option.name, scope=scope)
     config.store()
     echo.echo_success(f"'{option.name}' unset {scope_text}")
+
+    if option.requires_daemon_restart:
+        echo.echo_report('Run `verdi daemon restart` for this change to take effect.')
 
 
 @verdi_config.command('caching')

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -53,18 +53,30 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
 
     model_config = ConfigDict(use_enum_values=True)
 
-    runner__poll__interval: int = Field(60, description='Polling interval in seconds to be used by process runners.')
+    runner__poll__interval: int = Field(
+        60,
+        description='Polling interval in seconds to be used by process runners.',
+        json_schema_extra={'requires_daemon_restart': True},
+    )
     daemon__default_workers: int = Field(
-        1, description='Default number of workers to be launched by `verdi daemon start`.'
+        1,
+        description='Default number of workers to be launched by `verdi daemon start`.',
+        json_schema_extra={'requires_daemon_restart': True},
     )
     daemon__timeout: int = Field(
         2,
         description='Used to set default timeout in the `DaemonClient` for calls to the daemon.',
     )
     daemon__worker_process_slots: int = Field(
-        200, description='Maximum number of concurrent process tasks that each daemon worker can handle.'
+        200,
+        description='Maximum number of concurrent process tasks that each daemon worker can handle.',
+        json_schema_extra={'requires_daemon_restart': True},
     )
-    daemon__recursion_limit: int = Field(3000, description='Maximum recursion depth for the daemon workers.')
+    daemon__recursion_limit: int = Field(
+        3000,
+        description='Maximum recursion depth for the daemon workers.',
+        json_schema_extra={'requires_daemon_restart': True},
+    )
     db__batch_size: int = Field(
         100000,
         description='Batch size for bulk CREATE operations in the database. Avoids hitting MaxAllocSize of PostgreSQL '
@@ -89,22 +101,22 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
             'Minimum level for the AiiDA logging stack. Can be changed for individual aiida packages in the advanced'
             ' options.'
         ),
-        json_schema_extra={'advanced': False},
+        json_schema_extra={'advanced': False, 'requires_daemon_restart': True},
     )
     logging__aiida_core_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INHERIT'),
         description='Minimum level for the aiida-core logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__verdi_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INHERIT'),
         description='Minimum level for the `verdi` command logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__disk_objectstore_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INHERIT'),
         description='Minimum level for the `disk_objectstore` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__database_handler: LogLevels = Field(
         cast(LogLevels, 'REPORT'),
@@ -114,72 +126,94 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
             'the actual emitted log messages. To take effect you need to also change one of the log levels '
             'to the same or higher verbosity (e.g. `logging.aiida_loglevel`).'
         ),
-        json_schema_extra={'advanced': False},
+        json_schema_extra={'advanced': False, 'requires_daemon_restart': True},
     )
     logging__db_loglevel: LogLevels = Field(
         cast(LogLevels, 'REPORT'),
         description='Deprecated: use ``logging.database_handler`` instead.',
-        json_schema_extra={'deprecated_by': 'logging.database_handler', 'advanced': True},
+        json_schema_extra={
+            'deprecated_by': 'logging.database_handler',
+            'advanced': True,
+            'requires_daemon_restart': True,
+        },
     )
     logging__plumpy_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INHERIT'),
         description='Minimum level for the `plumpy` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__kiwipy_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INHERIT'),
         description='Minimum level for the `kiwipy` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__paramiko_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'WARNING'),
         description='Minimum level for the `paramiko` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__alembic_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'WARNING'),
         description='Minimum level for the `alembic` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__sqlalchemy_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'WARNING'),
         description='Minimum level for the `sqlalchemy` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__circus_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INFO'),
         description='Minimum level for the `circus` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     logging__aiopika_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'WARNING'),
         description='Minimum level for the `aio_pika` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True},
+        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
     )
     warnings__showdeprecations: bool = Field(True, description='Whether to print AiiDA deprecation warnings.')
     warnings__rabbitmq_version: bool = Field(
         True, description='Whether to print a warning when an incompatible version of RabbitMQ is configured.'
     )
     transport__task_retry_initial_interval: int = Field(
-        20, description='Initial time interval for the exponential backoff mechanism.'
+        20,
+        description='Initial time interval for the exponential backoff mechanism.',
+        json_schema_extra={'requires_daemon_restart': True},
     )
     transport__task_maximum_attempts: int = Field(
-        5, description='Maximum number of transport task attempts before a Process is Paused.'
+        5,
+        description='Maximum number of transport task attempts before a Process is Paused.',
+        json_schema_extra={'requires_daemon_restart': True},
     )
     broker__task_timeout: int = Field(
-        10, description='Timeout in seconds for task/RPC communications with the message broker.'
+        10,
+        description='Timeout in seconds for task/RPC communications with the message broker.',
+        json_schema_extra={'requires_daemon_restart': True},
     )
     rmq__task_timeout: int = Field(
         10,
         description='Timeout in seconds for communications with RabbitMQ.',
-        json_schema_extra={'deprecated_by': 'broker.task_timeout'},
+        json_schema_extra={'deprecated_by': 'broker.task_timeout', 'requires_daemon_restart': True},
     )
     storage__sandbox: Optional[str] = Field(
         None, description='Absolute path to the directory to store sandbox folders.'
     )
-    caching__default_enabled: bool = Field(False, description='Enable calculation caching by default.')
-    caching__enabled_for: List[str] = Field([], description='Calculation entry points to enable caching on.')
-    caching__disabled_for: List[str] = Field([], description='Calculation entry points to disable caching on.')
+    caching__default_enabled: bool = Field(
+        False,
+        description='Enable calculation caching by default.',
+        json_schema_extra={'requires_daemon_restart': True},
+    )
+    caching__enabled_for: List[str] = Field(
+        [],
+        description='Calculation entry points to enable caching on.',
+        json_schema_extra={'requires_daemon_restart': True},
+    )
+    caching__disabled_for: List[str] = Field(
+        [],
+        description='Calculation entry points to disable caching on.',
+        json_schema_extra={'requires_daemon_restart': True},
+    )
 
     @field_validator('caching__enabled_for', 'caching__disabled_for')
     @classmethod

--- a/src/aiida/manage/configuration/options.py
+++ b/src/aiida/manage/configuration/options.py
@@ -62,6 +62,15 @@ class Option:
         """Return True if this option should be hidden from default ``verdi config list`` output."""
         return self._schema.get('advanced', False)
 
+    @property
+    def requires_daemon_restart(self) -> bool:
+        """Return whether changing this option requires restarting the daemon.
+
+        :return: Whether the option value is only picked up when daemon processes are started and therefore remains
+            stale in already running workers.
+        """
+        return self._schema.get('requires_daemon_restart', False)
+
     def validate(self, value: Any) -> Any:
         """Validate a value
 

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -93,13 +93,20 @@ def test_config_get_option(run_cli_command, config_with_profile_factory):
     assert option_value in result.output.strip()
 
 
-def test_config_unset_option(run_cli_command, config_with_profile_factory):
+@pytest.mark.parametrize(
+    'option_name, option_value, requires_daemon_restart',
+    (
+        ('daemon.timeout', '30', False),
+        ('daemon.default_workers', '2', True),
+    ),
+)
+def test_config_unset_option(
+    run_cli_command, config_with_profile_factory, option_name, option_value, requires_daemon_restart
+):
     """Test the `verdi config` command when unsetting an option."""
     from aiida.manage.configuration.options import get_option
 
     config_with_profile_factory()
-    option_name = 'daemon.timeout'
-    option_value = str(30)
 
     options = ['config', 'set', option_name, str(option_value)]
     result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
@@ -111,6 +118,11 @@ def test_config_unset_option(run_cli_command, config_with_profile_factory):
     options = ['config', 'unset', option_name]
     result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert f"'{option_name}' unset" in result.output.strip()
+
+    if requires_daemon_restart:
+        assert 'verdi daemon restart' in result.output
+    else:
+        assert 'verdi daemon restart' not in result.output
 
     options = ['config', 'get', option_name]
     result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
@@ -128,6 +140,41 @@ def test_config_set_handler_warns_when_ineffective(run_cli_command, config_with_
     result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert 'Warning' in result.output
     assert 'take effect' in result.output
+
+
+@pytest.mark.parametrize(
+    'option_name, value, effective_option_name, requires_daemon_restart',
+    (
+        ('daemon.default_workers', '2', 'daemon.default_workers', True),
+        ('daemon.timeout', '10', 'daemon.timeout', False),
+        ('logging.aiida_loglevel', 'DEBUG', 'logging.aiida_loglevel', True),
+        ('logging.db_loglevel', 'DEBUG', 'logging.database_handler', True),
+        ('caching.default_enabled', 'True', 'caching.default_enabled', True),
+        ('rmq.task_timeout', '5', 'broker.task_timeout', True),
+    ),
+)
+def test_config_set_option_requires_daemon_restart(
+    run_cli_command,
+    config_with_profile_factory,
+    option_name,
+    value,
+    effective_option_name,
+    requires_daemon_restart,
+):
+    """Test that `verdi config set` reports when an option requires restarting the daemon."""
+    config_with_profile_factory()
+    options = ['config', 'set', option_name, value]
+    result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
+
+    assert f"'{effective_option_name}' set to" in result.output
+
+    if option_name != effective_option_name:
+        assert 'deprecated using' in result.output
+
+    if requires_daemon_restart:
+        assert 'verdi daemon restart' in result.output
+    else:
+        assert 'verdi daemon restart' not in result.output
 
 
 def test_config_set_option_global_only(run_cli_command, config_with_profile_factory):

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -161,3 +161,13 @@ def test_option_advanced_property():
     """Test that ``Option.advanced`` defaults to False when not explicitly set."""
     assert get_option('daemon.timeout').advanced is False
     assert isinstance(get_option('daemon.timeout').advanced, bool)
+
+
+@pytest.mark.presto
+def test_option_requires_daemon_restart_property():
+    """Test that ``Option.requires_daemon_restart`` reflects the schema metadata."""
+    assert get_option('daemon.default_workers').requires_daemon_restart is True
+    assert get_option('logging.aiida_loglevel').requires_daemon_restart is True
+    assert get_option('caching.default_enabled').requires_daemon_restart is True
+    assert get_option('daemon.timeout').requires_daemon_restart is False
+    assert isinstance(get_option('daemon.timeout').requires_daemon_restart, bool)


### PR DESCRIPTION
Add a `requires_daemon_restart` option metadata flag and use it in `verdi config set|unset` to report when a change affects the daemon workers and requires a restart. Most options are affected by this setting but not all of them. The schema can be found in #7417.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added restart-required awareness to `verdi config set` and `verdi config unset`, showing a “verdi daemon restart” hint only when the selected option requires it.
  * Introduced an option attribute to surface whether changes take effect only after daemon restart.
* **Bug Fixes**
  * Improved CLI messaging to consistently use the effective option name after deprecated option remapping.
* **Tests**
  * Expanded test coverage for restart-required hints, including parametrized checks for multiple set/unset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->