### PR TITLE
Add `use_sftp` option to the `openssh` backend of `core.ssh_async`

### DIFF
--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -498,6 +498,26 @@ Security considerations
 
 
 
+Connecting to a server without SFTP support
+===========================================
+
+A few HPC centers do not provide SFTP at all, in which case every file transfer fails.
+The best course of action is to ask your HPC center to enable SFTP.
+If that is not possible, AiiDA can fall back to the legacy protocol.
+
+To do so, configure the computer with the ``openssh`` backend of the ``core.ssh_async`` transport and pass ``--no-use-sftp``, which adds the ``-O`` flag to every ``scp`` invocation:
+
+.. code-block:: console
+
+   $ verdi computer configure core.ssh_async <COMPUTER> --backend openssh --no-use-sftp
+
+.. note::
+
+   - ``use_sftp`` only affects the ``openssh`` backend. The default ``asyncssh`` backend speaks SFTP directly and cannot fall back, so it cannot be used against such servers.
+   - In general ``openssh`` backend, performs slower than ``asyncssh`` backend. That's the price to pay, if your server has a complex, and outdated setup.
+   - The option has no effect if your *local* OpenSSH client is older than 9.0, since ``scp`` already uses the legacy protocol there.
+
+
 Using kerberos tokens
 =====================
 

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -455,20 +455,40 @@ class _OpenSSH(_AsynchronousSSHBackend):
     Note: This class is not part of the public API and should not be used directly.
     """
 
-    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str, use_sftp: bool):
         super().__init__(machine, logger, bash_command)
+        self.use_sftp = use_sftp
+        self.scp_options: list[str] = []
 
         # Check if the local OpenSSH client version is 9.0 or higher.
         # OpenSSH 9.0+ changed scp to use SFTP protocol by default instead of RCP.
         # This affects how paths are interpreted - SFTP treats paths as binary data,
         # so shell quoting is not needed and can cause issues.
         openssh_version = get_openssh_version()
-        if openssh_version is not None and openssh_version >= 9:
+        self.is_openssh_9_or_higher = openssh_version is not None and openssh_version >= 9
+
+        if openssh_version is None:
+            self.logger.warning(
+                'Could not detect your OpenSSH version. '
+                'Not applied: `use_sftp=False`. In addition quoting paths might not function properly. '
+                'Report to maintainers.'
+            )
+            self.use_sftp = False
+        elif self.is_openssh_9_or_higher and self.use_sftp:
             self.logger.debug(f'Detected OpenSSH version {openssh_version}, using SFTP mode for scp commands.')
-            self.is_openssh_9_or_higher = True
+        elif self.is_openssh_9_or_higher and not self.use_sftp:
+            # `-O` forces the legacy protocol, for servers that do not implement SFTP.
+            self.scp_options = ['-O']
+            self.logger.debug(
+                f'Detected OpenSSH version {openssh_version}, using RCP mode for scp commands as configured.'
+            )
         else:
-            self.logger.debug(f'Detected OpenSSH version {openssh_version}, using RCP mode for scp commands.')
-            self.is_openssh_9_or_higher = False
+            self.logger.debug(
+                f'Detected OpenSSH version {openssh_version}, using RCP mode for scp commands. '
+                'Configuration overrides: `use_sftp=False`'
+            )
+            # Override the setting, as in legacy versions are not using sftp anuways
+            self.use_sftp = False
 
     async def openssh_execute(self, commands, stdin: str | None = None, timeout: float | None = None):
         """
@@ -520,7 +540,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
         return ''.join(result)
 
     def _escape_for_scp(self, path: str) -> str:
-        """Prepare a path for use in scp commands.
+        """Prepare a remote path for use in scp commands.
 
         OpenSSH >= 9.0 uses SFTP mode: paths are sent as binary, no
         escaping needed. OpenSSH < 9.0 uses RCP mode: paths are interpreted
@@ -700,7 +720,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
         return returncode, stdout, stderr
 
     async def get(self, remotepath: str, localpath: str, dereference: bool, preserve: bool, recursive: bool):
-        options = []
+        options = [*self.scp_options]
         if preserve:
             options.append('-p')
         if dereference:
@@ -717,7 +737,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
             raise OSError({stderr})
 
     async def put(self, localpath: str, remotepath: str, dereference: bool, preserve: bool, recursive: bool):
-        options = []
+        options = [*self.scp_options]
         if preserve:
             options.append('-p')
         if dereference:
@@ -747,7 +767,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
         recursive: bool,
         preserve: bool,
     ):
-        options = []
+        options = [*self.scp_options]
         if preserve:
             options.append('-p')
         if dereference:

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -104,10 +104,22 @@ class AsyncSshTransport(AsyncTransport):
                 'default': 'asyncssh',
                 'prompt': 'Type of async backend to use, `asyncssh` or `openssh`',
                 'help': '`openssh` uses the `ssh` command line tool to connect to the remote machine,'
-                'e.g. it is useful in case of multiplexing. '
+                'e.g. it is useful in case of multiplexing, or server not having SFTP implemented.'
                 'The `asyncssh` backend is the default and is recommended for most use cases.',
                 'non_interactive_default': True,
                 'callback': validate_backend,
+            },
+        ),
+        (
+            'use_sftp',
+            {
+                'default': True,
+                'switch': True,
+                'prompt': 'Server supports SFTP? (Only applies to `openssh` backend)',
+                'help': 'Some HPC centers do not allow SFTP protocol for file transfer.'
+                ' In this case, you should use `openssh` as connection backend, with having this setting as `False`.'
+                ' In that it applies `-O` to scp',
+                'non_interactive_default': True,
             },
         ),
     ]
@@ -145,7 +157,9 @@ class AsyncSshTransport(AsyncTransport):
         if kwargs.get('backend') == 'openssh':
             from .async_backend import _OpenSSH
 
-            self.async_backend = _OpenSSH(self.machine, self.logger, self._bash_command_str)
+            self.async_backend = _OpenSSH(
+                self.machine, self.logger, self._bash_command_str, use_sftp=kwargs.pop('use_sftp', True)
+            )
         else:
             # default backend is asyncssh
             from .async_backend import _AsyncSSH

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -248,6 +248,49 @@ def test_escape_for_scp_version_aware():
     assert backend._escape_for_scp(path) == '/path/with\\ spaces'
 
 
+@pytest.mark.parametrize(
+    'version, use_sftp, expected_use_sftp, expected_options',
+    (
+        # OpenSSH 9+ transfers over SFTP by default; `-O` forces the legacy RCP protocol.
+        (9, True, True, []),
+        (9, False, False, ['-O']),
+        # OpenSSH < 9 (or an undetectable version) already uses RCP, so `-O` is unnecessary
+        # and `use_sftp` is overridden to False.
+        (8, True, False, []),
+        (8, False, False, []),
+        (None, True, False, []),
+        (None, False, False, []),
+    ),
+)
+def test_use_sftp_selects_scp_mode(version, use_sftp, expected_use_sftp, expected_options):
+    """Test that `use_sftp=False` adds `-O`, but only if the client would otherwise transfer over SFTP."""
+    with patch('aiida.transports.plugins.async_backend.get_openssh_version', return_value=version):
+        backend = _OpenSSH('myhpc', MagicMock(), 'bash ', use_sftp=use_sftp)
+
+    assert backend.use_sftp is expected_use_sftp
+    assert backend.scp_options == expected_options
+
+
+def test_undetectable_openssh_version_warns():
+    """Test that an undetectable client version warns that `use_sftp=False` was not applied."""
+    logger = MagicMock()
+    with patch('aiida.transports.plugins.async_backend.get_openssh_version', return_value=None):
+        backend = _OpenSSH('myhpc', logger, 'bash ', use_sftp=False)
+
+    assert backend.scp_options == []
+    logger.warning.assert_called_once()
+    assert 'Could not detect your OpenSSH version' in logger.warning.call_args[0][0]
+
+
+@pytest.mark.parametrize('use_sftp, expected_options', ((True, []), (False, ['-O'])))
+def test_transport_passes_use_sftp_to_openssh_backend(use_sftp, expected_options):
+    """Test that the `use_sftp` config option reaches the openssh backend."""
+    with patch('aiida.transports.plugins.async_backend.get_openssh_version', return_value=9):
+        transport = AsyncSshTransport(machine='myhpc', backend='openssh', use_sftp=use_sftp)
+
+    assert transport.async_backend.scp_options == expected_options
+
+
 def test_scp_with_special_chars(tmp_path):
     """Test scp in both SFTP and RCP modes with special characters."""
     backend = _TestOpenSSH()


### PR DESCRIPTION
Servers without SFTP support cannot be used by `scp` since OpenSSH 9.0, which transfers over SFTP by default. Configuring a computer with `--no-use-sftp` now passes `-O` to force the legacy RCP protocol.

The flag is a no-op on OpenSSH < 9.0, which already uses RCP. If the local client version cannot be detected, a warning is emitted since the flag cannot be applied safely.

Real usecase: https://aiida.discourse.group/t/how-to-use-scp-rsync-instead-of-sftp-for-transport/693/11