### PR TITLE
🧪 Poll for worker count in daemon start tests

### DIFF
--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -39,13 +39,16 @@ def test_daemon_start(run_cli_command, stopped_daemon_client):
     run_cli_command(cmd_daemon.start)
 
     daemon_response = stopped_daemon_client.get_daemon_info()
-    worker_response = stopped_daemon_client.get_worker_info()
 
     assert 'status' in daemon_response
     assert daemon_response['status'] == 'ok'
 
-    assert 'info' in worker_response
-    assert len(worker_response['info']) == 1
+    # The daemon start command only waits for the circus daemon itself to be up, not for all workers to have been
+    # spawned, so poll for the expected number of workers instead of asserting on a single snapshot.
+    stopped_daemon_client._await_condition(
+        lambda: stopped_daemon_client.get_number_of_workers() == 1,
+        DaemonTimeoutException('The daemon failed to start 1 worker.'),
+    )
 
 
 @pytest.mark.parametrize('options', ([], ['--reset']))
@@ -69,13 +72,14 @@ def test_daemon_start_number(run_cli_command, stopped_daemon_client):
     run_cli_command(cmd_daemon.start, [str(number)])
 
     daemon_response = stopped_daemon_client.get_daemon_info()
-    worker_response = stopped_daemon_client.get_worker_info()
 
     assert 'status' in daemon_response
     assert daemon_response['status'] == 'ok'
 
-    assert 'info' in worker_response
-    assert len(worker_response['info']) == number
+    stopped_daemon_client._await_condition(
+        lambda: stopped_daemon_client.get_number_of_workers() == number,
+        DaemonTimeoutException(f'The daemon failed to start {number} workers.'),
+    )
 
 
 def test_daemon_start_number_config(run_cli_command, stopped_daemon_client, isolated_config):
@@ -87,13 +91,14 @@ def test_daemon_start_number_config(run_cli_command, stopped_daemon_client, isol
     run_cli_command(cmd_daemon.start, use_subprocess=False)
 
     daemon_response = stopped_daemon_client.get_daemon_info()
-    worker_response = stopped_daemon_client.get_worker_info()
 
     assert 'status' in daemon_response
     assert daemon_response['status'] == 'ok'
 
-    assert 'info' in worker_response
-    assert len(worker_response['info']) == number
+    stopped_daemon_client._await_condition(
+        lambda: stopped_daemon_client.get_number_of_workers() == number,
+        DaemonTimeoutException(f'The daemon failed to start {number} workers.'),
+    )
 
 
 def test_daemon_stop(run_cli_command, started_daemon_client):


### PR DESCRIPTION
The daemon start command only waits for the circus daemon itself to be responsive, not for all requested workers to have been spawned. The daemon start tests asserted on a single snapshot of the worker info, which could be taken while circus was still forking workers, making the tests flaky on slow CI runners.

Poll for the expected number of workers with a timeout instead, using the same pattern as test_daemon_stop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved daemon startup test reliability by polling until the expected number of workers reports as ready.
  * Improved timeout handling with clearer error messages when the expected worker count is not reached.
  * Updated start-related assertions to use readiness/status checks rather than validating worker info counts directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->