### PR TITLE
♻️ Rename ZMQ broker to ZeroMQ

### DIFF
--- a/docs/source/installation/guide_complete.rst
+++ b/docs/source/installation/guide_complete.rst
@@ -113,39 +113,39 @@ This way, the daemon helps AiiDA to scale as it is possible to run many processe
 
 AiiDA supports two broker backends:
 
-.. _installation:guide-complete:broker:zmq:
+.. _installation:guide-complete:broker:zeromq:
 
-ZMQ broker (built-in)
----------------------
+ZeroMQ broker (built-in)
+------------------------
 
 .. versionadded:: 2.9
 
-The ZMQ broker is a lightweight, built-in message broker that uses `ZeroMQ <https://zeromq.org/>`_ for communication.
+The ZeroMQ broker is a lightweight, built-in message broker that uses `ZeroMQ <https://zeromq.org/>`_ for communication.
 It requires no external services: the broker process is started and stopped automatically together with the daemon.
 
-The ZMQ broker is the easiest way to get a fully functional AiiDA installation with daemon support.
+The ZeroMQ broker is the easiest way to get a fully functional AiiDA installation with daemon support.
 No additional installation steps are needed beyond installing ``aiida-core`` itself.
 
-To create a profile that uses the ZMQ broker:
+To create a profile that uses the ZeroMQ broker:
 
 .. code-block:: console
 
-    verdi presto --use-zmq
+    verdi presto --use-zeromq
 
 Or when using ``verdi profile setup``:
 
 .. code-block:: console
 
-    verdi profile setup core.sqlite_dos --broker zmq
+    verdi profile setup core.sqlite_dos --broker zeromq
 
 .. note::
 
-    The ``verdi presto`` command automatically falls back to the ZMQ broker when RabbitMQ is not available on the localhost.
+    The ``verdi presto`` command automatically falls back to the ZeroMQ broker when RabbitMQ is not available on the localhost.
 
 .. tip::
 
     The ``broker.task_timeout`` configuration option controls how long a caller waits for a response from the broker (default: 10 seconds).
-    This option applies to both the ZMQ and RabbitMQ backends.
+    This option applies to both the ZeroMQ and RabbitMQ backends.
     It can be changed with ``verdi config set broker.task_timeout <seconds>``.
 
 .. _installation:guide-complete:rabbitmq:
@@ -153,9 +153,9 @@ Or when using ``verdi profile setup``:
 RabbitMQ
 --------
 
-`RabbitMQ <https://www.rabbitmq.com/>`_ is an external message broker service that can be used as an alternative to the built-in ZMQ broker.
+`RabbitMQ <https://www.rabbitmq.com/>`_ is an external message broker service that can be used as an alternative to the built-in ZeroMQ broker.
 
-Although it is possible to run AiiDA without RabbitMQ (using the ZMQ broker or no broker at all), RabbitMQ remains a well-tested option for production setups.
+Although it is possible to run AiiDA without RabbitMQ (using the ZeroMQ broker or no broker at all), RabbitMQ remains a well-tested option for production setups.
 
 .. tab-set::
 
@@ -302,10 +302,10 @@ The exact options available for the ``verdi profile setup`` command depend on th
 * ``--first-name``: First name for the default user that is created.
 * ``--last-name``: Last name for the default user that is created.
 * ``--institution``: Institution for the default user that is created.
-* ``--broker [rabbitmq|zmq|none]``: Which message broker backend to use.
+* ``--broker [rabbitmq|zeromq|none]``: Which message broker backend to use.
   The default is ``rabbitmq``, in which case the command tries to connect to RabbitMQ running on the localhost with default connection parameters.
   If this fails, a warning is issued and the profile is configured without a broker.
-  Use ``zmq`` for the built-in ZMQ broker (no external services required), or ``none`` to disable the broker entirely.
+  Use ``zeromq`` for the built-in ZeroMQ broker (no external services required), or ``none`` to disable the broker entirely.
   Once the profile is created, RabbitMQ can still be enabled through ``verdi profile configure-rabbitmq`` which allows to customize the connection parameters.
 
   .. versionadded:: 2.9

--- a/docs/source/installation/guide_quick.rst
+++ b/docs/source/installation/guide_quick.rst
@@ -51,7 +51,7 @@ A setup that is ideal for production work requires the PostgreSQL service and a 
 By default, ``verdi presto`` creates a profile that allows running AiiDA without these:
 
 * **Database**: The PostgreSQL database that is used to store queryable data, is replaced by SQLite.
-* **Broker**: The message broker that allows communication with and between processes is either set to the built-in ZMQ broker (automatic fallback) or disabled entirely.
+* **Broker**: The message broker that allows communication with and between processes is either set to the built-in ZeroMQ broker (automatic fallback) or disabled entirely.
 
 The following matrix shows the possible combinations of the database and broker options and their use cases:
 
@@ -60,13 +60,13 @@ The following matrix shows the possible combinations of the database and broker 
 +======================+====================================================+=============================================================+
 | **No broker**        | Quick start with AiiDA                             | [*not really relevant for any usecase*]                     |
 +----------------------+----------------------------------------------------+-------------------------------------------------------------+
-| **ZMQ broker**       | Getting started, light production                  | Production (no external services required)                  |
+| **ZeroMQ broker**    | Getting started, light production                  | Production (no external services required)                  |
 +----------------------+----------------------------------------------------+-------------------------------------------------------------+
 | **RabbitMQ**         | Production (low-throughput; beta, has limitations) | Production (maximum performance, ideal for high-throughput) |
 +----------------------+----------------------------------------------------+-------------------------------------------------------------+
 
 .. versionadded:: 2.9
-    The ZMQ broker row was added. Previously, only RabbitMQ and no-broker configurations were available.
+    The ZeroMQ broker row was added. Previously, only RabbitMQ and no-broker configurations were available.
 
 The sections below provide details on the use of the PostgreSQL and RabbitMQ services and the limitations when running AiiDA without them.
 
@@ -79,17 +79,17 @@ Part of AiiDA's functionality requires a `message broker <https://en.wikipedia.o
 The message broker is used to allow communication with processes and the :ref:`daemon <topics:daemon>` as well as between themselves.
 AiiDA supports two broker backends:
 
-* **ZMQ broker** (built-in): A lightweight broker that uses `ZeroMQ <https://zeromq.org/>`_ for inter-process communication.
+* **ZeroMQ broker** (built-in): A lightweight broker that uses `ZeroMQ <https://zeromq.org/>`_ for inter-process communication.
   It requires no external services and is started automatically with the daemon.
 * **RabbitMQ**: An external `message broker service <https://www.rabbitmq.com/>`_ that must be installed and managed separately.
 
 .. versionadded:: 2.9
-    The built-in ZMQ broker was added as an alternative to RabbitMQ.
+    The built-in ZeroMQ broker was added as an alternative to RabbitMQ.
 
 .. note::
     The ``verdi presto`` command automatically checks if RabbitMQ is running on the localhost.
     If it can successfully connect, it configures the profile with RabbitMQ.
-    Otherwise, it falls back to the built-in ZMQ broker.
+    Otherwise, it falls back to the built-in ZeroMQ broker.
     If you do not want to use a broker at all, use ``verdi presto --no-broker``.
 
 A profile **without any broker** has the following limitations:

--- a/docs/source/internals/broker.rst
+++ b/docs/source/internals/broker.rst
@@ -1,45 +1,45 @@
 .. _internal_architecture:broker:
 
-**********
-ZMQ Broker
-**********
+*************
+ZeroMQ Broker
+*************
 
 .. versionadded:: 2.9
 
-The ZMQ broker is AiiDA's built-in message broker, replacing the need for an external RabbitMQ service.
+The ZeroMQ broker is AiiDA's built-in message broker, replacing the need for an external RabbitMQ service.
 It implements the subset of AMQP semantics that AiiDA requires (tasks, RPC, broadcasts) using ZeroMQ as the transport layer.
 
 This page documents the internal architecture for developers working on the broker itself.
-For user-facing documentation, see the :ref:`installation guide <installation:guide-complete:broker:zmq>`.
+For user-facing documentation, see the :ref:`installation guide <installation:guide-complete:broker:zeromq>`.
 
 
 Process and thread architecture
 ===============================
 
-When ``verdi daemon start`` is run with a ZMQ-configured profile, circus launches two types of processes:
+When ``verdi daemon start`` is run with a ZeroMQ-configured profile, circus launches two types of processes:
 
 .. code-block:: text
 
     verdi daemon start
     └── circus (daemon supervisor)
-        ├── verdi devel zmq-broker      ← broker process (1 instance)
-        │   └── ZmqBrokerService
-        │       └── ZmqBrokerServer     (single-threaded, zmq.Poller event loop)
+        ├── verdi devel zeromq-broker      ← broker process (1 instance)
+        │   └── ZeromqBrokerService
+        │       └── ZeromqBrokerServer     (single-threaded poller event loop)
         │           └── PersistentQueue (file-based task durability)
         │
         └── verdi daemon worker         ← worker process(es) (1..N instances)
             └── Runner
-                └── ZmqBroker
-                    └── ZmqCommunicator
+                └── ZeromqBroker
+                    └── ZeromqCommunicator
                         ├── main thread     (public API: task_send, rpc_send, ...)
-                        └── loop thread     (private asyncio loop with ZMQ DEALER socket)
+                        └── loop thread     (private asyncio loop with ZeroMQ DEALER socket)
 
 Key points:
 
 - The **broker process** is single-threaded.
-  ``ZmqBrokerServer`` uses a ``zmq.Poller`` event loop (non-blocking I/O via epoll/kqueue underneath) — no asyncio, no threads.
-- Each **worker process** creates a ``ZmqCommunicator`` that runs a private asyncio event loop on a dedicated **background thread**.
-  All ZMQ socket I/O happens on that thread; public methods schedule work via ``call_soon_threadsafe``, so no locks are needed.
+  ``ZeromqBrokerServer`` uses a poller event loop (non-blocking I/O via epoll/kqueue underneath) — no asyncio, no threads.
+- Each **worker process** creates a ``ZeromqCommunicator`` that runs a private asyncio event loop on a dedicated **background thread**.
+  All ZeroMQ socket I/O happens on that thread; public methods schedule work via ``call_soon_threadsafe``, so no locks are needed.
 - The broker process is started **before** workers by circus, so its IPC socket is ready when workers connect.
   If it isn't ready yet, ``get_communicator()`` polls until the socket file appears.
 
@@ -47,16 +47,16 @@ Key points:
 Module overview
 ===============
 
-``ZmqCommunicator`` implements ``kiwipy.Communicator`` — the same interface that ``RmqThreadCommunicator`` implements for RabbitMQ.
+``ZeromqCommunicator`` implements ``kiwipy.Communicator`` — the same interface that ``RmqThreadCommunicator`` implements for RabbitMQ.
 plumpy and the AiiDA engine are unaware of which broker backend is in use; they only interact through this interface.
 
 .. code-block:: text
 
-    src/aiida/brokers/zmq/
-    ├── broker.py         ZmqBroker — the Broker interface for workers
-    ├── communicator.py   ZmqCommunicator — kiwipy.Communicator over ZMQ
-    ├── server.py         ZmqBrokerServer — the broker's message router
-    ├── service.py        ZmqBrokerService — process wrapper (PID, signals, status files)
+    src/aiida/brokers/zeromq/
+    ├── broker.py         ZeromqBroker — the Broker interface for workers
+    ├── communicator.py   ZeromqCommunicator — kiwipy.Communicator over ZeroMQ
+    ├── server.py         ZeromqBrokerServer — the broker's message router
+    ├── service.py        ZeromqBrokerService — process wrapper (PID, signals, status files)
     ├── queue.py          PersistentQueue — file-based durable task queue
     ├── protocol.py       Message types, encoding/decoding, factory functions
     └── defaults.py       Developer-tunable constants (not user-facing)
@@ -65,21 +65,21 @@ plumpy and the AiiDA engine are unaware of which broker backend is in use; they 
 Endpoint discovery
 ==================
 
-Unlike RabbitMQ, the ZMQ broker requires no connection configuration (no host, port, or credentials).
+Unlike RabbitMQ, the ZeroMQ broker requires no connection configuration (no host, port, or credentials).
 Discovery is file-based: both sides derive the broker directory from the profile UUID.
 
 1. On startup, the broker process writes the IPC socket path to ``~/.aiida/broker/{profile-uuid}/broker.sockets``.
-2. When a worker calls ``get_communicator()``, it reads that file to obtain the endpoint (e.g. ``ipc:///tmp/aiida_zmq_xyz/router.sock``).
+2. When a worker calls ``get_communicator()``, it reads that file to obtain the endpoint (e.g. ``ipc:///tmp/aiida_zeromq_xyz/router.sock``).
 3. The worker connects its DEALER socket to that endpoint.
 
-This means the ZMQ broker is **local-only** — IPC sockets do not work across machines.
+This means the ZeroMQ broker is **local-only** — IPC sockets do not work across machines.
 For distributed setups (workers on different hosts), use RabbitMQ.
 
 
 Socket architecture
 ===================
 
-All traffic flows through a single ZMQ ROUTER/DEALER socket pair over IPC:
+All traffic flows through a single ZeroMQ ROUTER/DEALER socket pair over IPC:
 
 .. code-block:: text
 
@@ -98,7 +98,7 @@ All traffic flows through a single ZMQ ROUTER/DEALER socket pair over IPC:
                  │     Broker process       │
                  │  ┌────────────────────┐  │
                  │  │   ROUTER socket    │  │
-                 │  │  (sync, zmq.Poller)│  │
+                 │  │  (sync, poller)    │  │
                  │  └────────────────────┘  │
                  │  ┌────────────────────┐  │
                  │  │  PersistentQueue   │  │
@@ -107,14 +107,14 @@ All traffic flows through a single ZMQ ROUTER/DEALER socket pair over IPC:
                  └──────────────────────────┘
 
 The ROUTER socket auto-prepends the sender's identity to incoming frames, enabling the broker to route replies back to specific clients.
-``ROUTER_MANDATORY`` is set so that sending to a disconnected identity raises ``ZMQError`` immediately rather than silently dropping the message.
+``ROUTER_MANDATORY`` is set so that sending to a disconnected identity raises a socket error immediately rather than silently dropping the message.
 
 
 Message protocol
 ================
 
 The protocol is defined in ``protocol.py``.
-All messages are JSON-encoded dicts sent as single ZMQ frames.
+All messages are JSON-encoded dicts sent as single ZeroMQ frames.
 Every message has a ``type`` field (a ``MessageType`` enum value) and an ``id`` (UUID hex).
 
 Message types
@@ -169,11 +169,11 @@ Message types
 AMQP mapping
 ------------
 
-The protocol maps AMQP concepts to ZMQ message types:
+The protocol maps AMQP concepts to ZeroMQ message types:
 
 .. code-block:: text
 
-    AMQP concept              ZMQ broker equivalent
+    AMQP concept              ZeroMQ broker equivalent
     ────────────────────────  ──────────────────────────────────
     publisher confirm         TASK_RESPONSE (immediate broker ack)
     basic.ack                 TASK_ACK
@@ -187,7 +187,7 @@ The protocol maps AMQP concepts to ZMQ message types:
 Wire format
 -----------
 
-Messages travel as ZMQ multipart frames:
+Messages travel as ZeroMQ multipart frames:
 
 .. code-block:: text
 
@@ -195,7 +195,7 @@ Messages travel as ZMQ multipart frames:
     Broker (ROUTER) receives:     [ client-identity | empty-delimiter | json-payload ]
     Broker (ROUTER) sends:        [ target-identity | empty-delimiter | json-payload ]
 
-The empty delimiter frame is a ZMQ convention for ROUTER/DEALER interop.
+The empty delimiter frame is a ZeroMQ convention for ROUTER/DEALER interop.
 The ROUTER socket automatically prepends the sender's identity on receive and uses the first frame as the routing target on send.
 
 Payload fields like ``body`` and ``result`` are opaque to the broker — they are pre-encoded by the sender (typically as YAML strings by plumpy/kiwipy) and passed through without inspection.
@@ -263,7 +263,7 @@ Deferred ACK pattern
 ====================
 
 The kiwipy/plumpy stack requires that task subscribers can return ``Future`` objects — plumpy's process runner does this because AiiDA processes are long-running and asynchronous.
-The ZMQ communicator must support this to be a compatible ``kiwipy.Communicator``.
+The ZeroMQ communicator must support this to be a compatible ``kiwipy.Communicator``.
 
 When a task subscriber returns a result, two paths are possible:
 
@@ -289,18 +289,18 @@ The same pattern applies to RPC: if the subscriber returns a ``Future``, the res
 Dead worker detection
 =====================
 
-Dead worker detection combines ZMQ transport features with application-level logic.
+Dead worker detection combines ZeroMQ transport features with application-level logic.
 
-**Detection** (ZMQ built-in):
+**Detection** (ZeroMQ built-in):
 the ROUTER socket is configured with ``HEARTBEAT_IVL`` and ``HEARTBEAT_TIMEOUT``.
-ZMQ sends periodic ping frames at the transport level; if a worker stops responding within the timeout, ZMQ disconnects it internally and emits an ``EVENT_DISCONNECTED`` on the monitor socket we attached to the ROUTER.
+ZeroMQ sends periodic ping frames at the transport level; if a worker stops responding within the timeout, ZeroMQ disconnects it internally and emits an ``EVENT_DISCONNECTED`` on the monitor socket we attached to the ROUTER.
 
 The problem is that this event only reports the file descriptor, not which client identity disconnected.
 So the event is just a **trigger** — it tells us *someone* died, but not *who*.
 
 **Identification** (our logic):
 on each ``EVENT_DISCONNECTED``, ``_handle_disconnect_event`` calls ``_probe_workers``, which sends a ``PING`` message to every worker identity that has in-flight tasks.
-With ``ROUTER_MANDATORY`` set on the socket, sending to a dead identity immediately raises ``ZMQError(EHOSTUNREACH)``.
+With ``ROUTER_MANDATORY`` set on the socket, sending to a dead identity immediately raises a socket error (``EHOSTUNREACH``).
 Any worker that fails the probe is removed via ``_remove_dead_worker``, which requeues all its assigned tasks and cleans up the subscriber registries.
 
 
@@ -327,17 +327,17 @@ Persistent queue (crash recovery)
 Service files
 =============
 
-``ZmqBrokerService`` manages the broker process lifecycle and writes files that ``ZmqBroker`` (in worker processes) reads to discover the broker:
+``ZeromqBrokerService`` manages the broker process lifecycle and writes files that ``ZeromqBroker`` (in worker processes) reads to discover the broker:
 
 .. code-block:: text
 
     ~/.aiida/broker/{profile-uuid}/
-    ├── broker.pid         "aiida-zmq-broker {pid}" — sentinel + PID for ownership check
+    ├── broker.pid         "aiida-zeromq-broker {pid}" — sentinel + PID for ownership check
     ├── broker.status      JSON with task counts, updated every STATUS_INTERVAL seconds
     ├── broker.sockets     path to the temp socket directory
     └── storage/           PersistentQueue data
 
-    /tmp/aiida_zmq_{random}/
+    /tmp/aiida_zeromq_{random}/
     └── router.sock        IPC socket (temp dir avoids 107-byte Unix path limit)
 
 
@@ -384,7 +384,7 @@ Timeouts
      - Peer considered dead after no heartbeat response for this duration.
    * - ``POLL_TIMEOUT``
      - 1s
-     - Server-side ``zmq.Poller`` timeout per iteration. Controls how quickly the broker responds to shutdown signals.
+     - Server-side poll timeout per iteration. Controls how quickly the broker responds to shutdown signals.
    * - ``STATUS_INTERVAL``
      - 5s
      - How often the broker service writes its status JSON to disk.

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -323,7 +323,7 @@ Below is a list with all available subcommands.
 
       By default the command creates a profile that uses SQLite for the database. For the
       message broker, it automatically checks for RabbitMQ running on localhost. If found, it
-      configures RabbitMQ as the broker. Otherwise, it falls back to the ZMQ broker, which
+      configures RabbitMQ as the broker. Otherwise, it falls back to the ZeroMQ broker, which
       requires no external services and is started automatically with the daemon.
 
       When the `--use-postgres` flag is toggled, the command tries to connect to the
@@ -332,9 +332,9 @@ Below is a list with all available subcommands.
       these credentials to try and automatically create a user and database. If successful,
       the newly created profile uses the new PostgreSQL database instead of SQLite.
 
-      When the `--use-zmq` flag is toggled, the command skips the RabbitMQ auto-detection and
-      directly configures the ZMQ broker. To switch to RabbitMQ later, use `verdi profile
-      configure-rabbitmq`.
+      When the `--use-zeromq` flag is toggled, the command skips the RabbitMQ auto-detection
+      and directly configures the ZeroMQ broker. To switch to RabbitMQ later, use `verdi
+      profile configure-rabbitmq`.
 
     Options:
       -p, --profile-name TEXT         Name of the profile. By default, a unique name starting
@@ -347,12 +347,12 @@ Below is a list with all available subcommands.
                                       options. The command attempts to automatically create a
                                       user and database to use for the profile, but this can
                                       fail depending on the configuration of the server.
-      --use-zmq                       When toggled on, the profile uses the ZMQ broker, which
-                                      requires no external services and is started
+      --use-zeromq                    When toggled on, the profile uses the ZeroMQ broker,
+                                      which requires no external services and is started
                                       automatically with the daemon. When not specified, the
                                       command automatically tries RabbitMQ first and falls
-                                      back to ZMQ if unavailable. To switch to RabbitMQ later,
-                                      use `verdi profile configure-rabbitmq`.
+                                      back to ZeroMQ if unavailable. To switch to RabbitMQ
+                                      later, use `verdi profile configure-rabbitmq`.
       --no-broker                     When toggled on, no message broker is configured. This
                                       means the daemon cannot be started and processes cannot
                                       be submitted. Useful for profiles used only for data

--- a/docs/source/topics/performance.rst
+++ b/docs/source/topics/performance.rst
@@ -35,7 +35,7 @@ Services
 For the default setup, AiiDA essentially has three services that influence its performance:
 
 * PostgreSQL (the database in which the provenance graph is stored)
-* Message broker (RabbitMQ or the built-in ZMQ broker, used by daemon workers to communicate)
+* Message broker (RabbitMQ or the built-in ZeroMQ broker, used by daemon workers to communicate)
 * Filesystem (files are stored by AiiDA in the file repository on a filesytem)
 
 For the simplest installations, PostgreSQL and the message broker are typically running on the same machine as AiiDA itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ requires-python = '>=3.10'
 
 [project.entry-points.'aiida.brokers']
 'core.rabbitmq' = 'aiida.brokers.rabbitmq.broker:RabbitmqBroker'
-'core.zmq' = 'aiida.brokers.zmq.broker:ZmqBroker'
+'core.zeromq' = 'aiida.brokers.zeromq.broker:ZeromqBroker'
 
 [project.entry-points.'aiida.calculations']
 'core.arithmetic.add' = 'aiida.calculations.arithmetic.add:ArithmeticAddCalculation'
@@ -439,8 +439,8 @@ filterwarnings = [
 ]
 markers = [
   'nightly: long running tests that should rarely be affected and so only run nightly',
-  'requires_rmq: requires RabbitMQ specifically (not compatible with ZMQ broker)',
-  'requires_broker: requires a message broker (RabbitMQ or ZMQ)',
+  'requires_rmq: requires RabbitMQ specifically (not compatible with ZeroMQ broker)',
+  'requires_broker: requires a message broker (RabbitMQ or ZeroMQ)',
   'requires_psql: requires a connection to PostgreSQL DB',
   'presto: automatic marker for tests needing no external services (not requires_rmq, not requires_psql)',
   'sphinx: set parameters for the sphinx `app` fixture'

--- a/src/aiida/brokers/__init__.py
+++ b/src/aiida/brokers/__init__.py
@@ -6,12 +6,12 @@
 
 from .broker import *
 from .rabbitmq import *
-from .zmq import *
+from .zeromq import *
 
 __all__ = (
     'Broker',
     'RabbitmqBroker',
-    'ZmqBroker',
+    'ZeromqBroker',
 )
 
 # fmt: on

--- a/src/aiida/brokers/zeromq/__init__.py
+++ b/src/aiida/brokers/zeromq/__init__.py
@@ -7,7 +7,7 @@
 from .broker import *
 
 __all__ = (
-    'ZmqBroker',
+    'ZeromqBroker',
 )
 
 # fmt: on

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -1,4 +1,4 @@
-"""ZMQ Broker - AiiDA Broker wrapper for ZMQ communicator."""
+"""ZeroMQ Broker - AiiDA Broker wrapper for ZeroMQ communicator."""
 
 from __future__ import annotations
 
@@ -14,34 +14,34 @@ import psutil
 from aiida.brokers.broker import Broker
 from aiida.common.log import AIIDA_LOGGER
 
-from .communicator import ZmqCommunicator
+from .communicator import ZeromqCommunicator
 from .defaults import BROKER_READY_TIMEOUT
 from .queue import PersistentQueue
 
 if t.TYPE_CHECKING:
     from aiida.manage.configuration.profile import Profile
 
-__all__ = ('ZmqBroker',)
+__all__ = ('ZeromqBroker',)
 
-LOGGER = AIIDA_LOGGER.getChild('broker.zmq')
+LOGGER = AIIDA_LOGGER.getChild('broker.zeromq')
 
 
-class ZmqBroker(Broker):
+class ZeromqBroker(Broker):
     """AiiDA Broker implementation using ZeroMQ.
 
-    Connects to a ZmqBrokerService for messaging and reads PID/status/socket
+    Connects to a ZeromqBrokerService for messaging and reads PID/status/socket
     files written by the service to discover endpoints and query status.
     """
 
     # Class attribute for type discovery
-    Communicator = ZmqCommunicator
+    Communicator = ZeromqCommunicator
 
     def __init__(self, profile: 'Profile') -> None:
         super().__init__(profile)
         self._init_paths(get_broker_base_path(profile))
 
     def _init_paths(self, broker_dir: Path) -> None:
-        self._communicator: ZmqCommunicator | None = None
+        self._communicator: ZeromqCommunicator | None = None
         self._broker_dir = broker_dir
         self._storage_path = broker_dir / 'storage'
         self._service_pid_file = broker_dir / 'broker.pid'
@@ -52,8 +52,8 @@ class ZmqBroker(Broker):
         if self.is_running:
             status = self.get_service_status()
             pid = status.get('pid', '?') if status else '?'
-            return f'ZMQ Broker (PID {pid}) @ {self._broker_dir}'
-        return f'ZMQ Broker @ {self._broker_dir} <not running>'
+            return f'ZeroMQ Broker (PID {pid}) @ {self._broker_dir}'
+        return f'ZeroMQ Broker @ {self._broker_dir} <not running>'
 
     @property
     def storage_path(self) -> Path:
@@ -80,12 +80,12 @@ class ZmqBroker(Broker):
             return None
         return f'ipc://{sockets_path}/router.sock'
 
-    _PID_SENTINEL = 'aiida-zmq-broker'
+    _PID_SENTINEL = 'aiida-zeromq-broker'
 
     def get_service_pid(self) -> int | None:
-        """Read the ZmqBrokerService PID from its PID file.
+        """Read the ZeromqBrokerService PID from its PID file.
 
-        The PID file contains ``aiida-zmq-broker <pid>`` as a sentinel so we
+        The PID file contains ``aiida-zeromq-broker <pid>`` as a sentinel so we
         can validate ownership without fragile command-line string matching.
         """
         if not self._service_pid_file.exists():
@@ -101,7 +101,7 @@ class ZmqBroker(Broker):
 
     @property
     def is_running(self) -> bool:
-        """Check if the ZmqBrokerService process is running."""
+        """Check if the ZeromqBrokerService process is running."""
         pid = self.get_service_pid()
         if pid is None:
             return False
@@ -112,7 +112,7 @@ class ZmqBroker(Broker):
             return False
 
     def get_service_status(self) -> dict[str, t.Any] | None:
-        """Read the ZmqBrokerService status from its status file."""
+        """Read the ZeromqBrokerService status from its status file."""
         if not self._service_status_file.exists():
             return None
         try:
@@ -130,7 +130,7 @@ class ZmqBroker(Broker):
 
     # --- Communicator ---
 
-    def get_communicator(self, wait_for_broker: float = BROKER_READY_TIMEOUT) -> ZmqCommunicator:
+    def get_communicator(self, wait_for_broker: float = BROKER_READY_TIMEOUT) -> ZeromqCommunicator:
         """Get or create a communicator connected to the broker.
 
         :param wait_for_broker: Seconds to wait for the broker to become ready.
@@ -160,7 +160,7 @@ class ZmqBroker(Broker):
 
             from aiida.manage.configuration import get_config_option
 
-            self._communicator = ZmqCommunicator(
+            self._communicator = ZeromqCommunicator(
                 router_endpoint=router_endpoint,
                 task_timeout=get_config_option('broker.task_timeout'),
             )
@@ -168,28 +168,28 @@ class ZmqBroker(Broker):
 
         return self._communicator
 
-    def iterate_tasks(self) -> t.Iterator['ZmqIncomingTask']:
+    def iterate_tasks(self) -> t.Iterator['ZeromqIncomingTask']:
         queue_path = self._storage_path / 'tasks'
         if not queue_path.exists():
             return
 
         queue = PersistentQueue(queue_path)
         for task_id, task_data in queue.get_all_pending():
-            yield ZmqIncomingTask(task_id, task_data, queue)
+            yield ZeromqIncomingTask(task_id, task_data, queue)
 
     def close(self) -> None:
         if self._communicator is not None:
             self._communicator.close()
             self._communicator = None
 
-    def __enter__(self) -> 'ZmqBroker':
+    def __enter__(self) -> 'ZeromqBroker':
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: t.Any) -> None:
         self.close()
 
 
-class ZmqIncomingTask:
+class ZeromqIncomingTask:
     """Wrapper providing an interface compatible with RabbitMQ incoming tasks."""
 
     def __init__(self, task_id: str, task_data: dict[str, t.Any], queue: PersistentQueue) -> None:

--- a/src/aiida/brokers/zeromq/communicator.py
+++ b/src/aiida/brokers/zeromq/communicator.py
@@ -8,7 +8,7 @@
 ###########################################################################
 """ZeroMQ Communicator - client implementing kiwipy Communicator interface.
 
-Uses an internal asyncio event loop on a background thread for all ZMQ I/O.
+Uses an internal asyncio event loop on a background thread for all ZeroMQ I/O.
 Public methods schedule work onto the loop via ``call_soon_threadsafe``,
 eliminating the need for locks around shared state.  This follows the same
 pattern as kiwipy's ``RmqThreadCommunicator``.
@@ -47,10 +47,10 @@ _LOGGER = logging.getLogger(__name__)
 _T = TypeVar('_T')
 
 
-class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
-    """ZMQ client implementing kiwipy Communicator interface.
+class ZeromqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
+    """ZeroMQ client implementing kiwipy Communicator interface.
 
-    Connects to a ZmqBrokerService to send/receive messages.
+    Connects to a ZeromqBrokerService to send/receive messages.
 
     Socket architecture:
         DEALER - Connects to broker ROUTER for all communication
@@ -58,7 +58,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
 
     Threading model:
         A private asyncio event loop runs on a dedicated background thread.
-        All ZMQ socket I/O and mutable-state access happen exclusively on
+        All ZeroMQ socket I/O and mutable-state access happen exclusively on
         that loop, so no locks are needed.  Public methods schedule work
         onto the loop and block until the result is ready.
     """
@@ -73,7 +73,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
         self._client_id = client_id or f'client-{uuid.uuid4().hex[:8]}'
         self._task_timeout = task_timeout
 
-        # ZMQ sockets (created on the event loop thread)
+        # ZeroMQ sockets (created on the event loop thread)
         self._context: zmq.asyncio.Context | None = None
         self._dealer: zmq.asyncio.Socket | None = None
 
@@ -119,12 +119,12 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
         """Start the communicator.
 
         Creates a background thread running an asyncio event loop, connects
-        ZMQ sockets, and starts polling coroutines.
+        ZeroMQ sockets, and starts polling coroutines.
         """
         if not self._closed:
             return
 
-        _LOGGER.info('Starting ZMQ Communicator: %s', self._client_id)
+        _LOGGER.info('Starting ZeroMQ Communicator: %s', self._client_id)
 
         self._loop = asyncio.new_event_loop()
         ready: Future[bool] = Future()
@@ -134,7 +134,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
 
         # Block until the loop thread has set up sockets and is polling.
         ready.result(timeout=LOOP_TIMEOUT)
-        _LOGGER.info('ZMQ Communicator started')
+        _LOGGER.info('ZeroMQ Communicator started')
 
     def _run_loop(self, ready: Future[bool]) -> None:
         """Entry point for the background thread."""
@@ -180,7 +180,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
         if self._closed:
             return
 
-        _LOGGER.info('Closing ZMQ Communicator: %s', self._client_id)
+        _LOGGER.info('Closing ZeroMQ Communicator: %s', self._client_id)
         self._closed = True
 
         if self._loop is not None and self._loop.is_running():
@@ -206,9 +206,9 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
                 self._loop_thread.join(timeout=LOOP_JOIN_TIMEOUT)
 
                 if self._loop_thread.is_alive():
-                    _LOGGER.warning('ZMQ loop thread did not join in time, terminating ZMQ context')
-                    # Force-terminate the ZMQ context to unblock the poll loop.
-                    # This causes recv_multipart to raise ZMQError, exiting the thread.
+                    _LOGGER.warning('ZeroMQ loop thread did not join in time, terminating ZeroMQ context')
+                    # Force-terminate the ZeroMQ context to unblock the poll loop.
+                    # This causes recv_multipart to raise a socket error, exiting the thread.
                     if self._context is not None:
                         self._context.term()
                         self._context = None
@@ -217,7 +217,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
         self._loop = None
         self._loop_thread = None
 
-        _LOGGER.info('ZMQ Communicator closed')
+        _LOGGER.info('ZeroMQ Communicator closed')
 
     def _do_close_on_loop(self) -> None:
         """Cleanup that must run on the event loop thread."""
@@ -252,7 +252,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
                 future.cancel()
         self._pending_futures.clear()
 
-    def __enter__(self) -> 'ZmqCommunicator':
+    def __enter__(self) -> 'ZeromqCommunicator':
         self.start()
         return self
 
@@ -478,7 +478,7 @@ class ZmqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
                 self._dispatch_dealer_message(msg)
             except zmq.ZMQError:
                 if not self._closed:
-                    _LOGGER.error('ZMQ error in dealer poll')
+                    _LOGGER.error('ZeroMQ error in dealer poll')
                 break
             except asyncio.CancelledError:
                 break

--- a/src/aiida/brokers/zeromq/defaults.py
+++ b/src/aiida/brokers/zeromq/defaults.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Default constants for the ZMQ broker.
+"""Default constants for the ZeroMQ broker.
 
 These are **developer-tunable** defaults, not exposed to end users via
 ``verdi config``.  User-facing options live in the config schema
@@ -34,7 +34,7 @@ BROKER_READY_TIMEOUT: float = 10.0
 
 # -- Server (broker-side) -----------------------------------------------------
 
-# ZMQ socket polling interval in seconds.
+# ZeroMQ socket polling interval in seconds.
 POLL_TIMEOUT: float = 1.0
 
 # ZMTP heartbeat interval (seconds) — how often the broker pings connected peers.

--- a/src/aiida/brokers/zeromq/protocol.py
+++ b/src/aiida/brokers/zeromq/protocol.py
@@ -6,11 +6,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Application-level message protocol for the ZMQ broker.
+"""Application-level message protocol for the ZeroMQ broker.
 
 This protocol implements the subset of AMQP semantics that AiiDA requires
 (via kiwipy's ``Communicator`` interface, originally designed for RabbitMQ)
-using ZMQ as the transport layer instead of raw TCP.
+using ZeroMQ as the transport layer instead of raw TCP.
 
 Socket architecture:
     A single ROUTER/DEALER pair carries all traffic (tasks, RPC, broadcasts).
@@ -19,13 +19,13 @@ Socket architecture:
     to specific clients. Broadcasts are sent by the server to all connected
     clients (derived from subscriber registries).
 
-What ZMQ provides (transport layer):
+What ZeroMQ provides (transport layer):
     - Identity-based routing (ROUTER auto-prepends sender identity to messages)
     - Automatic reconnection and async I/O
     - ZMTP heartbeats for dead peer detection
     - IPC transport for same-machine communication
 
-What ZMQ does NOT provide (requiring this protocol):
+What ZeroMQ does NOT provide (requiring this protocol):
     - Request-reply correlation (matching responses to requests)
     - Task acknowledgment and redelivery on worker death
     - Persistent/durable queues
@@ -35,7 +35,7 @@ What ZMQ does NOT provide (requiring this protocol):
 
 AMQP concepts mapped to message types:
     ========================  ================================
-    AMQP concept              ZMQ broker message type
+    AMQP concept              ZeroMQ broker message type
     ========================  ================================
     ``basic.ack``             ``TASK_ACK``
     ``basic.nack``            ``TASK_NACK``
@@ -47,7 +47,7 @@ AMQP concepts mapped to message types:
     ========================  ================================
 
 Why not use an AMQP library directly: the goal is to eliminate the RabbitMQ
-server dependency. ZMQ provides the transport primitives; this module adds
+server dependency. ZeroMQ provides the transport primitives; this module adds
 only the AMQP-like semantics that ``kiwipy.Communicator`` requires.
 """
 
@@ -60,7 +60,7 @@ from typing import Any
 
 
 class MessageType(str, Enum):
-    """Message types for the ZMQ broker protocol."""
+    """Message types for the ZeroMQ broker protocol."""
 
     # Task messages
     TASK = 'task'

--- a/src/aiida/brokers/zeromq/queue.py
+++ b/src/aiida/brokers/zeromq/queue.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Persistent queue implementation for ZMQ broker."""
+"""Persistent queue implementation for ZeroMQ broker."""
 
 from __future__ import annotations
 

--- a/src/aiida/brokers/zeromq/server.py
+++ b/src/aiida/brokers/zeromq/server.py
@@ -31,8 +31,8 @@ from .queue import PersistentQueue
 _LOGGER = logging.getLogger(__name__)
 
 
-class ZmqBrokerServer:
-    """Standalone ZMQ message broker server.
+class ZeromqBrokerServer:
+    """Standalone ZeroMQ message broker server.
 
     Uses a single ROUTER socket for all communication (tasks, RPC, broadcasts).
 
@@ -68,7 +68,7 @@ class ZmqBrokerServer:
         # Derive endpoint from sockets_path
         self._router_endpoint = f'ipc://{self._sockets_path}/router.sock'
 
-        # ZMQ context and sockets
+        # ZeroMQ context and sockets
         self._context: zmq.Context | None = None  # type: ignore[type-arg]
         self._router: zmq.Socket | None = None  # type: ignore[type-arg]
         self._poller: zmq.Poller | None = None
@@ -138,11 +138,11 @@ class ZmqBrokerServer:
         if self._running:
             return
 
-        _LOGGER.info('Starting ZMQ Broker Server')
+        _LOGGER.info('Starting ZeroMQ Broker Server')
         _LOGGER.info('Storage path: %s', self._storage_path)
         _LOGGER.info('ROUTER endpoint: %s', self._router_endpoint)
 
-        # Create ZMQ context
+        # Create ZeroMQ context
         self._context = zmq.Context()
 
         # ROUTER socket for request-reply
@@ -162,7 +162,7 @@ class ZmqBrokerServer:
         self._poller.register(self._monitor, zmq.POLLIN)
 
         self._running = True
-        _LOGGER.info('ZMQ Broker Server started')
+        _LOGGER.info('ZeroMQ Broker Server started')
 
     def stop(self) -> None:
         """Stop the broker server.
@@ -172,7 +172,7 @@ class ZmqBrokerServer:
         if not self._running:
             return
 
-        _LOGGER.info('Stopping ZMQ Broker Server')
+        _LOGGER.info('Stopping ZeroMQ Broker Server')
         self._running = False
 
         if self._poller:
@@ -194,7 +194,7 @@ class ZmqBrokerServer:
             self._context.term()
             self._context = None
 
-        _LOGGER.info('ZMQ Broker Server stopped')
+        _LOGGER.info('ZeroMQ Broker Server stopped')
 
     def run_forever(self, poll_timeout: float = POLL_TIMEOUT) -> None:
         """Run the broker event loop.
@@ -549,7 +549,7 @@ class ZmqBrokerServer:
 
         Sends a PING to each worker identity that has tasks assigned.
         With ROUTER_MANDATORY, sending to a dead identity raises
-        ZMQError(EHOSTUNREACH), identifying the dead worker.
+        a socket error with ``EHOSTUNREACH``, identifying the dead worker.
         """
         if not self._task_worker_assignments:
             return

--- a/src/aiida/brokers/zeromq/service.py
+++ b/src/aiida/brokers/zeromq/service.py
@@ -1,4 +1,4 @@
-"""ZMQ Broker Service - process wrapper for ZmqBrokerServer.
+"""ZeroMQ Broker Service - process wrapper for ZeromqBrokerServer.
 
 Manages PID/status files, socket directory, and signal handling.
 Circus handles process lifecycle (daemonization, keepalive, log capture).
@@ -17,13 +17,13 @@ import typing as t
 from pathlib import Path
 
 from .defaults import POLL_TIMEOUT, STATUS_INTERVAL
-from .server import ZmqBrokerServer
+from .server import ZeromqBrokerServer
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class ZmqBrokerService:
-    """Process wrapper for ZmqBrokerServer.
+class ZeromqBrokerService:
+    """Process wrapper for ZeromqBrokerServer.
 
     Directory structure:
         {base_path}/
@@ -43,7 +43,7 @@ class ZmqBrokerService:
         self._sockets_file = self._base_path / 'broker.sockets'
         self._pid_file = self._base_path / 'broker.pid'
         self._status_file = self._base_path / 'broker.status'
-        self._server: ZmqBrokerServer | None = None
+        self._server: ZeromqBrokerServer | None = None
         self._running = False
 
     @property
@@ -74,15 +74,15 @@ class ZmqBrokerService:
                 pass
 
         # Use temp directory for sockets (Unix IPC path limit ~107 bytes)
-        self._sockets_path = Path(tempfile.mkdtemp(prefix='aiida_zmq_'))
+        self._sockets_path = Path(tempfile.mkdtemp(prefix='aiida_zeromq_'))
         self._sockets_file.write_text(str(self._sockets_path))
 
-        self._server = ZmqBrokerServer(
+        self._server = ZeromqBrokerServer(
             storage_path=self._storage_path,
             sockets_path=self._sockets_path,
         )
 
-        self._pid_file.write_text(f'aiida-zmq-broker {os.getpid()}')
+        self._pid_file.write_text(f'aiida-zeromq-broker {os.getpid()}')
 
         # SIGINT (ctrl-c / circus graceful) + SIGTERM (circus stop)
         signal.signal(signal.SIGINT, self._handle_shutdown)
@@ -133,7 +133,7 @@ class ZmqBrokerService:
 
 def run_broker_service(base_path: str | Path) -> None:
     """Entry point for ``verdi daemon broker``."""
-    ZmqBrokerService(base_path=base_path).run_forever()
+    ZeromqBrokerService(base_path=base_path).run_forever()
 
 
 if __name__ == '__main__':

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -84,7 +84,7 @@ def execute_client_command(
 @options.TIMEOUT(default=None, required=False, type=int)
 @decorators.with_dbenv()
 @decorators.requires_broker
-@decorators.check_circus_zmq_version
+@decorators.check_circus_zeromq_version
 def start(foreground, number, timeout):
     """Start the daemon with NUMBER workers.
 
@@ -152,12 +152,12 @@ def status(ctx, all_profiles, timeout):
 
         start_time = format_local_time(daemon_response['info']['create_time'])
 
-        # Build broker status lines for managed brokers (e.g., ZMQ)
+        # Build broker status lines for managed brokers (e.g., ZeroMQ)
         broker_lines: list[str] = []
         broker = get_manager().get_broker()
-        from aiida.brokers.zmq.broker import ZmqBroker
+        from aiida.brokers.zeromq.broker import ZeromqBroker
 
-        if isinstance(broker, ZmqBroker):
+        if isinstance(broker, ZeromqBroker):
             if broker.is_running:
                 status_info = broker.get_service_status()
                 if status_info:
@@ -293,7 +293,7 @@ def restart(ctx, reset, no_wait, timeout):
 @click.argument('number', required=False, type=int, callback=validate_daemon_workers)
 @decorators.with_dbenv()
 @decorators.requires_broker
-@decorators.check_circus_zmq_version
+@decorators.check_circus_zeromq_version
 def start_circus(foreground, number):
     """This will actually launch the circus daemon, either daemonized in the background or in the foreground.
 
@@ -320,12 +320,12 @@ def worker():
 @decorators.with_dbenv()
 @decorators.requires_broker
 def broker():
-    """Run the ZMQ broker server in the current process.
+    """Run the ZeroMQ broker server in the current process.
 
     .. note:: this should not be called directly from the commandline!
     """
-    from aiida.brokers.zmq.broker import get_broker_base_path
-    from aiida.brokers.zmq.service import run_broker_service
+    from aiida.brokers.zeromq.broker import get_broker_base_path
+    from aiida.brokers.zeromq.service import run_broker_service
     from aiida.manage.manager import get_manager
 
     profile = get_manager().get_profile()

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -128,11 +128,11 @@ def detect_postgres_config(
     'user and database to use for the profile, but this can fail depending on the configuration of the server.',
 )
 @click.option(
-    '--use-zmq',
+    '--use-zeromq',
     is_flag=True,
-    help='When toggled on, the profile uses the ZMQ broker, which requires no external services and is started '
+    help='When toggled on, the profile uses the ZeroMQ broker, which requires no external services and is started '
     'automatically with the daemon. When not specified, the command automatically tries RabbitMQ first and falls back '
-    'to ZMQ if unavailable. To switch to RabbitMQ later, use `verdi profile configure-rabbitmq`.',
+    'to ZeroMQ if unavailable. To switch to RabbitMQ later, use `verdi profile configure-rabbitmq`.',
 )
 @click.option(
     '--no-broker',
@@ -161,7 +161,7 @@ def verdi_presto(
     profile_name,
     email,
     use_postgres,
-    use_zmq,
+    use_zeromq,
     no_broker,
     postgres_hostname,
     postgres_port,
@@ -188,15 +188,15 @@ def verdi_presto(
 
     By default the command creates a profile that uses SQLite for the database. For the message broker, it automatically
     checks for RabbitMQ running on localhost. If found, it configures RabbitMQ as the broker. Otherwise, it falls back
-    to the ZMQ broker, which requires no external services and is started automatically with the daemon.
+    to the ZeroMQ broker, which requires no external services and is started automatically with the daemon.
 
     When the `--use-postgres` flag is toggled, the command tries to connect to the PostgreSQL server with connection
     paramaters taken from the `--postgres-hostname`, `--postgres-port`, `--postgres-username` and `--postgres-password`
     options. It uses these credentials to try and automatically create a user and database. If successful, the newly
     created profile uses the new PostgreSQL database instead of SQLite.
 
-    When the `--use-zmq` flag is toggled, the command skips the RabbitMQ auto-detection and directly configures the ZMQ
-    broker. To switch to RabbitMQ later, use `verdi profile configure-rabbitmq`.
+    When the `--use-zeromq` flag is toggled, the command skips the RabbitMQ auto-detection and directly configures the
+    ZeroMQ broker. To switch to RabbitMQ later, use `verdi profile configure-rabbitmq`.
     """
     from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
     from aiida.common import exceptions
@@ -235,20 +235,20 @@ def verdi_presto(
         echo.echo_report('`--no-broker` enabled: configuring the profile without a broker.')
         broker_backend = None
         broker_config = None
-    elif use_zmq:
-        echo.echo_report('`--use-zmq` enabled: configuring the profile with ZMQ broker.')
-        broker_backend = 'core.zmq'
+    elif use_zeromq:
+        echo.echo_report('`--use-zeromq` enabled: configuring the profile with ZeroMQ broker.')
+        broker_backend = 'core.zeromq'
         broker_config = {}
     else:
         try:
             broker_config = detect_rabbitmq_config()
         except ConnectionError:
-            echo.echo_report('RabbitMQ server not found: falling back to ZMQ broker.')
+            echo.echo_report('RabbitMQ server not found: falling back to ZeroMQ broker.')
             echo.echo_warning(
-                'The ZMQ broker is a new feature. If you experience issues, '
+                'The ZeroMQ broker is a new feature. If you experience issues, '
                 'recreate the profile with `verdi presto --no-broker`.'
             )
-            broker_backend = 'core.zmq'
+            broker_backend = 'core.zeromq'
             broker_config = {}
         else:
             echo.echo_report('RabbitMQ server detected: configuring the profile with RabbitMQ broker.')

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -602,10 +602,10 @@ def process_repair(manager, broker, dry_run, force):
     # Revive zombie processes that no longer have a process task
     zombies = set_active_processes.difference(set_process_tasks)
     if zombies:
-        from aiida.brokers.zmq.broker import ZmqBroker
+        from aiida.brokers.zeromq.broker import ZeromqBroker
 
-        if isinstance(broker, ZmqBroker):
-            # For ZMQ, the broker runs inside the daemon (which must be stopped for repair).
+        if isinstance(broker, ZeromqBroker):
+            # For ZeroMQ, the broker runs inside the daemon (which must be stopped for repair).
             # Write revival tasks directly to the persistent queue on disk — the broker will
             # pick them up when the daemon is restarted.  This avoids starting a temporary
             # broker process and the timing issues that come with it.
@@ -613,7 +613,7 @@ def process_repair(manager, broker, dry_run, force):
 
             from plumpy.process_comms import create_continue_body
 
-            from aiida.brokers.zmq.queue import PersistentQueue
+            from aiida.brokers.zeromq.queue import PersistentQueue
 
             queue_path = broker.storage_path / 'tasks'
             queue = PersistentQueue(queue_path)

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -52,7 +52,7 @@ def command_create_profile(
     :param first_name: First name for the default user.
     :param last_name: Last name for the default user.
     :param institution: Institution for the default user.
-    :param broker: Message broker backend ('rabbitmq', 'zmq', or 'none').
+    :param broker: Message broker backend ('rabbitmq', 'zeromq', or 'none').
     :param use_rabbitmq: Deprecated. Use ``broker`` instead. If False, equivalent to ``broker='none'``.
     :param kwargs: Arguments to initialise instance of the selected storage implementation.
     """
@@ -91,11 +91,11 @@ def command_create_profile(
 
         echo.echo_report('RabbitMQ can be reconfigured with `verdi profile configure-rabbitmq`.')
 
-    elif broker == 'zmq':
-        broker_backend = 'core.zmq'
+    elif broker == 'zeromq':
+        broker_backend = 'core.zeromq'
         broker_config = {}
-        echo.echo_success('ZMQ broker configured (no external service required).')
-        echo.echo_report('The ZMQ broker service will be started automatically with the daemon.')
+        echo.echo_success('ZeroMQ broker configured (no external service required).')
+        echo.echo_report('The ZeroMQ broker service will be started automatically with the daemon.')
 
     else:  # broker == 'none'
         echo.echo_report('Creating profile without a message broker.')

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -134,12 +134,12 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     # Getting the daemon and broker status
     broker = manager.get_broker()
 
-    from aiida.brokers.zmq.broker import ZmqBroker
+    from aiida.brokers.zeromq.broker import ZeromqBroker
 
     if broker:
         # For RabbitMQ: verify broker connectivity as a separate status line
-        # For ZMQ: broker info is shown alongside the daemon status below
-        if not isinstance(broker, ZmqBroker):
+        # For ZeroMQ: broker info is shown alongside the daemon status below
+        if not isinstance(broker, ZeromqBroker):
             try:
                 broker.get_communicator()
             except Exception as exc:
@@ -179,9 +179,9 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     else:
         daemon_status = ServiceStatus.UP
         daemon_msg = f'Daemon is running with PID {status["pid"]}'
-        # Append broker info for managed brokers (e.g., ZMQ)
+        # Append broker info for managed brokers (e.g., ZeroMQ)
 
-        if broker and isinstance(broker, ZmqBroker):
+        if broker and isinstance(broker, ZeromqBroker):
             if broker.is_running:
                 status_info = broker.get_service_status()
                 if status_info:

--- a/src/aiida/cmdline/params/options/commands/setup.py
+++ b/src/aiida/cmdline/params/options/commands/setup.py
@@ -351,11 +351,11 @@ SETUP_USE_RABBITMQ = options.OverridableOption(
 SETUP_BROKER_BACKEND = options.OverridableOption(
     '--broker',
     prompt='Message broker',
-    type=click.Choice(['rabbitmq', 'zmq', 'none']),
+    type=click.Choice(['rabbitmq', 'zeromq', 'none']),
     default='rabbitmq',
     cls=options.interactive.InteractiveOption,
     help='Message broker backend for process control. Use "rabbitmq" for RabbitMQ (requires external server), '
-    '"zmq" for ZeroMQ (built-in, no external dependencies), or "none" to disable (limited functionality).',
+    '"zeromq" for ZeroMQ (built-in, no external dependencies), or "none" to disable (limited functionality).',
 )
 
 SETUP_BROKER_PROTOCOL = QUICKSETUP_BROKER_PROTOCOL.clone(

--- a/src/aiida/cmdline/utils/decorators.py
+++ b/src/aiida/cmdline/utils/decorators.py
@@ -219,13 +219,13 @@ def only_if_daemon_not_running(echo_function=echo.echo_critical, message: str | 
 
 
 @decorator
-def check_circus_zmq_version(wrapped, _, args, kwargs):
-    """Function decorator to check for the right ZMQ version before trying to run circus.
+def check_circus_zeromq_version(wrapped, _, args, kwargs):
+    """Function decorator to check for the right ZeroMQ version before trying to run circus.
 
     Example::
 
         @click.command()
-        @check_circus_zmq_version
+        @check_circus_zeromq_version
         def do_circus_stuff():
             pass
     """
@@ -236,7 +236,7 @@ def check_circus_zmq_version(wrapped, _, args, kwargs):
         if len(zmq_version) < 2:
             raise ValueError()
     except (AttributeError, ValueError):
-        echo.echo_critical('Unknown PyZQM version - aborting...')
+        echo.echo_critical('Unknown PyZMQ version - aborting...')
 
     if zmq_version[0] < 13 or (zmq_version[0] == 13 and zmq_version[1] < 1):
         echo.echo_critical('AiiDA daemon needs PyZMQ >= 13.1.0 to run - aborting...')

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -283,7 +283,7 @@ class DaemonClient:
 
     @property
     def cmd_start_broker(self) -> list[str]:
-        """Return the command to start the ZMQ broker server process."""
+        """Return the command to start the ZeroMQ broker server process."""
         return [self._verdi_bin, '-p', self.profile.name, 'daemon', 'broker']
 
     @property
@@ -942,9 +942,9 @@ class DaemonClient:
 
         watchers = []
 
-        # Start ZMQ broker before workers so its sockets are ready when workers connect.
+        # Start ZeroMQ broker before workers so its sockets are ready when workers connect.
         # Skip if a broker is already running (e.g. started by the test fixture).
-        if self.profile.process_control_backend == 'core.zmq':
+        if self.profile.process_control_backend == 'core.zeromq':
             from aiida.manage.manager import get_manager
 
             broker_instance = get_manager().get_broker()

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -130,15 +130,16 @@ def submit(
     current_manager = manager.get_manager()
     profile = current_manager.get_profile()
 
-    if profile is not None and profile.process_control_backend == 'core.zmq':
+    if profile is not None and profile.process_control_backend == 'core.zeromq':
         daemon_client = current_manager.get_daemon_client()
         # Note: ``is_daemon_running`` only checks for a PID file, so a stale PID from a crashed daemon will let this
         # check pass.
         if not daemon_client.is_daemon_running:
             msg = (
-                'Cannot submit because the daemon is not running. The ZMQ broker is bundled into the daemon for this '
-                'profile, so submission requires `verdi daemon start`. To run the process locally without the daemon '
-                'instead, use `aiida.engine.run` (or `run_get_node`).'
+                'Cannot submit because the daemon is not running. The ZeroMQ broker is bundled into the daemon for '
+                'this profile, so submission requires `verdi daemon start`. To run the process locally without the '
+                'daemon instead, '
+                'use `aiida.engine.run` (or `run_get_node`).'
             )
             raise InvalidOperation(msg)
 

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -359,8 +359,8 @@ class Manager:
             # Backwards compatibility. Before adding broker entry points, profiles used to define ``rabbitmq``.
             if entry_point == 'rabbitmq':
                 entry_point = 'core.rabbitmq'
-            elif entry_point == 'zmq':
-                entry_point = 'core.zmq'
+            elif entry_point == 'zeromq':
+                entry_point = 'core.zeromq'
 
             broker_cls = BrokerFactory(entry_point)
             self._broker = broker_cls(self._profile)

--- a/tests/brokers/test_zeromq.py
+++ b/tests/brokers/test_zeromq.py
@@ -6,29 +6,29 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for the `aiida.brokers.zmq` module."""
+"""Tests for the `aiida.brokers.zeromq` module."""
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aiida.brokers.zmq import ZmqBroker
-from aiida.brokers.zmq.communicator import ZmqCommunicator
-from aiida.brokers.zmq.queue import PersistentQueue
-from aiida.brokers.zmq.server import ZmqBrokerServer
-from aiida.brokers.zmq.service import ZmqBrokerService
-from tests.conftest import start_zmq_broker, stop_zmq_broker
+from aiida.brokers.zeromq import ZeromqBroker
+from aiida.brokers.zeromq.communicator import ZeromqCommunicator
+from aiida.brokers.zeromq.queue import PersistentQueue
+from aiida.brokers.zeromq.server import ZeromqBrokerServer
+from aiida.brokers.zeromq.service import ZeromqBrokerService
+from tests.conftest import start_zeromq_broker, stop_zeromq_broker
 
 
-def _create_broker_with_base_path(base_path: Path) -> ZmqBroker:
-    """Create a ZmqBroker with a custom base path for testing."""
-    with patch('aiida.brokers.zmq.broker.get_broker_base_path', return_value=base_path):
-        return ZmqBroker(MagicMock())
+def _create_broker_with_base_path(base_path: Path) -> ZeromqBroker:
+    """Create a ZeromqBroker with a custom base path for testing."""
+    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=base_path):
+        return ZeromqBroker(MagicMock())
 
 
-class TestZmqBrokerStatusQueries:
-    """Tests for ZmqBroker status queries (file-based)."""
+class TestZeromqBrokerStatusQueries:
+    """Tests for ZeromqBroker status queries (file-based)."""
 
     def test_is_running_no_pid_file(self, tmp_path):
         """Test is_running returns False when no PID file exists."""
@@ -53,59 +53,59 @@ class TestZmqBrokerStatusQueries:
     def test_start_stop_cycle(self, tmp_path):
         """Test querying a running broker service."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
             assert broker.is_running
             assert broker.get_service_pid() is not None
             assert broker.router_endpoint is not None
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
         assert not broker.is_running
 
     def test_start_already_running(self, tmp_path):
         """Test starting when already running is idempotent."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            start_zmq_broker(broker)  # idempotent
+            start_zeromq_broker(broker)  # idempotent
             assert broker.is_running
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_stop_not_running(self, tmp_path):
         """Test stopping when not running is a no-op."""
         broker = _create_broker_with_base_path(tmp_path)
-        stop_zmq_broker(broker)  # Should not raise
+        stop_zeromq_broker(broker)  # Should not raise
 
     def test_restart(self, tmp_path):
         """Test restarting the broker service."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
             old_pid = broker.get_service_pid()
-            stop_zmq_broker(broker)
-            start_zmq_broker(broker)
+            stop_zeromq_broker(broker)
+            start_zeromq_broker(broker)
             assert broker.is_running
 
             new_pid = broker.get_service_pid()
             assert new_pid != old_pid
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
 
-class TestZmqBrokerServer:
-    """Tests for the ZmqBrokerServer."""
+class TestZeromqBrokerServer:
+    """Tests for the ZeromqBrokerServer."""
 
     def test_init(self, tmp_path):
         """Test server initialization."""
         storage_path = tmp_path / 'storage'
         sockets_path = tmp_path / 'sockets'
 
-        server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+        server = ZeromqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
         assert server.storage_path == storage_path
         assert server.sockets_path == sockets_path
 
@@ -114,12 +114,12 @@ class TestZmqBrokerServer:
         import tempfile
 
         # Use short temp directory to avoid socket path length limit
-        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+        with tempfile.TemporaryDirectory(prefix='zeromq') as tmp:
             tmp_path = Path(tmp)
             storage_path = tmp_path / 's'
             sockets_path = tmp_path / 'k'
 
-            server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+            server = ZeromqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
             server.start()
 
             try:
@@ -134,12 +134,12 @@ class TestZmqBrokerServer:
         import tempfile
 
         # Use short temp directory to avoid socket path length limit
-        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+        with tempfile.TemporaryDirectory(prefix='zeromq') as tmp:
             tmp_path = Path(tmp)
             storage_path = tmp_path / 's'
             sockets_path = tmp_path / 'k'
 
-            server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+            server = ZeromqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
             server.start()
 
             try:
@@ -150,19 +150,19 @@ class TestZmqBrokerServer:
                 server.stop()
 
 
-class TestZmqBrokerService:
-    """Tests for the ZmqBrokerService."""
+class TestZeromqBrokerService:
+    """Tests for the ZeromqBrokerService."""
 
     def test_init(self, tmp_path):
         """Test service initialization."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         assert service.base_path == tmp_path
         assert service.pid_file == tmp_path / 'broker.pid'
         assert service.status_file == tmp_path / 'broker.status'
 
     def test_start_stop(self, tmp_path):
         """Test starting and stopping the service."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         service.start()
 
         try:
@@ -247,16 +247,16 @@ class TestPersistentQueue:
         assert task_id2 in task_ids
 
 
-class TestZmqCommunicator:
-    """Tests for the ZmqCommunicator."""
+class TestZeromqCommunicator:
+    """Tests for the ZeromqCommunicator."""
 
     def test_init(self, tmp_path):
         """Test communicator initialization."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            communicator = ZmqCommunicator(
+            communicator = ZeromqCommunicator(
                 router_endpoint=broker.router_endpoint,
             )
             communicator.start()
@@ -268,50 +268,50 @@ class TestZmqCommunicator:
 
             assert communicator.is_closed() is True
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_context_manager(self, tmp_path):
         """Test communicator as context manager."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            with ZmqCommunicator(
+            with ZeromqCommunicator(
                 router_endpoint=broker.router_endpoint,
             ) as communicator:
                 assert communicator.is_closed() is False
 
             assert communicator.is_closed() is True
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
 
-class TestZmqBrokerIntegration:
-    """Integration tests for the ZMQ broker with AiiDA."""
+class TestZeromqBrokerIntegration:
+    """Integration tests for the ZeroMQ broker with AiiDA."""
 
     @pytest.fixture
-    def zmq_broker(self, tmp_path):
-        """Create a ZMQ broker for testing."""
+    def zeromq_broker(self, tmp_path):
+        """Create a ZeroMQ broker for testing."""
         broker_dir = tmp_path / 'broker' / 'test-uuid'
         broker = _create_broker_with_base_path(broker_dir)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         yield broker
 
-        stop_zmq_broker(broker)
+        stop_zeromq_broker(broker)
 
-    def test_broker_lifecycle(self, zmq_broker):
+    def test_broker_lifecycle(self, zeromq_broker):
         """Test the broker lifecycle."""
-        assert zmq_broker.is_running
+        assert zeromq_broker.is_running
 
-        status = zmq_broker.get_service_status()
+        status = zeromq_broker.get_service_status()
         assert status is not None
         assert 'pid' in status
 
-    def test_communicator_connection(self, zmq_broker):
+    def test_communicator_connection(self, zeromq_broker):
         """Test connecting a communicator to the broker."""
-        communicator = ZmqCommunicator(
-            router_endpoint=zmq_broker.router_endpoint,
+        communicator = ZeromqCommunicator(
+            router_endpoint=zeromq_broker.router_endpoint,
         )
         communicator.start()
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for ``aiida.brokers.zmq.broker.ZmqBroker`` and ``ZmqIncomingTask``."""
+"""Tests for ``aiida.brokers.zeromq.broker.ZeromqBroker`` and ``ZeromqIncomingTask``."""
 
 from __future__ import annotations
 
@@ -16,20 +16,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aiida.brokers.zmq import ZmqBroker
-from aiida.brokers.zmq.broker import ZmqIncomingTask
-from aiida.brokers.zmq.communicator import ZmqCommunicator
-from aiida.brokers.zmq.queue import PersistentQueue
-from tests.conftest import start_zmq_broker, stop_zmq_broker
+from aiida.brokers.zeromq import ZeromqBroker
+from aiida.brokers.zeromq.broker import ZeromqIncomingTask
+from aiida.brokers.zeromq.communicator import ZeromqCommunicator
+from aiida.brokers.zeromq.queue import PersistentQueue
+from tests.conftest import start_zeromq_broker, stop_zeromq_broker
 
 
-def _create_broker_with_base_path(base_path: Path) -> ZmqBroker:
-    with patch('aiida.brokers.zmq.broker.get_broker_base_path', return_value=base_path):
-        return ZmqBroker(MagicMock())
+def _create_broker_with_base_path(base_path: Path) -> ZeromqBroker:
+    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=base_path):
+        return ZeromqBroker(MagicMock())
 
 
-class TestZmqBrokerStatusQueries:
-    """Tests for ZmqBroker status queries (file-based)."""
+class TestZeromqBrokerStatusQueries:
+    """Tests for ZeromqBroker status queries (file-based)."""
 
     def test_is_running_no_pid_file(self, tmp_path):
         """Test is_running returns False when no PID file exists."""
@@ -54,59 +54,59 @@ class TestZmqBrokerStatusQueries:
     def test_start_stop_cycle(self, tmp_path):
         """Test querying a running broker service."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
             assert broker.is_running
             assert broker.get_service_pid() is not None
             assert broker.router_endpoint is not None
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
         assert not broker.is_running
 
     def test_start_already_running(self, tmp_path):
         """Test starting when already running is idempotent."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            start_zmq_broker(broker)  # idempotent
+            start_zeromq_broker(broker)  # idempotent
             assert broker.is_running
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_stop_not_running(self, tmp_path):
         """Test stopping when not running is a no-op."""
         broker = _create_broker_with_base_path(tmp_path)
-        stop_zmq_broker(broker)  # Should not raise
+        stop_zeromq_broker(broker)  # Should not raise
 
     def test_restart(self, tmp_path):
         """Test restarting the broker service."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
             old_pid = broker.get_service_pid()
-            stop_zmq_broker(broker)
-            start_zmq_broker(broker)
+            stop_zeromq_broker(broker)
+            start_zeromq_broker(broker)
             assert broker.is_running
 
             new_pid = broker.get_service_pid()
             assert new_pid != old_pid
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_str_running(self, tmp_path):
         """Test __str__ when running."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
         try:
             s = str(broker)
-            assert 'ZMQ Broker' in s
+            assert 'ZeroMQ Broker' in s
             assert 'PID' in s
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_str_not_running(self, tmp_path):
         """Test __str__ when not running."""
@@ -140,7 +140,7 @@ class TestZmqBrokerStatusQueries:
         """Test PID file with sentinel format."""
         broker = _create_broker_with_base_path(tmp_path)
         pid_file = tmp_path / 'broker.pid'
-        pid_file.write_text('aiida-zmq-broker 12345')
+        pid_file.write_text('aiida-zeromq-broker 12345')
         assert broker.get_service_pid() == 12345
 
     def test_get_service_pid_bare_format(self, tmp_path):
@@ -161,7 +161,7 @@ class TestZmqBrokerStatusQueries:
         """Test is_running with stale PID."""
         broker = _create_broker_with_base_path(tmp_path)
         pid_file = tmp_path / 'broker.pid'
-        pid_file.write_text('aiida-zmq-broker 999999')  # Non-existent PID
+        pid_file.write_text('aiida-zeromq-broker 999999')  # Non-existent PID
         assert not broker.is_running
 
     def test_get_service_status_valid(self, tmp_path):
@@ -184,7 +184,7 @@ class TestZmqBrokerStatusQueries:
         """Test _cleanup_stale_service_files removes all stale files."""
         broker = _create_broker_with_base_path(tmp_path)
 
-        (tmp_path / 'broker.pid').write_text('aiida-zmq-broker 1')
+        (tmp_path / 'broker.pid').write_text('aiida-zeromq-broker 1')
         (tmp_path / 'broker.status').write_text('{}')
         sockets_dir = tmp_path / 'test_sockets'
         sockets_dir.mkdir()
@@ -198,13 +198,13 @@ class TestZmqBrokerStatusQueries:
         assert not sockets_dir.exists()
 
 
-class TestZmqBrokerCommunicator:
-    """Tests for ZmqBroker communicator management."""
+class TestZeromqBrokerCommunicator:
+    """Tests for ZeromqBroker communicator management."""
 
     def test_get_communicator_and_close(self, tmp_path):
         """Test get_communicator and close."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
             with patch('aiida.manage.configuration.get_config_option', return_value=None):
@@ -217,7 +217,7 @@ class TestZmqBrokerCommunicator:
                 assert comm2 is comm
         finally:
             broker.close()
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_get_communicator_timeout(self, tmp_path):
         """Test get_communicator raises on timeout when broker not running."""
@@ -232,8 +232,8 @@ class TestZmqBrokerCommunicator:
             assert b is broker
 
 
-class TestZmqBrokerTasks:
-    """Tests for ZmqBroker task iteration."""
+class TestZeromqBrokerTasks:
+    """Tests for ZeromqBroker task iteration."""
 
     def test_iterate_tasks_no_queue(self, tmp_path):
         """Test iterate_tasks when queue path doesn't exist."""
@@ -251,18 +251,18 @@ class TestZmqBrokerTasks:
 
         tasks = list(broker.iterate_tasks())
         assert len(tasks) == 2
-        assert all(isinstance(t, ZmqIncomingTask) for t in tasks)
+        assert all(isinstance(t, ZeromqIncomingTask) for t in tasks)
 
 
-class TestZmqIncomingTask:
-    """Tests for ZmqIncomingTask."""
+class TestZeromqIncomingTask:
+    """Tests for ZeromqIncomingTask."""
 
     def test_processing_context_manager(self, tmp_path):
-        """Test ZmqIncomingTask.processing context manager."""
+        """Test ZeromqIncomingTask.processing context manager."""
         queue = PersistentQueue(tmp_path)
         queue.push('t1', {'body': 'test_body'})
 
-        task = ZmqIncomingTask('t1', {'body': 'test_body'}, queue)
+        task = ZeromqIncomingTask('t1', {'body': 'test_body'}, queue)
         assert task.body == 'test_body'
 
         with task.processing() as outcome:
@@ -272,32 +272,32 @@ class TestZmqIncomingTask:
         assert queue.remove_pending('t1') is False
 
 
-class TestZmqBrokerIntegration:
-    """Integration tests for the ZMQ broker with AiiDA."""
+class TestZeromqBrokerIntegration:
+    """Integration tests for the ZeroMQ broker with AiiDA."""
 
     @pytest.fixture
-    def zmq_broker(self, tmp_path):
-        """Create a ZMQ broker for testing."""
+    def zeromq_broker(self, tmp_path):
+        """Create a ZeroMQ broker for testing."""
         broker_dir = tmp_path / 'broker' / 'test-uuid'
         broker = _create_broker_with_base_path(broker_dir)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         yield broker
 
-        stop_zmq_broker(broker)
+        stop_zeromq_broker(broker)
 
-    def test_broker_lifecycle(self, zmq_broker):
+    def test_broker_lifecycle(self, zeromq_broker):
         """Test the broker lifecycle."""
-        assert zmq_broker.is_running
+        assert zeromq_broker.is_running
 
-        status = zmq_broker.get_service_status()
+        status = zeromq_broker.get_service_status()
         assert status is not None
         assert 'pid' in status
 
-    def test_communicator_connection(self, zmq_broker):
+    def test_communicator_connection(self, zeromq_broker):
         """Test connecting a communicator to the broker."""
-        communicator = ZmqCommunicator(
-            router_endpoint=zmq_broker.router_endpoint,
+        communicator = ZeromqCommunicator(
+            router_endpoint=zeromq_broker.router_endpoint,
         )
         communicator.start()
 

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for ``aiida.brokers.zmq.communicator.ZmqCommunicator``."""
+"""Tests for ``aiida.brokers.zeromq.communicator.ZeromqCommunicator``."""
 
 from __future__ import annotations
 
@@ -18,26 +18,26 @@ from unittest.mock import MagicMock, patch
 import kiwipy
 import pytest
 
-from aiida.brokers.zmq import ZmqBroker
-from aiida.brokers.zmq.communicator import ZmqCommunicator
-from tests.conftest import start_zmq_broker, stop_zmq_broker
+from aiida.brokers.zeromq import ZeromqBroker
+from aiida.brokers.zeromq.communicator import ZeromqCommunicator
+from tests.conftest import start_zeromq_broker, stop_zeromq_broker
 
 
-def _create_broker_with_base_path(base_path: Path) -> ZmqBroker:
-    with patch('aiida.brokers.zmq.broker.get_broker_base_path', return_value=base_path):
-        return ZmqBroker(MagicMock())
+def _create_broker_with_base_path(base_path: Path) -> ZeromqBroker:
+    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=base_path):
+        return ZeromqBroker(MagicMock())
 
 
-class TestZmqCommunicatorLifecycle:
+class TestZeromqCommunicatorLifecycle:
     """Tests for communicator initialization and lifecycle."""
 
     def test_init(self, tmp_path):
         """Test communicator initialization."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            communicator = ZmqCommunicator(router_endpoint=broker.router_endpoint)
+            communicator = ZeromqCommunicator(router_endpoint=broker.router_endpoint)
             communicator.start()
 
             try:
@@ -47,57 +47,57 @@ class TestZmqCommunicatorLifecycle:
 
             assert communicator.is_closed() is True
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_context_manager(self, tmp_path):
         """Test communicator as context manager."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            with ZmqCommunicator(router_endpoint=broker.router_endpoint) as communicator:
+            with ZeromqCommunicator(router_endpoint=broker.router_endpoint) as communicator:
                 assert communicator.is_closed() is False
 
             assert communicator.is_closed() is True
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_close_idempotent(self, tmp_path):
         """Test close is idempotent."""
         broker = _create_broker_with_base_path(tmp_path)
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
         try:
-            comm = ZmqCommunicator(router_endpoint=broker.router_endpoint)
+            comm = ZeromqCommunicator(router_endpoint=broker.router_endpoint)
             comm.start()
             comm.close()
             comm.close()  # should not raise
             assert comm.is_closed()
         finally:
-            stop_zmq_broker(broker)
+            stop_zeromq_broker(broker)
 
     def test_ensure_open_raises_when_closed(self):
         """Test _ensure_open raises when communicator is closed."""
-        comm = ZmqCommunicator(router_endpoint='ipc:///tmp/fake')
+        comm = ZeromqCommunicator(router_endpoint='ipc:///tmp/fake')
         with pytest.raises(RuntimeError, match='closed'):
             comm.task_send({'x': 1})
 
 
-class TestZmqCommunicatorMessaging:
+class TestZeromqCommunicatorMessaging:
     """Tests for communicator messaging operations with a real broker."""
 
     @pytest.fixture
     def broker_and_comm(self, tmp_path):
         broker = _create_broker_with_base_path(tmp_path / 'broker')
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
-        comm = ZmqCommunicator(router_endpoint=broker.router_endpoint)
+        comm = ZeromqCommunicator(router_endpoint=broker.router_endpoint)
         comm.start()
 
         yield broker, comm
 
         comm.close()
-        stop_zmq_broker(broker)
+        stop_zeromq_broker(broker)
 
     def test_task_send_no_reply(self, broker_and_comm):
         """Test task_send with no_reply=True returns None."""
@@ -152,25 +152,25 @@ class TestZmqCommunicatorMessaging:
         comm.remove_broadcast_subscriber('my-bcast')
 
 
-class TestZmqCommunicatorRoundTrip:
+class TestZeromqCommunicatorRoundTrip:
     """Integration tests for full task, RPC, and broadcast round-trips."""
 
     @pytest.fixture
     def sender_and_worker(self, tmp_path):
         broker = _create_broker_with_base_path(tmp_path / 'broker')
-        start_zmq_broker(broker)
+        start_zeromq_broker(broker)
 
-        sender = ZmqCommunicator(router_endpoint=broker.router_endpoint, client_id='sender')
+        sender = ZeromqCommunicator(router_endpoint=broker.router_endpoint, client_id='sender')
         sender.start()
 
-        worker = ZmqCommunicator(router_endpoint=broker.router_endpoint, client_id='worker')
+        worker = ZeromqCommunicator(router_endpoint=broker.router_endpoint, client_id='worker')
         worker.start()
 
         yield broker, sender, worker
 
         worker.close()
         sender.close()
-        stop_zmq_broker(broker)
+        stop_zeromq_broker(broker)
 
     def test_task_round_trip(self, sender_and_worker):
         """Test task send gets immediate broker acknowledgment.

--- a/tests/brokers/test_zeromq_payload_optimization.py
+++ b/tests/brokers/test_zeromq_payload_optimization.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for ZMQ single-layer JSON encoding.
+"""Tests for ZeroMQ single-layer JSON encoding.
 
 This module tests that the message protocol uses a single JSON encoding layer
 for both the envelope and payload, including UUID serialization support.
@@ -20,13 +20,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aiida.brokers.zmq.protocol import (
+from aiida.brokers.zeromq.protocol import (
     MessageType,
     _UUIDEncoder,
     decode_message,
     encode_message,
 )
-from aiida.brokers.zmq.server import ZmqBrokerServer
+from aiida.brokers.zeromq.server import ZeromqBrokerServer
 
 
 @pytest.mark.presto
@@ -112,9 +112,9 @@ class TestCommunicatorPayloadEncoding:
 
     def test_send_encodes_body_as_json_native(self):
         """Test that _send passes body through as a JSON-native object (no pre-encoding)."""
-        from aiida.brokers.zmq.communicator import ZmqCommunicator
+        from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 
-        comm = ZmqCommunicator(router_endpoint='ipc://test')
+        comm = ZeromqCommunicator(router_endpoint='ipc://test')
         comm._dealer = MagicMock()
         comm._closed = False
 
@@ -139,9 +139,9 @@ class TestCommunicatorPayloadEncoding:
 
     def test_send_encodes_result_as_json_native(self):
         """Test that _send passes result through as a JSON-native object."""
-        from aiida.brokers.zmq.communicator import ZmqCommunicator
+        from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 
-        comm = ZmqCommunicator(router_endpoint='ipc://test')
+        comm = ZeromqCommunicator(router_endpoint='ipc://test')
         comm._dealer = MagicMock()
         comm._closed = False
 
@@ -167,9 +167,9 @@ class TestCommunicatorPayloadEncoding:
 
     def test_send_ignores_none_body(self):
         """Test that _send doesn't fail with None body."""
-        from aiida.brokers.zmq.communicator import ZmqCommunicator
+        from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 
-        comm = ZmqCommunicator(router_endpoint='ipc://test')
+        comm = ZeromqCommunicator(router_endpoint='ipc://test')
         comm._dealer = MagicMock()
         comm._closed = False
 
@@ -191,9 +191,9 @@ class TestCommunicatorPayloadEncoding:
 
     def test_dispatch_passes_body_directly(self):
         """Test that _dispatch_dealer_message passes body directly (no post-decode)."""
-        from aiida.brokers.zmq.communicator import ZmqCommunicator
+        from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 
-        comm = ZmqCommunicator(router_endpoint='ipc://test')
+        comm = ZeromqCommunicator(router_endpoint='ipc://test')
         comm._dealer = MagicMock()
         comm._closed = False
 
@@ -217,12 +217,12 @@ class TestCommunicatorPayloadEncoding:
         assert received_body == original_body
 
     def test_communicator_no_encoder_decoder_params(self):
-        """Verify ZmqCommunicator.__init__ has no encoder/decoder parameters."""
+        """Verify ZeromqCommunicator.__init__ has no encoder/decoder parameters."""
         import inspect
 
-        from aiida.brokers.zmq.communicator import ZmqCommunicator
+        from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 
-        sig = inspect.signature(ZmqCommunicator.__init__)
+        sig = inspect.signature(ZeromqCommunicator.__init__)
         param_names = [p for p in sig.parameters.keys() if p != 'self']
         assert 'encoder' not in param_names
         assert 'decoder' not in param_names
@@ -233,10 +233,10 @@ class TestServerInitializationOptimization:
     """Tests for server.py encoder/decoder parameter removal."""
 
     def test_server_init_no_encoder_parameter(self, tmp_path):
-        """Test ZmqBrokerServer.__init__ has no encoder/decoder parameters."""
+        """Test ZeromqBrokerServer.__init__ has no encoder/decoder parameters."""
         import inspect
 
-        sig = inspect.signature(ZmqBrokerServer.__init__)
+        sig = inspect.signature(ZeromqBrokerServer.__init__)
         param_names = [p for p in sig.parameters.keys() if p != 'self']
         assert 'storage_path' in param_names
         assert 'sockets_path' in param_names
@@ -248,7 +248,7 @@ class TestServerInitializationOptimization:
         storage_path = tmp_path / 'storage'
         sockets_path = tmp_path / 'sockets'
 
-        server = ZmqBrokerServer(storage_path, sockets_path)
+        server = ZeromqBrokerServer(storage_path, sockets_path)
         assert server.storage_path == storage_path
         assert server.sockets_path == sockets_path
 
@@ -259,7 +259,7 @@ class TestQueueCompressionOptimization:
 
     def test_queue_push_no_indent(self, tmp_path):
         """Test that queue.push writes JSON without indent."""
-        from aiida.brokers.zmq.queue import PersistentQueue
+        from aiida.brokers.zeromq.queue import PersistentQueue
 
         queue = PersistentQueue(tmp_path / 'queue')
 
@@ -287,7 +287,7 @@ class TestQueueCompressionOptimization:
 
     def test_queue_pop_handles_minified_json(self, tmp_path):
         """Test that queue.pop can read minified JSON."""
-        from aiida.brokers.zmq.queue import PersistentQueue
+        from aiida.brokers.zeromq.queue import PersistentQueue
 
         queue = PersistentQueue(tmp_path / 'queue')
 
@@ -318,12 +318,12 @@ class TestQueueCompressionOptimization:
 
 @pytest.mark.presto
 class TestTaskBodyPreEncoding:
-    """Tests for task body handling in ZmqIncomingTask."""
+    """Tests for task body handling in ZeromqIncomingTask."""
 
-    def test_zmq_incoming_task_reads_body_directly(self):
-        """Test that ZmqIncomingTask reads body directly as a JSON-native object."""
-        from aiida.brokers.zmq.broker import ZmqIncomingTask
-        from aiida.brokers.zmq.queue import PersistentQueue
+    def test_zeromq_incoming_task_reads_body_directly(self):
+        """Test that ZeromqIncomingTask reads body directly as a JSON-native object."""
+        from aiida.brokers.zeromq.broker import ZeromqIncomingTask
+        from aiida.brokers.zeromq.queue import PersistentQueue
 
         original_body = {'function': 'test_function', 'args': [1, 2, 3]}
 
@@ -335,14 +335,14 @@ class TestTaskBodyPreEncoding:
         }
 
         queue = MagicMock(spec=PersistentQueue)
-        task = ZmqIncomingTask(task_id='task-123', task_data=task_data, queue=queue)
+        task = ZeromqIncomingTask(task_id='task-123', task_data=task_data, queue=queue)
 
         assert task.body == original_body
 
-    def test_zmq_incoming_task_handles_none_body(self):
-        """Test that ZmqIncomingTask handles None body."""
-        from aiida.brokers.zmq.broker import ZmqIncomingTask
-        from aiida.brokers.zmq.queue import PersistentQueue
+    def test_zeromq_incoming_task_handles_none_body(self):
+        """Test that ZeromqIncomingTask handles None body."""
+        from aiida.brokers.zeromq.broker import ZeromqIncomingTask
+        from aiida.brokers.zeromq.queue import PersistentQueue
 
         task_data = {
             'id': 'task-456',
@@ -351,7 +351,7 @@ class TestTaskBodyPreEncoding:
         }
 
         queue = MagicMock(spec=PersistentQueue)
-        task = ZmqIncomingTask(task_id='task-456', task_data=task_data, queue=queue)
+        task = ZeromqIncomingTask(task_id='task-456', task_data=task_data, queue=queue)
 
         assert task.body is None
 

--- a/tests/brokers/test_zeromq_queue.py
+++ b/tests/brokers/test_zeromq_queue.py
@@ -6,11 +6,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for ``aiida.brokers.zmq.queue.PersistentQueue``."""
+"""Tests for ``aiida.brokers.zeromq.queue.PersistentQueue``."""
 
 from __future__ import annotations
 
-from aiida.brokers.zmq.queue import PersistentQueue
+from aiida.brokers.zeromq.queue import PersistentQueue
 
 
 class TestPersistentQueue:

--- a/tests/brokers/test_zeromq_server.py
+++ b/tests/brokers/test_zeromq_server.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for ``aiida.brokers.zmq.server.ZmqBrokerServer``."""
+"""Tests for ``aiida.brokers.zeromq.server.ZeromqBrokerServer``."""
 
 from __future__ import annotations
 
@@ -17,27 +17,27 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aiida.brokers.zmq.protocol import MessageType, decode_message, encode_message
-from aiida.brokers.zmq.server import ZmqBrokerServer
+from aiida.brokers.zeromq.protocol import MessageType, decode_message, encode_message
+from aiida.brokers.zeromq.server import ZeromqBrokerServer
 
 
-class TestZmqBrokerServerInit:
-    """Tests for ZmqBrokerServer initialization and lifecycle."""
+class TestZeromqBrokerServerInit:
+    """Tests for ZeromqBrokerServer initialization and lifecycle."""
 
     def test_init(self, tmp_path):
         """Test server initialization."""
         storage_path = tmp_path / 'storage'
         sockets_path = tmp_path / 'sockets'
 
-        server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+        server = ZeromqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
         assert server.storage_path == storage_path
         assert server.sockets_path == sockets_path
 
     def test_start_stop(self):
         """Test starting and stopping the server."""
-        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+        with tempfile.TemporaryDirectory(prefix='zeromq') as tmp:
             tmp_path = Path(tmp)
-            server = ZmqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
+            server = ZeromqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
             server.start()
 
             try:
@@ -49,9 +49,9 @@ class TestZmqBrokerServerInit:
 
     def test_start_idempotent(self):
         """Test start is idempotent."""
-        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+        with tempfile.TemporaryDirectory(prefix='zeromq') as tmp:
             tmp_path = Path(tmp)
-            server = ZmqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
+            server = ZeromqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
             server.start()
             try:
                 server.start()  # should be no-op
@@ -61,19 +61,19 @@ class TestZmqBrokerServerInit:
 
     def test_stop_idempotent(self, tmp_path):
         """Test stop when not running is no-op."""
-        server = ZmqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
+        server = ZeromqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
         server.stop()  # should not raise
 
     def test_run_once_not_running(self, tmp_path):
         """Test run_once when not running returns False."""
-        server = ZmqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
+        server = ZeromqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
         assert server.run_once() is False
 
     def test_get_status(self, tmp_path):
         """Test get_status returns expected keys."""
-        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+        with tempfile.TemporaryDirectory(prefix='zeromq') as tmp:
             tmp_path = Path(tmp)
-            server = ZmqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
+            server = ZeromqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
             server.start()
 
             try:
@@ -84,7 +84,7 @@ class TestZmqBrokerServerInit:
                 server.stop()
 
 
-class TestZmqBrokerServerMessageHandling:
+class TestZeromqBrokerServerMessageHandling:
     """Tests for server message handling paths.
 
     Calls handler methods directly to test dispatch logic without real sockets.
@@ -94,7 +94,7 @@ class TestZmqBrokerServerMessageHandling:
     def server(self, tmp_path):
         storage_path = tmp_path / 'storage'
         sockets_path = tmp_path / 'sockets'
-        return ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+        return ZeromqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
 
     # --- Task handling ---
 
@@ -376,14 +376,14 @@ class TestZmqBrokerServerMessageHandling:
         assert status['pending_tasks'] == 0
 
 
-class TestZmqBrokerServerWithSockets:
-    """Tests using a real running server with ZMQ sockets."""
+class TestZeromqBrokerServerWithSockets:
+    """Tests using a real running server with ZeroMQ sockets."""
 
     @pytest.fixture
     def running_server(self):
-        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+        with tempfile.TemporaryDirectory(prefix='zeromq') as tmp:
             tmp_path = Path(tmp)
-            server = ZmqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
+            server = ZeromqBrokerServer(storage_path=tmp_path / 's', sockets_path=tmp_path / 'k')
             server.start()
             try:
                 yield server
@@ -397,12 +397,12 @@ class TestZmqBrokerServerWithSockets:
 
     def test_handle_router_message_live(self, running_server):
         """Test sending a message through the actual ROUTER socket."""
-        import zmq as zmq_sync
+        import zmq
 
-        ctx = zmq_sync.Context()
+        ctx = zmq.Context()
         try:
-            dealer = ctx.socket(zmq_sync.DEALER)
-            dealer.setsockopt_string(zmq_sync.IDENTITY, 'test-client')
+            dealer = ctx.socket(zmq.DEALER)
+            dealer.setsockopt_string(zmq.IDENTITY, 'test-client')
             dealer.connect(running_server.router_endpoint)
             time.sleep(0.1)
 
@@ -433,8 +433,8 @@ class TestZmqBrokerServerWithSockets:
             running_server.run_once(timeout=0.5)
 
             # Worker should receive the task (poll with timeout to avoid race)
-            poller = zmq_sync.Poller()
-            poller.register(dealer, zmq_sync.POLLIN)
+            poller = zmq.Poller()
+            poller.register(dealer, zmq.POLLIN)
             socks = dict(poller.poll(timeout=2000))
             assert dealer in socks, 'Worker did not receive dispatched task'
 

--- a/tests/brokers/test_zeromq_service.py
+++ b/tests/brokers/test_zeromq_service.py
@@ -6,29 +6,29 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Tests for ``aiida.brokers.zmq.service.ZmqBrokerService``."""
+"""Tests for ``aiida.brokers.zeromq.service.ZeromqBrokerService``."""
 
 from __future__ import annotations
 
 import threading
 import time
 
-from aiida.brokers.zmq.service import ZmqBrokerService
+from aiida.brokers.zeromq.service import ZeromqBrokerService
 
 
-class TestZmqBrokerService:
-    """Tests for the ZmqBrokerService."""
+class TestZeromqBrokerService:
+    """Tests for the ZeromqBrokerService."""
 
     def test_init(self, tmp_path):
         """Test service initialization."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         assert service.base_path == tmp_path
         assert service.pid_file == tmp_path / 'broker.pid'
         assert service.status_file == tmp_path / 'broker.status'
 
     def test_start_stop(self, tmp_path):
         """Test starting and stopping the service."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         service.start()
 
         try:
@@ -42,7 +42,7 @@ class TestZmqBrokerService:
 
     def test_start_idempotent(self, tmp_path):
         """Test start is idempotent."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         service.start()
         try:
             service.start()  # should be no-op
@@ -52,7 +52,7 @@ class TestZmqBrokerService:
 
     def test_stop_idempotent(self, tmp_path):
         """Test stop when not running is no-op."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         service.stop()  # should not raise
 
     def test_orphaned_sockets_cleanup(self, tmp_path):
@@ -62,7 +62,7 @@ class TestZmqBrokerService:
         old_sockets.mkdir()
         sockets_file.write_text(str(old_sockets))
 
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
         service.start()
         try:
             assert not old_sockets.exists()
@@ -71,7 +71,7 @@ class TestZmqBrokerService:
 
     def test_run_forever_with_early_stop(self, tmp_path):
         """Test run_forever exits when _running is set to False."""
-        service = ZmqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(base_path=tmp_path)
 
         def stop_after_delay():
             time.sleep(0.5)

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -43,7 +43,7 @@ def test_get_default_presto_profile_name(monkeypatch, profile_names, expected):
 
 @pytest.mark.usefixtures('empty_config', 'mock_daemon_client')
 def test_presto_without_rmq(run_cli_command, monkeypatch):
-    """Test the ``verdi presto`` without RabbitMQ falls back to ZMQ."""
+    """Test the ``verdi presto`` without RabbitMQ falls back to ZeroMQ."""
     from aiida.brokers.rabbitmq import defaults
 
     def detect_rabbitmq_config(**kwargs):
@@ -59,13 +59,13 @@ def test_presto_without_rmq(run_cli_command, monkeypatch):
         assert profile.name == 'presto'
         localhost = Computer.collection.get(label='localhost')
         assert localhost.is_configured
-        # When RabbitMQ is not available, presto falls back to ZMQ broker
-        assert profile.process_control_backend == 'core.zmq'
+        # When RabbitMQ is not available, presto falls back to ZeroMQ broker
+        assert profile.process_control_backend == 'core.zeromq'
 
 
 @pytest.mark.usefixtures('empty_config', 'mock_daemon_client')
 def test_presto(run_cli_command):
-    """Test that ``verdi presto`` configures a broker (RabbitMQ if available, otherwise ZMQ)."""
+    """Test that ``verdi presto`` configures a broker (RabbitMQ if available, otherwise ZeroMQ)."""
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile `presto`.' in result.output
 
@@ -73,8 +73,8 @@ def test_presto(run_cli_command):
         assert profile.name == 'presto'
         localhost = Computer.collection.get(label='localhost')
         assert localhost.is_configured
-        # Presto auto-detects RabbitMQ, falls back to ZMQ if not available
-        assert profile.process_control_backend in ('core.rabbitmq', 'core.zmq')
+        # Presto auto-detects RabbitMQ, falls back to ZeroMQ if not available
+        assert profile.process_control_backend in ('core.rabbitmq', 'core.zeromq')
 
 
 @pytest.mark.requires_psql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,14 +63,14 @@ class TestBrokerBackend(Enum):
     """Options for the '--broker-backend' CLI argument when running pytest."""
 
     RMQ = 'rmq'
-    ZMQ = 'zmq'
+    ZEROMQ = 'zmq'
     NONE = 'none'
 
 
-def start_zmq_broker(broker, timeout: float = 10.0):
-    """Start a ZMQ broker service subprocess for testing.
+def start_zeromq_broker(broker, timeout: float = 10.0):
+    """Start a ZeroMQ broker service subprocess for testing.
 
-    :param broker: A ``ZmqBroker`` instance (has ``base_path``, ``is_running``, etc.)
+    :param broker: A ``ZeromqBroker`` instance (has ``base_path``, ``is_running``, etc.)
     """
     broker.base_path.mkdir(parents=True, exist_ok=True)
 
@@ -78,7 +78,7 @@ def start_zmq_broker(broker, timeout: float = 10.0):
         return
 
     subprocess.Popen(
-        [sys.executable, '-m', 'aiida.brokers.zmq.service', '--base-path', str(broker.base_path)],
+        [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--base-path', str(broker.base_path)],
         start_new_session=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -91,13 +91,13 @@ def start_zmq_broker(broker, timeout: float = 10.0):
             return
         time.sleep(0.1)
 
-    raise TimeoutError(f'ZMQ broker did not start within {timeout}s')
+    raise TimeoutError(f'ZeroMQ broker did not start within {timeout}s')
 
 
-def stop_zmq_broker(broker, timeout: float = 5.0):
-    """Stop a ZMQ broker service subprocess for testing.
+def stop_zeromq_broker(broker, timeout: float = 5.0):
+    """Stop a ZeroMQ broker service subprocess for testing.
 
-    :param broker: A ``ZmqBroker`` instance
+    :param broker: A ``ZeromqBroker`` instance
     """
     pid = broker.get_service_pid()
     if pid is None or not broker.is_running:
@@ -129,7 +129,7 @@ def pytest_collection_modifyitems(items, config):
 
     Most notably, we add the 'presto' marker for all tests that
     are not marked with requires_rmq, requires_psql, or nightly.
-    Tests marked requires_broker are included in presto since ZMQ
+    Tests marked requires_broker are included in presto since ZeroMQ
     broker is available without external services.
     """
     filepath_psqldos = Path(__file__).parent / 'storage' / 'psql_dos'
@@ -147,9 +147,9 @@ def pytest_collection_modifyitems(items, config):
     # Handle broker backend selection
     broker_backend = config.option.broker_backend
 
-    # If using ZMQ, skip tests that specifically require RabbitMQ (requires_rmq marker)
+    # If using ZeroMQ, skip tests that specifically require RabbitMQ (requires_rmq marker)
     # but allow tests with requires_broker marker (they work with any broker)
-    if broker_backend is TestBrokerBackend.ZMQ:
+    if broker_backend is TestBrokerBackend.ZEROMQ:
         if config.option.markexpr != '':
             config.option.markexpr += ' and (not requires_rmq)'
         else:
@@ -169,7 +169,7 @@ def pytest_collection_modifyitems(items, config):
         if filepath_item.is_relative_to(filepath_django) or filepath_item.is_relative_to(filepath_sqla):
             item.add_marker('nightly')
 
-        # Add 'requires_broker' for tests that depend on 'daemon_client' fixture (works with RMQ or ZMQ)
+        # Add 'requires_broker' for tests that depend on 'daemon_client' fixture (works with RMQ or ZeroMQ)
         if 'daemon_client' in item.fixturenames:
             item.add_marker('requires_broker')
 
@@ -178,7 +178,7 @@ def pytest_collection_modifyitems(items, config):
             item.add_marker('requires_psql')
 
         # Add 'presto' marker to tests that don't need external services.
-        # Tests with requires_broker ARE included (ZMQ broker needs no external service).
+        # Tests with requires_broker ARE included (ZeroMQ broker needs no external service).
         # Tests with requires_rmq, requires_psql, or nightly are excluded.
         markers = [marker.name for marker in item.iter_markers()]
         if 'requires_rmq' not in markers and 'requires_psql' not in markers and 'nightly' not in markers:
@@ -294,12 +294,12 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
 
     # Determine broker based on CLI option and markers
     if 'presto' in marker_opts:
-        # Presto tests use ZMQ broker (no external service required)
-        broker = 'core.zmq'
+        # Presto tests use ZeroMQ broker (no external service required)
+        broker = 'core.zeromq'
     elif broker_backend is TestBrokerBackend.RMQ:
         broker = 'core.rabbitmq'
-    elif broker_backend is TestBrokerBackend.ZMQ:
-        broker = 'core.zmq'
+    elif broker_backend is TestBrokerBackend.ZEROMQ:
+        broker = 'core.zeromq'
     else:  # TestBrokerBackend.NONE
         broker = None
 
@@ -316,14 +316,14 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
     with aiida_profile_factory(
         aiida_config, storage_backend=storage, storage_config=config, broker_backend=broker
     ) as profile:
-        # Start ZMQ broker service if needed (tests don't use circus)
+        # Start ZeroMQ broker service if needed (tests don't use circus)
         broker_instance = get_manager().get_broker()
         if broker_instance is not None and hasattr(broker_instance, 'is_running'):
-            start_zmq_broker(broker_instance)
+            start_zeromq_broker(broker_instance)
             try:
                 yield profile
             finally:
-                stop_zmq_broker(broker_instance)
+                stop_zeromq_broker(broker_instance)
         else:
             yield profile
 

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.requires_broker
 def test_ipc_socket_file_length_limit():
     """The maximum length of socket filepaths is often limited by the operating system.
     For MacOS it is limited to 103 bytes, versus 107 bytes on Unix. This limit is
-    exposed by the Zmq library which is used by Circus library that is used to
+    exposed by the ZeroMQ library which is used by Circus library that is used to
     daemonize the daemon runners. This test verifies that the three endpoints used
     for the Circus client have a filepath that does not exceed that path limit.
 

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -105,7 +105,7 @@ def test_submit_no_broker(arithmetic_add_builder, monkeypatch, manager):
 def test_submit_without_daemon(aiida_config_tmp, aiida_profile_factory, config_sqlite_dos):
     """Test ``submit`` raises a meaningful error if the daemon is not running.
 
-    A ZMQ profile is used here because the daemon check is specific to the ZMQ broker.
+    A ZeroMQ profile is used here because the daemon check is specific to the ZeroMQ broker.
     """
     from aiida.manage import get_manager
 
@@ -113,7 +113,7 @@ def test_submit_without_daemon(aiida_config_tmp, aiida_profile_factory, config_s
         aiida_config_tmp,
         storage_backend='core.sqlite_dos',
         storage_config=config_sqlite_dos(),
-        broker_backend='core.zmq',
+        broker_backend='core.zeromq',
         broker_config={},
     ):
         assert not get_manager().get_daemon_client().is_daemon_running

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -445,10 +445,10 @@ def test_run_launchers():
 def test_submit_launchers():
     """Verify that submit to daemon works.
 
-    Marked ``requires_rmq`` (not ``requires_broker``) because under the ``core.zmq`` profile the broker is bundled into
-    the daemon, so ``aiida.engine.launch.submit`` raises ``InvalidOperation`` when the daemon is not up — which a CI
-    run with only the broker started would trip. The ZMQ submit-of-process-function path is exercised by the daemon
-    system tests under ``.github/system_tests/test_daemon.py``.
+    Marked ``requires_rmq`` (not ``requires_broker``) because under the ``core.zeromq`` profile the broker is bundled
+    into the daemon, so ``aiida.engine.launch.submit`` raises ``InvalidOperation`` when the daemon is not up — which a
+    CI run with only the broker started would trip. The ZeroMQ submit-of-process-function path is exercised by the
+    daemon system tests under ``.github/system_tests/test_daemon.py``.
     """
     # Process function can be submitted and will be run by a daemon worker as long as the function is importable
     # Note that the actual running is not tested here but is done so in `.github/system_tests/test_daemon.py`.

--- a/tests/engine/test_zeromq.py
+++ b/tests/engine/test_zeromq.py
@@ -6,10 +6,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Module to test ZMQ broker process control.
+"""Module to test ZeroMQ broker process control.
 
 These tests mirror tests/engine/test_rmq.py but use the requires_broker marker
-so they run with the ZMQ broker backend.
+so they run with the ZeroMQ broker backend.
 """
 
 import asyncio
@@ -25,7 +25,7 @@ from tests.utils import processes as test_processes
 
 @pytest.mark.requires_broker
 class TestProcessControl:
-    """Test process control with ZMQ broker."""
+    """Test process control with ZeroMQ broker."""
 
     TIMEOUT = 2.0
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -22,7 +22,7 @@ def test_presto_mark_and_another_mark(request):
 
 @pytest.mark.requires_broker
 def test_presto_mark_with_requires_broker(request):
-    """Test that presto marker IS added for requires_broker tests (ZMQ needs no external service)"""
+    """Test that presto marker IS added for requires_broker tests (ZeroMQ needs no external service)"""
     own_markers = [marker.name for marker in request.node.own_markers]
 
     assert len(own_markers) == 2


### PR DESCRIPTION
When working on more `verdi profile configure-broker`, the discrepancy between the RabbitMQ plugin name `core.rabbitmq` and ZeroMQ plugin name `core.zmq` caused some friction.

Rename the built-in broker backend, module path and test files from `zmq`/`Zmq*` to `zeromq`/`Zeromq*`.

Note: There hasn't been a release, so no breaking change.

Keep the underlying PyZMQ imports unchanged, aliased internally where needed, since the upstream module name remains `zmq`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration & CLI**
  * Updated profile setup and `verdi presto` to use `zeromq` / `--use-zeromq` (replacing `zmq` / `--use-zmq`) and select the bundled ZeroMQ broker backend where applicable.
  * Aligned broker backend detection and status output with the ZeroMQ naming.

* **Documentation**
  * Updated installation and internal broker documentation to consistently use “ZeroMQ”, including built-in broker options and the local-only IPC limitation, plus corrected command/anchor wording.

* **Tests**
  * Migrated broker/communicator/server/service tests to target the ZeroMQ variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->