### PR TITLE
✨ Add verdi profile configure-broker command

### DIFF
--- a/docs/source/installation/guide_complete.rst
+++ b/docs/source/installation/guide_complete.rst
@@ -306,7 +306,7 @@ The exact options available for the ``verdi profile setup`` command depend on th
   The default is ``rabbitmq``, in which case the command tries to connect to RabbitMQ running on the localhost with default connection parameters.
   If this fails, a warning is issued and the profile is configured without a broker.
   Use ``zeromq`` for the built-in ZeroMQ broker (no external services required), or ``none`` to disable the broker entirely.
-  Once the profile is created, RabbitMQ can still be enabled through ``verdi profile configure-rabbitmq`` which allows to customize the connection parameters.
+  Once the profile is created, RabbitMQ can still be enabled through ``verdi profile configure-broker core.rabbitmq``, which allows customizing the connection parameters.
 
   .. versionadded:: 2.9
       The ``--broker`` option replaces the deprecated ``--use-rabbitmq/--no-use-rabbitmq`` flags.

--- a/docs/source/installation/guide_quick.rst
+++ b/docs/source/installation/guide_quick.rst
@@ -100,7 +100,7 @@ A profile **without any broker** has the following limitations:
 
 .. tip::
     A profile created by ``verdi presto`` can easily start using RabbitMQ as the broker at a later stage.
-    Once a RabbitMQ service is available (see :ref:`install RabbitMQ <installation:guide-complete:rabbitmq>` for instructions to install it), run ``verdi profile configure-rabbitmq`` to configure its use for the profile.
+    Once a RabbitMQ service is available (see :ref:`install RabbitMQ <installation:guide-complete:rabbitmq>` for instructions to install it), run ``verdi profile configure-broker core.rabbitmq`` to configure its use for the profile.
 
 .. _installation:guide-quick:limitations:postgresql:
 

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -334,7 +334,7 @@ Below is a list with all available subcommands.
 
       When the `--use-zeromq` flag is toggled, the command skips the RabbitMQ auto-detection
       and directly configures the ZeroMQ broker. To switch to RabbitMQ later, use `verdi
-      profile configure-rabbitmq`.
+      profile configure-broker core.rabbitmq`.
 
     Options:
       -p, --profile-name TEXT         Name of the profile. By default, a unique name starting
@@ -352,7 +352,8 @@ Below is a list with all available subcommands.
                                       automatically with the daemon. When not specified, the
                                       command automatically tries RabbitMQ first and falls
                                       back to ZeroMQ if unavailable. To switch to RabbitMQ
-                                      later, use `verdi profile configure-rabbitmq`.
+                                      later, use `verdi profile configure-broker
+                                      core.rabbitmq`.
       --no-broker                     When toggled on, no message broker is configured. This
                                       means the daemon cannot be started and processes cannot
                                       be submitted. Useful for profiles used only for data
@@ -412,7 +413,9 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      configure-rabbitmq  Configure RabbitMQ for a profile.
+      configure-broker    Configure the process control broker for a profile.
+      configure-rabbitmq  Configure RabbitMQ for a profile. (DEPRECATED: Please use `verdi
+                          profile configure-broker core.rabbitmq` instead.)
       delete              Delete one or more profiles.
       dump                Dump all data in an AiiDA profile's storage to disk.
       list                Display a list of all available profiles.

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -4,17 +4,33 @@ from __future__ import annotations
 
 import abc
 import typing as t
+from dataclasses import dataclass
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from aiida.manage.configuration.profile import Profile
 
-__all__ = ('Broker',)
+__all__ = ('Broker', 'BrokerConfigField')
+
+
+@dataclass(frozen=True)
+class BrokerConfigField:
+    """Metadata for a broker configuration field."""
+
+    name: str
+    prompt: str
+    help: str
+    default: t.Any
+    param_type: str
+    choices: tuple[str, ...] | None = None
+    hide_input: bool = False
 
 
 class Broker(abc.ABC):
     """Interface for a message broker that facilitates communication with and between process runners."""
+
+    _config_fields: tuple[BrokerConfigField, ...] = ()
 
     def __init__(self, profile: 'Profile') -> None:
         """Construct a new instance.
@@ -22,6 +38,16 @@ class Broker(abc.ABC):
         :param profile: The profile.
         """
         self._profile = profile
+
+    @classmethod
+    def get_detected_config(cls, get_value: 'Callable[[str], t.Any]') -> dict[str, t.Any]:
+        """Return detected configuration values for CLI defaults.
+
+        The callable should return the current value for a config field name.
+
+        :return: Mapping of configuration field names to detected values.
+        """
+        return {}
 
     @abc.abstractmethod
     def get_communicator(self) -> t.Any:

--- a/src/aiida/brokers/cli.py
+++ b/src/aiida/brokers/cli.py
@@ -1,0 +1,114 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Common CLI utilities for broker plugins."""
+
+from __future__ import annotations
+
+import functools
+import typing as t
+from collections.abc import Callable
+
+import click
+
+from aiida.brokers.broker import Broker
+from aiida.cmdline.params import types
+from aiida.cmdline.params.options.interactive import InteractiveOption
+from aiida.plugins import BrokerFactory
+
+__all__ = ('configure_broker_options',)
+
+ParamTypeFactory = Callable[[t.Any], click.ParamType | t.Any]
+
+_PARAM_TYPES: dict[str, ParamTypeFactory] = {
+    'choice': lambda field: click.Choice(field.choices or ()),
+    'non_empty_string': lambda _field: types.NonEmptyStringParamType(),
+    'hostname': lambda _field: types.HostnameType(),
+    'int': lambda _field: click.INT,
+    'string': lambda _field: click.types.StringParamType(),
+}
+
+
+def _get_profile_config_default(ctx: click.Context, option_name: str, default: t.Any) -> t.Any:
+    """Return the current profile value for a broker config option, if available."""
+    profile = ctx.params.get('profile')
+
+    if profile is None:
+        return default
+
+    try:
+        return profile.dictionary['process_control']['config'][option_name]
+    except (KeyError, TypeError):
+        return default
+
+
+def _get_detected_config(ctx: click.Context, broker_cls: type[Broker]) -> dict[str, t.Any]:
+    """Return detected broker configuration for interactive defaults, cached on the click context."""
+    cache_key = f'configure_broker_detected_config:{broker_cls.__module__}.{broker_cls.__name__}'
+
+    if cache_key not in ctx.obj:
+        try:
+            ctx.obj[cache_key] = broker_cls.get_detected_config(lambda key: _get_profile_config_default(ctx, key, None))
+        except ConnectionError:
+            ctx.obj[cache_key] = {}
+
+    return t.cast(dict[str, t.Any], ctx.obj[cache_key])
+
+
+def _get_option_default(broker_cls: type[Broker], ctx: click.Context, option_name: str, default: t.Any) -> t.Any:
+    """Return the interactive default for a broker configuration option."""
+    detected_config = _get_detected_config(ctx, broker_cls)
+    return detected_config.get(option_name, _get_profile_config_default(ctx, option_name, default))
+
+
+def _get_param_type(field: t.Any) -> click.ParamType | t.Any:
+    """Return the click parameter type for a broker configuration field."""
+    try:
+        factory = _PARAM_TYPES[field.param_type]
+    except KeyError as exception:
+        valid_kinds = ', '.join(sorted(_PARAM_TYPES))
+        msg = f'unsupported broker config field param type `{field.param_type}`; valid kinds: {valid_kinds}'
+        raise ValueError(msg) from exception
+
+    return factory(field)
+
+
+def configure_broker_options(
+    entry_point_name: str,
+) -> Callable[[Callable[..., t.Any]], Callable[..., t.Any]]:
+    """Return a decorator that adds broker configuration options to a command."""
+    broker_cls = BrokerFactory(entry_point_name)
+
+    def apply_options(func: Callable[..., t.Any]) -> Callable[..., t.Any]:
+        decorators = [
+            click.option(
+                f'--{field.name.replace("_", "-")}',
+                required=True,
+                prompt=field.prompt,
+                help=field.help,
+                default=field.default,
+                show_default=not field.hide_input,
+                type=_get_param_type(field),
+                hide_input=field.hide_input,
+                cls=InteractiveOption,
+                contextual_default=functools.partial(
+                    _get_option_default,
+                    broker_cls,
+                    option_name=field.name,
+                    default=field.default,
+                ),
+            )
+            for field in broker_cls._config_fields
+        ]
+
+        for decorator in reversed(decorators):
+            func = decorator(func)
+
+        return func
+
+    return apply_options

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -7,7 +7,8 @@ import sys
 import typing as t
 from collections.abc import Iterator
 
-from aiida.brokers.broker import Broker
+from aiida.brokers.broker import Broker, BrokerConfigField
+from aiida.brokers.rabbitmq import defaults
 from aiida.common.log import AIIDA_LOGGER
 from aiida.manage.configuration import get_config_option
 
@@ -26,6 +27,59 @@ __all__ = ('RabbitmqBroker',)
 
 class RabbitmqBroker(Broker):
     """Implementation of the message broker interface using RabbitMQ through ``kiwipy``."""
+
+    _config_fields = (
+        BrokerConfigField(
+            name='broker_protocol',
+            prompt='Broker protocol',
+            help='Protocol to use for the message broker.',
+            default=defaults.BROKER_DEFAULTS.protocol,
+            param_type='choice',
+            choices=('amqp', 'amqps'),
+        ),
+        BrokerConfigField(
+            name='broker_username',
+            prompt='Broker username',
+            help='Username to use for authentication with the message broker.',
+            default=defaults.BROKER_DEFAULTS.username,
+            param_type='non_empty_string',
+        ),
+        BrokerConfigField(
+            name='broker_password',
+            prompt='Broker password',
+            help='Password to use for authentication with the message broker.',
+            default=defaults.BROKER_DEFAULTS.password,
+            param_type='non_empty_string',
+            hide_input=True,
+        ),
+        BrokerConfigField(
+            name='broker_host',
+            prompt='Broker host',
+            help='Hostname for the message broker.',
+            default=defaults.BROKER_DEFAULTS.host,
+            param_type='hostname',
+        ),
+        BrokerConfigField(
+            name='broker_port',
+            prompt='Broker port',
+            help='Port for the message broker.',
+            default=defaults.BROKER_DEFAULTS.port,
+            param_type='int',
+        ),
+        BrokerConfigField(
+            name='broker_virtual_host',
+            prompt='Broker virtual host',
+            help='Name of the virtual host for the message broker without leading forward slash.',
+            default=defaults.BROKER_DEFAULTS.virtual_host,
+            param_type='string',
+        ),
+    )
+
+    @classmethod
+    def get_detected_config(cls, get_value: t.Callable[[str], t.Any]) -> dict[str, t.Any]:
+        """Return detected RabbitMQ configuration values for CLI defaults."""
+        connection_params = {field.name.removeprefix('broker_'): get_value(field.name) for field in cls._config_fields}
+        return defaults.detect_rabbitmq_config(**connection_params)
 
     def __init__(self, profile: Profile) -> None:
         """Construct a new instance.

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -132,7 +132,7 @@ def detect_postgres_config(
     is_flag=True,
     help='When toggled on, the profile uses the ZeroMQ broker, which requires no external services and is started '
     'automatically with the daemon. When not specified, the command automatically tries RabbitMQ first and falls back '
-    'to ZeroMQ if unavailable. To switch to RabbitMQ later, use `verdi profile configure-rabbitmq`.',
+    'to ZeroMQ if unavailable. To switch to RabbitMQ later, use `verdi profile configure-broker core.rabbitmq`.',
 )
 @click.option(
     '--no-broker',
@@ -196,7 +196,7 @@ def verdi_presto(
     created profile uses the new PostgreSQL database instead of SQLite.
 
     When the `--use-zeromq` flag is toggled, the command skips the RabbitMQ auto-detection and directly configures the
-    ZeroMQ broker. To switch to RabbitMQ later, use `verdi profile configure-rabbitmq`.
+    ZeroMQ broker. To switch to RabbitMQ later, use `verdi profile configure-broker core.rabbitmq`.
     """
     from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
     from aiida.common import exceptions

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -89,7 +89,7 @@ def command_create_profile(
             echo.echo_success(f'RabbitMQ server detected with connection parameters: {broker_config}')
             broker_backend = broker
 
-        echo.echo_report('RabbitMQ can be reconfigured with `verdi profile configure-rabbitmq`.')
+        echo.echo_report('RabbitMQ can be reconfigured with `verdi profile configure-broker core.rabbitmq`.')
 
     elif broker == 'core.zeromq':
         broker_backend = broker
@@ -99,7 +99,9 @@ def command_create_profile(
 
     else:  # broker == 'none'
         echo.echo_report('Creating profile without a message broker.')
-        echo.echo_report('It can be configured at a later point in time with `verdi profile configure-rabbitmq`.')
+        echo.echo_report(
+            'It can be configured at a later point in time with `verdi profile configure-broker core.rabbitmq`.'
+        )
         echo.echo_report(f'See {docs.URL_NO_BROKER} for details on the limitations of running without a broker.')
 
     try:
@@ -149,7 +151,143 @@ def profile_setup():
     """Set up a new profile."""
 
 
-@verdi_profile.command('configure-rabbitmq')
+def _update_profile_broker_configuration(
+    ctx: click.Context,
+    profile: Profile,
+    *,
+    backend: str | None,
+    config: dict | None,
+) -> None:
+    """Update the broker configuration for a profile."""
+    profile.set_process_controller(name=backend, config=config)
+    ctx.obj.config.update_profile(profile)
+    ctx.obj.config.store()
+
+
+def _configure_profile_broker(ctx: click.Context, profile: Profile | None, backend: str, force: bool, **kwargs) -> None:
+    """Configure a broker for a profile."""
+    if profile is None:
+        profile = ctx.obj.profile
+
+    if profile is None:
+        echo.echo_critical('no profile to configure')
+
+    from aiida.engine.daemon.client import DaemonClient
+
+    daemon_client = DaemonClient(profile)
+    daemon_running = profile.process_control_backend is not None and daemon_client.is_daemon_running
+
+    if backend == 'core.rabbitmq':
+        from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
+
+        broker_config = {key: value for key, value in kwargs.items() if key.startswith('broker_')}
+        connection_params = {key.removeprefix('broker_'): value for key, value in broker_config.items()}
+
+        try:
+            broker_config = detect_rabbitmq_config(**connection_params)
+        except ConnectionError as exception:
+            echo.echo_warning(f'Unable to connect to RabbitMQ server: {exception}')
+            if not force:
+                click.confirm('Do you want to continue with the provided configuration?', abort=True)
+        else:
+            echo.echo_success('Connected to RabbitMQ with the provided connection parameters')
+
+        _update_profile_broker_configuration(ctx, profile, backend=backend, config=broker_config)
+        echo.echo_success(f'RabbitMQ configuration for `{profile.name}` updated to: {broker_config}')
+
+        if daemon_running:
+            echo.echo_warning(
+                'The daemon is currently running. It will need to be restarted for changes to take effect.'
+            )
+            if not force:
+                click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
+                echo.echo_report('Restarting the daemon...')
+                daemon_client.restart_daemon()
+                echo.echo_success('Daemon restarted successfully.')
+
+        return
+
+    if backend == 'core.zeromq':
+        _update_profile_broker_configuration(ctx, profile, backend=backend, config={})
+        echo.echo_success(f'ZeroMQ configuration for `{profile.name}` updated.')
+        echo.echo_report('The ZeroMQ broker service will be started automatically with the daemon.')
+
+        if daemon_running:
+            echo.echo_warning(
+                'The daemon is currently running. It will need to be restarted for changes to take effect.'
+            )
+            if not force:
+                click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
+                echo.echo_report('Restarting the daemon...')
+                daemon_client.restart_daemon()
+                echo.echo_success('Daemon restarted successfully.')
+
+        return
+
+    if backend == 'none':
+        from aiida.common import docs
+
+        _update_profile_broker_configuration(ctx, profile, backend=None, config=None)
+        echo.echo_report(f'Broker disabled for `{profile.name}`.')
+
+        if daemon_running:
+            echo.echo_warning('The daemon is currently running. It will need to be stopped for changes to take effect.')
+            click.confirm('Do you want to apply the configuration and stop the daemon?', abort=True)
+            echo.echo_report('Stopping the daemon...')
+            daemon_client.stop_daemon(wait=True)
+            echo.echo_success('Daemon stopped successfully.')
+
+        echo.echo_report(f'See {docs.URL_NO_BROKER} for details on the limitations of running without a broker.')
+        return
+
+    msg = f'unsupported broker backend: {backend}'
+    raise click.BadParameter(msg, param_hint='backend')
+
+
+@verdi_profile.group('configure-broker')
+def profile_configure_broker():
+    """Configure the process control broker for a profile."""
+
+
+@profile_configure_broker.command('core.rabbitmq')
+@arguments.PROFILE(default=defaults.get_default_profile)
+@options.FORCE()
+@setup.SETUP_BROKER_PROTOCOL()
+@setup.SETUP_BROKER_USERNAME()
+@setup.SETUP_BROKER_PASSWORD()
+@setup.SETUP_BROKER_HOST()
+@setup.SETUP_BROKER_PORT()
+@setup.SETUP_BROKER_VIRTUAL_HOST()
+@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
+@click.pass_context
+def profile_configure_broker_rabbitmq(ctx, /, profile, force, non_interactive, **kwargs):
+    """Configure RabbitMQ for a profile."""
+    _configure_profile_broker(ctx, profile, 'core.rabbitmq', force, **kwargs)
+
+
+@profile_configure_broker.command('core.zeromq')
+@arguments.PROFILE(default=defaults.get_default_profile)
+@options.FORCE()
+@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
+@click.pass_context
+def profile_configure_broker_zeromq(ctx, /, profile, force, non_interactive):
+    """Configure ZeroMQ for a profile."""
+    _configure_profile_broker(ctx, profile, 'core.zeromq', force)
+
+
+@profile_configure_broker.command('none')
+@arguments.PROFILE(default=defaults.get_default_profile)
+@options.FORCE()
+@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
+@click.pass_context
+def profile_configure_broker_none(ctx, /, profile, force, non_interactive):
+    """Disable the broker for a profile."""
+    _configure_profile_broker(ctx, profile, 'none', force)
+
+
+@verdi_profile.command(
+    'configure-rabbitmq', deprecated='Please use `verdi profile configure-broker core.rabbitmq` instead.'
+)
 @arguments.PROFILE(default=defaults.get_default_profile)
 @options.FORCE()
 @setup.SETUP_BROKER_PROTOCOL()
@@ -163,47 +301,12 @@ def profile_setup():
 def profile_configure_rabbitmq(ctx, /, profile, non_interactive, force, **kwargs):
     """Configure RabbitMQ for a profile.
 
+    .. deprecated:: 2.9
+       Use ``verdi profile configure-broker core.rabbitmq`` instead.
+
     Enable RabbitMQ for a profile that was created without a broker, or reconfigure existing connection details.
     """
-    from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
-
-    broker_config = {key: value for key, value in kwargs.items() if key.startswith('broker_')}
-    connection_params = {key.lstrip('broker_'): value for key, value in broker_config.items()}
-
-    try:
-        broker_config = detect_rabbitmq_config(**connection_params)
-    except ConnectionError as exception:
-        echo.echo_warning(f'Unable to connect to RabbitMQ server: {exception}')
-        if not force:
-            click.confirm('Do you want to continue with the provided configuration?', abort=True)
-    else:
-        echo.echo_success('Connected to RabbitMQ with the provided connection parameters')
-
-    daemon_client = None
-    daemon_running = False
-
-    # Only check daemon status if the profile already has a broker configured.
-    # If no broker is configured yet, there can't be a daemon running.
-    if profile.process_control_backend is not None:
-        from aiida.engine.daemon.client import DaemonClient
-
-        daemon_client = DaemonClient(profile)
-        daemon_running = daemon_client.is_daemon_running
-
-    if daemon_running:
-        echo.echo_warning('The daemon is currently running. It will need to be restarted for changes to take effect.')
-        click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
-
-    profile.set_process_controller(name='core.rabbitmq', config=broker_config)
-    ctx.obj.config.update_profile(profile)
-    ctx.obj.config.store()
-
-    echo.echo_success(f'RabbitMQ configuration for `{profile.name}` updated to: {broker_config}')
-
-    if daemon_running and daemon_client is not None:
-        echo.echo_report('Restarting the daemon...')
-        daemon_client.restart_daemon()
-        echo.echo_success('Daemon restarted successfully.')
+    _configure_profile_broker(ctx, profile, 'core.rabbitmq', force, **kwargs)
 
 
 @verdi_profile.command('list')

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import click
 
+from aiida.brokers.cli import configure_broker_options
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.groups import DynamicEntryPointCommandGroup
 from aiida.cmdline.params import arguments, options
@@ -79,10 +80,10 @@ def command_create_profile(
     broker_config = None
 
     if broker == 'core.rabbitmq':
-        from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
+        import aiida.brokers.rabbitmq.defaults as rabbitmq_defaults
 
         try:
-            broker_config = detect_rabbitmq_config()
+            broker_config = rabbitmq_defaults.detect_rabbitmq_config()
         except ConnectionError as exception:
             echo.echo_warning(f'RabbitMQ server not reachable: {exception}.')
         else:
@@ -164,7 +165,9 @@ def _update_profile_broker_configuration(
     ctx.obj.config.store()
 
 
-def _configure_profile_broker(ctx: click.Context, profile: Profile | None, backend: str, force: bool, **kwargs) -> None:
+def _configure_profile_broker(
+    ctx: click.Context, profile: Profile | None, backend: str, non_interactive: bool, force: bool, **kwargs
+) -> None:
     """Configure a broker for a profile."""
     if profile is None:
         profile = ctx.obj.profile
@@ -174,32 +177,52 @@ def _configure_profile_broker(ctx: click.Context, profile: Profile | None, backe
 
     from aiida.engine.daemon.client import DaemonClient
 
-    daemon_client = DaemonClient(profile)
-    daemon_running = profile.process_control_backend is not None and daemon_client.is_daemon_running
+    def get_daemon_client() -> DaemonClient | None:
+        """Return the daemon client and whether the daemon is running for the profile."""
+        try:
+            daemon_client = DaemonClient(profile)
+        except exceptions.ConfigurationError as exception:
+            msg = f'Daemon might need to be restarted or stopped but unable to determine daemon status: {exception}'
+            echo.echo_warning(msg)
+            return None
+        return daemon_client
 
     if backend == 'core.rabbitmq':
-        from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
+        import aiida.brokers.rabbitmq.defaults as rabbitmq_defaults
 
         broker_config = {key: value for key, value in kwargs.items() if key.startswith('broker_')}
         connection_params = {key.removeprefix('broker_'): value for key, value in broker_config.items()}
 
         try:
-            broker_config = detect_rabbitmq_config(**connection_params)
+            broker_config = rabbitmq_defaults.detect_rabbitmq_config(**connection_params)
         except ConnectionError as exception:
-            echo.echo_warning(f'Unable to connect to RabbitMQ server: {exception}')
+            msg = (
+                f'Unable to connect to RabbitMQ server: {exception}'
+                'Check that the connection parameters are correct and that the RabbitMQ server is running.'
+            )
+            echo.echo_warning(msg)
             if not force:
-                click.confirm('Do you want to continue with the provided configuration?', abort=True)
+                if non_interactive:
+                    msg = (
+                        f'Aborting RabbitMQ configuration for `{profile.name}`. '
+                        'Rerun with `--force` to store them anyway.'
+                    )
+                    echo.echo_critical(msg)
+                else:
+                    click.confirm('Do you want to continue with the provided configuration?', abort=True)
+
         else:
             echo.echo_success('Connected to RabbitMQ with the provided connection parameters')
 
         _update_profile_broker_configuration(ctx, profile, backend=backend, config=broker_config)
         echo.echo_success(f'RabbitMQ configuration for `{profile.name}` updated to: {broker_config}')
 
-        if daemon_running:
+        daemon_client = get_daemon_client()
+        if daemon_client and daemon_client.is_daemon_running:
             echo.echo_warning(
                 'The daemon is currently running. It will need to be restarted for changes to take effect.'
             )
-            if not force:
+            if not non_interactive:
                 click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
                 echo.echo_report('Restarting the daemon...')
                 daemon_client.restart_daemon()
@@ -212,11 +235,12 @@ def _configure_profile_broker(ctx: click.Context, profile: Profile | None, backe
         echo.echo_success(f'ZeroMQ configuration for `{profile.name}` updated.')
         echo.echo_report('The ZeroMQ broker service will be started automatically with the daemon.')
 
-        if daemon_running:
+        daemon_client = get_daemon_client()
+        if daemon_client and daemon_client.is_daemon_running:
             echo.echo_warning(
                 'The daemon is currently running. It will need to be restarted for changes to take effect.'
             )
-            if not force:
+            if not non_interactive:
                 click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
                 echo.echo_report('Restarting the daemon...')
                 daemon_client.restart_daemon()
@@ -230,12 +254,14 @@ def _configure_profile_broker(ctx: click.Context, profile: Profile | None, backe
         _update_profile_broker_configuration(ctx, profile, backend=None, config=None)
         echo.echo_report(f'Broker disabled for `{profile.name}`.')
 
-        if daemon_running:
+        daemon_client = get_daemon_client()
+        if daemon_client and daemon_client.is_daemon_running:
             echo.echo_warning('The daemon is currently running. It will need to be stopped for changes to take effect.')
-            click.confirm('Do you want to apply the configuration and stop the daemon?', abort=True)
-            echo.echo_report('Stopping the daemon...')
-            daemon_client.stop_daemon(wait=True)
-            echo.echo_success('Daemon stopped successfully.')
+            if not force:
+                click.confirm('Do you want to apply the configuration and stop the daemon?', abort=True)
+                echo.echo_report('Stopping the daemon...')
+                daemon_client.stop_daemon(wait=True)
+                echo.echo_success('Daemon stopped successfully.')
 
         echo.echo_report(f'See {docs.URL_NO_BROKER} for details on the limitations of running without a broker.')
         return
@@ -252,37 +278,32 @@ def profile_configure_broker():
 @profile_configure_broker.command('core.rabbitmq')
 @arguments.PROFILE(default=defaults.get_default_profile)
 @options.FORCE()
-@setup.SETUP_BROKER_PROTOCOL()
-@setup.SETUP_BROKER_USERNAME()
-@setup.SETUP_BROKER_PASSWORD()
-@setup.SETUP_BROKER_HOST()
-@setup.SETUP_BROKER_PORT()
-@setup.SETUP_BROKER_VIRTUAL_HOST()
-@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
+@configure_broker_options('core.rabbitmq')
+@options.NON_INTERACTIVE()
 @click.pass_context
 def profile_configure_broker_rabbitmq(ctx, /, profile, force, non_interactive, **kwargs):
     """Configure RabbitMQ for a profile."""
-    _configure_profile_broker(ctx, profile, 'core.rabbitmq', force, **kwargs)
+    _configure_profile_broker(ctx, profile, 'core.rabbitmq', non_interactive, force, **kwargs)
 
 
 @profile_configure_broker.command('core.zeromq')
 @arguments.PROFILE(default=defaults.get_default_profile)
 @options.FORCE()
-@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
+@options.NON_INTERACTIVE()
 @click.pass_context
 def profile_configure_broker_zeromq(ctx, /, profile, force, non_interactive):
     """Configure ZeroMQ for a profile."""
-    _configure_profile_broker(ctx, profile, 'core.zeromq', force)
+    _configure_profile_broker(ctx, profile, 'core.zeromq', non_interactive, force)
 
 
 @profile_configure_broker.command('none')
 @arguments.PROFILE(default=defaults.get_default_profile)
 @options.FORCE()
-@options.NON_INTERACTIVE(default=True, show_default='--non-interactive')
+@options.NON_INTERACTIVE()
 @click.pass_context
 def profile_configure_broker_none(ctx, /, profile, force, non_interactive):
     """Disable the broker for a profile."""
-    _configure_profile_broker(ctx, profile, 'none', force)
+    _configure_profile_broker(ctx, profile, 'none', non_interactive, force)
 
 
 @verdi_profile.command(
@@ -306,7 +327,7 @@ def profile_configure_rabbitmq(ctx, /, profile, non_interactive, force, **kwargs
 
     Enable RabbitMQ for a profile that was created without a broker, or reconfigure existing connection details.
     """
-    _configure_profile_broker(ctx, profile, 'core.rabbitmq', force, **kwargs)
+    _configure_profile_broker(ctx, profile, 'core.rabbitmq', non_interactive, force, **kwargs)
 
 
 @verdi_profile.command('list')

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -36,7 +36,7 @@ def command_create_profile(
     first_name: str | None = None,
     last_name: str | None = None,
     institution: str | None = None,
-    broker: str = 'rabbitmq',
+    broker: str = 'core.rabbitmq',
     use_rabbitmq: bool | None = None,
     **kwargs,
 ):
@@ -52,7 +52,7 @@ def command_create_profile(
     :param first_name: First name for the default user.
     :param last_name: Last name for the default user.
     :param institution: Institution for the default user.
-    :param broker: Message broker backend ('rabbitmq', 'zeromq', or 'none').
+    :param broker: Message broker backend ('core.rabbitmq', 'core.zeromq', or 'none').
     :param use_rabbitmq: Deprecated. Use ``broker`` instead. If False, equivalent to ``broker='none'``.
     :param kwargs: Arguments to initialise instance of the selected storage implementation.
     """
@@ -78,7 +78,7 @@ def command_create_profile(
     broker_backend = None
     broker_config = None
 
-    if broker == 'rabbitmq':
+    if broker == 'core.rabbitmq':
         from aiida.brokers.rabbitmq.defaults import detect_rabbitmq_config
 
         try:
@@ -87,12 +87,12 @@ def command_create_profile(
             echo.echo_warning(f'RabbitMQ server not reachable: {exception}.')
         else:
             echo.echo_success(f'RabbitMQ server detected with connection parameters: {broker_config}')
-            broker_backend = 'core.rabbitmq'
+            broker_backend = broker
 
         echo.echo_report('RabbitMQ can be reconfigured with `verdi profile configure-rabbitmq`.')
 
-    elif broker == 'zeromq':
-        broker_backend = 'core.zeromq'
+    elif broker == 'core.zeromq':
+        broker_backend = broker
         broker_config = {}
         echo.echo_success('ZeroMQ broker configured (no external service required).')
         echo.echo_report('The ZeroMQ broker service will be started automatically with the daemon.')

--- a/src/aiida/cmdline/params/options/commands/setup.py
+++ b/src/aiida/cmdline/params/options/commands/setup.py
@@ -351,11 +351,11 @@ SETUP_USE_RABBITMQ = options.OverridableOption(
 SETUP_BROKER_BACKEND = options.OverridableOption(
     '--broker',
     prompt='Message broker',
-    type=click.Choice(['rabbitmq', 'zeromq', 'none']),
-    default='rabbitmq',
+    type=click.Choice(['core.rabbitmq', 'core.zeromq', 'none']),
+    default='core.rabbitmq',
     cls=options.interactive.InteractiveOption,
-    help='Message broker backend for process control. Use "rabbitmq" for RabbitMQ (requires external server), '
-    '"zeromq" for ZeroMQ (built-in, no external dependencies), or "none" to disable (limited functionality).',
+    help='Message broker backend for process control. Use "core.rabbitmq" for RabbitMQ (requires external server), '
+    '"core.zeromq" for ZeroMQ (built-in, no external dependencies), or "none" to disable (limited functionality).',
 )
 
 SETUP_BROKER_PROTOCOL = QUICKSETUP_BROKER_PROTOCOL.clone(

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -149,8 +149,9 @@ def submit(
         raise InvalidOperation(
             'Cannot submit because the runner does not have a process controller, probably because the profile does '
             'not define a broker like RabbitMQ. If a RabbitMQ server is available, the profile can be configured to '
-            'use it with `verdi profile configure-rabbitmq`. Otherwise, use :meth:`aiida.engine.launch.run` instead to '
-            'run the process in the local Python interpreter instead of submitting it to the daemon. '
+            'use it with `verdi profile configure-broker core.rabbitmq`. Otherwise, use '
+            ':meth:`aiida.engine.launch.run` instead to run the process in the local Python interpreter instead of '
+            'submitting it to the daemon. '
             f'See {URL_NO_BROKER} for more details.'
         )
 

--- a/src/aiida/manage/configuration/profile.py
+++ b/src/aiida/manage/configuration/profile.py
@@ -133,10 +133,10 @@ class Profile:
         """Return the configuration required by the process control backend."""
         return self._attributes[self.KEY_PROCESS][self.KEY_PROCESS_CONFIG] or {}
 
-    def set_process_controller(self, name: str, config: Dict[str, Any]) -> None:
+    def set_process_controller(self, name: str | None, config: Dict[str, Any] | None) -> None:
         """Set the process control backend and its configuration.
 
-        :param name: the name of the process backend
+        :param name: the name of the process backend, or ``None`` to disable it
         :param config: the configuration of the process backend
         """
         self._attributes.setdefault(self.KEY_PROCESS, {})

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -418,7 +418,7 @@ def test_setup_broker_core_zeromq(run_cli_command, isolated_config):
 
 
 @pytest.mark.requires_rmq
-def test_configure_broker_rmq(run_cli_command, isolated_config):
+def test_configure_broker_rmq(run_cli_command, isolated_config, monkeypatch):
     """Test the ``verdi profile configure-broker core.rabbitmq`` command."""
     profile_name = 'profile'
 
@@ -434,18 +434,6 @@ def test_configure_broker_rmq(run_cli_command, isolated_config):
     cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=False)
     assert profile.process_control_backend == 'core.rabbitmq'
     assert 'Connected to RabbitMQ with the provided connection parameters' in cli_result.stdout
-
-    # Verify that running in non-interactive mode is the default
-    options = ['core.rabbitmq', profile_name]
-    cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=True)
-    assert profile.process_control_backend == 'core.rabbitmq'
-    assert 'Connected to RabbitMQ with the provided connection parameters' in cli_result.stdout
-
-    # Verify that configuring with incorrect options and `--force` raises a warning but still configures the broker
-    options = ['core.rabbitmq', profile_name, '-f', '--broker-port', '1234']
-    cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=False)
-    assert 'Unable to connect to RabbitMQ server: Failed to connect' in cli_result.stdout
-    assert profile.process_control_config['broker_port'] == 1234
 
     # Call it again to check it works to reconfigure existing broker connection parameters
     options = ['core.rabbitmq', profile_name, '-n', '--broker-port', '5672']
@@ -523,8 +511,38 @@ def test_configure_rabbitmq_deprecated(run_cli_command, isolated_config):
     assert 'Please use `verdi profile configure-broker core.rabbitmq` instead.' in cli_result.output
 
 
+def test_configure_broker_rabbitmq_interactive_defaults_use_detected_config(
+    run_cli_command, isolated_config, monkeypatch
+):
+    """Test interactive RabbitMQ prompts are seeded from detected connection parameters."""
+    profile_name = 'profile-rmq-interactive-defaults'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+
+    detected_config = {
+        'broker_protocol': 'amqps',
+        'broker_username': 'detected-user',
+        'broker_password': 'detected-password',
+        'broker_host': 'detected-host',
+        'broker_port': 4321,
+        'broker_virtual_host': 'detected-vhost',
+    }
+    monkeypatch.setattr('aiida.brokers.rabbitmq.defaults.detect_rabbitmq_config', lambda **_kwargs: detected_config)
+
+    cli_result = run_cli_command(
+        cmd_profile.profile_configure_broker,
+        ['core.rabbitmq', profile_name],
+        use_subprocess=False,
+        user_input='\n\n\n\n\n\n',
+    )
+    assert cli_result.exception is None, cli_result.output
+    assert 'Broker protocol (amqp, amqps)' in cli_result.output
+    assert '[amqps]' in cli_result.output
+
+
 def test_configure_broker_rmq_non_interactive_failed_validation(run_cli_command, isolated_config, monkeypatch):
-    """Test ``configure-broker core.rabbitmq`` still prompts on failed validation."""
+    """Test ``configure-broker core.rabbitmq`` aborts on failed validation in non-interactive mode."""
     profile_name = 'profile-rmq-non-interactive'
 
     options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
@@ -540,15 +558,16 @@ def test_configure_broker_rmq_non_interactive_failed_validation(run_cli_command,
         cmd_profile.profile_configure_broker,
         ['core.rabbitmq', profile_name, '-n', '--broker-port', '1234'],
         use_subprocess=False,
-        user_input='y\n',
+        raises=True,
     )
     assert 'Unable to connect to RabbitMQ server: Failed to connect' in cli_result.output
-    assert 'Do you want to continue with the provided configuration?' in cli_result.output
-    assert profile.process_control_config['broker_port'] == 1234
+    assert f'Aborting RabbitMQ configuration for `{profile.name}`.' in cli_result.output
+    assert 'Rerun with `--force` to store them anyway.' in cli_result.output
+    assert profile.process_control_config == {}
 
 
 def test_configure_broker_zmq_non_interactive_restart(run_cli_command, isolated_config, monkeypatch):
-    """Test ``configure-broker core.zeromq`` still prompts before restarting the daemon."""
+    """Test ``configure-broker core.zeromq -n`` does not prompt before restarting the daemon."""
     profile_name = 'profile-zmq-non-interactive'
 
     options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--broker', 'core.zeromq']
@@ -575,15 +594,14 @@ def test_configure_broker_zmq_non_interactive_restart(run_cli_command, isolated_
         cmd_profile.profile_configure_broker,
         ['core.zeromq', profile_name, '-n'],
         use_subprocess=False,
-        user_input='y\n',
     )
     assert (
         'The daemon is currently running. It will need to be restarted for changes to take effect.' in cli_result.output
     )
-    assert 'Do you want to apply the configuration and restart the daemon?' in cli_result.output
-    assert 'Restarting the daemon...' in cli_result.output
-    assert 'Daemon restarted successfully.' in cli_result.output
-    assert called['restart_daemon'] is True
+    assert 'Do you want to apply the configuration and restart the daemon?' not in cli_result.output
+    assert 'Restarting the daemon...' not in cli_result.output
+    assert 'Daemon restarted successfully.' not in cli_result.output
+    assert called['restart_daemon'] is False
 
 
 def test_configure_broker_invalid_backend():
@@ -592,7 +610,7 @@ def test_configure_broker_invalid_backend():
     profile = configuration.get_profile()
 
     with pytest.raises(click.BadParameter, match='unsupported broker backend: invalid'):
-        cmd_profile._configure_profile_broker(ctx, profile, 'invalid', False)
+        cmd_profile._configure_profile_broker(ctx, profile, 'invalid', False, False)
 
 
 def test_configure_broker_uses_loaded_profile_when_default_profile_is_missing(run_cli_command, isolated_config):

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -361,6 +361,34 @@ def test_setup_email_required(run_cli_command, isolated_config, tmp_path, entry_
         assert 'Invalid value for --email: The option is required for storages that are not read-only.' in result.output
 
 
+@pytest.mark.parametrize('broker', ('core.rabbitmq', 'core.zeromq', 'none'))
+def test_setup_broker(run_cli_command, isolated_config, monkeypatch, broker):
+    """Test the ``--broker`` option only accepts the new broker entry-point names."""
+    if broker == 'core.rabbitmq':
+        rabbitmq_config = {
+            'broker_protocol': 'amqp',
+            'broker_username': 'guest',
+            'broker_password': 'guest',
+            'broker_host': '127.0.0.1',
+            'broker_port': 5672,
+            'broker_virtual_host': '',
+        }
+        monkeypatch.setattr('aiida.brokers.rabbitmq.defaults.detect_rabbitmq_config', lambda: rabbitmq_config)
+
+    profile_name = f'profile-{broker.replace(".", "-")}'
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--broker', broker]
+
+    result = run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    assert f'Created new profile `{profile_name}`.' in result.output
+    assert profile_name in isolated_config.profile_names
+
+    profile = isolated_config.get_profile(profile_name)
+    if broker == 'none':
+        assert profile.process_control_backend is None
+    else:
+        assert profile.process_control_backend == broker
+
+
 def test_setup_no_use_rabbitmq(run_cli_command, isolated_config):
     """Test the ``--no-use-rabbitmq`` option."""
     profile_name = 'profile-no-broker'

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -10,13 +10,16 @@
 
 from unittest.mock import patch
 
+import click
 import pytest
 from pgtest.pgtest import PGTest
 
 from aiida import orm
 from aiida.cmdline.commands import cmd_profile, cmd_verdi
+from aiida.common import docs
 from aiida.engine.daemon.client import DaemonException, DaemonStalePidException, DaemonTimeoutException
 from aiida.manage import configuration
+from aiida.manage.configuration import profile_context
 from aiida.plugins import StorageFactory
 from aiida.tools.archive.create import create_archive
 
@@ -402,8 +405,21 @@ def test_setup_no_use_rabbitmq(run_cli_command, isolated_config):
     assert profile.process_control_config == {}
 
 
-def test_configure_rabbitmq(run_cli_command, isolated_config):
-    """Test the ``verdi profile configure-rabbitmq`` command."""
+def test_setup_broker_core_zeromq(run_cli_command, isolated_config):
+    """Test the ``--broker core.zeromq`` option."""
+    profile_name = 'profile-broker-core-zmq'
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--broker', 'core.zeromq']
+
+    result = run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    assert f'Created new profile `{profile_name}`.' in result.output
+    profile = isolated_config.get_profile(profile_name)
+    assert profile.process_control_backend == 'core.zeromq'
+    assert profile.process_control_config == {}
+
+
+@pytest.mark.requires_rmq
+def test_configure_broker_rmq(run_cli_command, isolated_config):
+    """Test the ``verdi profile configure-broker core.rabbitmq`` command."""
     profile_name = 'profile'
 
     # First setup a profile without a broker configured
@@ -414,30 +430,189 @@ def test_configure_rabbitmq(run_cli_command, isolated_config):
     assert profile.process_control_config == {}
 
     # Now run the command to configure the broker
-    options = [profile_name, '-n']
-    cli_result = run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=False)
+    options = ['core.rabbitmq', profile_name, '-n']
+    cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=False)
     assert profile.process_control_backend == 'core.rabbitmq'
     assert 'Connected to RabbitMQ with the provided connection parameters' in cli_result.stdout
 
     # Verify that running in non-interactive mode is the default
-    options = [
-        profile_name,
-    ]
-    run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=True)
+    options = ['core.rabbitmq', profile_name]
+    cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=True)
     assert profile.process_control_backend == 'core.rabbitmq'
     assert 'Connected to RabbitMQ with the provided connection parameters' in cli_result.stdout
 
     # Verify that configuring with incorrect options and `--force` raises a warning but still configures the broker
-    options = [profile_name, '-f', '--broker-port', '1234']
-    cli_result = run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=False)
+    options = ['core.rabbitmq', profile_name, '-f', '--broker-port', '1234']
+    cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=False)
     assert 'Unable to connect to RabbitMQ server: Failed to connect' in cli_result.stdout
     assert profile.process_control_config['broker_port'] == 1234
 
     # Call it again to check it works to reconfigure existing broker connection parameters
-    options = [profile_name, '-n', '--broker-port', '5672']
-    cli_result = run_cli_command(cmd_profile.profile_configure_rabbitmq, options, use_subprocess=False)
+    options = ['core.rabbitmq', profile_name, '-n', '--broker-port', '5672']
+    cli_result = run_cli_command(cmd_profile.profile_configure_broker, options, use_subprocess=False)
     assert 'Connected to RabbitMQ with the provided connection parameters' in cli_result.stdout
     assert profile.process_control_config['broker_port'] == 5672
+
+
+def test_configure_broker_zeromq(run_cli_command, isolated_config):
+    """Test ``verdi profile configure-broker core.zeromq``."""
+    profile_name = 'profile-zeromq'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    profile = isolated_config.get_profile(profile_name)
+    assert profile.process_control_backend is None
+    assert profile.process_control_config == {}
+
+    cli_result = run_cli_command(
+        cmd_profile.profile_configure_broker, ['core.zeromq', profile_name, '-n'], use_subprocess=False
+    )
+    assert profile.process_control_backend == 'core.zeromq'
+    assert profile.process_control_config == {}
+    assert f'ZeroMQ configuration for `{profile.name}` updated.' in cli_result.stdout
+    assert 'The ZeroMQ broker service will be started automatically with the daemon.' in cli_result.stdout
+
+
+def test_configure_broker_zeromq_rejects_rabbitmq_options(run_cli_command, isolated_config):
+    """Test RabbitMQ options are rejected for the ZeroMQ backend command."""
+    profile_name = 'profile-zeromq-ignored-options'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+
+    cli_result = run_cli_command(
+        cmd_profile.profile_configure_broker,
+        ['core.zeromq', profile_name, '-n', '--broker-port', '1234'],
+        use_subprocess=False,
+        raises=True,
+    )
+
+    assert 'No such option: --broker-port' in cli_result.output
+
+
+def test_configure_broker_none(run_cli_command, isolated_config):
+    """Test ``verdi profile configure-broker none``."""
+    profile_name = 'profile-none'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--broker', 'core.zeromq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    profile = isolated_config.get_profile(profile_name)
+    assert profile.process_control_backend == 'core.zeromq'
+
+    cli_result = run_cli_command(
+        cmd_profile.profile_configure_broker, ['none', profile_name, '-n'], use_subprocess=False
+    )
+    assert profile.process_control_backend is None
+    assert profile.process_control_config == {}
+    assert f'Broker disabled for `{profile.name}`.' in cli_result.stdout
+    assert docs.URL_NO_BROKER in cli_result.stdout
+
+
+@pytest.mark.requires_rmq
+def test_configure_rabbitmq_deprecated(run_cli_command, isolated_config):
+    """Test the deprecated ``verdi profile configure-rabbitmq`` command."""
+    profile_name = 'profile-deprecated-rmq'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    profile = isolated_config.get_profile(profile_name)
+
+    cli_result = run_cli_command(cmd_profile.profile_configure_rabbitmq, [profile_name, '-n'], use_subprocess=False)
+    assert profile.process_control_backend == 'core.rabbitmq'
+    assert 'Deprecated:' in cli_result.output
+    assert 'Please use `verdi profile configure-broker core.rabbitmq` instead.' in cli_result.output
+
+
+def test_configure_broker_rmq_non_interactive_failed_validation(run_cli_command, isolated_config, monkeypatch):
+    """Test ``configure-broker core.rabbitmq`` still prompts on failed validation."""
+    profile_name = 'profile-rmq-non-interactive'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    profile = isolated_config.get_profile(profile_name)
+
+    def detect_rabbitmq_config(**_kwargs):
+        raise ConnectionError('Failed to connect')
+
+    monkeypatch.setattr('aiida.brokers.rabbitmq.defaults.detect_rabbitmq_config', detect_rabbitmq_config)
+
+    cli_result = run_cli_command(
+        cmd_profile.profile_configure_broker,
+        ['core.rabbitmq', profile_name, '-n', '--broker-port', '1234'],
+        use_subprocess=False,
+        user_input='y\n',
+    )
+    assert 'Unable to connect to RabbitMQ server: Failed to connect' in cli_result.output
+    assert 'Do you want to continue with the provided configuration?' in cli_result.output
+    assert profile.process_control_config['broker_port'] == 1234
+
+
+def test_configure_broker_zmq_non_interactive_restart(run_cli_command, isolated_config, monkeypatch):
+    """Test ``configure-broker core.zeromq`` still prompts before restarting the daemon."""
+    profile_name = 'profile-zmq-non-interactive'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--broker', 'core.zeromq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+
+    called = {'restart_daemon': False}
+
+    class DaemonClient:
+        """Test double for a running daemon client."""
+
+        def __init__(self, profile):
+            self.profile = profile
+
+        @property
+        def is_daemon_running(self):
+            return True
+
+        def restart_daemon(self):
+            called['restart_daemon'] = True
+
+    monkeypatch.setattr('aiida.engine.daemon.client.DaemonClient', DaemonClient)
+
+    cli_result = run_cli_command(
+        cmd_profile.profile_configure_broker,
+        ['core.zeromq', profile_name, '-n'],
+        use_subprocess=False,
+        user_input='y\n',
+    )
+    assert (
+        'The daemon is currently running. It will need to be restarted for changes to take effect.' in cli_result.output
+    )
+    assert 'Do you want to apply the configuration and restart the daemon?' in cli_result.output
+    assert 'Restarting the daemon...' in cli_result.output
+    assert 'Daemon restarted successfully.' in cli_result.output
+    assert called['restart_daemon'] is True
+
+
+def test_configure_broker_invalid_backend():
+    """Test an invalid backend passed to the helper raises ``BadParameter``."""
+    ctx = type('Context', (), {'obj': type('Object', (), {'profile': configuration.get_profile()})()})()
+    profile = configuration.get_profile()
+
+    with pytest.raises(click.BadParameter, match='unsupported broker backend: invalid'):
+        cmd_profile._configure_profile_broker(ctx, profile, 'invalid', False)
+
+
+def test_configure_broker_uses_loaded_profile_when_default_profile_is_missing(run_cli_command, isolated_config):
+    """Test ``configure-broker`` falls back to the loaded profile when no default profile is configured."""
+    profile_name = 'profile-loaded-profile'
+
+    options = ['core.sqlite_dos', '-n', '--email', 'a@a', '--profile-name', profile_name, '--no-use-rabbitmq']
+    run_cli_command(cmd_profile.profile_setup, options, use_subprocess=False)
+    isolated_config._default_profile = None
+
+    with profile_context(profile_name, allow_switch=True):
+        cli_result = run_cli_command(
+            cmd_profile.profile_configure_broker,
+            ['core.zeromq', '-n'],
+            use_subprocess=False,
+        )
+
+    profile = isolated_config.get_profile(profile_name)
+    assert cli_result.exit_code == 0
+    assert profile.process_control_backend == 'core.zeromq'
 
 
 class TestVerdiProfileDumpCLI:
@@ -532,7 +707,7 @@ class TestVerdiProfileDumpCLI:
         run_cli_command(cmd_profile.profile_dump, options)
 
         # Verify the dump method was called with expected arguments
-        args, kwargs = mock_dump.call_args
+        _, kwargs = mock_dump.call_args
         assert kwargs['output_path'] == test_path.resolve()
         assert kwargs['all_entries'] is True
         assert kwargs['groups'] == [group]  # Converted to `orm.Group`

--- a/utils/autogenerate_all_imports.py
+++ b/utils/autogenerate_all_imports.py
@@ -98,10 +98,11 @@ def gather_all(
 ) -> list[str]:
     """Recursively gather __all__ names."""
     all_list = [] if all_list is None else all_list
+    skipped = set(skip_children.get('/'.join(cur_path), []))
     for key, val in cur_dict.items():
         if key == '__all__':
-            all_list.extend(val)
-        elif key not in skip_children.get('/'.join(cur_path), []):
+            all_list.extend(name for name in val if name not in skipped)
+        elif key not in skipped:
             gather_all(cur_path + [key], val, skip_children, all_list)
     return all_list
 
@@ -200,6 +201,9 @@ if __name__ == '__main__':
         # skipped since we don't want to expose the implementation at the top-level
         'storage': ['psql_dos', 'sqlite_zip', 'sqlite_temp'],
         'orm': ['implementation'],
+        # skipped since re-exporting CLI helpers from the package root can trigger cyclic imports see issue #7429
+        'brokers': ['cli'],
+        'brokers/broker': ['BrokerConfigField'],
         # skip all since the module requires extra requirements
         'restapi': ['*'],
     }


### PR DESCRIPTION
Add `verdi profile configure-broker core.rabbitmq|core.zeromq` so the broker can be changed in both directions after setup. This replaces `verdi profile configure-rabbitmq` that is deprecated. The first commit commit creates the new command with basically the same behavior of `verdi profile configure-rabbitmq` only with additional argument support to switch to zmq. The second commit introduces a contract between the broker plugin and the cli the broker class specifies the configuration parameters it requires to be setup similar as it is done in transport. This allows use follow more strictly the plugin structure of the brokers similar as we do for transport. This is not yet fully finished since a lot of deprecated cli commands would require a refactor since they heavily couple with rabbitmq broker. I decided that to wait till we can remove these deprecated cli commands to reduce the amount of work needed to be done. Thus all entities that need be exposed through this contract are not yet exposed our public API. This results in a bit awkward usage of private members but that is better than exposing entities that probably will break soon.
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `verdi profile configure-broker` with `core.rabbitmq`, `core.zeromq`, and `none`, and updated broker selection in `verdi profile setup` to use `core.*` backends (default: `core.rabbitmq`).
* **Documentation**
  * Updated installation guides, `verdi presto` help, and CLI reference to use `verdi profile configure-broker core.rabbitmq`.
  * Deprecated `verdi profile configure-rabbitmq` (now a compatibility wrapper with a deprecation notice).
* **Bug Fixes**
  * Improved guidance and behavior for broker configuration/reconfiguration, including handling broker disabling (`none`) and non-interactive failure/restart scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->