### PR TITLE
👌 Revise ZMQ broker log and coupling with aiida settings

### DIFF
--- a/docs/source/internals/broker.rst
+++ b/docs/source/internals/broker.rst
@@ -371,7 +371,7 @@ Service files
 
 .. code-block:: text
 
-    {config_dir}/broker/{profile-uuid}/      (config_dir is typically ~/.aiida)
+    {config_dir}/broker/{profile-uuid}-{profile-name}/      (config_dir is typically ~/.aiida)
     ├── broker.pid         "aiida-zeromq-broker {pid}" — sentinel + PID for ownership check
     ├── broker.status      JSON with task counts, updated every STATUS_INTERVAL seconds
     ├── broker.sockets     path to the temp socket directory

--- a/docs/source/internals/broker.rst
+++ b/docs/source/internals/broker.rst
@@ -69,7 +69,7 @@ Endpoint discovery
 
 Unlike RabbitMQ, the ZeroMQ broker needs no connection configuration: no host, no port, no credentials.
 Discovery is file-based.
-Both sides derive the broker directory from the profile UUID as ``{config_dir}/broker/{profile-uuid}`` (typically ``~/.aiida/broker/{profile-uuid}``).
+Both sides derive the broker directory from the profile UUID as ``{config_dir}/broker/{profile-uuid}-{profile-name}``.
 
 1. On startup, the broker process creates a temporary socket directory (e.g. ``/tmp/aiida_zeromq_xyz``) and writes its path to ``{config_dir}/broker/{profile-uuid}/broker.sockets``.
 2. When a worker calls ``get_communicator()``, it reads that file and derives the endpoint as ``ipc://{sockets_dir}/router.sock``.

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -25,6 +25,8 @@ class BrokerConfigField:
     param_type: str
     choices: tuple[str, ...] | None = None
     hide_input: bool = False
+    expose_cli: bool = True
+    """Whether the field is exposed as a CLI option. If ``False``, the default value is always used."""
 
 
 class Broker(abc.ABC):
@@ -38,6 +40,14 @@ class Broker(abc.ABC):
         :param profile: The profile.
         """
         self._profile = profile
+
+    @classmethod
+    def get_default_config(cls) -> dict[str, t.Any]:
+        """Return the default broker configuration derived from the declared config fields.
+
+        :return: Mapping of configuration field names to their default values.
+        """
+        return {field.name: field.default for field in cls._config_fields}
 
     @classmethod
     def get_detected_config(cls, get_value: 'Callable[[str], t.Any]') -> dict[str, t.Any]:

--- a/src/aiida/brokers/cli.py
+++ b/src/aiida/brokers/cli.py
@@ -26,6 +26,7 @@ __all__ = ('configure_broker_options',)
 ParamTypeFactory = Callable[[t.Any], click.ParamType | t.Any]
 
 _PARAM_TYPES: dict[str, ParamTypeFactory] = {
+    'bool': lambda _field: click.BOOL,
     'choice': lambda field: click.Choice(field.choices or ()),
     'non_empty_string': lambda _field: types.NonEmptyStringParamType(),
     'hostname': lambda _field: types.HostnameType(),
@@ -104,6 +105,7 @@ def configure_broker_options(
                 ),
             )
             for field in broker_cls._config_fields
+            if field.expose_cli
         ]
 
         for decorator in reversed(decorators):

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -11,7 +11,8 @@ from pathlib import Path
 
 import psutil
 
-from aiida.brokers.broker import Broker
+from aiida.brokers.broker import Broker, BrokerConfigField
+from aiida.common.exceptions import ConfigurationError
 from aiida.common.log import AIIDA_LOGGER
 
 from .communicator import ZeromqCommunicator
@@ -37,11 +38,35 @@ class ZeromqBroker(Broker):
     # Class attribute for type discovery
     Communicator = ZeromqCommunicator
 
-    def __init__(self, profile: 'Profile') -> None:
-        from aiida.manage.configuration import get_config
+    _config_fields = (
+        BrokerConfigField(
+            name='supervised_by_daemon',
+            prompt='Managed by daemon',
+            help='Whether the lifecycle of the broker service is managed by the daemon.',
+            default=True,
+            param_type='bool',
+            # Running the broker service outside of the daemon is not yet supported, so the setting is not
+            # configurable and always stored with its default.
+            expose_cli=False,
+        ),
+    )
 
+    def __init__(self, profile: 'Profile') -> None:
         super().__init__(profile)
         self._communicator: ZeromqCommunicator | None = None
+
+        # The broker service determines this location, not this client. Currently the service is always managed by
+        # the daemon, so the daemon client is the authority for the directory.
+        if not profile.process_control_config.get('supervised_by_daemon', True):
+            msg = (
+                'The ZeroMQ broker service is not managed by the daemon (`supervised_by_daemon` is false in the broker '
+                'settings), so the location of its state files is unknown. Running the broker service outside of the '
+                'daemon is not yet supported.'
+            )
+            raise ConfigurationError(msg)
+
+        from aiida.manage.configuration import get_config
+
         zmq_broker_service_dir = get_config().filepaths(profile)['zmq_broker_service']['dir']
         zmq_broker_service_log_path = get_config().filepaths(profile)['zmq_broker_service']['log']
         layout = ZeromqBrokerService.FilepathLayout(zmq_broker_service_dir, zmq_broker_service_log_path)

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -70,7 +70,7 @@ class ZeromqBroker(Broker):
         zmq_broker_service_dir = get_config().filepaths(profile)['zmq_broker_service']['dir']
         zmq_broker_service_log_path = get_config().filepaths(profile)['zmq_broker_service']['log']
         layout = ZeromqBrokerService.FilepathLayout(zmq_broker_service_dir, zmq_broker_service_log_path)
-        self._broker_dir = layout.base_path
+        self._service_dir = layout.service_dir
         self._service_pid_file = layout.pid_file
         self._service_status_file = layout.status_file
         self._service_sockets_file = layout.sockets_file
@@ -80,16 +80,16 @@ class ZeromqBroker(Broker):
         if self.is_running:
             status = self.get_service_status()
             pid = status.get('pid', '?') if status else '?'
-            return f'ZeroMQ Broker (PID {pid}) @ {self._broker_dir}'
-        return f'ZeroMQ Broker @ {self._broker_dir} <not running>'
+            return f'ZeroMQ Broker (PID {pid}) @ {self._service_dir}'
+        return f'ZeroMQ Broker @ {self._service_dir} <not running>'
 
     @property
     def storage_path(self) -> Path:
         return self._storage_path
 
     @property
-    def base_path(self) -> Path:
-        return self._broker_dir
+    def service_dir(self) -> Path:
+        return self._service_dir
 
     # --- Status queries (read PID/status/socket files) ---
 

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -17,6 +17,7 @@ from aiida.common.log import AIIDA_LOGGER
 from .communicator import ZeromqCommunicator
 from .defaults import BROKER_READY_TIMEOUT
 from .queue import PersistentQueue
+from .service import PID_SENTINEL, ZeromqBrokerService
 
 if t.TYPE_CHECKING:
     from aiida.manage.configuration.profile import Profile
@@ -37,16 +38,18 @@ class ZeromqBroker(Broker):
     Communicator = ZeromqCommunicator
 
     def __init__(self, profile: 'Profile') -> None:
-        super().__init__(profile)
-        self._init_paths(get_broker_base_path(profile))
+        from aiida.manage.configuration import get_config
 
-    def _init_paths(self, broker_dir: Path) -> None:
+        super().__init__(profile)
         self._communicator: ZeromqCommunicator | None = None
-        self._broker_dir = broker_dir
-        self._storage_path = broker_dir / 'storage'
-        self._service_pid_file = broker_dir / 'broker.pid'
-        self._service_status_file = broker_dir / 'broker.status'
-        self._service_sockets_file = broker_dir / 'broker.sockets'
+        zmq_broker_service_dir = get_config().filepaths(profile)['zmq_broker_service']['dir']
+        zmq_broker_service_log_path = get_config().filepaths(profile)['zmq_broker_service']['log']
+        layout = ZeromqBrokerService.FilepathLayout(zmq_broker_service_dir, zmq_broker_service_log_path)
+        self._broker_dir = layout.base_path
+        self._service_pid_file = layout.pid_file
+        self._service_status_file = layout.status_file
+        self._service_sockets_file = layout.sockets_file
+        self._storage_path = layout.storage_path
 
     def __str__(self) -> str:
         if self.is_running:
@@ -80,7 +83,8 @@ class ZeromqBroker(Broker):
             return None
         return f'ipc://{sockets_path}/router.sock'
 
-    _PID_SENTINEL = 'aiida-zeromq-broker'
+    # protects from global overwrites
+    _PID_SENTINEL = PID_SENTINEL
 
     def get_service_pid(self) -> int | None:
         """Read the ZeromqBrokerService PID from its PID file.
@@ -207,10 +211,3 @@ class ZeromqIncomingTask:
 
         yield _Outcome()
         self._queue.remove_pending(self._task_id)
-
-
-def get_broker_base_path(profile: 'Profile') -> Path:
-    from aiida.manage.configuration import get_config_path
-
-    config_dir = Path(get_config_path()).parent  # type: ignore[no-untyped-call]
-    return config_dir / 'broker' / profile.uuid

--- a/src/aiida/brokers/zeromq/service.py
+++ b/src/aiida/brokers/zeromq/service.py
@@ -30,7 +30,7 @@ class ZeromqBrokerService:
     """Process wrapper for ZeromqBrokerServer.
 
     Directory structure:
-        {base_path}/
+        {service_dir}/
         ├── storage/        # Task queue persistence
         ├── broker.log      # Broker log file, location is configurable
         ├── broker.pid      # PID file
@@ -44,38 +44,38 @@ class ZeromqBrokerService:
     class FilepathLayout:
         """Canonical filesystem layout for the ZMQ broker state files."""
 
-        def __init__(self, base_path: Path | str, log_file_path: Path | str | None = None) -> None:
-            self.base_path = Path(base_path)
+        def __init__(self, service_dir: Path | str, log_file_path: Path | str | None = None) -> None:
+            self.service_dir = Path(service_dir)
             self._log_file_path = None if log_file_path is None else Path(log_file_path)
 
         @property
         def storage_path(self) -> Path:
             """Return the persistent storage directory."""
-            return self.base_path / 'storage'
+            return self.service_dir / 'storage'
 
         @property
         def log_file(self) -> Path:
             """Return the broker log file."""
-            return self.base_path / 'broker.log' if self._log_file_path is None else self._log_file_path
+            return self.service_dir / 'broker.log' if self._log_file_path is None else self._log_file_path
 
         @property
         def pid_file(self) -> Path:
             """Return the broker PID file."""
-            return self.base_path / 'broker.pid'
+            return self.service_dir / 'broker.pid'
 
         @property
         def status_file(self) -> Path:
             """Return the broker status file."""
-            return self.base_path / 'broker.status'
+            return self.service_dir / 'broker.status'
 
         @property
         def sockets_file(self) -> Path:
             """Return the file containing the temporary sockets directory path."""
-            return self.base_path / 'broker.sockets'
+            return self.service_dir / 'broker.sockets'
 
-    def __init__(self, base_path: Path | str, log_file_path: Path | str | None = None):
-        self._layout = self.FilepathLayout(base_path, log_file_path=log_file_path)
-        self._base_path = self._layout.base_path
+    def __init__(self, service_dir: Path | str, log_file_path: Path | str | None = None):
+        self._layout = self.FilepathLayout(service_dir, log_file_path=log_file_path)
+        self._service_dir = self._layout.service_dir
         self._storage_path = self._layout.storage_path
         self._sockets_path: Path | None = None
         self._log_file = self._layout.log_file
@@ -86,8 +86,8 @@ class ZeromqBrokerService:
         self._running = False
 
     @property
-    def base_path(self) -> Path:
-        return self._base_path
+    def service_dir(self) -> Path:
+        return self._service_dir
 
     @property
     def log_file(self) -> Path:
@@ -105,7 +105,7 @@ class ZeromqBrokerService:
         if self._running:
             return
 
-        self._base_path.mkdir(parents=True, exist_ok=True)
+        self._service_dir.mkdir(parents=True, exist_ok=True)
 
         # Clean up any orphaned socket directory from a previous unclean shutdown
         if self._sockets_file.exists():
@@ -174,10 +174,10 @@ class ZeromqBrokerService:
         temp_file.rename(self._status_file)
 
 
-def run_broker_service(base_path: str | Path, log_file_path: Path | str | None = None) -> None:
+def run_broker_service(service_dir: str | Path, log_file_path: Path | str | None = None) -> None:
     """Run the ZeroMQ broker service."""
-    service = ZeromqBrokerService(base_path=base_path, log_file_path=log_file_path)
-    service.base_path.mkdir(parents=True, exist_ok=True)
+    service = ZeromqBrokerService(service_dir=service_dir, log_file_path=log_file_path)
+    service.service_dir.mkdir(parents=True, exist_ok=True)
     configure_logging(daemon=True, daemon_log_file=service.log_file)
     service.run_forever()
 
@@ -186,7 +186,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--base-path', '-b', required=True)
+    parser.add_argument('--service-dir', '-s', required=True)
     parser.add_argument('--log-file-path', '-l', required=False)
     args = parser.parse_args()
-    run_broker_service(base_path=args.base_path, log_file_path=args.log_file_path)
+    run_broker_service(service_dir=args.service_dir, log_file_path=args.log_file_path)

--- a/src/aiida/brokers/zeromq/service.py
+++ b/src/aiida/brokers/zeromq/service.py
@@ -1,7 +1,7 @@
 """ZeroMQ Broker Service - process wrapper for ZeromqBrokerServer.
 
-Manages PID/status files, socket directory, and signal handling.
-Circus handles process lifecycle (daemonization, keepalive, log capture).
+Manages PID/status files, socket directory, signal handling, and broker logging.
+Circus handles process lifecycle (daemonization and keepalive).
 """
 
 from __future__ import annotations
@@ -16,10 +16,14 @@ import time
 import typing as t
 from pathlib import Path
 
+from aiida.common.log import configure_logging
+
 from .defaults import POLL_TIMEOUT, STATUS_INTERVAL
 from .server import ZeromqBrokerServer
 
 _LOGGER = logging.getLogger(__name__)
+
+PID_SENTINEL = 'aiida-zeromq-broker'
 
 
 class ZeromqBrokerService:
@@ -28,6 +32,7 @@ class ZeromqBrokerService:
     Directory structure:
         {base_path}/
         ├── storage/        # Task queue persistence
+        ├── broker.log      # Broker log file, location is configurable
         ├── broker.pid      # PID file
         ├── broker.status   # Status JSON file
         └── broker.sockets  # Path to temp socket directory
@@ -36,19 +41,57 @@ class ZeromqBrokerService:
         └── router.sock
     """
 
-    def __init__(self, base_path: Path | str):
-        self._base_path = Path(base_path)
-        self._storage_path = self._base_path / 'storage'
+    class FilepathLayout:
+        """Canonical filesystem layout for the ZMQ broker state files."""
+
+        def __init__(self, base_path: Path | str, log_file_path: Path | str | None = None) -> None:
+            self.base_path = Path(base_path)
+            self._log_file_path = None if log_file_path is None else Path(log_file_path)
+
+        @property
+        def storage_path(self) -> Path:
+            """Return the persistent storage directory."""
+            return self.base_path / 'storage'
+
+        @property
+        def log_file(self) -> Path:
+            """Return the broker log file."""
+            return self.base_path / 'broker.log' if self._log_file_path is None else self._log_file_path
+
+        @property
+        def pid_file(self) -> Path:
+            """Return the broker PID file."""
+            return self.base_path / 'broker.pid'
+
+        @property
+        def status_file(self) -> Path:
+            """Return the broker status file."""
+            return self.base_path / 'broker.status'
+
+        @property
+        def sockets_file(self) -> Path:
+            """Return the file containing the temporary sockets directory path."""
+            return self.base_path / 'broker.sockets'
+
+    def __init__(self, base_path: Path | str, log_file_path: Path | str | None = None):
+        self._layout = self.FilepathLayout(base_path, log_file_path=log_file_path)
+        self._base_path = self._layout.base_path
+        self._storage_path = self._layout.storage_path
         self._sockets_path: Path | None = None
-        self._sockets_file = self._base_path / 'broker.sockets'
-        self._pid_file = self._base_path / 'broker.pid'
-        self._status_file = self._base_path / 'broker.status'
+        self._log_file = self._layout.log_file
+        self._sockets_file = self._layout.sockets_file
+        self._pid_file = self._layout.pid_file
+        self._status_file = self._layout.status_file
         self._server: ZeromqBrokerServer | None = None
         self._running = False
 
     @property
     def base_path(self) -> Path:
         return self._base_path
+
+    @property
+    def log_file(self) -> Path:
+        return self._log_file
 
     @property
     def pid_file(self) -> Path:
@@ -82,7 +125,7 @@ class ZeromqBrokerService:
             sockets_path=self._sockets_path,
         )
 
-        self._pid_file.write_text(f'aiida-zeromq-broker {os.getpid()}')
+        self._pid_file.write_text(f'{PID_SENTINEL} {os.getpid()}')
 
         # SIGINT (ctrl-c / circus graceful) + SIGTERM (circus stop)
         signal.signal(signal.SIGINT, self._handle_shutdown)
@@ -131,9 +174,12 @@ class ZeromqBrokerService:
         temp_file.rename(self._status_file)
 
 
-def run_broker_service(base_path: str | Path) -> None:
-    """Entry point for ``verdi daemon broker``."""
-    ZeromqBrokerService(base_path=base_path).run_forever()
+def run_broker_service(base_path: str | Path, log_file_path: Path | str | None = None) -> None:
+    """Run the ZeroMQ broker service."""
+    service = ZeromqBrokerService(base_path=base_path, log_file_path=log_file_path)
+    service.base_path.mkdir(parents=True, exist_ok=True)
+    configure_logging(daemon=True, daemon_log_file=service.log_file)
+    service.run_forever()
 
 
 if __name__ == '__main__':
@@ -141,5 +187,6 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--base-path', '-b', required=True)
+    parser.add_argument('--log-file-path', '-l', required=False)
     args = parser.parse_args()
-    run_broker_service(base_path=args.base_path)
+    run_broker_service(base_path=args.base_path, log_file_path=args.log_file_path)

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -167,7 +167,7 @@ def status(ctx, all_profiles, timeout):
                     broker_lines.append(
                         f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]'
                     )
-                    broker_lines.append(f'Broker directory: {broker.broker_dir}')
+                    broker_lines.append(f'Broker directory: {broker.service_dir}')
             else:
                 broker_lines.append('Broker is NOT running')
 
@@ -317,11 +317,11 @@ def worker():
 
 
 @verdi_daemon.command('broker', hidden=True)
-@click.option('--base-path', 'base_path', required=True)
+@click.option('--service-dir', 'service_dir', required=True)
 @click.option('--log-file-path', 'log_file_path', required=False)
 @decorators.with_dbenv()
 @decorators.requires_broker
-def broker(base_path, log_file_path):
+def broker(service_dir, log_file_path):
     """Run the ZeroMQ broker service in the current process.
 
     Sets up the profile enviromment (e.g. logging configuration) before running the broker.
@@ -341,4 +341,4 @@ def broker(base_path, log_file_path):
         msg = f'Only ZeromqBroker can be started through verdi but got broker of type {type(broker)}.'
         raise TypeError(msg)
 
-    run_broker_service(base_path=base_path, log_file_path=log_file_path)
+    run_broker_service(service_dir=service_dir, log_file_path=log_file_path)

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -167,7 +167,7 @@ def status(ctx, all_profiles, timeout):
                     broker_lines.append(
                         f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]'
                     )
-                    broker_lines.append(f'Broker directory: {broker.base_path}')
+                    broker_lines.append(f'Broker directory: {broker.broker_dir}')
             else:
                 broker_lines.append('Broker is NOT running')
 
@@ -317,18 +317,28 @@ def worker():
 
 
 @verdi_daemon.command('broker', hidden=True)
+@click.option('--base-path', 'base_path', required=True)
+@click.option('--log-file-path', 'log_file_path', required=False)
 @decorators.with_dbenv()
 @decorators.requires_broker
-def broker():
-    """Run the ZeroMQ broker server in the current process.
+def broker(base_path, log_file_path):
+    """Run the ZeroMQ broker service in the current process.
+
+    Sets up the profile enviromment (e.g. logging configuration) before running the broker.
 
     .. note:: this should not be called directly from the commandline!
     """
-    from aiida.brokers.zeromq.broker import get_broker_base_path
+    from aiida.brokers.zeromq.broker import ZeromqBroker
     from aiida.brokers.zeromq.service import run_broker_service
     from aiida.manage.manager import get_manager
 
     profile = get_manager().get_profile()
     if profile is None:
         echo.echo_critical('No profile loaded.')
-    run_broker_service(base_path=get_broker_base_path(profile))
+
+    broker = get_manager().get_broker()
+    if not isinstance(broker, ZeromqBroker):
+        msg = f'Only ZeromqBroker can be started through verdi but got broker of type {type(broker)}.'
+        raise TypeError(msg)
+
+    run_broker_service(base_path=base_path, log_file_path=log_file_path)

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -202,6 +202,7 @@ def verdi_presto(
     from aiida.common import exceptions
     from aiida.manage.configuration import create_profile, load_profile
     from aiida.orm import Computer
+    from aiida.plugins import BrokerFactory
 
     if profile_name in ctx.obj.config.profile_names:
         raise click.BadParameter(f'The profile `{profile_name}` already exists.', param_hint='--profile-name')
@@ -238,7 +239,7 @@ def verdi_presto(
     elif use_zeromq:
         echo.echo_report('`--use-zeromq` enabled: configuring the profile with ZeroMQ broker.')
         broker_backend = 'core.zeromq'
-        broker_config = {}
+        broker_config = BrokerFactory(broker_backend).get_default_config()
     else:
         try:
             broker_config = detect_rabbitmq_config()
@@ -249,7 +250,7 @@ def verdi_presto(
                 'recreate the profile with `verdi presto --no-broker`.'
             )
             broker_backend = 'core.zeromq'
-            broker_config = {}
+            broker_config = BrokerFactory(broker_backend).get_default_config()
         else:
             echo.echo_report('RabbitMQ server detected: configuring the profile with RabbitMQ broker.')
             broker_backend = 'core.rabbitmq'

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -93,8 +93,10 @@ def command_create_profile(
         echo.echo_report('RabbitMQ can be reconfigured with `verdi profile configure-broker core.rabbitmq`.')
 
     elif broker == 'core.zeromq':
+        from aiida.plugins import BrokerFactory
+
         broker_backend = broker
-        broker_config = {}
+        broker_config = BrokerFactory(broker).get_default_config()
         echo.echo_success('ZeroMQ broker configured (no external service required).')
         echo.echo_report('The ZeroMQ broker service will be started automatically with the daemon.')
 
@@ -231,7 +233,11 @@ def _configure_profile_broker(
         return
 
     if backend == 'core.zeromq':
-        _update_profile_broker_configuration(ctx, profile, backend=backend, config={})
+        from aiida.plugins import BrokerFactory
+
+        _update_profile_broker_configuration(
+            ctx, profile, backend=backend, config=BrokerFactory(backend).get_default_config()
+        )
         echo.echo_success(f'ZeroMQ configuration for `{profile.name}` updated.')
         echo.echo_report('The ZeroMQ broker service will be started automatically with the daemon.')
 

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -39,6 +39,8 @@ from aiida.manage.manager import get_manager
 if TYPE_CHECKING:
     from circus.client import CircusClient
 
+    from aiida.manage.configuration.config import CircusEndpointFilepaths, CircusEndpointName
+
 LOGGER = AIIDA_LOGGER.getChild('engine.daemon.client')
 
 VERDI_BIN = shutil.which('verdi')
@@ -335,8 +337,13 @@ class DaemonClient:
         return self._config.filepaths(self.profile)['circus']['socket']['file']
 
     @property
-    def circus_socket_endpoints(self) -> dict[str, str]:
-        return self._config.filepaths(self.profile)['circus']['socket']
+    def circus_socket_endpoints(self) -> 'CircusEndpointFilepaths':
+        socket_filepaths = self._config.filepaths(self.profile)['circus']['socket']
+        return {
+            'controller': socket_filepaths['controller'],
+            'pubsub': socket_filepaths['pubsub'],
+            'stats': socket_filepaths['stats'],
+        }
 
     @property
     def daemon_log_file(self) -> str:
@@ -528,7 +535,7 @@ class DaemonClient:
 
         return endpoint
 
-    def get_ipc_endpoint(self, endpoint):
+    def get_ipc_endpoint(self, endpoint: 'CircusEndpointName'):
         """Get the ipc endpoint string for a circus daemon endpoint for a given socket.
 
         :param endpoint: The circus endpoint for which to return a socket.
@@ -537,9 +544,9 @@ class DaemonClient:
         filepath = self.get_circus_socket_directory()
         filename = self.circus_socket_endpoints[endpoint]
         template = 'ipc://{filepath}/{filename}'
-        endpoint = template.format(filepath=filepath, filename=filename)
+        endpoint_string = template.format(filepath=filepath, filename=filename)
 
-        return endpoint
+        return endpoint_string
 
     def get_tcp_endpoint(self, port=None):
         """Get the tcp endpoint string for a circus daemon endpoint.

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -971,35 +971,37 @@ class DaemonClient:
         from aiida.brokers.zeromq import ZeromqBroker
         from aiida.manage.manager import get_manager
 
-        try:
-            broker_instance = get_manager().get_broker()
-        except Exception:
-            LOGGER.warning('Could not load the broker instance while preparing daemon watchers.', exc_info=True)
-            broker_instance = None
-        if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_running:
-            # prepare zmq broker service profile directory
-            pathlib.Path(self.zmq_broker_service_dir).mkdir(parents=True, exist_ok=True)
+        supervised_by_daemon = self.profile.process_control_config.get('supervised_by_daemon', True)
+        if self.profile.process_control_backend == 'core.zeromq' and supervised_by_daemon:
+            try:
+                broker_instance = get_manager().get_broker()
+            except Exception:
+                LOGGER.warning('Could not load the broker instance while preparing daemon watchers.', exc_info=True)
+                broker_instance = None
+            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_running:
+                # prepare zmq broker service profile directory
+                pathlib.Path(self.zmq_broker_service_dir).mkdir(parents=True, exist_ok=True)
 
-            watchers.append(
-                {
-                    'cmd': ' '.join(self._cmd_start_zmq_broker),
-                    'name': f'{self.daemon_name}-zmq-broker-service',
-                    'numprocesses': 1,
-                    'virtualenv': self.virtualenv,
-                    'copy_env': True,
-                    'stdout_stream': {
-                        'class': 'FileStream',
-                        'filename': self.zmq_broker_service_log_file,
-                        'time_format': '%Y-%m-%d %H:%M:%S',
-                    },
-                    'stderr_stream': {
-                        'class': 'FileStream',
-                        'filename': self.zmq_broker_service_log_file,
-                        'time_format': '%Y-%m-%d %H:%M:%S',
-                    },
-                    'env': self.get_env(),
-                }
-            )
+                watchers.append(
+                    {
+                        'cmd': ' '.join(self._cmd_start_zmq_broker),
+                        'name': f'{self.daemon_name}-zmq-broker-service',
+                        'numprocesses': 1,
+                        'virtualenv': self.virtualenv,
+                        'copy_env': True,
+                        'stdout_stream': {
+                            'class': 'FileStream',
+                            'filename': self.zmq_broker_service_log_file,
+                            'time_format': '%Y-%m-%d %H:%M:%S',
+                        },
+                        'stderr_stream': {
+                            'class': 'FileStream',
+                            'filename': self.zmq_broker_service_log_file,
+                            'time_format': '%Y-%m-%d %H:%M:%S',
+                        },
+                        'env': self.get_env(),
+                    }
+                )
 
         watchers.append(
             {

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -15,6 +15,7 @@ import enum
 import json
 import os
 import pathlib
+import shlex
 import shutil
 import socket
 import subprocess
@@ -282,9 +283,32 @@ class DaemonClient:
         return [self._verdi_bin, '-p', self.profile.name, 'daemon', 'worker']
 
     @property
-    def cmd_start_broker(self) -> list[str]:
-        """Return the command to start the ZeroMQ broker server process."""
-        return [self._verdi_bin, '-p', self.profile.name, 'daemon', 'broker']
+    def zmq_broker_service_dir(self) -> str:
+        """Return the directory for the ZMQ broker service files, derived from the settings.
+
+        The daemon manages the broker service and therefore determines where the service writes its state files.
+        """
+        return self._config.filepaths(self.profile)['zmq_broker_service']['dir']
+
+    @property
+    def zmq_broker_service_log_file(self) -> str:
+        """Return the log file of the ZMQ broker service, derived from the settings."""
+        return self._config.filepaths(self.profile)['zmq_broker_service']['log']
+
+    @property
+    def _cmd_start_zmq_broker(self) -> list[str]:
+        """Return the command to start the ZMQ broker service process."""
+        return [
+            self._verdi_bin,
+            '-p',
+            self.profile.name,
+            'daemon',
+            'broker',
+            '--base-path',
+            shlex.quote(self.zmq_broker_service_dir),
+            '--log-file-path',
+            shlex.quote(self.zmq_broker_service_log_file),
+        ]
 
     @property
     def loglevel(self) -> str:
@@ -944,35 +968,38 @@ class DaemonClient:
 
         # Start ZeroMQ broker before workers so its sockets are ready when workers connect.
         # Skip if a broker is already running (e.g. started by the test fixture).
-        if self.profile.process_control_backend == 'core.zeromq':
-            from aiida.manage.manager import get_manager
+        from aiida.brokers.zeromq import ZeromqBroker
+        from aiida.manage.manager import get_manager
 
+        try:
             broker_instance = get_manager().get_broker()
-            broker_already_running = (
-                broker_instance is not None and hasattr(broker_instance, 'is_running') and broker_instance.is_running
-            )
+        except Exception:
+            LOGGER.warning('Could not load the broker instance while preparing daemon watchers.', exc_info=True)
+            broker_instance = None
+        if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_running:
+            # prepare zmq broker service profile directory
+            pathlib.Path(self.zmq_broker_service_dir).mkdir(parents=True, exist_ok=True)
 
-            if not broker_already_running:
-                watchers.append(
-                    {
-                        'cmd': ' '.join(self.cmd_start_broker),
-                        'name': f'{self.daemon_name}-broker',
-                        'numprocesses': 1,
-                        'virtualenv': self.virtualenv,
-                        'copy_env': True,
-                        'stdout_stream': {
-                            'class': 'FileStream',
-                            'filename': self.daemon_log_file,
-                            'time_format': '%Y-%m-%d %H:%M:%S',
-                        },
-                        'stderr_stream': {
-                            'class': 'FileStream',
-                            'filename': self.daemon_log_file,
-                            'time_format': '%Y-%m-%d %H:%M:%S',
-                        },
-                        'env': self.get_env(),
-                    }
-                )
+            watchers.append(
+                {
+                    'cmd': ' '.join(self._cmd_start_zmq_broker),
+                    'name': f'{self.daemon_name}-zmq-broker-service',
+                    'numprocesses': 1,
+                    'virtualenv': self.virtualenv,
+                    'copy_env': True,
+                    'stdout_stream': {
+                        'class': 'FileStream',
+                        'filename': self.zmq_broker_service_log_file,
+                        'time_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'stderr_stream': {
+                        'class': 'FileStream',
+                        'filename': self.zmq_broker_service_log_file,
+                        'time_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'env': self.get_env(),
+                }
+            )
 
         watchers.append(
             {

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -306,7 +306,7 @@ class DaemonClient:
             self.profile.name,
             'daemon',
             'broker',
-            '--base-path',
+            '--service-dir',
             shlex.quote(self.zmq_broker_service_dir),
             '--log-file-path',
             shlex.quote(self.zmq_broker_service_log_file),

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -258,17 +258,17 @@ class ProfileStorageConfig(BaseModel, defer_build=True):
 
 
 class ProcessControlConfig(BaseModel, defer_build=True):
-    """Schema for the process control configuration of an AiiDA profile."""
+    """Schema for the process control configuration of an AiiDA profile.
 
-    broker_protocol: str = Field('amqp', description='Protocol for connecting to the message broker.')
-    broker_username: str = Field('guest', description='Username for message broker authentication.')
-    broker_password: str = Field('guest', description='Password for message broker.')
-    broker_host: str = Field('127.0.0.1', description='Hostname of the message broker.')
-    broker_port: int = Field(5432, description='Port of the message broker.')
-    broker_virtual_host: str = Field('', description='Virtual host to use for the message broker.')
-    broker_parameters: dict[str, Any] = Field(
-        default_factory=dict, description='Arguments to be encoded as query parameters.'
+    The ``config`` entries are broker plugin specific: each broker plugin declares its supported fields and their
+    defaults through ``aiida.brokers.broker.Broker._config_fields``, which is the source of truth for its
+    configuration.
+    """
+
+    backend: Optional[str] = Field(
+        None, description='Entry point name of the broker plugin, or ``None`` if no broker is configured.'
     )
+    config: Optional[Dict[str, Any]] = Field(None, description='Configuration of the broker plugin.')
 
 
 class ProfileSchema(BaseModel, defer_build=True):

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -965,6 +965,7 @@ class Config:
         daemon_dir = _config_path_resolver.daemon_dir
         daemon_log_dir = _config_path_resolver.daemon_log_dir
         profile_log_dir = _config_path_resolver.profile_log_dir
+        zmq_broker_service_base_dir = _config_path_resolver.zmq_broker_service_base_dir
 
         return {
             'profile': {
@@ -985,5 +986,9 @@ class Config:
                 'log': str(daemon_log_dir / f'aiida-{profile.name}.log'),
                 'pid': str(daemon_dir / f'aiida-{profile.name}.pid'),
                 'daemon_env_info': str(daemon_dir / f'aiida-{profile.name}-env-info.json'),
+            },
+            'zmq_broker_service': {
+                'dir': str(zmq_broker_service_base_dir / f'{profile.uuid}-{profile.name}'),
+                'log': str(zmq_broker_service_base_dir / f'{profile.uuid}-{profile.name}' / 'broker.log'),
             },
         }

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -21,7 +21,7 @@ import os
 import shutil
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypeAlias, TypedDict, cast
 
 from pydantic import (
     BaseModel,
@@ -39,6 +39,62 @@ from .options import Option, get_option, get_option_names, parse_option, resolve
 from .profile import Profile
 
 LOGGER = AIIDA_LOGGER.getChild('manage.configuration.config')
+
+
+CircusEndpointName: TypeAlias = Literal['controller', 'pubsub', 'stats']
+
+
+class CircusEndpointFilepaths(TypedDict):
+    """Typed dictionary for Circus endpoint socket file names."""
+
+    controller: str
+    pubsub: str
+    stats: str
+
+
+class CircusSocketFilepaths(CircusEndpointFilepaths):
+    """Typed dictionary for Circus socket file paths."""
+
+    file: str
+
+
+class ProfileFilepaths(TypedDict):
+    """Typed dictionary for profile log file paths."""
+
+    log: str
+
+
+class CircusFilepaths(TypedDict):
+    """Typed dictionary for Circus file paths."""
+
+    log: str
+    pid: str
+    port: str
+    socket: CircusSocketFilepaths
+
+
+class DaemonFilepaths(TypedDict):
+    """Typed dictionary for daemon file paths."""
+
+    log: str
+    pid: str
+    daemon_env_info: str
+
+
+class ZeromqBrokerServiceFilepaths(TypedDict):
+    """Typed dictionary for ZeroMQ broker file paths."""
+
+    dir: str
+    log: str
+
+
+class ConfigFilepaths(TypedDict):
+    """Typed dictionary for profile-related file paths."""
+
+    profile: ProfileFilepaths
+    circus: CircusFilepaths
+    daemon: DaemonFilepaths
+    zmq_broker_service: ZeromqBrokerServiceFilepaths
 
 
 class ConfigVersionSchema(BaseModel, defer_build=True):
@@ -954,7 +1010,7 @@ class Config:
             handle.close()
             shutil.move(handle.name, self.filepath)
 
-    def filepaths(self, profile: Profile):
+    def filepaths(self, profile: Profile) -> ConfigFilepaths:
         """Return the filepaths used by a profile.
 
         :return: a dictionary of filepaths

--- a/src/aiida/manage/configuration/settings.py
+++ b/src/aiida/manage/configuration/settings.py
@@ -23,6 +23,7 @@ DEFAULT_AIIDA_USER = 'aiida@localhost'
 DEFAULT_CONFIG_DIR_NAME = '.aiida'
 DEFAULT_CONFIG_FILE_NAME = 'config.json'
 DEFAULT_CONFIG_INDENT_SIZE = 4
+DEFAULT_ZMQ_BROKER_SERVICE_BASE_DIR_NAME = 'broker'
 DEFAULT_DAEMON_DIR_NAME = 'daemon'
 DEFAULT_DAEMON_LOG_DIR_NAME = 'log'
 DEFAULT_PROFILE_LOG_DIR_NAME = 'log'
@@ -81,6 +82,10 @@ class AiiDAConfigPathResolver:
         return self._aiida_path / DEFAULT_DAEMON_DIR_NAME / DEFAULT_DAEMON_LOG_DIR_NAME
 
     @property
+    def zmq_broker_service_base_dir(self) -> pathlib.Path:
+        return self._aiida_path / DEFAULT_ZMQ_BROKER_SERVICE_BASE_DIR_NAME
+
+    @property
     def profile_log_dir(self) -> pathlib.Path:
         return self._aiida_path / DEFAULT_PROFILE_LOG_DIR_NAME
 
@@ -104,6 +109,7 @@ def _create_instance_directories(aiida_config_folder: pathlib.Path | None) -> No
         path_resolver.aiida_path,
         path_resolver.daemon_dir,
         path_resolver.daemon_log_dir,
+        path_resolver.zmq_broker_service_base_dir,
         path_resolver.profile_log_dir,
         path_resolver.access_control_dir,
     ]

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -117,9 +117,9 @@ class TestZeromqBrokerStatusQueries:
         """Test storage_path property."""
         assert zeromq_broker.storage_path == tmp_path / 'storage'
 
-    def test_base_path(self, zeromq_broker, tmp_path):
-        """Test base_path property."""
-        assert zeromq_broker.base_path == tmp_path
+    def test_service_dir(self, zeromq_broker, tmp_path):
+        """Test service_dir property."""
+        assert zeromq_broker.service_dir == tmp_path
 
     def test_get_sockets_path_no_file(self, zeromq_broker):
         """Test _get_sockets_path when file missing."""
@@ -127,37 +127,37 @@ class TestZeromqBrokerStatusQueries:
 
     def test_get_sockets_path_os_error(self, zeromq_broker):
         """Test _get_sockets_path when read fails."""
-        sockets_file = zeromq_broker.base_path / 'broker.sockets'
+        sockets_file = zeromq_broker.service_dir / 'broker.sockets'
         sockets_file.mkdir()  # directory instead of file => OSError on read_text
         assert zeromq_broker._get_sockets_path() is None
 
     def test_get_service_pid_sentinel_format(self, zeromq_broker):
         """Test PID file with sentinel format."""
-        pid_file = zeromq_broker.base_path / 'broker.pid'
+        pid_file = zeromq_broker.service_dir / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 12345')
         assert zeromq_broker.get_service_pid() == 12345
 
     def test_get_service_pid_bare_format(self, zeromq_broker):
         """Test PID file with bare PID fallback."""
-        pid_file = zeromq_broker.base_path / 'broker.pid'
+        pid_file = zeromq_broker.service_dir / 'broker.pid'
         pid_file.write_text('54321')
         assert zeromq_broker.get_service_pid() == 54321
 
     def test_get_service_pid_invalid(self, zeromq_broker):
         """Test PID file with invalid content."""
-        pid_file = zeromq_broker.base_path / 'broker.pid'
+        pid_file = zeromq_broker.service_dir / 'broker.pid'
         pid_file.write_text('garbage text')
         assert zeromq_broker.get_service_pid() is None
 
     def test_is_running_stale_pid(self, zeromq_broker):
         """Test is_running with stale PID."""
-        pid_file = zeromq_broker.base_path / 'broker.pid'
+        pid_file = zeromq_broker.service_dir / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 999999')  # Non-existent PID
         assert not zeromq_broker.is_running
 
     def test_get_service_status_valid(self, zeromq_broker):
         """Test get_service_status with valid JSON."""
-        status_file = zeromq_broker.base_path / 'broker.status'
+        status_file = zeromq_broker.service_dir / 'broker.status'
         status_file.write_text(json.dumps({'pid': 123, 'running': True}))
         status = zeromq_broker.get_service_status()
         assert status is not None
@@ -165,25 +165,25 @@ class TestZeromqBrokerStatusQueries:
 
     def test_get_service_status_invalid_json(self, zeromq_broker):
         """Test get_service_status with invalid JSON."""
-        status_file = zeromq_broker.base_path / 'broker.status'
+        status_file = zeromq_broker.service_dir / 'broker.status'
         status_file.write_text('{INVALID JSON')
         assert zeromq_broker.get_service_status() is None
 
     def test_cleanup_stale_service_files(self, zeromq_broker):
         """Test _cleanup_stale_service_files removes all stale files."""
 
-        broker_dir = zeromq_broker.base_path
-        (broker_dir / 'broker.pid').write_text('aiida-zeromq-broker 1')
-        (broker_dir / 'broker.status').write_text('{}')
-        sockets_dir = broker_dir / 'test_sockets'
+        service_dir = zeromq_broker.service_dir
+        (service_dir / 'broker.pid').write_text('aiida-zeromq-broker 1')
+        (service_dir / 'broker.status').write_text('{}')
+        sockets_dir = service_dir / 'test_sockets'
         sockets_dir.mkdir()
-        (broker_dir / 'broker.sockets').write_text(str(sockets_dir))
+        (service_dir / 'broker.sockets').write_text(str(sockets_dir))
 
         zeromq_broker._cleanup_stale_service_files()
 
-        assert not (broker_dir / 'broker.pid').exists()
-        assert not (broker_dir / 'broker.status').exists()
-        assert not (broker_dir / 'broker.sockets').exists()
+        assert not (service_dir / 'broker.pid').exists()
+        assert not (service_dir / 'broker.status').exists()
+        assert not (service_dir / 'broker.sockets').exists()
         assert not sockets_dir.exists()
 
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -87,7 +87,7 @@ class TestZeromqBrokerStatusQueries:
         start_zeromq_broker(zeromq_broker)
         try:
             s = str(zeromq_broker)
-            assert 'ZeroMQ zeromq_broker' in s
+            assert 'ZeroMQ Broker' in s
             assert 'PID' in s
         finally:
             stop_zeromq_broker(zeromq_broker)
@@ -109,64 +109,65 @@ class TestZeromqBrokerStatusQueries:
         """Test _get_sockets_path when file missing."""
         assert zeromq_broker._get_sockets_path() is None
 
-    def test_get_sockets_path_os_error(self, zeromq_broker, tmp_path):
+    def test_get_sockets_path_os_error(self, zeromq_broker):
         """Test _get_sockets_path when read fails."""
-        sockets_file = tmp_path / 'broker.sockets'
+        sockets_file = zeromq_broker.base_path / 'broker.sockets'
         sockets_file.mkdir()  # directory instead of file => OSError on read_text
         assert zeromq_broker._get_sockets_path() is None
 
-    def test_get_service_pid_sentinel_format(self, zeromq_broker, tmp_path):
+    def test_get_service_pid_sentinel_format(self, zeromq_broker):
         """Test PID file with sentinel format."""
-        pid_file = tmp_path / 'broker.pid'
+        pid_file = zeromq_broker.base_path / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 12345')
         assert zeromq_broker.get_service_pid() == 12345
 
-    def test_get_service_pid_bare_format(self, zeromq_broker, tmp_path):
+    def test_get_service_pid_bare_format(self, zeromq_broker):
         """Test PID file with bare PID fallback."""
-        pid_file = tmp_path / 'broker.pid'
+        pid_file = zeromq_broker.base_path / 'broker.pid'
         pid_file.write_text('54321')
         assert zeromq_broker.get_service_pid() == 54321
 
-    def test_get_service_pid_invalid(self, zeromq_broker, tmp_path):
+    def test_get_service_pid_invalid(self, zeromq_broker):
         """Test PID file with invalid content."""
-        pid_file = tmp_path / 'broker.pid'
+        pid_file = zeromq_broker.base_path / 'broker.pid'
         pid_file.write_text('garbage text')
         assert zeromq_broker.get_service_pid() is None
 
-    def test_is_running_stale_pid(self, zeromq_broker, tmp_path):
+    def test_is_running_stale_pid(self, zeromq_broker):
         """Test is_running with stale PID."""
-        pid_file = tmp_path / 'broker.pid'
+        pid_file = zeromq_broker.base_path / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 999999')  # Non-existent PID
         assert not zeromq_broker.is_running
 
-    def test_get_service_status_valid(self, zeromq_broker, tmp_path):
+    def test_get_service_status_valid(self, zeromq_broker):
         """Test get_service_status with valid JSON."""
-        status_file = tmp_path / 'broker.status'
+        status_file = zeromq_broker.base_path / 'broker.status'
         status_file.write_text(json.dumps({'pid': 123, 'running': True}))
         status = zeromq_broker.get_service_status()
         assert status is not None
         assert status['pid'] == 123
 
-    def test_get_service_status_invalid_json(self, zeromq_broker, tmp_path):
+    def test_get_service_status_invalid_json(self, zeromq_broker):
         """Test get_service_status with invalid JSON."""
-        status_file = tmp_path / 'broker.status'
+        status_file = zeromq_broker.base_path / 'broker.status'
         status_file.write_text('{INVALID JSON')
         assert zeromq_broker.get_service_status() is None
 
-    def test_cleanup_stale_service_files(self, zeromq_broker, tmp_path):
+    def test_cleanup_stale_service_files(self, zeromq_broker):
         """Test _cleanup_stale_service_files removes all stale files."""
 
-        (tmp_path / 'broker.pid').write_text('aiida-zeromq-broker 1')
-        (tmp_path / 'broker.status').write_text('{}')
-        sockets_dir = tmp_path / 'test_sockets'
+        broker_dir = zeromq_broker.base_path
+        (broker_dir / 'broker.pid').write_text('aiida-zeromq-broker 1')
+        (broker_dir / 'broker.status').write_text('{}')
+        sockets_dir = broker_dir / 'test_sockets'
         sockets_dir.mkdir()
-        (tmp_path / 'broker.sockets').write_text(str(sockets_dir))
+        (broker_dir / 'broker.sockets').write_text(str(sockets_dir))
 
         zeromq_broker._cleanup_stale_service_files()
 
-        assert not (tmp_path / 'broker.pid').exists()
-        assert not (tmp_path / 'broker.status').exists()
-        assert not (tmp_path / 'broker.sockets').exists()
+        assert not (broker_dir / 'broker.pid').exists()
+        assert not (broker_dir / 'broker.status').exists()
+        assert not (broker_dir / 'broker.sockets').exists()
         assert not sockets_dir.exists()
 
 
@@ -209,9 +210,9 @@ class TestZeromqBrokerTasks:
         tasks = list(zeromq_broker.iterate_tasks())
         assert tasks == []
 
-    def test_iterate_tasks_with_data(self, zeromq_broker, tmp_path):
+    def test_iterate_tasks_with_data(self, zeromq_broker):
         """Test iterate_tasks with pending tasks."""
-        queue_path = tmp_path / 'storage' / 'tasks'
+        queue_path = zeromq_broker.storage_path / 'tasks'
         queue = PersistentQueue(queue_path)
         queue.push('task-1', {'body': 'hello'})
         queue.push('task-2', {'body': 'world'})

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -11,14 +11,30 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aiida.brokers.zeromq.broker import ZeromqIncomingTask
+from aiida.brokers.zeromq.broker import ZeromqBroker, ZeromqIncomingTask
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from aiida.brokers.zeromq.queue import PersistentQueue
 from tests.conftest import start_zeromq_broker, stop_zeromq_broker
+
+
+def test_get_default_config():
+    """Test that the default broker settings declare the service as managed by the daemon."""
+    assert ZeromqBroker.get_default_config() == {'supervised_by_daemon': True}
+
+
+def test_not_supervised_by_daemon_raises():
+    """Test that broker construction fails when the service is not managed by the daemon."""
+    from aiida.common.exceptions import ConfigurationError
+
+    profile = MagicMock()
+    profile.process_control_config = {'supervised_by_daemon': False}
+
+    with pytest.raises(ConfigurationError, match='not managed by the daemon'):
+        ZeromqBroker(profile)
 
 
 class TestZeromqBrokerStatusQueries:

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -11,178 +11,150 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from aiida.brokers.zeromq import ZeromqBroker
 from aiida.brokers.zeromq.broker import ZeromqIncomingTask
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from aiida.brokers.zeromq.queue import PersistentQueue
 from tests.conftest import start_zeromq_broker, stop_zeromq_broker
 
 
-def _create_broker_with_base_path(base_path: Path) -> ZeromqBroker:
-    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=base_path):
-        return ZeromqBroker(MagicMock())
-
-
 class TestZeromqBrokerStatusQueries:
     """Tests for ZeromqBroker status queries (file-based)."""
 
-    def test_is_running_no_pid_file(self, tmp_path):
+    def test_is_running_no_pid_file(self, zeromq_broker):
         """Test is_running returns False when no PID file exists."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert not broker.is_running
+        assert not zeromq_broker.is_running
 
-    def test_get_service_pid_no_file(self, tmp_path):
+    def test_get_service_pid_no_file(self, zeromq_broker):
         """Test get_service_pid returns None when no PID file exists."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert broker.get_service_pid() is None
+        assert zeromq_broker.get_service_pid() is None
 
-    def test_get_service_status_no_file(self, tmp_path):
+    def test_get_service_status_no_file(self, zeromq_broker):
         """Test get_service_status returns None when no status file exists."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert broker.get_service_status() is None
+        assert zeromq_broker.get_service_status() is None
 
-    def test_endpoints_no_sockets_file(self, tmp_path):
+    def test_endpoints_no_sockets_file(self, zeromq_broker):
         """Test endpoints return None when sockets file doesn't exist."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert broker.router_endpoint is None
+        assert zeromq_broker.router_endpoint is None
 
-    def test_start_stop_cycle(self, tmp_path):
-        """Test querying a running broker service."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+    def test_start_stop_cycle(self, zeromq_broker):
+        """Test querying a running zeromq_broker service."""
+        start_zeromq_broker(zeromq_broker)
 
         try:
-            assert broker.is_running
-            assert broker.get_service_pid() is not None
-            assert broker.router_endpoint is not None
+            assert zeromq_broker.is_running
+            assert zeromq_broker.get_service_pid() is not None
+            assert zeromq_broker.router_endpoint is not None
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
-        assert not broker.is_running
+        assert not zeromq_broker.is_running
 
-    def test_start_already_running(self, tmp_path):
+    def test_start_already_running(self, zeromq_broker):
         """Test starting when already running is idempotent."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+        start_zeromq_broker(zeromq_broker)
 
         try:
-            start_zeromq_broker(broker)  # idempotent
-            assert broker.is_running
+            start_zeromq_broker(zeromq_broker)  # idempotent
+            assert zeromq_broker.is_running
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
-    def test_stop_not_running(self, tmp_path):
+    def test_stop_not_running(self, zeromq_broker):
         """Test stopping when not running is a no-op."""
-        broker = _create_broker_with_base_path(tmp_path)
-        stop_zeromq_broker(broker)  # Should not raise
+        stop_zeromq_broker(zeromq_broker)  # Should not raise
 
-    def test_restart(self, tmp_path):
-        """Test restarting the broker service."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+    def test_restart(self, zeromq_broker):
+        """Test restarting the zeromq_broker service."""
+        start_zeromq_broker(zeromq_broker)
 
         try:
-            old_pid = broker.get_service_pid()
-            stop_zeromq_broker(broker)
-            start_zeromq_broker(broker)
-            assert broker.is_running
+            old_pid = zeromq_broker.get_service_pid()
+            stop_zeromq_broker(zeromq_broker)
+            start_zeromq_broker(zeromq_broker)
+            assert zeromq_broker.is_running
 
-            new_pid = broker.get_service_pid()
+            new_pid = zeromq_broker.get_service_pid()
             assert new_pid != old_pid
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
-    def test_str_running(self, tmp_path):
+    def test_str_running(self, zeromq_broker):
         """Test __str__ when running."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+        start_zeromq_broker(zeromq_broker)
         try:
-            s = str(broker)
-            assert 'ZeroMQ Broker' in s
+            s = str(zeromq_broker)
+            assert 'ZeroMQ zeromq_broker' in s
             assert 'PID' in s
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
-    def test_str_not_running(self, tmp_path):
+    def test_str_not_running(self, zeromq_broker):
         """Test __str__ when not running."""
-        broker = _create_broker_with_base_path(tmp_path)
-        s = str(broker)
+        s = str(zeromq_broker)
         assert 'not running' in s
 
-    def test_storage_path(self, tmp_path):
+    def test_storage_path(self, zeromq_broker, tmp_path):
         """Test storage_path property."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert broker.storage_path == tmp_path / 'storage'
+        assert zeromq_broker.storage_path == tmp_path / 'storage'
 
-    def test_base_path(self, tmp_path):
+    def test_base_path(self, zeromq_broker, tmp_path):
         """Test base_path property."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert broker.base_path == tmp_path
+        assert zeromq_broker.base_path == tmp_path
 
-    def test_get_sockets_path_no_file(self, tmp_path):
+    def test_get_sockets_path_no_file(self, zeromq_broker):
         """Test _get_sockets_path when file missing."""
-        broker = _create_broker_with_base_path(tmp_path)
-        assert broker._get_sockets_path() is None
+        assert zeromq_broker._get_sockets_path() is None
 
-    def test_get_sockets_path_os_error(self, tmp_path):
+    def test_get_sockets_path_os_error(self, zeromq_broker, tmp_path):
         """Test _get_sockets_path when read fails."""
-        broker = _create_broker_with_base_path(tmp_path)
         sockets_file = tmp_path / 'broker.sockets'
         sockets_file.mkdir()  # directory instead of file => OSError on read_text
-        assert broker._get_sockets_path() is None
+        assert zeromq_broker._get_sockets_path() is None
 
-    def test_get_service_pid_sentinel_format(self, tmp_path):
+    def test_get_service_pid_sentinel_format(self, zeromq_broker, tmp_path):
         """Test PID file with sentinel format."""
-        broker = _create_broker_with_base_path(tmp_path)
         pid_file = tmp_path / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 12345')
-        assert broker.get_service_pid() == 12345
+        assert zeromq_broker.get_service_pid() == 12345
 
-    def test_get_service_pid_bare_format(self, tmp_path):
+    def test_get_service_pid_bare_format(self, zeromq_broker, tmp_path):
         """Test PID file with bare PID fallback."""
-        broker = _create_broker_with_base_path(tmp_path)
         pid_file = tmp_path / 'broker.pid'
         pid_file.write_text('54321')
-        assert broker.get_service_pid() == 54321
+        assert zeromq_broker.get_service_pid() == 54321
 
-    def test_get_service_pid_invalid(self, tmp_path):
+    def test_get_service_pid_invalid(self, zeromq_broker, tmp_path):
         """Test PID file with invalid content."""
-        broker = _create_broker_with_base_path(tmp_path)
         pid_file = tmp_path / 'broker.pid'
         pid_file.write_text('garbage text')
-        assert broker.get_service_pid() is None
+        assert zeromq_broker.get_service_pid() is None
 
-    def test_is_running_stale_pid(self, tmp_path):
+    def test_is_running_stale_pid(self, zeromq_broker, tmp_path):
         """Test is_running with stale PID."""
-        broker = _create_broker_with_base_path(tmp_path)
         pid_file = tmp_path / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 999999')  # Non-existent PID
-        assert not broker.is_running
+        assert not zeromq_broker.is_running
 
-    def test_get_service_status_valid(self, tmp_path):
+    def test_get_service_status_valid(self, zeromq_broker, tmp_path):
         """Test get_service_status with valid JSON."""
-        broker = _create_broker_with_base_path(tmp_path)
         status_file = tmp_path / 'broker.status'
         status_file.write_text(json.dumps({'pid': 123, 'running': True}))
-        status = broker.get_service_status()
+        status = zeromq_broker.get_service_status()
         assert status is not None
         assert status['pid'] == 123
 
-    def test_get_service_status_invalid_json(self, tmp_path):
+    def test_get_service_status_invalid_json(self, zeromq_broker, tmp_path):
         """Test get_service_status with invalid JSON."""
-        broker = _create_broker_with_base_path(tmp_path)
         status_file = tmp_path / 'broker.status'
         status_file.write_text('{INVALID JSON')
-        assert broker.get_service_status() is None
+        assert zeromq_broker.get_service_status() is None
 
-    def test_cleanup_stale_service_files(self, tmp_path):
+    def test_cleanup_stale_service_files(self, zeromq_broker, tmp_path):
         """Test _cleanup_stale_service_files removes all stale files."""
-        broker = _create_broker_with_base_path(tmp_path)
 
         (tmp_path / 'broker.pid').write_text('aiida-zeromq-broker 1')
         (tmp_path / 'broker.status').write_text('{}')
@@ -190,7 +162,7 @@ class TestZeromqBrokerStatusQueries:
         sockets_dir.mkdir()
         (tmp_path / 'broker.sockets').write_text(str(sockets_dir))
 
-        broker._cleanup_stale_service_files()
+        zeromq_broker._cleanup_stale_service_files()
 
         assert not (tmp_path / 'broker.pid').exists()
         assert not (tmp_path / 'broker.status').exists()
@@ -201,55 +173,50 @@ class TestZeromqBrokerStatusQueries:
 class TestZeromqBrokerCommunicator:
     """Tests for ZeromqBroker communicator management."""
 
-    def test_get_communicator_and_close(self, tmp_path):
+    def test_get_communicator_and_close(self, zeromq_broker):
         """Test get_communicator and close."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+        start_zeromq_broker(zeromq_broker)
 
         try:
             with patch('aiida.manage.configuration.get_config_option', return_value=None):
-                comm = broker.get_communicator(wait_for_broker=5.0)
+                comm = zeromq_broker.get_communicator(wait_for_broker=5.0)
                 assert comm is not None
                 assert not comm.is_closed()
 
                 # Second call returns cached instance
-                comm2 = broker.get_communicator()
+                comm2 = zeromq_broker.get_communicator()
                 assert comm2 is comm
         finally:
-            broker.close()
-            stop_zeromq_broker(broker)
+            zeromq_broker.close()
+            stop_zeromq_broker(zeromq_broker)
 
-    def test_get_communicator_timeout(self, tmp_path):
-        """Test get_communicator raises on timeout when broker not running."""
-        broker = _create_broker_with_base_path(tmp_path)
+    def test_get_communicator_timeout(self, zeromq_broker):
+        """Test get_communicator raises on timeout when zeromq_broker not running."""
         with pytest.raises(ConnectionError, match='did not become ready'):
-            broker.get_communicator(wait_for_broker=0.5)
+            zeromq_broker.get_communicator(wait_for_broker=0.5)
 
-    def test_context_manager(self, tmp_path):
+    def test_context_manager(self, zeromq_broker):
         """Test __enter__ / __exit__."""
-        broker = _create_broker_with_base_path(tmp_path)
-        with broker as b:
-            assert b is broker
+        with zeromq_broker as instance:
+            assert instance is zeromq_broker
 
 
 class TestZeromqBrokerTasks:
     """Tests for ZeromqBroker task iteration."""
 
-    def test_iterate_tasks_no_queue(self, tmp_path):
+    def test_iterate_tasks_no_queue(self, zeromq_broker):
         """Test iterate_tasks when queue path doesn't exist."""
-        broker = _create_broker_with_base_path(tmp_path)
-        tasks = list(broker.iterate_tasks())
+        tasks = list(zeromq_broker.iterate_tasks())
         assert tasks == []
 
-    def test_iterate_tasks_with_data(self, tmp_path):
+    def test_iterate_tasks_with_data(self, zeromq_broker, tmp_path):
         """Test iterate_tasks with pending tasks."""
-        broker = _create_broker_with_base_path(tmp_path)
         queue_path = tmp_path / 'storage' / 'tasks'
         queue = PersistentQueue(queue_path)
         queue.push('task-1', {'body': 'hello'})
         queue.push('task-2', {'body': 'world'})
 
-        tasks = list(broker.iterate_tasks())
+        tasks = list(zeromq_broker.iterate_tasks())
         assert len(tasks) == 2
         assert all(isinstance(t, ZeromqIncomingTask) for t in tasks)
 
@@ -273,21 +240,19 @@ class TestZeromqIncomingTask:
 
 
 class TestZeromqBrokerIntegration:
-    """Integration tests for the ZeroMQ broker with AiiDA."""
+    """Integration tests for the ZeroMQ zeromq_broker with AiiDA."""
 
     @pytest.fixture
-    def zeromq_broker(self, tmp_path):
-        """Create a ZeroMQ broker for testing."""
-        broker_dir = tmp_path / 'broker' / 'test-uuid'
-        broker = _create_broker_with_base_path(broker_dir)
-        start_zeromq_broker(broker)
+    def zeromq_broker(self, zeromq_broker):
+        """Create a ZeroMQ zeromq_broker for testing."""
+        start_zeromq_broker(zeromq_broker)
 
-        yield broker
+        yield zeromq_broker
 
-        stop_zeromq_broker(broker)
+        stop_zeromq_broker(zeromq_broker)
 
     def test_broker_lifecycle(self, zeromq_broker):
-        """Test the broker lifecycle."""
+        """Test the zeromq_broker lifecycle."""
         assert zeromq_broker.is_running
 
         status = zeromq_broker.get_service_status()
@@ -295,7 +260,7 @@ class TestZeromqBrokerIntegration:
         assert 'pid' in status
 
     def test_communicator_connection(self, zeromq_broker):
-        """Test connecting a communicator to the broker."""
+        """Test connecting a communicator to the zeromq_broker."""
         communicator = ZeromqCommunicator(
             router_endpoint=zeromq_broker.router_endpoint,
         )

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -12,32 +12,23 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import Future
-from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import kiwipy
 import pytest
 
-from aiida.brokers.zeromq import ZeromqBroker
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from tests.conftest import start_zeromq_broker, stop_zeromq_broker
-
-
-def _create_broker_with_base_path(base_path: Path) -> ZeromqBroker:
-    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=base_path):
-        return ZeromqBroker(MagicMock())
 
 
 class TestZeromqCommunicatorLifecycle:
     """Tests for communicator initialization and lifecycle."""
 
-    def test_init(self, tmp_path):
+    def test_init(self, zeromq_broker):
         """Test communicator initialization."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+        start_zeromq_broker(zeromq_broker)
 
         try:
-            communicator = ZeromqCommunicator(router_endpoint=broker.router_endpoint)
+            communicator = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint)
             communicator.start()
 
             try:
@@ -47,34 +38,32 @@ class TestZeromqCommunicatorLifecycle:
 
             assert communicator.is_closed() is True
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
-    def test_context_manager(self, tmp_path):
+    def test_context_manager(self, zeromq_broker):
         """Test communicator as context manager."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+        start_zeromq_broker(zeromq_broker)
 
         try:
-            with ZeromqCommunicator(router_endpoint=broker.router_endpoint) as communicator:
+            with ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint) as communicator:
                 assert communicator.is_closed() is False
 
             assert communicator.is_closed() is True
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
-    def test_close_idempotent(self, tmp_path):
+    def test_close_idempotent(self, zeromq_broker):
         """Test close is idempotent."""
-        broker = _create_broker_with_base_path(tmp_path)
-        start_zeromq_broker(broker)
+        start_zeromq_broker(zeromq_broker)
 
         try:
-            comm = ZeromqCommunicator(router_endpoint=broker.router_endpoint)
+            comm = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint)
             comm.start()
             comm.close()
             comm.close()  # should not raise
             assert comm.is_closed()
         finally:
-            stop_zeromq_broker(broker)
+            stop_zeromq_broker(zeromq_broker)
 
     def test_ensure_open_raises_when_closed(self):
         """Test _ensure_open raises when communicator is closed."""
@@ -84,69 +73,68 @@ class TestZeromqCommunicatorLifecycle:
 
 
 class TestZeromqCommunicatorMessaging:
-    """Tests for communicator messaging operations with a real broker."""
+    """Tests for communicator messaging operations with a real zeromq_broker."""
 
     @pytest.fixture
-    def broker_and_comm(self, tmp_path):
-        broker = _create_broker_with_base_path(tmp_path / 'broker')
-        start_zeromq_broker(broker)
+    def zeromq_broker_and_comm(self, zeromq_broker):
+        start_zeromq_broker(zeromq_broker)
 
-        comm = ZeromqCommunicator(router_endpoint=broker.router_endpoint)
+        comm = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint)
         comm.start()
 
-        yield broker, comm
+        yield zeromq_broker, comm
 
         comm.close()
-        stop_zeromq_broker(broker)
+        stop_zeromq_broker(zeromq_broker)
 
-    def test_task_send_no_reply(self, broker_and_comm):
+    def test_task_send_no_reply(self, zeromq_broker_and_comm):
         """Test task_send with no_reply=True returns None."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         result = comm.task_send({'cmd': 'test'}, no_reply=True)
         assert result is None
 
-    def test_task_send_with_reply(self, broker_and_comm):
+    def test_task_send_with_reply(self, zeromq_broker_and_comm):
         """Test task_send returns a Future."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         future = comm.task_send({'cmd': 'test'}, no_reply=False)
         assert isinstance(future, Future)
 
-    def test_add_remove_task_subscriber(self, broker_and_comm):
+    def test_add_remove_task_subscriber(self, zeromq_broker_and_comm):
         """Test task subscriber management."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         ident = comm.add_task_subscriber(lambda c, t: None, identifier='test-worker')
         assert ident == 'test-worker'
         comm.remove_task_subscriber('test-worker')
 
-    def test_rpc_send(self, broker_and_comm):
+    def test_rpc_send(self, zeromq_broker_and_comm):
         """Test rpc_send returns a Future."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         future = comm.rpc_send('some-recipient', {'action': 'ping'})
         assert isinstance(future, Future)
 
-    def test_add_remove_rpc_subscriber(self, broker_and_comm):
+    def test_add_remove_rpc_subscriber(self, zeromq_broker_and_comm):
         """Test RPC subscriber management."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         ident = comm.add_rpc_subscriber(lambda c, m: 'ok', identifier='my-rpc')
         assert ident == 'my-rpc'
         comm.remove_rpc_subscriber('my-rpc')
 
-    def test_duplicate_rpc_subscriber(self, broker_and_comm):
+    def test_duplicate_rpc_subscriber(self, zeromq_broker_and_comm):
         """Test duplicate RPC subscriber raises."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         comm.add_rpc_subscriber(lambda c, m: None, identifier='dup')
         with pytest.raises(kiwipy.DuplicateSubscriberIdentifier):
             comm.add_rpc_subscriber(lambda c, m: None, identifier='dup')
 
-    def test_broadcast_send(self, broker_and_comm):
+    def test_broadcast_send(self, zeromq_broker_and_comm):
         """Test broadcast_send returns True."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         result = comm.broadcast_send(body='hello', subject='test.subject')
         assert result is True
 
-    def test_add_remove_broadcast_subscriber(self, broker_and_comm):
+    def test_add_remove_broadcast_subscriber(self, zeromq_broker_and_comm):
         """Test broadcast subscriber management."""
-        _, comm = broker_and_comm
+        _, comm = zeromq_broker_and_comm
         ident = comm.add_broadcast_subscriber(lambda c, b, s, subj, cid: None, identifier='my-bcast')
         assert ident == 'my-bcast'
         comm.remove_broadcast_subscriber('my-bcast')
@@ -156,26 +144,25 @@ class TestZeromqCommunicatorRoundTrip:
     """Integration tests for full task, RPC, and broadcast round-trips."""
 
     @pytest.fixture
-    def sender_and_worker(self, tmp_path):
-        broker = _create_broker_with_base_path(tmp_path / 'broker')
-        start_zeromq_broker(broker)
+    def sender_and_worker(self, zeromq_broker):
+        start_zeromq_broker(zeromq_broker)
 
-        sender = ZeromqCommunicator(router_endpoint=broker.router_endpoint, client_id='sender')
+        sender = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint, client_id='sender')
         sender.start()
 
-        worker = ZeromqCommunicator(router_endpoint=broker.router_endpoint, client_id='worker')
+        worker = ZeromqCommunicator(router_endpoint=zeromq_broker.router_endpoint, client_id='worker')
         worker.start()
 
-        yield broker, sender, worker
+        yield zeromq_broker, sender, worker
 
         worker.close()
         sender.close()
-        stop_zeromq_broker(broker)
+        stop_zeromq_broker(zeromq_broker)
 
     def test_task_round_trip(self, sender_and_worker):
-        """Test task send gets immediate broker acknowledgment.
+        """Test task send gets immediate zeromq_broker acknowledgment.
 
-        The broker sends an immediate TASK_RESPONSE when the task is queued
+        The zeromq broker sends an immediate TASK_RESPONSE when the task is queued
         (matching RabbitMQ publisher-confirm semantics).  The worker processes
         the task independently.
         """
@@ -187,7 +174,7 @@ class TestZeromqCommunicatorRoundTrip:
         future = sender.task_send({'x': 21})
         assert future is not None
 
-        # The sender's Future resolves with the broker's acceptance, not the worker's result
+        # The sender's Future resolves with the zeromq_broker's acceptance, not the worker's result
         result = future.result(timeout=5.0)
         assert result.result() is True
 
@@ -224,7 +211,7 @@ class TestZeromqCommunicatorRoundTrip:
         assert received[0] == ('ping', 'test.ping')
 
     def test_task_with_deferred_future(self, sender_and_worker):
-        """Test task send with deferred handler gets immediate broker ack."""
+        """Test task send with deferred handler gets immediate zeromq_broker ack."""
         _, sender, worker = sender_and_worker
 
         def handle_task(comm, body):
@@ -236,7 +223,7 @@ class TestZeromqCommunicatorRoundTrip:
         time.sleep(0.5)
 
         future = sender.task_send({'val': 5})
-        # Sender gets immediate broker acknowledgment, not the worker's deferred result
+        # Sender gets immediate zeromq_broker acknowledgment, not the worker's deferred result
         result = future.result(timeout=5.0)
         assert result.result() is True
 

--- a/tests/brokers/test_zeromq_service.py
+++ b/tests/brokers/test_zeromq_service.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import threading
 import time
+from unittest.mock import patch
 
-from aiida.brokers.zeromq.service import ZeromqBrokerService
+from aiida.brokers.zeromq.service import ZeromqBrokerService, run_broker_service
 
 
 class TestZeromqBrokerService:
@@ -23,8 +24,21 @@ class TestZeromqBrokerService:
         """Test service initialization."""
         service = ZeromqBrokerService(base_path=tmp_path)
         assert service.base_path == tmp_path
+        assert service.log_file == tmp_path / 'broker.log'
         assert service.pid_file == tmp_path / 'broker.pid'
         assert service.status_file == tmp_path / 'broker.status'
+
+    def test_run_broker_service_configures_logging(self, tmp_path):
+        """Test ``run_broker_service`` configures persistent broker logging."""
+        with (
+            patch('aiida.brokers.zeromq.service.configure_logging') as mock_configure_logging,
+            patch.object(ZeromqBrokerService, 'run_forever') as mock_run_forever,
+        ):
+            run_broker_service(base_path=tmp_path)
+
+        mock_configure_logging.assert_called_once_with(daemon=True, daemon_log_file=tmp_path / 'broker.log')
+        mock_run_forever.assert_called_once_with()
+        assert tmp_path.is_dir()
 
     def test_start_stop(self, tmp_path):
         """Test starting and stopping the service."""

--- a/tests/brokers/test_zeromq_service.py
+++ b/tests/brokers/test_zeromq_service.py
@@ -22,8 +22,8 @@ class TestZeromqBrokerService:
 
     def test_init(self, tmp_path):
         """Test service initialization."""
-        service = ZeromqBrokerService(base_path=tmp_path)
-        assert service.base_path == tmp_path
+        service = ZeromqBrokerService(service_dir=tmp_path)
+        assert service.service_dir == tmp_path
         assert service.log_file == tmp_path / 'broker.log'
         assert service.pid_file == tmp_path / 'broker.pid'
         assert service.status_file == tmp_path / 'broker.status'
@@ -34,7 +34,7 @@ class TestZeromqBrokerService:
             patch('aiida.brokers.zeromq.service.configure_logging') as mock_configure_logging,
             patch.object(ZeromqBrokerService, 'run_forever') as mock_run_forever,
         ):
-            run_broker_service(base_path=tmp_path)
+            run_broker_service(service_dir=tmp_path)
 
         mock_configure_logging.assert_called_once_with(daemon=True, daemon_log_file=tmp_path / 'broker.log')
         mock_run_forever.assert_called_once_with()
@@ -42,7 +42,7 @@ class TestZeromqBrokerService:
 
     def test_start_stop(self, tmp_path):
         """Test starting and stopping the service."""
-        service = ZeromqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(service_dir=tmp_path)
         service.start()
 
         try:
@@ -56,7 +56,7 @@ class TestZeromqBrokerService:
 
     def test_start_idempotent(self, tmp_path):
         """Test start is idempotent."""
-        service = ZeromqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(service_dir=tmp_path)
         service.start()
         try:
             service.start()  # should be no-op
@@ -66,7 +66,7 @@ class TestZeromqBrokerService:
 
     def test_stop_idempotent(self, tmp_path):
         """Test stop when not running is no-op."""
-        service = ZeromqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(service_dir=tmp_path)
         service.stop()  # should not raise
 
     def test_orphaned_sockets_cleanup(self, tmp_path):
@@ -76,7 +76,7 @@ class TestZeromqBrokerService:
         old_sockets.mkdir()
         sockets_file.write_text(str(old_sockets))
 
-        service = ZeromqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(service_dir=tmp_path)
         service.start()
         try:
             assert not old_sockets.exists()
@@ -85,7 +85,7 @@ class TestZeromqBrokerService:
 
     def test_run_forever_with_early_stop(self, tmp_path):
         """Test run_forever exits when _running is set to False."""
-        service = ZeromqBrokerService(base_path=tmp_path)
+        service = ZeromqBrokerService(service_dir=tmp_path)
 
         def stop_after_delay():
             time.sleep(0.5)

--- a/tests/cmdline/commands/test_profile.py
+++ b/tests/cmdline/commands/test_profile.py
@@ -414,7 +414,7 @@ def test_setup_broker_core_zeromq(run_cli_command, isolated_config):
     assert f'Created new profile `{profile_name}`.' in result.output
     profile = isolated_config.get_profile(profile_name)
     assert profile.process_control_backend == 'core.zeromq'
-    assert profile.process_control_config == {}
+    assert profile.process_control_config == {'supervised_by_daemon': True}
 
 
 @pytest.mark.requires_rmq
@@ -456,7 +456,7 @@ def test_configure_broker_zeromq(run_cli_command, isolated_config):
         cmd_profile.profile_configure_broker, ['core.zeromq', profile_name, '-n'], use_subprocess=False
     )
     assert profile.process_control_backend == 'core.zeromq'
-    assert profile.process_control_config == {}
+    assert profile.process_control_config == {'supervised_by_daemon': True}
     assert f'ZeroMQ configuration for `{profile.name}` updated.' in cli_result.stdout
     assert 'The ZeroMQ broker service will be started automatically with the daemon.' in cli_result.stdout
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,8 +71,13 @@ class TestBrokerBackend(Enum):
 
 @pytest.fixture
 def zeromq_broker(tmp_path):
-    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=tmp_path):
-        yield ZeromqBroker(MagicMock())
+    """Create a ZMQ broker instance rooted in ``tmp_path``."""
+    profile = MagicMock()
+    config = MagicMock()
+    config.filepaths.return_value = {'zmq_broker_service': {'dir': str(tmp_path), 'log': str(tmp_path / 'broker.log')}}
+
+    with patch('aiida.manage.configuration.get_config', return_value=config):
+        yield ZeromqBroker(profile)
 
 
 def start_zeromq_broker(broker, timeout: float = 10.0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,8 @@ class TestBrokerBackend(Enum):
 def zeromq_broker(tmp_path):
     """Create a ZMQ broker instance rooted in ``tmp_path``."""
     profile = MagicMock()
+    profile.process_control_config = {'supervised_by_daemon': True}
+    profile.name = 'test-profile'
     config = MagicMock()
     config.filepaths.return_value = {'zmq_broker_service': {'dir': str(tmp_path), 'log': str(tmp_path / 'broker.log')}}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,13 @@ import typing as t
 import warnings
 from enum import Enum
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
 
 from aiida import get_profile, orm
+from aiida.brokers import ZeromqBroker
 from aiida.common.folders import Folder
 from aiida.common.links import LinkType
 from aiida.manage import get_manager
@@ -65,6 +67,12 @@ class TestBrokerBackend(Enum):
     RMQ = 'rmq'
     ZEROMQ = 'zmq'
     NONE = 'none'
+
+
+@pytest.fixture
+def zeromq_broker(tmp_path):
+    with patch('aiida.brokers.zeromq.broker.get_broker_base_path', return_value=tmp_path):
+        yield ZeromqBroker(MagicMock())
 
 
 def start_zeromq_broker(broker, timeout: float = 10.0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,15 +85,15 @@ def zeromq_broker(tmp_path):
 def start_zeromq_broker(broker, timeout: float = 10.0):
     """Start a ZeroMQ broker service subprocess for testing.
 
-    :param broker: A ``ZeromqBroker`` instance (has ``base_path``, ``is_running``, etc.)
+    :param broker: A ``ZeromqBroker`` instance (has ``service_dir``, ``is_running``, etc.)
     """
-    broker.base_path.mkdir(parents=True, exist_ok=True)
+    broker.service_dir.mkdir(parents=True, exist_ok=True)
 
     if broker.is_running:
         return
 
     subprocess.Popen(
-        [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--base-path', str(broker.base_path)],
+        [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--service-dir', str(broker.service_dir)],
         start_new_session=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -232,13 +232,17 @@ def test_basic_properties(config_with_profile):
     assert isinstance(config.dictionary, dict)
 
 
-def test_filepaths_includes_daemon_env_info(config_with_profile):
-    """Test that ``filepaths`` returns a ``daemon_env_info`` entry for the daemon."""
+def test_filepaths_include_daemon_and_zmq_broker_entries(config_with_profile):
+    """Test that ``filepaths`` returns the daemon env info and ZMQ broker entries."""
     config = config_with_profile
     profile = config.get_profile(config.default_profile_name)
     filepaths = config.filepaths(profile)
     assert 'daemon_env_info' in filepaths['daemon']
     assert filepaths['daemon']['daemon_env_info'].endswith('-env-info.json')
+    assert 'zmq_broker_service' in filepaths
+    expected_dir_suffix = f'{profile.uuid}-{profile.name}'
+    assert filepaths['zmq_broker_service']['dir'].endswith(expected_dir_suffix)
+    assert filepaths['zmq_broker_service']['log'].endswith(f'{expected_dir_suffix}/broker.log')
 
 
 def test_setting_versions(config_with_profile):


### PR DESCRIPTION
There are two major changes that are separated in commits. The first change can be found in the second commit: The ZeroMQ broker service logged into the daemon log file, and the broker client and the service determied the location of the service state files independently of the daemon that starts the service. This commit now adds the ZMQ broker paths to the configuration filepaths so a single place defines them, mirroring how the daemon paths are handled:
```
    Config -> DaemonClient -> ZeromqBrokerService 
    Config -> ZeromqBroker -> verdi commands
```
The daemon client now passes the base path and log file explicitly to the hidden `verdi daemon broker` command instead of the service deriving them itself. The new `ZeromqBrokerService.FilepathLayout` defines the file layout
below the base path and is shared by the ZeromqBroker client and the service and thus can construct the same path from the config.

The second major change is in the third commit. The ZeromqBroker client guessed the location of the broker service state files from the configuration filepaths. This only works because the daemon starts the service at that location, and would silently break once the service is run in any other way. This coupling is now made explicit: the broker settings of the profile now store `supervised_by_daemon` (hardcoded to true for now) and the broker client queries the daemon client for the service directory. If the service is not supervised by the daemon, broker construction fails with a `ConfigurationError` until running the service standalone is supported. This requires extension BrokerConfigField to add it as a configurable setting but not expose it to the other when configuring the broker.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-profile ZeroMQ broker *service* directory and log locations, named with both profile UUID and profile name.
  * ZeroMQ broker settings now derive defaults automatically, including correct handling of boolean broker options.
* **Bug Fixes**
  * Improved behavior when ZeroMQ broker is not daemon-supervised (startup now fails fast with a clear error).
  * `verdi daemon status` now reports the broker service directory (not the old base path).
* **Documentation**
  * Updated ZeroMQ broker internal endpoint/directory documentation to match the new naming scheme.
* **Tests**
  * Updated and expanded ZeroMQ broker/service, CLI, and configuration tests for the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->