### PR TITLE
✨ Support remote URLs in `core.sqlite_zip` storage

### DIFF
--- a/docs/source/howto/archive_profile.md
+++ b/docs/source/howto/archive_profile.md
@@ -28,6 +28,25 @@ The easiest way to inspect the contents of an archive is to create a profile tha
 !verdi profile setup core.sqlite_zip -n --profile-name archive --filepath process.aiida
 ```
 
+The `--filepath` option also accepts a `http://` or `https://` URL of an archive hosted online:
+
+```{code-block} console
+verdi profile setup core.sqlite_zip -n --profile-name archive --filepath https://example.com/process.aiida
+```
+
+In this case, the archive is not downloaded in full: the profile stores the URL and AiiDA uses [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to fetch only the SQLite database (once per Python session, on first query) and to stream individual repository files on demand.
+Note that the server hosting the archive must support range requests, and the archive must already be at the latest archive format version, since a remote archive cannot be migrated in place (download it and run `verdi archive migrate` on the local copy instead).
+The HTTP requests use a timeout of 60 seconds by default, which can be changed via the `storage.remote_archive_timeout` configuration option, e.g. `verdi config set storage.remote_archive_timeout 120`.
+
+Alternatively, if you do not want to create a profile at all, you can pass the location of the archive directly to the `verdi -p/--profile` option, as a `file:///absolute/path` URL of a local archive or an `http(s)://` URL of a remote one:
+
+```{code-block} console
+verdi -p file:///path/to/process.aiida process list -a
+verdi -p https://example.com/process.aiida shell
+```
+
+This creates a temporary profile that mounts the archive for the duration of the command only: nothing is added to the AiiDA configuration file and any temporary files are cleaned up when the command finishes.
+
 You can now inspect the contents of the `process.aiida` archive by using the `archive` profile in the same way you would a standard AiiDA profile.
 For example, you can start an interactive shell using `verdi -p archive shell` or if you are already in a notebook simply load the profile:
 

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
 - pydantic~=2.12
 - pytz~=2021.1
 - pyyaml~=6.0
+- remotezip~=0.12.3
 - requests~=2.0
 - sqlalchemy<3,>=2.0.20
 - tabulate<0.10.0,>=0.9.0

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
 - pydantic~=2.12
 - pytz~=2021.1
 - pyyaml~=6.0
+- remotezip~=0.12.3
 - requests~=2.0
 - sqlalchemy<3,>=2.0.20
 - tabulate<0.10.0,>=0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   'pydantic~=2.12',
   'pytz~=2021.1',
   'pyyaml~=6.0',
+  'remotezip~=0.12.3',
   'requests~=2.0',
   'sqlalchemy>=2.0.20,<3',
   'tabulate>=0.9.0,<0.10.0',
@@ -393,6 +394,7 @@ module = [
   'mayavi.*',
   'pgsu.*',
   'pgtest.*',
+  'remotezip.*',
   'trogon.*',
   'wrapt.*'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
   'pydantic~=2.12',
   'pytz~=2021.1',
   'pyyaml~=6.0',
+  'remotezip~=0.12.3',
   'requests~=2.0',
   'sqlalchemy>=2.0.20,<3',
   'tabulate>=0.9.0,<0.10.0',
@@ -412,6 +413,7 @@ module = [
   'mayavi.*',
   'pgsu.*',
   'pgtest.*',
+  'remotezip.*',
   'trogon.*',
   'wrapt.*'
 ]

--- a/src/aiida/cmdline/commands/cmd_verdi.py
+++ b/src/aiida/cmdline/commands/cmd_verdi.py
@@ -18,7 +18,7 @@ from ..params import options, types
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
 @click.group(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
-@options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
+@options.PROFILE(type=types.ProfileParamType(load_profile=True, accept_archive_location=True), expose_value=False)
 @options.VERBOSITY()
 @click.version_option(__version__, package_name='aiida_core', message='AiiDA version %(version)s')
 def verdi():

--- a/src/aiida/cmdline/params/types/profile.py
+++ b/src/aiida/cmdline/params/types/profile.py
@@ -36,6 +36,9 @@ class ProfileParamType(LabelStringType):
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         self._cannot_exist = kwargs.pop('cannot_exist', False)
         self._load_profile = kwargs.pop('load_profile', False)  # If True, will load the profile converted from value
+        # If True, a value that looks like an archive location (``http(s)://`` URL or ``file://`` path) is converted
+        # to an ephemeral archive profile, instead of being interpreted as the name of a configured profile.
+        self._accept_archive_location = kwargs.pop('accept_archive_location', False)
         super().__init__(*args, **kwargs)
 
     @staticmethod
@@ -60,26 +63,69 @@ class ProfileParamType(LabelStringType):
         if isinstance(value, Profile):
             return value
 
-        value = super().convert(value, param, ctx)
-
-        try:
-            profile = config.get_profile(value)
-        except (MissingConfigurationError, ProfileConfigurationError) as exception:
-            if not self._cannot_exist:
-                self.fail(str(exception))
-
-            # Create a new empty profile
-            profile = Profile(value, {}, validate=False)
+        if (
+            self._accept_archive_location
+            and not self._cannot_exist
+            and isinstance(value, str)
+            and value.lower().startswith(('http://', 'https://', 'file://'))
+        ):
+            profile = self._convert_archive_location(value, param, ctx)
         else:
-            if self._cannot_exist:
-                self.fail(str(f'the profile `{value}` already exists'))
+            value = super().convert(value, param, ctx)
+
+            try:
+                profile = config.get_profile(value)
+            except (MissingConfigurationError, ProfileConfigurationError) as exception:
+                if not self._cannot_exist:
+                    self.fail(str(exception))
+
+                # Create a new empty profile
+                profile = Profile(value, {}, validate=False)
+            else:
+                if self._cannot_exist:
+                    self.fail(str(f'the profile `{value}` already exists'))
 
         if self._load_profile:
-            load_profile(profile.name)
+            load_profile(profile)
 
         ctx.obj.profile = profile  # type: ignore[union-attr]
 
-        return profile  # type: ignore[no-any-return]
+        return profile
+
+    def _convert_archive_location(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> Profile:
+        """Create an ephemeral profile mounting the ``.aiida`` archive at the given location as its storage.
+
+        The profile uses the read-only ``core.sqlite_zip`` storage backend and is not added to the configuration
+        file, so it only lives for the duration of the current interpreter.
+
+        :param value: the location of the archive: an ``http(s)://`` URL of a remote archive, or a ``file://`` URL
+            of a local one. The latter must be of the form ``file:///absolute/path`` (an empty or ``localhost`` host
+            is accepted); percent-encoded characters in the path are decoded.
+        """
+        from pathlib import Path
+        from urllib.parse import urlsplit
+
+        from aiida.common.utils import url2pathname
+        from aiida.storage.sqlite_zip.backend import SqliteZipBackend
+
+        filepath: str | Path = value
+
+        if value.lower().startswith('file://'):
+            parts = urlsplit(value)
+            if parts.netloc not in ('', 'localhost'):
+                self.fail(
+                    f'unsupported host `{parts.netloc}` in the file URL `{value}`: '
+                    'use the form `file:///absolute/path`.',
+                    param,
+                    ctx,
+                )
+            filepath = Path(url2pathname(parts.path))
+            if not filepath.is_file():
+                self.fail(f'the archive `{filepath}` does not exist.', param, ctx)
+
+        return SqliteZipBackend.create_profile(filepath)
 
     def shell_complete(self, ctx: click.Context, param: click.Parameter, incomplete: str) -> list[CompletionItem]:
         """Return possible completions based on an incomplete value

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -55,7 +55,7 @@ __all__ += (
 import os
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from aiida.common.warnings import AiidaDeprecationWarning
 
@@ -152,12 +152,13 @@ def _merge_deprecated_cache_yaml(config, filepath):
     shutil.move(cache_path, cache_path_backup)
 
 
-def load_profile(profile: Optional[str] = None, allow_switch=False) -> 'Profile':
+def load_profile(profile: Union[None, str, 'Profile'] = None, allow_switch=False) -> 'Profile':
     """Load a global profile, unloading any previously loaded profile.
 
     .. note:: if a profile is already loaded and no explicit profile is specified, nothing will be done
 
-    :param profile: the name of the profile to load, by default will use the one marked as default in the config
+    :param profile: the name of the profile, or the ``Profile`` instance, to load, by default will use the one marked
+        as default in the config
     :param allow_switch: if True, will allow switching to a different profile when storage is already loaded
 
     :return: the loaded `Profile` instance

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -54,7 +54,7 @@ __all__ += (
 import os
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from aiida.common.warnings import AiidaDeprecationWarning
 
@@ -151,12 +151,13 @@ def _merge_deprecated_cache_yaml(config, filepath):
     shutil.move(cache_path, cache_path_backup)
 
 
-def load_profile(profile: str | None = None, allow_switch=False) -> 'Profile':
+def load_profile(profile: Union[None, str, 'Profile'] = None, allow_switch=False) -> 'Profile':
     """Load a global profile, unloading any previously loaded profile.
 
     .. note:: if a profile is already loaded and no explicit profile is specified, nothing will be done
 
-    :param profile: the name of the profile to load, by default will use the one marked as default in the config
+    :param profile: the name of the profile, or the ``Profile`` instance, to load, by default will use the one marked
+        as default in the config
     :param allow_switch: if True, will allow switching to a different profile when storage is already loaded
 
     :return: the loaded `Profile` instance

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -199,6 +199,11 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
     storage__sandbox: Optional[str] = Field(
         None, description='Absolute path to the directory to store sandbox folders.'
     )
+    storage__remote_archive_timeout: int = Field(
+        60,
+        description='Timeout in seconds for HTTP requests when reading a remote archive, i.e. a `core.sqlite_zip` '
+        'storage with a URL as filepath.',
+    )
     caching__default_enabled: bool = Field(
         False,
         description='Enable calculation caching by default.',
@@ -722,6 +727,8 @@ class Config:
         else:
             LOGGER.debug('Profile `%s` has no broker configured, skipping daemon shutdown.', profile.name)
         if delete_storage:
+            from aiida.storage.sqlite_zip.utils import is_url
+
             storage_cls = StorageFactory(profile.storage_backend)
             if profile.storage_backend == 'core.sqlite_zip':
                 filepath = profile.storage_config.get('filepath')
@@ -729,6 +736,10 @@ class Config:
                     LOGGER.warning(
                         f'Profile `{profile.name}` has the `core.sqlite_zip` backend, but no filepath is configured. '
                         'Profile deletion will proceed anyway.'
+                    )
+                elif is_url(filepath):
+                    LOGGER.report(
+                        f'Profile `{profile.name}` points to the remote archive `{filepath}`, which is left untouched.'
                     )
                 elif not Path(filepath).exists():
                     LOGGER.warning(

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -252,7 +252,14 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
         description='Timeout in seconds for communications with RabbitMQ.',
         json_schema_extra={'deprecated_by': 'broker.task_timeout', 'requires_daemon_restart': True},
     )
-    storage__sandbox: str | None = Field(None, description='Absolute path to the directory to store sandbox folders.')
+    storage__sandbox: Optional[str] = Field(
+        None, description='Absolute path to the directory to store sandbox folders.'
+    )
+    storage__remote_archive_timeout: int = Field(
+        60,
+        description='Timeout in seconds for HTTP requests when reading a remote archive, i.e. a `core.sqlite_zip` '
+        'storage with a URL as filepath.',
+    )
     caching__default_enabled: bool = Field(
         False,
         description='Enable calculation caching by default.',
@@ -774,6 +781,8 @@ class Config:
         else:
             LOGGER.debug('Profile `%s` has no broker configured, skipping daemon shutdown.', profile.name)
         if delete_storage:
+            from aiida.storage.sqlite_zip.utils import is_url
+
             storage_cls = StorageFactory(profile.storage_backend)
             if profile.storage_backend == 'core.sqlite_zip':
                 filepath = profile.storage_config.get('filepath')
@@ -781,6 +790,10 @@ class Config:
                     LOGGER.warning(
                         f'Profile `{profile.name}` has the `core.sqlite_zip` backend, but no filepath is configured. '
                         'Profile deletion will proceed anyway.'
+                    )
+                elif is_url(filepath):
+                    LOGGER.report(
+                        f'Profile `{profile.name}` points to the remote archive `{filepath}`, which is left untouched.'
                     )
                 elif not Path(filepath).exists():
                     LOGGER.warning(

--- a/src/aiida/manage/configuration/schema/config-v9.schema.json
+++ b/src/aiida/manage/configuration/schema/config-v9.schema.json
@@ -160,6 +160,11 @@
           "type": "string",
           "description": "Absolute path to the directory to store sandbox folders."
         },
+        "storage.remote_archive_timeout": {
+          "type": "integer",
+          "default": 60,
+          "description": "Timeout in seconds for HTTP requests when reading a remote archive, i.e. a `core.sqlite_zip` storage with a URL as filepath."
+        },
         "caching.default_enabled": {
           "type": "boolean",
           "default": false,

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -10,20 +10,25 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import re
 import shutil
 import tarfile
 import tempfile
+import weakref
 import zipfile
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, BinaryIO, NoReturn, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, NoReturn, Optional, Tuple, Union, cast
 from zipfile import ZipFile, is_zipfile
 
 from pydantic import field_validator
+from sqlalchemy.future.engine import Engine
 from sqlalchemy.orm import Session
 
 from aiida import __version__
@@ -32,6 +37,7 @@ from aiida.common.exceptions import (
     CorruptStorage,
     IncompatibleExternalDependencies,
     StorageMigrationError,
+    UnreachableStorage,
 )
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.pydantic import AiiDABaseModel, MetadataField
@@ -48,8 +54,13 @@ from .utils import (
     ReadOnlyError,
     create_sqla_engine,
     extract_metadata,
+    is_url,
+    open_remote_zip,
     read_version,
 )
+
+if TYPE_CHECKING:
+    from remotezip import RemoteZip
 
 __all__ = ('SqliteZipBackend',)
 
@@ -74,6 +85,41 @@ def validate_sqlite_version() -> None:
         raise IncompatibleExternalDependencies(message)
 
 
+class _ArchiveResources:
+    """Container for the resources opened by a :class:`SqliteZipBackend` instance.
+
+    The container is registered with :func:`weakref.finalize`, such that the resources are released both when the
+    backend is garbage collected and at interpreter exit. To that end, it must not hold a reference to the backend
+    instance itself, as that would keep the backend alive until interpreter exit.
+    """
+
+    def __init__(self) -> None:
+        self.db_file: Optional[Path] = None
+        self.session: Optional[Session] = None
+        self.repo: Optional['_RoBackendRepository'] = None
+        self.remote_zip: Optional['RemoteZip'] = None
+
+    def close(self) -> None:
+        """Release all resources: close the session and any open zip handle, and delete the temporary database."""
+        if self.session:
+            self.session.close()
+            bind = self.session.get_bind()
+            if isinstance(bind, Engine):
+                # Fully dispose of the connection pool, so the database file is no longer held open by a pooled
+                # connection and can be deleted also on platforms that refuse to delete open files (Windows).
+                bind.dispose()
+        if self.db_file and self.db_file.exists():
+            self.db_file.unlink()
+        if self.repo:
+            self.repo.close()
+        if self.remote_zip:
+            self.remote_zip.close()
+        self.session = None
+        self.db_file = None
+        self.repo = None
+        self.remote_zip = None
+
+
 class SqliteZipBackend(StorageBackend):
     """A read-only backend for a sqlite/zip format.
 
@@ -96,14 +142,20 @@ class SqliteZipBackend(StorageBackend):
     class CliModel(AiiDABaseModel):
         """Model describing required information to configure an instance of the storage."""
 
-        filepath: str = MetadataField(title='Filepath of the archive', description='Filepath of the archive.')
+        filepath: str = MetadataField(
+            title='Filepath of the archive', description='Filepath or URL (http/https) of the archive.'
+        )
 
         @field_validator('filepath')
         @classmethod
         def filepath_exists_and_is_absolute(cls, value: str) -> str:
-            """Validate the filepath exists and return the resolved and absolute filepath."""
+            """Validate the filepath exists and return the resolved and absolute filepath, unless it is a URL."""
+            if is_url(value):
+                return value
             filepath = Path(value)
-            assert filepath.is_file(), f'The archive `{value}` does not exist.'
+            if not filepath.is_file():
+                msg = f'The archive `{value}` does not exist.'
+                raise ValueError(msg)
             return str(filepath.resolve().absolute())
 
     @classmethod
@@ -114,8 +166,22 @@ class SqliteZipBackend(StorageBackend):
 
     @staticmethod
     def create_profile(filepath: str | Path, options: dict | None = None) -> Profile:
-        """Create a new profile instance for this backend, from the path to the zip file."""
-        profile_name = Path(filepath).name
+        """Create a new profile instance for this backend, from the path or URL of the zip file.
+
+        The profile name is derived from the archive filename, with any character that is not alphanumeric or an
+        underscore replaced by an underscore, followed by a short hash of the full location, such that distinct
+        locations sharing the same filename map to distinct (but deterministic) profile names.
+        """
+        location = str(filepath)
+        if is_url(filepath):
+            from urllib.parse import urlsplit
+
+            name = urlsplit(location).path.rstrip('/').rsplit('/', 1)[-1] or 'remote_archive'
+        else:
+            name = Path(filepath).name
+        digest = hashlib.sha256(location.encode()).hexdigest()[:8]
+        sanitized = re.sub(r'\W', '_', name)
+        profile_name = f'{sanitized}_{digest}'
         return Profile(
             profile_name,
             {
@@ -141,7 +207,28 @@ class SqliteZipBackend(StorageBackend):
         validate_sqlite_version()
         from archive_path import ZipPath
 
-        filepath_archive = Path(profile.storage_config['filepath'])
+        filepath = profile.storage_config['filepath']
+
+        if is_url(filepath):
+            # A remote archive cannot be created, reset or migrated in place: it can only be validated to already
+            # be at the target schema version.
+            if reset:
+                msg = f'cannot reset a remote archive: {filepath}'
+                raise ReadOnlyError(msg)
+            target_version = cls.version_head()
+            current_version = cls.get_current_archive_version(inpath=filepath)
+            cls.validate_archive_versions(current_version=current_version, target_version=target_version)
+            if current_version != target_version:
+                msg = (
+                    f'The remote archive at `{filepath}` has version {current_version} but version {target_version} '
+                    'is required, and a remote archive cannot be migrated in place. Download the file and migrate it '
+                    'locally with `verdi archive migrate`.'
+                )
+                raise StorageMigrationError(msg)
+            LOGGER.report(f'Remote {cls.__name__} is already at target version {target_version}.')
+            return False
+
+        filepath_archive = Path(filepath)
 
         if filepath_archive.exists() and not reset:
             from .migrator import migrate
@@ -210,12 +297,20 @@ class SqliteZipBackend(StorageBackend):
 
         validate_sqlite_version()
         super().__init__(profile)
-        self._path = Path(profile.storage_config['filepath'])
-        validate_storage(self._path)
-        # lazy open the archive zipfile and extract the database file
-        self._db_file: Optional[Path] = None
-        self._session: Optional[Session] = None
-        self._repo: Optional[_RoBackendRepository] = None
+        filepath = profile.storage_config['filepath']
+        self._path: Union[Path, str] = filepath if is_url(filepath) else Path(filepath)
+        # The resources (database session, temporary database file, repository, remote zip handle) are opened lazily
+        # and kept in a separate container, registered with ``weakref.finalize``: this releases them both when the
+        # backend is garbage collected and at interpreter exit, without keeping the backend instance alive (as e.g.
+        # ``atexit.register(self.close)`` would) and without calling ``close`` during interpreter finalization (as
+        # ``__del__`` would).
+        self._resources = _ArchiveResources()
+        self._finalizer = weakref.finalize(self, self._resources.close)
+        if is_url(filepath):
+            # Open a single handle to the remote zip file, reused for the metadata, the database and the repository:
+            # each new handle downloads the full central directory of the zip file, which can be expensive.
+            self._resources.remote_zip = open_remote_zip(filepath)
+        validate_storage(self._path, zip_handle=self._resources.remote_zip)
         self._closed = False
 
     def __str__(self) -> str:
@@ -224,19 +319,15 @@ class SqliteZipBackend(StorageBackend):
 
     @property
     def is_closed(self) -> bool:
-        return self._closed
+        # A dead finalizer means the resources were already released, e.g. by the interpreter-exit hook of
+        # ``weakref.finalize``, in which case the backend is effectively closed even if ``close`` was never called.
+        return self._closed or not self._finalizer.alive
 
     def close(self) -> None:
         """Close the backend"""
-        if self._session:
-            self._session.close()
-        if self._db_file and self._db_file.exists():
-            self._db_file.unlink()
-        if self._repo:
-            self._repo.close()
-        self._session = None
-        self._db_file = None
-        self._repo = None
+        # Calling the finalizer releases the resources and marks it dead, so it will not fire again on garbage
+        # collection or at interpreter exit; calling it on an already closed backend is a no-op.
+        self._finalizer()
         self._closed = True
 
     def get_session(self) -> Session:
@@ -245,33 +336,61 @@ class SqliteZipBackend(StorageBackend):
 
         if self._closed:
             raise ClosedStorage(str(self))
-        if self._session is None:
-            if is_zipfile(self._path):
-                _, path = tempfile.mkstemp()
-                db_file = self._db_file = Path(path)
-                with db_file.open('wb') as handle:
-                    try:
-                        extract_file_in_zip(self._path, DB_FILENAME, handle, search_limit=4)
-                    except Exception as exc:
-                        raise CorruptStorage(f'database could not be read: {exc}') from exc
+        if self._resources.session is None:
+            if is_url(self._path) or is_zipfile(self._path):
+                fd, path = tempfile.mkstemp()
+                os.close(fd)
+                db_file = self._resources.db_file = Path(path)
+                try:
+                    with db_file.open('wb') as handle:
+                        if is_url(self._path):
+                            import requests
+                            from remotezip import RemoteZipError
+
+                            # Fetch only the database file from the remote zip, using HTTP range requests. The
+                            # handle is always set in the constructor for URL paths.
+                            zip_handle = cast('RemoteZip', self._resources.remote_zip)
+                            try:
+                                with zip_handle.open(DB_FILENAME) as source:
+                                    shutil.copyfileobj(source, handle)
+                            except (RemoteZipError, requests.RequestException) as exc:
+                                msg = f'Could not read the database from the remote archive `{self._path}`: {exc}'
+                                raise UnreachableStorage(msg) from exc
+                            except Exception as exc:
+                                msg = f'database could not be read: {exc}'
+                                raise CorruptStorage(msg) from exc
+                        else:
+                            try:
+                                extract_file_in_zip(self._path, DB_FILENAME, handle, search_limit=4)
+                            except Exception as exc:
+                                msg = f'database could not be read: {exc}'
+                                raise CorruptStorage(msg) from exc
+                except BaseException:
+                    # Do not leave the temporary file behind if the extraction fails: a subsequent call would
+                    # create a new temporary file, orphaning this one forever.
+                    db_file.unlink(missing_ok=True)
+                    self._resources.db_file = None
+                    raise
             else:
-                db_file = self._path / DB_FILENAME
+                db_file = Path(self._path) / DB_FILENAME
                 if not db_file.exists():
                     raise CorruptStorage(f'database could not be read: non-existent {db_file}')
-            self._session = Session(create_sqla_engine(db_file), future=True)
-        return self._session
+            self._resources.session = Session(create_sqla_engine(db_file), future=True)
+        return self._resources.session
 
     def get_repository(self) -> '_RoBackendRepository':
         if self._closed:
             raise ClosedStorage(str(self))
-        if self._repo is None:
-            if is_zipfile(self._path):
-                self._repo = ZipfileBackendRepository(self._path)
-            elif (self._path / REPO_FOLDER).exists():
-                self._repo = FolderBackendRepository(self._path / REPO_FOLDER)
+        if self._resources.repo is None:
+            if is_url(self._path):
+                self._resources.repo = ZipfileBackendRepository(self._path, zip_handle=self._resources.remote_zip)
+            elif is_zipfile(self._path):
+                self._resources.repo = ZipfileBackendRepository(self._path)
+            elif (Path(self._path) / REPO_FOLDER).exists():
+                self._resources.repo = FolderBackendRepository(Path(self._path) / REPO_FOLDER)
             else:
-                raise CorruptStorage(f'repository could not be read: non-existent {self._path / REPO_FOLDER}')
-        return self._repo
+                raise CorruptStorage(f'repository could not be read: non-existent {Path(self._path) / REPO_FOLDER}')
+        return self._resources.repo
 
     def query(self) -> orm.SqliteQueryBuilder:
         return orm.SqliteQueryBuilder(self)
@@ -337,7 +456,11 @@ class SqliteZipBackend(StorageBackend):
 
     def delete(self) -> None:
         """Delete the storage and all the data."""
-        filepath = Path(self.profile.storage_config['filepath'])
+        filepath = self.profile.storage_config['filepath']
+        if is_url(filepath):
+            LOGGER.report(f'Profile pointed to the remote archive `{filepath}`, which is left untouched.')
+            return
+        filepath = Path(filepath)
         if filepath.exists():
             filepath.unlink()
             LOGGER.report(f'Deleted archive at `{filepath}`.')
@@ -358,7 +481,7 @@ class SqliteZipBackend(StorageBackend):
 
     def get_info(self, detailed: bool = False) -> dict[str, Any]:
         # since extracting the database file is expensive, we only do it if detailed is True
-        results = {'metadata': extract_metadata(self._path)}
+        results = {'metadata': extract_metadata(self._path, zip_handle=self._resources.remote_zip)}
 
         # Truncate entities_starting_set in metadata if not detailed
         if not detailed:
@@ -387,9 +510,10 @@ class SqliteZipBackend(StorageBackend):
     def get_current_archive_version(inpath: Union[str, Path]) -> str:
         """Return the current version from metadata, raising if invalid/corrupt."""
 
-        inpath = Path(inpath)
-        if not (tarfile.is_tarfile(str(inpath)) or zipfile.is_zipfile(str(inpath))):
-            raise CorruptStorage(f'The input file is neither a tar nor a zip file: {inpath}')
+        if not is_url(inpath):
+            inpath = Path(inpath)
+            if not (tarfile.is_tarfile(str(inpath)) or zipfile.is_zipfile(str(inpath))):
+                raise CorruptStorage(f'The input file is neither a tar nor a zip file: {inpath}')
 
         metadata = extract_metadata(inpath, search_limit=None)
 
@@ -423,9 +547,9 @@ class _RoBackendRepository(AbstractRepositoryBackend):
     def __init__(self, path: str | Path):
         """Initialise the repository backend.
 
-        :param path: the path to the zip file
+        :param path: the path to the zip file or folder, or the URL of a remote zip file
         """
-        self._path = Path(path)
+        self._path: Union[Path, str] = path if is_url(path) else Path(path)
         self._closed = False
 
     def close(self) -> None:
@@ -481,13 +605,21 @@ class ZipfileBackendRepository(_RoBackendRepository):
     i.e. files named by the sha256 hash of the file contents, inside a ``repo`` directory.
     """
 
-    def __init__(self, path: str | Path):
+    def __init__(self, path: str | Path, zip_handle: Optional[ZipFile] = None):
+        """Initialise the repository backend.
+
+        :param path: the path to the zip file, or the URL of a remote zip file.
+        :param zip_handle: optionally, an already-open zip file handle for ``path``, which is reused instead of
+            opening a new one. The caller remains responsible for closing it: the repository only closes the
+            handle if it opened it itself.
+        """
         super().__init__(path)
         self._folder = REPO_FOLDER
-        self.__zipfile: None | ZipFile = None
+        self.__zipfile: None | ZipFile = zip_handle
+        self.__owns_zipfile: bool = zip_handle is None
 
     def close(self) -> None:
-        if self.__zipfile:
+        if self.__zipfile and self.__owns_zipfile:
             self.__zipfile.close()
         super().close()
 
@@ -497,10 +629,13 @@ class ZipfileBackendRepository(_RoBackendRepository):
         if self._closed:
             raise ClosedStorage(f'repository is closed: {self._path}')
         if self.__zipfile is None:
-            try:
-                self.__zipfile = ZipFile(self._path, mode='r')
-            except Exception as exc:
-                raise CorruptStorage(f'repository could not be read {self._path}: {exc}') from exc
+            if is_url(self._path):
+                self.__zipfile = open_remote_zip(str(self._path))
+            else:
+                try:
+                    self.__zipfile = ZipFile(self._path, mode='r')
+                except Exception as exc:
+                    raise CorruptStorage(f'repository could not be read {self._path}: {exc}') from exc
         return self.__zipfile
 
     def has_object(self, key: str) -> bool:
@@ -537,16 +672,17 @@ class FolderBackendRepository(_RoBackendRepository):
     """
 
     def has_object(self, key: str) -> bool:
-        return self._path.joinpath(key).is_file()
+        return Path(self._path).joinpath(key).is_file()
 
     def list_objects(self) -> Iterable[str]:
-        for subpath in self._path.iterdir():
+        for subpath in Path(self._path).iterdir():
             if subpath.is_file():
                 yield subpath.name
 
     @contextmanager
     def open(self, key: str) -> Iterator[BinaryIO]:
-        if not self._path.joinpath(key).is_file():
+        filepath = Path(self._path).joinpath(key)
+        if not filepath.is_file():
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
-        with self._path.joinpath(key).open('rb', encoding='utf-8') as handle:
+        with filepath.open('rb') as handle:
             yield cast(BinaryIO, handle)

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -10,20 +10,25 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import re
 import shutil
 import tarfile
 import tempfile
+import weakref
 import zipfile
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, BinaryIO, NoReturn, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, NoReturn, Optional, Tuple, Union, cast
 from zipfile import ZipFile, is_zipfile
 
 from pydantic import field_validator
+from sqlalchemy.future.engine import Engine
 from sqlalchemy.orm import Session
 
 from aiida import __version__
@@ -32,6 +37,7 @@ from aiida.common.exceptions import (
     CorruptStorage,
     IncompatibleExternalDependencies,
     StorageMigrationError,
+    UnreachableStorage,
 )
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.pydantic import AiiDABaseModel, MetadataField
@@ -48,8 +54,13 @@ from .utils import (
     ReadOnlyError,
     create_sqla_engine,
     extract_metadata,
+    is_url,
+    open_remote_zip,
     read_version,
 )
+
+if TYPE_CHECKING:
+    from remotezip import RemoteZip
 
 __all__ = ('SqliteZipBackend',)
 
@@ -74,6 +85,41 @@ def validate_sqlite_version() -> None:
         raise IncompatibleExternalDependencies(message)
 
 
+class _ArchiveResources:
+    """Container for the resources opened by a :class:`SqliteZipBackend` instance.
+
+    The container is registered with :func:`weakref.finalize`, such that the resources are released both when the
+    backend is garbage collected and at interpreter exit. To that end, it must not hold a reference to the backend
+    instance itself, as that would keep the backend alive until interpreter exit.
+    """
+
+    def __init__(self) -> None:
+        self.db_file: Path | None = None
+        self.session: Session | None = None
+        self.repo: _RoBackendRepository | None = None
+        self.remote_zip: RemoteZip | None = None
+
+    def close(self) -> None:
+        """Release all resources: close the session and any open zip handle, and delete the temporary database."""
+        if self.session:
+            self.session.close()
+            bind = self.session.get_bind()
+            if isinstance(bind, Engine):
+                # Fully dispose of the connection pool, so the database file is no longer held open by a pooled
+                # connection and can be deleted also on platforms that refuse to delete open files (Windows).
+                bind.dispose()
+        if self.db_file and self.db_file.exists():
+            self.db_file.unlink()
+        if self.repo:
+            self.repo.close()
+        if self.remote_zip:
+            self.remote_zip.close()
+        self.session = None
+        self.db_file = None
+        self.repo = None
+        self.remote_zip = None
+
+
 class SqliteZipBackend(StorageBackend):
     """A read-only backend for a sqlite/zip format.
 
@@ -96,14 +142,20 @@ class SqliteZipBackend(StorageBackend):
     class CliModel(AiiDABaseModel):
         """Model describing required information to configure an instance of the storage."""
 
-        filepath: str = MetadataField(title='Filepath of the archive', description='Filepath of the archive.')
+        filepath: str = MetadataField(
+            title='Filepath of the archive', description='Filepath or URL (http/https) of the archive.'
+        )
 
         @field_validator('filepath')
         @classmethod
         def filepath_exists_and_is_absolute(cls, value: str) -> str:
-            """Validate the filepath exists and return the resolved and absolute filepath."""
+            """Validate the filepath exists and return the resolved and absolute filepath, unless it is a URL."""
+            if is_url(value):
+                return value
             filepath = Path(value)
-            assert filepath.is_file(), f'The archive `{value}` does not exist.'
+            if not filepath.is_file():
+                msg = f'The archive `{value}` does not exist.'
+                raise ValueError(msg)
             return str(filepath.resolve().absolute())
 
     @classmethod
@@ -114,8 +166,22 @@ class SqliteZipBackend(StorageBackend):
 
     @staticmethod
     def create_profile(filepath: str | Path, options: dict | None = None) -> Profile:
-        """Create a new profile instance for this backend, from the path to the zip file."""
-        profile_name = Path(filepath).name
+        """Create a new profile instance for this backend, from the path or URL of the zip file.
+
+        The profile name is derived from the archive filename, with any character that is not alphanumeric or an
+        underscore replaced by an underscore, followed by a short hash of the full location, such that distinct
+        locations sharing the same filename map to distinct (but deterministic) profile names.
+        """
+        location = str(filepath)
+        if is_url(filepath):
+            from urllib.parse import urlsplit
+
+            name = urlsplit(location).path.rstrip('/').rsplit('/', 1)[-1] or 'remote_archive'
+        else:
+            name = Path(filepath).name
+        digest = hashlib.sha256(location.encode()).hexdigest()[:8]
+        sanitized = re.sub(r'\W', '_', name)
+        profile_name = f'{sanitized}_{digest}'
         return Profile(
             profile_name,
             {
@@ -141,7 +207,28 @@ class SqliteZipBackend(StorageBackend):
         validate_sqlite_version()
         from archive_path import ZipPath
 
-        filepath_archive = Path(profile.storage_config['filepath'])
+        filepath = profile.storage_config['filepath']
+
+        if is_url(filepath):
+            # A remote archive cannot be created, reset or migrated in place: it can only be validated to already
+            # be at the target schema version.
+            if reset:
+                msg = f'cannot reset a remote archive: {filepath}'
+                raise ReadOnlyError(msg)
+            target_version = cls.version_head()
+            current_version = cls.get_current_archive_version(inpath=filepath)
+            cls.validate_archive_versions(current_version=current_version, target_version=target_version)
+            if current_version != target_version:
+                msg = (
+                    f'The remote archive at `{filepath}` has version {current_version} but version {target_version} '
+                    'is required, and a remote archive cannot be migrated in place. Download the file and migrate it '
+                    'locally with `verdi archive migrate`.'
+                )
+                raise StorageMigrationError(msg)
+            LOGGER.report(f'Remote {cls.__name__} is already at target version {target_version}.')
+            return False
+
+        filepath_archive = Path(filepath)
 
         if filepath_archive.exists() and not reset:
             from .migrator import migrate
@@ -210,12 +297,20 @@ class SqliteZipBackend(StorageBackend):
 
         validate_sqlite_version()
         super().__init__(profile)
-        self._path = Path(profile.storage_config['filepath'])
-        validate_storage(self._path)
-        # lazy open the archive zipfile and extract the database file
-        self._db_file: Path | None = None
-        self._session: Session | None = None
-        self._repo: _RoBackendRepository | None = None
+        filepath = profile.storage_config['filepath']
+        self._path: Path | str = filepath if is_url(filepath) else Path(filepath)
+        # The resources (database session, temporary database file, repository, remote zip handle) are opened lazily
+        # and kept in a separate container, registered with ``weakref.finalize``: this releases them both when the
+        # backend is garbage collected and at interpreter exit, without keeping the backend instance alive (as e.g.
+        # ``atexit.register(self.close)`` would) and without calling ``close`` during interpreter finalization (as
+        # ``__del__`` would).
+        self._resources = _ArchiveResources()
+        self._finalizer = weakref.finalize(self, self._resources.close)
+        if is_url(filepath):
+            # Open a single handle to the remote zip file, reused for the metadata, the database and the repository:
+            # each new handle downloads the full central directory of the zip file, which can be expensive.
+            self._resources.remote_zip = open_remote_zip(filepath)
+        validate_storage(self._path, zip_handle=self._resources.remote_zip)
         self._closed = False
 
     def __str__(self) -> str:
@@ -224,19 +319,15 @@ class SqliteZipBackend(StorageBackend):
 
     @property
     def is_closed(self) -> bool:
-        return self._closed
+        # A dead finalizer means the resources were already released, e.g. by the interpreter-exit hook of
+        # ``weakref.finalize``, in which case the backend is effectively closed even if ``close`` was never called.
+        return self._closed or not self._finalizer.alive
 
     def close(self) -> None:
         """Close the backend"""
-        if self._session:
-            self._session.close()
-        if self._db_file and self._db_file.exists():
-            self._db_file.unlink()
-        if self._repo:
-            self._repo.close()
-        self._session = None
-        self._db_file = None
-        self._repo = None
+        # Calling the finalizer releases the resources and marks it dead, so it will not fire again on garbage
+        # collection or at interpreter exit; calling it on an already closed backend is a no-op.
+        self._finalizer()
         self._closed = True
 
     def get_session(self) -> Session:
@@ -245,33 +336,61 @@ class SqliteZipBackend(StorageBackend):
 
         if self._closed:
             raise ClosedStorage(str(self))
-        if self._session is None:
-            if is_zipfile(self._path):
-                _, path = tempfile.mkstemp()
-                db_file = self._db_file = Path(path)
-                with db_file.open('wb') as handle:
-                    try:
-                        extract_file_in_zip(self._path, DB_FILENAME, handle, search_limit=4)
-                    except Exception as exc:
-                        raise CorruptStorage(f'database could not be read: {exc}') from exc
+        if self._resources.session is None:
+            if is_url(self._path) or is_zipfile(self._path):
+                fd, path = tempfile.mkstemp()
+                os.close(fd)
+                db_file = self._resources.db_file = Path(path)
+                try:
+                    with db_file.open('wb') as handle:
+                        if is_url(self._path):
+                            import requests
+                            from remotezip import RemoteZipError
+
+                            # Fetch only the database file from the remote zip, using HTTP range requests. The
+                            # handle is always set in the constructor for URL paths.
+                            zip_handle = cast('RemoteZip', self._resources.remote_zip)
+                            try:
+                                with zip_handle.open(DB_FILENAME) as source:
+                                    shutil.copyfileobj(source, handle)
+                            except (RemoteZipError, requests.RequestException) as exc:
+                                msg = f'Could not read the database from the remote archive `{self._path}`: {exc}'
+                                raise UnreachableStorage(msg) from exc
+                            except Exception as exc:
+                                msg = f'database could not be read: {exc}'
+                                raise CorruptStorage(msg) from exc
+                        else:
+                            try:
+                                extract_file_in_zip(self._path, DB_FILENAME, handle, search_limit=4)
+                            except Exception as exc:
+                                msg = f'database could not be read: {exc}'
+                                raise CorruptStorage(msg) from exc
+                except BaseException:
+                    # Do not leave the temporary file behind if the extraction fails: a subsequent call would
+                    # create a new temporary file, orphaning this one forever.
+                    db_file.unlink(missing_ok=True)
+                    self._resources.db_file = None
+                    raise
             else:
-                db_file = self._path / DB_FILENAME
+                db_file = Path(self._path) / DB_FILENAME
                 if not db_file.exists():
                     raise CorruptStorage(f'database could not be read: non-existent {db_file}')
-            self._session = Session(create_sqla_engine(db_file), future=True)
-        return self._session
+            self._resources.session = Session(create_sqla_engine(db_file), future=True)
+        return self._resources.session
 
     def get_repository(self) -> _RoBackendRepository:
         if self._closed:
             raise ClosedStorage(str(self))
-        if self._repo is None:
-            if is_zipfile(self._path):
-                self._repo = ZipfileBackendRepository(self._path)
-            elif (self._path / REPO_FOLDER).exists():
-                self._repo = FolderBackendRepository(self._path / REPO_FOLDER)
+        if self._resources.repo is None:
+            if is_url(self._path):
+                self._resources.repo = ZipfileBackendRepository(self._path, zip_handle=self._resources.remote_zip)
+            elif is_zipfile(self._path):
+                self._resources.repo = ZipfileBackendRepository(self._path)
+            elif (Path(self._path) / REPO_FOLDER).exists():
+                self._resources.repo = FolderBackendRepository(Path(self._path) / REPO_FOLDER)
             else:
-                raise CorruptStorage(f'repository could not be read: non-existent {self._path / REPO_FOLDER}')
-        return self._repo
+                raise CorruptStorage(f'repository could not be read: non-existent {Path(self._path) / REPO_FOLDER}')
+        return self._resources.repo
 
     def query(self) -> orm.SqliteQueryBuilder:
         return orm.SqliteQueryBuilder(self)
@@ -337,7 +456,11 @@ class SqliteZipBackend(StorageBackend):
 
     def delete(self) -> None:
         """Delete the storage and all the data."""
-        filepath = Path(self.profile.storage_config['filepath'])
+        filepath = self.profile.storage_config['filepath']
+        if is_url(filepath):
+            LOGGER.report(f'Profile pointed to the remote archive `{filepath}`, which is left untouched.')
+            return
+        filepath = Path(filepath)
         if filepath.exists():
             filepath.unlink()
             LOGGER.report(f'Deleted archive at `{filepath}`.')
@@ -358,7 +481,7 @@ class SqliteZipBackend(StorageBackend):
 
     def get_info(self, detailed: bool = False) -> dict[str, Any]:
         # since extracting the database file is expensive, we only do it if detailed is True
-        results = {'metadata': extract_metadata(self._path)}
+        results = {'metadata': extract_metadata(self._path, zip_handle=self._resources.remote_zip)}
 
         # Truncate entities_starting_set in metadata if not detailed
         if not detailed:
@@ -387,9 +510,10 @@ class SqliteZipBackend(StorageBackend):
     def get_current_archive_version(inpath: str | Path) -> str:
         """Return the current version from metadata, raising if invalid/corrupt."""
 
-        inpath = Path(inpath)
-        if not (tarfile.is_tarfile(str(inpath)) or zipfile.is_zipfile(str(inpath))):
-            raise CorruptStorage(f'The input file is neither a tar nor a zip file: {inpath}')
+        if not is_url(inpath):
+            inpath = Path(inpath)
+            if not (tarfile.is_tarfile(str(inpath)) or zipfile.is_zipfile(str(inpath))):
+                raise CorruptStorage(f'The input file is neither a tar nor a zip file: {inpath}')
 
         metadata = extract_metadata(inpath, search_limit=None)
 
@@ -423,9 +547,9 @@ class _RoBackendRepository(AbstractRepositoryBackend):
     def __init__(self, path: str | Path):
         """Initialise the repository backend.
 
-        :param path: the path to the zip file
+        :param path: the path to the zip file or folder, or the URL of a remote zip file
         """
-        self._path = Path(path)
+        self._path: Path | str = path if is_url(path) else Path(path)
         self._closed = False
 
     def close(self) -> None:
@@ -481,13 +605,21 @@ class ZipfileBackendRepository(_RoBackendRepository):
     i.e. files named by the sha256 hash of the file contents, inside a ``repo`` directory.
     """
 
-    def __init__(self, path: str | Path):
+    def __init__(self, path: str | Path, zip_handle: ZipFile | None = None):
+        """Initialise the repository backend.
+
+        :param path: the path to the zip file, or the URL of a remote zip file.
+        :param zip_handle: optionally, an already-open zip file handle for ``path``, which is reused instead of
+            opening a new one. The caller remains responsible for closing it: the repository only closes the
+            handle if it opened it itself.
+        """
         super().__init__(path)
         self._folder = REPO_FOLDER
-        self.__zipfile: None | ZipFile = None
+        self.__zipfile: None | ZipFile = zip_handle
+        self.__owns_zipfile: bool = zip_handle is None
 
     def close(self) -> None:
-        if self.__zipfile:
+        if self.__zipfile and self.__owns_zipfile:
             self.__zipfile.close()
         super().close()
 
@@ -497,10 +629,13 @@ class ZipfileBackendRepository(_RoBackendRepository):
         if self._closed:
             raise ClosedStorage(f'repository is closed: {self._path}')
         if self.__zipfile is None:
-            try:
-                self.__zipfile = ZipFile(self._path, mode='r')
-            except Exception as exc:
-                raise CorruptStorage(f'repository could not be read {self._path}: {exc}') from exc
+            if is_url(self._path):
+                self.__zipfile = open_remote_zip(str(self._path))
+            else:
+                try:
+                    self.__zipfile = ZipFile(self._path, mode='r')
+                except Exception as exc:
+                    raise CorruptStorage(f'repository could not be read {self._path}: {exc}') from exc
         return self.__zipfile
 
     def has_object(self, key: str) -> bool:
@@ -537,16 +672,17 @@ class FolderBackendRepository(_RoBackendRepository):
     """
 
     def has_object(self, key: str) -> bool:
-        return self._path.joinpath(key).is_file()
+        return Path(self._path).joinpath(key).is_file()
 
     def list_objects(self) -> Iterable[str]:
-        for subpath in self._path.iterdir():
+        for subpath in Path(self._path).iterdir():
             if subpath.is_file():
                 yield subpath.name
 
     @contextmanager
     def open(self, key: str) -> Iterator[BinaryIO]:
-        if not self._path.joinpath(key).is_file():
+        filepath = Path(self._path).joinpath(key)
+        if not filepath.is_file():
             raise FileNotFoundError(f'object with key `{key}` does not exist.')
-        with self._path.joinpath(key).open('rb', encoding='utf-8') as handle:
+        with filepath.open('rb') as handle:
             yield cast(BinaryIO, handle)

--- a/src/aiida/storage/sqlite_zip/migrator.py
+++ b/src/aiida/storage/sqlite_zip/migrator.py
@@ -17,7 +17,7 @@ import tempfile
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 from alembic.command import upgrade
 from alembic.config import Config
@@ -34,7 +34,10 @@ from aiida.storage.sqlite_zip.backend import SqliteZipBackend
 from .migrations.legacy import FINAL_LEGACY_VERSION, LEGACY_MIGRATE_FUNCTIONS
 from .migrations.legacy_to_main import LEGACY_TO_MAIN_REVISION, perform_v1_migration
 from .migrations.utils import copy_tar_to_zip, copy_zip_to_zip, update_metadata
-from .utils import DB_FILENAME, META_FILENAME, REPO_FOLDER, create_sqla_engine, extract_metadata, read_version
+from .utils import DB_FILENAME, META_FILENAME, REPO_FOLDER, create_sqla_engine, extract_metadata, is_url, read_version
+
+if TYPE_CHECKING:
+    from remotezip import RemoteZip
 
 
 def get_schema_version_head() -> str:
@@ -49,9 +52,12 @@ def list_versions() -> List[str]:
     return legacy_versions + alembic_versions
 
 
-def validate_storage(inpath: Path) -> None:
+def validate_storage(inpath: Union[str, Path], *, zip_handle: Optional['RemoteZip'] = None) -> None:
     """Validate that the storage is at the head version.
 
+    :param inpath: path to the storage instance, or URL of a remote zip file.
+    :param zip_handle: for a remote URL ``inpath``, optionally an already-open handle of the remote zip file, which
+        is reused (and not closed) instead of opening a new connection.
     :raises: :class:`aiida.common.exceptions.UnreachableStorage` if the file does not exist
     :raises: :class:`aiida.common.exceptions.CorruptStorage`
         if the version cannot be read from the storage.
@@ -59,14 +65,23 @@ def validate_storage(inpath: Path) -> None:
         if the storage is not compatible with the code API.
     """
     schema_version_code = get_schema_version_head()
-    schema_version_archive = read_version(inpath)
+    schema_version_archive = read_version(inpath, zip_handle=zip_handle)
     if schema_version_archive != schema_version_code:
-        raise IncompatibleStorageSchema(
+        if is_url(inpath):
+            hint = (
+                'A remote archive cannot be migrated in place: '
+                'download the file and run `verdi archive migrate` on the local copy.'
+            )
+        else:
+            hint = (
+                'To migrate the archive schema version to the current one, '
+                f'run the following command: verdi archive migrate {str(inpath)!r}'
+            )
+        msg = (
             f'Archive schema version `{schema_version_archive}` '
-            f'is incompatible with the required schema version `{schema_version_code}`. '
-            'To migrate the archive schema version to the current one, '
-            f'run the following command: verdi archive migrate {str(inpath)!r}'
+            f'is incompatible with the required schema version `{schema_version_code}`. ' + hint
         )
+        raise IncompatibleStorageSchema(msg)
 
 
 def migrate(

--- a/src/aiida/storage/sqlite_zip/migrator.py
+++ b/src/aiida/storage/sqlite_zip/migrator.py
@@ -18,7 +18,8 @@ import zipfile
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from collections.abc import Iterator
 
 from alembic.command import upgrade
 from alembic.config import Config
@@ -35,7 +36,10 @@ from aiida.storage.sqlite_zip.backend import SqliteZipBackend
 from .migrations.legacy import FINAL_LEGACY_VERSION, LEGACY_MIGRATE_FUNCTIONS
 from .migrations.legacy_to_main import LEGACY_TO_MAIN_REVISION, perform_v1_migration
 from .migrations.utils import copy_tar_to_zip, copy_zip_to_zip, update_metadata
-from .utils import DB_FILENAME, META_FILENAME, REPO_FOLDER, create_sqla_engine, extract_metadata, read_version
+from .utils import DB_FILENAME, META_FILENAME, REPO_FOLDER, create_sqla_engine, extract_metadata, is_url, read_version
+
+if TYPE_CHECKING:
+    from remotezip import RemoteZip
 
 
 def get_schema_version_head() -> str:
@@ -50,9 +54,12 @@ def list_versions() -> list[str]:
     return legacy_versions + alembic_versions
 
 
-def validate_storage(inpath: Path) -> None:
+def validate_storage(inpath: str | Path, *, zip_handle: Optional['RemoteZip'] = None) -> None:
     """Validate that the storage is at the head version.
 
+    :param inpath: path to the storage instance, or URL of a remote zip file.
+    :param zip_handle: for a remote URL ``inpath``, optionally an already-open handle of the remote zip file, which
+        is reused (and not closed) instead of opening a new connection.
     :raises: :class:`aiida.common.exceptions.UnreachableStorage` if the file does not exist
     :raises: :class:`aiida.common.exceptions.CorruptStorage`
         if the version cannot be read from the storage.
@@ -60,14 +67,23 @@ def validate_storage(inpath: Path) -> None:
         if the storage is not compatible with the code API.
     """
     schema_version_code = get_schema_version_head()
-    schema_version_archive = read_version(inpath)
+    schema_version_archive = read_version(inpath, zip_handle=zip_handle)
     if schema_version_archive != schema_version_code:
-        raise IncompatibleStorageSchema(
+        if is_url(inpath):
+            hint = (
+                'A remote archive cannot be migrated in place: '
+                'download the file and run `verdi archive migrate` on the local copy.'
+            )
+        else:
+            hint = (
+                'To migrate the archive schema version to the current one, '
+                f'run the following command: verdi archive migrate {str(inpath)!r}'
+            )
+        msg = (
             f'Archive schema version `{schema_version_archive}` '
-            f'is incompatible with the required schema version `{schema_version_code}`. '
-            'To migrate the archive schema version to the current one, '
-            f'run the following command: verdi archive migrate {str(inpath)!r}'
+            f'is incompatible with the required schema version `{schema_version_code}`. ' + hint
         )
+        raise IncompatibleStorageSchema(msg)
 
 
 def migrate(

--- a/src/aiida/storage/sqlite_zip/utils.py
+++ b/src/aiida/storage/sqlite_zip/utils.py
@@ -11,12 +11,15 @@
 import json
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from sqlalchemy import event
 from sqlalchemy.future.engine import Engine, create_engine
 
 from aiida.common.exceptions import AiidaException, CorruptStorage, UnreachableStorage
+
+if TYPE_CHECKING:
+    from remotezip import RemoteZip
 
 META_FILENAME = 'metadata.json'
 """The filename containing meta information about the storage instance."""
@@ -26,6 +29,47 @@ DB_FILENAME = 'db.sqlite3'
 
 REPO_FOLDER = 'repo'
 """The name of the folder containing the repository files."""
+
+
+def is_url(path: Union[str, Path]) -> bool:
+    """Return whether the path is a remote URL (``http://`` or ``https://``).
+
+    The scheme is compared case-insensitively, as URL schemes are case-insensitive per RFC 3986.
+    """
+    return isinstance(path, str) and path.lower().startswith(('http://', 'https://'))
+
+
+def open_remote_zip(url: str, *, timeout: Optional[float] = None) -> 'RemoteZip':
+    """Open a zip file over HTTP(S) using range requests, without downloading the whole file.
+
+    :param url: the URL of the remote zip file.
+    :param timeout: timeout in seconds for the HTTP requests. If ``None``, the value of the
+        ``storage.remote_archive_timeout`` configuration option is used.
+    :raises UnreachableStorage: if the URL cannot be reached or the server does not support range requests.
+    :raises CorruptStorage: if the remote file is not a valid zip file.
+    """
+    import requests
+    from remotezip import RangeNotSupported, RemoteZip, RemoteZipError
+
+    if timeout is None:
+        from aiida.manage.configuration import get_config_option
+
+        timeout = get_config_option('storage.remote_archive_timeout')
+
+    try:
+        return RemoteZip(url, timeout=timeout)
+    except zipfile.BadZipFile as exc:
+        msg = f'The remote file is not a valid zip file: {url}'
+        raise CorruptStorage(msg) from exc
+    except RangeNotSupported as exc:
+        msg = (
+            f'The server hosting `{url}` does not support HTTP range requests, which are required to read a remote '
+            'archive without downloading it in full. Download the file and use the local path instead.'
+        )
+        raise UnreachableStorage(msg) from exc
+    except (RemoteZipError, requests.RequestException) as exc:
+        msg = f'Could not reach remote archive `{url}`: {exc}'
+        raise UnreachableStorage(msg) from exc
 
 
 def sqlite_enforce_foreign_keys(dbapi_connection, _):
@@ -89,38 +133,59 @@ def create_sqla_engine(path: Union[str, Path], *, enforce_foreign_keys: bool = T
     return engine
 
 
-def extract_metadata(path: Union[str, Path], *, search_limit: Optional[int] = 10) -> Dict[str, Any]:
+def _read_metadata_from_zip_handle(zip_handle: 'RemoteZip') -> Any:
+    """Read and JSON-decode the metadata file from an open (remote) zip file handle."""
+    try:
+        return json.loads(zip_handle.read(META_FILENAME))
+    except Exception as exc:
+        msg = f'Could not read metadata: {exc}'
+        raise CorruptStorage(msg) from exc
+
+
+def extract_metadata(
+    path: Union[str, Path], *, search_limit: Optional[int] = 10, zip_handle: Optional['RemoteZip'] = None
+) -> Dict[str, Any]:
     """Extract the metadata dictionary from the archive.
 
+    :param path: path to the archive: a folder, zip file, tar file, or URL (``http(s)://``) of a remote zip file.
     :param search_limit: the maximum number of records to search for the metadata file in a zip file.
+    :param zip_handle: for a remote URL ``path``, optionally an already-open handle of the remote zip file, which is
+        reused (and not closed) instead of opening a new connection.
     """
     import tarfile
 
     from archive_path import read_file_in_tar, read_file_in_zip
 
-    path = Path(path)
-    if not path.exists():
-        raise UnreachableStorage(f'path not found: {path}')
-
-    if path.is_dir():
-        if not path.joinpath(META_FILENAME).is_file():
-            raise CorruptStorage('Could not find metadata file')
-        try:
-            metadata = json.loads(path.joinpath(META_FILENAME).read_text(encoding='utf8'))
-        except Exception as exc:
-            raise CorruptStorage(f'Could not read metadata: {exc}') from exc
-    elif path.is_file() and zipfile.is_zipfile(path):
-        try:
-            metadata = json.loads(read_file_in_zip(path, META_FILENAME, search_limit=search_limit))
-        except Exception as exc:
-            raise CorruptStorage(f'Could not read metadata: {exc}') from exc
-    elif path.is_file() and tarfile.is_tarfile(path):
-        try:
-            metadata = json.loads(read_file_in_tar(path, META_FILENAME))
-        except Exception as exc:
-            raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+    if is_url(path):
+        if zip_handle is not None:
+            metadata = _read_metadata_from_zip_handle(zip_handle)
+        else:
+            with open_remote_zip(str(path)) as handle:
+                metadata = _read_metadata_from_zip_handle(handle)
     else:
-        raise CorruptStorage('Path not a folder, zip or tar file')
+        path = Path(path)
+        if not path.exists():
+            raise UnreachableStorage(f'path not found: {path}')
+
+        if path.is_dir():
+            if not path.joinpath(META_FILENAME).is_file():
+                raise CorruptStorage('Could not find metadata file')
+            try:
+                metadata = json.loads(path.joinpath(META_FILENAME).read_text(encoding='utf8'))
+            except Exception as exc:
+                raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+        elif path.is_file() and zipfile.is_zipfile(path):
+            try:
+                metadata = json.loads(read_file_in_zip(path, META_FILENAME, search_limit=search_limit))
+            except Exception as exc:
+                raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+        elif path.is_file() and tarfile.is_tarfile(path):
+            try:
+                metadata = json.loads(read_file_in_tar(path, META_FILENAME))
+            except Exception as exc:
+                raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+        else:
+            raise CorruptStorage('Path not a folder, zip or tar file')
 
     if not isinstance(metadata, dict):
         raise CorruptStorage(f'Metadata is not a dictionary: {type(metadata)}')
@@ -128,17 +193,21 @@ def extract_metadata(path: Union[str, Path], *, search_limit: Optional[int] = 10
     return metadata
 
 
-def read_version(path: Union[str, Path], *, search_limit: Optional[int] = None) -> str:
+def read_version(
+    path: Union[str, Path], *, search_limit: Optional[int] = None, zip_handle: Optional['RemoteZip'] = None
+) -> str:
     """Read the version of the storage instance from the path.
 
     This is intended to work for all versions of the storage format.
 
-    :param path: path to storage instance, either a folder, zip file or tar file.
+    :param path: path to storage instance: a folder, zip file, tar file, or URL of a remote zip file.
     :param search_limit: the maximum number of records to search for the metadata file in a zip file.
+    :param zip_handle: for a remote URL ``path``, optionally an already-open handle of the remote zip file, which is
+        reused (and not closed) instead of opening a new connection.
 
     :raises: ``UnreachableStorage`` if a version cannot be read from the file
     """
-    metadata = extract_metadata(path, search_limit=search_limit)
+    metadata = extract_metadata(path, search_limit=search_limit, zip_handle=zip_handle)
     if 'export_version' in metadata:
         return metadata['export_version']
 

--- a/src/aiida/storage/sqlite_zip/utils.py
+++ b/src/aiida/storage/sqlite_zip/utils.py
@@ -11,12 +11,15 @@
 import json
 import zipfile
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from sqlalchemy import event
 from sqlalchemy.future.engine import Engine, create_engine
 
 from aiida.common.exceptions import AiidaException, CorruptStorage, UnreachableStorage
+
+if TYPE_CHECKING:
+    from remotezip import RemoteZip
 
 META_FILENAME = 'metadata.json'
 """The filename containing meta information about the storage instance."""
@@ -26,6 +29,47 @@ DB_FILENAME = 'db.sqlite3'
 
 REPO_FOLDER = 'repo'
 """The name of the folder containing the repository files."""
+
+
+def is_url(path: str | Path) -> bool:
+    """Return whether the path is a remote URL (``http://`` or ``https://``).
+
+    The scheme is compared case-insensitively, as URL schemes are case-insensitive per RFC 3986.
+    """
+    return isinstance(path, str) and path.lower().startswith(('http://', 'https://'))
+
+
+def open_remote_zip(url: str, *, timeout: float | None = None) -> 'RemoteZip':
+    """Open a zip file over HTTP(S) using range requests, without downloading the whole file.
+
+    :param url: the URL of the remote zip file.
+    :param timeout: timeout in seconds for the HTTP requests. If ``None``, the value of the
+        ``storage.remote_archive_timeout`` configuration option is used.
+    :raises UnreachableStorage: if the URL cannot be reached or the server does not support range requests.
+    :raises CorruptStorage: if the remote file is not a valid zip file.
+    """
+    import requests
+    from remotezip import RangeNotSupported, RemoteZip, RemoteZipError
+
+    if timeout is None:
+        from aiida.manage.configuration import get_config_option
+
+        timeout = get_config_option('storage.remote_archive_timeout')
+
+    try:
+        return RemoteZip(url, timeout=timeout)
+    except zipfile.BadZipFile as exc:
+        msg = f'The remote file is not a valid zip file: {url}'
+        raise CorruptStorage(msg) from exc
+    except RangeNotSupported as exc:
+        msg = (
+            f'The server hosting `{url}` does not support HTTP range requests, which are required to read a remote '
+            'archive without downloading it in full. Download the file and use the local path instead.'
+        )
+        raise UnreachableStorage(msg) from exc
+    except (RemoteZipError, requests.RequestException) as exc:
+        msg = f'Could not reach remote archive `{url}`: {exc}'
+        raise UnreachableStorage(msg) from exc
 
 
 def sqlite_enforce_foreign_keys(dbapi_connection, _):
@@ -89,38 +133,59 @@ def create_sqla_engine(path: str | Path, *, enforce_foreign_keys: bool = True, *
     return engine
 
 
-def extract_metadata(path: str | Path, *, search_limit: int | None = 10) -> dict[str, Any]:
+def _read_metadata_from_zip_handle(zip_handle: 'RemoteZip') -> Any:
+    """Read and JSON-decode the metadata file from an open (remote) zip file handle."""
+    try:
+        return json.loads(zip_handle.read(META_FILENAME))
+    except Exception as exc:
+        msg = f'Could not read metadata: {exc}'
+        raise CorruptStorage(msg) from exc
+
+
+def extract_metadata(
+    path: str | Path, *, search_limit: int | None = 10, zip_handle: Optional['RemoteZip'] = None
+) -> dict[str, Any]:
     """Extract the metadata dictionary from the archive.
 
+    :param path: path to the archive: a folder, zip file, tar file, or URL (``http(s)://``) of a remote zip file.
     :param search_limit: the maximum number of records to search for the metadata file in a zip file.
+    :param zip_handle: for a remote URL ``path``, optionally an already-open handle of the remote zip file, which is
+        reused (and not closed) instead of opening a new connection.
     """
     import tarfile
 
     from archive_path import read_file_in_tar, read_file_in_zip
 
-    path = Path(path)
-    if not path.exists():
-        raise UnreachableStorage(f'path not found: {path}')
-
-    if path.is_dir():
-        if not path.joinpath(META_FILENAME).is_file():
-            raise CorruptStorage('Could not find metadata file')
-        try:
-            metadata = json.loads(path.joinpath(META_FILENAME).read_text(encoding='utf8'))
-        except Exception as exc:
-            raise CorruptStorage(f'Could not read metadata: {exc}') from exc
-    elif path.is_file() and zipfile.is_zipfile(path):
-        try:
-            metadata = json.loads(read_file_in_zip(path, META_FILENAME, search_limit=search_limit))
-        except Exception as exc:
-            raise CorruptStorage(f'Could not read metadata: {exc}') from exc
-    elif path.is_file() and tarfile.is_tarfile(path):
-        try:
-            metadata = json.loads(read_file_in_tar(path, META_FILENAME))
-        except Exception as exc:
-            raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+    if is_url(path):
+        if zip_handle is not None:
+            metadata = _read_metadata_from_zip_handle(zip_handle)
+        else:
+            with open_remote_zip(str(path)) as handle:
+                metadata = _read_metadata_from_zip_handle(handle)
     else:
-        raise CorruptStorage('Path not a folder, zip or tar file')
+        path = Path(path)
+        if not path.exists():
+            raise UnreachableStorage(f'path not found: {path}')
+
+        if path.is_dir():
+            if not path.joinpath(META_FILENAME).is_file():
+                raise CorruptStorage('Could not find metadata file')
+            try:
+                metadata = json.loads(path.joinpath(META_FILENAME).read_text(encoding='utf8'))
+            except Exception as exc:
+                raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+        elif path.is_file() and zipfile.is_zipfile(path):
+            try:
+                metadata = json.loads(read_file_in_zip(path, META_FILENAME, search_limit=search_limit))
+            except Exception as exc:
+                raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+        elif path.is_file() and tarfile.is_tarfile(path):
+            try:
+                metadata = json.loads(read_file_in_tar(path, META_FILENAME))
+            except Exception as exc:
+                raise CorruptStorage(f'Could not read metadata: {exc}') from exc
+        else:
+            raise CorruptStorage('Path not a folder, zip or tar file')
 
     if not isinstance(metadata, dict):
         raise CorruptStorage(f'Metadata is not a dictionary: {type(metadata)}')
@@ -128,17 +193,21 @@ def extract_metadata(path: str | Path, *, search_limit: int | None = 10) -> dict
     return metadata
 
 
-def read_version(path: str | Path, *, search_limit: int | None = None) -> str:
+def read_version(
+    path: str | Path, *, search_limit: int | None = None, zip_handle: Optional['RemoteZip'] = None
+) -> str:
     """Read the version of the storage instance from the path.
 
     This is intended to work for all versions of the storage format.
 
-    :param path: path to storage instance, either a folder, zip file or tar file.
+    :param path: path to storage instance: a folder, zip file, tar file, or URL of a remote zip file.
     :param search_limit: the maximum number of records to search for the metadata file in a zip file.
+    :param zip_handle: for a remote URL ``path``, optionally an already-open handle of the remote zip file, which is
+        reused (and not closed) instead of opening a new connection.
 
     :raises: ``UnreachableStorage`` if a version cannot be read from the file
     """
-    metadata = extract_metadata(path, search_limit=search_limit)
+    metadata = extract_metadata(path, search_limit=search_limit, zip_handle=zip_handle)
     if 'export_version' in metadata:
         return metadata['export_version']
 

--- a/tests/cmdline/params/types/test_profile.py
+++ b/tests/cmdline/params/types/test_profile.py
@@ -1,0 +1,150 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the :class:`aiida.cmdline.params.types.profile.ProfileParamType`."""
+
+import os
+import re
+import subprocess
+import types
+
+import click
+import pytest
+
+from aiida.cmdline.params.types.profile import ProfileParamType
+from aiida.storage.sqlite_zip.backend import SqliteZipBackend
+
+
+@pytest.fixture
+def filepath_archive(tmp_path):
+    """Return the filepath of an initialised, empty archive."""
+    filepath = tmp_path / 'archive.aiida'
+    SqliteZipBackend.initialise(SqliteZipBackend.create_profile(filepath))
+    return filepath
+
+
+@pytest.fixture
+def ctx(aiida_config):
+    """Return a ``click`` context with the config on the user defined object, as ``VerdiContext`` provides it."""
+    context = click.Context(click.Command('test'))
+    context.obj = types.SimpleNamespace(config=aiida_config, profile=None)
+    return context
+
+
+def test_convert_archive_file_url(ctx, filepath_archive, aiida_config):
+    """Test that a ``file://`` value is converted to an ephemeral archive profile, without touching the config."""
+    profile = ProfileParamType(accept_archive_location=True).convert(f'file://{filepath_archive}', None, ctx)
+
+    assert profile.storage_backend == 'core.sqlite_zip'
+    assert profile.storage_config['filepath'] == str(filepath_archive)
+    assert ctx.obj.profile is profile
+    assert profile.name not in [p.name for p in aiida_config.profiles]
+
+
+def test_convert_archive_remote_url(ctx, aiida_config):
+    """Test that an ``https://`` value is converted to an ephemeral archive profile, without network access."""
+    url = 'https://example.com/some/path/export.aiida?download=1'
+    profile = ProfileParamType(accept_archive_location=True).convert(url, None, ctx)
+
+    assert profile.storage_backend == 'core.sqlite_zip'
+    assert profile.storage_config['filepath'] == url
+    assert re.fullmatch(r'export_aiida_[0-9a-f]{8}', profile.name)
+    assert profile.name not in [p.name for p in aiida_config.profiles]
+
+    # The name is deterministic: converting the same location again yields the same name
+    assert ProfileParamType(accept_archive_location=True).convert(url, None, ctx).name == profile.name
+
+    # ... but a different location with the same filename yields a different name
+    other = ProfileParamType(accept_archive_location=True).convert(f'{url}&other=1', None, ctx)
+    assert other.name != profile.name
+
+
+def test_convert_archive_file_url_localhost(ctx, filepath_archive):
+    """Test that the ``file://localhost/absolute/path`` form is accepted."""
+    profile = ProfileParamType(accept_archive_location=True).convert(f'file://localhost{filepath_archive}', None, ctx)
+    assert profile.storage_config['filepath'] == str(filepath_archive)
+
+
+def test_convert_archive_file_url_percent_encoded(ctx, tmp_path):
+    """Test that percent-encoded characters in a ``file://`` URL are decoded."""
+    filepath_archive = tmp_path / 'some archive.aiida'
+    SqliteZipBackend.initialise(SqliteZipBackend.create_profile(filepath_archive))
+
+    value = f'file://{str(filepath_archive).replace(" ", "%20")}'
+    profile = ProfileParamType(accept_archive_location=True).convert(value, None, ctx)
+    assert profile.storage_config['filepath'] == str(filepath_archive)
+
+
+def test_convert_archive_file_url_invalid_host(ctx):
+    """Test that a ``file://`` URL with a non-local host is rejected with a clear error."""
+    with pytest.raises(click.BadParameter, match=r'.*unsupported host `example.com`.*'):
+        ProfileParamType(accept_archive_location=True).convert('file://example.com/path/export.aiida', None, ctx)
+
+
+def test_convert_archive_file_url_non_existent(ctx, tmp_path):
+    """Test that a ``file://`` value pointing to a non-existent file raises."""
+    with pytest.raises(click.BadParameter, match=r'.*does not exist.*'):
+        ProfileParamType(accept_archive_location=True).convert(f'file://{tmp_path / "non-existent.aiida"}', None, ctx)
+
+
+def test_convert_archive_location_not_accepted_by_default(ctx):
+    """Test that archive locations are rejected unless ``accept_archive_location=True``.
+
+    This ensures that e.g. ``verdi profile delete <URL>`` fails label validation instead of silently creating an
+    ephemeral profile; only parameters that explicitly opt in (the ``verdi -p/--profile`` option) convert locations.
+    """
+    with pytest.raises(click.BadParameter):
+        ProfileParamType().convert('https://example.com/export.aiida', None, ctx)
+
+    with pytest.raises(click.BadParameter):
+        ProfileParamType().convert('file:///some/path/export.aiida', None, ctx)
+
+
+def test_convert_archive_url_cannot_exist(ctx):
+    """Test that URL values are not converted to archive profiles when ``cannot_exist=True``.
+
+    In that case the value is supposed to be the name for a new profile, so it should fail label validation.
+    """
+    with pytest.raises(click.BadParameter):
+        ProfileParamType(cannot_exist=True).convert('https://example.com/export.aiida', None, ctx)
+
+
+def test_verdi_ephemeral_archive_profile(filepath_archive, tmp_path):
+    """Test ``verdi -p file://<archive> <command>`` end-to-end in a subprocess.
+
+    The command should succeed without the profile being added to the configuration file and without leaving the
+    temporary database file behind after the process exits.
+    """
+    tmp_dir = tmp_path / 'tmpdir'
+    tmp_dir.mkdir()
+
+    env = os.environ.copy()
+    env['TMPDIR'] = str(tmp_dir)
+
+    filepath_config = tmp_path / 'aiida_config'
+    env['AIIDA_PATH'] = str(filepath_config)
+
+    result = subprocess.run(
+        ['verdi', '-p', f'file://{filepath_archive}', 'user', 'list'],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    # The command queried the storage, so the database was extracted to ``TMPDIR``: check it was cleaned up at exit.
+    # Only consider plain temporary files as created by ``tempfile.mkstemp``, to be robust against anything else in
+    # the subprocess writing to ``TMPDIR``.
+    leftovers = [path for path in tmp_dir.iterdir() if path.is_file() and path.name.startswith('tmp')]
+    assert leftovers == []
+
+    # The ephemeral profile was not added to the configuration file
+    config_file = filepath_config / '.aiida' / 'config.json'
+    assert config_file.exists(), 'the configuration file was not created'
+    assert 'archive' not in config_file.read_text()

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -532,7 +532,7 @@ def test_delete_profile_sqlite_zip(
     from aiida.storage.sqlite_zip import migrator
     from aiida.storage.sqlite_zip.backend import SqliteZipBackend
 
-    monkeypatch.setattr(migrator, 'validate_storage', lambda path: None)
+    monkeypatch.setattr(migrator, 'validate_storage', lambda path, **kwargs: None)
 
     config = config_with_profile
     profile_name = 'sqlite-zip-test-profile'

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -536,7 +536,7 @@ def test_delete_profile_sqlite_zip(
     from aiida.storage.sqlite_zip import migrator
     from aiida.storage.sqlite_zip.backend import SqliteZipBackend
 
-    monkeypatch.setattr(migrator, 'validate_storage', lambda path: None)
+    monkeypatch.setattr(migrator, 'validate_storage', lambda path, **kwargs: None)
 
     config = config_with_profile
     profile_name = 'sqlite-zip-test-profile'

--- a/tests/storage/sqlite_zip/test_backend.py
+++ b/tests/storage/sqlite_zip/test_backend.py
@@ -1,13 +1,105 @@
 """Tests for :mod:`aiida.storage.sqlite_zip.backend`."""
 
+import contextlib
+import functools
+import gc
+import hashlib
+import http.server
 import pathlib
+import re
+import threading
+import zipfile
 
 import pytest
 from pydantic_core import ValidationError
 
-from aiida.common.exceptions import IncompatibleExternalDependencies
-from aiida.storage.sqlite_zip.backend import SqliteZipBackend, validate_sqlite_version
+from aiida.common.exceptions import IncompatibleExternalDependencies, StorageMigrationError, UnreachableStorage
+from aiida.storage.sqlite_zip.backend import FolderBackendRepository, SqliteZipBackend, validate_sqlite_version
 from aiida.storage.sqlite_zip.migrator import validate_storage
+from aiida.storage.sqlite_zip.utils import ReadOnlyError, open_remote_zip
+
+
+class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """Minimal HTTP handler supporting single byte-range requests, as required by ``remotezip``."""
+
+    protocol_version = 'HTTP/1.1'
+
+    def log_message(self, format, *args):
+        """Silence request logging."""
+
+    def do_GET(self):  # noqa: N802
+        filepath = pathlib.Path(self.translate_path(self.path))
+        if not filepath.is_file():
+            self.send_error(404)
+            return
+        data = filepath.read_bytes()
+        range_header = self.headers.get('Range')
+
+        if range_header is None:
+            self.send_response(200)
+            self.send_header('Accept-Ranges', 'bytes')
+            self.send_header('Content-Length', str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+
+        match = re.fullmatch(r'bytes=(\d*)-(\d*)', range_header.strip())
+        if match is None:
+            self.send_error(400)
+            return
+        start_str, end_str = match.groups()
+        if start_str:
+            start = int(start_str)
+            end = int(end_str) if end_str else len(data) - 1
+        else:
+            # Suffix range, e.g. ``bytes=-100`` requests the last 100 bytes
+            start = max(0, len(data) - int(end_str))
+            end = len(data) - 1
+        end = min(end, len(data) - 1)
+        chunk = data[start : end + 1]
+
+        self.send_response(206)
+        self.send_header('Accept-Ranges', 'bytes')
+        self.send_header('Content-Range', f'bytes {start}-{end}/{len(data)}')
+        self.send_header('Content-Length', str(len(chunk)))
+        self.end_headers()
+        self.wfile.write(chunk)
+
+
+class NoRangeRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """Minimal HTTP handler that ignores range requests, always responding with the full content."""
+
+    def log_message(self, format, *args):
+        """Silence request logging."""
+
+
+@contextlib.contextmanager
+def serve_directory(handler_cls, directory):
+    """Serve ``directory`` over HTTP with the given request handler class, yielding the base URL."""
+    handler = functools.partial(handler_cls, directory=str(directory))
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f'http://127.0.0.1:{server.server_address[1]}'
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.fixture
+def serve_over_http(tmp_path):
+    """Serve ``tmp_path`` over HTTP with support for byte-range requests, yielding the base URL."""
+    with serve_directory(RangeRequestHandler, tmp_path) as url:
+        yield url
+
+
+@pytest.fixture
+def serve_over_http_no_ranges(tmp_path):
+    """Serve ``tmp_path`` over HTTP without support for byte-range requests, yielding the base URL."""
+    with serve_directory(NoRangeRequestHandler, tmp_path) as url:
+        yield url
 
 
 def test_initialise(tmp_path, caplog):
@@ -81,6 +173,151 @@ def test_validate_sqlite_version(monkeypatch):
     monkeypatch.setattr('sqlite3.sqlite_version', '100.0.0')
     monkeypatch.setattr('aiida.storage.sqlite_zip.backend.SUPPORTED_VERSION', '0.0.0')
     validate_sqlite_version()
+
+
+def test_model_url():
+    """Test :class:`aiida.storage.sqlite_zip.backend.SqliteZipBackend.CliModel` accepts URLs verbatim."""
+    url = 'https://example.com/archive.aiida'
+    model = SqliteZipBackend.CliModel(filepath=url)
+    assert model.filepath == url
+
+
+def test_remote_archive(tmp_path, serve_over_http):
+    """Test creating a profile from a remote archive URL and reading data and repository files from it."""
+    filepath_archive = tmp_path / 'archive.aiida'
+    SqliteZipBackend.initialise(SqliteZipBackend.create_profile(filepath_archive))
+
+    # Add a repository file to the archive
+    content = b'some repository content'
+    key = hashlib.sha256(content).hexdigest()
+    with zipfile.ZipFile(filepath_archive, 'a') as zip_handle:
+        zip_handle.writestr(f'repo/{key}', content)
+
+    url = f'{serve_over_http}/archive.aiida'
+    profile = SqliteZipBackend.create_profile(url)
+    assert profile.storage_config['filepath'] == url
+
+    # The archive is already at the head version, so no initialisation or migration is required
+    assert SqliteZipBackend.initialise(profile) is False
+
+    validate_storage(url)
+    backend = SqliteZipBackend(profile)
+
+    # The database is fetched from the remote zip and can be queried
+    from aiida.orm import QueryBuilder, User
+
+    assert QueryBuilder(backend=backend).append(User).count() == 0
+
+    # Repository files are streamed directly from the remote zip
+    repository = backend.get_repository()
+    assert list(repository.list_objects()) == [key]
+    assert repository.has_object(key)
+    with repository.open(key) as handle:
+        assert handle.read() == content
+
+    # The remote zip handle opened by the backend is reused by the repository, instead of fetching the central
+    # directory of the remote zip file again
+    assert repository._zipfile is backend._resources.remote_zip
+
+    backend.close()
+
+
+def test_remote_archive_range_not_supported(tmp_path, serve_over_http_no_ranges):
+    """Test that a server without support for HTTP range requests results in a clear error message."""
+    filepath_archive = tmp_path / 'archive.aiida'
+    SqliteZipBackend.initialise(SqliteZipBackend.create_profile(filepath_archive))
+
+    url = f'{serve_over_http_no_ranges}/archive.aiida'
+    with pytest.raises(UnreachableStorage, match='does not support HTTP range requests'):
+        open_remote_zip(url)
+
+
+def test_remote_archive_timeout(monkeypatch):
+    """Test that ``open_remote_zip`` passes the ``storage.remote_archive_timeout`` option to ``RemoteZip``."""
+    from aiida.manage import get_config_option
+
+    captured = {}
+
+    def mock_remote_zip(url, **kwargs):
+        captured.update(kwargs)
+        raise zipfile.BadZipFile(url)
+
+    monkeypatch.setattr('remotezip.RemoteZip', mock_remote_zip)
+
+    with pytest.raises(Exception, match='not a valid zip file'):
+        open_remote_zip('https://example.com/archive.aiida')
+    assert captured['timeout'] == get_config_option('storage.remote_archive_timeout')
+
+    with pytest.raises(Exception, match='not a valid zip file'):
+        open_remote_zip('https://example.com/archive.aiida', timeout=1.5)
+    assert captured['timeout'] == 1.5
+
+
+def test_folder_repository(tmp_path):
+    """Test reading repository files from an unpacked (folder-format) archive.
+
+    This is a regression test for ``FolderBackendRepository.open``, which used to pass an ``encoding`` argument to a
+    binary-mode ``open`` call, raising a ``ValueError`` for any file access.
+    """
+    filepath_archive = tmp_path / 'archive.aiida'
+    SqliteZipBackend.initialise(SqliteZipBackend.create_profile(filepath_archive))
+
+    content = b'some repository content'
+    key = hashlib.sha256(content).hexdigest()
+    with zipfile.ZipFile(filepath_archive, 'a') as zip_handle:
+        zip_handle.writestr(f'repo/{key}', content)
+
+    # Unpack the archive to a folder and create a backend directly from the folder
+    dirpath_archive = tmp_path / 'unpacked'
+    with zipfile.ZipFile(filepath_archive) as zip_handle:
+        zip_handle.extractall(dirpath_archive)
+
+    backend = SqliteZipBackend(SqliteZipBackend.create_profile(dirpath_archive))
+    repository = backend.get_repository()
+    assert isinstance(repository, FolderBackendRepository)
+
+    assert list(repository.list_objects()) == [key]
+    assert repository.has_object(key)
+    with repository.open(key) as handle:
+        assert handle.read() == content
+
+    backend.close()
+
+
+def test_backend_cleanup_on_garbage_collection(tmp_path):
+    """Test that the temporary database file is deleted when an unclosed backend is garbage collected."""
+    filepath_archive = tmp_path / 'archive.aiida'
+    SqliteZipBackend.initialise(SqliteZipBackend.create_profile(filepath_archive))
+
+    backend = SqliteZipBackend(SqliteZipBackend.create_profile(filepath_archive))
+    backend.get_session()
+    db_file = backend._resources.db_file
+    assert db_file is not None and db_file.exists()
+
+    del backend
+    gc.collect()
+    assert not db_file.exists()
+
+
+def test_initialise_remote_migration_needed(monkeypatch):
+    """Test that ``initialise`` raises for a remote archive that is not at the target version."""
+    profile = SqliteZipBackend.create_profile('https://example.com/archive.aiida')
+
+    monkeypatch.setattr(
+        'aiida.storage.sqlite_zip.backend.SqliteZipBackend.get_current_archive_version',
+        lambda inpath: '0.9',
+    )
+
+    with pytest.raises(StorageMigrationError, match='cannot be migrated in place'):
+        SqliteZipBackend.initialise(profile)
+
+
+def test_initialise_remote_reset():
+    """Test that ``initialise`` with ``reset=True`` raises for a remote archive."""
+    profile = SqliteZipBackend.create_profile('https://example.com/archive.aiida')
+
+    with pytest.raises(ReadOnlyError, match='cannot reset a remote archive'):
+        SqliteZipBackend.initialise(profile, reset=True)
 
 
 def test_initialise_migration_needed(tmp_path, caplog, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pytz" },
     { name = "pyyaml" },
+    { name = "remotezip" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "tabulate" },
@@ -257,6 +258,7 @@ requires-dist = [
     { name = "python-memcached", marker = "extra == 'rest'", specifier = "~=1.59" },
     { name = "pytz", specifier = "~=2021.1" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "remotezip", specifier = "~=0.12.3" },
     { name = "requests", specifier = "~=2.0" },
     { name = "seekpath", marker = "extra == 'atomic-tools'", specifier = "~=1.9,>=1.9.3" },
     { name = "seekpath", marker = "extra == 'rest'", specifier = "~=1.9,>=1.9.3" },
@@ -4843,6 +4845,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "remotezip"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/8d/908ad46bff752568a409ee6ac797c3c6817501db06f142989e3208414569/remotezip-0.12.3.tar.gz", hash = "sha256:bf1ebe2be9f07a6e1c14d0e52ecffccd7a3e808dff4f9ba523c5e84d867a3fe3", size = 7835, upload-time = "2024-02-26T19:51:04.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/18/22316545b712dbed0119c7d3b8683a566c7da26353e344a4188b99f12692/remotezip-0.12.3-py3-none-any.whl", hash = "sha256:f70a4026879439ecb0a2cf848a7c176ae5ee142bbe51ec69e3344e150b2a52de", size = 8099, upload-time = "2024-02-26T19:51:02.968Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pytz" },
     { name = "pyyaml" },
+    { name = "remotezip" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "tabulate" },
@@ -259,6 +260,7 @@ requires-dist = [
     { name = "python-memcached", marker = "extra == 'rest'", specifier = "~=1.59" },
     { name = "pytz", specifier = "~=2021.1" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "remotezip", specifier = "~=0.12.3" },
     { name = "requests", specifier = "~=2.0" },
     { name = "seekpath", marker = "extra == 'atomic-tools'", specifier = "~=1.9,>=1.9.3" },
     { name = "seekpath", marker = "extra == 'rest'", specifier = "~=1.9,>=1.9.3" },
@@ -4851,6 +4853,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "remotezip"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/8d/908ad46bff752568a409ee6ac797c3c6817501db06f142989e3208414569/remotezip-0.12.3.tar.gz", hash = "sha256:bf1ebe2be9f07a6e1c14d0e52ecffccd7a3e808dff4f9ba523c5e84d867a3fe3", size = 7835, upload-time = "2024-02-26T19:51:04.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/18/22316545b712dbed0119c7d3b8683a566c7da26353e344a4188b99f12692/remotezip-0.12.3-py3-none-any.whl", hash = "sha256:f70a4026879439ecb0a2cf848a7c176ae5ee142bbe51ec69e3344e150b2a52de", size = 8099, upload-time = "2024-02-26T19:51:02.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `filepath` of the `core.sqlite_zip` storage backend now also accepts an `http://` or `https://` URL of an archive hosted online, e.g.:

    verdi profile setup core.sqlite_zip -n --profile-name archive \
        --filepath https://example.com/export.aiida

The archive is never downloaded in full. Using the `remotezip` library (added as a new dependency), only the SQLite database is fetched via HTTP range requests (to a temporary file, once per Python session, on first query), and repository files are streamed individually from the remote zip on demand. Each storage instance opens a single connection to the remote archive, reused for validation, database extraction and repository access. The server hosting the archive must support range requests, and the timeout of the HTTP requests can be changed via the new `storage.remote_archive_timeout` configuration option (default: 60 seconds).

Since a remote archive cannot be migrated in place, profile setup fails with a clear error if the archive is not at the target schema version, instructing the user to download the file and run `verdi archive migrate` on the local copy. Similarly, resetting a remote archive raises, and `verdi profile delete --delete-data` reports that the remote archive is left untouched instead of warning that the file does not exist.

The `-p/--profile` option of `verdi` now also accepts the location of a `.aiida` archive, as a `file:///absolute/path` URL of a local archive or an `http(s)://` URL of a remote one, e.g.:

    verdi -p file:///path/to/export.aiida process list -a
    verdi -p https://example.com/export.aiida shell

In this case an ephemeral profile is created that mounts the archive with the read-only `core.sqlite_zip` storage backend, for the duration of the command only: the profile is never added to the configuration file and any temporary files are cleaned up when the command finishes. Archive locations are only accepted by parameters that explicitly opt in via `ProfileParamType(accept_archive_location=True)`, currently only the top-level `-p/--profile` option: other profile parameters, such as the argument of `verdi profile delete`, keep treating such values as invalid profile names. As part of this,
`aiida.manage.configuration.load_profile` now also accepts a `Profile` instance in addition to a profile name.

Also fix a latent bug in `FolderBackendRepository.open`, which passed `encoding` to a binary-mode `open()` call, raising `ValueError` for any file access on unpacked folder-format archives.