### PR TITLE
🔧 Various smaller fixes before 2.9 release

### DIFF
--- a/docs/source/howto/faq.rst
+++ b/docs/source/howto/faq.rst
@@ -74,7 +74,7 @@ To determine exactly what might be going wrong, first :ref:`increase the logging
     $ verdi config set logging.aiida_loglevel DEBUG
     $ verdi daemon restart
 
-You can find the daemon log file in ``<AIIDA_PATH>/.aiida/daemon/log/aiida-<PROFILE_NAME>.log``.
+You can find the daemon log file in ``<AIIDA_PATH>/daemon/log/aiida-<PROFILE_NAME>.log``.
 Alternatively you can run ``verdi daemon logshow`` in a separate terminal to see the daemon log output and submit the problematic calculation or workflow again.
 The daemon log file does not have such a filter in place and logs everything.
 

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -415,11 +415,12 @@ To change it one can set it with the config option:
 
     $ verdi config set logging.aiida_loglevel DEBUG
 
-Each profile has three log files:
+Each profile has four log files:
 
-- ``<AIIDA_PATH>/log/aiida-<profile_name>.log`` -- client-side logs (task submissions, pause/play/kill messages, and process execution in running mode)
-- ``<AIIDA_PATH>/daemon/log/aiida-<profile_name>.log`` -- daemon worker logs
-- ``<AIIDA_PATH>/daemon/log/circus-<profile_name>.log`` -- circus supervisor internals
+- ``<AIIDA_PATH>/log/aiida-<PROFILE_NAME>.log`` -- client-side logs (task submissions, pause/play/kill messages, and process execution in running mode)
+- ``<AIIDA_PATH>/daemon/log/aiida-<PROFILE_NAME>.log`` -- daemon worker logs
+- ``<AIIDA_PATH>/daemon/log/circus-<PROFILE_NAME>.log`` -- circus supervisor internals
+- ``<AIIDA_PATH>/broker/<PROFILE_NAME>/broker.log`` --  ZeroMQ service log it ``core.zeromq`` is used as broker plugin
 
 By default, only messages at the ``REPORT`` level and above are shown in the terminal, while the log files capture all messages.
 AiiDA provides separate options to control the verbosity of what is also directed to the terminal and database:

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -11,7 +11,8 @@ if t.TYPE_CHECKING:
 
     from aiida.manage.configuration.profile import Profile
 
-__all__ = ('Broker', 'BrokerConfigField')
+# We intentionally do not expose BrokerConfigField to public API, because we might change it later
+__all__ = ('Broker',)
 
 
 @dataclass(frozen=True)

--- a/src/aiida/common/log.py
+++ b/src/aiida/common/log.py
@@ -231,7 +231,6 @@ def validate_handler(config: t.Any, option_name: str, scope: str | None = None) 
         return (
             f'`{option_name}` is set to `{log_level.value}` but no logger emits messages at that level: '
             f'the most verbose logger level is `{most_verbose_logger}` (`{most_verbose_level.value}`). '
-            f'Lower a logger level such as `logging.aiida_loglevel` for this setting to take effect.'
         )
 
     return None

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import psutil
 import pytest
@@ -105,6 +105,54 @@ class TestZeromqBrokerStatusQueries:
 
 class TestZeromqBrokerCommunicator:
     """Tests for ZeromqBroker communicator management."""
+
+    def test_get_communicator_breaks_when_endpoint_becomes_available(self, zeromq_broker, monkeypatch):
+        """Test get_communicator stops polling once the router endpoint appears."""
+        endpoint = 'ipc:///tmp/router.sock'
+
+        monkeypatch.setattr('aiida.brokers.zeromq.broker.BROKER_READY_TIMEOUT', 10.0)
+
+        with (
+            patch.object(ZeromqBroker, '_router_endpoint', new_callable=PropertyMock) as router_endpoint,
+            patch('aiida.brokers.zeromq.broker.time.monotonic', side_effect=[100.0, 100.1]),
+            patch('aiida.brokers.zeromq.broker.time.sleep') as sleep,
+            patch('aiida.manage.configuration.get_config_option', return_value=None),
+            patch('aiida.brokers.zeromq.broker.ZeromqCommunicator') as communicator_cls,
+        ):
+            router_endpoint.side_effect = [None, endpoint]
+            communicator = communicator_cls.return_value
+
+            result = zeromq_broker.get_communicator()
+
+            assert result is communicator
+            sleep.assert_called_once_with(0.2)
+            communicator_cls.assert_called_once_with(router_endpoint=endpoint, task_timeout=None)
+            communicator.start.assert_called_once()
+
+    def test_get_communicator_warns_while_waiting_for_endpoint(self, zeromq_broker, monkeypatch):
+        """Test get_communicator logs a warning after waiting for five seconds."""
+        endpoint = 'ipc:///tmp/router.sock'
+
+        monkeypatch.setattr('aiida.brokers.zeromq.broker.BROKER_READY_TIMEOUT', 10.0)
+
+        with (
+            patch.object(ZeromqBroker, '_router_endpoint', new_callable=PropertyMock) as router_endpoint,
+            patch('aiida.brokers.zeromq.broker.time.monotonic', side_effect=[100.0, 100.1, 105.1, 105.2]),
+            patch('aiida.brokers.zeromq.broker.time.sleep') as sleep,
+            patch('aiida.brokers.zeromq.broker.AIIDA_LOGGER.warning') as warning,
+            patch('aiida.manage.configuration.get_config_option', return_value=None),
+            patch('aiida.brokers.zeromq.broker.ZeromqCommunicator') as communicator_cls,
+        ):
+            router_endpoint.side_effect = [None, None, endpoint]
+            communicator = communicator_cls.return_value
+
+            result = zeromq_broker.get_communicator()
+
+            assert result is communicator
+            assert sleep.call_count == 2
+            warning.assert_called_once_with('Still waiting for broker to become ready...')
+            communicator_cls.assert_called_once_with(router_endpoint=endpoint, task_timeout=None)
+            communicator.start.assert_called_once()
 
     def test_get_communicator_and_close(self, zeromq_broker_with_server, monkeypatch):
         """Test get_communicator and close."""

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import psutil
 import pytest
 
 from aiida.brokers.zeromq.broker import ZeromqBroker, ZeromqIncomingTask
@@ -82,8 +83,10 @@ class TestZeromqBrokerStatusQueries:
     def test_is_running_stale_pid(self, zeromq_broker):
         """Test is_running with stale PID."""
         pid_file = zeromq_broker.service_dir / 'broker.pid'
-        pid_file.write_text('aiida-zeromq-broker 999999')  # Non-existent PID
-        assert not zeromq_broker.is_service_running()
+        pid_file.write_text('aiida-zeromq-broker 12345')
+
+        with patch('aiida.brokers.zeromq.broker.psutil.Process', side_effect=psutil.NoSuchProcess(pid=12345)):
+            assert not zeromq_broker.is_service_running()
 
     def test_get_service_status_valid(self, zeromq_broker):
         """Test get_service_status with valid JSON."""

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -139,7 +139,9 @@ def test_config_set_handler_warns_when_ineffective(run_cli_command, config_with_
     options = ['config', 'set', 'logging.terminal_handler', 'DEBUG']
     result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert 'Warning' in result.output
-    assert 'take effect' in result.output
+    assert 'no logger emits messages at that level' in result.output
+    assert 'logging.aiida_loglevel' in result.output
+    assert 'REPORT' in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -70,7 +70,9 @@ class TestValidateHandler:
         config = Mock(get_option=lambda name, scope=None: levels.get(name, 'WARNING'))
         message = log.validate_handler(config, 'logging.terminal_handler')
         assert message is not None
-        assert 'take effect' in message
+        assert 'no logger emits messages at that level' in message
+        assert 'logging.aiida_loglevel' in message
+        assert 'INFO' in message
 
     def test_no_warning_when_effective(self):
         """A handler level a logger actually emits at (here equal to it) is effective and should return ``None``."""

--- a/utils/autogenerate_all_imports.py
+++ b/utils/autogenerate_all_imports.py
@@ -203,7 +203,6 @@ if __name__ == '__main__':
         'orm': ['implementation'],
         # skipped since re-exporting CLI helpers from the package root can trigger cyclic imports see issue #7429
         'brokers': ['cli'],
-        'brokers/broker': ['BrokerConfigField'],
         # skip all since the module requires extra requirements
         'restapi': ['*'],
     }


### PR DESCRIPTION
Each commit describes the individual fix. They are all independent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ and troubleshooting guidance for daemon log locations, including the per-profile broker log path and the per-profile log file count.

* **Bug Fixes**
  * Improved ZeroMQ broker behavior around detecting stale services and polling for endpoint readiness.
  * Refined logging validation warnings when handler filters cannot take effect.

* **Refactor**
  * Limited broker module exports to the supported public interface.

* **Tests**
  * Expanded ZeroMQ broker and logging warning coverage, plus updated config/log assertion expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->