### PR TITLE
♻️ Privatize ZeroMQ broker endpoint and pid helpers and emphasize client nature

### DIFF
--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -101,7 +101,7 @@ class ZeromqBroker(Broker):
             return None
 
     @property
-    def router_endpoint(self) -> str | None:
+    def _router_endpoint(self) -> str | None:
         sockets_path = self._get_sockets_path()
         if sockets_path is None:
             return None
@@ -110,7 +110,7 @@ class ZeromqBroker(Broker):
     # protects from global overwrites
     _PID_SENTINEL = PID_SENTINEL
 
-    def get_service_pid(self) -> int | None:
+    def _get_service_pid(self) -> int | None:
         """Read the ZeromqBrokerService PID from its PID file.
 
         The PID file contains ``aiida-zeromq-broker <pid>`` as a sentinel so we
@@ -130,7 +130,7 @@ class ZeromqBroker(Broker):
     @property
     def is_running(self) -> bool:
         """Check if the ZeromqBrokerService process is running."""
-        pid = self.get_service_pid()
+        pid = self._get_service_pid()
         if pid is None:
             return False
         try:
@@ -150,32 +150,26 @@ class ZeromqBroker(Broker):
 
     # --- Communicator ---
 
-    def get_communicator(self, wait_for_broker: float = BROKER_READY_TIMEOUT) -> ZeromqCommunicator:
-        """Get or create a communicator connected to the broker.
-
-        :param wait_for_broker: Seconds to wait for the broker to become ready.
-            When the broker and workers are started concurrently (e.g. by circus),
-            the broker may not have written its socket files yet. This parameter
-            controls how long to poll before giving up.
-        """
+    def get_communicator(self) -> ZeromqCommunicator:
+        """Get or create a communicator connected to the broker."""
         if self._communicator is None:
-            router_endpoint = self.router_endpoint
+            router_endpoint = self._router_endpoint
 
             if router_endpoint is None:
                 # Broker may still be starting — poll until endpoint appears.
-                deadline = time.monotonic() + wait_for_broker
-                warning_deadline = deadline - (wait_for_broker - 5.0)
+                deadline = time.monotonic() + BROKER_READY_TIMEOUT
+                warning_deadline = deadline - (BROKER_READY_TIMEOUT - 5.0)
                 warning_issued = False
                 while time.monotonic() < deadline:
                     time.sleep(0.2)
-                    router_endpoint = self.router_endpoint
+                    router_endpoint = self._router_endpoint
                     if router_endpoint is not None:
                         break
                     if not warning_issued and time.monotonic() > warning_deadline:
                         AIIDA_LOGGER.warning('Still waiting for broker to become ready...')
                         warning_issued = True
                 else:
-                    msg = f'Broker did not become ready within {wait_for_broker}s: {self}'
+                    msg = f'Broker did not become ready within {BROKER_READY_TIMEOUT}s: {self}'
                     raise ConnectionError(msg)
 
             from aiida.manage.configuration import get_config_option

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -76,7 +76,7 @@ class ZeromqBroker(Broker):
         self._storage_path = layout.storage_path
 
     def __str__(self) -> str:
-        if self.is_running:
+        if self.is_service_running():
             status = self.get_service_status()
             pid = status.get('pid', '?') if status else '?'
             return f'ZeroMQ Broker (PID {pid}) @ {self._service_dir}'
@@ -127,8 +127,7 @@ class ZeromqBroker(Broker):
         except (ValueError, OSError):
             return None
 
-    @property
-    def is_running(self) -> bool:
+    def is_service_running(self) -> bool:
         """Check if the ZeromqBrokerService process is running."""
         pid = self._get_service_pid()
         if pid is None:

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -158,7 +158,7 @@ def status(ctx, all_profiles, timeout):
         from aiida.brokers.zeromq.broker import ZeromqBroker
 
         if isinstance(broker, ZeromqBroker):
-            if broker.is_running:
+            if broker.is_service_running():
                 status_info = broker.get_service_status()
                 if status_info:
                     broker_pid = status_info.get('pid', '?')

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -182,7 +182,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         # Append broker info for managed brokers (e.g., ZeroMQ)
 
         if broker and isinstance(broker, ZeromqBroker):
-            if broker.is_running:
+            if broker.is_service_running():
                 status_info = broker.get_service_status()
                 if status_info:
                     broker_pid = status_info.get('pid', '?')

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -985,7 +985,7 @@ class DaemonClient:
             except Exception:
                 LOGGER.warning('Could not load the broker instance while preparing daemon watchers.', exc_info=True)
                 broker_instance = None
-            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_running:
+            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_service_running():
                 # prepare zmq broker service profile directory
                 pathlib.Path(self.zmq_broker_service_dir).mkdir(parents=True, exist_ok=True)
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -17,7 +17,7 @@ import pytest
 
 from aiida.brokers.zeromq.broker import ZeromqBroker, ZeromqIncomingTask
 from aiida.brokers.zeromq.queue import PersistentQueue
-from tests.conftest import _run_zeromq_broker_server
+from tests.conftest import _patch_zmq_broker_service_filepaths, _run_zeromq_broker_server
 
 
 @pytest.fixture(scope='module')
@@ -27,12 +27,7 @@ def zeromq_broker_with_server(tmp_path_factory):
     profile = MagicMock()
     profile.process_control_config = {'supervised_by_daemon': True}
     profile.name = 'test-profile'
-    config = MagicMock()
-    config.filepaths.return_value = {
-        'zmq_broker_service': {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
-    }
-
-    with patch('aiida.manage.configuration.get_config', return_value=config):
+    with _patch_zmq_broker_service_filepaths(profile, service_dir):
         broker = ZeromqBroker(profile)
         with _run_zeromq_broker_server(broker):
             yield broker

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -59,7 +59,7 @@ class TestZeromqBrokerStatusQueries:
 
     def test_is_running_no_pid_file(self, zeromq_broker):
         """Test is_running returns False when no PID file exists."""
-        assert not zeromq_broker.is_running
+        assert not zeromq_broker.is_service_running()
 
     def test_get_service_status_no_file(self, zeromq_broker):
         """Test get_service_status returns None when no status file exists."""
@@ -88,7 +88,7 @@ class TestZeromqBrokerStatusQueries:
         """Test is_running with stale PID."""
         pid_file = zeromq_broker.service_dir / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 999999')  # Non-existent PID
-        assert not zeromq_broker.is_running
+        assert not zeromq_broker.is_service_running()
 
     def test_get_service_status_valid(self, zeromq_broker):
         """Test get_service_status with valid JSON."""
@@ -178,7 +178,7 @@ class TestZeromqBrokerIntegration:
 
     def test_broker_lifecycle(self, zeromq_broker_with_server):
         """Test the zeromq_broker lifecycle."""
-        assert zeromq_broker_with_server.is_running
+        assert zeromq_broker_with_server.is_service_running()
 
         status = zeromq_broker_with_server.get_service_status()
         assert status is not None

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aiida.brokers.zeromq.broker import ZeromqBroker, ZeromqIncomingTask
-from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from aiida.brokers.zeromq.queue import PersistentQueue
 from tests.conftest import _run_zeromq_broker_server
 
@@ -62,17 +61,9 @@ class TestZeromqBrokerStatusQueries:
         """Test is_running returns False when no PID file exists."""
         assert not zeromq_broker.is_running
 
-    def test_get_service_pid_no_file(self, zeromq_broker):
-        """Test get_service_pid returns None when no PID file exists."""
-        assert zeromq_broker.get_service_pid() is None
-
     def test_get_service_status_no_file(self, zeromq_broker):
         """Test get_service_status returns None when no status file exists."""
         assert zeromq_broker.get_service_status() is None
-
-    def test_endpoints_no_sockets_file(self, zeromq_broker):
-        """Test endpoints return None when sockets file doesn't exist."""
-        assert zeromq_broker.router_endpoint is None
 
     def test_str_running(self, zeromq_broker_with_server):
         """Test __str__ when running."""
@@ -92,34 +83,6 @@ class TestZeromqBrokerStatusQueries:
     def test_service_dir(self, zeromq_broker, tmp_path):
         """Test service_dir property."""
         assert zeromq_broker.service_dir == tmp_path
-
-    def test_get_sockets_path_no_file(self, zeromq_broker):
-        """Test _get_sockets_path when file missing."""
-        assert zeromq_broker._get_sockets_path() is None
-
-    def test_get_sockets_path_os_error(self, zeromq_broker):
-        """Test _get_sockets_path when read fails."""
-        sockets_file = zeromq_broker.service_dir / 'broker.sockets'
-        sockets_file.mkdir()  # directory instead of file => OSError on read_text
-        assert zeromq_broker._get_sockets_path() is None
-
-    def test_get_service_pid_sentinel_format(self, zeromq_broker):
-        """Test PID file with sentinel format."""
-        pid_file = zeromq_broker.service_dir / 'broker.pid'
-        pid_file.write_text('aiida-zeromq-broker 12345')
-        assert zeromq_broker.get_service_pid() == 12345
-
-    def test_get_service_pid_bare_format(self, zeromq_broker):
-        """Test PID file with bare PID fallback."""
-        pid_file = zeromq_broker.service_dir / 'broker.pid'
-        pid_file.write_text('54321')
-        assert zeromq_broker.get_service_pid() == 54321
-
-    def test_get_service_pid_invalid(self, zeromq_broker):
-        """Test PID file with invalid content."""
-        pid_file = zeromq_broker.service_dir / 'broker.pid'
-        pid_file.write_text('garbage text')
-        assert zeromq_broker.get_service_pid() is None
 
     def test_is_running_stale_pid(self, zeromq_broker):
         """Test is_running with stale PID."""
@@ -145,11 +108,12 @@ class TestZeromqBrokerStatusQueries:
 class TestZeromqBrokerCommunicator:
     """Tests for ZeromqBroker communicator management."""
 
-    def test_get_communicator_and_close(self, zeromq_broker_with_server):
+    def test_get_communicator_and_close(self, zeromq_broker_with_server, monkeypatch):
         """Test get_communicator and close."""
         try:
             with patch('aiida.manage.configuration.get_config_option', return_value=None):
-                comm = zeromq_broker_with_server.get_communicator(wait_for_broker=5.0)
+                monkeypatch.setattr('aiida.brokers.zeromq.broker.BROKER_READY_TIMEOUT', 0.5)
+                comm = zeromq_broker_with_server.get_communicator()
                 assert comm is not None
                 assert not comm.is_closed()
 
@@ -159,10 +123,11 @@ class TestZeromqBrokerCommunicator:
         finally:
             zeromq_broker_with_server.close()
 
-    def test_get_communicator_timeout(self, zeromq_broker):
+    def test_get_communicator_timeout(self, zeromq_broker, monkeypatch):
         """Test get_communicator raises on timeout when zeromq_broker not running."""
+        monkeypatch.setattr('aiida.brokers.zeromq.broker.BROKER_READY_TIMEOUT', 0.5)
         with pytest.raises(ConnectionError, match='did not become ready'):
-            zeromq_broker.get_communicator(wait_for_broker=0.5)
+            zeromq_broker.get_communicator()
 
     def test_context_manager(self, zeromq_broker):
         """Test __enter__ / __exit__."""
@@ -209,7 +174,7 @@ class TestZeromqIncomingTask:
 
 
 class TestZeromqBrokerIntegration:
-    """Integration tests for the ZeroMQ zeromq_broker with AiiDA."""
+    """Integration tests for the ZeroMQ broker with AiiDA."""
 
     def test_broker_lifecycle(self, zeromq_broker_with_server):
         """Test the zeromq_broker lifecycle."""
@@ -218,15 +183,3 @@ class TestZeromqBrokerIntegration:
         status = zeromq_broker_with_server.get_service_status()
         assert status is not None
         assert 'pid' in status
-
-    def test_communicator_connection(self, zeromq_broker_with_server):
-        """Test connecting a communicator to the zeromq_broker."""
-        communicator = ZeromqCommunicator(
-            router_endpoint=zeromq_broker_with_server.router_endpoint,
-        )
-        communicator.start()
-
-        try:
-            assert not communicator.is_closed()
-        finally:
-            communicator.close()

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -13,14 +13,14 @@ from __future__ import annotations
 import time
 from concurrent.futures import Future
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import kiwipy
 import pytest
 
 from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
-from tests.conftest import _run_zeromq_broker_server
+from tests.conftest import _patch_zmq_broker_service_filepaths, _run_zeromq_broker_server
 
 
 def get_router_endpoint(broker: ZeromqBroker) -> str:
@@ -36,12 +36,8 @@ def zeromq_broker_with_server(tmp_path_factory):
     profile = MagicMock()
     profile.process_control_config = {'supervised_by_daemon': True}
     profile.name = 'test-profile'
-    config = MagicMock()
-    config.filepaths.return_value = {
-        'zmq_broker_service': {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
-    }
 
-    with patch('aiida.manage.configuration.get_config', return_value=config):
+    with _patch_zmq_broker_service_filepaths(profile, service_dir):
         broker = ZeromqBroker(profile)
         with _run_zeromq_broker_server(broker):
             yield broker

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import Future
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import kiwipy
@@ -20,6 +21,12 @@ import pytest
 from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
 from tests.conftest import _run_zeromq_broker_server
+
+
+def get_router_endpoint(broker: ZeromqBroker) -> str:
+    """Construct the router endpoint from the broker service socket file."""
+    sockets_path = Path((broker.service_dir / 'broker.sockets').read_text().strip())
+    return f'ipc://{sockets_path}/router.sock'
 
 
 @pytest.fixture(scope='module')
@@ -45,7 +52,7 @@ class TestZeromqCommunicatorLifecycle:
 
     def test_init(self, zeromq_broker_with_server):
         """Test communicator initialization."""
-        communicator = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint)
+        communicator = ZeromqCommunicator(router_endpoint=get_router_endpoint(zeromq_broker_with_server))
         communicator.start()
 
         try:
@@ -57,14 +64,14 @@ class TestZeromqCommunicatorLifecycle:
 
     def test_context_manager(self, zeromq_broker_with_server):
         """Test communicator as context manager."""
-        with ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint) as communicator:
+        with ZeromqCommunicator(router_endpoint=get_router_endpoint(zeromq_broker_with_server)) as communicator:
             assert communicator.is_closed() is False
 
         assert communicator.is_closed() is True
 
     def test_close_idempotent(self, zeromq_broker_with_server):
         """Test close is idempotent."""
-        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint)
+        comm = ZeromqCommunicator(router_endpoint=get_router_endpoint(zeromq_broker_with_server))
         comm.start()
         comm.close()
         comm.close()  # should not raise
@@ -81,65 +88,57 @@ class TestZeromqCommunicatorMessaging:
     """Tests for communicator messaging operations with a real zeromq_broker."""
 
     @pytest.fixture
-    def zeromq_broker_and_comm(self, zeromq_broker_with_server):
-        comm = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint)
+    def zeromq_comm(self, zeromq_broker_with_server):
+        comm = ZeromqCommunicator(router_endpoint=get_router_endpoint(zeromq_broker_with_server))
         comm.start()
 
-        yield zeromq_broker_with_server, comm
+        yield comm
 
         comm.close()
 
-    def test_task_send_no_reply(self, zeromq_broker_and_comm):
+    def test_task_send_no_reply(self, zeromq_comm):
         """Test task_send with no_reply=True returns None."""
-        _, comm = zeromq_broker_and_comm
-        result = comm.task_send({'cmd': 'test'}, no_reply=True)
+        result = zeromq_comm.task_send({'cmd': 'test'}, no_reply=True)
         assert result is None
 
-    def test_task_send_with_reply(self, zeromq_broker_and_comm):
+    def test_task_send_with_reply(self, zeromq_comm):
         """Test task_send returns a Future."""
-        _, comm = zeromq_broker_and_comm
-        future = comm.task_send({'cmd': 'test'}, no_reply=False)
+        future = zeromq_comm.task_send({'cmd': 'test'}, no_reply=False)
         assert isinstance(future, Future)
 
-    def test_add_remove_task_subscriber(self, zeromq_broker_and_comm):
+    def test_add_remove_task_subscriber(self, zeromq_comm):
         """Test task subscriber management."""
-        _, comm = zeromq_broker_and_comm
-        ident = comm.add_task_subscriber(lambda c, t: None, identifier='test-worker')
+        ident = zeromq_comm.add_task_subscriber(lambda c, t: None, identifier='test-worker')
         assert ident == 'test-worker'
-        comm.remove_task_subscriber('test-worker')
+        zeromq_comm.remove_task_subscriber('test-worker')
 
-    def test_rpc_send(self, zeromq_broker_and_comm):
+    def test_rpc_send(self, zeromq_comm):
         """Test rpc_send returns a Future."""
-        _, comm = zeromq_broker_and_comm
-        future = comm.rpc_send('some-recipient', {'action': 'ping'})
+        future = zeromq_comm.rpc_send('some-recipient', {'action': 'ping'})
         assert isinstance(future, Future)
 
-    def test_add_remove_rpc_subscriber(self, zeromq_broker_and_comm):
+    def test_add_remove_rpc_subscriber(self, zeromq_comm):
         """Test RPC subscriber management."""
-        _, comm = zeromq_broker_and_comm
-        ident = comm.add_rpc_subscriber(lambda c, m: 'ok', identifier='my-rpc')
+        ident = zeromq_comm.add_rpc_subscriber(lambda c, m: 'ok', identifier='my-rpc')
         assert ident == 'my-rpc'
-        comm.remove_rpc_subscriber('my-rpc')
+        zeromq_comm.remove_rpc_subscriber('my-rpc')
 
-    def test_duplicate_rpc_subscriber(self, zeromq_broker_and_comm):
+    def test_duplicate_rpc_subscriber(self, zeromq_comm):
         """Test duplicate RPC subscriber raises."""
-        _, comm = zeromq_broker_and_comm
-        comm.add_rpc_subscriber(lambda c, m: None, identifier='dup')
+        zeromq_comm.add_rpc_subscriber(lambda c, m: None, identifier='dup')
         with pytest.raises(kiwipy.DuplicateSubscriberIdentifier):
-            comm.add_rpc_subscriber(lambda c, m: None, identifier='dup')
+            zeromq_comm.add_rpc_subscriber(lambda c, m: None, identifier='dup')
 
-    def test_broadcast_send(self, zeromq_broker_and_comm):
+    def test_broadcast_send(self, zeromq_comm):
         """Test broadcast_send returns True."""
-        _, comm = zeromq_broker_and_comm
-        result = comm.broadcast_send(body='hello', subject='test.subject')
+        result = zeromq_comm.broadcast_send(body='hello', subject='test.subject')
         assert result is True
 
-    def test_add_remove_broadcast_subscriber(self, zeromq_broker_and_comm):
+    def test_add_remove_broadcast_subscriber(self, zeromq_comm):
         """Test broadcast subscriber management."""
-        _, comm = zeromq_broker_and_comm
-        ident = comm.add_broadcast_subscriber(lambda c, b, s, subj, cid: None, identifier='my-bcast')
+        ident = zeromq_comm.add_broadcast_subscriber(lambda c, b, s, subj, cid: None, identifier='my-bcast')
         assert ident == 'my-bcast'
-        comm.remove_broadcast_subscriber('my-bcast')
+        zeromq_comm.remove_broadcast_subscriber('my-bcast')
 
 
 class TestZeromqCommunicatorRoundTrip:
@@ -147,13 +146,13 @@ class TestZeromqCommunicatorRoundTrip:
 
     @pytest.fixture
     def sender_and_worker(self, zeromq_broker_with_server):
-        sender = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint, client_id='sender')
+        sender = ZeromqCommunicator(router_endpoint=get_router_endpoint(zeromq_broker_with_server), client_id='sender')
         sender.start()
 
-        worker = ZeromqCommunicator(router_endpoint=zeromq_broker_with_server.router_endpoint, client_id='worker')
+        worker = ZeromqCommunicator(router_endpoint=get_router_endpoint(zeromq_broker_with_server), client_id='worker')
         worker.start()
 
-        yield zeromq_broker_with_server, sender, worker
+        yield sender, worker
 
         worker.close()
         sender.close()
@@ -165,7 +164,7 @@ class TestZeromqCommunicatorRoundTrip:
         (matching RabbitMQ publisher-confirm semantics).  The worker processes
         the task independently.
         """
-        _, sender, worker = sender_and_worker
+        sender, worker = sender_and_worker
 
         worker.add_task_subscriber(lambda comm, body: body.get('x', 0) * 2, identifier='worker')
         time.sleep(0.5)
@@ -179,7 +178,7 @@ class TestZeromqCommunicatorRoundTrip:
 
     def test_rpc_round_trip(self, sender_and_worker):
         """Test full RPC send -> subscribe -> handle -> response cycle."""
-        _, sender, worker = sender_and_worker
+        sender, worker = sender_and_worker
 
         def handle_rpc(comm, msg):
             return f'echo: {msg}'
@@ -193,7 +192,7 @@ class TestZeromqCommunicatorRoundTrip:
 
     def test_broadcast_round_trip(self, sender_and_worker):
         """Test broadcast send and receive."""
-        _, sender, worker = sender_and_worker
+        sender, worker = sender_and_worker
         received = []
 
         def on_broadcast(comm, body, bsender, subject, cid):
@@ -211,7 +210,7 @@ class TestZeromqCommunicatorRoundTrip:
 
     def test_task_with_deferred_future(self, sender_and_worker):
         """Test task send with deferred handler gets immediate zeromq_broker ack."""
-        _, sender, worker = sender_and_worker
+        sender, worker = sender_and_worker
 
         def handle_task(comm, body):
             f = Future()
@@ -228,7 +227,7 @@ class TestZeromqCommunicatorRoundTrip:
 
     def test_rpc_with_deferred_future(self, sender_and_worker):
         """Test RPC handler returning a Future."""
-        _, sender, worker = sender_and_worker
+        sender, worker = sender_and_worker
 
         def handle_rpc(comm, msg):
             f = Future()
@@ -244,7 +243,7 @@ class TestZeromqCommunicatorRoundTrip:
 
     def test_rpc_subscriber_exception(self, sender_and_worker):
         """Test RPC handler that raises an exception propagates error."""
-        _, sender, worker = sender_and_worker
+        sender, worker = sender_and_worker
 
         def handle_rpc(comm, msg):
             raise ValueError('handler error')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def zeromq_broker(tmp_path):
 @contextmanager
 def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0):
     """Run a ZeroMQ broker service subprocess for the duration of a context."""
-    if zeromq_broker.is_running:
+    if zeromq_broker.is_service_running():
         raise ValueError('Broker server already running')
 
     zeromq_broker.service_dir.mkdir(parents=True, exist_ok=True)
@@ -122,7 +122,7 @@ def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0
             if process.poll() is not None:
                 msg = f'ZeroMQ broker exited before becoming ready with code {process.returncode}'
                 raise RuntimeError(msg)
-            if zeromq_broker.is_running:
+            if zeromq_broker.is_service_running():
                 break
             time.sleep(0.1)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,16 +71,32 @@ class TestBrokerBackend(Enum):
     NONE = 'none'
 
 
+@contextmanager
+def _patch_zmq_broker_service_filepaths(profile, service_dir: Path):
+    """Patch only the ZeroMQ broker-service filepaths for a test profile."""
+    config = get_config()
+    original_filepaths = config.filepaths
+
+    def filepaths(current_profile):
+        result = copy.deepcopy(original_filepaths(current_profile))
+
+        if current_profile is profile:
+            result['zmq_broker_service'] = {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
+
+        return result
+
+    with patch.object(config, 'filepaths', side_effect=filepaths):
+        yield
+
+
 @pytest.fixture
 def zeromq_broker(tmp_path):
     """Create a ZMQ broker instance rooted in ``tmp_path``."""
     profile = MagicMock()
     profile.process_control_config = {'supervised_by_daemon': True}
     profile.name = 'test-profile'
-    config = MagicMock()
-    config.filepaths.return_value = {'zmq_broker_service': {'dir': str(tmp_path), 'log': str(tmp_path / 'broker.log')}}
 
-    with patch('aiida.manage.configuration.get_config', return_value=config):
+    with _patch_zmq_broker_service_filepaths(profile, tmp_path):
         yield ZeromqBroker(profile)
 
 


### PR DESCRIPTION
Privatize ZeroMQ broker endpoint and pid helpers and change `is_running` property to `is_service_running()` function to emphasize client nature of the ZmqBroker that is not so clear. When supervised by daemon the check is just a process lookup but in the remote case we need to connect to the server. A function better indicates that things that are more involved are done than a property lookup. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZeroMQ broker “running” detection in daemon/status output and watcher setup by using the new liveness method.
  * Communicator startup now waits for router endpoint readiness and fails with a clear error after a fixed timeout.

* **Refactor**
  * Streamlined ZeroMQ broker liveness/status and router endpoint discovery helpers.
  * Updated communicator acquisition to remove the configurable wait parameter.

* **Tests**
  * Updated broker/communicator tests and fixtures to use the new liveness API, endpoint wiring, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->