### PR TITLE
♻️ Clarify config downgrade error message

### DIFF
--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -581,11 +581,14 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         filepath = filepath if filepath else ''
         msg = (
-            f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
-            f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
-            'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
-            f' at least version {CURRENT_CONFIG_VERSION} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
-            f' to rewrite it for an older version. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
+            f'The AiiDA configuration file {filepath} has version {current_version}, which is not compatible with '
+            f'the current AiiDA version that supports configuration versions up to {CURRENT_CONFIG_VERSION}. '
+            'Before switching to an older AiiDA version, use a newer AiiDA version that still supports '
+            f'configuration version {current_version} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
+            f'to rewrite the configuration file to version {CURRENT_CONFIG_VERSION}. '
+            'Be aware that AiiDA automatically updates the configuration file, so stop the daemon and avoid other '
+            f'AiiDA interactions after downgrading. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility '
+            'table.'
         )
         raise exceptions.ConfigurationVersionError(msg)
 

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -583,11 +583,11 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
         msg = (
             f'The AiiDA configuration file {filepath} has version {current_version}, which is not compatible with '
             f'the current AiiDA version that supports configuration versions up to {CURRENT_CONFIG_VERSION}. '
-            'Before switching to an older AiiDA version, use a newer AiiDA version that still supports '
+            'Before switching to an older AiiDA version, stop the daemon and avoid other AiiDA interactions. '
+            'Then use a newer AiiDA version that still supports '
             f'configuration version {current_version} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
-            f'to rewrite the configuration file to version {CURRENT_CONFIG_VERSION}. '
-            'Be aware that AiiDA automatically updates the configuration file, so stop the daemon and avoid other '
-            f'AiiDA interactions after downgrading. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility '
+            f'to rewrite the configuration file to version {CURRENT_CONFIG_VERSION}. See '
+            f'{URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility '
             'table.'
         )
         raise exceptions.ConfigurationVersionError(msg)


### PR DESCRIPTION
Improve the configuration compatibility error shown when a newer config is opened with an older AiiDA version.

The message now gives clearer downgrade instructions and warns users to stop the daemon and avoid other AiiDA interactions while downgrading the configuration file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the configuration compatibility error message with clearer guidance on upgrading AiiDA or safely downgrading the configuration, including stopping the daemon and rewriting the configuration file to the expected version.
  * Refined wording and references to the configuration compatibility table to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->