### PR TITLE
Update ruff to latest version 0.15

### DIFF
--- a/.docker/tests/conftest.py
+++ b/.docker/tests/conftest.py
@@ -56,7 +56,7 @@ def _docker_service_wait(docker_services):
         docker_services.wait_until_responsive(
             timeout=300.0,
             pause=10,
-            check=lambda: is_container_ready(),
+            check=is_container_ready,
         )
     except Exception:
         print('Timed out waiting for the profile and daemon to be up and running.')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
   - id: check-github-workflows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.13.3
+  rev: v0.15.21
   hooks:
   - id: ruff-format
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-github-workflows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.10
+  rev: v0.11.13
   hooks:
   - id: ruff-format
   - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-github-workflows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.13
+  rev: v0.12.12
   hooks:
   - id: ruff-format
   - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-github-workflows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.12
+  rev: v0.13.3
   hooks:
   - id: ruff-format
   - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -467,11 +467,13 @@ quote-style = 'single'
 ignore = [
   'F403',  # Star imports unable to detect undefined names
   'F405',  # Import may be undefined or defined from star imports
+  'PLC0415',  # import-outside-top-level
   'PLR0911',  # Too many return statements
   'PLR0912',  # Too many branches
   'PLR0913',  # Too many arguments in function definition
   'PLR0915',  # Too many statements
   'PLR2004',  # Magic value used in comparison
+  'PLW1641',  # Checks for classes that implement `__eq__` but not `__hash__`
   'RUF005',  # Consider iterable unpacking instead of concatenation
   'RUF012'  # Mutable class attributes should be annotated with `typing.ClassVar`
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -475,7 +475,9 @@ ignore = [
   'PLR2004',  # Magic value used in comparison
   'PLW1641',  # Checks for classes that implement `__eq__` but not `__hash__`
   'RUF005',  # Consider iterable unpacking instead of concatenation
-  'RUF012'  # Mutable class attributes should be annotated with `typing.ClassVar`
+  'RUF012',  # Mutable class attributes should be annotated with `typing.ClassVar`
+  'RUF043',  # Pattern passed to `match=` contains metacharacters but is neither escaped nor raw
+  'RUF059'  # Unpacked variable is never used
 ]
 select = [
   'E',  # pydocstyle

--- a/src/aiida/cmdline/commands/__init__.py
+++ b/src/aiida/cmdline/commands/__init__.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# ruff: noqa: F401, E402
+# ruff: noqa: F401
 """Sub commands of the ``verdi`` command line interface.
 
 The commands need to be imported here for them to be registered with the top-level command group.

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -109,7 +109,7 @@ def detect_postgres_config(
 @click.option(
     '-p',
     '--profile-name',
-    default=lambda: get_default_presto_profile_name(),
+    default=get_default_presto_profile_name,
     show_default=True,
     help=f'Name of the profile. By default, a unique name starting with `{DEFAULT_PROFILE_NAME_PREFIX}` is '
     'automatically generated.',

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -74,7 +74,7 @@ def verdi_process():
 
 
 @verdi_process.command('list')
-@options.PROJECT(type=types.LazyChoice(valid_projections), default=lambda: default_projections())
+@options.PROJECT(type=types.LazyChoice(valid_projections), default=default_projections)
 @options.ORDER_BY()
 @options.ORDER_DIRECTION()
 @options.GROUP(help='Only include entries that are a member of this group.')

--- a/src/aiida/engine/processes/builder.py
+++ b/src/aiida/engine/processes/builder.py
@@ -177,7 +177,7 @@ class ProcessBuilderNamespace(MutableMapping):
         :param kwds: keyword value pairs that should be mapped onto the ports.
         """
         if len(args) > 1:
-            raise TypeError(f'update expected at most 1 arguments, got {int(len(args))}')
+            raise TypeError(f'update expected at most 1 arguments, got {len(args)}')
 
         if args:
             for key, value in args[0].items():

--- a/src/aiida/engine/processes/workchains/workchain.py
+++ b/src/aiida/engine/processes/workchains/workchain.py
@@ -62,7 +62,7 @@ class Protect(ProcessStateMachineMeta):
 
     __SENTINEL = object()
 
-    def __new__(mcs, name, bases, namespace, **kwargs):  # noqa: N804
+    def __new__(mcs, name, bases, namespace, **kwargs):
         """Collect all methods that were marked as protected and raise if the subclass defines it.
 
         :raises RuntimeError: If the new class defines (i.e. overrides) a method that was decorated with ``final``.

--- a/src/aiida/manage/caching.py
+++ b/src/aiida/manage/caching.py
@@ -304,7 +304,7 @@ def _validate_identifier_pattern(*, identifier: str, strict: bool = False):
     # If there is no separator, it must be a fully qualified Python name.
     try:
         module_name = '.'.join(identifier.split('.')[:-1])
-        class_name = identifier.split('.')[-1]
+        class_name = identifier.rsplit('.', maxsplit=1)[-1]
         module = importlib.import_module(module_name)
         getattr(module, class_name)
     except (ModuleNotFoundError, AttributeError, IndexError) as exc:

--- a/src/aiida/orm/nodes/data/array/bands.py
+++ b/src/aiida/orm/nodes/data/array/bands.py
@@ -133,7 +133,7 @@ def find_bandgap(bandsdata, number_electrons=None, fermi_energy=None):
                     ]
                 )
             ]
-            number_electrons = int(round(sum(sum(i) for i in occupations) / num_kpoints))
+            number_electrons = round(sum(sum(i) for i in occupations) / num_kpoints)
 
             homo_indexes = [numpy.where(numpy.array([nint(_) for _ in x]) > 0)[0][-1] for x in occupations]
             if len(set(homo_indexes)) > 1:  # there must be intersections of valence and conduction bands

--- a/src/aiida/orm/utils/node.py
+++ b/src/aiida/orm/utils/node.py
@@ -151,7 +151,7 @@ def get_query_type_from_type_string(type_string):
 class AbstractNodeMeta(ABCMeta):
     """Some python black magic to set correctly the logger also in subclasses."""
 
-    def __new__(mcs, name, bases, namespace, **kwargs):  # noqa: N804
+    def __new__(mcs, name, bases, namespace, **kwargs):
         newcls = super().__new__(mcs, name, bases, namespace, **kwargs)
         newcls._logger = logging.getLogger(f'{namespace["__module__"]}.{name}')
         return newcls

--- a/src/aiida/restapi/common/utils.py
+++ b/src/aiida/restapi/common/utils.py
@@ -277,7 +277,7 @@ class Utils:
         if total_count == 0:
             last_page = 1
         else:
-            last_page = int(ceil(total_count / perpage))
+            last_page = ceil(total_count / perpage)
 
         ## Check validity of required page and calculate limit, offset,
         # previous,

--- a/src/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -369,7 +369,7 @@ class SqlaQueryBuilder(BackendQueryBuilder):
         self, alias: AliasedClass, field_key: str, entityspec: dict
     ) -> Union[ColumnElement, InstrumentedAttribute]:
         """Build the order_by parameter of the query."""
-        column_name = field_key.split('.')[0]
+        column_name = field_key.split('.', maxsplit=1)[0]
         attrpath = field_key.split('.')[1:]
         if attrpath and 'cast' not in entityspec.keys():
             # JSONB fields ar delimited by '.' must be cast
@@ -1166,7 +1166,7 @@ def _get_projection(
 
     :return: The projection
     """
-    column_name = projectable_entity_name.split('.')[0]
+    column_name = projectable_entity_name.split('.', maxsplit=1)[0]
     attr_key = projectable_entity_name.split('.')[1:]
 
     if column_name == '*':

--- a/src/aiida/tools/_dumping/utils.py
+++ b/src/aiida/tools/_dumping/utils.py
@@ -53,7 +53,7 @@ logger = AIIDA_LOGGER.getChild('tools._dumping.utils')
 class DumpTimes:
     """Holds relevant timestamps for a dump operation."""
 
-    current: datetime = field(default_factory=lambda: timezone.now())
+    current: datetime = field(default_factory=timezone.now)
     last: Optional[datetime] = None
 
     @classmethod

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -50,7 +50,7 @@ def test_presto_without_rmq(run_cli_command, monkeypatch):
         raise ConnectionError()
 
     # Patch the RabbitMQ detection function to pretend it could not find the service
-    monkeypatch.setattr(defaults, 'detect_rabbitmq_config', lambda: detect_rabbitmq_config())
+    monkeypatch.setattr(defaults, 'detect_rabbitmq_config', detect_rabbitmq_config)
 
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile `presto`.' in result.output

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -250,8 +250,10 @@ def test_process_kill_failing_ebm_transport(
     with fork_worker_context(monkeypatch.setattr, monkeypatch_args):
         node = submit_and_await(make_a_builder(), ProcessState.WAITING)
         await_condition(
-            lambda: node.process_status
-            == 'Pausing after failed transport task: upload_calculation failed 5 times consecutively',
+            lambda: (
+                node.process_status
+                == 'Pausing after failed transport task: upload_calculation failed 5 times consecutively'
+            ),
             timeout=kill_timeout,
         )
 
@@ -302,8 +304,9 @@ def test_process_kill_failing_ebm_kill(
         # this tests if the old task is cancelled and restarted successfully
         run_cli_command(cmd_process.process_kill, [str(node.pk)])
         await_condition(
-            lambda: 'Found active scheduler job cancelation that will be rescheduled.'
-            in get_process_function_report(node),
+            lambda: (
+                'Found active scheduler job cancelation that will be rescheduled.' in get_process_function_report(node)
+            ),
             timeout=kill_timeout,
         )
 

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -104,7 +104,7 @@ def test_configure_logging_inherits_aiida_loglevel_for_inherited_loggers(monkeyp
     isolated_config.set_option('logging.aiida_loglevel', 'ERROR')
 
     captured_config = {}
-    monkeypatch.setattr(logging.config, 'dictConfig', lambda config: captured_config.update(config))
+    monkeypatch.setattr(logging.config, 'dictConfig', captured_config.update)
 
     log.configure_logging()
 
@@ -123,7 +123,7 @@ def test_configure_logging_respects_explicit_inherited_logger_levels(monkeypatch
     isolated_config.set_option('logging.plumpy_loglevel', 'WARNING')
 
     captured_config = {}
-    monkeypatch.setattr(logging.config, 'dictConfig', lambda config: captured_config.update(config))
+    monkeypatch.setattr(logging.config, 'dictConfig', captured_config.update)
 
     log.configure_logging()
 


### PR DESCRIPTION
We use a very old ruff version. This PR updates it to 0.13.3

I purposefully do not update all the way to the latest version to ease the review.

There are some new rules that trigger a lot of new errors. I've put them to the ignore list to minimize churn, though some of those should probably be fixed as a follow-up.

~~This is blocked on #7440 which should be merged first.~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved band-gap electron-count rounding used for downstream calculations.
  * Corrected REST API pagination `last_page` computation while keeping the same ceiling behavior.
  * Refined the “too many positional arguments” builder error message formatting.
* **Command-Line**
  * Updated `verdi presto --profile-name` and `verdi process list --project` option defaults to use runtime callable defaults.
* **Chores**
  * Upgraded code-quality tooling and refreshed lint ignore rules and lint directive cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->