### PR TITLE
Update ruff to v0.9.10

### DIFF
--- a/.molecule/default/files/polish/cli.py
+++ b/.molecule/default/files/polish/cli.py
@@ -124,7 +124,7 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
 
     if not dry_run:
         try:
-            workchain_module = f"polish_workchains.{filename.replace('.py', '')}"
+            workchain_module = f'polish_workchains.{filename.replace(".py", "")}'
             workchains = importlib.import_module(workchain_module)
         except ImportError:
             click.echo(f'could not import the {workchain_module} module')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-github-workflows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.6
+  rev: v0.9.10
   hooks:
   - id: ruff-format
   - id: ruff

--- a/src/aiida/cmdline/commands/cmd_archive.py
+++ b/src/aiida/cmdline/commands/cmd_archive.py
@@ -332,7 +332,7 @@ class ExtrasImportCode(Enum):
     '--extras-mode-new',
     type=click.Choice(EXTRAS_MODE_NEW),
     default='import',
-    help='Specify whether to import extras of new nodes: ' 'import: import extras. ' 'none: do not import extras.',
+    help='Specify whether to import extras of new nodes: import: import extras. none: do not import extras.',
 )
 @click.option(
     '--comment-mode',

--- a/src/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -106,13 +106,13 @@ def bands_show(data, fmt):
     '--y-min-lim',
     type=click.FLOAT,
     default=None,
-    help='The minimum value for the y axis.' ' Default: minimum of all bands',
+    help='The minimum value for the y axis. Default: minimum of all bands',
 )
 @click.option(
     '--y-max-lim',
     type=click.FLOAT,
     default=None,
-    help='The maximum value for the y axis.' ' Default: maximum of all bands',
+    help='The maximum value for the y axis. Default: maximum of all bands',
 )
 @click.option(
     '-o',

--- a/src/aiida/cmdline/commands/cmd_data/cmd_export.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_export.py
@@ -52,7 +52,7 @@ EXPORT_OPTIONS = [
         '--gzip-threshold',
         type=click.INT,
         default=None,
-        help='Specify the minimum size of exported file which should' ' be gzipped.',
+        help='Specify the minimum size of exported file which should be gzipped.',
     ),
     click.option(
         '-o',

--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -446,7 +446,7 @@ def node_delete(identifier, dry_run, force, clean_workdir, **traversal_rules):
 
         if not force and not dry_run:
             echo.echo_warning(
-                f'YOU ARE ABOUT TO CLEAN {len(descendant_pks)} REMOTE DIRECTORIES! ' 'THIS CANNOT BE UNDONE!'
+                f'YOU ARE ABOUT TO CLEAN {len(descendant_pks)} REMOTE DIRECTORIES! THIS CANNOT BE UNDONE!'
             )
             echo.echo_info(
                 'Remote directories of nodes with the following pks would be cleaned: '
@@ -565,7 +565,7 @@ def verdi_graph():
 @click.option(
     '-e',
     '--engine',
-    help="The graphviz engine, e.g. 'dot', 'circo', ... " '(see http://www.graphviz.org/doc/info/output.html)',
+    help="The graphviz engine, e.g. 'dot', 'circo', ... (see http://www.graphviz.org/doc/info/output.html)",
     default='dot',
 )
 @click.option('-f', '--output-format', help="The output format used for rendering ('pdf', 'png', etc.).", default='pdf')
@@ -708,8 +708,8 @@ def comment_show(user, nodes):
         for comment in comments:
             comment_msg = [
                 f'Comment<{comment.pk}> for Node<{node.pk}> by {comment.user.email}',
-                f"Created on {timezone.localtime(comment.ctime).strftime('%Y-%m-%d %H:%M')}",
-                f"Last modified on {timezone.localtime(comment.mtime).strftime('%Y-%m-%d %H:%M')}",
+                f'Created on {timezone.localtime(comment.ctime).strftime("%Y-%m-%d %H:%M")}',
+                f'Last modified on {timezone.localtime(comment.mtime).strftime("%Y-%m-%d %H:%M")}',
                 f'\n{comment.content}\n',
             ]
             echo.echo('\n'.join(comment_msg))

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -223,12 +223,12 @@ def print_status(
     :param msg:  message string
     """
     symbol = STATUS_SYMBOLS[status]
-    echo.echo(f" {symbol['string']} ", fg=symbol['color'], nl=False)
-    echo.echo(f"{service + ':':12s} ", nl=False)
+    echo.echo(f' {symbol["string"]} ', fg=symbol['color'], nl=False)
+    echo.echo(f'{service + ":":12s} ', nl=False)
     lines = msg.split('\n')
     echo.echo(lines[0])
     for line in lines[1:]:
-        echo.echo(f"{'':15s} {line}")
+        echo.echo(f'{"":15s} {line}')
 
     if exception is not None:
         echo.echo_error(f'{type(exception).__name__}: {exception}')

--- a/src/aiida/cmdline/params/types/plugin.py
+++ b/src/aiida/cmdline/params/types/plugin.py
@@ -214,7 +214,7 @@ class PluginParamType(EntryPointType):
                 )
             elif not matching_groups:
                 raise ValueError(
-                    "entry point '{}' is not valid for any of the allowed " 'entry point groups: {}'.format(
+                    "entry point '{}' is not valid for any of the allowed entry point groups: {}".format(
                         name, ' '.join(self.groups)
                     )
                 )

--- a/src/aiida/cmdline/utils/common.py
+++ b/src/aiida/cmdline/utils/common.py
@@ -64,7 +64,7 @@ def get_env_with_venv_bin() -> MutableMapping:
     config = get_config()
 
     currenv = os.environ.copy()
-    currenv['PATH'] = f"{os.path.dirname(sys.executable)}:{currenv['PATH']}"
+    currenv['PATH'] = f'{os.path.dirname(sys.executable)}:{currenv["PATH"]}'
     currenv['AIIDA_PATH'] = config.dirpath
     currenv['PYTHONUNBUFFERED'] = 'True'
 
@@ -180,18 +180,18 @@ def get_node_info(node: orm.Node, include_summary: bool = True) -> str:
     nodes_output = node.base.links.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN))
 
     if nodes_input:
-        result += f"\n{format_nested_links(nodes_input.nested(), headers=['Inputs', 'PK', 'Type'])}"
+        result += f'\n{format_nested_links(nodes_input.nested(), headers=["Inputs", "PK", "Type"])}'
 
     if nodes_output:
-        result += f"\n{format_nested_links(nodes_output.nested(), headers=['Outputs', 'PK', 'Type'])}"
+        result += f'\n{format_nested_links(nodes_output.nested(), headers=["Outputs", "PK", "Type"])}'
 
     if nodes_caller:
         links = sorted(nodes_caller.all(), key=lambda x: x.node.ctime)
-        result += f"\n{format_flat_links(links, headers=['Caller', 'PK', 'Type'])}"
+        result += f'\n{format_flat_links(links, headers=["Caller", "PK", "Type"])}'
 
     if nodes_called:
         links = sorted(nodes_called.all(), key=lambda x: x.node.ctime)
-        result += f"\n{format_flat_links(links, headers=['Called', 'PK', 'Type'])}"
+        result += f'\n{format_flat_links(links, headers=["Called", "PK", "Type"])}'
 
     log_messages = orm.Log.collection.get_logs_for(node)
 
@@ -253,7 +253,7 @@ def format_nested_links(links: dict, headers: Sequence[str]) -> str:
     table = []
 
     for depth, label, pk, class_name in format_recursive(links):
-        table.append([f"{' ' * (depth * indent_size)}{label}", pk, class_name])
+        table.append([f'{" " * (depth * indent_size)}{label}', pk, class_name])
 
     result = f'\n{tabulate(table, headers=headers)}'
     tb.PRESERVE_WHITESPACE = False
@@ -279,7 +279,7 @@ def get_calcjob_report(calcjob: orm.CalcJobNode) -> str:
     report = []
 
     if calcjob_state == CalcJobState.WITHSCHEDULER:
-        state_string = f"{calcjob_state}, scheduler state: {scheduler_state if scheduler_state else '(unknown)'}"
+        state_string = f'{calcjob_state}, scheduler state: {scheduler_state if scheduler_state else "(unknown)"}'
     else:
         state_string = f'{calcjob_state}'
 

--- a/src/aiida/cmdline/utils/echo.py
+++ b/src/aiida/cmdline/utils/echo.py
@@ -224,7 +224,7 @@ def echo_formatted_list(
     if sort:
         entries = sorted(collection, key=sort)
 
-    template = f"{{symbol}}{' {}' * len(attributes)}"
+    template = f'{{symbol}}{" {}" * len(attributes)}'
 
     for entry in entries:
         if hide and hide(entry):

--- a/src/aiida/common/log.py
+++ b/src/aiida/common/log.py
@@ -101,7 +101,7 @@ def get_logging_config() -> dict[str, t.Any]:
         'disable_existing_loggers': False,
         'formatters': {
             'verbose': {
-                'format': '%(levelname)s %(asctime)s %(module)s %(process)d ' '%(thread)d %(message)s',
+                'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s',
             },
             'halfverbose': {
                 'format': '%(asctime)s <%(process)d> %(name)s: [%(levelname)s] %(message)s',

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -68,9 +68,9 @@ def validate_list_of_string_tuples(val: Any, tuple_length: int) -> bool:
     from aiida.common.exceptions import ValidationError
 
     err_msg = (
-        'the value must be a list (or tuple) '
-        'of length-N list (or tuples), whose elements are strings; '
-        'N={}'.format(tuple_length)
+        'the value must be a list (or tuple) of length-N list (or tuples), whose elements are strings; N={}'.format(
+            tuple_length
+        )
     )
 
     if not isinstance(val, (list, tuple)):
@@ -407,7 +407,7 @@ class Prettifier:
         try:
             self._prettifier_f = self.prettifiers[format]
         except KeyError:
-            raise ValueError(f"Unknown prettifier format {format}; valid formats: {', '.join(self.get_prettifiers())}")
+            raise ValueError(f'Unknown prettifier format {format}; valid formats: {", ".join(self.get_prettifiers())}')
 
     def prettify(self, label: str) -> str:
         """Prettify a label using the format passed in the initializer

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -1203,7 +1203,7 @@ class CalcJob(Process):
                 ) from exception
             if os.path.isabs(dest_rel_path):
                 raise PluginInternalError(
-                    '[presubmission of calc {}] ' 'The destination path of the remote copy ' 'is absolute! ({})'.format(
+                    '[presubmission of calc {}] The destination path of the remote copy is absolute! ({})'.format(
                         this_pk, dest_rel_path
                     )
                 )

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -266,12 +266,12 @@ def _resolve_futures(
     if not timeout or not futures:
         if futures:
             LOGGER.report(
-                f"Request to {infinitive} process(es) {','.join([str(proc.pk) for proc in futures.values()])}"
+                f'Request to {infinitive} process(es) {",".join([str(proc.pk) for proc in futures.values()])}'
                 ' sent. Skipping waiting for response.'
             )
         return
 
-    LOGGER.report(f"Waiting for process(es) {','.join([str(proc.pk) for proc in futures.values()])}.")
+    LOGGER.report(f'Waiting for process(es) {",".join([str(proc.pk) for proc in futures.values()])}.')
 
     # Ensure that when futures are only are completed if they return an actual value (not a future)
     unwrapped_futures = {unwrap_kiwi_future(future): process for future, process in futures.items()}

--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -529,7 +529,7 @@ class BaseRestartWorkChain(WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report(f"cleaned remote folders of calculations: {' '.join(cleaned_calcs)}")
+            self.report(f'cleaned remote folders of calculations: {" ".join(cleaned_calcs)}')
 
     def _wrap_bare_dict_inputs(self, port_namespace: 'PortNamespace', inputs: Dict[str, Any]) -> AttributeDict:
         """Wrap bare dictionaries in `inputs` in a `Dict` node if dictated by the corresponding inputs portnamespace.

--- a/src/aiida/engine/processes/workchains/workchain.py
+++ b/src/aiida/engine/processes/workchains/workchain.py
@@ -212,7 +212,7 @@ class WorkChain(Process, metaclass=Protect):
             if type(ctx) is not AttributeDict:
                 raise ValueError(
                     f'Can not update the context for key `{key}`:'
-                    f' found instance of `{type(ctx)}` at `{".".join(ctx_path[:index+1])}`, expected AttributeDict'
+                    f' found instance of `{type(ctx)}` at `{".".join(ctx_path[: index + 1])}`, expected AttributeDict'
                 )
 
         return ctx, ctx_path[-1]
@@ -286,7 +286,7 @@ class WorkChain(Process, metaclass=Protect):
     def _update_process_status(self) -> None:
         """Set the process status with a message accounting the current sub processes that we are waiting for."""
         if self._awaitables:
-            status = f"Waiting for child processes: {', '.join([str(_.pk) for _ in self._awaitables])}"
+            status = f'Waiting for child processes: {", ".join([str(_.pk) for _ in self._awaitables])}'
         else:
             status = None
         if self.paused:

--- a/src/aiida/engine/runners.py
+++ b/src/aiida/engine/runners.py
@@ -78,9 +78,9 @@ class Runner:
         :param persister: the persister to use to persist processes
 
         """
-        assert not (
-            broker_submit and persister is None
-        ), 'Must supply a persister if you want to submit using communicator'
+        assert not (broker_submit and persister is None), (
+            'Must supply a persister if you want to submit using communicator'
+        )
 
         self._loop = loop if loop else get_or_create_event_loop()
         self._poll_interval = poll_interval

--- a/src/aiida/engine/utils.py
+++ b/src/aiida/engine/utils.py
@@ -318,7 +318,7 @@ def get_process_state_change_timestamp(process_type: Optional[str] = None) -> Op
     valid_process_types = ['calculation', 'work']
 
     if process_type is not None and process_type not in valid_process_types:
-        raise ValueError(f"invalid value for process_type, valid values are {', '.join(valid_process_types)}")
+        raise ValueError(f'invalid value for process_type, valid values are {", ".join(valid_process_types)}')
 
     if process_type is None:
         process_types = valid_process_types

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -123,7 +123,7 @@ def _merge_deprecated_cache_yaml(config, filepath):
     cache_path_backup = None
     # Keep generating a new backup filename based on the current time until it does not exist
     while not cache_path_backup or os.path.isfile(cache_path_backup):
-        cache_path_backup = f"{cache_path}.{timezone.now().strftime('%Y%m%d-%H%M%S.%f')}"
+        cache_path_backup = f'{cache_path}.{timezone.now().strftime("%Y%m%d-%H%M%S.%f")}'
 
     warnings.warn(
         'cache_config.yml use is deprecated and support will be removed in `v3.0`. Merging into config.json and '

--- a/src/aiida/manage/profile_access.py
+++ b/src/aiida/manage/profile_access.py
@@ -63,7 +63,7 @@ class ProfileAccessManager:
         :raises ~aiida.common.exceptions.LockedProfileError: if the profile is locked.
         """
         error_message = (
-            f'process {self.process.pid} cannot access profile `{self.profile.name}` ' f'because it is being locked.'
+            f'process {self.process.pid} cannot access profile `{self.profile.name}` because it is being locked.'
         )
         self._raise_if_locked(error_message)
 
@@ -82,7 +82,7 @@ class ProfileAccessManager:
             # Check again in case a lock was created in the time between the first check and creating the
             # access record file.
             error_message = (
-                f'profile `{self.profile.name}` was locked while process ' f'{self.process.pid} was requesting access.'
+                f'profile `{self.profile.name}` was locked while process {self.process.pid} was requesting access.'
             )
             self._raise_if_locked(error_message)
 
@@ -103,14 +103,14 @@ class ProfileAccessManager:
         :raises ~aiida.common.exceptions.LockedProfileError: if there currently already is a lock on the profile.
         """
         error_message = (
-            f'process {self.process.pid} cannot lock profile `{self.profile.name}` ' f'because it is already locked.'
+            f'process {self.process.pid} cannot lock profile `{self.profile.name}` because it is already locked.'
         )
         self._raise_if_locked(error_message)
 
         self._clear_stale_pid_files()
 
         error_message = (
-            f'process {self.process.pid} cannot lock profile `{self.profile.name}` ' f'because it is being accessed.'
+            f'process {self.process.pid} cannot lock profile `{self.profile.name}` because it is being accessed.'
         )
         self._raise_if_active(error_message)
 

--- a/src/aiida/orm/autogroup.py
+++ b/src/aiida/orm/autogroup.py
@@ -48,7 +48,7 @@ class AutogroupManager:
         self._exclude: list[str] | None = None
         self._include: list[str] | None = None
 
-        self._group_label_prefix = f"Verdi autogroup on {timezone.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        self._group_label_prefix = f'Verdi autogroup on {timezone.now().strftime("%Y-%m-%d %H:%M:%S")}'
         self._group_label = None  # Actual group label, set by `get_or_create_group`
 
     @property
@@ -134,7 +134,7 @@ class AutogroupManager:
     def set_group_label_prefix(self, label_prefix: str | None) -> None:
         """Set the label of the group to be created (or use a default)."""
         if label_prefix is None:
-            label_prefix = f"Verdi autogroup on {timezone.now().strftime('%Y-%m-%d %H:%M:%S')}"
+            label_prefix = f'Verdi autogroup on {timezone.now().strftime("%Y-%m-%d %H:%M:%S")}'
         if not isinstance(label_prefix, str):
             raise exceptions.ValidationError('group label must be a string')
         self._group_label_prefix = label_prefix
@@ -220,7 +220,7 @@ class AutogroupManager:
             filters={
                 'or': [
                     {'label': {'==': label_prefix}},
-                    {'label': {'like': f"{escape_for_sql_like(f'{label_prefix}_')}%"}},
+                    {'label': {'like': f'{escape_for_sql_like(f"{label_prefix}_")}%'}},
                 ]
             },
             project='label',

--- a/src/aiida/orm/nodes/data/upf.py
+++ b/src/aiida/orm/nodes/data/upf.py
@@ -264,7 +264,7 @@ def parse_upf(fname, check_filename=True, encoding='utf-8'):
     if check_filename:
         if not os.path.basename(fname).lower().startswith(element.lower()):
             raise ParsingError(
-                'Filename {0} was recognized for element ' '{1}, but the filename does not start ' 'with {1}'.format(
+                'Filename {0} was recognized for element {1}, but the filename does not start with {1}'.format(
                     fname, element
                 )
             )

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -471,9 +471,9 @@ class QueryBuilder:
                     )
                 if joining_keyword:
                     raise ValueError(
-                        'You already specified joining specification {}\n'
-                        'But you now also want to specify {}'
-                        ''.format(joining_keyword, key)
+                        'You already specified joining specification {}\nBut you now also want to specify {}'.format(
+                            joining_keyword, key
+                        )
                     )
 
                 joining_keyword = key
@@ -664,17 +664,16 @@ class QueryBuilder:
                             this_order_spec = orderspec
                         else:
                             raise TypeError(
-                                'I was expecting a string or a dictionary\n' 'You provided {} {}\n' ''.format(
+                                'I was expecting a string or a dictionary\nYou provided {} {}\n'.format(
                                     type(orderspec), orderspec
                                 )
                             )
                         for key in this_order_spec:
                             if key not in allowed_keys:
                                 raise ValueError(
-                                    'The allowed keys for an order specification\n'
-                                    'are {}\n'
-                                    '{} is not valid\n'
-                                    ''.format(', '.join(allowed_keys), key)
+                                    'The allowed keys for an order specification\nare {}\n{} is not valid\n'.format(
+                                        ', '.join(allowed_keys), key
+                                    )
                                 )
                         this_order_spec['order'] = this_order_spec.get('order', 'asc')
                         if this_order_spec['order'] not in possible_orders:

--- a/src/aiida/orm/utils/builders/code.py
+++ b/src/aiida/orm/utils/builders/code.py
@@ -76,7 +76,7 @@ class CodeBuilder:
         # Complain if there are keys that are passed but not used
         if passed_keys - used:
             raise self.CodeValidationError(
-                f"Unknown parameters passed to the CodeBuilder: {', '.join(sorted(passed_keys - used))}"
+                f'Unknown parameters passed to the CodeBuilder: {", ".join(sorted(passed_keys - used))}'
             )
 
         return code

--- a/src/aiida/orm/utils/builders/computer.py
+++ b/src/aiida/orm/utils/builders/computer.py
@@ -102,12 +102,10 @@ class ComputerBuilder:
                 mpiprocs_per_machine = int(mpiprocs_per_machine)
             except ValueError:
                 raise self.ComputerValidationError(
-                    'Invalid value provided for mpiprocs_per_machine, ' 'must be a valid integer'
+                    'Invalid value provided for mpiprocs_per_machine, must be a valid integer'
                 )
             if mpiprocs_per_machine <= 0:
-                raise self.ComputerValidationError(
-                    'Invalid value provided for mpiprocs_per_machine, ' 'must be positive'
-                )
+                raise self.ComputerValidationError('Invalid value provided for mpiprocs_per_machine, must be positive')
             computer.set_default_mpiprocs_per_machine(mpiprocs_per_machine)
 
         def_memory_per_machine = self._get_and_count('default_memory_per_machine', used)
@@ -132,7 +130,7 @@ class ComputerBuilder:
         # Complain if there are keys that are passed but not used
         if passed_keys - used:
             raise self.ComputerValidationError(
-                f"Unknown parameters passed to the ComputerBuilder: {', '.join(sorted(passed_keys - used))}"
+                f'Unknown parameters passed to the ComputerBuilder: {", ".join(sorted(passed_keys - used))}'
             )
 
         return computer

--- a/src/aiida/plugins/entry_point.py
+++ b/src/aiida/plugins/entry_point.py
@@ -195,7 +195,7 @@ def format_entry_point_string(group: str, name: str, fmt: EntryPointFormat = Ent
     if fmt == EntryPointFormat.FULL:
         return f'{group}{ENTRY_POINT_STRING_SEPARATOR}{name}'
     if fmt == EntryPointFormat.PARTIAL:
-        return f'{group[len(ENTRY_POINT_GROUP_PREFIX):]}{ENTRY_POINT_STRING_SEPARATOR}{name}'
+        return f'{group[len(ENTRY_POINT_GROUP_PREFIX) :]}{ENTRY_POINT_STRING_SEPARATOR}{name}'
     if fmt == EntryPointFormat.MINIMAL:
         return f'{name}'
     raise ValueError('invalid EntryPointFormat')

--- a/src/aiida/restapi/common/utils.py
+++ b/src/aiida/restapi/common/utils.py
@@ -231,7 +231,7 @@ class Utils:
         # 3. perpage requires that the path contains a page request
         if perpage is not None and page is None:
             raise RestValidationError(
-                'perpage key requires that a page is ' 'requested (i.e. the path must contain ' '/page/)'
+                'perpage key requires that a page is requested (i.e. the path must contain /page/)'
             )
         # 4. No querystring if query type = projectable_properties'
         if query_type in ('projectable_properties',) and is_querystring_defined:
@@ -351,7 +351,7 @@ class Utils:
 
         def make_rel_url(rel, page):
             new_path_elems = path_elems + ['page', str(page)]
-            return f"<{'/'.join(new_path_elems)}{question_mark}{query_string}>; rel={rel}, "
+            return f'<{"/".join(new_path_elems)}{question_mark}{query_string}>; rel={rel}, '
 
         ## Setting non-mandatory parameters
         # set links to related pages

--- a/src/aiida/restapi/run_api.py
+++ b/src/aiida/restapi/run_api.py
@@ -44,7 +44,7 @@ def run_api(flask_app=api_classes.App, flask_api=api_classes.AiidaApi, **kwargs)
     api = configure_api(flask_app, flask_api, **kwargs)
 
     # Run app through built-in werkzeug server
-    print(f" * REST API running on http://{hostname}:{port}{API_CONFIG['PREFIX']}")
+    print(f' * REST API running on http://{hostname}:{port}{API_CONFIG["PREFIX"]}')
     api.app.run(debug=debug, host=hostname, port=int(port), threaded=True)
 
 

--- a/src/aiida/restapi/translator/base.py
+++ b/src/aiida/restapi/translator/base.py
@@ -200,7 +200,7 @@ class BaseTranslator:
         ## Validate input
         if not isinstance(orders, dict):
             raise InputValidationError(
-                'orders has to be a dictionary' "compatible with the 'order_by' section" 'of the query_help'
+                "orders has to be a dictionarycompatible with the 'order_by' sectionof the query_help"
             )
 
         ## Auxiliary_function to get the ordering cryterion
@@ -461,9 +461,9 @@ class BaseTranslator:
             raise RestInputValidationError('More than one node found. Provide longer starting pattern for id.')
         except NotExistent:
             raise RestInputValidationError(
-                "either no object's id starts"
-                " with '{}' or the corresponding object"
-                ' is not of type aiida.orm.{}'.format(node_id, self._aiida_type)
+                "either no object's id starts with '{}' or the corresponding object is not of type aiida.orm.{}".format(
+                    node_id, self._aiida_type
+                )
             )
         else:
             # create a permanent filter

--- a/src/aiida/restapi/translator/nodes/node.py
+++ b/src/aiida/restapi/translator/nodes/node.py
@@ -174,9 +174,7 @@ class NodeTranslator(BaseTranslator):
         """
         ## Check the compatibility of query_type and id
         if query_type != 'default' and id is None:
-            raise ValidationError(
-                'non default result/content can only be ' 'applied to a specific node (specify an id)'
-            )
+            raise ValidationError('non default result/content can only be applied to a specific node (specify an id)')
 
         ## Set the type of query
         self.set_query_type(

--- a/src/aiida/schedulers/datastructures.py
+++ b/src/aiida/schedulers/datastructures.py
@@ -151,7 +151,7 @@ class NodeNumberJobResource(JobResource):
                     raise ValueError(f'`{parameter}` must be an integer when specified')
 
         if kwargs:
-            raise ValueError(f"these parameters were not recognized: {', '.join(list(kwargs.keys()))}")
+            raise ValueError(f'these parameters were not recognized: {", ".join(list(kwargs.keys()))}')
 
         # At least two of the following parameters need to be defined as non-zero
         if [resources.num_machines, resources.num_mpiprocs_per_machine, resources.tot_num_mpiprocs].count(None) > 1:
@@ -240,7 +240,7 @@ class ParEnvJobResource(JobResource):
             raise ValueError('`tot_num_mpiprocs` must be greater than or equal to one.')
 
         if kwargs:
-            raise ValueError(f"these parameters were not recognized: {', '.join(list(kwargs.keys()))}")
+            raise ValueError(f'these parameters were not recognized: {", ".join(list(kwargs.keys()))}')
 
         return resources
 

--- a/src/aiida/schedulers/plugins/direct.py
+++ b/src/aiida/schedulers/plugins/direct.py
@@ -115,7 +115,7 @@ class DirectScheduler(BashCliScheduler):
                 command += f' {escape_for_bash(jobs)}'  # type: ignore[unreachable]
             else:
                 try:
-                    command += f" {' '.join(escape_for_bash(job) for job in jobs if job)}"
+                    command += f' {" ".join(escape_for_bash(job) for job in jobs if job)}'
                 except TypeError:
                     raise TypeError("If provided, the 'jobs' variable must be a string or a list of strings")
 

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -284,7 +284,7 @@ class LsfScheduler(BashCliScheduler):
         jobnum, state, walltime, queue[=partition], user, numnodes, numcores, title
         """
 
-        command = ['bjobs', '-noheader', f"-o '{' '.join(self._joblist_fields)} delimiter=\"{_FIELD_SEPARATOR}\"'"]
+        command = ['bjobs', '-noheader', f'-o \'{" ".join(self._joblist_fields)} delimiter="{_FIELD_SEPARATOR}"\'']
 
         if user and jobs:
             raise FeatureNotAvailable('Cannot query by user and job(s) in LSF')
@@ -413,7 +413,7 @@ class LsfScheduler(BashCliScheduler):
                     raise ValueError
             except ValueError as exc:
                 raise ValueError(
-                    'max_wallclock_seconds must be ' "a positive integer (in seconds)! It is instead '{}'" ''.format(
+                    "max_wallclock_seconds must be a positive integer (in seconds)! It is instead '{}'".format(
                         (job_tmpl.max_wallclock_seconds)
                     )
                 ) from exc

--- a/src/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/src/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -173,7 +173,7 @@ class PbsBaseClass(BashCliScheduler):
                 command.append(f'{escape_for_bash(jobs)}')  # type: ignore[unreachable]
             else:
                 try:
-                    command.append(f"{' '.join(escape_for_bash(j) for j in jobs)}")
+                    command.append(f'{" ".join(escape_for_bash(j) for j in jobs)}')
                 except TypeError:
                     raise TypeError("If provided, the 'jobs' variable must be a string or an iterable of strings")
 
@@ -271,8 +271,7 @@ class PbsBaseClass(BashCliScheduler):
             lines.append('#PBS -j oe')
             if job_tmpl.sched_error_path:
                 _LOGGER.info(
-                    'sched_join_files is True, but sched_error_path is set in '
-                    'PBSPro script; ignoring sched_error_path'
+                    'sched_join_files is True, but sched_error_path is set in PBSPro script; ignoring sched_error_path'
                 )
         elif job_tmpl.sched_error_path:
             lines.append(f'#PBS -e {job_tmpl.sched_error_path}')
@@ -537,7 +536,7 @@ class PbsBaseClass(BashCliScheduler):
             except ValueError:
                 _LOGGER.warning(
                     f"'resource_list.ncpus' is not an integer "
-                    f"({raw_data['resource_list.ncpus']}) for job id {this_job.job_id}!"
+                    f'({raw_data["resource_list.ncpus"]}) for job id {this_job.job_id}!'
                 )
 
             try:
@@ -548,7 +547,7 @@ class PbsBaseClass(BashCliScheduler):
             except ValueError:
                 _LOGGER.warning(
                     f"'resource_list.mpiprocs' is not an integer "
-                    f"({raw_data['resource_list.mpiprocs']}) for job id {this_job.job_id}!"
+                    f'({raw_data["resource_list.mpiprocs"]}) for job id {this_job.job_id}!'
                 )
 
             try:
@@ -558,7 +557,7 @@ class PbsBaseClass(BashCliScheduler):
             except ValueError:
                 _LOGGER.warning(
                     f"'resource_list.nodect' is not an integer "
-                    f"{raw_data['resource_list.nodect']}) for job id {this_job.job_id}!"
+                    f'{raw_data["resource_list.nodect"]}) for job id {this_job.job_id}!'
                 )
 
             # Double check of redundant info

--- a/src/aiida/schedulers/plugins/pbspro.py
+++ b/src/aiida/schedulers/plugins/pbspro.py
@@ -74,7 +74,7 @@ class PbsproScheduler(PbsBaseClass):
                     raise ValueError
             except ValueError:
                 raise ValueError(
-                    'max_wallclock_seconds must be ' "a positive integer (in seconds)! It is instead '{}'" ''.format(
+                    "max_wallclock_seconds must be a positive integer (in seconds)! It is instead '{}'".format(
                         max_wallclock_seconds
                     )
                 )

--- a/src/aiida/schedulers/plugins/sge.py
+++ b/src/aiida/schedulers/plugins/sge.py
@@ -226,7 +226,7 @@ class SgeScheduler(BashCliScheduler):
             lines.append('#$ -j y')
             if job_tmpl.sched_error_path:
                 self.logger.info(
-                    'sched_join_files is True, but sched_error_path is set in ' 'SGE script; ignoring sched_error_path'
+                    'sched_join_files is True, but sched_error_path is set in SGE script; ignoring sched_error_path'
                 )
         elif job_tmpl.sched_error_path:
             lines.append(f'#$ -e {job_tmpl.sched_error_path}')
@@ -255,7 +255,7 @@ class SgeScheduler(BashCliScheduler):
                     raise ValueError
             except ValueError:
                 raise ValueError(
-                    'max_wallclock_seconds must be ' "a positive integer (in seconds)! It is instead '{}'" ''.format(
+                    "max_wallclock_seconds must be a positive integer (in seconds)! It is instead '{}'".format(
                         (job_tmpl.max_wallclock_seconds)
                     )
                 )

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -238,7 +238,7 @@ class SlurmScheduler(BashCliScheduler):
             if len(joblist) == 1:
                 joblist += [joblist[0]]
 
-            command.append(f"--jobs={','.join(joblist)}")
+            command.append(f'--jobs={",".join(joblist)}')
 
         comm = ' '.join(command)
         self.logger.debug(f'squeue command: {comm}')
@@ -321,8 +321,7 @@ class SlurmScheduler(BashCliScheduler):
             # I specify a different --output file
             if job_tmpl.sched_error_path:
                 self.logger.info(
-                    'sched_join_files is True, but sched_error_path is set in '
-                    'SLURM script; ignoring sched_error_path'
+                    'sched_join_files is True, but sched_error_path is set in SLURM script; ignoring sched_error_path'
                 )
         elif job_tmpl.sched_error_path:
             lines.append(f'#SBATCH --error={job_tmpl.sched_error_path}')
@@ -363,7 +362,7 @@ class SlurmScheduler(BashCliScheduler):
                     raise ValueError
             except ValueError:
                 raise ValueError(
-                    'max_wallclock_seconds must be ' "a positive integer (in seconds)! It is instead '{}'" ''.format(
+                    "max_wallclock_seconds must be a positive integer (in seconds)! It is instead '{}'".format(
                         (job_tmpl.max_wallclock_seconds)
                     )
                 )
@@ -448,7 +447,7 @@ class SlurmScheduler(BashCliScheduler):
         # If I am here, no valid line could be found.
         self.logger.error(f'in _parse_submit_output{transport_string}: unable to find the job id: {stdout}')
         raise SchedulerError(
-            'Error during submission, could not retrieve the jobID from ' 'sbatch output; see log for more info.'
+            'Error during submission, could not retrieve the jobID from sbatch output; see log for more info.'
         )
 
     def _parse_joblist_output(self, retval: int, stdout: str, stderr: str) -> list[JobInfo]:
@@ -562,7 +561,7 @@ stderr='{stderr.strip()}'"""
                 this_job.num_machines = int(thisjob_dict['number_nodes'])
             except ValueError:
                 self.logger.warning(
-                    'The number of allocated nodes is not ' 'an integer ({}) for job id {}!'.format(
+                    'The number of allocated nodes is not an integer ({}) for job id {}!'.format(
                         thisjob_dict['number_nodes'], this_job.job_id
                     )
                 )

--- a/src/aiida/schedulers/plugins/torque.py
+++ b/src/aiida/schedulers/plugins/torque.py
@@ -68,7 +68,7 @@ class TorqueScheduler(PbsBaseClass):
                     raise ValueError
             except ValueError:
                 raise ValueError(
-                    'max_wallclock_seconds must be ' "a positive integer (in seconds)! It is instead '{}'" ''.format(
+                    "max_wallclock_seconds must be a positive integer (in seconds)! It is instead '{}'".format(
                         max_wallclock_seconds
                     )
                 )

--- a/src/aiida/sphinxext/process.py
+++ b/src/aiida/sphinxext/process.py
@@ -182,7 +182,7 @@ class AiidaProcessDirective(SphinxDirective):
             return valid_type.__name__
         except AttributeError:
             try:
-                return f"({', '.join(v.__name__ for v in valid_type)})"
+                return f'({", ".join(v.__name__ for v in valid_type)})'
             except (AttributeError, TypeError):
                 return str(valid_type)
 

--- a/src/aiida/storage/psql_dos/orm/extras_mixin.py
+++ b/src/aiida/storage/psql_dos/orm/extras_mixin.py
@@ -73,7 +73,7 @@ class ExtrasMixin:
         non_existing_keys = [key for key in keys if key not in self.model.extras]
 
         if non_existing_keys:
-            raise AttributeError(f"extras `{', '.join(non_existing_keys)}` do not exist")
+            raise AttributeError(f'extras `{", ".join(non_existing_keys)}` do not exist')
 
         for key in keys:
             self.bare_model.extras.pop(key)

--- a/src/aiida/storage/psql_dos/orm/nodes.py
+++ b/src/aiida/storage/psql_dos/orm/nodes.py
@@ -285,7 +285,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], ExtrasMixin, BackendNode
         non_existing_keys = [key for key in keys if key not in self.model.attributes]
 
         if non_existing_keys:
-            raise AttributeError(f"attributes `{', '.join(non_existing_keys)}` do not exist")
+            raise AttributeError(f'attributes `{", ".join(non_existing_keys)}` do not exist')
 
         for key in keys:
             self.bare_model.attributes.pop(key)

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v06_to_v07.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v06_to_v07.py
@@ -85,12 +85,12 @@ def data_migration_legacy_process_attributes(data):
     if illegal_cases:
         headers = ['UUID/PK', 'process_state']
         warning_message = (
-            'Found ProcessNodes with active process states ' 'that should never have been allowed to be exported.'
+            'Found ProcessNodes with active process states that should never have been allowed to be exported.'
         )
         write_database_integrity_violation(illegal_cases, headers, warning_message)
 
         raise CorruptStorage(
-            'Your export archive is corrupt! ' 'Please see the log-file in your current directory for more details.'
+            'Your export archive is corrupt! Please see the log-file in your current directory for more details.'
         )
 
 

--- a/src/aiida/storage/sqlite_zip/orm.py
+++ b/src/aiida/storage/sqlite_zip/orm.py
@@ -49,9 +49,9 @@ class SqliteEntityOverride:
     @classmethod
     def _class_check(cls):
         """Assert that the class is correctly configured"""
-        assert issubclass(
-            cls.MODEL_CLASS, models.SqliteBase
-        ), 'Must set the MODEL_CLASS in the derived class to a SQLA model'
+        assert issubclass(cls.MODEL_CLASS, models.SqliteBase), (
+            'Must set the MODEL_CLASS in the derived class to a SQLA model'
+        )
 
     @classmethod
     def from_dbmodel(cls, dbmodel, backend):

--- a/src/aiida/tools/archive/create.py
+++ b/src/aiida/tools/archive/create.py
@@ -244,7 +244,7 @@ def create_archive(
                 entity_ids[EntityTypes.USER].add(entry.pk)
             else:
                 raise ArchiveExportError(
-                    f'I was given {entry} ({type(entry)}),' ' which is not a User, Node, Computer, or Group instance'
+                    f'I was given {entry} ({type(entry)}), which is not a User, Node, Computer, or Group instance'
                 )
         group_nodes, link_data = _collect_required_entities(
             querybuilder,
@@ -680,7 +680,7 @@ def _check_unsealed_nodes(querybuilder: QbType, node_ids: set[int], batch_size: 
     if unsealed_node_pks:
         raise ExportValidationError(
             'All ProcessNodes must be sealed before they can be exported. '
-            f"Node(s) with PK(s): {', '.join(str(pk) for pk in unsealed_node_pks)} is/are not sealed."
+            f'Node(s) with PK(s): {", ".join(str(pk) for pk in unsealed_node_pks)} is/are not sealed.'
         )
 
 
@@ -775,7 +775,7 @@ def get_init_summary(
     """Get summary for archive initialisation"""
     parameters: list[list[Any]] = [['Path', str(outfile)], ['Version', archive_version], ['Compression', compression]]
 
-    result = f"\n{tabulate(parameters, headers=['Archive Parameters', ''])}"
+    result = f'\n{tabulate(parameters, headers=["Archive Parameters", ""])}'
 
     inclusions: list[list[Any]] = [
         ['Computers/Nodes/Groups/Users', 'All' if collect_all else 'Selected'],
@@ -783,10 +783,10 @@ def get_init_summary(
         ['Node Comments', include_comments],
         ['Node Logs', include_logs],
     ]
-    result += f"\n\n{tabulate(inclusions, headers=['Inclusion rules', ''])}"
+    result += f'\n\n{tabulate(inclusions, headers=["Inclusion rules", ""])}'
 
     if not collect_all:
-        rules_table = [[f"Follow links {' '.join(name.split('_'))}s", value] for name, value in traversal_rules.items()]
-        result += f"\n\n{tabulate(rules_table, headers=['Traversal rules', ''])}"
+        rules_table = [[f'Follow links {" ".join(name.split("_"))}s', value] for name, value in traversal_rules.items()]
+        result += f'\n\n{tabulate(rules_table, headers=["Traversal rules", ""])}'
 
     return result + '\n'

--- a/src/aiida/tools/data/array/kpoints/legacy.py
+++ b/src/aiida/tools/data/array/kpoints/legacy.py
@@ -337,9 +337,9 @@ def get_explicit_kpoints_path(
     explicit_kpoints = [tuple(point_coordinates[path[0][0]])]
     labels = [(0, path[0][0])]
 
-    assert all(
-        [_.is_integer() for _ in num_points if isinstance(_, (float, numpy.float64))]
-    ), f'Could not determine number of points as a whole number. num_points={num_points}'
+    assert all([_.is_integer() for _ in num_points if isinstance(_, (float, numpy.float64))]), (
+        f'Could not determine number of points as a whole number. num_points={num_points}'
+    )
     num_points = [int(_) for _ in num_points]
 
     for count_piece, i in enumerate(path):

--- a/src/aiida/tools/data/cif.py
+++ b/src/aiida/tools/data/cif.py
@@ -163,7 +163,7 @@ def refine_inline(node):
 
     if len(node.values.keys()) > 1:
         raise ValueError(
-            'CifData seems to contain more than one data ' 'block -- multiblock CIF files are not ' 'supported yet'
+            'CifData seems to contain more than one data block -- multiblock CIF files are not supported yet'
         )
 
     name = next(iter(node.values.keys()))
@@ -171,7 +171,7 @@ def refine_inline(node):
     original_atoms = node.get_ase(index=None)
     if len(original_atoms) > 1:
         raise ValueError(
-            'CifData seems to contain more than one crystal ' 'structure -- such refinement is not supported ' 'yet'
+            'CifData seems to contain more than one crystal structure -- such refinement is not supported yet'
         )
 
     original_atoms = original_atoms[0]

--- a/src/aiida/tools/data/orbital/orbital.py
+++ b/src/aiida/tools/data/orbital/orbital.py
@@ -104,7 +104,7 @@ class Orbital:
     def __str__(self) -> str:
         orb_dict = self.get_orbital_dict()
 
-        position_string = f"{orb_dict['position'][0]:.4f},{orb_dict['position'][1]:.4f},{orb_dict['position'][2]:.4f}"
+        position_string = f'{orb_dict["position"][0]:.4f},{orb_dict["position"][1]:.4f},{orb_dict["position"][2]:.4f}'
         return f'Orbital @ {position_string}'
 
     def _validate_keys(self, input_dict):

--- a/src/aiida/tools/dbimporters/plugins/cod.py
+++ b/src/aiida/tools/dbimporters/plugins/cod.py
@@ -19,7 +19,7 @@ class CodDbImporter(DbImporter):
         for value in values:
             if not isinstance(value, int) and not isinstance(value, str):
                 raise ValueError(f"incorrect value for keyword '{alias}' only integers and strings are accepted")
-        return f"{key} IN ({', '.join(str(int(i)) for i in values)})"
+        return f'{key} IN ({", ".join(str(int(i)) for i in values)})'
 
     def _str_exact_clause(self, key, alias, values):
         """Returns SQL query predicate for querying string fields."""
@@ -30,7 +30,7 @@ class CodDbImporter(DbImporter):
             if isinstance(value, int):
                 value = str(value)  # noqa: PLW2901
             clause_parts.append(f"'{value}'")
-        return f"{key} IN ({', '.join(clause_parts)})"
+        return f'{key} IN ({", ".join(clause_parts)})'
 
     def _str_exact_or_none_clause(self, key, alias, values):
         """Returns SQL query predicate for querying string fields, allowing
@@ -163,9 +163,9 @@ class CodDbImporter(DbImporter):
                 sql_parts.append(f'({self._keywords[key][1](self, self._keywords[key][0], key, values)})')
 
         if kwargs:
-            raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
+            raise NotImplementedError(f'following keyword(s) are not implemented: {", ".join(kwargs.keys())}')
 
-        return f"SELECT file, svnrevision FROM data WHERE {' AND '.join(sql_parts)}"
+        return f'SELECT file, svnrevision FROM data WHERE {" AND ".join(sql_parts)}'
 
     def query(self, **kwargs):
         """Performs a query on the COD database using ``keyword = value`` pairs,
@@ -256,9 +256,9 @@ class CodSearchResults(DbSearchResults):
 
         :param result_dict: dictionary, describing an entry in the results.
         """
-        url = f"{self._base_url + result_dict['id']}.cif"
+        url = f'{self._base_url + result_dict["id"]}.cif'
         if 'svnrevision' in result_dict and result_dict['svnrevision'] is not None:
-            return f"{url}@{result_dict['svnrevision']}"
+            return f'{url}@{result_dict["svnrevision"]}'
 
         return url
 

--- a/src/aiida/tools/dbimporters/plugins/icsd.py
+++ b/src/aiida/tools/dbimporters/plugins/icsd.py
@@ -104,7 +104,7 @@ class IcsdDbImporter(DbImporter):
         for value in values:
             if not isinstance(value, int) and not isinstance(value, str):
                 raise ValueError("incorrect value for keyword '" + alias + ' only integers and strings are accepted')
-        return f"{key} IN ({', '.join(str(int(i)) for i in values)})"
+        return f'{key} IN ({", ".join(str(int(i)) for i in values)})'
 
     def _str_exact_clause(self, key, alias, values):
         """Return SQL query predicate for querying string fields."""

--- a/src/aiida/tools/dbimporters/plugins/mpod.py
+++ b/src/aiida/tools/dbimporters/plugins/mpod.py
@@ -54,14 +54,14 @@ class MpodDbImporter(DbImporter):
                 get_parts.append(value[1](self, value[0], key, values))
 
         if kwargs:
-            raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
+            raise NotImplementedError(f'following keyword(s) are not implemented: {", ".join(kwargs.keys())}')
 
         queries = []
         for element in elements:
             clauses = [self._str_clause('formula', 'element', element)]
-            queries.append(f"{self._query_url}?{'&'.join(get_parts + clauses)}")
+            queries.append(f'{self._query_url}?{"&".join(get_parts + clauses)}')
         if not queries:
-            queries.append(f"{self._query_url}?{'&'.join(get_parts)}")
+            queries.append(f'{self._query_url}?{"&".join(get_parts)}')
 
         return queries
 
@@ -94,7 +94,7 @@ class MpodDbImporter(DbImporter):
             self._query_url = query_url
 
         if kwargs:
-            raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
+            raise NotImplementedError(f'following keyword(s) are not implemented: {", ".join(kwargs.keys())}')
 
     def get_supported_keywords(self):
         """Returns the list of all supported query keywords.
@@ -129,7 +129,7 @@ class MpodSearchResults(DbSearchResults):
 
         :param result_dict: dictionary, describing an entry in the results.
         """
-        return f"{self._base_url + result_dict['id']}.mpod"
+        return f'{self._base_url + result_dict["id"]}.mpod'
 
 
 class MpodEntry(CifEntry):

--- a/src/aiida/tools/dbimporters/plugins/nninc.py
+++ b/src/aiida/tools/dbimporters/plugins/nninc.py
@@ -45,9 +45,9 @@ class NnincDbImporter(DbImporter):
                     get_parts.append(value[1](self, value[0], key, values))
 
         if kwargs:
-            raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
+            raise NotImplementedError(f'following keyword(s) are not implemented: {", ".join(kwargs.keys())}')
 
-        return f"{self._query_url}?{'&'.join(get_parts)}"
+        return f'{self._query_url}?{"&".join(get_parts)}'
 
     def query(self, **kwargs):
         """Performs a query on the NNIN/C Pseudopotential Virtual Vault using
@@ -125,7 +125,7 @@ class NnincSearchResults(DbSearchResults):
 
         :param result_dict: dictionary, describing an entry in the results.
         """
-        return f"{self._base_url + result_dict['id']}.UPF"
+        return f'{self._base_url + result_dict["id"]}.UPF'
 
 
 class NnincEntry(UpfEntry):

--- a/src/aiida/tools/dbimporters/plugins/oqmd.py
+++ b/src/aiida/tools/dbimporters/plugins/oqmd.py
@@ -37,7 +37,7 @@ class OqmdDbImporter(DbImporter):
         if not isinstance(elements, list):
             elements = [elements]
 
-        return f"{self._query_url}/materials/composition/{''.join(elements)}"
+        return f'{self._query_url}/materials/composition/{"".join(elements)}'
 
     def query(self, **kwargs):
         """Performs a query on the OQMD database using ``keyword = value`` pairs,
@@ -70,7 +70,7 @@ class OqmdDbImporter(DbImporter):
             self._query_url = query_url
 
         if kwargs:
-            raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
+            raise NotImplementedError(f'following keyword(s) are not implemented: {", ".join(kwargs.keys())}')
 
     def get_supported_keywords(self):
         """Returns the list of all supported query keywords.

--- a/src/aiida/tools/dbimporters/plugins/pcod.py
+++ b/src/aiida/tools/dbimporters/plugins/pcod.py
@@ -49,9 +49,9 @@ class PcodDbImporter(CodDbImporter):
                     values = [values]
                 sql_parts.append(f'({value[1](self, value[0], key, values)})')
         if kwargs:
-            raise NotImplementedError(f"following keyword(s) are not implemented: {', '.join(kwargs.keys())}")
+            raise NotImplementedError(f'following keyword(s) are not implemented: {", ".join(kwargs.keys())}')
 
-        return f"SELECT file FROM data WHERE {' AND '.join(sql_parts)}"
+        return f'SELECT file FROM data WHERE {" AND ".join(sql_parts)}'
 
     def query(self, **kwargs):
         """Performs a query on the PCOD database using ``keyword = value`` pairs,
@@ -88,7 +88,7 @@ class PcodSearchResults(CodSearchResults):
 
         :param result_dict: dictionary, describing an entry in the results.
         """
-        return f"{self._base_url + result_dict['id'][0]}/{result_dict['id'][0:3]}/{result_dict['id']}.cif"
+        return f'{self._base_url + result_dict["id"][0]}/{result_dict["id"][0:3]}/{result_dict["id"]}.cif'
 
 
 class PcodEntry(CodEntry):

--- a/src/aiida/tools/graph/age_entities.py
+++ b/src/aiida/tools/graph/age_entities.py
@@ -136,7 +136,7 @@ class AbstractSetContainer(metaclass=ABCMeta):
         return len(self.keyset)
 
     def __repr__(self) -> str:
-        return f"{{{','.join(map(str, self.keyset))}}}"
+        return f'{{{",".join(map(str, self.keyset))}}}'
 
     def __eq__(self, other: Any) -> Any:
         return self.keyset == other.keyset

--- a/src/aiida/tools/graph/graph_traversers.py
+++ b/src/aiida/tools/graph/graph_traversers.py
@@ -165,7 +165,7 @@ def validate_traversal_rules(
         rules_applied[name] = follow
 
     if traversal_rules:
-        error_message = f"unrecognized keywords: {', '.join(traversal_rules.keys())}"
+        error_message = f'unrecognized keywords: {", ".join(traversal_rules.keys())}'
         raise exceptions.ValidationError(error_message)
 
     valid_output = {

--- a/src/aiida/tools/visualization/graph.py
+++ b/src/aiida/tools/visualization/graph.py
@@ -215,13 +215,13 @@ def default_node_sublabels(node: orm.Node) -> str:
     """
     class_node_type = node.class_node_type
     if class_node_type == 'data.core.int.Int.':
-        sublabel = f"value: {node.base.attributes.get('value', '')}"
+        sublabel = f'value: {node.base.attributes.get("value", "")}'
     elif class_node_type == 'data.core.float.Float.':
-        sublabel = f"value: {node.base.attributes.get('value', '')}"
+        sublabel = f'value: {node.base.attributes.get("value", "")}'
     elif class_node_type == 'data.core.str.Str.':
-        sublabel = f"{node.base.attributes.get('value', '')}"
+        sublabel = f'{node.base.attributes.get("value", "")}'
     elif class_node_type == 'data.core.bool.Bool.':
-        sublabel = f"{node.base.attributes.get('value', '')}"
+        sublabel = f'{node.base.attributes.get("value", "")}'
     elif class_node_type == 'data.core.code.Code.':
         label = '?' if node.computer is None else node.computer.label
         sublabel = f'{os.path.basename(node.get_execname())}@{label}'
@@ -241,7 +241,7 @@ def default_node_sublabels(node: orm.Node) -> str:
             sublabel_lines.append(', '.join(sg_numbers))
         sublabel = '; '.join(sublabel_lines)
     elif class_node_type == 'data.core.upf.UpfData.':
-        sublabel = f"{node.base.attributes.get('element', '')}"
+        sublabel = f'{node.base.attributes.get("element", "")}'
     elif isinstance(node, orm.ProcessNode):
         sublabel_list = []
         if node.process_state is not None:

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -412,7 +412,7 @@ class _AsyncSSH(_AsynchronousSSHBackend):
                         self.logger.warning(f'There was nonempty stderr in the cp command: {stderr}')
                 else:
                     self.logger.error(
-                        "Problem executing cp. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
+                        "Problem executing cp. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
                             retval, stdout, stderr, command
                         )
                     )
@@ -420,9 +420,9 @@ class _AsyncSSH(_AsynchronousSSHBackend):
                         raise FileNotFoundError(f'Error while executing cp: {stderr}')
 
                     raise OSError(
-                        'Error while executing cp. Exit code: {}, '
-                        "stdout: '{}', stderr: '{}', "
-                        "command: '{}'".format(retval, stdout, stderr, command)
+                        "Error while executing cp. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
+                            retval, stdout, stderr, command
+                        )
                     )
 
             cp_exe = 'cp'
@@ -570,7 +570,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
             if await self.path_exists(path):
                 raise FileExistsError(f'Directory already exists: {path}')
 
-        commands = self.ssh_command_generator(f"mkdir {'-p' if parents else ''} {{}}", paths=[path])
+        commands = self.ssh_command_generator(f'mkdir {"-p" if parents else ""} {{}}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:
@@ -583,7 +583,7 @@ class _OpenSSH(_AsynchronousSSHBackend):
     async def chmod(self, path: str, mode: int, follow_symlinks: bool = True):
         # chmod works with octal numbers, so we have to convert the mode to octal
         mode = oct(mode)[2:]  # type: ignore[assignment]
-        commands = self.ssh_command_generator(f"chmod {'-h' if not follow_symlinks else ''} {mode} {{}}", paths=[path])
+        commands = self.ssh_command_generator(f'chmod {"-h" if not follow_symlinks else ""} {mode} {{}}', paths=[path])
         returncode, stdout, stderr = await self.openssh_execute(commands)
 
         if returncode != 0:

--- a/src/aiida/transports/plugins/local.py
+++ b/src/aiida/transports/plugins/local.py
@@ -83,7 +83,7 @@ class LocalTransport(BlockingTransport):
 
     def __str__(self):
         """Return a description as a string."""
-        return f"local [{'OPEN' if self._is_open else 'CLOSED'}]"
+        return f'local [{"OPEN" if self._is_open else "CLOSED"}]'
 
     @property
     def curdir(self):

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -401,7 +401,7 @@ class SshTransport(BlockingTransport):
             self._client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         else:
             raise ValueError(
-                'Unknown value of the key policy, allowed values ' 'are: RejectPolicy, WarningPolicy, AutoAddPolicy'
+                'Unknown value of the key policy, allowed values are: RejectPolicy, WarningPolicy, AutoAddPolicy'
             )
 
         self._connect_args = {}
@@ -571,17 +571,17 @@ class SshTransport(BlockingTransport):
         """Return a useful string."""
         conn_info = self._machine
         try:
-            conn_info = f"{self._connect_args['username']}@{conn_info}"
+            conn_info = f'{self._connect_args["username"]}@{conn_info}'
         except KeyError:
             # No username explicitly defined: ignore
             pass
         try:
-            conn_info += f":{self._connect_args['port']}"
+            conn_info += f':{self._connect_args["port"]}'
         except KeyError:
             # No port explicitly defined: ignore
             pass
 
-        return f"{'OPEN' if self._is_open else 'CLOSED'} [{conn_info}]"
+        return f'{"OPEN" if self._is_open else "CLOSED"} [{conn_info}]'
 
     def chdir(self, path: TransportPath):
         """
@@ -1288,7 +1288,7 @@ class SshTransport(BlockingTransport):
                 self.logger.warning(f'There was nonempty stderr in the cp command: {stderr}')
         else:
             self.logger.error(
-                "Problem executing cp. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
+                "Problem executing cp. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
                     retval, stdout, stderr, command
                 )
             )
@@ -1296,7 +1296,7 @@ class SshTransport(BlockingTransport):
                 raise FileNotFoundError(f'Error while executing cp: {stderr}')
 
             raise OSError(
-                'Error while executing cp. Exit code: {}, ' "stdout: '{}', stderr: '{}', " "command: '{}'".format(
+                "Error while executing cp. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
                     retval, stdout, stderr, command
                 )
             )
@@ -1425,7 +1425,7 @@ class SshTransport(BlockingTransport):
         else:
             command_to_execute = command
 
-        self.logger.debug(f'Command to be executed: {command_to_execute[:self._MAX_EXEC_COMMAND_LOG_SIZE]}')
+        self.logger.debug(f'Command to be executed: {command_to_execute[: self._MAX_EXEC_COMMAND_LOG_SIZE]}')
 
         # Note: The default shell will eat one level of escaping, while
         # 'bash -l -c ...' will eat another. Thus, we need to escape again.
@@ -1562,19 +1562,19 @@ class SshTransport(BlockingTransport):
         """
         further_params = []
         if 'username' in self._connect_args:
-            further_params.append(f"-l {escape_for_bash(self._connect_args['username'])}")
+            further_params.append(f'-l {escape_for_bash(self._connect_args["username"])}')
 
         if self._connect_args.get('port'):
-            further_params.append(f"-p {self._connect_args['port']}")
+            further_params.append(f'-p {self._connect_args["port"]}')
 
         if self._connect_args.get('key_filename'):
-            further_params.append(f"-i {escape_for_bash(self._connect_args['key_filename'])}")
+            further_params.append(f'-i {escape_for_bash(self._connect_args["key_filename"])}')
 
         if self._connect_args.get('proxy_jump'):
-            further_params.append(f"-o ProxyJump={escape_for_bash(self._connect_args['proxy_jump'])}")
+            further_params.append(f'-o ProxyJump={escape_for_bash(self._connect_args["proxy_jump"])}')
 
         if self._connect_args.get('proxy_command'):
-            further_params.append(f"-o ProxyCommand={escape_for_bash(self._connect_args['proxy_command'])}")
+            further_params.append(f'-o ProxyCommand={escape_for_bash(self._connect_args["proxy_command"])}')
 
         further_params_str = ' '.join(further_params)
 

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -202,7 +202,7 @@ class AsyncSshTransport(AsyncTransport):
         self._is_open = False
 
     def __str__(self):
-        return f"{'OPEN' if self._is_open else 'CLOSED'} [AsyncSshTransport]"
+        return f'{"OPEN" if self._is_open else "CLOSED"} [AsyncSshTransport]'
 
     async def get_async(
         self,
@@ -841,7 +841,7 @@ class AsyncSshTransport(AsyncTransport):
                 self.logger.warning(f'There was nonempty stderr in the tar command: {stderr}')
         else:
             self.logger.error(
-                "Problem executing tar. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
+                "Problem executing tar. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
                     retval, stdout, stderr, tar_command
                 )
             )

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -365,7 +365,7 @@ class Transport(abc.ABC):
         :type gid: int
         """
         warn_deprecation(
-            'The `Transport.chown` method is deprecated and will be removed. ' 'It is not used internally by AiiDA.',
+            'The `Transport.chown` method is deprecated and will be removed. It is not used internally by AiiDA.',
             version=3,
         )
         raise NotImplementedError('chown is not implemented for this transport.')
@@ -1117,8 +1117,7 @@ class Transport(abc.ABC):
         :type gid: int
         """
         warn_deprecation(
-            'The `Transport.chown_async` method is deprecated and will be removed. '
-            'It is not used internally by AiiDA.',
+            'The `Transport.chown_async` method is deprecated and will be removed. It is not used internally by AiiDA.',
             version=3,
         )
         raise NotImplementedError('chown_async is not implemented for this transport.')
@@ -1664,7 +1663,7 @@ class BlockingTransport(Transport):
         copy_items = ' '.join([str(Path(item).relative_to(root_dir)) for item in copy_list])
         # note: order of the flags is important
         tar_command = (
-            f"tar -c{compression_flag!s}{'h' if dereference else ''}f {remotedestination!s} -C {root_dir!s} "
+            f'tar -c{compression_flag!s}{"h" if dereference else ""}f {remotedestination!s} -C {root_dir!s} '
             + copy_items
         )
 
@@ -1675,7 +1674,7 @@ class BlockingTransport(Transport):
                 self.logger.warning(f'There was nonempty stderr in the tar command: {stderr}')
         else:
             self.logger.error(
-                "Problem executing tar. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
+                "Problem executing tar. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
                     retval, stdout, stderr, tar_command
                 )
             )
@@ -1721,7 +1720,7 @@ class BlockingTransport(Transport):
                 self.logger.warning(f'There was nonempty stderr in the tar command: {stderr}')
         else:
             self.logger.error(
-                "Problem executing tar. Exit code: {}, stdout: '{}', " "stderr: '{}', command: '{}'".format(
+                "Problem executing tar. Exit code: {}, stdout: '{}', stderr: '{}', command: '{}'".format(
                     retval, stdout, stderr, tar_command
                 )
             )

--- a/tests/calculations/arithmetic/test_add.py
+++ b/tests/calculations/arithmetic/test_add.py
@@ -43,7 +43,7 @@ def test_add_default(fixture_sandbox, aiida_localhost, generate_calc_job):
 
     with fixture_sandbox.open(options['input_filename'].default) as handle:
         input_written = handle.read()
-        assert input_written == f"echo $(({inputs['x'].value} + {inputs['y'].value}))\n"
+        assert input_written == f'echo $(({inputs["x"].value} + {inputs["y"].value}))\n'
 
 
 @pytest.mark.requires_broker

--- a/tests/calculations/test_templatereplacer.py
+++ b/tests/calculations/test_templatereplacer.py
@@ -54,7 +54,7 @@ def test_base_template(fixture_sandbox, aiida_localhost, generate_calc_job):
     # Check the content of the generated script
     with fixture_sandbox.open(inputs['template']['input_file_name']) as handle:
         input_written = handle.read()
-        assert input_written == f"echo $(({inputs['parameters']['x']} + {inputs['parameters']['y']}))"
+        assert input_written == f'echo $(({inputs["parameters"]["x"]} + {inputs["parameters"]["y"]}))'
 
 
 @pytest.mark.requires_broker

--- a/tests/cmdline/commands/test_archive_import.py
+++ b/tests/cmdline/commands/test_archive_import.py
@@ -86,17 +86,17 @@ def test_import_to_group(run_cli_command, newest_archive):
     # Invoke `verdi import` again, making sure Group count doesn't change
     options = ['-G', group.label] + [archives[0]]
     run_cli_command(cmd_archive.import_archive, options)
-    assert (
-        group.count() == nodes_in_group
-    ), f'The Group count should not have changed from {nodes_in_group}. Instead it is now {group.count()}'
+    assert group.count() == nodes_in_group, (
+        f'The Group count should not have changed from {nodes_in_group}. Instead it is now {group.count()}'
+    )
 
     # Invoke `verdi import` again with new archive, making sure Group count is upped
     options = ['-G', group.label] + [archives[1]]
     run_cli_command(cmd_archive.import_archive, options)
-    assert (
-        group.count() > nodes_in_group
-    ), 'There should now be more than {} nodes in group {} , instead there are {}'.format(
-        nodes_in_group, group_label, group.count()
+    assert group.count() > nodes_in_group, (
+        'There should now be more than {} nodes in group {} , instead there are {}'.format(
+            nodes_in_group, group_label, group.count()
+        )
     )
 
 

--- a/tests/cmdline/commands/test_computer.py
+++ b/tests/cmdline/commands/test_computer.py
@@ -413,7 +413,7 @@ class TestVerdiComputerConfigure:
         # I just pass the first four arguments:
         # the username, the port, look_for_keys, and the key_filename
         # This testing also checks that an empty key_filename is ok
-        command_input = f"{remote_username}\n{port}\n{'yes' if look_for_keys else 'no'}\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+        command_input = f'{remote_username}\n{port}\n{"yes" if look_for_keys else "no"}\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n'
 
         result = self.cli_runner(computer_configure, ['core.ssh', comp.label], user_input=command_input)
         assert comp.is_configured, result.output
@@ -542,9 +542,9 @@ class TestVerdiComputerConfigure:
 
         # verifying correctness by comparing internal and loaded yaml object
         configure_setup_data = yaml.safe_load(exported_setup_filename.read_text())
-        assert configure_setup_data == self.comp_builder.get_computer_spec(
-            comp
-        ), 'Internal computer configuration does not agree with exported one.'
+        assert configure_setup_data == self.comp_builder.get_computer_spec(comp), (
+            'Internal computer configuration does not agree with exported one.'
+        )
 
     def test_computer_export_setup_overwrite(self, tmp_path):
         """Test if overwriting behavior of `verdi computer export setup` command works as expected"""
@@ -609,9 +609,9 @@ class TestVerdiComputerConfigure:
         # Write sorted output file
         result = self.cli_runner(computer_export_config, [comp.label, exported_config_filename])
         assert 'Success' in result.output, 'Command should have run successfull.'
-        assert (
-            str(exported_config_filename) in result.output
-        ), 'Filename should be in terminal output but was not found.'
+        assert str(exported_config_filename) in result.output, (
+            'Filename should be in terminal output but was not found.'
+        )
         assert exported_config_filename.exists(), f"'{exported_config_filename}' was not created during export."
 
         content = exported_config_filename.read_text()
@@ -619,17 +619,17 @@ class TestVerdiComputerConfigure:
 
         # verifying correctness by comparing internal and loaded yaml object
         configure_config_data = yaml.safe_load(exported_config_filename.read_text())
-        assert (
-            configure_config_data == comp.get_configuration()
-        ), 'Internal computer configuration does not agree with exported one.'
+        assert configure_config_data == comp.get_configuration(), (
+            'Internal computer configuration does not agree with exported one.'
+        )
 
         # Check that unsorted output file creation works as expected
         exported_config_filename.unlink()
         result = self.cli_runner(computer_export_config, [comp.label, exported_config_filename, '--no-sort'])
         assert 'Success' in result.output, 'Command should have run successfull.'
-        assert (
-            str(exported_config_filename) in result.output
-        ), 'Filename should be in terminal output but was not found.'
+        assert str(exported_config_filename) in result.output, (
+            'Filename should be in terminal output but was not found.'
+        )
         assert exported_config_filename.exists(), f"'{exported_config_filename}' was not created during export."
 
         # Check contents

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -146,9 +146,9 @@ class DummyVerdiDataListable:
 
             options = [flag, '0']
             res = self.cli_runner(listing_cmd, options)
-            assert (
-                search_string_bytes not in res.stdout_bytes
-            ), f'A not expected string {search_string} was found in the listing'
+            assert search_string_bytes not in res.stdout_bytes, (
+                f'A not expected string {search_string} was found in the listing'
+            )
 
         # Check that the group filter works as expected
         # if ids is not None:
@@ -383,7 +383,7 @@ class TestVerdiDataDict:
         res = self.cli_runner(cmd_dict.dictionary_show, options)
         assert res.exit_code == 0, 'The command verdi data core.dict show did not finish correctly'
         assert b'"a": 1' in res.stdout_bytes, (
-            'The string "a": 1 was not found in the output' ' of verdi data core.dict show'
+            'The string "a": 1 was not found in the output of verdi data core.dict show'
         )
 
 
@@ -409,12 +409,12 @@ class TestVerdiDataRemote:
         options = [str(self.rmt.pk)]
         res = self.cli_runner(cmd_remote.remote_show, options)
         assert res.exit_code == 0, 'The command verdi data core.upf show did not finish correctly'
-        assert (
-            b'Remote computer name:' in res.stdout_bytes
-        ), 'The string "Remote computer name:" was not found in the output of verdi data core.upf show'
-        assert (
-            b'Remote folder full path:' in res.stdout_bytes
-        ), 'The string "Remote folder full path:" was not found in the output of verdi data core.upf show'
+        assert b'Remote computer name:' in res.stdout_bytes, (
+            'The string "Remote computer name:" was not found in the output of verdi data core.upf show'
+        )
+        assert b'Remote folder full path:' in res.stdout_bytes, (
+            'The string "Remote folder full path:" was not found in the output of verdi data core.upf show'
+        )
 
     def test_remotelshelp(self):
         output = sp.check_output(['verdi', 'data', 'core.remote', 'ls', '--help'])
@@ -425,7 +425,7 @@ class TestVerdiDataRemote:
         res = self.cli_runner(cmd_remote.remote_ls, options)
         assert res.exit_code == 0, 'The command verdi data core.upf ls did not finish correctly'
         assert b'file.txt' in res.stdout_bytes, (
-            'The file "file.txt" was not found in the output' ' of verdi data core.upf ls'
+            'The file "file.txt" was not found in the output of verdi data core.upf ls'
         )
 
     def test_remotecathelp(self):
@@ -437,7 +437,7 @@ class TestVerdiDataRemote:
         res = self.cli_runner(cmd_remote.remote_cat, options)
         assert res.exit_code == 0, 'The command verdi data core.upf cat did not finish correctly'
         assert b'test string' in res.stdout_bytes, (
-            'The string "test string" was not found in the output' ' of verdi data core.upf cat file.txt'
+            'The string "test string" was not found in the output of verdi data core.upf cat file.txt'
         )
 
 
@@ -541,7 +541,7 @@ class TestVerdiDataTrajectory(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_showhelp(self):
         res = self.cli_runner(cmd_trajectory.trajectory_show, ['--help'])
         assert b'Usage:' in res.stdout_bytes, (
-            'The string "Usage: " was not found in the output' ' of verdi data trajecotry show --help'
+            'The string "Usage: " was not found in the output of verdi data trajecotry show --help'
         )
 
     def test_list(self):
@@ -651,19 +651,19 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_importhelp(self):
         res = self.cli_runner(cmd_structure.structure_import, ['--help'])
         assert b'Usage:' in res.stdout_bytes, (
-            'The string "Usage: " was not found in the output' ' of verdi core.data structure import --help'
+            'The string "Usage: " was not found in the output of verdi core.data structure import --help'
         )
 
     def test_importhelp_ase(self):
         res = self.cli_runner(cmd_structure.import_ase, ['--help'])
         assert b'Usage:' in res.stdout_bytes, (
-            'The string "Usage: " was not found in the output' ' of verdi data core.structure import ase --help'
+            'The string "Usage: " was not found in the output of verdi data core.structure import ase --help'
         )
 
     def test_importhelp_aiida_xyz(self):
         res = self.cli_runner(cmd_structure.import_aiida_xyz, ['--help'])
         assert b'Usage:' in res.stdout_bytes, (
-            'The string "Usage: " was not found in the output' ' of verdi data core.structure import aiida-xyz --help'
+            'The string "Usage: " was not found in the output of verdi data core.structure import aiida-xyz --help'
         )
 
     def test_import_aiida_xyz(self):
@@ -690,10 +690,10 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
             ]
             res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, (
-                'The string "Successfully imported" was not found in the output' ' of verdi data core.structure import.'
+                'The string "Successfully imported" was not found in the output of verdi data core.structure import.'
             )
             assert b'PK' in res.stdout_bytes, (
-                'The string "PK" was not found in the output' ' of verdi data core.structure import.'
+                'The string "PK" was not found in the output of verdi data core.structure import.'
             )
 
     def test_import_aiida_xyz_2(self):
@@ -713,10 +713,10 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
             ]
             res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, (
-                'The string "Successfully imported" was not found in the output' ' of verdi data core.structure import.'
+                'The string "Successfully imported" was not found in the output of verdi data core.structure import.'
             )
             assert b'dry-run' in res.stdout_bytes, (
-                'The string "dry-run" was not found in the output' ' of verdi data core.structure import.'
+                'The string "dry-run" was not found in the output of verdi data core.structure import.'
             )
 
     def test_import_aiida_xyz_w_group_label(self):
@@ -748,10 +748,10 @@ class TestVerdiDataStructure(DummyVerdiDataListable, DummyVerdiDataExportable):
             ]
             res = self.cli_runner(cmd_structure.import_aiida_xyz, options)
             assert b'Successfully imported' in res.stdout_bytes, (
-                'The string "Successfully imported" was not found in the output' ' of verdi data core.structure import.'
+                'The string "Successfully imported" was not found in the output of verdi data core.structure import.'
             )
             assert b'PK' in res.stdout_bytes, (
-                'The string "PK" was not found in the output' ' of verdi data core.structure import.'
+                'The string "PK" was not found in the output of verdi data core.structure import.'
             )
             res = self.cli_runner(cmd_group.group_show, [group_label])
             for grpline in [group_label, 'StructureData']:
@@ -778,10 +778,10 @@ PRIMVEC
             ]
             res = self.cli_runner(cmd_structure.import_ase, options)
             assert b'Successfully imported' in res.stdout_bytes, (
-                'The string "Successfully imported" was not found in the output' ' of verdi data core.structure import.'
+                'The string "Successfully imported" was not found in the output of verdi data core.structure import.'
             )
             assert b'PK' in res.stdout_bytes, (
-                'The string "PK" was not found in the output' ' of verdi data core.structure import.'
+                'The string "PK" was not found in the output of verdi data core.structure import.'
             )
 
     @pytest.mark.skipif(not has_ase(), reason='Unable to import ase')
@@ -804,10 +804,10 @@ PRIMVEC
             options = [fhandle.name, '--label', 'another  structure', '--group', group_label]
             res = self.cli_runner(cmd_structure.import_ase, options)
             assert b'Successfully imported' in res.stdout_bytes, (
-                'The string "Successfully imported" was not found in the output' ' of verdi data core.structure import.'
+                'The string "Successfully imported" was not found in the output of verdi data core.structure import.'
             )
             assert b'PK' in res.stdout_bytes, (
-                'The string "PK" was not found in the output' ' of verdi data core.structure import.'
+                'The string "PK" was not found in the output of verdi data core.structure import.'
             )
             res = self.cli_runner(cmd_group.group_show, [group_label])
             for grpline in [group_label, 'StructureData']:
@@ -887,15 +887,13 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
     def test_showhelp(self):
         options = ['--help']
         res = self.cli_runner(cmd_cif.cif_show, options)
-        assert b'Usage:' in res.stdout_bytes, (
-            'The string "Usage: " was not found in the output' ' of verdi data show help'
-        )
+        assert b'Usage:' in res.stdout_bytes, 'The string "Usage: " was not found in the output of verdi data show help'
 
     def test_importhelp(self):
         options = ['--help']
         res = self.cli_runner(cmd_cif.cif_import, options)
         assert b'Usage:' in res.stdout_bytes, (
-            'The string "Usage: " was not found in the output' ' of verdi data import help'
+            'The string "Usage: " was not found in the output of verdi data import help'
         )
 
     def test_import(self):
@@ -906,7 +904,7 @@ class TestVerdiDataCif(DummyVerdiDataListable, DummyVerdiDataExportable):
             options = [fhandle.name]
             res = self.cli_runner(cmd_cif.cif_import, options)
             assert b'imported uuid' in res.stdout_bytes, (
-                'The string "imported uuid" was not found in the output' ' of verdi data import.'
+                'The string "imported uuid" was not found in the output of verdi data import.'
             )
 
     def test_content(self):
@@ -965,7 +963,7 @@ class TestVerdiDataUpf:
         options = [self.filepath_pseudos, 'test_group', 'test description']
         res = self.cli_runner(cmd_upf.upf_uploadfamily, options)
         assert b'UPF files found: 4' in res.stdout_bytes, (
-            'The string "UPF files found: 4" was not found in the' ' output of verdi data core.upf uploadfamily'
+            'The string "UPF files found: 4" was not found in the output of verdi data core.upf uploadfamily'
         )
 
     def test_uploadfamilyhelp(self):
@@ -988,15 +986,15 @@ class TestVerdiDataUpf:
         options = [tmp_path, 'test_group']
         self.cli_runner(cmd_upf.upf_exportfamily, options)
         output = sp.check_output(['ls', tmp_path])
-        assert (
-            b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output
-        ), f'Sub-command verdi data core.upf exportfamily --help failed: {output}'
-        assert (
-            b'O.pbesol-n-rrkjus_psl.0.1-tested-pslib030.UPF' in output
-        ), 'Sub-command verdi data core.upf exportfamily --help failed.'
-        assert (
-            b'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output
-        ), 'Sub-command verdi data core.upf exportfamily --help failed.'
+        assert b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output, (
+            f'Sub-command verdi data core.upf exportfamily --help failed: {output}'
+        )
+        assert b'O.pbesol-n-rrkjus_psl.0.1-tested-pslib030.UPF' in output, (
+            'Sub-command verdi data core.upf exportfamily --help failed.'
+        )
+        assert b'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF' in output, (
+            'Sub-command verdi data core.upf exportfamily --help failed.'
+        )
         assert b'C_pbe_v1.2.uspp.F.UPF' in output, 'Sub-command verdi data core.upf exportfamily --help failed.'
 
     def test_listfamilieshelp(self):
@@ -1010,19 +1008,19 @@ class TestVerdiDataUpf:
         options = ['-d', '-e', 'Ba']
         res = self.cli_runner(cmd_upf.upf_listfamilies, options)
 
-        assert (
-            b'test_group' in res.stdout_bytes
-        ), f'The string "test_group" was not found in the output of verdi data core.upf listfamilies: {res.output}'
+        assert b'test_group' in res.stdout_bytes, (
+            f'The string "test_group" was not found in the output of verdi data core.upf listfamilies: {res.output}'
+        )
 
         assert b'test description' in res.stdout_bytes, (
-            'The string "test_group" was not found in the' ' output of verdi data core.upf listfamilies'
+            'The string "test_group" was not found in the output of verdi data core.upf listfamilies'
         )
 
         options = ['-d', '-e', 'Fe']
         res = self.cli_runner(cmd_upf.upf_listfamilies, options)
-        assert (
-            b'No valid UPF pseudopotential' in res.stdout_bytes
-        ), 'The string "No valid UPF pseudopotential" was not found in the output of verdi data core.upf listfamilies'
+        assert b'No valid UPF pseudopotential' in res.stdout_bytes, (
+            'The string "No valid UPF pseudopotential" was not found in the output of verdi data core.upf listfamilies'
+        )
 
     def test_importhelp(self):
         output = sp.check_output(['verdi', 'data', 'core.upf', 'import', '--help'])
@@ -1032,6 +1030,6 @@ class TestVerdiDataUpf:
         options = [os.path.join(self.filepath_pseudos, 'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF')]
         res = self.cli_runner(cmd_upf.upf_import, options)
 
-        assert (
-            b'Imported' in res.stdout_bytes
-        ), f'The string "Imported" was not found in the output of verdi data import: {res.output}'
+        assert b'Imported' in res.stdout_bytes, (
+            f'The string "Imported" was not found in the output of verdi data import: {res.output}'
+        )

--- a/tests/cmdline/commands/test_group.py
+++ b/tests/cmdline/commands/test_group.py
@@ -364,20 +364,20 @@ class TestVerdiGroup:
         # The current `verdi group show` does not support ordering so we cannot rely on that for now to test if only
         # one of the nodes is shown
         assert len(result.output.strip().split('\n')) == 1
-        assert _pk_in_output(nodes[0].pk, result.output) or _pk_in_output(
-            nodes[1].pk, result.output
-        ), f'Neither found PK {nodes[0].pk} nor {nodes[1].pk} in expression {result.output!r}'
+        assert _pk_in_output(nodes[0].pk, result.output) or _pk_in_output(nodes[1].pk, result.output), (
+            f'Neither found PK {nodes[0].pk} nor {nodes[1].pk} in expression {result.output!r}'
+        )
 
         # Repeat test with `limit=1` but without the `--raw` flag as it has a different code path that is affected
         result = run_cli_command(cmd_group.group_show, [label, '--limit', '1'], use_subprocess=True)
 
         # Check that one, and only one pk appears in the output
-        assert _pk_in_output(nodes[0].pk, result.output) or _pk_in_output(
-            nodes[1].pk, result.output
-        ), f'Neither found PK {nodes[0].pk} nor PK {nodes[1].pk} in expression {result.output!r}'
-        assert not (
-            _pk_in_output(nodes[0].pk, result.output) and _pk_in_output(nodes[1].pk, result.output)
-        ), f'Found both PKs {nodes[0].pk} and {nodes[1].pk} (but only one is allowed) in expression {result.output!r}'
+        assert _pk_in_output(nodes[0].pk, result.output) or _pk_in_output(nodes[1].pk, result.output), (
+            f'Neither found PK {nodes[0].pk} nor PK {nodes[1].pk} in expression {result.output!r}'
+        )
+        assert not (_pk_in_output(nodes[0].pk, result.output) and _pk_in_output(nodes[1].pk, result.output)), (
+            f'Found both PKs {nodes[0].pk} and {nodes[1].pk} (but only one is allowed) in expression {result.output!r}'
+        )
 
     def test_description(self, run_cli_command):
         """Test `verdi group description` command."""

--- a/tests/cmdline/commands/test_node.py
+++ b/tests/cmdline/commands/test_node.py
@@ -691,7 +691,7 @@ class TestVerdiDelete:
         result = run_cli_command(cmd_node.node_delete, options + all_workflow_pks)
         assert (
             'Report: Remote folders of these node are marked for '
-            f"deletion: {' '.join(str(remote_node.pk) for remote_node in self.remote_nodes)}"
+            f'deletion: {" ".join(str(remote_node.pk) for remote_node in self.remote_nodes)}'
             in str(result.stdout_bytes)
         )
         assert f'Report: {self.total_nodes} Node(s) marked for deletion' in str(result.stdout_bytes)
@@ -710,7 +710,7 @@ class TestVerdiDelete:
         result = run_cli_command(cmd_node.node_delete, options + all_workflow_pks)
         assert (
             'Report: Remote folders of these node are marked for '
-            f"deletion: {' '.join(str(remote_node.pk) for remote_node in self.remote_nodes)}"
+            f'deletion: {" ".join(str(remote_node.pk) for remote_node in self.remote_nodes)}'
             in str(result.stdout_bytes)
         )
         assert f'Report: {self.total_nodes} Node(s) marked for deletion' in str(result.stdout_bytes)

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -375,7 +375,7 @@ class TestAutoGroups:
                 queryb = QueryBuilder().append(Node, filters={'id': pk}, tag='node')
                 queryb.append(AutoGroup, with_node='node', project='*')
                 all_auto_groups = queryb.all()
-                assert (
-                    len(all_auto_groups) == 1
-                ), 'There should be only one autogroup associated with the node just created'
+                assert len(all_auto_groups) == 1, (
+                    'There should be only one autogroup associated with the node just created'
+                )
                 assert all_auto_groups[0][0].label.startswith(autogroup_label)

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -192,12 +192,12 @@ class TestProcess:
 
         def on_entered(self, from_state):
             if self._state.LABEL.value == 'finished':
-                assert (
-                    self.node.is_finished_ok
-                ), 'Node state should have been updated before plumpy.Process.on_entered is invoked.'
-                assert (
-                    self.node.outputs.result.value == 2
-                ), 'Outputs should have been attached before plumpy.Process.on_entered is invoked.'
+                assert self.node.is_finished_ok, (
+                    'Node state should have been updated before plumpy.Process.on_entered is invoked.'
+                )
+                assert self.node.outputs.result.value == 2, (
+                    'Outputs should have been attached before plumpy.Process.on_entered is invoked.'
+                )
             original_on_entered(self, from_state)
 
         monkeypatch.setattr(plumpy.Process, 'on_entered', on_entered)

--- a/tests/engine/test_transport.py
+++ b/tests/engine/test_transport.py
@@ -213,10 +213,10 @@ class TestTransportQueue:
 
             # Verify each task got a fresh transport (no existing request in queue)
             for state in transport_states:
-                assert not state[
-                    'had_existing_request'
-                ], f"Task {state['task_id']} should not have found an existing request"
-                assert state['is_open'], f"Task {state['task_id']} transport should be open"
+                assert not state['had_existing_request'], (
+                    f'Task {state["task_id"]} should not have found an existing request'
+                )
+                assert state['is_open'], f'Task {state["task_id"]} transport should be open'
 
         finally:
             transport_class._DEFAULT_SAFE_OPEN_INTERVAL = original_interval

--- a/tests/manage/test_caching_config.py
+++ b/tests/manage/test_caching_config.py
@@ -65,7 +65,7 @@ def test_merge_deprecated_yaml(tmp_path):
             .parent.joinpath('configuration/migrations/test_samples/reference/6.json')
             .read_text(encoding='utf-8')
         )
-        config_dictionary['profiles']['default']['storage']['config']['repository_uri'] = f"file:///{tmp_path/'repo'}"
+        config_dictionary['profiles']['default']['storage']['config']['repository_uri'] = f'file:///{tmp_path / "repo"}'
         cache_dictionary = {
             'default': {
                 'default': True,

--- a/tests/orm/implementation/test_comments.py
+++ b/tests/orm/implementation/test_comments.py
@@ -163,9 +163,9 @@ class TestBackendComment:
 
         # Make sure they exist
         count_comments_found = orm.QueryBuilder().append(orm.Comment, filters={'uuid': {'in': comment_uuids}}).count()
-        assert count_comments_found == len(
-            comment_uuids
-        ), f'There should be {len(comment_uuids)} Comments, instead {count_comments_found} Comment(s) was/were found'
+        assert count_comments_found == len(comment_uuids), (
+            f'There should be {len(comment_uuids)} Comments, instead {count_comments_found} Comment(s) was/were found'
+        )
 
         # Delete last two comments (comment2, comment3)
         filters = {'or': [{'id': comment2.id}, {'uuid': str(comment3.uuid)}]}
@@ -192,9 +192,9 @@ class TestBackendComment:
 
         # Make sure they exist
         count_comments_found = orm.QueryBuilder().append(orm.Comment, filters={'uuid': {'in': comment_uuids}}).count()
-        assert count_comments_found == len(
-            comment_uuids
-        ), f'There should be {len(comment_uuids)} Comments, instead {count_comments_found} Comment(s) was/were found'
+        assert count_comments_found == len(comment_uuids), (
+            f'There should be {len(comment_uuids)} Comments, instead {count_comments_found} Comment(s) was/were found'
+        )
 
         # Delete comments for self.node
         filters = {'dbnode_id': self.node.id}

--- a/tests/orm/implementation/test_logs.py
+++ b/tests/orm/implementation/test_logs.py
@@ -156,9 +156,9 @@ class TestBackendLog:
 
         # Make sure they exist
         count_logs_found = orm.QueryBuilder().append(orm.Log, filters={'uuid': {'in': log_uuids}}).count()
-        assert count_logs_found == len(
-            log_uuids
-        ), f'There should be {len(log_uuids)} Logs, instead {count_logs_found} Log(s) was/were found'
+        assert count_logs_found == len(log_uuids), (
+            f'There should be {len(log_uuids)} Logs, instead {count_logs_found} Log(s) was/were found'
+        )
 
         # Delete last two logs (log2, log3)
         filters = {'or': [{'id': log2.id}, {'uuid': str(log3.uuid)}]}
@@ -185,9 +185,9 @@ class TestBackendLog:
 
         # Make sure they exist
         count_logs_found = orm.QueryBuilder().append(orm.Log, filters={'uuid': {'in': log_uuids}}).count()
-        assert count_logs_found == len(
-            log_uuids
-        ), f'There should be {len(log_uuids)} Logs, instead {count_logs_found} Log(s) was/were found'
+        assert count_logs_found == len(log_uuids), (
+            f'There should be {len(log_uuids)} Logs, instead {count_logs_found} Log(s) was/were found'
+        )
 
         # Delete logs for self.node
         filters = {'dbnode_id': self.node.id}
@@ -300,8 +300,7 @@ class TestBackendLog:
         self.backend.logs.delete_many(filters=filters)
         log_count_after = orm.QueryBuilder().append(orm.Log).count()
         assert log_count_after == log_count_before, (
-            'The number of logs changed after performing `delete_many`, '
-            "while filtering for a non-existing 'dbnode_id'"
+            "The number of logs changed after performing `delete_many`, while filtering for a non-existing 'dbnode_id'"
         )
 
     def test_delete_many_same_twice(self):

--- a/tests/orm/nodes/data/test_upf.py
+++ b/tests/orm/nodes/data/test_upf.py
@@ -152,7 +152,7 @@ class TestUpfParser:
         # regular upf file version 1 header
         upf_contents = '\n'.join(
             [
-                '<PP_INFO>' 'Human readable section is completely irrelevant for parsing!',
+                '<PP_INFO>Human readable section is completely irrelevant for parsing!',
                 '<PP_HEADER',
                 'contents before element tag',
                 'O                     Element',
@@ -273,7 +273,7 @@ class TestUpfParser:
                 'Human readable section is completely irrelevant for parsing!',
                 '<PP_HEADER',
                 'contents before element tag',
-                'element="Ab"' 'contents following element tag',
+                'element="Ab"contents following element tag',
                 '>',
             ]
         )
@@ -290,7 +290,7 @@ class TestUpfParser:
         # upf file header contents
         upf_contents = '\n'.join(
             [
-                '<PP_INFO>' 'Human readable section is completely irrelevant for parsing!',
+                '<PP_INFO>Human readable section is completely irrelevant for parsing!',
                 '<PP_HEADER',
                 'contents before element tag',
                 'element should be here but is missing',
@@ -335,7 +335,7 @@ class TestUpfParser:
         # upf file header contents
         upf_contents = '\n'.join(
             [
-                '<PP_INFO>' 'Human readable section is completely irrelevant for parsing!',
+                '<PP_INFO>Human readable section is completely irrelevant for parsing!',
                 '<PP_HEADER',
                 'contents before element tag',
                 'Ab                     Element',

--- a/tests/orm/test_autogroups.py
+++ b/tests/orm/test_autogroups.py
@@ -30,27 +30,27 @@ def test_get_or_create(backend):
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = label_prefix
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )
 
     # Second group (only one with no suffix existing)
     autogroup = AutogroupManager(backend)
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = f'{label_prefix}_1'
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )
 
     # Second group (only one suffix _1 existing)
     autogroup = AutogroupManager(backend)
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = f'{label_prefix}_2'
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )
 
     # I create a group with a large integer suffix (9)
     AutoGroup(label=f'{label_prefix}_9').store()
@@ -59,9 +59,9 @@ def test_get_or_create(backend):
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = f'{label_prefix}_10'
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )
 
     # I create a group with a non-integer suffix (15a), it should be ignored
     AutoGroup(label=f'{label_prefix}_15b').store()
@@ -70,9 +70,9 @@ def test_get_or_create(backend):
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = f'{label_prefix}_11'
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )
 
 
 def test_get_or_create_invalid_prefix(backend):
@@ -95,15 +95,15 @@ def test_get_or_create_invalid_prefix(backend):
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = label_prefix
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )
 
     # Second group (only one with no suffix existing)
     autogroup = AutogroupManager(backend)
     autogroup.set_group_label_prefix(label_prefix)
     group = autogroup.get_or_create_group()
     expected_label = f'{label_prefix}_1'
-    assert (
-        group.label == expected_label
-    ), f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    assert group.label == expected_label, (
+        f"The auto-group should be labelled '{expected_label}', it is instead '{group.label}'"
+    )

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -903,12 +903,12 @@ class TestQueryBuilderCornerCases:
 
         # AbstractCode query should find all code types
         abstract_results = qb().append(orm.AbstractCode).all(flat=True)
-        assert (
-            installed_code in abstract_results
-        ), f'InstalledCode not found with AbstractCode query. Result: {abstract_results}'
-        assert (
-            portable_code in abstract_results
-        ), f'PortableCode not found with AbstractCode query. Result: {abstract_results}'
+        assert installed_code in abstract_results, (
+            f'InstalledCode not found with AbstractCode query. Result: {abstract_results}'
+        )
+        assert portable_code in abstract_results, (
+            f'PortableCode not found with AbstractCode query. Result: {abstract_results}'
+        )
         assert legacy_code in abstract_results, f'Code not found with AbstractCode query. Result: {abstract_results}'
         assert len(abstract_results) == 3
 

--- a/tests/orm/utils/test_remote.py
+++ b/tests/orm/utils/test_remote.py
@@ -59,5 +59,5 @@ def test_clean_mapping_remote_paths_skips_unconfigured_computer(tmp_path, monkey
     assert mock_clean.call_args.args[0] is folder_configured
 
     assert warnings == [
-        f'Skipping 1 remote folders on `{unconfigured.label}`: ' f'computer is not configured for user `{user.email}`'
+        f'Skipping 1 remote folders on `{unconfigured.label}`: computer is not configured for user `{user.email}`'
     ]

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -54,7 +54,7 @@ def server_url():
     from aiida.restapi.common.config import API_CONFIG, CLI_DEFAULTS
 
     def _server_url(hostname: Optional[str] = None, port: Optional[int] = None):
-        return f"http://{hostname or CLI_DEFAULTS['HOST_NAME']}:{port or CLI_DEFAULTS['PORT']}{API_CONFIG['PREFIX']}"
+        return f'http://{hostname or CLI_DEFAULTS["HOST_NAME"]}:{port or CLI_DEFAULTS["PORT"]}{API_CONFIG["PREFIX"]}'
 
     return _server_url
 

--- a/tests/restapi/test_routes.py
+++ b/tests/restapi/test_routes.py
@@ -403,7 +403,7 @@ class TestRestApi:
         """If we use the page, limit and offset at same time, it
         would return the error message.
         """
-        expected_error = 'requesting a specific page is incompatible with ' 'limit and offset'
+        expected_error = 'requesting a specific page is incompatible with limit and offset'
         self.process_test(
             'computers', '/computers/page/2?offset=2&limit=1&orderby=+id', expected_errormsg=expected_error
         )
@@ -439,7 +439,7 @@ class TestRestApi:
         If we request the page which exceeds the total no. of pages then
         it would return the error message.
         """
-        expected_error = 'Non existent page requested. The page range is [1 : ' '3]'
+        expected_error = 'Non existent page requested. The page range is [1 : 3]'
         self.process_test('computers', '/computers/page/4?perpage=2&orderby=+id', expected_errormsg=expected_error)
 
     ############### list filters ########################

--- a/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_4_dblog_update.py
+++ b/tests/storage/psql_dos/migrations/sqlalchemy_branch/test_4_dblog_update.py
@@ -233,18 +233,14 @@ class TestDbLogMigrationRecordCleaning:
                 .with_entities(column('dbnode_id'))
                 .one()[0]
             )
-            assert dbnode_id_1 == self.to_check['CalculationNode'][0], (
-                'The the referenced node is not ' 'the expected one'
-            )
+            assert dbnode_id_1 == self.to_check['CalculationNode'][0], 'The the referenced node is not the expected one'
             dbnode_id_2 = (
                 session.query(DbLog)
                 .filter(DbLog.id == self.to_check['CalculationNode'][3])
                 .with_entities(column('dbnode_id'))
                 .one()[0]
             )
-            assert dbnode_id_2 == self.to_check['CalculationNode'][2], (
-                'The the referenced node is not ' 'the expected one'
-            )
+            assert dbnode_id_2 == self.to_check['CalculationNode'][2], 'The the referenced node is not the expected one'
 
     def test_dblog_correct_export_of_logs(self):
         """Verify that export log methods for legacy workflows, unknown entities and log records that

--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -227,9 +227,9 @@ def test_get_and_terminate_unreferenced_connections():
         # Verify the external connection appears in unreferenced connections
         unreferenced = storage.get_unreferenced_connections()
         unreferenced_ports = [port for _, _, port in unreferenced]
-        assert (
-            external_port in unreferenced_ports
-        ), f'External connection port {external_port} not found in {unreferenced_ports}'
+        assert external_port in unreferenced_ports, (
+            f'External connection port {external_port} not found in {unreferenced_ports}'
+        )
 
         # Terminate only our specific connection (not all unreferenced ones)
         # This prevents killing connections from parallel tests

--- a/tests/storage/psql_dos/test_schema.py
+++ b/tests/storage/psql_dos/test_schema.py
@@ -49,9 +49,9 @@ class TestRelationshipsSQLA:
         # Check that the result of outputs_q is a query
         from sqlalchemy.orm.dynamic import AppenderQuery
 
-        assert isinstance(
-            n_1.backend_entity.bare_model.outputs_q, AppenderQuery
-        ), 'This is expected to be an AppenderQuery'
+        assert isinstance(n_1.backend_entity.bare_model.outputs_q, AppenderQuery), (
+            'This is expected to be an AppenderQuery'
+        )
 
         # Check that the result of outputs is correct
         out = {_.pk for _ in n_1.backend_entity.bare_model.outputs}
@@ -76,9 +76,9 @@ class TestRelationshipsSQLA:
         # Check that the result of outputs_q is a query
         from sqlalchemy.orm.dynamic import AppenderQuery
 
-        assert isinstance(
-            n_1.backend_entity.bare_model.inputs_q, AppenderQuery
-        ), 'This is expected to be an AppenderQuery'
+        assert isinstance(n_1.backend_entity.bare_model.inputs_q, AppenderQuery), (
+            'This is expected to be an AppenderQuery'
+        )
 
         # Check that the result of inputs is correct
         out = {_.pk for _ in n_3.backend_entity.bare_model.inputs}

--- a/tests/tools/archive/migration/test_v012_to_v013.py
+++ b/tests/tools/archive/migration/test_v012_to_v013.py
@@ -23,4 +23,4 @@ def test_migrate_v12_to_v13(core_archive, migrate_from_func):
             assert values['transport_type'] in [
                 'core.local',
                 'core.ssh',
-            ], f"encountered illegal transport entry point string `{values['transport_type']}`"
+            ], f'encountered illegal transport entry point string `{values["transport_type"]}`'

--- a/tests/tools/archive/migration/test_v04_to_v05.py
+++ b/tests/tools/archive/migration/test_v04_to_v05.py
@@ -23,14 +23,14 @@ def test_migrate_external(migrate_from_func):
         for computer in data['export_data']['Computer'].values():
             assert change not in computer, f"'{change}' unexpectedly found for {computer}"
         # metadata.json
-        assert (
-            change not in metadata['all_fields_info']['Computer']
-        ), f"'{change}' unexpectedly found in metadata.json for Computer"
+        assert change not in metadata['all_fields_info']['Computer'], (
+            f"'{change}' unexpectedly found in metadata.json for Computer"
+        )
     for change in removed_node_attrs:
         # data.json
         for node in data['export_data']['Node'].values():
             assert change not in node, f"'{change}' unexpectedly found for {node}"
         # metadata.json
-        assert (
-            change not in metadata['all_fields_info']['Node']
-        ), f"'{change}' unexpectedly found in metadata.json for Node"
+        assert change not in metadata['all_fields_info']['Node'], (
+            f"'{change}' unexpectedly found in metadata.json for Node"
+        )

--- a/tests/tools/archive/migration/test_v06_to_v07.py
+++ b/tests/tools/archive/migration/test_v06_to_v07.py
@@ -28,24 +28,24 @@ def test_migrate_external(migrate_from_func):
         if data['export_data']['Node'][node_pk]['node_type'].startswith('process.'):
             # Check if illegal attributes were removed successfully
             for attr in illegal_attrs:
-                assert (
-                    attr not in attrs
-                ), f"key '{attr}' should have been removed from attributes for Node <pk={node_pk}>"
+                assert attr not in attrs, (
+                    f"key '{attr}' should have been removed from attributes for Node <pk={node_pk}>"
+                )
 
             # Check new attributes were added successfully
             for attr, attr_value in new_attrs.items():
                 assert attr in attrs, f"key '{attr}' was not added to attributes for Node <pk={node_pk}>"
-                assert (
-                    attrs[attr] == attr_value
-                ), f"key '{attr}' should have had the value {attr_value}, but did instead have {attrs[attr]}"
+                assert attrs[attr] == attr_value, (
+                    f"key '{attr}' should have had the value {attr_value}, but did instead have {attrs[attr]}"
+                )
 
     # Check Attribute and Link have been removed
     illegal_entities = {'Attribute', 'Link'}
     for dict_ in ('unique_identifiers', 'all_fields_info'):
         for entity in illegal_entities:
-            assert (
-                entity not in metadata[dict_]
-            ), f"key '{entity}' should have been removed from '{dict_}' in metadata.json"
+            assert entity not in metadata[dict_], (
+                f"key '{entity}' should have been removed from '{dict_}' in metadata.json"
+            )
 
 
 def test_migration_0040_corrupt_archive():

--- a/tests/tools/archive/migration/test_v07_to_v08.py
+++ b/tests/tools/archive/migration/test_v07_to_v08.py
@@ -19,7 +19,7 @@ def test_migrate_external(migrate_from_func):
     illegal_label = '_return'
     for link in data.get('links_uuid'):
         assert link['label'] != illegal_label, (
-            f'The illegal link label {illegal_label} was not expected to be present - ' "it should now be 'result'"
+            f"The illegal link label {illegal_label} was not expected to be present - it should now be 'result'"
         )
 
 

--- a/tests/tools/archive/migration/test_v08_to_v09.py
+++ b/tests/tools/archive/migration/test_v08_to_v09.py
@@ -21,7 +21,7 @@ def test_migrate_external(migrate_from_func):
             'core.upf',
             'core.import',
             'core.auto',
-        ], f"encountered illegal type string `{attributes['type_string']}`"
+        ], f'encountered illegal type string `{attributes["type_string"]}`'
 
 
 def test_migration_dbgroup_type_string():

--- a/tests/tools/archive/orm/test_codes.py
+++ b/tests/tools/archive/orm/test_codes.py
@@ -69,12 +69,12 @@ def test_input_code(aiida_profile_clean, tmp_path, aiida_localhost):
     # Check that the link is in place
     import_links = get_all_node_links()
     assert sorted(export_links) == sorted(import_links)
-    assert (
-        len(export_links) == links_count
-    ), f'Expected to find only one link from code to the calculation node before export. {len(export_links)} found.'
-    assert (
-        len(import_links) == links_count
-    ), f'Expected to find only one link from code to the calculation node after import. {len(import_links)} found.'
+    assert len(export_links) == links_count, (
+        f'Expected to find only one link from code to the calculation node before export. {len(export_links)} found.'
+    )
+    assert len(import_links) == links_count, (
+        f'Expected to find only one link from code to the calculation node after import. {len(import_links)} found.'
+    )
 
 
 def test_solo_code(aiida_profile, tmp_path, aiida_localhost):

--- a/tests/tools/archive/orm/test_computers.py
+++ b/tests/tools/archive/orm/test_computers.py
@@ -254,7 +254,7 @@ def test_different_computer_same_name_import(aiida_profile, tmp_path, aiida_loca
     # Check that there are no calculations
     builder = orm.QueryBuilder()
     builder.append(orm.CalcJobNode, project=['*'])
-    assert builder.count() == 0, 'There should not be any ' 'calculations in the database at ' 'this point.'
+    assert builder.count() == 0, 'There should not be any calculations in the database at this point.'
 
     # Import all the calculations
     import_archive(filename1)

--- a/tests/tools/archive/orm/test_groups.py
+++ b/tests/tools/archive/orm/test_groups.py
@@ -184,13 +184,13 @@ def test_import_to_group(tmp_path, aiida_profile_clean):
 
     # Check Group for content
     builder = orm.QueryBuilder().append(orm.Group, filters={'label': group_label}, project='uuid')
-    assert (
-        builder.count() == 1
-    ), f'There should be exactly one Group with label {group_label}. Instead {builder.count()} was found.'
+    assert builder.count() == 1, (
+        f'There should be exactly one Group with label {group_label}. Instead {builder.count()} was found.'
+    )
     imported_group = load_group(builder.all()[0][0])
     assert imported_group.uuid == group_uuid
     assert imported_group.count() == len(node_uuids), (
-        '{} Nodes were found in the automatic import group, instead there should have been exactly {} ' 'Nodes'.format(
+        '{} Nodes were found in the automatic import group, instead there should have been exactly {} Nodes'.format(
             imported_group.count(), len(node_uuids)
         )
     )
@@ -207,7 +207,7 @@ def test_import_to_group(tmp_path, aiida_profile_clean):
     imported_group = load_group(label=group_label)
     assert imported_group.uuid == group_uuid
     assert imported_group.count() == len(node_uuids), (
-        '{} Nodes were found in the automatic import group, instead there should have been exactly {} ' 'Nodes'.format(
+        '{} Nodes were found in the automatic import group, instead there should have been exactly {} Nodes'.format(
             imported_group.count(), len(node_uuids)
         )
     )

--- a/tests/tools/archive/orm/test_links.py
+++ b/tests/tools/archive/orm/test_links.py
@@ -363,9 +363,9 @@ def test_high_level_workflow_links(aiida_profile_clean, tmp_path, aiida_localhos
             export_set = [tuple(_) for _ in export_links]
             import_set = [tuple(_) for _ in import_links]
 
-            assert set(export_set) == set(
-                import_set
-            ), f'Failed with c1={calcs[0]}, c2={calcs[1]}, w1={works[0]}, w2={works[1]}'
+            assert set(export_set) == set(import_set), (
+                f'Failed with c1={calcs[0]}, c2={calcs[1]}, w1={works[0]}, w2={works[1]}'
+            )
 
 
 def prepare_link_flags_export(nodes_to_export, test_data):
@@ -397,10 +397,10 @@ def link_flags_import_helper(test_data, reset_db):
         for node_type, node_cls in nodes_util.items():
             if node_type in expected_nodes:
                 builder = orm.QueryBuilder().append(node_cls, project='uuid')
-                assert builder.count() == len(
-                    expected_nodes[node_type]
-                ), 'Expected {} {} node(s), but got {}. Test: "{}"'.format(
-                    len(expected_nodes[node_type]), node_type, builder.count(), test
+                assert builder.count() == len(expected_nodes[node_type]), (
+                    'Expected {} {} node(s), but got {}. Test: "{}"'.format(
+                        len(expected_nodes[node_type]), node_type, builder.count(), test
+                    )
                 )
                 for node_uuid in builder.iterall():
                     assert node_uuid[0] in expected_nodes[node_type], f'Failed for test: "{test}"'
@@ -675,8 +675,9 @@ def test_multiple_post_return_links(tmp_path, aiida_profile_clean):
 
     links = get_all_node_links()
     assert len(links) == 1, (
-        'Only a single Link (from Calc. to Data) is expected, '
-        'instead {} were found (in, out, label, type): {}'.format(len(links), links)
+        'Only a single Link (from Calc. to Data) is expected, instead {} were found (in, out, label, type): {}'.format(
+            len(links), links
+        )
     )
     for from_uuid, to_uuid, found_label, found_type in links:
         assert from_uuid == calc_uuid
@@ -696,7 +697,7 @@ def test_multiple_post_return_links(tmp_path, aiida_profile_clean):
         assert node[0] in [data_uuid, calc_uuid, work_uuid]
 
     links = get_all_node_links()
-    assert (
-        len(links) == 2
-    ), f'Exactly two Links are expected, instead {len(links)} were found (in, out, label, type): {links}'
+    assert len(links) == 2, (
+        f'Exactly two Links are expected, instead {len(links)} were found (in, out, label, type): {links}'
+    )
     assert sorted(links) == sorted(before_links)

--- a/tests/tools/dumping/integration_tests.py
+++ b/tests/tools/dumping/integration_tests.py
@@ -1099,9 +1099,9 @@ class TestProfileDumping:
             # Should detect no changes via log
             profile.dump(output_path=output_path, all_entries=True)
 
-        assert (
-            'No changes detected since last dump' in caplog.text
-        ), "Engine did not log the expected 'No changes detected' message."
+        assert 'No changes detected since last dump' in caplog.text, (
+            "Engine did not log the expected 'No changes detected' message."
+        )
         compare_tree(expected=initial_tree, base_path=tmp_path)  # Structure remains identical
 
     @pytest.mark.usefixtures('aiida_profile_clean')
@@ -1135,9 +1135,9 @@ class TestProfileDumping:
         # Check mtime of original node dir DID NOT change
         mtime_orig_node_after = original_node_dump_path.stat().st_mtime
         # Use approx comparison due to potential filesystem time resolution issues
-        assert (
-            abs(mtime_orig_node_before - mtime_orig_node_after) < 0.1
-        ), 'Original node dump directory was modified in time-filtered incremental update'
+        assert abs(mtime_orig_node_before - mtime_orig_node_after) < 0.1, (
+            'Original node dump directory was modified in time-filtered incremental update'
+        )
 
         # Check new node dir DOES exist
         new_node_dir_name = f'{new_node.process_label}-{new_node.pk}'

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -1259,9 +1259,9 @@ def test_asynchronous_execution(custom_transport, tmp_path):
             # SSH connection etc.) and I don't want to have false failures.
             # Actually, if the time is short, it could mean also that the execution failed!
             # So I double check later that the execution was successful.
-            assert (
-                elapsed_time < 5
-            ), 'Getting back control after remote execution took more than 5 seconds! Probably submission blocks'
+            assert elapsed_time < 5, (
+                'Getting back control after remote execution took more than 5 seconds! Probably submission blocks'
+            )
 
             # Check that the job is still running
             # Wait 0.2 more seconds, so that I don't do a super-quick check that might return True
@@ -1321,7 +1321,7 @@ def test_compress_error_handling(custom_transport: Transport, tmp_path_remote: P
             transport.compress('unsupported_format', tmp_path_remote, tmp_path_remote / 'archive.tar', '/')
 
         # if the remotesource does not exist
-        with pytest.raises(OSError, match=f"{tmp_path_remote / 'non_existing'} does not exist"):
+        with pytest.raises(OSError, match=f'{tmp_path_remote / "non_existing"} does not exist'):
             transport.compress('tar', tmp_path_remote / 'non_existing', tmp_path_remote / 'archive.tar', '/')
 
         # if a matching pattern of the remote source is not found
@@ -1331,7 +1331,7 @@ def test_compress_error_handling(custom_transport: Transport, tmp_path_remote: P
         # if the remotedestination already exists
         Path(tmp_path_remote / 'already_exist.tar').touch()
         with pytest.raises(
-            OSError, match=f"The remote destination {tmp_path_remote / 'already_exist.tar'} already exists."
+            OSError, match=f'The remote destination {tmp_path_remote / "already_exist.tar"} already exists.'
         ):
             transport.compress('tar', tmp_path_remote, tmp_path_remote / 'already_exist.tar', '/', overwrite=False)
 
@@ -1342,7 +1342,7 @@ def test_compress_error_handling(custom_transport: Transport, tmp_path_remote: P
         # if the root_dir is not a directory
         with pytest.raises(
             OSError,
-            match=f"The relative root {tmp_path_remote / 'non_existing_folder'} does not exist, or is not a directory.",
+            match=f'The relative root {tmp_path_remote / "non_existing_folder"} does not exist, or is not a directory.',
         ):
             transport.compress(
                 'tar', tmp_path_remote, tmp_path_remote / 'archive.tar', tmp_path_remote / 'non_existing_folder'

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -147,9 +147,9 @@ class TestSemaphoreBehavior:
         tasks = [transport.exec_command_wait_async(f'cmd{i}') for i in range(5)]
         await asyncio.gather(*tasks)
 
-        assert (
-            max_concurrent <= max_allowed
-        ), f'Semaphore should limit to {max_allowed} concurrent ops, got {max_concurrent}'
+        assert max_concurrent <= max_allowed, (
+            f'Semaphore should limit to {max_allowed} concurrent ops, got {max_concurrent}'
+        )
         assert max_concurrent == max_allowed, f'Expected {max_allowed} concurrent ops to verify semaphore is being used'
 
 

--- a/utils/dependency_management.py
+++ b/utils/dependency_management.py
@@ -219,7 +219,7 @@ def validate_environment_yml():
     # the install_requirements for setuptools.
     if conda_dependencies:
         raise DependencySpecificationError(
-            "The 'environment.yml' file contains dependencies that are missing " "in 'pyproject.toml':\n- {}".format(
+            "The 'environment.yml' file contains dependencies that are missing in 'pyproject.toml':\n- {}".format(
                 '\n- '.join(map(str, conda_dependencies))
             )
         )

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -110,7 +110,7 @@ def validate_verdi_documentation():
     # Generate the new block with the command help strings
     header = 'Commands'
     message = 'Below is a list with all available subcommands.'
-    block = [f"{header}\n{'=' * len(header)}\n{message}\n\n"]
+    block = [f'{header}\n{"=" * len(header)}\n{message}\n\n']
 
     for name, command in sorted(verdi.commands.items()):
         if name == 'tui':


### PR DESCRIPTION
We use a very old ruff version. This PR updates it to 0.9.10. This is still very old, I purposefully do not update all the way to the latest version to ease the review.

In particular, this PR contains only formatter changes. Once this PR is merged, the resulting commit can be added to `.git-blame-ignore-revs` to preserver git-blame.

In a follow-up upgrade in #7439, there are some linter changes as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized string formatting, quoting, whitespace, and multiline expressions throughout the application.
  * Improved consistency of CLI output, logs, warnings, validation errors, and transport messages.
* **Documentation**
  * Clarified help text for archive import, band export, data export, node graph, and status commands.
* **Chores**
  * Updated code-quality tooling configuration.
* **Tests**
  * Refined assertions and expected messages to match the standardized output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->