### PR TITLE
👌  Capture broker probe failures in status

### DIFF
--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -86,7 +86,7 @@ class Broker(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_service_status(self) -> BrokerServiceStatus | None:
+    def probe_service_status(self) -> BrokerServiceStatus | None:
         """Return service status information for the broker, if available.
 
         :return: Structured service status information, or ``None`` if no status is available.

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -86,10 +86,12 @@ class Broker(abc.ABC):
         """
 
     @abc.abstractmethod
-    def probe_service_status(self) -> BrokerServiceStatus | None:
-        """Return service status information for the broker, if available.
+    def probe_service_status(self) -> BrokerServiceStatus:
+        """Return service status information for the broker.
 
-        :return: Structured service status information, or ``None`` if no status is available.
+        Retrieval failures should be captured in the returned status payload instead of raising.
+
+        :return: Structured service status information.
         """
 
     @abc.abstractmethod

--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -79,7 +79,7 @@ class Broker(abc.ABC):
         """
 
     @abc.abstractmethod
-    def is_service_reachable(self) -> bool:
+    def check_service_reachable(self) -> bool:
         """Return whether the broker service is reachable from this client.
 
         :return: ``True`` if the broker service can be reached, ``False`` otherwise.

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -104,20 +104,19 @@ class RabbitmqBroker(Broker):
 
         try:
             properties = self.get_communicator().server_properties
+            status: BrokerServiceStatus = {'connected': True}
+            status.update(
+                {
+                    key: t.cast(JsonValue, value.decode('utf-8') if isinstance(value, bytes) else value)
+                    for key, value in properties.items()
+                }
+            )
+            return status
         except Exception as exception:
             return {'connected': False, 'error': f'{type(exception).__name__}: {exception}'}
         finally:
             if not had_communicator:
                 self.close()
-
-        status: BrokerServiceStatus = {'connected': True}
-        status.update(
-            {
-                key: t.cast(JsonValue, value.decode('utf-8') if isinstance(value, bytes) else value)
-                for key, value in properties.items()
-            }
-        )
-        return status
 
     def check_service_reachable(self) -> bool:
         """Return whether the RabbitMQ service is reachable."""

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -98,7 +98,7 @@ class RabbitmqBroker(Broker):
         except ConnectionError:
             return f'RabbitMQ @ {url} <Connection failed>'
 
-    def get_service_status(self) -> BrokerServiceStatus | None:
+    def probe_service_status(self) -> BrokerServiceStatus | None:
         """Return status information reported by the RabbitMQ server."""
         properties = self.get_communicator().server_properties
         return {

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -113,7 +113,9 @@ class RabbitmqBroker(Broker):
             )
             return status
         except Exception as exception:
-            return {'connected': False, 'error': f'{type(exception).__name__}: {exception}'}
+            error = f'{type(exception).__name__}: {exception}'
+            LOGGER.error('Failed to probe broker status: %s', error)
+            return {'connected': False, 'error': error}
         finally:
             if not had_communicator:
                 self.close()

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -119,7 +119,7 @@ class RabbitmqBroker(Broker):
         )
         return status
 
-    def is_service_reachable(self) -> bool:
+    def check_service_reachable(self) -> bool:
         """Return whether the RabbitMQ service is reachable."""
         had_communicator = self._communicator is not None
 

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -98,13 +98,26 @@ class RabbitmqBroker(Broker):
         except ConnectionError:
             return f'RabbitMQ @ {url} <Connection failed>'
 
-    def probe_service_status(self) -> BrokerServiceStatus | None:
+    def probe_service_status(self) -> BrokerServiceStatus:
         """Return status information reported by the RabbitMQ server."""
-        properties = self.get_communicator().server_properties
-        return {
-            key: t.cast(JsonValue, value.decode('utf-8') if isinstance(value, bytes) else value)
-            for key, value in properties.items()
-        }
+        had_communicator = self._communicator is not None
+
+        try:
+            properties = self.get_communicator().server_properties
+        except Exception as exception:
+            return {'connected': False, 'error': f'{type(exception).__name__}: {exception}'}
+        finally:
+            if not had_communicator:
+                self.close()
+
+        status: BrokerServiceStatus = {'connected': True}
+        status.update(
+            {
+                key: t.cast(JsonValue, value.decode('utf-8') if isinstance(value, bytes) else value)
+                for key, value in properties.items()
+            }
+        )
+        return status
 
     def is_service_reachable(self) -> bool:
         """Return whether the RabbitMQ service is reachable."""

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -138,14 +138,23 @@ class ZeromqBroker(Broker):
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             return False
 
-    def probe_service_status(self) -> BrokerServiceStatus | None:
+    def probe_service_status(self) -> BrokerServiceStatus:
         """Read the ZeromqBrokerService status from its status file."""
+        connected = self.is_service_reachable()
+
         if not self._service_status_file.exists():
-            return None
+            return {
+                'connected': connected,
+                'error': f'Status file `{self._service_status_file}` does not exist.',
+            }
+
         try:
-            return t.cast(BrokerServiceStatus, json.loads(self._service_status_file.read_text()))
-        except (json.JSONDecodeError, OSError):
-            return None
+            status = t.cast(BrokerServiceStatus, json.loads(self._service_status_file.read_text()))
+        except (json.JSONDecodeError, OSError) as exception:
+            return {'connected': connected, 'error': f'{type(exception).__name__}: {exception}'}
+
+        status['connected'] = connected
+        return status
 
     # --- Communicator ---
 

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -76,7 +76,7 @@ class ZeromqBroker(Broker):
         self._storage_path = layout.storage_path
 
     def __str__(self) -> str:
-        if self.is_service_reachable():
+        if self.check_service_reachable():
             status = self.probe_service_status()
             pid = status.get('pid', '?') if status else '?'
             return f'ZeroMQ Broker (PID {pid}) @ {self._service_dir}'
@@ -127,7 +127,7 @@ class ZeromqBroker(Broker):
         except (ValueError, OSError):
             return None
 
-    def is_service_reachable(self) -> bool:
+    def check_service_reachable(self) -> bool:
         """Check if the ZeromqBrokerService process is running."""
         pid = self._get_service_pid()
         if pid is None:
@@ -140,7 +140,7 @@ class ZeromqBroker(Broker):
 
     def probe_service_status(self) -> BrokerServiceStatus:
         """Read the ZeromqBrokerService status from its status file."""
-        connected = self.is_service_reachable()
+        connected = self.check_service_reachable()
 
         if not self._service_status_file.exists():
             return {

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -77,7 +77,7 @@ class ZeromqBroker(Broker):
 
     def __str__(self) -> str:
         if self.is_service_reachable():
-            status = self.get_service_status()
+            status = self.probe_service_status()
             pid = status.get('pid', '?') if status else '?'
             return f'ZeroMQ Broker (PID {pid}) @ {self._service_dir}'
         return f'ZeroMQ Broker @ {self._service_dir} <not running>'
@@ -138,7 +138,7 @@ class ZeromqBroker(Broker):
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             return False
 
-    def get_service_status(self) -> BrokerServiceStatus | None:
+    def probe_service_status(self) -> BrokerServiceStatus | None:
         """Read the ZeromqBrokerService status from its status file."""
         if not self._service_status_file.exists():
             return None

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -149,7 +149,14 @@ class ZeromqBroker(Broker):
             }
 
         try:
-            status = t.cast(BrokerServiceStatus, json.loads(self._service_status_file.read_text()))
+            loaded_status = json.loads(self._service_status_file.read_text())
+            if not isinstance(loaded_status, dict):
+                msg = f'Invalid ZeroMQ service status file found: {loaded_status}'
+                LOGGER.warning(msg)
+                status: BrokerServiceStatus = {'error': msg}
+            else:
+                status = t.cast(BrokerServiceStatus, loaded_status)
+                status['error'] = None
         except (json.JSONDecodeError, OSError) as exception:
             return {'connected': connected, 'error': f'{type(exception).__name__}: {exception}'}
 

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -143,22 +143,23 @@ class ZeromqBroker(Broker):
         connected = self.check_service_reachable()
 
         if not self._service_status_file.exists():
-            return {
-                'connected': connected,
-                'error': f'Status file `{self._service_status_file}` does not exist.',
-            }
+            error = f'Status file `{self._service_status_file}` does not exist.'
+            LOGGER.warning('Failed to probe broker status: %s', error)
+            return {'connected': connected, 'error': error}
 
         try:
             loaded_status = json.loads(self._service_status_file.read_text())
             if not isinstance(loaded_status, dict):
                 msg = f'Invalid ZeroMQ service status file found: {loaded_status}'
-                LOGGER.warning(msg)
+                LOGGER.warning('Failed to probe broker status: %s', msg)
                 status: BrokerServiceStatus = {'error': msg}
             else:
                 status = t.cast(BrokerServiceStatus, loaded_status)
                 status['error'] = None
         except (json.JSONDecodeError, OSError) as exception:
-            return {'connected': connected, 'error': f'{type(exception).__name__}: {exception}'}
+            error = f'{type(exception).__name__}: {exception}'
+            LOGGER.warning('Failed to probe broker status: %s', error)
+            return {'connected': connected, 'error': error}
 
         status['connected'] = connected
         return status

--- a/src/aiida/cmdline/commands/cmd_bug_report.py
+++ b/src/aiida/cmdline/commands/cmd_bug_report.py
@@ -74,10 +74,10 @@ def _check_storage() -> dict[str, Any]:
     try:
         storage = manager.get_profile_storage()
         status = str(storage)
-        connected = True
+        error = None
     except Exception as exception:
-        connected = False
-        status = _format_exception(exception)
+        status = None
+        error = _format_exception(exception)
     finally:
         if not storage_loaded:
             try:
@@ -85,7 +85,7 @@ def _check_storage() -> dict[str, Any]:
             except Exception as exception:
                 LOGGER.warning(f'Failed to reset storage while collecting bug report diagnostics: {exception}')
 
-    return {'connected': connected, 'status': status}
+    return {'retrieval_error': error, 'status': status}
 
 
 def _check_broker() -> dict[str, Any]:
@@ -97,19 +97,22 @@ def _check_broker() -> dict[str, Any]:
     # this to avoid resetting a broker that was already loaded before running diagnostics, so use the private cache
     # attribute here and only reset brokers that this check caused to be loaded.
     broker_loaded = manager._broker is not None
-    status: dict[str, Any] | str | None = None
+    status: dict[str, Any] | None = None
 
     try:
         broker = manager.get_broker()
 
         if broker is None:
-            return {'connected': False, 'status': 'No broker configured for this profile.'}
+            return {
+                'retrieval_error': 'No broker configured for this profile.',
+                'status': None,
+            }
 
         status = broker.probe_service_status()
-        connected = bool(status.get('connected', False))
+        error = None
     except Exception as exception:
-        connected = False
-        status = _format_exception(exception)
+        status = None
+        error = _format_exception(exception)
     finally:
         if not broker_loaded:
             try:
@@ -117,7 +120,7 @@ def _check_broker() -> dict[str, Any]:
             except Exception as exception:
                 LOGGER.warning(f'Failed to reset broker while collecting bug report diagnostics: {exception}')
 
-    return {'connected': connected, 'status': status}
+    return {'retrieval_error': error, 'status': status}
 
 
 def _check_daemon() -> dict[str, Any]:
@@ -127,9 +130,9 @@ def _check_daemon() -> dict[str, Any]:
     try:
         status = get_manager().get_daemon_client().get_status()
     except Exception as exception:
-        return {'connected': False, 'status': _format_exception(exception)}
+        return {'retrieval_error': _format_exception(exception), 'status': None}
 
-    return {'connected': True, 'status': status}
+    return {'retrieval_error': None, 'status': status}
 
 
 def _collect_python_info() -> dict[str, Any]:

--- a/src/aiida/cmdline/commands/cmd_bug_report.py
+++ b/src/aiida/cmdline/commands/cmd_bug_report.py
@@ -106,7 +106,7 @@ def _check_broker() -> dict[str, Any]:
             return {'connected': False, 'status': 'No broker configured for this profile.'}
 
         status = broker.probe_service_status()
-        connected = status is not None
+        connected = bool(status.get('connected', False))
     except Exception as exception:
         connected = False
         status = _format_exception(exception)

--- a/src/aiida/cmdline/commands/cmd_bug_report.py
+++ b/src/aiida/cmdline/commands/cmd_bug_report.py
@@ -105,7 +105,7 @@ def _check_broker() -> dict[str, Any]:
         if broker is None:
             return {'connected': False, 'status': 'No broker configured for this profile.'}
 
-        status = broker.get_service_status()
+        status = broker.probe_service_status()
         connected = status is not None
     except Exception as exception:
         connected = False

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -158,18 +158,17 @@ def status(ctx, all_profiles, timeout):
         from aiida.brokers.zeromq.broker import ZeromqBroker
 
         if isinstance(broker, ZeromqBroker):
-            if broker.is_service_reachable():
-                status_info = broker.probe_service_status()
-                if status_info:
-                    broker_pid = status_info.get('pid', '?')
-                    pending = status_info.get('pending_tasks', 0)
-                    processing = status_info.get('processing_tasks', 0)
-                    broker_lines.append(
-                        f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]'
-                    )
-                    broker_lines.append(f'Broker directory: {broker.service_dir}')
+            status_info = broker.probe_service_status()
+            if status_info.get('connected', False):
+                broker_pid = status_info.get('pid', '?')
+                pending = status_info.get('pending_tasks', 0)
+                processing = status_info.get('processing_tasks', 0)
+                broker_lines.append(
+                    f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]'
+                )
+                broker_lines.append(f'Broker directory: {broker.service_dir}')
             else:
-                broker_lines.append('Broker is NOT running')
+                broker_lines.append(str(status_info.get('error', 'Broker is NOT running')))
 
         lines = [
             f'Daemon is running as PID {daemon_response["info"]["pid"]} since {start_time}',

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -161,14 +161,14 @@ def status(ctx, all_profiles, timeout):
             status_info = broker.probe_service_status()
             if status_info.get('connected', False):
                 broker_pid = status_info.get('pid', '?')
-                pending = status_info.get('pending_tasks', 0)
-                processing = status_info.get('processing_tasks', 0)
+                pending = status_info.get('pending_tasks', '?')
+                processing = status_info.get('processing_tasks', '?')
                 broker_lines.append(
                     f'Broker is running as PID {broker_pid} [{pending} pending, {processing} processing]'
                 )
-                broker_lines.append(f'Broker directory: {broker.service_dir}')
             else:
-                broker_lines.append(str(status_info.get('error', 'Broker is NOT running')))
+                broker_lines.append('Broker is NOT running.')
+            broker_lines.append(f'Broker directory: {broker.service_dir}')
 
         lines = [
             f'Daemon is running as PID {daemon_response["info"]["pid"]} since {start_time}',

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -159,7 +159,7 @@ def status(ctx, all_profiles, timeout):
 
         if isinstance(broker, ZeromqBroker):
             if broker.is_service_reachable():
-                status_info = broker.get_service_status()
+                status_info = broker.probe_service_status()
                 if status_info:
                     broker_pid = status_info.get('pid', '?')
                     pending = status_info.get('pending_tasks', 0)

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -183,7 +183,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
 
         if broker and isinstance(broker, ZeromqBroker):
             if broker.is_service_reachable():
-                status_info = broker.get_service_status()
+                status_info = broker.probe_service_status()
                 if status_info:
                     broker_pid = status_info.get('pid', '?')
                     pending = status_info.get('pending_tasks', 0)

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -185,12 +185,12 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
             status_info = broker.probe_service_status()
             if status_info.get('connected', False):
                 broker_pid = status_info.get('pid', '?')
-                pending = status_info.get('pending_tasks', 0)
-                processing = status_info.get('processing_tasks', 0)
+                pending = status_info.get('pending_tasks', '?')
+                processing = status_info.get('processing_tasks', '?')
                 daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
             else:
-                error = status_info.get('error', 'Broker is NOT running')
-                daemon_msg += f', {error}'
+                daemon_status = ServiceStatus.WARNING
+                daemon_msg += ', Broker is NOT running (run `verdi daemon status` for more information)'
 
         daemon_lines = [daemon_msg]
 

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -182,15 +182,15 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         # Append broker info for managed brokers (e.g., ZeroMQ)
 
         if broker and isinstance(broker, ZeromqBroker):
-            if broker.is_service_reachable():
-                status_info = broker.probe_service_status()
-                if status_info:
-                    broker_pid = status_info.get('pid', '?')
-                    pending = status_info.get('pending_tasks', 0)
-                    processing = status_info.get('processing_tasks', 0)
-                    daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
+            status_info = broker.probe_service_status()
+            if status_info.get('connected', False):
+                broker_pid = status_info.get('pid', '?')
+                pending = status_info.get('pending_tasks', 0)
+                processing = status_info.get('processing_tasks', 0)
+                daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
             else:
-                daemon_msg += ', Broker is NOT running'
+                error = status_info.get('error', 'Broker is NOT running')
+                daemon_msg += f', {error}'
 
         daemon_lines = [daemon_msg]
 

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -985,7 +985,7 @@ class DaemonClient:
             except Exception:
                 LOGGER.warning('Could not load the broker instance while preparing daemon watchers.', exc_info=True)
                 broker_instance = None
-            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.is_service_reachable():
+            if isinstance(broker_instance, ZeromqBroker) and not broker_instance.check_service_reachable():
                 # prepare zmq broker service profile directory
                 pathlib.Path(self.zmq_broker_service_dir).mkdir(parents=True, exist_ok=True)
 

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -67,6 +67,18 @@ def test_probe_service_status_failure(monkeypatch, manager):
     assert broker.probe_service_status() == {'connected': False, 'error': 'ConnectionError: connection failed'}
 
 
+def test_probe_service_status_invalid_property_encoding(monkeypatch, manager):
+    """Test RabbitMQ service status captures non-UTF-8 server properties in the payload."""
+    broker = manager.get_broker()
+    communicator = MagicMock(server_properties={'product': b'\xff'})
+    monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
+
+    status = broker.probe_service_status()
+
+    assert status['connected'] is False
+    assert str(status['error']).startswith('UnicodeDecodeError:')
+
+
 def test_check_service_reachable(monkeypatch, manager):
     """Test RabbitMQ service reachability checks open and close a fresh communicator."""
     broker = manager.get_broker()

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -55,7 +55,7 @@ def test_probe_service_status(monkeypatch, manager):
     assert broker.probe_service_status() == {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'}
 
 
-def test_probe_service_status_failure(monkeypatch, manager):
+def test_probe_service_status_failure(monkeypatch, manager, caplog):
     """Test RabbitMQ service status captures connection failures in the payload."""
     broker = manager.get_broker()
 
@@ -65,9 +65,10 @@ def test_probe_service_status_failure(monkeypatch, manager):
     monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
 
     assert broker.probe_service_status() == {'connected': False, 'error': 'ConnectionError: connection failed'}
+    assert 'Failed to probe broker status: ConnectionError: connection failed' in caplog.text
 
 
-def test_probe_service_status_invalid_property_encoding(monkeypatch, manager):
+def test_probe_service_status_invalid_property_encoding(monkeypatch, manager, caplog):
     """Test RabbitMQ service status captures non-UTF-8 server properties in the payload."""
     broker = manager.get_broker()
     communicator = MagicMock(server_properties={'product': b'\xff'})
@@ -77,6 +78,7 @@ def test_probe_service_status_invalid_property_encoding(monkeypatch, manager):
 
     assert status['connected'] is False
     assert str(status['error']).startswith('UnicodeDecodeError:')
+    assert 'Failed to probe broker status: UnicodeDecodeError:' in caplog.text
 
 
 def test_check_service_reachable(monkeypatch, manager):

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -46,13 +46,13 @@ def test_str_method(monkeypatch, manager):
     assert unsafe_url not in broker_string
 
 
-def test_get_service_status(monkeypatch, manager):
+def test_probe_service_status(monkeypatch, manager):
     """Test RabbitMQ service status is derived from server properties."""
     broker = manager.get_broker()
     communicator = MagicMock(server_properties={'product': b'RabbitMQ', 'version': '3.12.0'})
     monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
 
-    assert broker.get_service_status() == {'product': 'RabbitMQ', 'version': '3.12.0'}
+    assert broker.probe_service_status() == {'product': 'RabbitMQ', 'version': '3.12.0'}
 
 
 def test_is_service_reachable(monkeypatch, manager):

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -52,7 +52,19 @@ def test_probe_service_status(monkeypatch, manager):
     communicator = MagicMock(server_properties={'product': b'RabbitMQ', 'version': '3.12.0'})
     monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
 
-    assert broker.probe_service_status() == {'product': 'RabbitMQ', 'version': '3.12.0'}
+    assert broker.probe_service_status() == {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'}
+
+
+def test_probe_service_status_failure(monkeypatch, manager):
+    """Test RabbitMQ service status captures connection failures in the payload."""
+    broker = manager.get_broker()
+
+    def raise_connection_error():
+        raise ConnectionError('connection failed')
+
+    monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
+
+    assert broker.probe_service_status() == {'connected': False, 'error': 'ConnectionError: connection failed'}
 
 
 def test_is_service_reachable(monkeypatch, manager):

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -67,7 +67,7 @@ def test_probe_service_status_failure(monkeypatch, manager):
     assert broker.probe_service_status() == {'connected': False, 'error': 'ConnectionError: connection failed'}
 
 
-def test_is_service_reachable(monkeypatch, manager):
+def test_check_service_reachable(monkeypatch, manager):
     """Test RabbitMQ service reachability checks open and close a fresh communicator."""
     broker = manager.get_broker()
     communicator = MagicMock()
@@ -75,7 +75,7 @@ def test_is_service_reachable(monkeypatch, manager):
     monkeypatch.setattr(broker, 'get_communicator', lambda: communicator)
     monkeypatch.setattr(broker, 'close', close)
 
-    assert broker.is_service_reachable() is True
+    assert broker.check_service_reachable() is True
     close.assert_called_once_with()
 
 
@@ -90,7 +90,7 @@ def test_is_service_reachable_false(monkeypatch, manager):
     monkeypatch.setattr(broker, 'get_communicator', raise_connection_error)
     monkeypatch.setattr(broker, 'close', close)
 
-    assert broker.is_service_reachable() is False
+    assert broker.check_service_reachable() is False
     close.assert_called_once_with()
 
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -57,9 +57,9 @@ class TestZeromqBrokerStatusQueries:
         """Test is_running returns False when no PID file exists."""
         assert not zeromq_broker.is_service_reachable()
 
-    def test_get_service_status_no_file(self, zeromq_broker):
-        """Test get_service_status returns None when no status file exists."""
-        assert zeromq_broker.get_service_status() is None
+    def test_probe_service_status_no_file(self, zeromq_broker):
+        """Test probe_service_status returns None when no status file exists."""
+        assert zeromq_broker.probe_service_status() is None
 
     def test_str_running(self, zeromq_broker_with_server):
         """Test __str__ when running."""
@@ -88,19 +88,19 @@ class TestZeromqBrokerStatusQueries:
         with patch('aiida.brokers.zeromq.broker.psutil.Process', side_effect=psutil.NoSuchProcess(pid=12345)):
             assert not zeromq_broker.is_service_reachable()
 
-    def test_get_service_status_valid(self, zeromq_broker):
-        """Test get_service_status with valid JSON."""
+    def test_probe_service_status_valid(self, zeromq_broker):
+        """Test probe_service_status with valid JSON."""
         status_file = zeromq_broker.service_dir / 'broker.status'
         status_file.write_text(json.dumps({'pid': 123, 'running': True}))
-        status = zeromq_broker.get_service_status()
+        status = zeromq_broker.probe_service_status()
         assert status is not None
         assert status['pid'] == 123
 
-    def test_get_service_status_invalid_json(self, zeromq_broker):
-        """Test get_service_status with invalid JSON."""
+    def test_probe_service_status_invalid_json(self, zeromq_broker):
+        """Test probe_service_status with invalid JSON."""
         status_file = zeromq_broker.service_dir / 'broker.status'
         status_file.write_text('{INVALID JSON')
-        assert zeromq_broker.get_service_status() is None
+        assert zeromq_broker.probe_service_status() is None
 
 
 class TestZeromqBrokerCommunicator:
@@ -226,6 +226,6 @@ class TestZeromqBrokerIntegration:
         """Test the zeromq_broker lifecycle."""
         assert zeromq_broker_with_server.is_service_reachable()
 
-        status = zeromq_broker_with_server.get_service_status()
+        status = zeromq_broker_with_server.probe_service_status()
         assert status is not None
         assert 'pid' in status

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -58,8 +58,11 @@ class TestZeromqBrokerStatusQueries:
         assert not zeromq_broker.is_service_reachable()
 
     def test_probe_service_status_no_file(self, zeromq_broker):
-        """Test probe_service_status returns None when no status file exists."""
-        assert zeromq_broker.probe_service_status() is None
+        """Test probe_service_status captures a missing status file in the payload."""
+        assert zeromq_broker.probe_service_status() == {
+            'connected': False,
+            'error': f'Status file `{zeromq_broker.service_dir / "broker.status"}` does not exist.',
+        }
 
     def test_str_running(self, zeromq_broker_with_server):
         """Test __str__ when running."""
@@ -93,14 +96,16 @@ class TestZeromqBrokerStatusQueries:
         status_file = zeromq_broker.service_dir / 'broker.status'
         status_file.write_text(json.dumps({'pid': 123, 'running': True}))
         status = zeromq_broker.probe_service_status()
-        assert status is not None
+        assert status['connected'] is False
         assert status['pid'] == 123
 
     def test_probe_service_status_invalid_json(self, zeromq_broker):
-        """Test probe_service_status with invalid JSON."""
+        """Test probe_service_status captures invalid JSON in the payload."""
         status_file = zeromq_broker.service_dir / 'broker.status'
         status_file.write_text('{INVALID JSON')
-        assert zeromq_broker.probe_service_status() is None
+        status = zeromq_broker.probe_service_status()
+        assert status['connected'] is False
+        assert 'JSONDecodeError:' in str(status['error'])
 
 
 class TestZeromqBrokerCommunicator:
@@ -227,5 +232,5 @@ class TestZeromqBrokerIntegration:
         assert zeromq_broker_with_server.is_service_reachable()
 
         status = zeromq_broker_with_server.probe_service_status()
-        assert status is not None
+        assert status['connected'] is True
         assert 'pid' in status

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -55,7 +55,7 @@ class TestZeromqBrokerStatusQueries:
 
     def test_is_running_no_pid_file(self, zeromq_broker):
         """Test is_running returns False when no PID file exists."""
-        assert not zeromq_broker.is_service_reachable()
+        assert not zeromq_broker.check_service_reachable()
 
     def test_probe_service_status_no_file(self, zeromq_broker):
         """Test probe_service_status captures a missing status file in the payload."""
@@ -89,7 +89,7 @@ class TestZeromqBrokerStatusQueries:
         pid_file.write_text('aiida-zeromq-broker 12345')
 
         with patch('aiida.brokers.zeromq.broker.psutil.Process', side_effect=psutil.NoSuchProcess(pid=12345)):
-            assert not zeromq_broker.is_service_reachable()
+            assert not zeromq_broker.check_service_reachable()
 
     def test_probe_service_status_valid(self, zeromq_broker):
         """Test probe_service_status with valid JSON."""
@@ -239,7 +239,7 @@ class TestZeromqBrokerIntegration:
 
     def test_broker_lifecycle(self, zeromq_broker_with_server):
         """Test the zeromq_broker lifecycle."""
-        assert zeromq_broker_with_server.is_service_reachable()
+        assert zeromq_broker_with_server.check_service_reachable()
 
         status = zeromq_broker_with_server.probe_service_status()
         assert status['connected'] is True

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -107,6 +107,16 @@ class TestZeromqBrokerStatusQueries:
         assert status['connected'] is False
         assert 'JSONDecodeError:' in str(status['error'])
 
+    def test_probe_service_status_invalid_payload_type(self, zeromq_broker, caplog):
+        """Test probe_service_status captures valid JSON with an invalid top-level type."""
+        status_file = zeromq_broker.service_dir / 'broker.status'
+        status_file.write_text(json.dumps(['invalid']))
+
+        status = zeromq_broker.probe_service_status()
+
+        assert status == {'connected': False, 'error': "Invalid ZeroMQ service status file found: ['invalid']"}
+        assert "Invalid ZeroMQ service status file found: ['invalid']" in caplog.text
+
 
 class TestZeromqBrokerCommunicator:
     """Tests for ZeromqBroker communicator management."""

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -44,7 +44,7 @@ class DummyBroker:
         return object()
 
     def probe_service_status(self):
-        return {'product': 'RabbitMQ', 'version': '3.12.0'}
+        return {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'}
 
     def close(self):
         self.closed = True
@@ -71,7 +71,7 @@ class BrokenStorageCloseBackend(DummyStorageBackend):
         raise RuntimeError('storage close unavailable')
 
 
-def _make_zeromq_broker(service_dir: pathlib.Path, is_running: bool, status: dict | None) -> ZeromqBroker:
+def _make_zeromq_broker(service_dir: pathlib.Path, is_running: bool, status: dict) -> ZeromqBroker:
     """Create a ``ZeromqBroker`` instance without invoking its constructor."""
     broker = ZeromqBroker.__new__(ZeromqBroker)
     broker._service_dir = service_dir
@@ -170,7 +170,10 @@ def test_collect_diagnostics(monkeypatch, tmp_path):
             _get_daemon_client_ok,
             {
                 'storage': {'connected': True, 'status': 'DummyStorageBackend'},
-                'broker': {'connected': True, 'status': {'product': 'RabbitMQ', 'version': '3.12.0'}},
+                'broker': {
+                    'connected': True,
+                    'status': {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'},
+                },
                 'daemon': {'connected': True, 'status': {'pid': 1234}},
             },
             id='connected',
@@ -206,8 +209,8 @@ def test_collect_diagnostics_services(
 @pytest.mark.parametrize(
     ('is_running', 'status'),
     [
-        (True, {'pid': 4321, 'pending_tasks': 0}),
-        (False, None),
+        (True, {'connected': True, 'pid': 4321, 'pending_tasks': 0}),
+        (False, {'connected': False, 'error': 'Broker is NOT running'}),
     ],
 )
 def test_check_broker_zeromq_status(monkeypatch, tmp_path, is_running, status):
@@ -218,7 +221,7 @@ def test_check_broker_zeromq_status(monkeypatch, tmp_path, is_running, status):
 
     result = cmd_bug_report._check_broker()
 
-    assert result['connected'] is (status is not None)
+    assert result['connected'] is status['connected']
     assert result['status'] == status
 
 
@@ -375,7 +378,10 @@ def test_check_broker_reset_failure_is_logged(monkeypatch, caplog):
 
     result = cmd_bug_report._check_broker()
 
-    assert result == {'connected': True, 'status': {'product': 'RabbitMQ', 'version': '3.12.0'}}
+    assert result == {
+        'connected': True,
+        'status': {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'},
+    }
     assert 'Failed to reset broker while collecting bug report diagnostics' in caplog.text
 
 
@@ -393,7 +399,10 @@ def test_check_broker_does_not_reset_preloaded_broker(monkeypatch):
 
     result = cmd_bug_report._check_broker()
 
-    assert result == {'connected': True, 'status': {'product': 'RabbitMQ', 'version': '3.12.0'}}
+    assert result == {
+        'connected': True,
+        'status': {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'},
+    }
     assert reset_called is False
     assert broker.closed is False
 

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -43,7 +43,7 @@ class DummyBroker:
     def get_communicator(self):
         return object()
 
-    def get_service_status(self):
+    def probe_service_status(self):
         return {'product': 'RabbitMQ', 'version': '3.12.0'}
 
     def close(self):
@@ -76,7 +76,7 @@ def _make_zeromq_broker(service_dir: pathlib.Path, is_running: bool, status: dic
     broker = ZeromqBroker.__new__(ZeromqBroker)
     broker._service_dir = service_dir
     broker.is_service_reachable = lambda: is_running
-    broker.get_service_status = lambda: status
+    broker.probe_service_status = lambda: status
     return broker
 
 

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -169,25 +169,28 @@ def test_collect_diagnostics(monkeypatch, tmp_path):
             DummyBroker,
             _get_daemon_client_ok,
             {
-                'storage': {'connected': True, 'status': 'DummyStorageBackend'},
+                'storage': {'retrieval_error': None, 'status': 'DummyStorageBackend'},
                 'broker': {
-                    'connected': True,
+                    'retrieval_error': None,
                     'status': {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'},
                 },
-                'daemon': {'connected': True, 'status': {'pid': 1234}},
+                'daemon': {'retrieval_error': None, 'status': {'pid': 1234}},
             },
-            id='connected',
+            id='status-retrieved',
         ),
         pytest.param(
             BrokenStorageBackend,
             None,
             _get_daemon_client_error,
             {
-                'storage': {'connected': False, 'status': 'RuntimeError: storage unavailable'},
-                'broker': {'connected': False, 'status': 'No broker configured for this profile.'},
-                'daemon': {'connected': False, 'status': 'RuntimeError: daemon unavailable'},
+                'storage': {'retrieval_error': 'RuntimeError: storage unavailable', 'status': None},
+                'broker': {
+                    'retrieval_error': 'No broker configured for this profile.',
+                    'status': None,
+                },
+                'daemon': {'retrieval_error': 'RuntimeError: daemon unavailable', 'status': None},
             },
-            id='not-connected',
+            id='status-not-retrieved',
         ),
     ],
 )
@@ -221,8 +224,7 @@ def test_check_broker_zeromq_status(monkeypatch, tmp_path, is_running, status):
 
     result = cmd_bug_report._check_broker()
 
-    assert result['connected'] is status['connected']
-    assert result['status'] == status
+    assert result == {'retrieval_error': None, 'status': status}
 
 
 def test_get_config_data(monkeypatch, tmp_path):
@@ -345,8 +347,8 @@ def test_check_storage_failure_after_instantiation(monkeypatch):
     monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
 
     assert cmd_bug_report._check_storage() == {
-        'connected': False,
-        'status': 'RuntimeError: storage string unavailable',
+        'retrieval_error': 'RuntimeError: storage string unavailable',
+        'status': None,
     }
 
 
@@ -362,7 +364,7 @@ def test_check_storage_close_failure_is_logged(monkeypatch, caplog):
 
     result = cmd_bug_report._check_storage()
 
-    assert result == {'connected': True, 'status': 'DummyStorageBackend'}
+    assert result == {'retrieval_error': None, 'status': 'DummyStorageBackend'}
     assert 'Failed to reset storage while collecting bug report diagnostics' in caplog.text
 
 
@@ -379,7 +381,7 @@ def test_check_broker_reset_failure_is_logged(monkeypatch, caplog):
     result = cmd_bug_report._check_broker()
 
     assert result == {
-        'connected': True,
+        'retrieval_error': None,
         'status': {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'},
     }
     assert 'Failed to reset broker while collecting bug report diagnostics' in caplog.text
@@ -400,7 +402,7 @@ def test_check_broker_does_not_reset_preloaded_broker(monkeypatch):
     result = cmd_bug_report._check_broker()
 
     assert result == {
-        'connected': True,
+        'retrieval_error': None,
         'status': {'connected': True, 'product': 'RabbitMQ', 'version': '3.12.0'},
     }
     assert reset_called is False
@@ -425,7 +427,7 @@ def test_check_storage_does_not_reset_preloaded_storage(monkeypatch):
 
     result = cmd_bug_report._check_storage()
 
-    assert result == {'connected': True, 'status': 'DummyStorageBackend'}
+    assert result == {'retrieval_error': None, 'status': 'DummyStorageBackend'}
     assert reset_called is False
     assert storage.closed is False
 
@@ -444,7 +446,7 @@ def test_bug_report_command(run_cli_command, tmp_path):
 
     assert diagnostics['aiida_version'] == aiida.__version__
     assert diagnostics['profile'] is not None
-    assert diagnostics['services']['storage']['connected'] is True
+    assert diagnostics['services']['storage']['retrieval_error'] is None
 
 
 def test_bug_report_command_default_output(run_cli_command, monkeypatch, tmp_path):

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -14,8 +14,10 @@ from unittest.mock import patch
 import pytest
 
 from aiida import get_profile
+from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.cmdline.commands import cmd_daemon
 from aiida.engine.daemon.client import DaemonClient, DaemonTimeoutException
+from aiida.manage import get_manager
 
 pytestmark = pytest.mark.requires_broker
 
@@ -195,6 +197,26 @@ def get_worker_info_broken(_):
         'info': {'4990': 'No such process (stopped?)'},
         'id': '4e1d768a522a44b59f85039806f9af14',
     }
+
+
+@patch.object(DaemonClient, 'get_status', lambda *_, **__: {'status': 'running'})
+@patch.object(DaemonClient, 'get_daemon_info', get_daemon_info)
+@patch.object(DaemonClient, 'get_worker_info', get_worker_info)
+@patch('aiida.cmdline.utils.common.format_local_time', format_local_time)
+def test_daemon_status_surfaces_zeromq_probe_error(run_cli_command, monkeypatch, tmp_path):
+    """Test ``verdi daemon status`` surfaces ZeroMQ probe errors even when the broker is reachable."""
+    broker = ZeromqBroker.__new__(ZeromqBroker)
+    broker._service_dir = tmp_path
+    broker._service_log_file = tmp_path / 'broker.log'
+    broker._service_status_file = tmp_path / 'broker.status'
+    broker._service_status_file.write_text('{INVALID JSON')
+    broker.check_service_reachable = lambda: True
+    monkeypatch.setattr(get_manager(), 'get_broker', lambda: broker)
+
+    result = run_cli_command(cmd_daemon.status, use_subprocess=False)
+
+    assert 'Failed to probe broker status: JSONDecodeError' in result.output
+    assert 'Broker is running as PID ? [? pending, ? processing]' in result.output
 
 
 @patch.object(DaemonClient, 'get_status', lambda *_, **__: {'status': 'running'})

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -13,10 +13,12 @@ import sys
 import pytest
 
 from aiida import __version__, get_profile
+from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.cmdline.commands import cmd_status
 from aiida.cmdline.utils.echo import ExitCode
 from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.engine.daemon.client import DaemonClient
+from aiida.manage import get_manager
 from aiida.storage.psql_dos import migrator
 
 
@@ -133,6 +135,25 @@ def test_sqlite_version(run_cli_command, monkeypatch):
         monkeypatch.setattr('aiida.storage.sqlite_zip.backend.validate_sqlite_version', mock_)
         result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
         assert mock_.call_count == 0
+
+
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_status_surfaces_zeromq_probe_error(run_cli_command, monkeypatch, tmp_path):
+    """Test ``verdi status`` surfaces ZeroMQ probe errors even when the broker is reachable."""
+    broker = ZeromqBroker.__new__(ZeromqBroker)
+    broker._service_dir = tmp_path
+    broker._service_log_file = tmp_path / 'broker.log'
+    broker._service_status_file = tmp_path / 'broker.status'
+    broker._service_status_file.write_text('{INVALID JSON')
+    broker.check_service_reachable = lambda: True
+    monkeypatch.setattr(get_manager(), 'get_broker', lambda: broker)
+    monkeypatch.setattr(DaemonClient, 'get_status', lambda self, timeout=None: {'pid': 12345})
+    monkeypatch.setattr(DaemonClient, 'get_daemon_env_info', lambda self: None)
+
+    result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+
+    assert 'Failed to probe broker status: JSONDecodeError' in result.output
+    assert 'Broker is running as PID ? [? pending, ? processing]' not in result.output
 
 
 @pytest.mark.usefixtures('stopped_daemon_client')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def zeromq_broker(tmp_path):
 @contextmanager
 def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0):
     """Run a ZeroMQ broker service subprocess for the duration of a context."""
-    if zeromq_broker.is_service_reachable():
+    if zeromq_broker.check_service_reachable():
         raise ValueError('Broker server already running')
 
     zeromq_broker.service_dir.mkdir(parents=True, exist_ok=True)
@@ -122,7 +122,7 @@ def _run_zeromq_broker_server(zeromq_broker: ZeromqBroker, timeout: float = 10.0
             if process.poll() is not None:
                 msg = f'ZeroMQ broker exited before becoming ready with code {process.returncode}'
                 raise RuntimeError(msg)
-            if zeromq_broker.is_service_reachable():
+            if zeromq_broker.check_service_reachable():
                 break
             time.sleep(0.1)
         else:


### PR DESCRIPTION
The name `get_service_status()` did not reflect the client-server nature so it was renamed to `probe_service_status()`. Also None is removed as possible return type. In case of an error the error msg should be included in the returned status dict. My main concern was that in `verdi bug-report` I assumed that a failure of the former `get_service_status()` means that there is no connection but a failure could have different reasons. I let the implementation decide to resolve the error and include it in the status field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified broker availability checks with a new “probe” workflow that always returns structured status details, including explicit error information on failures.
  * Renamed reachability API to `check_service_reachable()` and updated ZeroMQ/RabbitMQ behavior and messaging accordingly.
  * `verdi status`, `verdi daemon status`, and `verdi bug-report` now surface richer broker diagnostics, including broker-log error hints when probe parsing fails.
* **Tests**
  * Updated and expanded broker and command-line tests to match the new probe/status contract and verify CLI error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->