### PR TITLE
♻️ Rename broker_service config filepaths key

### DIFF
--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -66,8 +66,8 @@ class ZeromqBroker(Broker):
 
         from aiida.manage.configuration import get_config
 
-        zmq_broker_service_dir = get_config().filepaths(profile)['zmq_broker_service']['dir']
-        zmq_broker_service_log_path = get_config().filepaths(profile)['zmq_broker_service']['log']
+        zmq_broker_service_dir = get_config().filepaths(profile)['broker_service']['dir']
+        zmq_broker_service_log_path = get_config().filepaths(profile)['broker_service']['log']
         layout = ZeromqBrokerService.FilepathLayout(zmq_broker_service_dir, zmq_broker_service_log_path)
         self._service_dir = layout.service_dir
         self._service_pid_file = layout.pid_file

--- a/src/aiida/cmdline/commands/cmd_bug_report.py
+++ b/src/aiida/cmdline/commands/cmd_bug_report.py
@@ -219,7 +219,7 @@ def _get_log_files() -> list[pathlib.Path]:
         filepaths['profile']['log'],
         filepaths['circus']['log'],
         filepaths['daemon']['log'],
-        filepaths['zmq_broker_service']['log'],
+        filepaths['broker_service']['log'],
     ]
 
     for log_filepath in log_filepaths:

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -290,12 +290,12 @@ class DaemonClient:
 
         The daemon manages the broker service and therefore determines where the service writes its state files.
         """
-        return self._config.filepaths(self.profile)['zmq_broker_service']['dir']
+        return self._config.filepaths(self.profile)['broker_service']['dir']
 
     @property
     def zmq_broker_service_log_file(self) -> str:
         """Return the log file of the ZMQ broker service, derived from the settings."""
-        return self._config.filepaths(self.profile)['zmq_broker_service']['log']
+        return self._config.filepaths(self.profile)['broker_service']['log']
 
     @property
     def _cmd_start_zmq_broker(self) -> list[str]:

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -94,7 +94,7 @@ class ConfigFilepaths(TypedDict):
     profile: ProfileFilepaths
     circus: CircusFilepaths
     daemon: DaemonFilepaths
-    zmq_broker_service: ZeromqBrokerServiceFilepaths
+    broker_service: ZeromqBrokerServiceFilepaths
 
 
 class ConfigVersionSchema(BaseModel, defer_build=True):
@@ -1043,7 +1043,7 @@ class Config:
                 'pid': str(daemon_dir / f'aiida-{profile.name}.pid'),
                 'daemon_env_info': str(daemon_dir / f'aiida-{profile.name}-env-info.json'),
             },
-            'zmq_broker_service': {
+            'broker_service': {
                 'dir': str(zmq_broker_service_base_dir / f'{profile.uuid}-{profile.name}'),
                 'log': str(zmq_broker_service_base_dir / f'{profile.uuid}-{profile.name}' / 'broker.log'),
             },

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -111,7 +111,7 @@ def _make_filepaths(dirpath: pathlib.Path) -> dict:
         'profile': {'log': str(dirpath / 'profile.log')},
         'daemon': {'log': str(dirpath / 'daemon.log')},
         'circus': {'log': str(dirpath / 'circus.log')},
-        'zmq_broker_service': {'dir': str(dirpath / 'broker'), 'log': str(dirpath / 'broker' / 'broker.log')},
+        'broker_service': {'dir': str(dirpath / 'broker'), 'log': str(dirpath / 'broker' / 'broker.log')},
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def _patch_zmq_broker_service_filepaths(profile, service_dir: Path):
         result = copy.deepcopy(original_filepaths(current_profile))
 
         if current_profile is profile:
-            result['zmq_broker_service'] = {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
+            result['broker_service'] = {'dir': str(service_dir), 'log': str(service_dir / 'broker.log')}
 
         return result
 

--- a/tests/manage/configuration/test_config.py
+++ b/tests/manage/configuration/test_config.py
@@ -239,10 +239,10 @@ def test_filepaths_include_daemon_and_zmq_broker_entries(config_with_profile):
     filepaths = config.filepaths(profile)
     assert 'daemon_env_info' in filepaths['daemon']
     assert filepaths['daemon']['daemon_env_info'].endswith('-env-info.json')
-    assert 'zmq_broker_service' in filepaths
+    assert 'broker_service' in filepaths
     expected_dir_suffix = f'{profile.uuid}-{profile.name}'
-    assert filepaths['zmq_broker_service']['dir'].endswith(expected_dir_suffix)
-    assert filepaths['zmq_broker_service']['log'].endswith(f'{expected_dir_suffix}/broker.log')
+    assert filepaths['broker_service']['dir'].endswith(expected_dir_suffix)
+    assert filepaths['broker_service']['log'].endswith(f'{expected_dir_suffix}/broker.log')
 
 
 def test_setting_versions(config_with_profile):


### PR DESCRIPTION
Rename the config filepaths entry for the managed broker service from `zmq_broker_service` to `broker_service`.

This keeps the configuration payload more generic while leaving existing internal variable names unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized broker service configuration and file paths under the `broker_service` setting.
  * Broker startup, daemon management, and diagnostic tools now consistently locate the broker service directory and log file.
  * `verdi bug-report` now includes the correct broker log in generated diagnostic bundles.

* **Documentation**
  * Existing configurations using `zmq_broker_service` should be updated to `broker_service`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->