### PR TITLE
👌 Expose part of `verdi daemon` commands when no broker is defined

### DIFF
--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -126,7 +126,6 @@ def status(ctx, all_profiles, timeout):
     from aiida.cmdline.utils.common import format_local_time
     from aiida.cmdline.utils.daemon import validate_daemon_env
     from aiida.engine.daemon.client import DaemonException, get_daemon_client
-    from aiida.manage.manager import get_manager
 
     if all_profiles is True:
         profiles = [profile for profile in ctx.obj.config.profiles if not profile.is_test_profile]
@@ -169,7 +168,11 @@ def status(ctx, all_profiles, timeout):
 
         # Build broker status lines for managed brokers (e.g., ZeroMQ)
         broker_lines: list[str] = []
-        broker = get_manager().get_broker()
+        broker = None
+        if profile.process_control_backend is not None:
+            from aiida.plugins import BrokerFactory
+
+            broker = BrokerFactory(profile.process_control_backend)(profile)
 
         from aiida.brokers.zeromq.broker import ZeromqBroker
 

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -21,6 +21,20 @@ from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators, echo
 
 
+def _warn_daemon_functionless_when_no_broker(profile_name: str, has_broker: bool) -> bool:
+    """Return whether daemon functionality is available for the profile, warning if not."""
+    if has_broker:
+        return True
+
+    from aiida.common.docs import URL_NO_BROKER
+
+    echo.echo_warning(
+        f'Profile `{profile_name}` does not define a broker, so the daemon has no functionality because it '
+        f'cannot pass messages to workers. See {URL_NO_BROKER} for more details.'
+    )
+    return False
+
+
 def validate_daemon_workers(ctx, param, value):
     """Validate the value for the number of daemon workers to start with default set by config."""
     if value is None:
@@ -102,7 +116,6 @@ def start(foreground, number, timeout):
 @options.TIMEOUT(default=None, required=False, type=int)
 @click.pass_context
 @decorators.requires_loaded_profile()
-@decorators.requires_broker
 def status(ctx, all_profiles, timeout):
     """Print the status of the current daemon or all daemons.
 
@@ -126,6 +139,8 @@ def status(ctx, all_profiles, timeout):
         client = get_daemon_client(profile.name)
         echo.echo('Profile: ', fg=echo.COLORS['report'], bold=True, nl=False)
         echo.echo(f'{profile.name}', bold=True)
+
+        _warn_daemon_functionless_when_no_broker(profile.name, profile.process_control_backend is not None)
 
         try:
             client.get_status(timeout=timeout)
@@ -155,6 +170,7 @@ def status(ctx, all_profiles, timeout):
         # Build broker status lines for managed brokers (e.g., ZeroMQ)
         broker_lines: list[str] = []
         broker = get_manager().get_broker()
+
         from aiida.brokers.zeromq.broker import ZeromqBroker
 
         if isinstance(broker, ZeromqBroker):
@@ -224,6 +240,8 @@ def logshow():
 
     client = get_daemon_client()
 
+    _warn_daemon_functionless_when_no_broker(client.profile.name, client.profile.process_control_backend is not None)
+
     with subprocess.Popen(['tail', '-f', client.daemon_log_file], env=client.get_env()) as process:
         process.wait()
 
@@ -232,7 +250,6 @@ def logshow():
 @click.option('--no-wait', is_flag=True, help='Do not wait for confirmation.')
 @click.option('--all', 'all_profiles', is_flag=True, help='Stop all daemons.')
 @options.TIMEOUT(default=None, required=False, type=int)
-@decorators.requires_broker
 @click.pass_context
 def stop(ctx, no_wait, all_profiles, timeout):
     """Stop the daemon.
@@ -291,7 +308,6 @@ def restart(ctx, reset, no_wait, timeout):
 @click.option('--foreground', is_flag=True, help='Run in foreground.')
 @click.argument('number', required=False, type=int, callback=validate_daemon_workers)
 @decorators.with_dbenv()
-@decorators.requires_broker
 @decorators.check_circus_zeromq_version
 def start_circus(foreground, number):
     """This will actually launch the circus daemon, either daemonized in the background or in the foreground.

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -225,7 +225,7 @@ def _configure_profile_broker(
                 'The daemon is currently running. It will need to be restarted for changes to take effect.'
             )
             if not non_interactive:
-                click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
+                click.confirm('Do you want to restart the daemon to load the new configuration?', abort=True)
                 echo.echo_report('Restarting the daemon...')
                 daemon_client.restart_daemon()
                 echo.echo_success('Daemon restarted successfully.')
@@ -247,7 +247,7 @@ def _configure_profile_broker(
                 'The daemon is currently running. It will need to be restarted for changes to take effect.'
             )
             if not non_interactive:
-                click.confirm('Do you want to apply the configuration and restart the daemon?', abort=True)
+                click.confirm('Do you want to restart the daemon to load the new configuration?', abort=True)
                 echo.echo_report('Restarting the daemon...')
                 daemon_client.restart_daemon()
                 echo.echo_success('Daemon restarted successfully.')
@@ -262,9 +262,9 @@ def _configure_profile_broker(
 
         daemon_client = get_daemon_client()
         if daemon_client and daemon_client.is_daemon_running:
-            echo.echo_warning('The daemon is currently running. It will need to be stopped for changes to take effect.')
+            echo.echo_warning('The daemon is currently running. It is no longer needed and can be stopped.')
             if not force:
-                click.confirm('Do you want to apply the configuration and stop the daemon?', abort=True)
+                click.confirm('Do you want to stop the daemon?', abort=True)
                 echo.echo_report('Stopping the daemon...')
                 daemon_client.stop_daemon(wait=True)
                 echo.echo_success('Daemon stopped successfully.')

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -263,7 +263,7 @@ def _configure_profile_broker(
         daemon_client = get_daemon_client()
         if daemon_client and daemon_client.is_daemon_running:
             echo.echo_warning('The daemon is currently running. It is no longer needed and can be stopped.')
-            if not force:
+            if not non_interactive:
                 click.confirm('Do you want to stop the daemon?', abort=True)
                 echo.echo_report('Stopping the daemon...')
                 daemon_client.stop_daemon(wait=True)

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -149,12 +149,6 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
                 print_status(ServiceStatus.UP, 'broker', str(broker))
             finally:
                 broker.close()
-    if not broker:
-        print_status(
-            ServiceStatus.WARNING,
-            'broker',
-            f'No broker defined for this profile: certain functionality not available.\nSee {URL_NO_BROKER}',
-        )
 
     # Getting the daemon status
     if profile.process_control_backend is None:
@@ -170,16 +164,8 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
                 print_status(
                     ServiceStatus.WARNING,
                     'daemon',
-                    'Daemon appears to be running but no broker is defined for this profile: '
-                    'The daemon has no functionality because it cannot pass messages to workers.\n'
-                    f'See {URL_NO_BROKER}.',
-                )
-            else:
-                print_status(
-                    ServiceStatus.WARNING,
-                    'daemon',
-                    'No broker defined for this profile: '
-                    'The daemon has no functionality because it cannot pass messages to workers.\n'
+                    'Daemon appears to be running but no broker is defined for this profile. '
+                    'The daemon has no functionality because messages cannot passed to workers.\n'
                     f'See {URL_NO_BROKER}.',
                 )
     else:

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -207,15 +207,17 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
                     processing = status_info.get('processing_tasks', '?')
                     daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
                 else:
-                    daemon_status = ServiceStatus.WARNING
                     daemon_msg += ', Broker is NOT running (run `verdi daemon status` for more information)'
+                    daemon_status = ServiceStatus.ERROR
+                    exit_code = ExitCode.CRITICAL
 
             daemon_lines = [daemon_msg]
 
             # Check for package mismatches
             drift_error = validate_daemon_env(daemon_client)
             if drift_error is not None:
-                daemon_status = ServiceStatus.WARNING
+                if daemon_status == ServiceStatus.UP:
+                    daemon_status = ServiceStatus.WARNING
                 daemon_lines.append(drift_error)
 
             print_status(daemon_status, 'daemon', '\n'.join(daemon_lines))

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -190,6 +190,7 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
             print_status(ServiceStatus.WARNING, 'daemon', str(exception))
         except DaemonException as exception:
             print_status(ServiceStatus.ERROR, 'daemon', str(exception))
+            exit_code = ExitCode.CRITICAL
         except Exception as exception:
             message = 'Error getting daemon status'
             print_status(ServiceStatus.ERROR, 'daemon', message, exception=exception, print_traceback=print_traceback)

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -62,7 +62,6 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
     from aiida import __version__
     from aiida.cmdline.utils.daemon import validate_daemon_env
     from aiida.common.docs import URL_NO_BROKER
-    from aiida.common.exceptions import ConfigurationError
     from aiida.engine.daemon.client import DaemonException, DaemonNotRunningException
     from aiida.manage.configuration.settings import AiiDAConfigDir
     from aiida.manage.manager import get_manager
@@ -150,7 +149,6 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
                 print_status(ServiceStatus.UP, 'broker', str(broker))
             finally:
                 broker.close()
-
     if not broker:
         print_status(
             ServiceStatus.WARNING,
@@ -159,48 +157,68 @@ def verdi_status(print_traceback: bool, no_rmq: bool) -> None:
         )
 
     # Getting the daemon status
-    try:
-        daemon_client = manager.get_daemon_client()
-        status = daemon_client.get_status()
-    except ConfigurationError:
-        print_status(
-            ServiceStatus.WARNING,
-            'daemon',
-            f'No broker defined for this profile: daemon is not available. See {URL_NO_BROKER}',
-        )
-    except DaemonNotRunningException as exception:
-        print_status(ServiceStatus.WARNING, 'daemon', str(exception))
-    except DaemonException as exception:
-        print_status(ServiceStatus.ERROR, 'daemon', str(exception))
-    except Exception as exception:
-        message = 'Error getting daemon status'
-        print_status(ServiceStatus.ERROR, 'daemon', message, exception=exception, print_traceback=print_traceback)
-        exit_code = ExitCode.CRITICAL
-    else:
-        daemon_status = ServiceStatus.UP
-        daemon_msg = f'Daemon is running with PID {status["pid"]}'
-        # Append broker info for managed brokers (e.g., ZeroMQ)
-
-        if broker and isinstance(broker, ZeromqBroker):
-            status_info = broker.probe_service_status()
-            if status_info.get('connected', False):
-                broker_pid = status_info.get('pid', '?')
-                pending = status_info.get('pending_tasks', '?')
-                processing = status_info.get('processing_tasks', '?')
-                daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
+    if profile.process_control_backend is None:
+        try:
+            daemon_client = manager.get_daemon_client()
+            is_daemon_running = daemon_client.is_daemon_running
+        except Exception as exception:
+            message = 'Error getting daemon status'
+            print_status(ServiceStatus.ERROR, 'daemon', message, exception=exception, print_traceback=print_traceback)
+            exit_code = ExitCode.CRITICAL
+        else:
+            if is_daemon_running:
+                print_status(
+                    ServiceStatus.WARNING,
+                    'daemon',
+                    'Daemon appears to be running but no broker is defined for this profile: '
+                    'The daemon has no functionality because it cannot pass messages to workers.\n'
+                    f'See {URL_NO_BROKER}.',
+                )
             else:
+                print_status(
+                    ServiceStatus.WARNING,
+                    'daemon',
+                    'No broker defined for this profile: '
+                    'The daemon has no functionality because it cannot pass messages to workers.\n'
+                    f'See {URL_NO_BROKER}.',
+                )
+    else:
+        try:
+            daemon_client = manager.get_daemon_client()
+            status = daemon_client.get_status()
+        except DaemonNotRunningException as exception:
+            print_status(ServiceStatus.WARNING, 'daemon', str(exception))
+        except DaemonException as exception:
+            print_status(ServiceStatus.ERROR, 'daemon', str(exception))
+        except Exception as exception:
+            message = 'Error getting daemon status'
+            print_status(ServiceStatus.ERROR, 'daemon', message, exception=exception, print_traceback=print_traceback)
+            exit_code = ExitCode.CRITICAL
+        else:
+            daemon_status = ServiceStatus.UP
+            daemon_msg = f'Daemon is running with PID {status["pid"]}'
+            # Append broker info for managed brokers (e.g., ZeroMQ)
+
+            if broker and isinstance(broker, ZeromqBroker):
+                status_info = broker.probe_service_status()
+                if status_info.get('connected', False):
+                    broker_pid = status_info.get('pid', '?')
+                    pending = status_info.get('pending_tasks', '?')
+                    processing = status_info.get('processing_tasks', '?')
+                    daemon_msg += f', Broker PID {broker_pid} [{pending} pending, {processing} processing]'
+                else:
+                    daemon_status = ServiceStatus.WARNING
+                    daemon_msg += ', Broker is NOT running (run `verdi daemon status` for more information)'
+
+            daemon_lines = [daemon_msg]
+
+            # Check for package mismatches
+            drift_error = validate_daemon_env(daemon_client)
+            if drift_error is not None:
                 daemon_status = ServiceStatus.WARNING
-                daemon_msg += ', Broker is NOT running (run `verdi daemon status` for more information)'
+                daemon_lines.append(drift_error)
 
-        daemon_lines = [daemon_msg]
-
-        # Check for package mismatches
-        drift_error = validate_daemon_env(daemon_client)
-        if drift_error is not None:
-            daemon_status = ServiceStatus.WARNING
-            daemon_lines.append(drift_error)
-
-        print_status(daemon_status, 'daemon', '\n'.join(daemon_lines))
+            print_status(daemon_status, 'daemon', '\n'.join(daemon_lines))
 
     # Note: click does not forward return values to the exit code, see https://github.com/pallets/click/issues/747
     if exit_code != ExitCode.SUCCESS:

--- a/src/aiida/cmdline/utils/decorators.py
+++ b/src/aiida/cmdline/utils/decorators.py
@@ -330,7 +330,7 @@ def requires_broker(wrapped, _, args, kwargs):
 
     if manager.get_broker() is None:
         echo.echo_critical(
-            f'profile `{profile.name}` does not define a broker and so cannot use this functionality.'
+            f'profile `{profile.name}` does not define a broker and so cannot use this functionality. '
             f'See {URL_NO_BROKER} for more details.'
         )
 

--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -229,19 +229,11 @@ class DaemonClient:
 
         :param profile: The profile instance.
         """
-        from aiida.common.docs import URL_NO_BROKER
-
         type_check(profile, Profile)
         self._config = get_config()
         self._profile = profile
         self._socket_directory: str | None = None
         self._daemon_timeout: int = self._config.get_option('daemon.timeout', scope=profile.name)
-
-        if self._profile.process_control_backend is None:
-            raise ConfigurationError(
-                f'profile `{self._profile.name}` does not define a broker so the daemon cannot be used. '
-                f'See {URL_NO_BROKER} for more details.'
-            )
 
     @property
     def profile(self) -> Profile:

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -17,7 +17,6 @@ from aiida import get_profile
 from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.cmdline.commands import cmd_daemon
 from aiida.engine.daemon.client import DaemonClient, DaemonTimeoutException
-from aiida.manage import get_manager
 
 pytestmark = pytest.mark.requires_broker
 
@@ -232,11 +231,11 @@ def test_daemon_status_surfaces_zeromq_probe_error(run_cli_command, monkeypatch,
     """Test ``verdi daemon status`` surfaces ZeroMQ probe errors even when the broker is reachable."""
     broker = ZeromqBroker.__new__(ZeromqBroker)
     broker._service_dir = tmp_path
-    broker._service_log_file = tmp_path / 'broker.log'
+    broker._service_pid_file = tmp_path / 'broker.pid'
     broker._service_status_file = tmp_path / 'broker.status'
     broker._service_status_file.write_text('{INVALID JSON')
     broker.check_service_reachable = lambda: True
-    monkeypatch.setattr(get_manager(), 'get_broker', lambda: broker)
+    monkeypatch.setattr('aiida.plugins.BrokerFactory', lambda entry_point: lambda profile: broker)
 
     result = run_cli_command(cmd_daemon.status, use_subprocess=False)
 
@@ -248,13 +247,38 @@ def test_daemon_status_surfaces_zeromq_probe_error(run_cli_command, monkeypatch,
 @patch.object(DaemonClient, 'get_daemon_info', get_daemon_info)
 @patch.object(DaemonClient, 'get_worker_info', get_worker_info)
 @patch('aiida.cmdline.utils.common.format_local_time', format_local_time)
-def test_daemon_status_worker_info(run_cli_command):
+def test_daemon_status_worker_info(run_cli_command, isolated_config, profile_factory, monkeypatch, tmp_path):
     """Test `get_status` output if everything is working normally with a single worker."""
     result = run_cli_command(cmd_daemon.status)
     assert 'Daemon is running as PID 111015 since 2019-12-17 11:42:18' in result.output
     assert 'Active workers [1]:' in result.output
     assert '4990    0.231        0  2019-12-17 12:27:38' in result.output
     assert 'Use `verdi daemon [incr | decr] [num]`' in result.output
+
+    profile_one = profile_factory('profile-one', process_control_backend='core.zeromq', test_profile=False)
+    profile_two = profile_factory('profile-two', process_control_backend='core.zeromq', test_profile=False)
+    isolated_config.add_profile(profile_one)
+    isolated_config.add_profile(profile_two)
+
+    brokers = {}
+    broker = ZeromqBroker.__new__(ZeromqBroker)
+    broker._service_dir = tmp_path / 'broker-one'
+    broker.probe_service_status = lambda: {'connected': True, 'pid': 111, 'pending_tasks': 2, 'processing_tasks': 1}
+    brokers[profile_one.name] = broker
+
+    broker = ZeromqBroker.__new__(ZeromqBroker)
+    broker._service_dir = tmp_path / 'broker-two'
+    broker.probe_service_status = lambda: {'connected': False, 'error': 'ConnectionError: connection failed'}
+    brokers[profile_two.name] = broker
+
+    monkeypatch.setattr('aiida.plugins.BrokerFactory', lambda entry_point: lambda profile: brokers[profile.name])
+
+    result = run_cli_command(cmd_daemon.status, ['--all'], use_subprocess=False)
+
+    assert 'Profile: profile-one' in result.output
+    assert 'Profile: profile-two' in result.output
+    assert 'Broker is running as PID 111 [2 pending, 1 processing]' in result.output
+    assert 'Broker is NOT running' in result.output
 
 
 @patch.object(DaemonClient, 'get_status', lambda *_, **__: {'status': 'running'})

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -138,6 +138,31 @@ def test_daemon_status_no_profile(run_cli_command):
     assert 'No profile loaded: make sure at least one profile is configured and a default is set.' in result.output
 
 
+@pytest.mark.usefixtures('stopped_daemon_client')
+def test_daemon_status_no_broker(run_cli_command):
+    """Test ``verdi daemon status`` warns if the profile does not define a broker and still checks status."""
+    from aiida.manage.manager import get_manager
+
+    manager = get_manager()
+    profile = manager.get_profile()
+    assert profile is not None
+
+    old_backend = profile.process_control_backend
+    old_config = profile.process_control_config
+
+    try:
+        profile.set_process_controller(None, None)
+        manager.reset_broker()
+        result = run_cli_command(cmd_daemon.status, raises=True, use_subprocess=False)
+    finally:
+        profile.set_process_controller(old_backend, old_config)
+        manager.reset_broker()
+
+    assert result.exit_code == 3
+    assert 'the daemon has no functionality because it cannot pass messages to workers' in result.output
+    assert 'The daemon is not running.' in result.output
+
+
 @pytest.mark.usefixtures('started_daemon_client', 'isolated_config')
 def test_daemon_status_timeout(run_cli_command):
     """Test ``verdi daemon status`` with the ``--timeout`` option.

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -60,6 +60,29 @@ def test_status_no_rmq(run_cli_command):
         assert string in result.output
 
 
+def test_status_no_broker(run_cli_command):
+    """Test `verdi status` reports that daemon functionality is unavailable without a broker."""
+    from aiida.manage.manager import get_manager
+
+    manager = get_manager()
+    profile = manager.get_profile()
+    assert profile is not None
+
+    old_backend = profile.process_control_backend
+    old_config = profile.process_control_config
+
+    try:
+        profile.set_process_controller(None, None)
+        manager.reset_broker()
+        result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
+    finally:
+        profile.set_process_controller(old_backend, old_config)
+        manager.reset_broker()
+
+    assert result.exit_code is ExitCode.SUCCESS.value
+    assert 'No broker defined for this profile: The daemon has no functionality' in result.output
+
+
 @pytest.mark.requires_psql
 def test_storage_unable_to_connect(run_cli_command):
     """Test `verdi status` when there is an unknown error while connecting to the storage."""

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -17,7 +17,7 @@ from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.cmdline.commands import cmd_status
 from aiida.cmdline.utils.echo import ExitCode
 from aiida.common.warnings import AiidaDeprecationWarning
-from aiida.engine.daemon.client import DaemonClient
+from aiida.engine.daemon.client import DaemonClient, DaemonException
 from aiida.manage import get_manager
 from aiida.storage.psql_dos import migrator
 
@@ -81,6 +81,19 @@ def test_status_no_broker(run_cli_command):
 
     assert result.exit_code is ExitCode.SUCCESS.value
     assert 'No broker defined for this profile: The daemon has no functionality' in result.output
+
+
+def test_status_daemon_exception(run_cli_command, monkeypatch):
+    """Test `verdi status` returns a critical exit code on daemon errors."""
+
+    def raise_daemon_exception(self):
+        raise DaemonException('Connection failed.')
+
+    monkeypatch.setattr(DaemonClient, 'get_status', raise_daemon_exception)
+
+    result = run_cli_command(cmd_status.verdi_status, raises=True, use_subprocess=False)
+    assert 'Connection failed.' in result.output
+    assert result.exit_code is ExitCode.CRITICAL
 
 
 @pytest.mark.requires_psql

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -60,8 +60,8 @@ def test_status_no_rmq(run_cli_command):
         assert string in result.output
 
 
-def test_status_no_broker(run_cli_command):
-    """Test `verdi status` reports that daemon functionality is unavailable without a broker."""
+def test_status_no_broker(run_cli_command, monkeypatch):
+    """Test `verdi status` reports when a brokerless profile still has a running daemon."""
     from aiida.manage.manager import get_manager
 
     manager = get_manager()
@@ -74,13 +74,14 @@ def test_status_no_broker(run_cli_command):
     try:
         profile.set_process_controller(None, None)
         manager.reset_broker()
+        monkeypatch.setattr(DaemonClient, 'is_daemon_running', property(lambda self: True))
         result = run_cli_command(cmd_status.verdi_status, use_subprocess=False)
     finally:
         profile.set_process_controller(old_backend, old_config)
         manager.reset_broker()
 
     assert result.exit_code is ExitCode.SUCCESS.value
-    assert 'No broker defined for this profile: The daemon has no functionality' in result.output
+    assert 'Daemon appears to be running but no broker is defined for this profile' in result.output
 
 
 def test_status_daemon_exception(run_cli_command, monkeypatch):


### PR DESCRIPTION
Because with `verdi profile configure-broker none` it is now possible to end up with a profile without a broker after starting the daemon, it needs to be considered that the daemon is running for this option. I did not want to enforce a daemon shutdown when `verdi profile configure-broker none` is set because it might affect peoples running calculation. It there makes sense to have `verdi daemon` commands to be working which were before this PR erroring out when no broker was defined, especially if one wants to stop the daemon. I also think it is better for logical understanding for the user if one can interact with the daemon without a broker, so it is clearer that they are two separate processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `verdi daemon status`/`verdi daemon logshow` to handle profiles without broker/daemon functionality with clearer per-profile messaging and more accurate exit codes.
  * Updated `verdi daemon stop` (and the hidden start flow) so broker presence is no longer required at command start time.
* **User Experience**
  * Refined `verdi profile configure-broker` confirmation prompts (RabbitMQ/ZeroMQ restart wording; improved non-interactive behavior when disabling the broker).
* **Tests**
  * Added/expanded regression coverage for `verdi daemon status` and `verdi status` when no broker/process controller is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->