### PR TITLE
🧪 Test/fields process node coverage

### DIFF
--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Test for entity fields"""
 
-import sys
 from importlib.metadata import entry_points
 
 import pytest
@@ -20,16 +19,7 @@ from aiida.plugins import load_entry_point
 
 EPS = entry_points()
 
-# These regression tests compare ``repr()`` output of field objects against YAML reference
-# files. Since ``repr()`` of ``typing`` generics is not stable across Python versions
-# (e.g. Python 3.14 renders ``typing.Dict`` as ``dict`` and ``typing.Optional[X]`` as
-# ``X | None``), the reference files are only valid for the Python version they were
-# generated with. Rather than maintaining two sets of reference files, we skip on
-# Python versions that don't match.
-skip_below_py314 = pytest.mark.skipif(sys.version_info < (3, 14), reason='typing repr fixtures require Python >=3.14.0')
 
-
-@skip_below_py314
 @pytest.mark.parametrize(
     'entity_cls',
     (orm.AuthInfo, orm.Comment, orm.Computer, orm.Group, orm.Log, orm.User),
@@ -47,11 +37,10 @@ def node_and_data_entry_points() -> list[tuple[str, str]]:
     _eps: list[tuple[str, str]] = []
     eps = entry_points()
     for group in ['aiida.node', 'aiida.data']:
-        _eps.extend((group, ep.name) for ep in eps.select(group=group) if ep.name.startswith('core.'))
+        _eps.extend((group, ep.name) for ep in eps.select(group=group))
     return _eps
 
 
-@skip_below_py314
 def test_all_node_fields(node_and_data_entry_points: list[tuple[str, str]], data_regression):
     """Test that all the node fields are correctly registered."""
     for group, name in node_and_data_entry_points:

--- a/tests/orm/test_fields/fields_aiida.node.data.Data.yml
+++ b/tests/orm/test_fields/fields_aiida.node.data.Data.yml
@@ -1,23 +1,20 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-source: QbDictField('source', dtype=typing.Optional[dict], is_attribute=True, is_subscriptable=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.data.data.Data.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=<class 'str'>, doc='The type of the node.')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.ProcessNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.ProcessNode.yml
@@ -1,30 +1,35 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.process.ProcessNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=<class 'str'>, doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.calculation.CalculationNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.calculation.CalculationNode.yml
@@ -1,30 +1,36 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.calculation.calculation.CalculationNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=typing.Literal['process.calculation.CalculationNode.'],
+  doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.calculation.calcfunction.CalcFunctionNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.calculation.calcfunction.CalcFunctionNode.yml
@@ -1,30 +1,36 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=typing.Literal['process.calculation.calcfunction.CalcFunctionNode.'],
+  doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.calculation.calcjob.CalcJobNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.calculation.calcjob.CalcJobNode.yml
@@ -1,46 +1,57 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-detailed_job_info: QbDictField('detailed_job_info', dtype=typing.Optional[dict], is_attribute=True)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-imported: QbField('imported', dtype=typing.Optional[bool], is_attribute=True)
-job_id: QbStrField('job_id', dtype=typing.Optional[str], is_attribute=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-last_job_info: QbStrField('last_job_info', dtype=typing.Optional[str], is_attribute=True)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-remote_workdir: QbStrField('remote_workdir', dtype=typing.Optional[str], is_attribute=True)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-retrieve_list:
-  QbArrayField('retrieve_list', dtype=typing.Optional[typing.List[str]],
-  is_attribute=True)
-retrieve_temporary_list:
-  QbArrayField('retrieve_temporary_list', dtype=typing.Optional[typing.List[str]],
-  is_attribute=True)
-scheduler_lastchecktime:
-  QbStrField('scheduler_lastchecktime', dtype=typing.Optional[str],
-  is_attribute=True)
-scheduler_state: QbStrField('scheduler_state', dtype=typing.Optional[str], is_attribute=True)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-state: QbStrField('state', dtype=typing.Optional[str], is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+detailed_job_info: QbDictField('attributes.detailed_job_info', dtype=dict | None,
+  doc='The detailed job info returned by the scheduler')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+imported: QbAnyField('attributes.imported', dtype=bool | None, doc='Whether the node
+  has been migrated')
+job_id: QbStrField('attributes.job_id', dtype=str | None, doc='The scheduler job id')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+last_job_info: QbDictField('attributes.last_job_info', dtype=dict | None, doc='The
+  last job info returned by the scheduler')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=typing.Literal['process.calculation.calcjob.CalcJobNode.'],
+  doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+remote_workdir: QbStrField('attributes.remote_workdir', dtype=str | None, doc='The
+  path to the remote (on cluster) scratch folder')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+retrieve_list: QbAnyField('attributes.retrieve_list', dtype=collections.abc.Sequence[str
+  | tuple[str, str, int]] | None, doc='The list of files to retrieve from the remote
+  cluster')
+retrieve_temporary_list: QbAnyField('attributes.retrieve_temporary_list', dtype=collections.abc.Sequence[str
+  | tuple[str, str, int]] | None, doc='The list of temporary files to retrieve from
+  the remote cluster')
+scheduler_lastchecktime: QbNumericField('attributes.scheduler_lastchecktime', dtype=datetime.datetime
+  | None, doc='The last time the scheduler was checked, in isoformat')
+scheduler_state: QbStrField('attributes.scheduler_state', dtype=str | None, doc='The
+  state of the scheduler')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+state: QbStrField('attributes.state', dtype=str | None, doc='The active state of the
+  calculation job')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.workflow.WorkflowNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.workflow.WorkflowNode.yml
@@ -1,30 +1,36 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.workflow.workflow.WorkflowNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=typing.Literal['process.workflow.WorkflowNode.'],
+  doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.workflow.workchain.WorkChainNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.workflow.workchain.WorkChainNode.yml
@@ -1,30 +1,36 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.workflow.workchain.WorkChainNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=typing.Literal['process.workflow.workchain.WorkChainNode.'],
+  doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.workflow.workfunction.WorkFunctionNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.workflow.workfunction.WorkFunctionNode.yml
@@ -1,30 +1,36 @@
-attributes:
-  QbDictField('attributes', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-computer: QbNumericField('computer', dtype=typing.Optional[str], is_attribute=False)
-ctime: QbNumericField('ctime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-description: QbStrField('description', dtype=typing.Optional[str], is_attribute=False)
-exception: QbStrField('exception', dtype=typing.Optional[str], is_attribute=True)
-exit_message: QbStrField('exit_message', dtype=typing.Optional[str], is_attribute=True)
-exit_status: QbNumericField('exit_status', dtype=typing.Optional[int], is_attribute=True)
-extras:
-  QbDictField('extras', dtype=typing.Optional[typing.Dict[str, typing.Any]],
-  is_attribute=False, is_subscriptable=True)
-label: QbStrField('label', dtype=typing.Optional[str], is_attribute=False)
-mtime: QbNumericField('mtime', dtype=typing.Optional[datetime.datetime], is_attribute=False)
-node_type: QbStrField('node_type', dtype=typing.Optional[str], is_attribute=False)
-paused: QbField('paused', dtype=<class 'bool'>, is_attribute=True)
-pk: QbNumericField('pk', dtype=typing.Optional[int], is_attribute=False)
-process_label: QbStrField('process_label', dtype=typing.Optional[str], is_attribute=True)
-process_state: QbStrField('process_state', dtype=typing.Optional[str], is_attribute=True)
-process_status: QbStrField('process_status', dtype=typing.Optional[str], is_attribute=True)
-process_type: QbStrField('process_type', dtype=typing.Optional[str], is_attribute=False)
-repository_content:
-  QbDictField('repository_content', dtype=typing.Optional[dict[str,
-  bytes]], is_attribute=False)
-repository_metadata:
-  QbDictField('repository_metadata', dtype=typing.Optional[typing.Dict[str,
-  typing.Any]], is_attribute=False)
-sealed: QbField('sealed', dtype=<class 'bool'>, is_attribute=True)
-user: QbNumericField('user', dtype=typing.Optional[int], is_attribute=False)
-uuid: QbStrField('uuid', dtype=typing.Optional[str], is_attribute=False)
+attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode.AttributesModel'>,
+  doc='The node attributes')
+computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
+ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
+  time of the node')
+description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
+exception: QbStrField('attributes.exception', dtype=str | None, doc='The process exception
+  message')
+exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The process
+  exit message')
+exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
+  exit status')
+extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
+label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
+mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
+  time of the node')
+node_type: QbStrField('node_type', dtype=typing.Literal['process.workflow.workfunction.WorkFunctionNode.'],
+  doc='The type of the node.')
+paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+  is paused')
+pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
+process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
+  label')
+process_state: QbStrField('attributes.process_state', dtype=str | None, doc='The process
+  state enum')
+process_status: QbStrField('attributes.process_status', dtype=str | None, doc='The
+  process status is a generic status message')
+process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
+  the node')
+repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
+  doc='Virtual hierarchy of the file repository')
+sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+  is sealed')
+user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
+  the node')
+uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')


### PR DESCRIPTION
Split off from #7254.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned ORM field schema expectations with stricter, more accurate typing and nullability across process, calculation, workflow, and data nodes.
  * Standardized node “attributes” handling and removed obsolete `repository_content` mappings.

* **Tests**
  * Expanded entry-point coverage to include all node and data plugins.
  * Updated field validation fixtures for the latest ORM schemas (including UUIDs, timestamps, and metadata/extras).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->