### PR TITLE
🐛 `docker-build`: quote the bake metadata heredoc

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Write metadata output to a json file
       run: |
-        cat << EOF > bake_metadata.json
+        cat << 'EOF' > bake_metadata.json
         ${{ steps.build.outputs.metadata }}
         EOF
 


### PR DESCRIPTION
The `Write metadata output to a json file` step pipes the bake metadata through an unquoted heredoc:

    cat << EOF > bake_metadata.json
    ${{ steps.build.outputs.metadata }}
    EOF

GitHub substitutes the metadata textually, and the shell then expands what it finds. The metadata's `buildx.build.provenance` embeds the push event payload, commit messages included, so every backtick in a commit message is treated as command substitution: its contents run on the runner and vanish from the JSON.

    in:   {"message":"Rename from `zmq_broker_service` to `broker_service`."}
    out:  {"message":"Rename from  to ."}

This is not hypothetical: our own commit convention is ``<emoji> `Scope`: description``, so conventional commit messages are exactly the ones this mangles. It had been corrupting the recorded metadata silently for a while. #7444 is the example above, and it still produced parseable JSON, so nothing went red and nobody noticed. #7254's message carries 26 backticks, enough for the substitution to run past a string terminator and leave the pretty-printed JSON's real newlines inside a string literal, so the following `github-script` step died on

    SyntaxError: Bad control character in string literal in JSON

and `Docker Images` has been red on `main` since. (The earlier red run on #7444 was an unrelated arm64 `ports.ubuntu.com` timeout.)

Quote the delimiter so the shell leaves the payload alone. `${{ }}` is GitHub-side templating and still expands, so only the shell expansion is suppressed. Incidentally this also closes a script-injection path, since commit messages reaching `bash` is exactly that, though a fork PR can't reach this workflow and anyone who can get a commit onto `main` can already run code in CI, so the practical gain is mostly that the metadata is no longer silently corrupted.

<details>
<summary>Reproducing the mangling outside CI</summary>

The payload has to be inlined textually the way GitHub does it, before `bash` sees the script (passing it via a shell variable hides the bug, since that is the expansion the fix suppresses):

```bash
METADATA='{"message": "Rename from `zmq_broker_service` to `broker_service`."}'
printf 'cat << EOF > old.json\n%s\nEOF\n' "$METADATA" > old_step.sh
bash old_step.sh
```

```
old_step.sh: line 1: zmq_broker_service: command not found
old_step.sh: line 1: broker_service: command not found
$ cat old.json
{"message": "Rename from  to ."}
```

Swapping in `<< 'EOF'` preserves the message byte for byte.

</details>
