### PR TITLE
🧪 test_calc_job: fix daemon-restart flake

### DIFF
--- a/src/aiida/manage/tests/pytest_fixtures.py
+++ b/src/aiida/manage/tests/pytest_fixtures.py
@@ -727,7 +727,7 @@ def submit_and_await(started_daemon_client):
     def _factory(
         submittable: Process | ProcessBuilder | ProcessNode,
         state: plumpy.ProcessState = plumpy.ProcessState.FINISHED,
-        timeout: int = 20,
+        timeout: float = 20,
         **kwargs,
     ):
         """Submit a process and wait for it to achieve the given state.
@@ -735,9 +735,10 @@ def submit_and_await(started_daemon_client):
         :param submittable: A process, a process builder or a process node. If it is a process or builder, it is
             submitted first before awaiting the desired state.
         :param state: The process state to wait for, by default it waits for the submittable to be ``FINISHED``.
-        :param timeout: The time to wait for the process to achieve the state.
+        :param timeout: The number of seconds to wait for the process to achieve the state.
         :param kwargs: If the ``submittable`` is a process class, it is instantiated with the ``kwargs`` as inputs.
-        :raises RuntimeError: If the process fails to achieve the specified state before the timeout expires.
+        :raises RuntimeError: If the process terminates in a state other than the one specified, or if it fails to
+            achieve the specified state before the timeout expires.
         """
         if inspect.isclass(submittable) and issubclass(submittable, Process):  # type: ignore[unreachable]
             node = submit(submittable, **kwargs)  # type: ignore[unreachable]
@@ -748,23 +749,34 @@ def submit_and_await(started_daemon_client):
         else:
             raise ValueError(f'type of submittable `{type(submittable)}` is not supported.')
 
-        start_time = time.time()
+        start_time = time.monotonic()
+        # Terminal members of ``ProcessState``, mirroring ``ProcessNode.is_terminated``.
+        terminal_states = (plumpy.ProcessState.EXCEPTED, plumpy.ProcessState.FINISHED, plumpy.ProcessState.KILLED)
 
-        while node.process_state is not state:
-            if node.is_excepted:
-                raise RuntimeError(f'The process excepted: {node.exception}')
+        while True:
+            # Read ``process_state`` once per iteration: each access re-queries the database, so splitting the target
+            # and terminal checks across reads could straddle a transition and fail just as ``state`` is reached.
+            current_state = node.process_state
 
-            if time.time() - start_time >= timeout:
+            if current_state is state:
+                return node
+
+            # A terminal state cannot change, so waiting for a different one would only delay the failure.
+            if current_state in terminal_states:
+                if current_state is plumpy.ProcessState.EXCEPTED:
+                    raise RuntimeError(f'The process excepted: {node.exception}')
+                msg = f'The process terminated in state `{current_state}` while waiting for state `{state}`.'
+                raise RuntimeError(msg)
+
+            if time.monotonic() - start_time >= timeout:
                 daemon_log_file = pathlib.Path(started_daemon_client.daemon_log_file).read_text(encoding='utf-8')
                 daemon_status = 'running' if started_daemon_client.is_daemon_running else 'stopped'
                 raise RuntimeError(
-                    f'Timed out waiting for process with state `{node.process_state}` to enter state `{state}`.\n'
+                    f'Timed out waiting for process with state `{current_state}` to enter state `{state}`.\n'
                     f'Daemon <{started_daemon_client.profile.name}|{daemon_status}> log file content: \n'
                     f'{daemon_log_file}'
                 )
             time.sleep(0.1)
-
-        return node
 
     return _factory
 

--- a/src/aiida/tools/pytest_fixtures/daemon.py
+++ b/src/aiida/tools/pytest_fixtures/daemon.py
@@ -141,13 +141,13 @@ def submit_and_await(started_daemon_client):
         else:
             raise ValueError(f'type of submittable `{type(submittable)}` is not supported.')
 
-        start_time = time.time()
+        start_time = time.monotonic()
 
         while node.process_state is not state:
             if node.is_excepted:
                 raise RuntimeError(f'The process excepted: {node.exception}')
 
-            if time.time() - start_time >= timeout:
+            if time.monotonic() - start_time >= timeout:
                 daemon_log_file = pathlib.Path(started_daemon_client.daemon_log_file).read_text(encoding='utf-8')
                 daemon_status = 'running' if started_daemon_client.is_daemon_running else 'stopped'
                 raise RuntimeError(

--- a/src/aiida/tools/pytest_fixtures/daemon.py
+++ b/src/aiida/tools/pytest_fixtures/daemon.py
@@ -113,9 +113,10 @@ def submit_and_await(started_daemon_client):
     :param submittable: A process, a process builder or a process node. If it is a process or builder, it is submitted
         first before awaiting the desired state.
     :param state: The process state to wait for, by default it waits for the submittable to be ``FINISHED``.
-    :param timeout: The time to wait for the process to achieve the state.
+    :param timeout: The number of seconds to wait for the process to achieve the state.
     :param kwargs: If the ``submittable`` is a process class, it is instantiated with the ``kwargs`` as inputs.
-    :raises RuntimeError: If the process fails to achieve the specified state before the timeout expires.
+    :raises RuntimeError: If the process terminates in a state other than the one specified, or if it fails to
+        achieve the specified state before the timeout expires.
     :returns `~aiida.orm.nodes.process.process.ProcessNode`: The process node.
     """
     from aiida.engine import ProcessState
@@ -123,7 +124,7 @@ def submit_and_await(started_daemon_client):
     def factory(
         submittable: type[Process] | ProcessBuilder | ProcessNode,
         state: ProcessState = ProcessState.FINISHED,
-        timeout: int = 20,
+        timeout: float = 20,
         **kwargs,
     ):
         import inspect
@@ -142,21 +143,32 @@ def submit_and_await(started_daemon_client):
             raise ValueError(f'type of submittable `{type(submittable)}` is not supported.')
 
         start_time = time.monotonic()
+        # Terminal members of ``ProcessState``, mirroring ``ProcessNode.is_terminated``.
+        terminal_states = (ProcessState.EXCEPTED, ProcessState.FINISHED, ProcessState.KILLED)
 
-        while node.process_state is not state:
-            if node.is_excepted:
-                raise RuntimeError(f'The process excepted: {node.exception}')
+        while True:
+            # Read ``process_state`` once per iteration: each access re-queries the database, so splitting the target
+            # and terminal checks across reads could straddle a transition and fail just as ``state`` is reached.
+            current_state = node.process_state
+
+            if current_state is state:
+                return node
+
+            # A terminal state cannot change, so waiting for a different one would only delay the failure.
+            if current_state in terminal_states:
+                if current_state is ProcessState.EXCEPTED:
+                    raise RuntimeError(f'The process excepted: {node.exception}')
+                msg = f'The process terminated in state `{current_state}` while waiting for state `{state}`.'
+                raise RuntimeError(msg)
 
             if time.monotonic() - start_time >= timeout:
                 daemon_log_file = pathlib.Path(started_daemon_client.daemon_log_file).read_text(encoding='utf-8')
                 daemon_status = 'running' if started_daemon_client.is_daemon_running else 'stopped'
                 raise RuntimeError(
-                    f'Timed out waiting for process with state `{node.process_state}` to enter state `{state}`.\n'
+                    f'Timed out waiting for process with state `{current_state}` to enter state `{state}`.\n'
                     f'Daemon <{started_daemon_client.profile.name}|{daemon_status}> log file content: \n'
                     f'{daemon_log_file}'
                 )
             time.sleep(0.1)
-
-        return node
 
     return factory

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -1361,8 +1361,8 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
 
     daemon_client.restart_daemon(wait=True)
 
-    # The full stop/restart/reload/resume/finish cycle is heavy, so allow more than the fixture default: on a
-    # contended runner the post-restart wait alone has been measured at ~9s.
+    # The full stop/restart/reload/resume/finish cycle is heavy, so allow more than the fixture default: under CPU
+    # contention the post-restart wait alone approaches the 10 seconds this test used to allow.
     submit_and_await(node, plumpy.ProcessState.FINISHED, timeout=30)
 
     assert node.is_finished_ok, node.exit_status

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -1348,8 +1348,6 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
 
     This is a regression test for https://github.com/aiidateam/aiida-core/issues/5882.
     """
-    import time
-
     import plumpy
 
     daemon_client.start_daemon()
@@ -1363,19 +1361,10 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
 
     daemon_client.restart_daemon(wait=True)
 
-    start_time = time.time()
-    timeout = 10
+    # The full stop/restart/reload/resume/finish cycle is heavy, so allow more than the fixture default: on a
+    # contended runner the post-restart wait alone has been measured at ~9s.
+    submit_and_await(node, plumpy.ProcessState.FINISHED, timeout=30)
 
-    while node.process_state not in [plumpy.ProcessState.FINISHED, plumpy.ProcessState.EXCEPTED]:
-        if node.is_excepted:
-            raise AssertionError(f'The process excepted: {node.exception}')
-
-        if time.time() - start_time >= timeout:
-            raise AssertionError(f'process failed to terminate within timeout, current state: {node.process_state}')
-
-        time.sleep(0.1)
-
-    assert node.is_finished, node.process_state
     assert node.is_finished_ok, node.exit_status
 
 

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -1367,8 +1367,6 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
 
     This is a regression test for https://github.com/aiidateam/aiida-core/issues/5882.
     """
-    import time
-
     import plumpy
 
     daemon_client.start_daemon()
@@ -1382,19 +1380,10 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
 
     daemon_client.restart_daemon(wait=True)
 
-    start_time = time.time()
-    timeout = 10
+    # The full stop/restart/reload/resume/finish cycle is heavy, so allow more than the fixture default: under CPU
+    # contention the post-restart wait alone approaches the 10 seconds this test used to allow.
+    submit_and_await(node, plumpy.ProcessState.FINISHED, timeout=30)
 
-    while node.process_state not in [plumpy.ProcessState.FINISHED, plumpy.ProcessState.EXCEPTED]:
-        if node.is_excepted:
-            raise AssertionError(f'The process excepted: {node.exception}')
-
-        if time.time() - start_time >= timeout:
-            raise AssertionError(f'process failed to terminate within timeout, current state: {node.process_state}')
-
-        time.sleep(0.1)
-
-    assert node.is_finished, node.process_state
     assert node.is_finished_ok, node.exit_status
 
 


### PR DESCRIPTION
`test_restart_after_daemon_reset` flakes because its post-restart poll loop's 10s budget is too tight under load. `restart_daemon(wait=True)` returns once circus reports the worker up, well before it rebinds broker subscribers, RMQ redelivers the persisted `continue` task, and the job resumes. That resume runs ~3s idle but ~9s under contention. It always completes (forcing the wait past 10s reproduces the CI signature), so widening the budget is a real fix.

The hand-rolled loop is replaced by `submit_and_await`, the fixture the test already uses to await `WAITING` a few lines above, at a 30s budget that dumps the daemon log on expiry. The fixture clock also moves to `time.monotonic`, defensive against NTP steps; `brokers/zeromq/broker.py` already does this.

Leaves [#7152](https://github.com/aiidateam/aiida-core/issues/7152) open: its RabbitMQ `UnroutableError` is the same readiness gap as a hard publish-time failure.

<details>
<summary>How the flake happens (call trace)</summary>

```
# The post-restart resume, all of it inside the test's timeout. restart_daemon(wait=True)
# returns long before the daemon can make progress:

test: daemon_client.restart_daemon(wait=True)
  client.py:821   sends circus {'command':'restart','waiting':True}, returns on the circus ack
                  does NOT wait for worker startup, broker rebind, or process resume
  client.py:447   is_daemon_running() only checks the circus PID file (get_daemon_pid() is not None)

test: submit_and_await(node, FINISHED, timeout=30)   <-- clock starts; daemon not yet ready
  circus spawns the worker subprocess
  manager.py:507  ProcessLauncher(task_receiver)
  manager.py:515  add_task_subscriber(...)          binds the RMQ task-queue consumer
  RMQ redelivers the persisted, unacked `continue` task
                  (launcher.py:100: "RabbitMQ requeues the task ... worker lost its connection")
  launcher.py:41  ProcessLauncher._continue(pid)
  launcher.py:60    load_node(pk=pid)
  launcher.py:70    if node.is_terminated: ...       no -> resume from checkpoint
  launcher.py:87    await super()._continue(...)     rebuild Process, resume
  process: finish 1s sleep -> parse -> seal
                  every step scales with CPU/PSQL contention: ~3s idle, ~9s loaded, trips the old 10s

# The original #7152 UnroutableError is the same gap at publish time, on the first submit:

test: submit_and_await(builder, WAITING)
  launch.py:86    submit(builder)
  launch.py:169     runner.controller.continue_process(pid, ...)   publish `continue`, mandatory=True
                    subscriber not bound yet -> NO_ROUTE -> kiwipy.UnroutableError
```

</details>

<details>
<summary>Local verification</summary>

```
# controlled: sleep=12 forces the post-restart wait past the old 10s bound
OLD (10s hand-rolled loop)        FAIL, timeout at ProcessState.WAITING
NEW (submit_and_await timeout=30) PASS

# happy path, RMQ backend
test_restart_after_daemon_reset   1 passed
```

</details>