### PR TITLE
🧪 Pin release workflow and install-aiida-core action to py310

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -4,7 +4,7 @@ description: Install aiida-core package and its Python dependencies
 inputs:
   python-version:
     description: Python version
-    default: '3.9'              # Lowest supported version
+    default: '3.10'             # Lowest supported version
     required: false
   extras:
     description: list of optional dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.10'
 
     - name: Run sub-set of test suite
       run: pytest -s -m requires_broker --broker-backend zmq --db-backend=sqlite tests/


### PR DESCRIPTION
Pin the release workflow test job to Python 3.10. Also update the install-aiida-core composite action to default to Python 3.10, which is the lowest supported version in aiida-core.