### PR TITLE
🧪 Add nightly pre-commit check

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,24 @@ env:
 
 jobs:
 
+  pre-commit:
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install aiida-core and pre-commit
+      uses: ./.github/actions/install-aiida-core
+      with:
+        python-version: '3.11'
+        extras: pre-commit
+        from-lock: 'false'
+
+    - name: Run pre-commit
+      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+
   nightly-tests:
 
     if: github.repository == 'aiidateam/aiida-core'  # Prevent running the builds on forks as well

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -23,6 +23,7 @@ from typing import (
     Literal,
     NoReturn,
     TypeVar,
+    cast,
 )
 
 import pydantic as pdt
@@ -467,11 +468,14 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
             }
 
             name = model_cls.__name__.replace(suffix, 'WriteModel')
-            WriteModel = pdt.create_model(  # noqa: N806
-                name,
-                __base__=tuple(bases),
-                __module__=model_cls.__module__,
-                **model_fields,
+            WriteModel = cast(  # noqa: N806
+                type[OrmModel],
+                pdt.create_model(
+                    name,
+                    __base__=tuple(bases),
+                    __module__=model_cls.__module__,
+                    **model_fields,
+                ),
             )
             WriteModel.__qualname__ = model_cls.__qualname__.replace(suffix, 'WriteModel')
             WriteModel.__pydantic_decorators__.field_serializers = serializers


### PR DESCRIPTION
Add a pre-commit job to the nightly workflow with from-lock=false to detect errors in the release workflow earlier. I think the from-lock: false option makes sense to have as another layer of tests, and we do not need to run it for every test but it is really annoying to only solve the issues on release. I add it to the nightly so these problems can be earlier fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated pre-commit validation to the nightly workflow to catch formatting and code-quality issues early.

- **Refactor**
  - Improved internal typing for dynamically generated entity models, making development and maintenance more reliable without impacting public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->