### PR TITLE
🧪 Harden GitHub Actions workflows

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -30,7 +30,7 @@ runs:
       python-version: ${{ inputs.python-version }}
 
   - name: Set up uv
-    uses: astral-sh/setup-uv@v6
+    uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e   # v6.8.0
     with:
       version: 0.11.21
       python-version: ${{ inputs.python-version }}

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
 
   - name: Slack notification
-    uses: rtCamp/action-slack-notify@v2
+    uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58   # v2.4.0
     env:
       SLACK_ICON: https://www.materialscloud.org/discover/images/0ba0a17d.aiida-logo-128.png
       SLACK_CHANNEL: dev-aiida-core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,12 @@ version: 2
 updates:
 # Maintain dependencies for GitHub Actions
 - package-ecosystem: github-actions
-  directory: /
+  # The root directory covers .github/workflows/ but not the local composite
+  # actions, which need to be listed explicitly.
+  directories:
+  - /
+  - /.github/actions/install-aiida-core
+  - /.github/actions/slack-notification
   schedule:
     interval: monthly
   groups:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,12 +14,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   run-and-upload:
 
     # Only run if branch or PR base is pointing to the upstream repo
     if: github.repository == 'aiidateam/aiida-core'
+
+    permissions:
+      # Push benchmark results to gh-pages and comment on commits on alerts
+      contents: write
 
     strategy:
       fail-fast: false
@@ -52,6 +59,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
@@ -63,7 +72,7 @@ jobs:
       run: pytest --db-backend psql --benchmark-only --benchmark-json benchmark.json tests/
 
     - name: Store benchmark result
-      uses: aiidateam/github-action-benchmark@v3
+      uses: aiidateam/github-action-benchmark@8f431658bf624a63bea7dd506756badb1241d48e   # v3.0.0
       with:
         benchmark-data-dir-path: dev/bench/${{ matrix.os }}/psql_dos
         name: pytest-benchmarks:${{ matrix.os }},psql_dos

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -56,6 +59,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql graphviz
@@ -77,7 +82,7 @@ jobs:
 
     - name: Upload coverage report
       if: matrix.python-version == 3.14 && github.repository == 'aiidateam/aiida-core'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac   # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: aiida-pytests-py3.14
@@ -107,6 +112,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install graphviz
       run: sudo apt update && sudo apt install graphviz
@@ -135,6 +142,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install graphviz
       run: sudo apt update && sudo apt install graphviz
@@ -160,6 +169,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
@@ -203,6 +214,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
@@ -222,7 +235,7 @@ jobs:
 
     - name: Upload coverage report
       if: github.repository == 'aiidateam/aiida-core'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac   # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: test-pytest-fixtures

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     if: ${{ github.event.pull_request.head.repo.fork }}
@@ -36,12 +39,14 @@ jobs:
 
     - name: Checkout Repo
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f   # v3.12.0
 
     - name: Build images
-      uses: docker/bake-action@v6.10.0
+      uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4   # v6.10.0
       with:
         # Load to Docker engine for testing
         load: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,11 @@ on:
         description: Images identified by digests
         value: ${{ jobs.build.outputs.images }}
 
+permissions:
+  contents: read
+  # Push built images to ghcr.io
+  packages: write
+
 jobs:
   build:
     name: ${{ inputs.platforms }}
@@ -37,20 +42,22 @@ jobs:
 
     - name: Checkout Repo ⚡️
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up QEMU
       if: ${{ inputs.platforms != 'linux/amd64' }}
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8   # v4.2.0
       with:
         # Workaround for https://github.com/tonistiigi/binfmt/issues/215
         image: tonistiigi/binfmt:qemu-v7.0.0-28
         cache-image: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f   # v3.12.0
 
     - name: Login to GitHub Container Registry 🔑
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0   # v4.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -58,7 +65,7 @@ jobs:
 
     - name: Build and upload to ghcr.io 📤
       id: build
-      uses: docker/bake-action@v6.10.0
+      uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4   # v6.10.0
       with:
         push: true
         workdir: .docker/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,11 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  # Push image tags to ghcr.io
+  packages: write
+
 jobs:
 
   release:
@@ -37,16 +42,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Login to GitHub Container Registry 🔑
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0   # v4.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to DockerHub 🔑
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0   # v4.4.0
       if: inputs.registry == 'docker.io'
       with:
         registry: docker.io
@@ -87,7 +94,7 @@ jobs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051   # v5.10.0
       env: ${{ fromJSON(steps.build_vars.outputs.vars) }}
       with:
         images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ matrix.target }}
@@ -108,7 +115,7 @@ jobs:
         echo "src=$src" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Push image
-      uses: akhilerm/tag-push-action@v2.2.0
+      uses: akhilerm/tag-push-action@f35ff2cb99d407368b5c727adbcc14a2ed81d509   # v2.2.0
       with:
         src: ${{ steps.images.outputs.src }}
         dst: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  # Pull images built in the build step from ghcr.io
+  packages: read
+
 jobs:
 
   test:
@@ -29,9 +34,11 @@ jobs:
 
     - name: Checkout Repo ⚡️
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Login to GitHub Container Registry 🔑
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0   # v4.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  # The reusable workflows called below push images to ghcr.io
+  packages: write
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,6 +7,9 @@ on:
     branches-ignore: [gh-pages]
     paths: [docs/**]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -19,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core and docs deps
       uses: ./.github/actions/install-aiida-core
@@ -31,17 +36,23 @@ jobs:
       id: linkcheck
       run: |
         make -C docs html linkcheck 2>&1 | tee check.log
-        echo "::set-output name=broken::$(grep '(line\s*[0-9]*)\(\s\)broken\(\s\)' check.log)"
+        {
+          echo 'broken<<EOF_BROKEN'
+          grep '(line\s*[0-9]*)\(\s\)broken\(\s\)' check.log || true
+          echo 'EOF_BROKEN'
+        } >> "$GITHUB_OUTPUT"
       env:
         SPHINXOPTS: -nW --keep-going
 
     - name: Show docs build check results
+      env:
+        BROKEN_LINKS: ${{ steps.linkcheck.outputs.broken }}
       run: |
-        if [ -z "${{ steps.linkcheck.outputs.broken }}" ]; then
+        if [ -z "$BROKEN_LINKS" ]; then
             echo "No broken links found."
             exit 0
         else
             echo "Broken links found:"
-            echo "${{ steps.linkcheck.outputs.broken }}"
+            echo "$BROKEN_LINKS"
             exit 1
         fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -33,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core and pre-commit
       uses: ./.github/actions/install-aiida-core
@@ -75,6 +80,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql
@@ -146,6 +153,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core
       id: install

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches-ignore: [gh-pages]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -21,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install python dependencies
       uses: ./.github/actions/install-aiida-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
     tags:
     - v[0-9]+.[0-9]+.[0-9]+*
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -29,6 +32,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
@@ -46,6 +51,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core and pre-commit
       uses: ./.github/actions/install-aiida-core
@@ -65,6 +72,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install aiida-core
       uses: ./.github/actions/install-aiida-core
@@ -90,6 +99,8 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
@@ -99,7 +110,7 @@ jobs:
     - name: Build
       run: flit build
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b   # v1.14.0
 
 
   publish-testpypi:
@@ -118,6 +129,8 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
@@ -127,6 +140,6 @@ jobs:
     - name: Build
       run: flit build
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b   # v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -21,6 +21,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   validate-dependency-specification:
@@ -32,6 +35,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
@@ -39,7 +44,7 @@ jobs:
         python-version: '3.11'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v7.3.1
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098   # v7.3.1
       with:
         version: latest
 
@@ -59,9 +64,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167   # v3.3.0
       with:
         channels: conda-forge
 
@@ -84,6 +91,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
@@ -126,9 +135,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167   # v3.3.0
       with:
         channels: conda-forge
 
@@ -194,6 +205,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install system dependencies
       run: sudo apt update && sudo apt install postgresql graphviz


### PR DESCRIPTION
Apply defense-in-depth hardening to all workflows against the common supply-chain attack patterns on GitHub Actions (cf. the March 2025 tj-actions/changed-files compromise): a compromised dependency, action, or crafted input executes inside a job and abuses the job's GITHUB_TOKEN or a moved git tag to escalate from there.

1. Declare least-privilege `permissions` in every workflow

   Without an explicit `permissions` block, jobs receive the repository's default token permissions, which may include write access. Every workflow now declares a top-level `permissions: contents: read`, with broader grants only where a job demonstrably needs them:

   - benchmark.yml (run-and-upload): `contents: write` to push benchmark results to gh-pages and write commit comments on performance alerts.
   - docker-build.yml / docker-publish.yml: `packages: write` to push images to ghcr.io; docker-test.yml only `packages: read`.
   - docker.yml (the caller): `contents: read, packages: write`, because reusable workflows can at most inherit the calling workflow's token permissions.
   - release.yml publish jobs keep their existing narrow `id-token: write` grant for PyPI trusted publishing.

   With this, the token is read-only in every job that executes the
   test suite or a large third-party dependency tree.

2. Set `persist-credentials: false` on every actions/checkout

   By default, checkout writes the GITHUB_TOKEN into .git/config,
   where it stays readable by every subsequent step for the rest of
   the job, including anything a compromised transitive dependency
   runs. No step in this repository relies on the persisted
   credential:

   - The benchmark push to gh-pages authenticates via the explicit `github-token` input of github-action-benchmark.
   - `git ls-remote ... origin` in docker-publish.yml works unauthenticated since the repository is public.

3. Fix script injection in docs-build.yml

   The "Show docs build check results" step interpolated `${{ steps.linkcheck.outputs.broken }}` directly into a `run:` script. That value derives from the Sphinx linkcheck log and thus contains URLs controlled by anyone who can touch documentation in a PR; a crafted URL could break out of the `echo` and run arbitrary shell commands. The value is now passed through an environment variable, which is not subject to shell re-parsing. The step also migrates from the long-deprecated `::set-output` command to $GITHUB_OUTPUT, using a heredoc delimiter so that multi-line grep output cannot smuggle in additional outputs.

4. Pin third-party actions to full commit SHAs

   Mutable tags (`@v4`) and branches (`@release/v1`) can be pointed at malicious commits if an action repository or maintainer account is compromised; a full commit SHA cannot. All actions outside the GitHub-maintained `actions/` organization are now pinned to the commit their previous ref resolved to at the time of writing, with the version kept in a trailing comment. Dependabot understands this convention and will keep bumping the pinned SHAs. `actions/*` remain on major tags: they are maintained by the same party that operates the runner, so SHA-pinning them adds comparatively little.

   Most notably, pypa/gh-action-pypi-publish was previously tracked via the moving `release/v1` branch while holding an OIDC token authorized to publish aiida-core to PyPI.

5. Extend Dependabot to the local composite actions

   For the github-actions ecosystem, `directory: /` only scans .github/workflows/. The composite actions under .github/actions/ were silently never updated (their setup-uv was stuck on v6 while workflows had moved to v7). Both action directories are now listed explicitly, so the SHA pins introduced here keep receiving updates.