### PR TITLE
Transport: `core.ssh_async`: allow to run SFTP/scp on a dedicated data transfer node

### DIFF
--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -497,6 +497,31 @@ Security considerations
 * On shared systems, ensure your credential files and downloaded keys are not readable by others.
 
 
+.. _how-to:ssh:data-node:
+
+Using a dedicated data transfer node with ``core.ssh_async``
+============================================================
+
+Some HPC centers provide a dedicated *data transfer node*, tuned for moving large amounts of data, and ask their users not to run heavy transfers on the login node.
+The ``core.ssh_async`` transport plugin can perform your file transfers there, while still submitting and monitoring your calculations on the login node.
+
+Configuring AiiDA
+^^^^^^^^^^^^^^^^^
+
+The data transfer node needs a password-less setup, exactly like the login host: a ``Host <HOST>`` entry in your ``~/.ssh/config``, and ``ssh <HOST>`` connecting without prompting you.
+Once that works, pass it to the ``data_node_host`` option:
+
+.. code-block:: console
+
+   $ verdi computer configure core.ssh_async YOURCOMPUTER
+   ...
+   Login host as in 'ssh <HOST>' (needs a password-less setup, with the host key in known_hosts) [<HPC>]: <HPC>
+   Data transfer host as in 'ssh <HOST>', also requires a password-less SSH setup in your SSH config ('None' to use the login host) [None]: <HPC-DATA>
+   ...
+
+or ``--data-node-host <HPC-DATA>`` non-interactively.
+Leaving it at ``None`` keeps the previous behaviour, where both the file transfers and the calculation commands run through the login host.
+
 
 Connecting to a server without SFTP support
 ===========================================

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -55,9 +55,10 @@ class _AsynchronousSSHBackend(abc.ABC):
     Note: Subclasses should not be part of the public API and should not be used directly.
     """
 
-    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+    def __init__(self, machine: str, data_machine: str, logger: logging.LoggerAdapter, bash_command: str):
         self.bash_command = bash_command + '-c '
         self.machine = machine
+        self.data_machine = data_machine
         self.logger = logger
 
     @abc.abstractmethod
@@ -226,14 +227,29 @@ class _AsyncSSH(_AsynchronousSSHBackend):
     Note: This class is not part of the public API and should not be used directly.
     """
 
-    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
-        super().__init__(machine, logger, bash_command)
-
     async def open(self):
-        self._conn = await asyncssh.connect(self.machine)
-        self._sftp = await self._conn.start_sftp_client()
+        conn = await asyncssh.connect(self.machine)
+        data_conn = None
+        try:
+            data_conn = conn if self.data_machine == self.machine else await asyncssh.connect(self.data_machine)
+            sftp = await data_conn.start_sftp_client()
+        except BaseException:
+            # `BaseException` rather than `Exception`, to also release them when the open is cancelled.
+            if data_conn is not None and data_conn is not conn:
+                data_conn.close()
+                await data_conn.wait_closed()
+            conn.close()
+            await conn.wait_closed()
+            raise
+
+        self._conn = conn
+        self._data_conn = data_conn
+        self._sftp = sftp
 
     async def close(self):
+        if self._data_conn is not self._conn:
+            self._data_conn.close()
+            await self._data_conn.wait_closed()
         self._conn.close()
         await self._conn.wait_closed()
 
@@ -455,8 +471,15 @@ class _OpenSSH(_AsynchronousSSHBackend):
     Note: This class is not part of the public API and should not be used directly.
     """
 
-    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str, use_sftp: bool):
-        super().__init__(machine, logger, bash_command)
+    def __init__(
+        self,
+        machine: str,
+        data_machine: str,
+        logger: logging.LoggerAdapter,
+        bash_command: str,
+        use_sftp: bool,
+    ):
+        super().__init__(machine, data_machine, logger, bash_command)
         self.use_sftp = use_sftp
         self.scp_options: list[str] = []
 
@@ -731,7 +754,12 @@ class _OpenSSH(_AsynchronousSSHBackend):
             options.append('-r')
 
         returncode, stdout, stderr = await self.openssh_execute(
-            ['scp', *options, f'{self.machine}:{self._escape_for_scp(remotepath)}', self._escape_for_scp(localpath)]
+            [
+                'scp',
+                *options,
+                f'{self.data_machine}:{self._escape_for_scp(remotepath)}',
+                self._escape_for_scp(localpath),
+            ]
         )
         if returncode != 0:
             raise OSError({stderr})
@@ -748,7 +776,12 @@ class _OpenSSH(_AsynchronousSSHBackend):
             options.append('-r')
 
         returncode, stdout, stderr = await self.openssh_execute(
-            ['scp', *options, self._escape_for_scp(localpath), f'{self.machine}:{self._escape_for_scp(remotepath)}']
+            [
+                'scp',
+                *options,
+                self._escape_for_scp(localpath),
+                f'{self.data_machine}:{self._escape_for_scp(remotepath)}',
+            ]
         )
         if returncode != 0:
             raise OSError({stderr})
@@ -800,8 +833,8 @@ class _OpenSSH(_AsynchronousSSHBackend):
             [
                 'scp',
                 *options,
-                f'{self.machine}:{self._escape_for_scp(remotesource)}',
-                f'{self.machine}:{self._escape_for_scp(remotedestination)}',
+                f'{self.data_machine}:{self._escape_for_scp(remotesource)}',
+                f'{self.data_machine}:{self._escape_for_scp(remotedestination)}',
             ]
         )
         if returncode != 0:

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -62,7 +62,8 @@ class AsyncSshTransport(AsyncTransport):
             'host',
             {
                 'type': str,
-                'prompt': "Host as in 'ssh <HOST>' (needs a password-less setup, with the host key in known_hosts)",
+                'prompt': "Login host as in 'ssh <HOST>'"
+                ' (needs a password-less setup, with the host key in known_hosts)',
                 'help': (
                     'Password-less host-setup to connect, as in command `ssh <HOST>`.'
                     ' You need to have a `Host <HOST>` entry defined in your `~/.ssh/config` file.'
@@ -70,6 +71,21 @@ class AsyncSshTransport(AsyncTransport):
                     ' connect once manually (e.g. run `ssh <HOST>`) to add it, otherwise the connection could fail.'
                     " Note, if not provided, we will use the 'hostname' that was set by you during setup."
                 ),
+                'non_interactive_default': True,
+            },
+        ),
+        (
+            'data_node_host',
+            {
+                'type': str,
+                'default': 'None',
+                'prompt': "Data transfer host as in 'ssh <HOST>', also requires a password-less SSH setup in your"
+                " SSH config ('None' to use the login host)",
+                'help': ' (optional) Some HPC centers provide a dedicated data transfer node in order to not'
+                ' overwhelm their login node. If set, all file operations (SFTP or scp) are performed on this'
+                ' host, while shell commands are still executed on the login host.'
+                ' As for `host`, this requires a password-less setup, with a `Host <HOST>` entry defined in your'
+                ' `~/.ssh/config` file.',
                 'non_interactive_default': True,
             },
         ),
@@ -147,6 +163,9 @@ class AsyncSshTransport(AsyncTransport):
         # NOTE: to guarantee a connection,
         # a computer with core.ssh_async transport plugin should be configured before any instantiation.
         self.machine = kwargs.pop('host', kwargs.pop('machine'))
+        data_node_host = kwargs.pop('data_node_host', 'None')
+        self.data_machine = self.machine if not data_node_host or data_node_host == 'None' else data_node_host
+
         self._max_io_allowed = kwargs.pop('max_io_allowed', self._DEFAULT_max_io_allowed)
         self._semaphore = asyncio.Semaphore(self._max_io_allowed)
         self.auth_script = kwargs.pop('authentication_script', 'None')
@@ -158,13 +177,19 @@ class AsyncSshTransport(AsyncTransport):
             from .async_backend import _OpenSSH
 
             self.async_backend = _OpenSSH(
-                self.machine, self.logger, self._bash_command_str, use_sftp=kwargs.pop('use_sftp', True)
+                self.machine,
+                self.data_machine,
+                self.logger,
+                self._bash_command_str,
+                use_sftp=kwargs.pop('use_sftp', True),
             )
         else:
             # default backend is asyncssh
             from .async_backend import _AsyncSSH
 
-            self.async_backend = _AsyncSSH(self.machine, self.logger, self._bash_command_str)  # type: ignore[assignment]
+            self.async_backend = _AsyncSSH(  # type: ignore[assignment]
+                self.machine, self.data_machine, self.logger, self._bash_command_str
+            )
 
     @property
     def max_io_allowed(self):

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aiida.transports.plugins.async_backend import _OpenSSH, get_openssh_version
+from aiida.transports.plugins.async_backend import _AsyncSSH, _OpenSSH, get_openssh_version
 from aiida.transports.plugins.ssh_async import AsyncSshTransport
 
 
@@ -74,6 +74,117 @@ class TestAuthenticationScript:
         await transport.open_async()
 
         assert transport.auth_script == 'None'
+
+
+class TestDataNodeHost:
+    """Tests for performing file transfers on a dedicated data transfer node."""
+
+    @staticmethod
+    def _patch_connect():
+        """Patch `asyncssh.connect`, returning the `host -> connection mock` mapping it fills in."""
+        connections = {}
+
+        async def fake_connect(host):
+            connection = AsyncMock()
+            # `close()` is called synchronously, only `wait_closed()` is awaited.
+            connection.close = MagicMock()
+            connections[host] = connection
+            return connection
+
+        return connections, patch('aiida.transports.plugins.async_backend.asyncssh.connect', side_effect=fake_connect)
+
+    @pytest.mark.asyncio
+    async def test_asyncssh_starts_sftp_client_on_data_node(self):
+        """The SFTP client is started on the data node, so that all SFTP traffic is carried out there."""
+        connections, patcher = self._patch_connect()
+        backend = _AsyncSSH('login.hpc', 'dtn.hpc', MagicMock(), 'bash -l ')
+
+        with patcher:
+            await backend.open()
+
+        assert sorted(connections) == ['dtn.hpc', 'login.hpc']
+        connections['dtn.hpc'].start_sftp_client.assert_awaited_once()
+        connections['login.hpc'].start_sftp_client.assert_not_awaited()
+
+        await backend.close()
+
+        connections['dtn.hpc'].close.assert_called_once()
+        connections['login.hpc'].close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_asyncssh_opens_a_single_connection_without_data_node(self):
+        """Without a data node, the SFTP client shares the login connection, no second one is opened."""
+        connections, patcher = self._patch_connect()
+        backend = _AsyncSSH('login.hpc', 'login.hpc', MagicMock(), 'bash -l ')
+
+        with patcher:
+            await backend.open()
+
+        assert list(connections) == ['login.hpc']
+        assert backend._data_conn is backend._conn
+        connections['login.hpc'].start_sftp_client.assert_awaited_once()
+
+        await backend.close()
+
+        connections['login.hpc'].close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'fails_at, error',
+        [('connect', OSError), ('sftp', RuntimeError), ('sftp', asyncio.CancelledError)],
+    )
+    async def test_asyncssh_closes_connections_if_open_fails(self, fails_at, error):
+        """A failed `open` closes the connections it already established, instead of leaking them."""
+        connections = {}
+
+        async def fake_connect(host):
+            if fails_at == 'connect' and host == 'dtn.hpc':
+                raise error()
+            connection = AsyncMock()
+            connection.close = MagicMock()
+            if fails_at == 'sftp':
+                connection.start_sftp_client.side_effect = error()
+            connections[host] = connection
+            return connection
+
+        backend = _AsyncSSH('login.hpc', 'dtn.hpc', MagicMock(), 'bash -l ')
+        patcher = patch('aiida.transports.plugins.async_backend.asyncssh.connect', side_effect=fake_connect)
+
+        with patcher, pytest.raises(error):
+            await backend.open()
+
+        assert connections, 'the login connection should have been established'
+        for connection in connections.values():
+            connection.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_openssh_addresses_scp_to_data_node_and_ssh_to_login_node(self):
+        """`scp` transfers are addressed to the data node, while `ssh` commands stay on the login node."""
+        backend = _OpenSSH('login.hpc', 'dtn.hpc', MagicMock(), 'bash -l ', use_sftp=True)
+        executed = []
+
+        async def fake_execute(commands, stdin=None, timeout=None):
+            executed.append(commands)
+            return 0, '', ''
+
+        backend.openssh_execute = fake_execute
+
+        await backend.get('/remote/x', '/local/x', dereference=False, preserve=False, recursive=False)
+        await backend.put('/local/x', '/remote/x', dereference=False, preserve=False, recursive=False)
+        await backend.copy('/remote/x', '/remote/y', dereference=False, recursive=False, preserve=False)
+        await backend.run('squeue -u aiida-user')
+
+        scp_commands = [command for command in executed if command[0] == 'scp']
+        ssh_commands = [command for command in executed if command[0] == 'ssh']
+
+        assert len(scp_commands) == 3, 'get(), put() and copy() should each issue exactly one scp'
+        for command in scp_commands:
+            assert any(argument.startswith('dtn.hpc:') for argument in command)
+            assert not any(argument.startswith('login.hpc:') for argument in command)
+
+        assert ssh_commands, 'run() should still be executed over ssh'
+        for command in ssh_commands:
+            assert command[1] == 'login.hpc'
 
 
 class TestSemaphoreBehavior:
@@ -265,7 +376,7 @@ def test_escape_for_scp_version_aware():
 def test_use_sftp_selects_scp_mode(version, use_sftp, expected_use_sftp, expected_options):
     """Test that `use_sftp=False` adds `-O`, but only if the client would otherwise transfer over SFTP."""
     with patch('aiida.transports.plugins.async_backend.get_openssh_version', return_value=version):
-        backend = _OpenSSH('myhpc', MagicMock(), 'bash ', use_sftp=use_sftp)
+        backend = _OpenSSH('myhpc', 'myhpc', MagicMock(), 'bash ', use_sftp=use_sftp)
 
     assert backend.use_sftp is expected_use_sftp
     assert backend.scp_options == expected_options
@@ -275,7 +386,7 @@ def test_undetectable_openssh_version_warns():
     """Test that an undetectable client version warns that `use_sftp=False` was not applied."""
     logger = MagicMock()
     with patch('aiida.transports.plugins.async_backend.get_openssh_version', return_value=None):
-        backend = _OpenSSH('myhpc', logger, 'bash ', use_sftp=False)
+        backend = _OpenSSH('myhpc', 'myhpc', logger, 'bash ', use_sftp=False)
 
     assert backend.scp_options == []
     logger.warning.assert_called_once()


### PR DESCRIPTION
Use case:
https://aiida.discourse.group/t/how-to-use-scp-rsync-instead-of-sftp-for-transport/693/13

NOTE: Check against Merlin 7 before merge!
UPDATE: yes!
https://hpce.pages.psi.ch/merlin7/03-how-to-use-merlin/transfer-data/
First of all they allow data transfer on login node. So it's necessary to split it.  If however at some point they enforce using data node, according to their documentation it should done via `scp` as they don't allow ssh connection for data node. So the solution in that case would be to use `openssh` backend.
