### PR TITLE
Fix `QbField` issues

### DIFF
--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from functools import singledispatchmethod
 from pprint import pformat
 from types import UnionType
+from uuid import UUID
 
 from aiida.common.lang import isidentifier
 from aiida.common.warnings import warn_deprecation
@@ -504,7 +505,7 @@ def add_field(
         return QbBoolField(**kwargs)
     elif root_type in (list, tuple, Sequence):
         return QbArrayField(**kwargs)
-    elif root_type in (str, t.Literal):
+    elif root_type in (str, t.Literal, UUID):
         return QbStrField(**kwargs)
     elif root_type is dict:
         return QbDictField(**kwargs)

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -205,8 +205,11 @@ class QbBoolField(QbField):
         return self.as_filter() | other
 
     def __invert__(self) -> QbFieldFilters:
-        """Return a filter for only values that are False."""
-        return QbFieldFilters(((self, '==', False),))
+        """Return a filter for only values that are not `True`.
+
+        Some booleans are optional, so not `False`, but rather `None` (absent).
+        """
+        return QbFieldFilters(((self, '!==', True),))
 
 
 class QbArrayField(QbField):

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -375,14 +375,14 @@ class QbFieldFilters:
     def __and__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """``a & b`` -> {'and': [`a.filters`, `b.filters`]}."""
         qb_filters = other.as_filter() if isinstance(other, QbBoolField) else other
-        qb_filters = self._resolve_redundancy(qb_filters, 'and')
-        return qb_filters or QbFieldFilters({'and': [self.filters, qb_filters.filters]})
+        resolved = self._resolve_redundancy(qb_filters, 'and')
+        return resolved or QbFieldFilters({'and': [self.filters, qb_filters.filters]})
 
     def __or__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """``a | b`` -> {'or': [`a.filters`, `b.filters`]}."""
         qb_filters = other.as_filter() if isinstance(other, QbBoolField) else other
-        qb_filters = self._resolve_redundancy(qb_filters, 'or')
-        return qb_filters or QbFieldFilters({'or': [self.filters, qb_filters.filters]})
+        resolved = self._resolve_redundancy(qb_filters, 'or')
+        return resolved or QbFieldFilters({'or': [self.filters, qb_filters.filters]})
 
     def __invert__(self) -> QbFieldFilters:
         """~(a > b) -> a !> b; ~(a !> b) -> a > b"""

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -187,6 +187,13 @@ class QbNumericField(QbField):
         return QbFieldFilters(((self, '>=', value),))
 
 
+class QbBoolField(QbField):
+    """A boolean (`bool`) flavor of `QbField`.
+
+    Currently not implementing any additional functionality but here for future expansion.
+    """
+
+
 class QbArrayField(QbField):
     """An array (`list`) flavor of `QbField`."""
 
@@ -492,7 +499,8 @@ def add_field(
     root_type = extract_root_type(dtype) if dtype else None
     if root_type in (int, float, datetime.datetime):
         return QbNumericField(**kwargs)
-    elif root_type in (list, tuple):
+    elif root_type is bool:
+        return QbBoolField(**kwargs)
         return QbArrayField(**kwargs)
     elif root_type in (str, t.Literal):
         return QbStrField(**kwargs)

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -190,10 +190,23 @@ class QbNumericField(QbField):
 
 
 class QbBoolField(QbField):
-    """A boolean (`bool`) flavor of `QbField`.
+    """A boolean (`bool`) flavor of `QbField`."""
 
-    Currently not implementing any additional functionality but here for future expansion.
-    """
+    def as_filter(self):
+        """Return a filter for only values that are True."""
+        return QbFieldFilters(((self, '==', True),))
+
+    def __and__(self, other):
+        """Return a filter for only values that are True and satisfy the other filter."""
+        return self.as_filter() & other
+
+    def __or__(self, other):
+        """Return a filter for only values that are True or satisfy the other filter."""
+        return self.as_filter() | other
+
+    def __invert__(self):
+        """Return a filter for only values that are False."""
+        return QbFieldFilters(((self, '==', False),))
 
 
 class QbArrayField(QbField):
@@ -359,12 +372,16 @@ class QbFieldFilters:
             raise TypeError(f'cannot compare QbFieldFilters to {type(other)}')
         return self.filters == other.filters
 
-    def __and__(self, other: QbFieldFilters) -> QbFieldFilters:
+    def __and__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """``a & b`` -> {'and': [`a.filters`, `b.filters`]}."""
+        if isinstance(other, QbBoolField):
+            other = other.as_filter()
         return self._resolve_redundancy(other, 'and') or QbFieldFilters({'and': [self.filters, other.filters]})
 
-    def __or__(self, other: QbFieldFilters) -> QbFieldFilters:
+    def __or__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """``a | b`` -> {'or': [`a.filters`, `b.filters`]}."""
+        if isinstance(other, QbBoolField):
+            other = other.as_filter()
         return self._resolve_redundancy(other, 'or') or QbFieldFilters({'or': [self.filters, other.filters]})
 
     def __invert__(self) -> QbFieldFilters:

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import datetime
 import typing as t
+from collections.abc import Sequence
 from copy import deepcopy
 from functools import singledispatchmethod
 from pprint import pformat
@@ -501,6 +502,7 @@ def add_field(
         return QbNumericField(**kwargs)
     elif root_type is bool:
         return QbBoolField(**kwargs)
+    elif root_type in (list, tuple, Sequence):
         return QbArrayField(**kwargs)
     elif root_type in (str, t.Literal):
         return QbStrField(**kwargs)

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -269,7 +269,7 @@ class QbDictField(QbField):
         """Return a filter for only values with these keys"""
         return QbFieldFilters(((self, 'has_key', value),))
 
-    def __getitem__(self, key: str) -> QbAnyField:
+    def __getitem__(self, key: str) -> QbField:
         """Return a new `QbField` with a nested key."""
         return QbAnyField(
             key=f'{self.key}.{key}',
@@ -307,6 +307,13 @@ class QbAttributesField(QbDictField):
             return children[key]
 
         raise AttributeError(key)
+
+    def __getitem__(self, key: str) -> QbField:
+        """Return a typed child field if known; otherwise return a generic QbAnyField."""
+        children = getattr(self, '_typed_children', None) or {}
+        if key in children:
+            return children[key]
+        return super().__getitem__(key)
 
     def __dir__(self) -> list[str]:
         """Expose typed children for autocompletion."""

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -374,15 +374,15 @@ class QbFieldFilters:
 
     def __and__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """``a & b`` -> {'and': [`a.filters`, `b.filters`]}."""
-        if isinstance(other, QbBoolField):
-            other = other.as_filter()
-        return self._resolve_redundancy(other, 'and') or QbFieldFilters({'and': [self.filters, other.filters]})
+        qb_filters = other.as_filter() if isinstance(other, QbBoolField) else other
+        qb_filters = self._resolve_redundancy(qb_filters, 'and')
+        return qb_filters or QbFieldFilters({'and': [self.filters, qb_filters.filters]})
 
     def __or__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """``a | b`` -> {'or': [`a.filters`, `b.filters`]}."""
-        if isinstance(other, QbBoolField):
-            other = other.as_filter()
-        return self._resolve_redundancy(other, 'or') or QbFieldFilters({'or': [self.filters, other.filters]})
+        qb_filters = other.as_filter() if isinstance(other, QbBoolField) else other
+        qb_filters = self._resolve_redundancy(qb_filters, 'or')
+        return qb_filters or QbFieldFilters({'or': [self.filters, qb_filters.filters]})
 
     def __invert__(self) -> QbFieldFilters:
         """~(a > b) -> a !> b; ~(a !> b) -> a > b"""

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -192,19 +192,19 @@ class QbNumericField(QbField):
 class QbBoolField(QbField):
     """A boolean (`bool`) flavor of `QbField`."""
 
-    def as_filter(self):
+    def as_filter(self) -> QbFieldFilters:
         """Return a filter for only values that are True."""
         return QbFieldFilters(((self, '==', True),))
 
-    def __and__(self, other):
+    def __and__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """Return a filter for only values that are True and satisfy the other filter."""
         return self.as_filter() & other
 
-    def __or__(self, other):
+    def __or__(self, other: QbFieldFilters | QbBoolField) -> QbFieldFilters:
         """Return a filter for only values that are True or satisfy the other filter."""
         return self.as_filter() | other
 
-    def __invert__(self):
+    def __invert__(self) -> QbFieldFilters:
         """Return a filter for only values that are False."""
         return QbFieldFilters(((self, '==', False),))
 

--- a/src/aiida/orm/nodes/data/numeric.py
+++ b/src/aiida/orm/nodes/data/numeric.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Module for defintion of base `Data` sub class for numeric based data types."""
 
+from aiida.orm.pydantic import OrmMetadataField
+
 from .base import BaseType, to_aiida_type
 
 __all__ = ('NumericType',)
@@ -41,6 +43,12 @@ def _right_operator(func):
 
 class NumericType(BaseType):
     """Sub class of Data to store numbers, overloading common operators (``+``, ``*``, ...)."""
+
+    class AttributesModel(BaseType.AttributesModel):
+        value: int | float = OrmMetadataField(
+            title='Numeric value',
+            description='The value of the numeric data',
+        )
 
     @_left_operator
     def __add__(self, other):

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -56,7 +56,7 @@ __all__ = ('QueryBuilder',)
 # re-usable type annotations
 EntityClsType = type[Union[entities.Entity, 'Process']]
 ProjectType = str | dict | Sequence[str | dict]
-FilterType = dict[str, Any] | fields.QbFieldFilters
+FilterType = dict[str, Any] | fields.QbFieldFilters | fields.QbBoolField
 OrderByType = dict | list[dict] | tuple[dict, ...]
 
 LOGGER = AIIDA_LOGGER.getChild('querybuilder')

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -706,6 +706,8 @@ class QueryBuilder:
     @staticmethod
     def _process_filters(filters: FilterType) -> dict[str, Any]:
         """Process filters."""
+        if isinstance(filters, fields.QbBoolField):
+            filters = filters.as_filter()
         if not isinstance(filters, (dict, fields.QbFieldFilters)):
             raise TypeError('Filters must be either a dictionary or QbFieldFilters')
 

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -270,3 +270,22 @@ def test_boolean_query():
     result = query(filters=~orm.Bool.fields.value & (orm.Bool.fields.label == 'false'))
     assert len(result) == 1
     assert result == [False]
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_boolean_null_attribute_query():
+    """Test querying for null (absent) boolean attribute."""
+
+    node = orm.KpointsData().store()
+
+    result = (
+        orm.QueryBuilder()
+        .append(
+            orm.KpointsData,
+            filters=~orm.KpointsData.fields.attributes.pbc1,
+            project=orm.KpointsData.fields.pk,
+        )
+        .all(flat=True)
+    )
+
+    assert result == [node.pk]

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -233,8 +233,8 @@ def test_query_subscriptable():
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_boolean_query():
     """Test using boolean fields in a query."""
-    orm.Bool(True).store()
-    orm.Bool(False).store()
+    orm.Bool(True, label='true').store()
+    orm.Bool(False, label='false').store()
 
     def query(filters):
         return (
@@ -263,10 +263,10 @@ def test_boolean_query():
     assert len(result) == 0
     assert result == []
 
-    result = query(filters=(orm.Bool.fields.pk == 1) & orm.Bool.fields.value)
+    result = query(filters=(orm.Bool.fields.label == 'true') & orm.Bool.fields.value)
     assert len(result) == 1
     assert result == [True]
 
-    result = query(filters=~orm.Bool.fields.value & (orm.Bool.fields.pk == 2))
+    result = query(filters=~orm.Bool.fields.value & (orm.Bool.fields.label == 'false'))
     assert len(result) == 1
     assert result == [False]

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -273,19 +273,31 @@ def test_boolean_query():
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-def test_boolean_null_attribute_query():
-    """Test querying for null (absent) boolean attribute."""
+def test_boolean_query_absent_attribute():
+    """Negating a boolean field must match rows where the attribute is absent.
 
-    node = orm.KpointsData().store()
+    Flag-style attributes like ``paused`` are stored as ``True`` or not at all: ``unpause()``
+    deletes the key rather than storing ``False``. So ``~field`` has to match every row where
+    the attribute is not ``True``, absent rows included.
+    """
+    # One node stays paused: the `paused` attribute is stored as `True`.
+    paused_node = orm.CalculationNode().store()
+    paused_node.pause()
 
-    result = (
-        orm.QueryBuilder()
-        .append(
-            orm.KpointsData,
-            filters=~orm.KpointsData.fields.attributes.pbc1,
-            project=orm.KpointsData.fields.pk,
-        )
-        .all(flat=True)
-    )
+    # One node is paused and then unpaused: the `paused` attribute is deleted, not set to `False`.
+    unpaused_node = orm.CalculationNode().store()
+    unpaused_node.pause()
+    unpaused_node.unpause()
 
-    assert result == [node.pk]
+    # The stored state the query relies on: `True` on one node, absent on the other, even though
+    # the `.paused` property reads back `False` for the absent case (via `attributes.get(key, False)`).
+    assert paused_node.base.attributes.all == {'paused': True}
+    assert unpaused_node.base.attributes.all == {}
+    assert unpaused_node.paused is False
+
+    def count(filters):
+        return orm.QueryBuilder().append(orm.CalculationNode, filters=filters).count()
+
+    assert count(orm.CalculationNode.fields.paused) == 1  # only the paused node
+    assert count(~orm.CalculationNode.fields.paused) == 1  # only the unpaused node
+    assert count(orm.CalculationNode.fields.paused | ~orm.CalculationNode.fields.paused) == 2  # both

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -257,7 +257,7 @@ def test_boolean_query():
 
     result = query(filters=orm.Bool.fields.value | ~orm.Bool.fields.value)
     assert len(result) == 2
-    assert result == [True, False]
+    assert set(result) == {True, False}
 
     result = query(filters=~orm.Bool.fields.value & orm.Bool.fields.value)
     assert len(result) == 0

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -8,6 +8,8 @@
 ###########################################################################
 """Test for entity fields"""
 
+import typing as t
+
 import pytest
 from importlib_metadata import entry_points
 
@@ -274,7 +276,7 @@ def test_boolean_query():
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_boolean_query_absent_attribute():
-    """Negating a boolean field must match rows where the attribute is absent.
+    """Test sparse boolean field negation.
 
     Flag-style attributes like ``paused`` are stored as ``True`` or not at all: ``unpause()``
     deletes the key rather than storing ``False``. So ``~field`` has to match every row where
@@ -301,3 +303,20 @@ def test_boolean_query_absent_attribute():
     assert count(orm.CalculationNode.fields.paused) == 1  # only the paused node
     assert count(~orm.CalculationNode.fields.paused) == 1  # only the unpaused node
     assert count(orm.CalculationNode.fields.paused | ~orm.CalculationNode.fields.paused) == 2  # both
+
+
+def test_attribute_field_access():
+    """Test both modes of attribute field access."""
+    node = orm.Int(42)
+    value_attr_field = node.fields.value
+    assert node.fields.attributes.value is value_attr_field
+    assert node.fields.attributes['value'] is value_attr_field
+
+
+def test_unknown_attribute_field_access():
+    """Test unknown attribute access returns a generic `QbAnyField`."""
+    node = orm.Data()
+    unknown_attr = node.fields.attributes['unknown']
+    assert isinstance(unknown_attr, orm.fields.QbAnyField)
+    assert unknown_attr.key == 'attributes.unknown'
+    assert unknown_attr.dtype is t.Any

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -228,3 +228,45 @@ def test_query_subscriptable():
         .all()
     )
     assert result == [[1, 2]]
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_boolean_query():
+    """Test using boolean fields in a query."""
+    orm.Bool(True).store()
+    orm.Bool(False).store()
+
+    def query(filters):
+        return (
+            orm.QueryBuilder()
+            .append(
+                orm.Bool,
+                filters=filters,
+                project=orm.Bool.fields.value,
+            )
+            .all(flat=True)
+        )
+
+    result = query(filters=orm.Bool.fields.value)
+    assert len(result) == 1
+    assert result == [True]
+
+    result = query(filters=~orm.Bool.fields.value)
+    assert len(result) == 1
+    assert result == [False]
+
+    result = query(filters=orm.Bool.fields.value | ~orm.Bool.fields.value)
+    assert len(result) == 2
+    assert result == [True, False]
+
+    result = query(filters=~orm.Bool.fields.value & orm.Bool.fields.value)
+    assert len(result) == 0
+    assert result == []
+
+    result = query(filters=(orm.Bool.fields.pk == 1) & orm.Bool.fields.value)
+    assert len(result) == 1
+    assert result == [True]
+
+    result = query(filters=~orm.Bool.fields.value & (orm.Bool.fields.pk == 2))
+    assert len(result) == 1
+    assert result == [False]

--- a/tests/orm/test_fields/fields_AuthInfo.yml
+++ b/tests/orm/test_fields/fields_AuthInfo.yml
@@ -1,7 +1,7 @@
 auth_params: QbDictField('auth_params', dtype=dict[str, typing.Any], doc='Dictionary
   of authentication parameters')
 computer: QbNumericField('computer', dtype=<class 'int'>, doc='The PK of the computer')
-enabled: QbAnyField('enabled', dtype=<class 'bool'>, doc='Whether the instance is
+enabled: QbBoolField('enabled', dtype=<class 'bool'>, doc='Whether the instance is
   enabled')
 metadata: QbDictField('metadata', dtype=dict[str, typing.Any], doc='Dictionary of
   metadata')

--- a/tests/orm/test_fields/fields_Comment.yml
+++ b/tests/orm/test_fields/fields_Comment.yml
@@ -7,4 +7,4 @@ node: QbNumericField('node', dtype=<class 'int'>, doc='Node PK that the comment 
   attached to')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 user: QbNumericField('user', dtype=<class 'int'>, doc='User PK that created the comment')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the comment')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the comment')

--- a/tests/orm/test_fields/fields_Computer.yml
+++ b/tests/orm/test_fields/fields_Computer.yml
@@ -9,4 +9,4 @@ scheduler_type: QbStrField('scheduler_type', dtype=<class 'str'>, doc='Scheduler
   of the computer')
 transport_type: QbStrField('transport_type', dtype=<class 'str'>, doc='Transport type
   of the computer')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the computer')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the computer')

--- a/tests/orm/test_fields/fields_Group.yml
+++ b/tests/orm/test_fields/fields_Group.yml
@@ -6,4 +6,4 @@ time: QbNumericField('time', dtype=<class 'datetime.datetime'>, doc='The creatio
   time of the node, defaults to now (timezone-aware)')
 type_string: QbStrField('type_string', dtype=<class 'str'>, doc='The type of the group')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the group owner')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the group')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the group')

--- a/tests/orm/test_fields/fields_Log.yml
+++ b/tests/orm/test_fields/fields_Log.yml
@@ -7,4 +7,4 @@ node: QbNumericField('node', dtype=<class 'int'>, doc='Associated node')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 time: QbNumericField('time', dtype=<class 'datetime.datetime'>, doc='The time at which
   the log was created')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.array.ArrayData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.ArrayData.yml
@@ -18,4 +18,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.array.bands.BandsData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.bands.BandsData.yml
@@ -21,11 +21,11 @@ node_type: QbStrField('node_type', dtype=typing.Literal['data.core.array.bands.B
   doc='The type of the node.')
 offset: QbArrayField('attributes.offset', dtype=list[float] | None, doc='Offset of
   kpoints')
-pbc1: QbAnyField('attributes.pbc1', dtype=bool | None, doc='Periodicity in the first
+pbc1: QbBoolField('attributes.pbc1', dtype=bool | None, doc='Periodicity in the first
   lattice vector direction')
-pbc2: QbAnyField('attributes.pbc2', dtype=bool | None, doc='Periodicity in the second
+pbc2: QbBoolField('attributes.pbc2', dtype=bool | None, doc='Periodicity in the second
   lattice vector direction')
-pbc3: QbAnyField('attributes.pbc3', dtype=bool | None, doc='Periodicity in the third
+pbc3: QbBoolField('attributes.pbc3', dtype=bool | None, doc='Periodicity in the third
   lattice vector direction')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
@@ -37,4 +37,4 @@ units: QbStrField('attributes.units', dtype=str | None, doc='Units in which the 
   in bands were stored')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.array.kpoints.KpointsData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.kpoints.KpointsData.yml
@@ -19,11 +19,11 @@ node_type: QbStrField('node_type', dtype=typing.Literal['data.core.array.kpoints
   doc='The type of the node.')
 offset: QbArrayField('attributes.offset', dtype=list[float] | None, doc='Offset of
   kpoints')
-pbc1: QbAnyField('attributes.pbc1', dtype=bool | None, doc='Periodicity in the first
+pbc1: QbBoolField('attributes.pbc1', dtype=bool | None, doc='Periodicity in the first
   lattice vector direction')
-pbc2: QbAnyField('attributes.pbc2', dtype=bool | None, doc='Periodicity in the second
+pbc2: QbBoolField('attributes.pbc2', dtype=bool | None, doc='Periodicity in the second
   lattice vector direction')
-pbc3: QbAnyField('attributes.pbc3', dtype=bool | None, doc='Periodicity in the third
+pbc3: QbBoolField('attributes.pbc3', dtype=bool | None, doc='Periodicity in the third
   lattice vector direction')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
@@ -33,4 +33,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.array.projection.ProjectionData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.projection.ProjectionData.yml
@@ -18,4 +18,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.array.trajectory.TrajectoryData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.trajectory.TrajectoryData.yml
@@ -21,4 +21,4 @@ source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the d
 symbols: QbArrayField('attributes.symbols', dtype=list[str], doc='List of symbols')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.array.xy.XyData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.array.xy.XyData.yml
@@ -18,12 +18,12 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 x_name: QbStrField('attributes.x_name', dtype=<class 'str'>, doc='The name of the
   x array')
 x_units: QbStrField('attributes.x_units', dtype=<class 'str'>, doc='The units of the
   x array')
-y_names: QbAnyField('attributes.y_names', dtype=collections.abc.Sequence[str], doc='The
+y_names: QbArrayField('attributes.y_names', dtype=collections.abc.Sequence[str], doc='The
   names of the y arrays')
-y_units: QbAnyField('attributes.y_units', dtype=collections.abc.Sequence[str], doc='The
+y_units: QbArrayField('attributes.y_units', dtype=collections.abc.Sequence[str], doc='The
   units of the y arrays')

--- a/tests/orm/test_fields/fields_aiida.data.core.base.BaseType.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.base.BaseType.yml
@@ -18,5 +18,5 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 value: QbAnyField('attributes.value', dtype=typing.Any, doc='The value of the data')

--- a/tests/orm/test_fields/fields_aiida.data.core.bool.Bool.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.bool.Bool.yml
@@ -18,6 +18,6 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-value: QbAnyField('attributes.value', dtype=<class 'bool'>, doc='The value of the
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+value: QbBoolField('attributes.value', dtype=<class 'bool'>, doc='The value of the
   boolean')

--- a/tests/orm/test_fields/fields_aiida.data.core.cif.CifData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.cif.CifData.yml
@@ -30,4 +30,4 @@ spacegroup_numbers: QbArrayField('attributes.spacegroup_numbers', dtype=list[str
   | None, doc='List of space group numbers of the structure')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.code.Code.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.Code.yml
@@ -12,7 +12,7 @@ description: QbStrField('description', dtype=<class 'str'>, doc='The node descri
 extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
 input_plugin: QbStrField('attributes.input_plugin', dtype=str | None, doc='The name
   of the input plugin to be used for this code')
-is_local: QbAnyField('attributes.is_local', dtype=bool | None, doc='Whether the code
+is_local: QbBoolField('attributes.is_local', dtype=bool | None, doc='Whether the code
   is local or remote')
 label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
 local_executable: QbStrField('attributes.local_executable', dtype=str | None, doc='Path
@@ -31,17 +31,17 @@ remote_exec_path: QbStrField('attributes.remote_exec_path', dtype=str | None, do
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
-use_double_quotes: QbAnyField('attributes.use_double_quotes', dtype=<class 'bool'>,
+use_double_quotes: QbBoolField('attributes.use_double_quotes', dtype=<class 'bool'>,
   doc='Whether the executable and arguments of the code in the submission script should
   be escaped with single or double quotes')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-with_mpi: QbAnyField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+with_mpi: QbBoolField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
   should be run as an MPI program. This option can be left unspecified in which case
   `None` will be set and it is left up to the calculation job plugin or inputs whether
   to run with MPI')
-wrap_cmdline_params: QbAnyField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
+wrap_cmdline_params: QbBoolField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
   doc='Whether all command line parameters to be passed to the engine command should
   be wrapped in a double quotes to form a single argument. This should be set to `True`
   for Docker')

--- a/tests/orm/test_fields/fields_aiida.data.core.code.abstract.AbstractCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.abstract.AbstractCode.yml
@@ -24,17 +24,17 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
-use_double_quotes: QbAnyField('attributes.use_double_quotes', dtype=<class 'bool'>,
+use_double_quotes: QbBoolField('attributes.use_double_quotes', dtype=<class 'bool'>,
   doc='Whether the executable and arguments of the code in the submission script should
   be escaped with single or double quotes')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-with_mpi: QbAnyField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+with_mpi: QbBoolField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
   should be run as an MPI program. This option can be left unspecified in which case
   `None` will be set and it is left up to the calculation job plugin or inputs whether
   to run with MPI')
-wrap_cmdline_params: QbAnyField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
+wrap_cmdline_params: QbBoolField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
   doc='Whether all command line parameters to be passed to the engine command should
   be wrapped in a double quotes to form a single argument. This should be set to `True`
   for Docker')

--- a/tests/orm/test_fields/fields_aiida.data.core.code.containerized.ContainerizedCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.containerized.ContainerizedCode.yml
@@ -32,17 +32,17 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
-use_double_quotes: QbAnyField('attributes.use_double_quotes', dtype=<class 'bool'>,
+use_double_quotes: QbBoolField('attributes.use_double_quotes', dtype=<class 'bool'>,
   doc='Whether the executable and arguments of the code in the submission script should
   be escaped with single or double quotes')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-with_mpi: QbAnyField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+with_mpi: QbBoolField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
   should be run as an MPI program. This option can be left unspecified in which case
   `None` will be set and it is left up to the calculation job plugin or inputs whether
   to run with MPI')
-wrap_cmdline_params: QbAnyField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
+wrap_cmdline_params: QbBoolField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
   doc='Whether all command line parameters to be passed to the engine command should
   be wrapped in a double quotes to form a single argument. This should be set to `True`
   for Docker')

--- a/tests/orm/test_fields/fields_aiida.data.core.code.installed.InstalledCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.installed.InstalledCode.yml
@@ -27,17 +27,17 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
-use_double_quotes: QbAnyField('attributes.use_double_quotes', dtype=<class 'bool'>,
+use_double_quotes: QbBoolField('attributes.use_double_quotes', dtype=<class 'bool'>,
   doc='Whether the executable and arguments of the code in the submission script should
   be escaped with single or double quotes')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-with_mpi: QbAnyField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+with_mpi: QbBoolField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
   should be run as an MPI program. This option can be left unspecified in which case
   `None` will be set and it is left up to the calculation job plugin or inputs whether
   to run with MPI')
-wrap_cmdline_params: QbAnyField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
+wrap_cmdline_params: QbBoolField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
   doc='Whether all command line parameters to be passed to the engine command should
   be wrapped in a double quotes to form a single argument. This should be set to `True`
   for Docker')

--- a/tests/orm/test_fields/fields_aiida.data.core.code.portable.PortableCode.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.code.portable.PortableCode.yml
@@ -26,17 +26,17 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
-use_double_quotes: QbAnyField('attributes.use_double_quotes', dtype=<class 'bool'>,
+use_double_quotes: QbBoolField('attributes.use_double_quotes', dtype=<class 'bool'>,
   doc='Whether the executable and arguments of the code in the submission script should
   be escaped with single or double quotes')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-with_mpi: QbAnyField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+with_mpi: QbBoolField('attributes.with_mpi', dtype=bool | None, doc='Whether the executable
   should be run as an MPI program. This option can be left unspecified in which case
   `None` will be set and it is left up to the calculation job plugin or inputs whether
   to run with MPI')
-wrap_cmdline_params: QbAnyField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
+wrap_cmdline_params: QbBoolField('attributes.wrap_cmdline_params', dtype=<class 'bool'>,
   doc='Whether all command line parameters to be passed to the engine command should
   be wrapped in a double quotes to form a single argument. This should be set to `True`
   for Docker')

--- a/tests/orm/test_fields/fields_aiida.data.core.dict.Dict.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.dict.Dict.yml
@@ -18,4 +18,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.enum.EnumData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.enum.EnumData.yml
@@ -21,5 +21,5 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 value: QbAnyField('attributes.value', dtype=typing.Any, doc='The member value')

--- a/tests/orm/test_fields/fields_aiida.data.core.float.Float.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.float.Float.yml
@@ -18,6 +18,6 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 value: QbNumericField('attributes.value', dtype=<class 'float'>, doc='The value of
   the float')

--- a/tests/orm/test_fields/fields_aiida.data.core.folder.FolderData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.folder.FolderData.yml
@@ -18,4 +18,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.int.Int.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.int.Int.yml
@@ -18,6 +18,6 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 value: QbNumericField('attributes.value', dtype=<class 'int'>, doc='The value of the
   integer')

--- a/tests/orm/test_fields/fields_aiida.data.core.jsonable.JsonableData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.jsonable.JsonableData.yml
@@ -22,4 +22,4 @@ the_module: QbStrField('attributes.@module', '@module', dtype=<class 'str'>, doc
   module name of the wrapped object')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.list.List.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.list.List.yml
@@ -18,6 +18,6 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 value: QbArrayField('attributes.list', 'list', dtype=list[typing.Any], doc='Content
   of the data')

--- a/tests/orm/test_fields/fields_aiida.data.core.numeric.NumericType.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.numeric.NumericType.yml
@@ -18,5 +18,6 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
-value: QbAnyField('attributes.value', dtype=typing.Any, doc='The value of the data')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+value: QbNumericField('attributes.value', dtype=int | float, doc='The value of the
+  numeric data')

--- a/tests/orm/test_fields/fields_aiida.data.core.orbital.OrbitalData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.orbital.OrbitalData.yml
@@ -18,4 +18,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.remote.RemoteData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.remote.RemoteData.yml
@@ -21,4 +21,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.remote.stash.RemoteStashData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.remote.stash.RemoteStashData.yml
@@ -20,4 +20,4 @@ stash_mode: QbAnyField('attributes.stash_mode', dtype=<enum 'StashMode'>, doc='T
   mode with which the data was stashed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.remote.stash.compress.RemoteStashCompressedData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.remote.stash.compress.RemoteStashCompressedData.yml
@@ -3,11 +3,11 @@ attributes: QbAttributesField('attributes', dtype=<class 'aiida.orm.nodes.data.r
 computer: QbNumericField('computer', dtype=int | None, doc='The PK of the computer')
 ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creation
   time of the node')
-dereference: QbAnyField('attributes.dereference', dtype=<class 'bool'>, doc='The format
-  of the compression used when stashed')
+dereference: QbBoolField('attributes.dereference', dtype=<class 'bool'>, doc='The
+  format of the compression used when stashed')
 description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
 extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
-fail_on_missing: QbAnyField('attributes.fail_on_missing', dtype=<class 'bool'>, doc='Whether
+fail_on_missing: QbBoolField('attributes.fail_on_missing', dtype=<class 'bool'>, doc='Whether
   stashing should fail if any files are missing')
 label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
 mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
@@ -28,4 +28,4 @@ target_basepath: QbStrField('attributes.target_basepath', dtype=<class 'str'>, d
   the target basepath')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.remote.stash.custom.RemoteStashCustomData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.remote.stash.custom.RemoteStashCustomData.yml
@@ -24,4 +24,4 @@ target_basepath: QbStrField('attributes.target_basepath', dtype=<class 'str'>, d
   the target basepath')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.remote.stash.folder.RemoteStashFolderData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.remote.stash.folder.RemoteStashFolderData.yml
@@ -5,7 +5,7 @@ ctime: QbNumericField('ctime', dtype=<class 'datetime.datetime'>, doc='The creat
   time of the node')
 description: QbStrField('description', dtype=<class 'str'>, doc='The node description')
 extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
-fail_on_missing: QbAnyField('attributes.fail_on_missing', dtype=<class 'bool'>, doc='Whether
+fail_on_missing: QbBoolField('attributes.fail_on_missing', dtype=<class 'bool'>, doc='Whether
   stashing should fail if any files are missing')
 label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
 mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
@@ -26,4 +26,4 @@ target_basepath: QbStrField('attributes.target_basepath', dtype=<class 'str'>, d
   the target basepath')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.singlefile.SinglefileData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.singlefile.SinglefileData.yml
@@ -20,4 +20,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.str.Str.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.str.Str.yml
@@ -18,5 +18,5 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
 value: QbStrField('attributes.value', dtype=<class 'str'>, doc='The value of the string')

--- a/tests/orm/test_fields/fields_aiida.data.core.structure.StructureData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.structure.StructureData.yml
@@ -13,11 +13,11 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['data.core.structure.StructureData.'],
   doc='The type of the node.')
-pbc1: QbAnyField('attributes.pbc1', dtype=<class 'bool'>, doc='Whether periodic in
+pbc1: QbBoolField('attributes.pbc1', dtype=<class 'bool'>, doc='Whether periodic in
   the a direction')
-pbc2: QbAnyField('attributes.pbc2', dtype=<class 'bool'>, doc='Whether periodic in
+pbc2: QbBoolField('attributes.pbc2', dtype=<class 'bool'>, doc='Whether periodic in
   the b direction')
-pbc3: QbAnyField('attributes.pbc3', dtype=<class 'bool'>, doc='Whether periodic in
+pbc3: QbBoolField('attributes.pbc3', dtype=<class 'bool'>, doc='Whether periodic in
   the c direction')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_type: QbStrField('process_type', dtype=str | None, doc='The process type of
@@ -28,4 +28,4 @@ sites: QbArrayField('attributes.sites', dtype=list[dict], doc='The atomic sites'
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.data.core.upf.UpfData.yml
+++ b/tests/orm/test_fields/fields_aiida.data.core.upf.UpfData.yml
@@ -20,4 +20,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.data.Data.yml
+++ b/tests/orm/test_fields/fields_aiida.node.data.Data.yml
@@ -17,4 +17,4 @@ repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.A
 source: QbDictField('attributes.source', dtype=dict | None, doc='Source of the data')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.ProcessNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.ProcessNode.yml
@@ -15,7 +15,7 @@ label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
 mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modification
   time of the node')
 node_type: QbStrField('node_type', dtype=<class 'str'>, doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -28,8 +28,8 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
   the node')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.calculation.CalculationNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.calculation.CalculationNode.yml
@@ -16,7 +16,7 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['process.calculation.CalculationNode.'],
   doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -29,8 +29,8 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
   the node')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.calculation.calcfunction.CalcFunctionNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.calculation.calcfunction.CalcFunctionNode.yml
@@ -16,7 +16,7 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['process.calculation.calcfunction.CalcFunctionNode.'],
   doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -29,8 +29,8 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
   the node')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.calculation.calcjob.CalcJobNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.calculation.calcjob.CalcJobNode.yml
@@ -13,7 +13,7 @@ exit_message: QbStrField('attributes.exit_message', dtype=str | None, doc='The p
 exit_status: QbNumericField('attributes.exit_status', dtype=int | None, doc='The process
   exit status')
 extras: QbDictField('extras', dtype=dict[str, typing.Any], doc='The node extras')
-imported: QbAnyField('attributes.imported', dtype=bool | None, doc='Whether the node
+imported: QbBoolField('attributes.imported', dtype=bool | None, doc='Whether the node
   has been migrated')
 job_id: QbStrField('attributes.job_id', dtype=str | None, doc='The scheduler job id')
 label: QbStrField('label', dtype=<class 'str'>, doc='The node label')
@@ -23,7 +23,7 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['process.calculation.calcjob.CalcJobNode.'],
   doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -38,20 +38,20 @@ remote_workdir: QbStrField('attributes.remote_workdir', dtype=str | None, doc='T
   path to the remote (on cluster) scratch folder')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-retrieve_list: QbAnyField('attributes.retrieve_list', dtype=collections.abc.Sequence[str
+retrieve_list: QbArrayField('attributes.retrieve_list', dtype=collections.abc.Sequence[str
   | tuple[str, str, int]] | None, doc='The list of files to retrieve from the remote
   cluster')
-retrieve_temporary_list: QbAnyField('attributes.retrieve_temporary_list', dtype=collections.abc.Sequence[str
+retrieve_temporary_list: QbArrayField('attributes.retrieve_temporary_list', dtype=collections.abc.Sequence[str
   | tuple[str, str, int]] | None, doc='The list of temporary files to retrieve from
   the remote cluster')
 scheduler_lastchecktime: QbNumericField('attributes.scheduler_lastchecktime', dtype=datetime.datetime
   | None, doc='The last time the scheduler was checked, in isoformat')
 scheduler_state: QbStrField('attributes.scheduler_state', dtype=str | None, doc='The
   state of the scheduler')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 state: QbStrField('attributes.state', dtype=str | None, doc='The active state of the
   calculation job')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.workflow.WorkflowNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.workflow.WorkflowNode.yml
@@ -16,7 +16,7 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['process.workflow.WorkflowNode.'],
   doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -29,8 +29,8 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
   the node')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.workflow.workchain.WorkChainNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.workflow.workchain.WorkChainNode.yml
@@ -16,7 +16,7 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['process.workflow.workchain.WorkChainNode.'],
   doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -29,8 +29,8 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
   the node')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')

--- a/tests/orm/test_fields/fields_aiida.node.process.workflow.workfunction.WorkFunctionNode.yml
+++ b/tests/orm/test_fields/fields_aiida.node.process.workflow.workfunction.WorkFunctionNode.yml
@@ -16,7 +16,7 @@ mtime: QbNumericField('mtime', dtype=<class 'datetime.datetime'>, doc='The modif
   time of the node')
 node_type: QbStrField('node_type', dtype=typing.Literal['process.workflow.workfunction.WorkFunctionNode.'],
   doc='The type of the node.')
-paused: QbAnyField('attributes.paused', dtype=bool | None, doc='Whether the process
+paused: QbBoolField('attributes.paused', dtype=bool | None, doc='Whether the process
   is paused')
 pk: QbNumericField('pk', dtype=<class 'int'>, doc='The primary key of the entity')
 process_label: QbStrField('attributes.process_label', dtype=str | None, doc='The process
@@ -29,8 +29,8 @@ process_type: QbStrField('process_type', dtype=str | None, doc='The process type
   the node')
 repository_metadata: QbDictField('repository_metadata', dtype=dict[str, typing.Any],
   doc='Virtual hierarchy of the file repository')
-sealed: QbAnyField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
+sealed: QbBoolField('attributes.sealed', dtype=<class 'bool'>, doc='Whether the node
   is sealed')
 user: QbNumericField('user', dtype=<class 'int'>, doc='The PK of the user who owns
   the node')
-uuid: QbAnyField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')
+uuid: QbStrField('uuid', dtype=<class 'uuid.UUID'>, doc='The UUID of the node')


### PR DESCRIPTION
This PR fixes the following incorrect `QbAnyField` assignments:

| type | correct QB field class |
|-|-|
|`bool`|`QbBoolField`|
|`UUID`|`QbStrField`|
|`Sequence`|`QbArrayField`|

Regarding the new `QbBoolField`, this now allows for the following:
- `filters=CalcJobNode.fields.paused`
- `filters=... & CalcJobNode.fields.paused` (or `|`)
- `filters=CalcJobNode.fields.paused & ...` (or `|`)
- `filters=~CalcJobNode.fields.paused` (implemented as "not True" instead of "is False" - see [reason](https://github.com/aiidateam/aiida-core/pull/7463#discussion_r3712645405))

In other words, boolean-based queries are now supported!

For `Enum` field annotations, I keep it as `QbAnyField`, as the value can be anything (we have `int`, `str`, and `tuple[str]` in core). Also, I was thinking of falling back to `QbField` if the annotation is not matched but decided in the end to keep it all-permissive, i.e., `QbAnyField`.

Lastly, this PR also addresses the issue that `attributes['value']` doesn't return the same `QbField` as `attributes.value` when `value` is a defined attribute on the node model. When the key is not a defined attribute, we defer to the `QbDictField` indexing behavior of returning a `QbAnyField`.

This addresses a part of #7461 but does not yet close it.