### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # currently active dependency manager (DM) to trigger an automatic review
 # request from the DM upon changes. Please see AEP-002 for details:
 # https://github.com/aiidateam/AEP/tree/master/002_dependency_management
-environment.yml                 @danielhollas @agoscinski @GeigerJ2
-pyproject.toml                  @danielhollas @agoscinski @GeigerJ2
-uv.lock                         @danielhollas @agoscinski @GeigerJ2
-utils/dependency_management.py  @danielhollas @agoscinski @GeigerJ2
+environment.yml                 @agoscinski @GeigerJ2
+pyproject.toml                  @agoscinski @GeigerJ2
+uv.lock                         @agoscinski @GeigerJ2
+utils/dependency_management.py  @agoscinski @GeigerJ2


### PR DESCRIPTION
I am still happy to be tagged for reviews when needed, but don't want to be tagged automatically anytime somebody touches pyproject.toml :-) 