### PR TITLE
🧪 Stabilize several flaky tests

### DIFF
--- a/tests/storage/psql_dos/test_backend.py
+++ b/tests/storage/psql_dos/test_backend.py
@@ -106,6 +106,7 @@ def test_maintain(caplog, monkeypatch, kwargs, logged_texts):
         assert text in message_list
 
 
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_info(monkeypatch):
     """Test the ``get_info`` method."""
     from aiida import orm


### PR DESCRIPTION
Reset the profile before `test_get_info` so the node creation timestamps are not affected by data created in earlier tests.

This avoids flaky assertions on the first and last created node reported by the storage backend.