### PR TITLE
🔧 Add explicit CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit config for aiida-core.
+# Reference: https://docs.coderabbit.ai/reference/configuration
+#
+# CodeRabbit reviews every non-draft PR automatically. Open a PR as a draft to
+# iterate without review. Commands to comment on a PR:
+#
+#   @coderabbitai review         re-review the latest changes
+#   @coderabbitai full review    full re-review from scratch
+#   @coderabbitai resolve        resolve all its comments
+#   @coderabbitai configuration  print the effective config
+#   @coderabbitai help           list every command
+#
+# AGENTS.md / CLAUDE.md already steer reviews as guidance (default); no config needed.
+
+language: en-US
+
+reviews:
+  # Surface only higher-signal comments; `chill` (default) or `assertive` for more.
+  profile: quiet
+
+  auto_review:
+    enabled: true                   # full review of a non-draft PR once, when it opens
+    auto_incremental_review: false  # no re-review on push; ask again with `@coderabbitai full review`
+    drafts: false                   # so opening as a draft is how you skip review while iterating
+
+  # Don't write a summary into the PR description unasked; `@coderabbitai summary` on demand.
+  high_level_summary: false
+
+  # CodeRabbit reviews the diff, so it can suggest a test that already exists just
+  # outside the changed lines. Nudge it to look first (a hint, not a guarantee).
+  path_instructions:
+  - path: tests/**
+    instructions: >-
+      Before suggesting a new test, check the surrounding test file and module
+      for an equivalent existing test, and do not propose one that duplicates
+      existing coverage.
+
+  # Each of these opens a bot-authored PR or commits to the branch, and AGENTS.md
+  # / AI_POLICY.md require a human author for every PR. `autofix` stays on: it
+  # applies a suggestion a human already read and accepted.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    fix_ci:
+      enabled: false
+    resolve_merge_conflict:
+      enabled: false
+
+  tools:
+    ruff:
+      enabled: false  # already enforced by pre-commit and CI; avoids duplicate comments
+    languagetool:
+      enabled: false  # noisy grammar/spell checks on prose and docstrings
+
+chat:
+  auto_reply: false  # don't chime into threads unless tagged
+
+knowledge_base:
+  # CodeRabbit remembers preferences from your chat replies and applies them to
+  # later reviews. If a comment is wrong (e.g. it suggests a test that already
+  # exists), reply and tag `@coderabbitai` explaining why, and it won't repeat it.
+  # On by default; kept explicit because this is how we correct the bot over time.
+  learnings:
+    scope: auto  # auto = repo-local for a public repo like this one

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -27,6 +27,9 @@ Before requesting review, contributors must ensure that all CI checks pass (`uv 
 PRs that fail CI and receive no further attention from the contributor will be closed.
 The same goes for PRs that show signs of being unverified AI output.
 
+On repositories where CodeRabbit is enabled, it reviews every non-draft PR automatically.
+Open your PR as a draft if you want to iterate without review, and address its comments before tagging maintainers.
+
 ### Curate your PR
 
 All PRs must be thoughtfully authored, including the title, description, and commit messages.


### PR DESCRIPTION
EDITED AGAIN:

Adds a `.coderabbit.yaml` for aiida-core. After discussing in the team we're keeping CodeRabbit's automatic reviews on, just tuned so they're less noisy.

How reviews behave with this config:
- Draft PR: not reviewed. Open your PR as a draft while you're still iterating.
- Normal PR: one full review when it opens.
- After you push more commits: no automatic re-review. Ask for another full review by commenting CodeRabbit's full-review command (the exact commands are listed at the top of `.coderabbit.yaml`).

What else it changes:
- `profile: quiet` so only the higher-signal comments surface; bump to `chill` if it feels too sparse.
- `high_level_summary: false` so it doesn't rewrite the PR description on its own.
- Turned off the finishing touches that open bot-authored PRs or commit to your branch (docstrings, unit tests, fix-ci, conflict resolution), since `AI_POLICY.md` requires a human author for every PR. `autofix` stays on: it applies a suggestion you already read and accepted.
- Disabled its bundled `ruff` (we already run ruff in pre-commit and CI) and `languagetool` (noisy grammar checks on prose and docstrings). The security scanners (gitleaks, checkov, semgrep) stay on.
- `chat.auto_reply: false` so it doesn't jump into discussion threads unless tagged.
- One line in `AI_POLICY.md` noting reviews are automatic and drafts skip them.

The config only takes effect once it's on `main`: CodeRabbit reads `.coderabbit.yaml` from the default branch, which is why it had no effect on this PR itself. The org-level web-app settings stay as the baseline for repos without their own file, and global overrides are empty, so this repo file wins once merged.

Our `AGENTS.md` / `CLAUDE.md` conventions already feed reviews automatically (CodeRabbit reads them by default), so nothing there needs to change.