### PR TITLE
🔧 Privatize ZeroMQ broker paths

### DIFF
--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -72,14 +72,6 @@ class ZeromqBroker(Broker):
             return f'ZeroMQ Broker (PID {pid}) @ {self._service_dir}'
         return f'ZeroMQ Broker @ {self._service_dir} <not running>'
 
-    @property
-    def storage_path(self) -> Path:
-        return self._storage_path
-
-    @property
-    def service_dir(self) -> Path:
-        return self._service_dir
-
     # --- Status queries (read PID/status/socket files) ---
 
     def _get_sockets_path(self) -> Path | None:
@@ -188,7 +180,7 @@ class ZeromqBroker(Broker):
 
         return self._communicator
 
-    def iterate_tasks(self) -> t.Iterator[ZeromqIncomingTask]:
+    def iterate_tasks(self) -> t.Iterator[t.Any]:
         queue_path = self._storage_path / 'tasks'
         if not queue_path.exists():
             return

--- a/src/aiida/cmdline/commands/cmd_daemon.py
+++ b/src/aiida/cmdline/commands/cmd_daemon.py
@@ -187,7 +187,7 @@ def status(ctx, all_profiles, timeout):
                 )
             else:
                 broker_lines.append('Broker is NOT running.')
-            broker_lines.append(f'Broker directory: {broker.service_dir}')
+            broker_lines.append(f'Broker directory: {broker._service_dir}')
 
         lines = [
             f'Daemon is running as PID {daemon_response["info"]["pid"]} since {start_time}',

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -615,7 +615,7 @@ def process_repair(manager, broker, dry_run, force):
 
             from aiida.brokers.zeromq.queue import PersistentQueue
 
-            queue_path = broker.storage_path / 'tasks'
+            queue_path = broker._storage_path / 'tasks'
             queue = PersistentQueue(queue_path)
             for pid in zombies:
                 task_id = uuid.uuid4().hex

--- a/src/aiida/tools/pytest_fixtures/broker.py
+++ b/src/aiida/tools/pytest_fixtures/broker.py
@@ -52,13 +52,13 @@ def run_aiida_broker_service_for_profile() -> t.Callable[..., t.ContextManager[Z
         broker = ZeromqBroker(profile)
 
         if broker.check_service_reachable():
-            msg = f'The ZeroMQ broker service is already running at `{broker.service_dir}`.'
+            msg = f'The ZeroMQ broker service is already running at `{broker._service_dir}`.'
             raise RuntimeError(msg)
 
-        broker.service_dir.mkdir(exist_ok=False)
+        broker._service_dir.mkdir(exist_ok=False)
 
         process = subprocess.Popen(
-            [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--service-dir', str(broker.service_dir)],
+            [sys.executable, '-m', 'aiida.brokers.zeromq.service', '--service-dir', str(broker._service_dir)],
             start_new_session=True,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
@@ -86,7 +86,7 @@ def run_aiida_broker_service_for_profile() -> t.Callable[..., t.ContextManager[Z
                     process.kill()
                     process.wait()
 
-            shutil.rmtree(broker.service_dir, ignore_errors=True)
+            shutil.rmtree(broker._service_dir, ignore_errors=True)
 
     return run_broker_service
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -73,7 +73,7 @@ class TestZeromqBrokerStatusQueries:
         """Test probe_service_status captures a missing status file in the payload."""
         assert zeromq_broker.probe_service_status() == {
             'connected': False,
-            'error': f'Status file `{zeromq_broker.service_dir / "broker.status"}` does not exist.',
+            'error': f'Status file `{zeromq_broker._service_dir / "broker.status"}` does not exist.',
         }
 
     def test_str_running(self, aiida_broker):
@@ -87,17 +87,17 @@ class TestZeromqBrokerStatusQueries:
         s = str(zeromq_broker)
         assert 'not running' in s
 
-    def test_storage_path(self, zeromq_broker, tmp_path):
-        """Test storage_path property."""
-        assert zeromq_broker.storage_path == tmp_path / 'storage'
+    def test__storage_path(self, zeromq_broker, tmp_path):
+        """Test internal storage path."""
+        assert zeromq_broker._storage_path == tmp_path / 'storage'
 
-    def test_service_dir(self, zeromq_broker, tmp_path):
-        """Test service_dir property."""
-        assert zeromq_broker.service_dir == tmp_path
+    def test__service_dir(self, zeromq_broker, tmp_path):
+        """Test internal service directory."""
+        assert zeromq_broker._service_dir == tmp_path
 
     def test_is_running_stale_pid(self, zeromq_broker):
         """Test is_running with stale PID."""
-        pid_file = zeromq_broker.service_dir / 'broker.pid'
+        pid_file = zeromq_broker._service_dir / 'broker.pid'
         pid_file.write_text('aiida-zeromq-broker 12345')
 
         with patch('aiida.brokers.zeromq.broker.psutil.Process', side_effect=psutil.NoSuchProcess(pid=12345)):
@@ -105,7 +105,7 @@ class TestZeromqBrokerStatusQueries:
 
     def test_probe_service_status_valid(self, zeromq_broker):
         """Test probe_service_status with valid JSON."""
-        status_file = zeromq_broker.service_dir / 'broker.status'
+        status_file = zeromq_broker._service_dir / 'broker.status'
         status_file.write_text(json.dumps({'pid': 123, 'running': True}))
         status = zeromq_broker.probe_service_status()
         assert status['connected'] is False
@@ -113,7 +113,7 @@ class TestZeromqBrokerStatusQueries:
 
     def test_probe_service_status_invalid_json(self, zeromq_broker):
         """Test probe_service_status captures invalid JSON in the payload."""
-        status_file = zeromq_broker.service_dir / 'broker.status'
+        status_file = zeromq_broker._service_dir / 'broker.status'
         status_file.write_text('{INVALID JSON')
         status = zeromq_broker.probe_service_status()
         assert status['connected'] is False
@@ -121,7 +121,7 @@ class TestZeromqBrokerStatusQueries:
 
     def test_probe_service_status_invalid_payload_type(self, zeromq_broker, caplog):
         """Test probe_service_status captures valid JSON with an invalid top-level type."""
-        status_file = zeromq_broker.service_dir / 'broker.status'
+        status_file = zeromq_broker._service_dir / 'broker.status'
         status_file.write_text(json.dumps(['invalid']))
 
         status = zeromq_broker.probe_service_status()
@@ -214,7 +214,7 @@ class TestZeromqBrokerTasks:
 
     def test_iterate_tasks_with_data(self, zeromq_broker):
         """Test iterate_tasks with pending tasks."""
-        queue_path = zeromq_broker.storage_path / 'tasks'
+        queue_path = zeromq_broker._storage_path / 'tasks'
         queue = PersistentQueue(queue_path)
         queue.push('task-1', {'body': 'hello'})
         queue.push('task-2', {'body': 'world'})

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -37,7 +37,7 @@ def aiida_broker():
 
 def get_router_endpoint(broker: ZeromqBroker) -> str:
     """Construct the router endpoint from the broker service socket file."""
-    sockets_path = Path((broker.service_dir / 'broker.sockets').read_text().strip())
+    sockets_path = Path((broker._service_dir / 'broker.sockets').read_text().strip())
     return f'ipc://{sockets_path}/router.sock'
 
 

--- a/tests/brokers/test_zeromq_payload_optimization.py
+++ b/tests/brokers/test_zeromq_payload_optimization.py
@@ -249,7 +249,7 @@ class TestServerInitializationOptimization:
         sockets_path = tmp_path / 'sockets'
 
         server = ZeromqBrokerServer(storage_path, sockets_path)
-        assert server.storage_path == storage_path
+        assert server._storage_path == storage_path
         assert server.sockets_path == sockets_path
 
 

--- a/tests/brokers/test_zeromq_server.py
+++ b/tests/brokers/test_zeromq_server.py
@@ -30,7 +30,7 @@ class TestZeromqBrokerServerInit:
         sockets_path = tmp_path / 'sockets'
 
         server = ZeromqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
-        assert server.storage_path == storage_path
+        assert server._storage_path == storage_path
         assert server.sockets_path == sockets_path
 
     def test_start_stop(self):


### PR DESCRIPTION
I don't want to expose anything to the public API which is not necessary, so I rather use private members in the code and tests than expose them in the public API if they are really not needed.