### PR TITLE
Revert "⬆️ Bump importlib-metadata to 9.0 (#7465)"

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - disk-objectstore~=1.5.0
 - docstring_parser
 - python-graphviz~=0.19
-- importlib-metadata~=9.0
+- importlib-metadata~=6.0
 - plumpy~=0.26.0
 - ipython>=7.6
 - jedi<0.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   'disk-objectstore~=1.5.0',
   'docstring-parser',
   'graphviz~=0.19',
-  'importlib-metadata~=9.0',
+  'importlib-metadata~=6.0',
   'plumpy~=0.26.0',
   'ipython>=7.6',
   'jedi<0.19',

--- a/src/aiida/cmdline/params/types/identifier.py
+++ b/src/aiida/cmdline/params/types/identifier.py
@@ -114,7 +114,7 @@ class IdentifierParamType(click.ParamType, ABC):
 
             for entry_point in self._entry_points:
                 try:
-                    sub_class = entry_point.load()
+                    sub_class = entry_point.load()  # type: ignore[no-untyped-call]
                 except ImportError as exception:
                     raise RuntimeError(f'failed to load the entry point {entry_point}: {exception}')
 

--- a/src/aiida/cmdline/params/types/plugin.py
+++ b/src/aiida/cmdline/params/types/plugin.py
@@ -169,7 +169,7 @@ class PluginParamType(EntryPointType):
             entry_point = entry_points_by_name.get(p)
             if entry_point is not None:
                 try:
-                    plugin = entry_point.load()
+                    plugin = entry_point.load()  # type: ignore[no-untyped-call]
                     if plugin.__doc__:
                         # extract the initial/summary paragraph (before double newline)
                         doc_summary = plugin.__doc__.strip().split('\n\n')[0]
@@ -260,7 +260,7 @@ class PluginParamType(EntryPointType):
 
         if self.load:
             try:
-                return entry_point.load()
+                return entry_point.load()  # type: ignore[no-untyped-call]
             except exceptions.LoadingEntryPointError as exception:
                 raise click.BadParameter(str(exception))
         else:

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ requires-dist = [
     { name = "flask-restful", marker = "extra == 'rest'", specifier = "~=0.3.10" },
     { name = "graphviz", specifier = "~=0.19" },
     { name = "gssapi", marker = "extra == 'ssh-kerberos'", specifier = "~=1.6" },
-    { name = "importlib-metadata", specifier = "~=9.0" },
+    { name = "importlib-metadata", specifier = "~=6.0" },
     { name = "ipykernel", marker = "extra == 'tests'", specifier = "~=6.9" },
     { name = "ipython", specifier = ">=7.6" },
     { name = "jedi", specifier = "<0.19" },
@@ -1900,14 +1900,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "6.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/eb/58c2ab27ee628ad801f56d4017fe62afab0293116f6d0b08f1d5bd46e06f/importlib_metadata-6.11.0.tar.gz", hash = "sha256:1231cf92d825c9e03cfc4da076a16de6422c863558229ea0b22b675657463443", size = 54593, upload-time = "2023-12-03T17:33:10.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9b/ecce94952ab5ea74c31dcf9ccf78ccd484eebebef06019bf8cb579ab4519/importlib_metadata-6.11.0-py3-none-any.whl", hash = "sha256:f0afba6205ad8f8947c7d338b5342d5db2afbfd82f9cbef7879a9539cc12eb9b", size = 23427, upload-time = "2023-12-03T17:33:08.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrading importlib-metadata from 6.0 changes the public EntryPoint behavior exposed by aiida-core. Version 7.0 removes the deprecated tuple-like EntryPoint interface, so callers can no longer index or unpack returned entry points. Version 9.0 also makes EntryPoint construction eagerly validating, raising earlier for invalid object references.

Since aiida-core returns EntryPoint objects from its public API and constructs them in plugin helpers and test fixtures, this is a compatibility and behavioral break that could lead to breaking downstream packages.

This reverts commit a2daebbb6f29b411d63cba9f46e63a7f1e8314d1.