### PR TITLE
🐛 Derive broker entry point from class

### DIFF
--- a/src/aiida/brokers/broker.py
+++ b/src/aiida/brokers/broker.py
@@ -6,6 +6,8 @@ import abc
 import typing as t
 from dataclasses import dataclass
 
+from aiida.common.lang import classproperty
+
 JsonPrimitive = str | int | float | bool | None
 JsonValue = JsonPrimitive | list['JsonValue'] | dict[str, 'JsonValue']
 BrokerServiceStatus = dict[str, JsonValue]
@@ -37,7 +39,21 @@ class BrokerConfigField:
 class Broker(abc.ABC):
     """Interface for a message broker that facilitates communication with and between process runners."""
 
+    ENTRY_POINT_GROUP = 'aiida.brokers'
     _config_fields: tuple[BrokerConfigField, ...] = ()
+
+    @classproperty
+    def ENTRY_POINT(cls) -> str:  # noqa: N802, N805
+        """Return the entry point name of this broker class."""
+        from aiida.plugins.entry_point import get_entry_point_from_class
+
+        group, entry_point = get_entry_point_from_class(cls.__module__, cls.__name__)
+
+        if group != cls.ENTRY_POINT_GROUP or entry_point is None:
+            msg = f'could not determine entry point for `{cls.__name__}` in group `{cls.ENTRY_POINT_GROUP}`'
+            raise RuntimeError(msg)
+
+        return entry_point.name
 
     def __init__(self, profile: Profile) -> None:
         """Construct a new instance.

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -62,6 +62,20 @@ def test_get_default_config():
     assert ZeromqBroker.get_default_config() == {'supervised_by_daemon': True}
 
 
+def test_entry_point():
+    """Test the broker entry point is derived from the class."""
+    assert ZeromqBroker.ENTRY_POINT == 'core.zeromq'
+
+
+def test_init_invalid_backend():
+    """Test the broker rejects profiles configured for a different backend."""
+    profile = MagicMock()
+    profile.process_control_backend = 'core.rabbitmq'
+
+    with pytest.raises(ValueError, match=r'should be `core\.zeromq`'):
+        ZeromqBroker(profile)
+
+
 class TestZeromqBrokerStatusQueries:
     """Tests for ZeromqBroker status queries (file-based)."""
 


### PR DESCRIPTION
Add a generic `Broker.ENTRY_POINT` classproperty that resolves the registered broker entry point from the concrete class.

Use this in `ZeromqBroker` when validating the configured backend, removing the hardcoded `core.zeromq` string and adding coverage for the derived entry point.

TODO: extend the same pattern to other plugin base classes where code currently hardcodes entry point names.