### PR TITLE
🔧 Stop re-exporting option redirect helper

### DIFF
--- a/src/aiida/manage/__init__.py
+++ b/src/aiida/manage/__init__.py
@@ -45,7 +45,6 @@ __all__ = (
     'get_option_names',
     'get_use_cache',
     'parse_option',
-    'resolve_deprecated_option_name',
     'upgrade_config',
 )
 

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -33,7 +33,6 @@ __all__ = (
     'get_option',
     'get_option_names',
     'parse_option',
-    'resolve_deprecated_option_name',
     'upgrade_config',
 )
 

--- a/src/aiida/manage/configuration/options.py
+++ b/src/aiida/manage/configuration/options.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from aiida.common.exceptions import ConfigurationError
 
-__all__ = ('Option', 'get_option', 'get_option_names', 'parse_option', 'resolve_deprecated_option_name')
+__all__ = ('Option', 'get_option', 'get_option_names', 'parse_option')
 
 
 class Option:


### PR DESCRIPTION
Remove `resolve_deprecated_option_name` from the generated second-level re-exports in `aiida.manage.configuration` and `aiida.manage`. This keeps the helper available from `aiida.manage.configuration.options`, while avoiding its inclusion in the public API surface.