### PR TITLE
 🐛 Create config in load_profile if needed

### DIFF
--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -140,7 +140,7 @@ class Manager:
         # Reconfigure the logging to make sure that profile specific logging config options are taken into account.
         # Note that we do not configure with `with_orm=True` because that will force the backend to be loaded.
         # This should instead be done lazily in `Manager.get_profile_storage`.
-        configure_logging(daemon_log_file=self.get_config().filepaths(self._profile)['profile']['log'])
+        configure_logging(daemon_log_file=self.get_config(create=True).filepaths(self._profile)['profile']['log'])
 
         # Check whether a development version is being run. Note that needs to be called after ``configure_logging``
         # because this function relies on the logging being properly configured for the warning to show.

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -1,10 +1,21 @@
 """Tests for the :mod:`aiida.manage.configuration` module."""
 
+from pathlib import Path
+
 import pytest
 
 import aiida
-from aiida.manage.configuration import Profile, create_profile, get_profile, profile_context
+from aiida.manage.configuration import (
+    Profile,
+    create_profile,
+    get_config_path,
+    get_profile,
+    load_profile,
+    profile_context,
+    reset_config,
+)
 from aiida.manage.manager import get_manager
+from aiida.storage.sqlite_temp import SqliteTempBackend
 
 
 @pytest.mark.parametrize('entry_point', ('core.sqlite_temp', 'core.sqlite_dos'))
@@ -86,3 +97,21 @@ def test_profile_context(config_with_profile, profile_factory):
         assert get_profile() == profile_alternate
 
     assert get_profile() == profile_original
+
+
+@pytest.mark.filterwarnings('ignore:Creating AiiDA configuration folder')
+def test_load_profile_creates_missing_config_for_temporary_profile(empty_config):
+    """Test loading a temporary profile recreates the configuration file if it is missing."""
+    filepath_config = Path(get_config_path())
+    assert filepath_config.is_file()
+
+    get_manager().unload_profile()
+    reset_config()
+    filepath_config.unlink()
+
+    assert not filepath_config.exists()
+
+    profile = SqliteTempBackend.create_profile('temp-profile')
+
+    assert load_profile(profile, allow_switch=True) == profile
+    assert filepath_config.is_file()


### PR DESCRIPTION
 Ensure loading a profile recreates the global config file when it is  missing. This restores support for loading temporary sqlite profiles in  a fresh AiiDA path. Due to c3625ed3a160cc40bb3f7bac65c0faad59afa178 configuring logging, which is done when loading a profile, requires access to the config file. While one can support a configuration-less temporary profile, such logic needs a more exposed to other aiida modules and should not be localized in the SqliteTempBackend. For a simple fix the config file is also created for profiles with SqliteTempBackend as database backend.