### PR TITLE
🐛 Avoid API break due to ORM upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ Scripts that previously ran `verdi daemon start` after `verdi presto` continue t
 
 `verdi storage maintain` now deletes each set of loose files right after the pack to which they were added is written, keeping peak disk usage near the initial size instead of needing roughly double. Pass `--no-incremental-cleanup` to retain the previous behavior (defer cleanup until all packs are written, at the cost of higher peak disk usage).
 
+**ORM model system: use specialized model classes instead of `Model`**
+
+The new ORM model system introduces specialized schemas such as `ReadModel`, `WriteModel`, `ConstructorModel`, and `CliModel` (where supported).
+
+The public `Model` attribute remains available as a deprecated compatibility wrapper for validation and introspection, to give plugin developers time to migrate during the experimental model-system transition. New integrations should use the specialized model classes directly.
+
+Update code as follows:
+
+- use `ReadModel` for read/serialization schemas
+- use `WriteModel` for attribute-based schemas
+- use `ConstructorModel` for constructor-based schemas, where supported
+- use `CliModel` for CLI-oriented schemas, where supported
+
+If existing plugin code still references `Class.Model`, keep it only as a temporary compatibility layer and migrate to the specialized models.
+
 ## v2.8.0 - 2026-03-16
 
 This release brings important improvements to the `BaseRestartWorkChain`, the engine, stashing, typing coverage, and dependency updates.

--- a/src/aiida/common/docs.py
+++ b/src/aiida/common/docs.py
@@ -3,3 +3,6 @@
 URL_BASE = 'https://aiida-core.readthedocs.io/en/stable'
 URL_NO_BROKER = f'{URL_BASE}/installation/guide_quick.html#quick-install-limitations'
 URL_CONFIG_SCHEMA_COMPATIBILITY = f'{URL_BASE}/reference/configuration_schema.html'
+URL_CHANGELOG_ORM_MODELS = (
+    f'{URL_BASE}/reference/_changelog.html#orm-model-system-use-specialized-model-classes-instead-of-model'
+)

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -230,6 +230,43 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
             'write': cls.WriteModel,
         }
 
+    @classmethod
+    def model_to_orm_fields(cls) -> dict[str, pdt.fields.FieldInfo]:
+        """Return the fields that are accepted for ORM construction.
+
+        This compatibility helper mirrors the write schema that is accepted by
+        ``from_model``.
+        """
+        warn_deprecation(
+            '`Entity.model_to_orm_fields()` is deprecated, use `WriteModel.model_fields` instead.',
+            version=3,
+            stacklevel=2,
+        )
+        return dict(cls.WriteModel.model_fields)
+
+    @classmethod
+    def model_to_orm_field_values(cls, model: OrmModel) -> dict[str, Any]:
+        """Return ORM constructor values for a model instance."""
+        warn_deprecation(
+            '`Entity.model_to_orm_field_values()` is deprecated, use `from_model()` to construct an entity '
+            'or call `_to_orm_field_values()` on a specialized model directly if you explicitly need the '
+            'intermediate dictionary.',
+            version=3,
+            stacklevel=2,
+        )
+        compat_model = cls.__dict__.get('_COMPAT_MODEL')
+        if compat_model is not None and isinstance(model, compat_model):
+            from aiida.common.docs import URL_CHANGELOG_ORM_MODELS
+
+            class_name = cast(Any, cls).__name__
+            msg = (
+                f'`{class_name}.Model` is deprecated and only supported for validation/introspection. '
+                f'Use `{class_name}.WriteModel` with `from_model()` instead. '
+                f'See {URL_CHANGELOG_ORM_MODELS}.'
+            )
+            raise ValueError(msg)
+        return model._to_orm_field_values()
+
     def to_model(
         self,
         *,
@@ -275,7 +312,7 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
             )
             raise ValueError(msg)
 
-        fields = model._to_orm_field_values()
+        fields = cls.model_to_orm_field_values(model)
         return cls(**fields)
 
     def serialize(

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -213,6 +213,7 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
         """The write schema of this entity, derived from the absolute schema."""
 
     _MODEL_MAP: ClassVar[dict[str, type[OrmModel]]]
+    _COMPAT_MODEL: ClassVar[type[OrmModel] | None] = None
 
     def __init__(self, backend_entity: BackendEntityType) -> None:
         """:param backend_entity: the backend model supporting this entity"""
@@ -220,6 +221,7 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
         call_with_super_check(self.initialize)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
+        cls._COMPAT_MODEL = None
         cls._patch_write_model()
         cls._patch_qb_fields()
         super().__init_subclass__(**kwargs)
@@ -261,6 +263,18 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
         :param model: An instance of the entity's model class.
         :return: An instance of the entity class.
         """
+        compat_model = cls.__dict__.get('_COMPAT_MODEL')
+        if compat_model is not None and isinstance(model, compat_model):
+            from aiida.common.docs import URL_CHANGELOG_ORM_MODELS
+
+            class_name = cast(Any, cls).__name__
+            msg = (
+                f'`{class_name}.Model` is deprecated and only supported for validation/introspection. '
+                f'Use `{class_name}.WriteModel` with `from_model()` instead. '
+                f'See {URL_CHANGELOG_ORM_MODELS}.'
+            )
+            raise ValueError(msg)
+
         fields = model._to_orm_field_values()
         return cls(**fields)
 
@@ -298,6 +312,75 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
         :return: The constructed entity instance.
         """
         return cls.from_model(cls.WriteModel(**serialized))
+
+    @classproperty
+    def Model(cls) -> type[OrmModel]:  # noqa: N802, N805
+        """Return the deprecated compatibility model class.
+
+        .. deprecated:: This will be removed in v3, use ``ReadModel``/``WriteModel`` instead.
+        """
+        class_name = cast(Any, cls).__name__
+        warn_deprecation(
+            f'`{class_name}.Model` is deprecated, use `{class_name}.ReadModel` and `{class_name}.WriteModel` instead.',
+            version=3,
+            stacklevel=3,
+        )
+        return cls._get_compat_model()
+
+    @classmethod
+    def _get_compat_model(cls) -> type[OrmModel]:
+        """Return the deprecated compatibility model class without emitting a warning."""
+        if cls._COMPAT_MODEL is None:
+            cls._patch_compat_model()
+
+        if cls._COMPAT_MODEL is None:
+            msg = f'failed to create compatibility model for `{cast(Any, cls).__name__}`'
+            raise RuntimeError(msg)
+
+        return cls._COMPAT_MODEL
+
+    @classmethod
+    def _patch_compat_model(cls) -> None:
+        """Patch the deprecated ``Model`` compatibility wrapper."""
+
+        def optionalize(annotation: Any) -> Any:
+            try:
+                return annotation | None
+            except TypeError:
+                return Any | None
+
+        model_fields: dict[str, Any] = {
+            key: (field.annotation, deepcopy(field)) for key, field in cls.WriteModel.model_fields.items()
+        }
+
+        for key, field in cls.ReadModel.model_fields.items():
+            if key in model_fields:
+                continue
+
+            model_fields[key] = (
+                optionalize(field.annotation),
+                OrmMetadataField(
+                    None,
+                    description=field.description,
+                    examples=getattr(field, 'examples', None),
+                    read_only=get_metadata(field, 'read_only', False),
+                ),
+            )
+
+        model = cast(
+            type[OrmModel],
+            pdt.create_model(
+                'Model',
+                __base__=OrmModel,
+                __module__=cls.ReadModel.__module__,
+                **model_fields,
+            ),
+        )
+        model.__qualname__ = f'{cast(Any, cls).__name__}.Model'
+        model.model_config = deepcopy(cls.ReadModel.model_config)
+        model.model_rebuild(force=True)
+
+        cls._COMPAT_MODEL = model
 
     @classproperty
     def objects(cls) -> CollectionType:  # noqa: N805

--- a/src/aiida/orm/fields.py
+++ b/src/aiida/orm/fields.py
@@ -18,6 +18,7 @@ from pprint import pformat
 from types import UnionType
 
 from aiida.common.lang import isidentifier
+from aiida.common.warnings import warn_deprecation
 
 __all__ = (
     'QbField',
@@ -93,9 +94,49 @@ class QbField:
         return self._backend_key
 
     @property
+    def doc(self) -> str:
+        """Return the field documentation string."""
+        warn_deprecation(
+            '`QbField.doc` is deprecated. Inspect the corresponding ORM model field description instead.',
+            version=3,
+            stacklevel=2,
+        )
+        return self._doc
+
+    @property
     def dtype(self) -> t.Any | None:
         """Return the primitive root type."""
         return extract_root_type(self._dtype)
+
+    @property
+    def annotation(self) -> t.Any | None:
+        """Return the full type annotation."""
+        warn_deprecation(
+            '`QbField.annotation` is deprecated. Inspect the corresponding ORM model field annotation instead.',
+            version=3,
+            stacklevel=2,
+        )
+        return self._dtype
+
+    @property
+    def is_attribute(self) -> bool:
+        """Return whether the field is stored in the attributes namespace."""
+        warn_deprecation(
+            '`QbField.is_attribute` is deprecated. Inspect the corresponding ORM model field metadata instead.',
+            version=3,
+            stacklevel=2,
+        )
+        return self._is_attribute
+
+    @property
+    def is_subscriptable(self) -> bool:
+        """Return whether nested lookup through ``field['key']`` is supported."""
+        warn_deprecation(
+            '`QbField.is_subscriptable` is deprecated. Inspect the corresponding ORM model field metadata instead.',
+            version=3,
+            stacklevel=2,
+        )
+        return isinstance(self, QbDictField)
 
     def in_(self, value: t.Iterable[t.Any]):
         """Return a filter for only values in the list"""

--- a/src/aiida/orm/nodes/data/array/array.py
+++ b/src/aiida/orm/nodes/data/array/array.py
@@ -10,6 +10,8 @@
 
 from __future__ import annotations
 
+import base64
+import io
 from collections.abc import Iterable, Iterator, Sequence
 from typing import Any, BinaryIO
 
@@ -115,6 +117,55 @@ class ArrayData(Data):
 
         for key, value in arrays.items():
             self.set_array(key, np.asarray(value))
+
+    @staticmethod
+    def save_arrays(arrays: dict[str, np.ndarray]) -> dict[str, bytes]:
+        """Serialize arrays to base64-encoded ``.npy`` payloads.
+
+        :param arrays: Mapping of array names to numpy arrays.
+        :return: Mapping of array names to base64-encoded bytes.
+        """
+        from aiida.common.warnings import warn_deprecation
+
+        warn_deprecation(
+            '`ArrayData.save_arrays` is deprecated. Use `numpy.save` with `io.BytesIO` directly instead.',
+            version=3,
+            stacklevel=2,
+        )
+
+        results = {}
+
+        for key, array in arrays.items():
+            stream = io.BytesIO()
+            np.save(stream, array, allow_pickle=False)
+            stream.seek(0)
+            results[key] = base64.encodebytes(stream.read())
+
+        return results
+
+    @staticmethod
+    def load_arrays(arrays: dict[str, bytes]) -> dict[str, np.ndarray]:
+        """Deserialize arrays from base64-encoded ``.npy`` payloads.
+
+        :param arrays: Mapping of array names to base64-encoded bytes.
+        :return: Mapping of array names to numpy arrays.
+        """
+        from aiida.common.warnings import warn_deprecation
+
+        warn_deprecation(
+            '`ArrayData.load_arrays` is deprecated. Use `numpy.load` with `io.BytesIO` directly instead.',
+            version=3,
+            stacklevel=2,
+        )
+
+        results = {}
+
+        for key, encoded in arrays.items():
+            stream = io.BytesIO(base64.decodebytes(encoded))
+            stream.seek(0)
+            results[key] = np.load(stream, allow_pickle=False)
+
+        return results
 
     @property
     def arrays(self) -> dict[str, np.ndarray]:

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -35,6 +35,7 @@ from aiida.common import exceptions
 from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
 from aiida.common.log import AIIDA_LOGGER
+from aiida.common.pydantic import get_metadata
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
 from aiida.orm.fields import QbAttributesField, QbFields, add_field
@@ -360,10 +361,103 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
 
     def __init_subclass__(cls, **kwargs) -> None:
         """Patch subclass models."""
+        cls._COMPAT_MODEL = None
         cls._patch_attributes_model()
         cls._patch_read_model()
         cls._patch_constructor_model()
         super().__init_subclass__(**kwargs)
+
+    @classmethod
+    def _patch_compat_model(cls) -> None:
+        """Patch the deprecated ``Model`` compatibility wrapper."""
+
+        def optionalize(annotation: Any) -> Any:
+            try:
+                return annotation | None
+            except TypeError:
+                return Any | None
+
+        def merge_field(
+            current: tuple[Any, pdt.fields.FieldInfo],
+            field: pdt.fields.FieldInfo,
+        ) -> tuple[Any, pdt.fields.FieldInfo]:
+            """Merge a compatibility field with a duplicate field from another schema."""
+            annotation, current_field = current
+            merged_field = deepcopy(field)
+
+            for metadata_key in ('orm_to_model', 'model_to_orm', 'orm_class'):
+                metadata_value = get_metadata(current_field, metadata_key)
+                if metadata_value is not None and get_metadata(merged_field, metadata_key) is None:
+                    merged_field.metadata.append({metadata_key: metadata_value})
+
+            if merged_field.description is None:
+                merged_field.description = current_field.description
+
+            return annotation, merged_field
+
+        model_fields: dict[str, tuple[Any, pdt.fields.FieldInfo]] = {}
+
+        for key, field in cls.WriteModel.model_fields.items():
+            if key in {'attributes', 'node_type'}:
+                continue
+            model_fields[key] = (field.annotation, deepcopy(field))
+
+        for key, field in cls.ReadModel.model_fields.items():
+            if key == 'attributes' or key in model_fields:
+                continue
+
+            model_fields[key] = (
+                optionalize(field.annotation),
+                OrmMetadataField(
+                    None,
+                    description=field.description,
+                    examples=getattr(field, 'examples', None),
+                    read_only=get_metadata(field, 'read_only', False),
+                ),
+            )
+
+        model_fields['attributes'] = (
+            dict[str, Any] | None,
+            OrmMetadataField(
+                None,
+                description='The node attributes',
+                may_be_large=True,
+            ),
+        )
+        model_fields['repository_content'] = (
+            dict[str, bytes] | None,
+            OrmMetadataField(
+                None,
+                description='Dictionary of repository file contents',
+                write_only=True,
+            ),
+        )
+
+        for key, field in cls.AttributesModel.model_fields.items():
+            current = model_fields.get(key)
+            model_fields[key] = (field.annotation, deepcopy(field)) if current is None else merge_field(current, field)
+
+        if cls.supports_constructor_model:
+            for key, field in cls.ConstructorArgsModel.model_fields.items():
+                current = model_fields.get(key)
+                model_fields[key] = (
+                    (field.annotation, deepcopy(field)) if current is None else merge_field(current, field)
+                )
+
+        model = cast(
+            type[OrmModel],
+            pdt.create_model(
+                'Model',
+                __base__=OrmModel,
+                __module__=cls.ReadModel.__module__,
+                **cast(dict[str, Any], model_fields),
+            ),
+        )
+        model.__qualname__ = f'{cast(Any, cls).__name__}.Model'
+        model.model_config = deepcopy(cls.ReadModel.model_config)
+        model.model_rebuild(force=True)
+
+        cls._COMPAT_MODEL = model
 
     @cached_property
     def base(self) -> NodeBase:
@@ -412,6 +506,17 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
         :param files: A mapping of target repository paths to file-like object callables (for efficient streaming).
         :return: The created node instance.
         """
+        compat_model = cls.__dict__.get('_COMPAT_MODEL')
+        if compat_model is not None and isinstance(model, compat_model):
+            from aiida.common.docs import URL_CHANGELOG_ORM_MODELS
+
+            class_name = cast(Any, cls).__name__
+            msg = (
+                f'`{class_name}.Model` is deprecated and only supported for validation/introspection. '
+                f'Use `{class_name}.WriteModel`, `{class_name}.ConstructorModel`, or `{class_name}.CliModel` '
+                f'with `from_model()` instead. See {URL_CHANGELOG_ORM_MODELS}.'
+            )
+            raise ValueError(msg)
         if isinstance(model, cls.WriteModel):
             return cls._from_write_model(model, files=files)
         if cls._ConstructorModel is not None and isinstance(model, cls.ConstructorModel):

--- a/tests/orm/models/test_legacy_model.py
+++ b/tests/orm/models/test_legacy_model.py
@@ -51,3 +51,42 @@ def test_legacy_model_cannot_be_used_with_from_model(orm_class, payload, expecte
 
     with pytest.raises(ValueError, match=expected_model_name):
         orm_class.from_model(model)
+
+
+@pytest.mark.presto
+@pytest.mark.parametrize(
+    ('orm_class', 'payload', 'expected_keys'),
+    (
+        (orm.User, {'email': 'write@aiida.net'}, {'email'}),
+        (orm.Int, {'node_type': orm.Int.class_node_type, 'attributes': {'value': 5}}, {'node_type', 'attributes'}),
+    ),
+)
+def test_model_to_orm_compatibility_helpers(orm_class, payload, expected_keys):
+    """The restored compatibility helpers should reflect the active write schema."""
+    with pytest.warns(AiidaDeprecationWarning, match='model_to_orm_fields'):
+        fields = orm_class.model_to_orm_fields()
+    assert expected_keys <= set(fields)
+
+    with pytest.warns(AiidaDeprecationWarning, match='model_to_orm_field_values'):
+        values = orm_class.model_to_orm_field_values(orm_class.WriteModel(**payload))
+    assert expected_keys <= set(values)
+
+
+@pytest.mark.presto
+@pytest.mark.parametrize(
+    ('orm_class', 'payload', 'expected_model_name'),
+    (
+        (orm.User, {'email': 'legacy@aiida.net'}, 'WriteModel'),
+        (orm.Int, {'user': 2, 'computer': 3, 'value': 5}, 'WriteModel'),
+    ),
+)
+def test_legacy_model_cannot_be_used_with_model_to_orm_field_values(orm_class, payload, expected_model_name):
+    """The restored compatibility helper should reject the deprecated ``Model`` wrapper."""
+    with pytest.warns(AiidaDeprecationWarning, match=r'\.Model` is deprecated'):
+        model_class = orm_class.Model
+
+    model = model_class(**payload)
+
+    with pytest.warns(AiidaDeprecationWarning, match='model_to_orm_field_values'):
+        with pytest.raises(ValueError, match=expected_model_name):
+            orm_class.model_to_orm_field_values(model)

--- a/tests/orm/models/test_legacy_model.py
+++ b/tests/orm/models/test_legacy_model.py
@@ -1,0 +1,53 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the deprecated ``Model`` compatibility wrapper."""
+
+import pytest
+
+from aiida import orm
+from aiida.common.warnings import AiidaDeprecationWarning
+
+
+@pytest.mark.presto
+@pytest.mark.parametrize(
+    ('orm_class', 'payload'),
+    (
+        (orm.User, {'email': 'legacy@aiida.net'}),
+        (orm.Int, {'value': 5}),
+        (orm.Dict, {'value': {'answer': 42}}),
+        (orm.Int, {'user': 2, 'computer': 3, 'value': 5}),
+    ),
+)
+def test_legacy_model_is_available_for_validation(orm_class, payload):
+    """The deprecated ``Model`` wrapper should remain available for validation."""
+    with pytest.warns(AiidaDeprecationWarning, match=r'\.Model` is deprecated'):
+        model_class = orm_class.Model
+
+    model = model_class(**payload)
+
+    assert isinstance(model, model_class)
+
+
+@pytest.mark.presto
+@pytest.mark.parametrize(
+    ('orm_class', 'payload', 'expected_model_name'),
+    (
+        (orm.User, {'email': 'legacy@aiida.net'}, 'WriteModel'),
+        (orm.Int, {'user': 2, 'computer': 3, 'value': 5}, 'WriteModel'),
+    ),
+)
+def test_legacy_model_cannot_be_used_with_from_model(orm_class, payload, expected_model_name):
+    """The deprecated ``Model`` wrapper should fail loudly when passed to ``from_model``."""
+    with pytest.warns(AiidaDeprecationWarning, match=r'\.Model` is deprecated'):
+        model_class = orm_class.Model
+
+    model = model_class(**payload)
+
+    with pytest.raises(ValueError, match=expected_model_name):
+        orm_class.from_model(model)

--- a/tests/orm/nodes/data/test_array.py
+++ b/tests/orm/nodes/data/test_array.py
@@ -11,6 +11,7 @@
 import numpy
 import pytest
 
+from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.orm import ArrayData, load_node
 
 
@@ -61,3 +62,22 @@ def test_get_array():
 
     node = ArrayData(numpy.array([1, 2]))
     assert (node.get_array() == numpy.array([1, 2])).all()
+
+
+def test_save_and_load_arrays():
+    """Test :meth:`aiida.orm.ArrayData.save_arrays` and ``load_arrays``."""
+    arrays = {
+        'a': numpy.array([1, 2, 3]),
+        'b': numpy.array([[1.0, 2.0], [3.0, 4.0]]),
+    }
+
+    with pytest.warns(AiidaDeprecationWarning, match='ArrayData.save_arrays'):
+        serialized = ArrayData.save_arrays(arrays)
+    assert set(serialized) == {'a', 'b'}
+    assert all(isinstance(value, bytes) for value in serialized.values())
+
+    with pytest.warns(AiidaDeprecationWarning, match='ArrayData.load_arrays'):
+        deserialized = ArrayData.load_arrays(serialized)
+    assert set(deserialized) == {'a', 'b'}
+    assert numpy.array_equal(deserialized['a'], arrays['a'])
+    assert numpy.array_equal(deserialized['b'], arrays['b'])

--- a/tests/orm/test_fields.py
+++ b/tests/orm/test_fields.py
@@ -12,6 +12,7 @@ import pytest
 from importlib_metadata import entry_points
 
 from aiida import orm
+from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.orm.fields import add_field
 from aiida.orm.pydantic import OrmMetadataField
 from aiida.plugins import load_entry_point
@@ -60,10 +61,20 @@ def test_add_field():
     node = NewNode()
 
     assert 'key1' in node.fields
+    with pytest.warns(AiidaDeprecationWarning, match='QbField.doc'):
+        assert node.fields.key1.doc == ''
     assert node.fields.key1.dtype is str
+    with pytest.warns(AiidaDeprecationWarning, match='QbField.annotation'):
+        assert node.fields.key1.annotation is str
+    with pytest.warns(AiidaDeprecationWarning, match='QbField.is_attribute'):
+        assert node.fields.key1.is_attribute is True
+    with pytest.warns(AiidaDeprecationWarning, match='QbField.is_subscriptable'):
+        assert node.fields.key1.is_subscriptable is False
     assert isinstance(node.fields.key1, orm.fields.QbStrField)
     assert node.fields.key1.backend_key == 'attributes.key1'
     assert node.fields.key1 == node.fields.attributes.key1
+    with pytest.warns(AiidaDeprecationWarning, match='QbField.is_subscriptable'):
+        assert node.fields.attributes.is_subscriptable is True
 
 
 @pytest.mark.parametrize('key', ('|', 'some.field', '1key'))


### PR DESCRIPTION
There have been several API breaks by the ORM model upgrade f4560285d611bbf4f2b702338ea466da4e210f4c While `aiida.orm.Entity.from_serialized` and `aiida.orm.Entity.from_serialize` have been marked as experimental functions. A few other functions have not been marked and have been just dropped. Most of them are just brought back and marked as deprecated. The `Model` class however is hard to recover with its previous behavior. While it is in the public API, its usage was mainly indirect through the AiiDA (de)serialization system that was marked as experimental. So its okay if we break its usage in the (de)serialization system by raising but we still need to preserve its direct reference as plugins might implement it for their orm data classes. Its hard to recreate the same Model class without bringing back a lot of code, so we take the middle solution by recreating the Model merging the ReadModel and WriteModel. Technically its still breaking the API since this merged model does not have the same API as the one before but at least it does not break any existing implementation of ORM classes that have a Model class or used one of the Model classes in aiida-core.