### PR TITLE
🔧 Make `verdi presto` daemon start opt-in

### DIFF
--- a/.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh
+++ b/.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh
@@ -18,11 +18,8 @@ verdi config set warnings.development_version False
 # If the environment variable `SETUP_DEFAULT_AIIDA_PROFILE` is not set, set it to `true`.
 if [[ ${SETUP_DEFAULT_AIIDA_PROFILE:-true} == true ]] && ! verdi profile show ${AIIDA_PROFILE_NAME} &> /dev/null; then
 
-    # Create AiiDA profile. Set AIIDA_NO_DAEMON_AUTOSTART because the
-    # Docker container manages the daemon lifecycle separately via
-    # s6-overlay (aiida-daemon-start runs after this script and
-    # run-before-daemon-start).
-    AIIDA_NO_DAEMON_AUTOSTART=1 verdi presto \
+    # Create AiiDA profile.
+    verdi presto \
         --verbosity info \
         --profile-name "${AIIDA_PROFILE_NAME:-default}" \
         --email "${AIIDA_USER_EMAIL:-aiida@localhost}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 ### Behavior changes
 
-**`verdi presto`: auto-starts the daemon** ([#7351](https://github.com/aiidateam/aiida-core/pull/7351))
-
-`verdi presto` now starts the daemon automatically after creating the profile, when a broker is configured.
-Scripts that previously ran `verdi daemon start` after `verdi presto` continue to work; the daemon-start invocation is idempotent.
-
 **`verdi storage maintain`: incrementally cleans loose files while packing** ([#7078](https://github.com/aiidateam/aiida-core/pull/7078))
 
 `verdi storage maintain` now deletes each set of loose files right after the pack to which they were added is written, keeping peak disk usage near the initial size instead of needing roughly double. Pass `--no-incremental-cleanup` to retain the previous behavior (defer cleanup until all packs are written, at the cost of higher peak disk usage).

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -339,7 +339,6 @@ Below is a list with all available subcommands.
       * Create a default user for the profile (email can be configured through the `--email` option)
       * Set up the localhost as a `Computer` and configure it
       * Set a number of configuration options with sensible defaults
-      * Start the daemon (unless `--no-broker` is specified)
 
       By default the command creates a profile that uses SQLite for the database. For the
       message broker, it automatically checks for RabbitMQ running on localhost. If found, it

--- a/src/aiida/cmdline/commands/cmd_presto.py
+++ b/src/aiida/cmdline/commands/cmd_presto.py
@@ -184,7 +184,6 @@ def verdi_presto(
     * Create a default user for the profile (email can be configured through the `--email` option)
     * Set up the localhost as a `Computer` and configure it
     * Set a number of configuration options with sensible defaults
-    * Start the daemon (unless `--no-broker` is specified)
 
     By default the command creates a profile that uses SQLite for the database. For the message broker, it automatically
     checks for RabbitMQ running on localhost. If found, it configures RabbitMQ as the broker. Otherwise, it falls back
@@ -293,9 +292,7 @@ def verdi_presto(
 
     echo.echo_success('Configured the localhost as a computer.')
 
-    # `AIIDA_NO_DAEMON_AUTOSTART` is an internal escape hatch for the Docker init script (see
-    # `.docker/aiida-core-base/s6-assets/init/aiida-prepare.sh`); deliberately undocumented in `--help`.
-    if broker_backend is not None and os.environ.get('AIIDA_NO_DAEMON_AUTOSTART') != '1':
+    if broker_backend is not None and os.environ.get('AIIDA_PRESTO_DAEMON_AUTOSTART'):
         from aiida.common.exceptions import ConfigurationError
         from aiida.engine.daemon.client import DaemonException, get_daemon_client
 

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -16,6 +16,8 @@ def mock_daemon_client(monkeypatch):
     """Mock the daemon client so the daemon is not actually started during tests."""
     from aiida.engine.daemon import client as daemon_client_mod
 
+    monkeypatch.delenv('AIIDA_PRESTO_DAEMON_AUTOSTART', raising=False)
+
     mock_client = MagicMock()
     monkeypatch.setattr(daemon_client_mod, 'get_daemon_client', lambda *args, **kwargs: mock_client)
     return mock_client
@@ -109,36 +111,31 @@ def test_presto_overdose(run_cli_command, config_with_profile_factory):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto_starts_daemon(run_cli_command, mock_daemon_client):
-    """Test that ``verdi presto`` auto-starts the daemon."""
-    result = run_cli_command(verdi_presto, ['--non-interactive'])
-    assert 'Starting the daemon' in result.output
-    mock_daemon_client.start_daemon.assert_called_once_with()
-
-
-@pytest.mark.usefixtures('empty_config')
-def test_presto_no_daemon_autostart_env(run_cli_command, mock_daemon_client, monkeypatch):
-    """Test that ``AIIDA_NO_DAEMON_AUTOSTART=1`` skips the daemon auto-start."""
-    monkeypatch.setenv('AIIDA_NO_DAEMON_AUTOSTART', '1')
+def test_presto_skips_daemon_by_default(run_cli_command, mock_daemon_client):
+    """Test that ``verdi presto`` does not auto-start the daemon by default."""
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile' in result.output
     assert 'Starting the daemon' not in result.output
     mock_daemon_client.start_daemon.assert_not_called()
 
 
-@pytest.mark.parametrize('value', ('0', 'true', 'false', '', 'banana'))
 @pytest.mark.usefixtures('empty_config')
-def test_presto_daemon_autostart_env_non_one(run_cli_command, mock_daemon_client, monkeypatch, value):
-    """Test that anything other than the literal string ``1`` does not skip the daemon.
-
-    Only ``AIIDA_NO_DAEMON_AUTOSTART=1`` is recognized; any other value (including ``0``, ``true``,
-    typos, or empty string) falls through to "start the daemon" so a misspelled or unrecognized
-    value doesn't silently disable the daemon.
-    """
-    monkeypatch.setenv('AIIDA_NO_DAEMON_AUTOSTART', value)
+def test_presto_daemon_autostart_env_non_empty(run_cli_command, mock_daemon_client, monkeypatch):
+    """Test that any non-empty ``AIIDA_PRESTO_DAEMON_AUTOSTART`` value starts the daemon."""
+    monkeypatch.setenv('AIIDA_PRESTO_DAEMON_AUTOSTART', 'SET')
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Starting the daemon' in result.output
     mock_daemon_client.start_daemon.assert_called_once_with()
+
+
+@pytest.mark.usefixtures('empty_config')
+def test_presto_daemon_autostart_env_empty(run_cli_command, mock_daemon_client, monkeypatch):
+    """Test that an empty ``AIIDA_PRESTO_DAEMON_AUTOSTART`` value does not start the daemon."""
+    monkeypatch.setenv('AIIDA_PRESTO_DAEMON_AUTOSTART', '')
+    result = run_cli_command(verdi_presto, ['--non-interactive'])
+    assert 'Created new profile' in result.output
+    assert 'Starting the daemon' not in result.output
+    mock_daemon_client.start_daemon.assert_not_called()
 
 
 @pytest.mark.usefixtures('empty_config')
@@ -151,10 +148,11 @@ def test_presto_no_broker_skips_daemon(run_cli_command, mock_daemon_client):
 
 
 @pytest.mark.usefixtures('empty_config')
-def test_presto_daemon_start_failure(run_cli_command, mock_daemon_client):
+def test_presto_daemon_start_failure(run_cli_command, mock_daemon_client, monkeypatch):
     """Test that ``verdi presto`` handles daemon start failure gracefully."""
     from aiida.engine.daemon.client import DaemonException
 
+    monkeypatch.setenv('AIIDA_PRESTO_DAEMON_AUTOSTART', 'True')
     mock_daemon_client.start_daemon.side_effect = DaemonException('Could not start daemon')
 
     result = run_cli_command(verdi_presto, ['--non-interactive'])


### PR DESCRIPTION
I decided to revert the change in 6a6f66a956008ea0163e5a3d5766c10716a8350f to not cause a behavioral break. You can still turn the behavior on by setting `AIIDA_DAEMON_AUTOSTART=1`