### PR TITLE
🔧 Rename RabbitmqBroker redaction flag

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -91,7 +91,7 @@ class RabbitmqBroker(Broker):
         self._prefix = f'aiida-{self._profile.uuid}'
 
     def __str__(self) -> str:
-        url = self.get_url(safe=True)
+        url = self.get_url(redact_credentials=True)
 
         try:
             return f'RabbitMQ v{self.get_rabbitmq_version()} @ {url}'
@@ -193,10 +193,10 @@ class RabbitmqBroker(Broker):
 
         return version, True
 
-    def get_url(self, safe: bool = False) -> str:
+    def get_url(self, redact_credentials: bool = False) -> str:
         """Return the RMQ url for this profile.
 
-        :param safe: If ``True``, redact embedded credentials in the returned URL.
+        :param redact_credentials: If ``True``, redact embedded credentials in the returned URL.
         """
         from urllib.parse import urlsplit, urlunsplit
 
@@ -208,7 +208,7 @@ class RabbitmqBroker(Broker):
         additional_kwargs = kwargs.pop('parameters', {})
         url = get_rmq_url(**kwargs, **additional_kwargs)
 
-        if not safe:
+        if not redact_credentials:
             return url
 
         parsed = urlsplit(url)

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -205,8 +205,8 @@ def test_get_rmq_url_quotes_credentials():
     assert url.startswith('amqp://user%2Fname:pass%3Fword%23fragment@127.0.0.1:5672?')
 
 
-def test_get_url_safe_quotes_then_redacts_credentials():
-    """Test safe broker URLs redact credentials after quoting reserved characters."""
+def test_get_url_redact_credentials_quotes_then_redacts_credentials():
+    """Test redacted broker URLs hide credentials after quoting reserved characters."""
     profile = SimpleNamespace(
         uuid='uuid',
         is_test_profile=False,
@@ -217,7 +217,7 @@ def test_get_url_safe_quotes_then_redacts_credentials():
     )
     broker = RabbitmqBroker(profile)
 
-    assert broker.get_url(safe=True).startswith('amqp://user%2Fname:***@127.0.0.1:5672?')
+    assert broker.get_url(redact_credentials=True).startswith('amqp://user%2Fname:***@127.0.0.1:5672?')
 
 
 @pytest.mark.parametrize('url', ('amqp://guest:guest@127.0.0.1:5672',))


### PR DESCRIPTION
Rename the `RabbitmqBroker.get_url` keyword argument from `safe` to `redact_credentials`.

The new name describes the behavior more clearly and avoids shipping the unreleased parameter under a vague API name. Update the RabbitMQ broker tests accordingly.