### PR TITLE
Release v2.7.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
         extras: '[pre-commit]'
         from-lock: 'false'
 
-    - name: Run pre-commit
-      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+    - name: Run mypy
+      run: pre-commit run mypy --all-files
 
   tests:
     if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && contains(fromJson(toJson(github.event.pull_request.labels)).*.name, 'test-release'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v2.7.4 - 2026-07-25
+
+This patch fixes a SQLite QueryBuilder regression where plugin code using filters such as `{'ctime': {'in': [...]}}` or `{'ctime': {'!in': [...]}}` with Python `datetime` values could fail.
+Plugins that compare or exclude nodes by creation/modification time should now work again with SQLite profiles.
+
+### Fixes
+
+#### Storage
+- Fix SQLite `IN` filters for non-JSON-serializable values ([#7486](https://github.com/aiidateam/aiida-core/pull/7486)) [[27d71c131]](https://github.com/aiidateam/aiida-core/commit/27d71c131c59943afa4e1ff58cdbf20d55442384)
+
+#### Configuration
+- Add guidance on how to fix config version error ([#7421](https://github.com/aiidateam/aiida-core/pull/7421)) [[7f1b98214]](https://github.com/aiidateam/aiida-core/commit/7f1b9821454bb46c69025392655accbf873f88d0)
+- Clarify config downgrade error message ([#7436](https://github.com/aiidateam/aiida-core/pull/7436)) [[9d7302c57]](https://github.com/aiidateam/aiida-core/commit/9d7302c5790b9897b15a286cc6620da9acc6ad11)
+- Add a config v10 migration for deprecated logging and broker options ([#7417](https://github.com/aiidateam/aiida-core/pull/7417)) [[4d2978c83]](https://github.com/aiidateam/aiida-core/commit/4d2978c834b27eaaf7b21e628c3c6f161f538af9)
+- Allow config downgrade for known migrations ([#7491](https://github.com/aiidateam/aiida-core/pull/7491)) [[7f36513db]](https://github.com/aiidateam/aiida-core/commit/7f36513db35f05e10d2fec6d6923951c564363d3)
+
+
 ## v2.7.3 - 2026-01-23
 
 ### Fixes

--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -27,7 +27,7 @@ __copyright__ = (
     'For further information please visit http://www.aiida.net/. All rights reserved.'
 )
 __license__ = 'MIT license, see LICENSE.txt file.'
-__version__ = '2.7.3'
+__version__ = '2.7.4'
 __authors__ = 'The AiiDA team.'
 __paper__ = (
     'S. P. Huber et al., "AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and '

--- a/src/aiida/cmdline/utils/defaults.py
+++ b/src/aiida/cmdline/utils/defaults.py
@@ -25,6 +25,10 @@ def get_default_profile():
     """
     try:
         config = get_config(create=True)
+    except exceptions.ConfigurationVersionError as exception:
+        if exception._can_downgrade:
+            return None
+        echo.echo_critical(str(exception))
     except exceptions.ConfigurationError as exception:
         echo.echo_critical(str(exception))
 

--- a/src/aiida/common/docs.py
+++ b/src/aiida/common/docs.py
@@ -2,3 +2,4 @@
 
 URL_BASE = 'https://aiida-core.readthedocs.io/en/stable'
 URL_NO_BROKER = f'{URL_BASE}/installation/guide_quick.html#quick-install-limitations'
+URL_CONFIG_SCHEMA_COMPATIBILITY = f'{URL_BASE}/reference/configuration_schema.html'

--- a/src/aiida/common/exceptions.py
+++ b/src/aiida/common/exceptions.py
@@ -180,9 +180,10 @@ class MissingConfigurationError(ConfigurationError):
 
 
 class ConfigurationVersionError(ConfigurationError):
-    """Configuration error raised when the configuration file version is not
-    compatible with the current version.
-    """
+    """Configuration error raised when the configuration file version is not compatible with the current version."""
+
+    # Hotfix see issue #7493
+    _can_downgrade: bool = False
 
 
 class ClosedStorage(AiidaException):

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -34,6 +34,8 @@ ConfigType = Dict[str, Any]
 
 CURRENT_CONFIG_VERSION = 9
 OLDEST_COMPATIBLE_CONFIG_VERSION = 9
+# Highest configuration version for which this code can run downgrade migrations, even if it cannot load it.
+MAXIMUM_DOWNGRADE_CONFIG_VERSION = 10
 
 CONFIG_LOGGER = AIIDA_LOGGER.getChild('config')
 
@@ -497,6 +499,41 @@ def get_oldest_compatible_version(config):
     return config.get('CONFIG_VERSION', {}).get('OLDEST_COMPATIBLE', 0)
 
 
+def config_can_be_downgraded(
+    config: ConfigType,
+    target: Optional[int] = None,
+    migrations: Iterable[type[SingleMigration]] = MIGRATIONS,
+) -> bool:
+    """Return whether the configuration can be downgraded to the target version.
+
+    This is intentionally distinct from :data:`CURRENT_CONFIG_VERSION`: an AiiDA version may not be able to load a
+    configuration for normal operation, but may still know enough migrations to rewrite it for an older version.
+
+    :param config: the configuration dictionary
+    :param target: the version to downgrade to, defaulting to :data:`CURRENT_CONFIG_VERSION`
+    :param migrations: the registered migrations to consider
+    :return: ``True`` if a chain of migrations exists to downgrade the configuration to the target version
+    """
+    target = CURRENT_CONFIG_VERSION if target is None else target
+    current = get_current_version(config)
+
+    if current <= target or current > MAXIMUM_DOWNGRADE_CONFIG_VERSION:
+        return False
+
+    used = []
+    while current > target:
+        try:
+            migrator = next(m for m in migrations if m.up_revision == current)
+        except StopIteration:
+            return False
+        if migrator in used:
+            return False
+        used.append(migrator)
+        current = migrator.down_revision
+
+    return current == target
+
+
 def upgrade_config(
     config: ConfigType, target: int = CURRENT_CONFIG_VERSION, migrations: Iterable[Type[SingleMigration]] = MIGRATIONS
 ) -> ConfigType:
@@ -534,6 +571,13 @@ def downgrade_config(
     :return: the migrated configuration dictionary
     """
     current = get_current_version(config)
+    if current > MAXIMUM_DOWNGRADE_CONFIG_VERSION:
+        msg = (
+            f'Cannot downgrade configuration version {current}: this AiiDA version can only downgrade configuration '
+            f'versions up to {MAXIMUM_DOWNGRADE_CONFIG_VERSION}.'
+        )
+        raise exceptions.ConfigurationError(msg)
+
     used = []
     while current > target:
         current = get_current_version(config)
@@ -580,13 +624,25 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
 
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         filepath = filepath if filepath else ''
-        msg = (
-            f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
-            f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
-            'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
-            f' at least version {CURRENT_CONFIG_VERSION} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
-            f' to rewrite it for an older version. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
-        )
-        raise exceptions.ConfigurationVersionError(msg)
+        can_downgrade = config_can_be_downgraded(config)
+        if can_downgrade:
+            msg = (
+                f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
+                f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
+                f'Run `verdi config downgrade {CURRENT_CONFIG_VERSION}` to rewrite it for this version. See '
+                f'{URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
+            )
+        else:
+            msg = (
+                f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
+                f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
+                'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
+                f'configuration version {current_version} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
+                'to rewrite it for this version. See '
+                f'{URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
+            )
+        error = exceptions.ConfigurationVersionError(msg)
+        error._can_downgrade = can_downgrade
+        raise error
 
     return CURRENT_CONFIG_VERSION > current_version

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -11,6 +11,7 @@
 from typing import Any, Dict, Iterable, Optional, Protocol, Type
 
 from aiida.common import exceptions
+from aiida.common.docs import URL_CONFIG_SCHEMA_COMPATIBILITY
 from aiida.common.log import AIIDA_LOGGER
 
 __all__ = (
@@ -503,10 +504,13 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
 
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         filepath = filepath if filepath else ''
-        raise exceptions.ConfigurationVersionError(
-            f'The configuration file has version {current_version} '
-            f'which is not compatible with the current version {CURRENT_CONFIG_VERSION}: {filepath}\n'
-            'Use a newer version of AiiDA to downgrade this configuration.'
+        msg = (
+            f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
+            f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
+            'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
+            f' at least version {CURRENT_CONFIG_VERSION} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
+            f' to rewrite it for an older version. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
         )
+        raise exceptions.ConfigurationVersionError(msg)
 
     return CURRENT_CONFIG_VERSION > current_version

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -505,11 +505,14 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         filepath = filepath if filepath else ''
         msg = (
-            f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
-            f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
-            'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
-            f' at least version {CURRENT_CONFIG_VERSION} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
-            f' to rewrite it for an older version. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
+            f'The AiiDA configuration file {filepath} has version {current_version}, which is not compatible with '
+            f'the current AiiDA version that supports configuration versions up to {CURRENT_CONFIG_VERSION}. '
+            'Before switching to an older AiiDA version, stop the daemon and avoid other AiiDA interactions. '
+            'Then use a newer AiiDA version that still supports '
+            f'configuration version {current_version} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
+            f'to rewrite the configuration file to version {CURRENT_CONFIG_VERSION}. See '
+            f'{URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility '
+            'table.'
         )
         raise exceptions.ConfigurationVersionError(msg)
 

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -392,6 +392,81 @@ class AddPrefixToStorageBackendTypes(SingleMigration):
                 )
 
 
+class RenameRmqAndLogging(SingleMigration):
+    """Migrate the logging (and related) configuration options introduced in version 10.
+
+    Deprecated options are renamed to their replacements: ``logging.db_loglevel`` becomes ``logging.database_handler``
+    and ``rmq.task_timeout`` becomes ``broker.task_timeout``. Any explicitly set value is moved to the new option.
+    """
+
+    down_revision = 9
+    down_compatible = 9
+    up_revision = 10
+    up_compatible = 10
+
+    option_renames = (
+        ('logging.db_loglevel', 'logging.database_handler'),
+        ('rmq.task_timeout', 'broker.task_timeout'),
+    )
+    advanced_logger_options = (
+        'logging.verdi_loglevel',
+        'logging.disk_objectstore_loglevel',
+        'logging.plumpy_loglevel',
+        'logging.kiwipy_loglevel',
+        'logging.paramiko_loglevel',
+        'logging.alembic_loglevel',
+        'logging.sqlalchemy_loglevel',
+        'logging.circus_loglevel',
+        'logging.aiopika_loglevel',
+    )
+    v10_only_options = (
+        'logging.aiida_core_loglevel',
+        'logging.terminal_handler',
+    )
+
+    @classmethod
+    def _rename_options(cls, options: dict[str, Any], *, downgrade: bool = False) -> None:
+        """Rename deprecated options between the version 9 and 10 names."""
+        for option_v9, option_v10 in cls.option_renames:
+            source, target = (option_v10, option_v9) if downgrade else (option_v9, option_v10)
+            if (value := options.pop(source, None)) is not None:
+                options.setdefault(target, value)
+
+    @classmethod
+    def _remove_v10_only_options(cls, options: dict[str, Any]) -> None:
+        """Remove options that did not exist before version 10."""
+        for option_name in cls.v10_only_options:
+            options.pop(option_name, None)
+
+    @classmethod
+    def _resolve_inherited_logger_options(cls, options: dict[str, Any], fallback_level: str) -> None:
+        """Resolve ``INHERIT`` for advanced logger options to the effective ``logging.aiida_loglevel``."""
+        for option_name in cls.advanced_logger_options:
+            if options.get(option_name) == 'INHERIT':
+                options[option_name] = fallback_level
+
+    def upgrade(self, config: ConfigType) -> None:
+        global_options = config.get('options', {})
+        self._rename_options(global_options)
+
+        for profile in config.get('profiles', {}).values():
+            self._rename_options(profile.get('options', {}))
+
+    def downgrade(self, config: ConfigType) -> None:
+        global_options = config.get('options', {})
+        global_fallback = global_options.get('logging.aiida_loglevel', 'REPORT')
+        self._resolve_inherited_logger_options(global_options, global_fallback)
+        self._rename_options(global_options, downgrade=True)
+        self._remove_v10_only_options(global_options)
+
+        for profile in config.get('profiles', {}).values():
+            options = profile.get('options', {})
+            profile_fallback = options.get('logging.aiida_loglevel', global_fallback)
+            self._resolve_inherited_logger_options(options, profile_fallback)
+            self._rename_options(options, downgrade=True)
+            self._remove_v10_only_options(options)
+
+
 MIGRATIONS = (
     Initial,
     AddProfileUuid,
@@ -402,6 +477,7 @@ MIGRATIONS = (
     MergeStorageBackendTypes,
     AddTestProfileKey,
     AddPrefixToStorageBackendTypes,
+    RenameRmqAndLogging,
 )
 
 
@@ -505,14 +581,11 @@ def config_needs_migrating(config, filepath: Optional[str] = None):
     if oldest_compatible_version > CURRENT_CONFIG_VERSION:
         filepath = filepath if filepath else ''
         msg = (
-            f'The AiiDA configuration file {filepath} has version {current_version}, which is not compatible with '
-            f'the current AiiDA version that supports configuration versions up to {CURRENT_CONFIG_VERSION}. '
-            'Before switching to an older AiiDA version, stop the daemon and avoid other AiiDA interactions. '
-            'Then use a newer AiiDA version that still supports '
-            f'configuration version {current_version} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
-            f'to rewrite the configuration file to version {CURRENT_CONFIG_VERSION}. See '
-            f'{URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility '
-            'table.'
+            f'The AiiDA configuration file {filepath} has version {current_version} which is not compatible with '
+            f'the current aiida version supporting up to version {CURRENT_CONFIG_VERSION}. '
+            'Before switching to an older AiiDA version, use a newer AiiDA version that supports '
+            f' at least version {CURRENT_CONFIG_VERSION} and run `verdi config downgrade {CURRENT_CONFIG_VERSION}` '
+            f' to rewrite it for an older version. See {URL_CONFIG_SCHEMA_COMPATIBILITY} for the compatibility table.'
         )
         raise exceptions.ConfigurationVersionError(msg)
 

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -506,11 +506,11 @@ def config_can_be_downgraded(
 ) -> bool:
     """Return whether the configuration can be downgraded to the target version.
 
-    This is intentionally distinct from :data:`CURRENT_CONFIG_VERSION`: an AiiDA version may not be able to load a
+    This is intentionally distinct from ``CURRENT_CONFIG_VERSION``: an AiiDA version may not be able to load a
     configuration for normal operation, but may still know enough migrations to rewrite it for an older version.
 
     :param config: the configuration dictionary
-    :param target: the version to downgrade to, defaulting to :data:`CURRENT_CONFIG_VERSION`
+    :param target: the version to downgrade to, defaulting to ``CURRENT_CONFIG_VERSION``
     :param migrations: the registered migrations to consider
     :return: ``True`` if a chain of migrations exists to downgrade the configuration to the target version
     """

--- a/src/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -807,7 +807,6 @@ class SqlaQueryBuilder(BackendQueryBuilder):
         """
         import json
 
-        from sqlalchemy import cast as sql_cast
         from sqlalchemy import func, type_coerce
 
         batch_threshold = 500_000
@@ -844,21 +843,29 @@ class SqlaQueryBuilder(BackendQueryBuilder):
 
         elif dialect_name == 'sqlite':
             # SQLite: Use json_each() with JSON array (SQLite has no native array type)
-            # - Serialize Python list to JSON string
-            # - json_each() extracts values from JSON, but returns them as TEXT
-            # - sql_cast: Generate SQL CAST() to convert TEXT to target column type
-            # Result: column IN (SELECT CAST(value AS coltype) FROM json_each(:json_param))
+            # - Serialize each value through the column's bind processor so its JSON
+            #   representation matches how it is stored (e.g. datetimes, which are not
+            #   directly JSON serializable and are stored by SQLite as strings).
+            # - No SQL CAST is applied: SQLite's comparison affinity coerces the json_each
+            #   values when the IN clause is evaluated. Casting the TEXT back to the column
+            #   type would corrupt string-stored values, e.g.
+            #   CAST('2026-07-23 12:00:00' AS DATETIME) evaluates to 2026.
+            # Result: column IN (SELECT value FROM json_each(:json_param))
             coltype: Any = column.type
-            json_array: str = json.dumps(obj=list(values_list))
+            dialect = session.bind.dialect
+            processor = coltype.dialect_impl(dialect).bind_processor(dialect)
+
+            def process(value: Any) -> Any:
+                return processor(value) if processor is not None and value is not None else value
+
+            json_array: str = json.dumps(obj=[process(value) for value in values_list])
 
             # Create table-valued function: json_each(json_array) returns virtual table
             json_each_table: TableValuedAlias = func.json_each(json_array).table_valued('value')
 
-            # Extract the 'value' column and cast from TEXT to target type
+            # Extract the 'value' column and let SQLite apply the column affinity at compare time
             value_col: KeyedColumnElement = json_each_table.c.value
-            subq: ScalarSelect[Any] = (
-                select(sql_cast(expression=value_col, type_=coltype)).select_from(json_each_table).scalar_subquery()
-            )
+            subq: ScalarSelect[Any] = select(value_col).select_from(json_each_table).scalar_subquery()
 
         else:
             msg = f'Unsupported database backend: {dialect_name}. AiiDA only supports PostgreSQL and SQLite.'

--- a/tests/cmdline/commands/test_config.py
+++ b/tests/cmdline/commands/test_config.py
@@ -8,6 +8,9 @@
 ###########################################################################
 """Tests for ``verdi config``."""
 
+import json
+import pathlib
+
 import pytest
 
 from aiida import get_profile
@@ -209,3 +212,30 @@ def test_config_downgrade(run_cli_command, config_with_profile_factory):
     options = ['config', 'downgrade', '1']
     result = run_cli_command(cmd_verdi.verdi, options, use_subprocess=False)
     assert 'Success: Downgraded' in result.output.strip()
+
+
+def test_config_downgrade_incompatible_but_downgradeable(run_cli_command, config_with_profile_factory, monkeypatch):
+    """Test `verdi config downgrade` can run even if the config cannot be loaded normally."""
+    from aiida.manage import configuration
+    from aiida.manage.configuration.migrations import migrations
+
+    config = config_with_profile_factory()
+    filepath = pathlib.Path(config.filepath)
+    dictionary = config.dictionary
+    dictionary['CONFIG_VERSION'] = {'CURRENT': 10, 'OLDEST_COMPATIBLE': 10}
+    dictionary.setdefault('options', {})['broker.task_timeout'] = 12
+    filepath.write_text(json.dumps(dictionary), encoding='utf8')
+
+    configuration.CONFIG = None
+    monkeypatch.setattr(migrations, 'CURRENT_CONFIG_VERSION', 9)
+    monkeypatch.setattr(migrations, 'MAXIMUM_DOWNGRADE_CONFIG_VERSION', 10)
+
+    result = run_cli_command(
+        cmd_verdi.verdi, ['config', 'downgrade', '9'], initialize_ctx_obj=False, use_subprocess=False
+    )
+
+    assert 'Success: Downgraded' in result.output.strip()
+    dictionary = json.loads(filepath.read_text(encoding='utf8'))
+    assert dictionary['CONFIG_VERSION'] == {'CURRENT': 9, 'OLDEST_COMPATIBLE': 9}
+    assert dictionary['options']['rmq.task_timeout'] == 12
+    assert 'broker.task_timeout' not in dictionary['options']

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -18,9 +18,10 @@ import pytest
 from aiida.common.exceptions import ConfigurationError, ConfigurationVersionError
 from aiida.manage.configuration.migrations import check_and_migrate_config
 from aiida.manage.configuration.migrations.migrations import (
-    CURRENT_CONFIG_VERSION,
+    MAXIMUM_DOWNGRADE_CONFIG_VERSION,
     MIGRATIONS,
     Initial,
+    config_can_be_downgraded,
     downgrade_config,
     upgrade_config,
 )
@@ -70,14 +71,35 @@ def test_downgrade_path_fail(load_config_sample):
         downgrade_config(config_initial, 4, migrations=[CircularMigration])
 
 
-def test_config_needs_migrating_incompatible_version():
+def test_config_needs_migrating_incompatible_version(monkeypatch):
     """An incompatible configuration version should raise with downgrade guidance."""
+    from aiida.manage.configuration.migrations import migrations
+
+    # Lower the loadable version below the downgrade cap so a config at the cap is unloadable but downgradeable,
+    # exercising the can_downgrade guidance path (config_needs_migrating downgrades to CURRENT_CONFIG_VERSION).
+    monkeypatch.setattr(migrations, 'CURRENT_CONFIG_VERSION', MAXIMUM_DOWNGRADE_CONFIG_VERSION - 1)
     config = {
-        'CONFIG_VERSION': {'CURRENT': CURRENT_CONFIG_VERSION + 1, 'OLDEST_COMPATIBLE': CURRENT_CONFIG_VERSION + 1}
+        'CONFIG_VERSION': {
+            'CURRENT': MAXIMUM_DOWNGRADE_CONFIG_VERSION,
+            'OLDEST_COMPATIBLE': MAXIMUM_DOWNGRADE_CONFIG_VERSION,
+        }
     }
 
-    with pytest.raises(ConfigurationVersionError, match=r'verdi config downgrade'):
+    with pytest.raises(ConfigurationVersionError, match=r'verdi config downgrade') as exception:
         check_and_migrate_config(config, filepath='/tmp/config.json')
+
+    assert exception.value._can_downgrade
+
+
+def test_config_can_be_downgraded():
+    """Test detecting whether a configuration can be downgraded by this AiiDA version."""
+    assert config_can_be_downgraded(
+        {'CONFIG_VERSION': {'CURRENT': MAXIMUM_DOWNGRADE_CONFIG_VERSION, 'OLDEST_COMPATIBLE': 0}},
+        target=MAXIMUM_DOWNGRADE_CONFIG_VERSION - 1,
+    )
+    assert not config_can_be_downgraded(
+        {'CONFIG_VERSION': {'CURRENT': MAXIMUM_DOWNGRADE_CONFIG_VERSION + 1, 'OLDEST_COMPATIBLE': 0}}
+    )
 
 
 def test_migrate_full(load_config_sample, monkeypatch):

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -15,9 +15,15 @@ import uuid
 
 import pytest
 
-from aiida.common.exceptions import ConfigurationError
+from aiida.common.exceptions import ConfigurationError, ConfigurationVersionError
 from aiida.manage.configuration.migrations import check_and_migrate_config
-from aiida.manage.configuration.migrations.migrations import MIGRATIONS, Initial, downgrade_config, upgrade_config
+from aiida.manage.configuration.migrations.migrations import (
+    CURRENT_CONFIG_VERSION,
+    MIGRATIONS,
+    Initial,
+    downgrade_config,
+    upgrade_config,
+)
 
 
 class CircularMigration(Initial):
@@ -62,6 +68,16 @@ def test_downgrade_path_fail(load_config_sample):
     # circular dependency
     with pytest.raises(ConfigurationError):
         downgrade_config(config_initial, 4, migrations=[CircularMigration])
+
+
+def test_config_needs_migrating_incompatible_version():
+    """An incompatible configuration version should raise with downgrade guidance."""
+    config = {
+        'CONFIG_VERSION': {'CURRENT': CURRENT_CONFIG_VERSION + 1, 'OLDEST_COMPATIBLE': CURRENT_CONFIG_VERSION + 1}
+    }
+
+    with pytest.raises(ConfigurationVersionError, match=r'verdi config downgrade'):
+        check_and_migrate_config(config, filepath='/tmp/config.json')
 
 
 def test_migrate_full(load_config_sample, monkeypatch):

--- a/tests/manage/configuration/migrations/test_samples/input/9.json
+++ b/tests/manage/configuration/migrations/test_samples/input/9.json
@@ -1,0 +1,35 @@
+{
+  "CONFIG_VERSION": { "CURRENT": 9, "OLDEST_COMPATIBLE": 9 },
+  "default_profile": "default",
+  "profiles": {
+    "default": {
+      "default_user_email": "email@aiida.net",
+      "PROFILE_UUID": "00000000000000000000000000000000",
+      "storage": {
+        "backend": "core.psql_dos",
+        "config": {
+          "database_engine": "postgresql_psycopg2",
+          "database_password": "some_random_password",
+          "database_name": "aiidadb_qs_some_user",
+          "database_hostname": "localhost",
+          "database_port": "5432",
+          "database_username": "aiida_qs_greschd",
+          "repository_uri": "file:////home/some_user/.aiida/repository-quicksetup/"
+        },
+        "_v6_backend": "django"
+      },
+      "process_control": {
+        "backend": "rabbitmq",
+        "config": {
+          "broker_protocol": "amqp",
+          "broker_username": "guest",
+          "broker_password": "guest",
+          "broker_host": "127.0.0.1",
+          "broker_port": 5672,
+          "broker_virtual_host": ""
+        }
+      },
+      "test_profile": false
+    }
+  }
+}

--- a/tests/manage/configuration/migrations/test_samples/reference/10.json
+++ b/tests/manage/configuration/migrations/test_samples/reference/10.json
@@ -1,0 +1,35 @@
+{
+  "CONFIG_VERSION": { "CURRENT": 10, "OLDEST_COMPATIBLE": 10 },
+  "default_profile": "default",
+  "profiles": {
+    "default": {
+      "default_user_email": "email@aiida.net",
+      "PROFILE_UUID": "00000000000000000000000000000000",
+      "storage": {
+        "backend": "core.psql_dos",
+        "config": {
+          "database_engine": "postgresql_psycopg2",
+          "database_password": "some_random_password",
+          "database_name": "aiidadb_qs_some_user",
+          "database_hostname": "localhost",
+          "database_port": "5432",
+          "database_username": "aiida_qs_greschd",
+          "repository_uri": "file:////home/some_user/.aiida/repository-quicksetup/"
+        },
+        "_v6_backend": "django"
+      },
+      "process_control": {
+        "backend": "rabbitmq",
+        "config": {
+          "broker_protocol": "amqp",
+          "broker_username": "guest",
+          "broker_password": "guest",
+          "broker_host": "127.0.0.1",
+          "broker_port": 5672,
+          "broker_virtual_host": ""
+        }
+      },
+      "test_profile": false
+    }
+  }
+}

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -38,6 +38,17 @@ class TestBasic:
         builder = orm.QueryBuilder().append(orm.Node, filters={'ctime': {'>': date.today() - timedelta(days=1)}})
         assert builder.count() == 1
 
+    @pytest.mark.usefixtures('aiida_profile_clean')
+    def test_datetime_in_filter_support(self):
+        """Verify that ``datetime`` values are supported for ``in`` and negated ``in`` filters."""
+        node = orm.Data().store()
+
+        builder = orm.QueryBuilder().append(orm.Data, filters={'ctime': {'in': [node.ctime]}})
+        assert builder.count() == 1
+
+        builder = orm.QueryBuilder().append(orm.Data, filters={'ctime': {'!in': [node.ctime]}})
+        assert builder.count() == 0
+
     def test_ormclass_type_classification(self):
         """This tests the classifications of the QueryBuilder"""
         from aiida.common.exceptions import DbContentError


### PR DESCRIPTION
We do the release to mainly include the fix 27d71c131c59943afa4e1ff58cdbf20d55442384 for downstream packages. We take the chance and also include the better error messages when the configuration is upgraded to a higher schema.