### PR TITLE
✨ Add support for authentication over core.async_ssh by password

### DIFF
--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -47,3 +47,26 @@ runs:
     run: |
       uv pip install --resolution ${{ inputs.resolution-strategy }} -e .${{ inputs.extras && format('[{0}]', inputs.extras) || '' }}
     shell: bash
+
+  - name: Set up gnome-keyring
+    run: |
+      sudo apt install -y gnome-keyring dbus-x11
+      # Start a D-Bus session bus and expose it to the following steps (pytest runs in
+      # a separate step, so the address must be persisted via GITHUB_ENV).
+      eval "$(dbus-launch --sh-syntax)"
+      # Create and unlock the "login" keyring by feeding a password on stdin. This is
+      # what registers it as the *default* Secret Service collection; without it the
+      # keyring backend fails with "Secret Service: no result found" because there is
+      # no default collection to store into. The password is arbitrary and only lives
+      # for the duration of the CI run.
+      eval "$(printf '%s' 'some_credentials' | gnome-keyring-daemon --daemonize --login)"
+      # Bring up the secrets (Secret Service) component of the just-initialised daemon.
+      eval "$(gnome-keyring-daemon --start --components=secrets,ssh)"
+      # Persist the session/daemon addresses so the pytest step talks to this same daemon.
+      {
+        echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+        echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID"
+        echo "GNOME_KEYRING_CONTROL=$GNOME_KEYRING_CONTROL"
+        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
+      } >> "$GITHUB_ENV"
+    shell: bash

--- a/.github/actions/install-aiida-core/action.yml
+++ b/.github/actions/install-aiida-core/action.yml
@@ -50,7 +50,7 @@ runs:
 
   - name: Set up gnome-keyring
     run: |
-      sudo apt install -y gnome-keyring dbus-x11
+      sudo apt install -y gnome-keyring dbus-x11 sshpass
       # Start a D-Bus session bus and expose it to the following steps (pytest runs in
       # a separate step, so the address must be persisted via GITHUB_ENV).
       eval "$(dbus-launch --sh-syntax)"

--- a/.github/workflows/setup_ssh.sh
+++ b/.github/workflows/setup_ssh.sh
@@ -7,3 +7,7 @@ ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
 
 # The permissions on the GitHub runner are 777 which will cause SSH to refuse the keys and cause authentication to fail
 chmod 755 "${HOME}"
+
+# set up ssh by password
+# runner is default user name in github CI, we set password to "password"
+echo "runner:password" | sudo chpasswd

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -38,7 +38,8 @@ The second option allows managing multiple remote compute resources (including H
 
 .. note::
 
-    The second option requires access through an SSH keypair.
+    The second option typically uses access through an SSH keypair.
+    If your compute resource does not support key-based authentication, the ``core.ssh_async`` transport can also be :ref:`configured with a login password <how-to:ssh:password>`.
     If your compute resource demands two-factor authentication, you may need to install AiiDA directly on the compute resource instead.
 
 
@@ -51,7 +52,7 @@ Each computer must satisfy the following requirements:
 * It has ``bash`` installed
 * (optional) It has batch scheduler installed (see the :ref:`list of supported schedulers <topics:schedulers>`)
 
-If you are configuring a remote computer, start by :ref:`configuring password-less SSH access <how-to:ssh>` to it.
+If you are configuring a remote computer, start by :ref:`configuring SSH access <how-to:ssh>` to it.
 
 .. note::
 
@@ -136,7 +137,7 @@ The second step configures private connection details using:
 
     $ verdi computer configure TRANSPORTTYPE COMPUTERLABEL
 
-Replace ``COMPUTERLABEL`` with the computer label chosen during the setup and replace ``TRANSPORTTYPE`` with the name of chosen transport type, i.e., ``core.local`` for the localhost computer and ``core.ssh`` for any remote computer.
+Replace ``COMPUTERLABEL`` with the computer label chosen during the setup and replace ``TRANSPORTTYPE`` with the name of chosen transport type, i.e., ``core.local`` for the localhost computer and ``core.ssh`` or ``core.ssh_async`` for remote computers.
 
 After the setup and configuration have been completed, let's check that everything is working properly:
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -5,10 +5,11 @@ How to setup SSH connections
 ****************************
 
 AiiDA communicates with remote computers via the SSH protocol.
-There are two ways of setting up an SSH connection for AiiDA:
+There are three ways of setting up an SSH connection for AiiDA:
 
 #. Using a passwordless SSH key (easier, less safe)
 #. Using a password-protected SSH key through ``ssh-agent`` (one more step, safer)
+#. Using a login password with ``core.ssh_async`` (only when key-based authentication is not available)
 
 .. _how-to:ssh:passwordless:
 
@@ -178,6 +179,32 @@ AiiDA configuration
 ^^^^^^^^^^^^^^^^^^^
 
 When :ref:`configuring the computer in AiiDA <how-to:run-codes:computer:configuration>`, simply make sure that ``Allow ssh agent`` is set to ``true`` (default).
+
+.. _how-to:ssh:password:
+
+Using login passwords with ``core.ssh_async``
+=============================================
+
+Key-based authentication is still the recommended way to use SSH with AiiDA.
+If a remote computer does not support key-based authentication, the ``core.ssh_async`` transport can authenticate with a login password.
+
+Passwords configured through ``verdi computer configure core.ssh_async`` are stored in the system secure storage.
+AiiDA stores only a redacted marker in the profile database.
+This requires a working system keyring, such as Secret Service on Linux, Keychain on macOS, or Credential Manager on Windows.
+AiiDA uses ``sshpass`` with a file descriptor so that the password is not exposed in command-line arguments.
+
+To configure a computer with password authentication, use the interactive configuration prompt:
+
+.. code-block:: console
+
+   $ verdi computer configure core.ssh_async YOURCOMPUTER
+   ...
+   Password:
+   ...
+
+Press enter at the password prompt to configure no password.
+To configure an empty password one cannot use the interactive configuration and has to explicitly specify ``--password ''`` as argument.
+
 
 .. _how-to:ssh:proxy:
 

--- a/docs/source/topics/transport.rst
+++ b/docs/source/topics/transport.rst
@@ -7,9 +7,11 @@ Transport plugins
 The term `transport` in AiiDA refers to a class that the engine uses to perform operations on local or remote machines where its :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob` are submitted.
 The base class :py:class:`~aiida.transports.transport.Transport` defines an interface for these operations, such as copying files and executing commands.
 A `transport plugin` is a class that implements this base class for a specific connection method.
-The ``aiida-core`` package ships with two transport plugins: the :py:class:`~aiida.transports.plugins.local.LocalTransport` and :py:class:`~aiida.transports.plugins.ssh.SshTransport` classes.
+The ``aiida-core`` package ships with local and SSH-based transport plugins.
 The ``local`` transport can be used to connect with the `localhost` and makes use only of some standard python modules like ``os`` and ``shutil``.
 The ``ssh`` transport, which can be used for machines that can be connected to over ssh, is simply a wrapper around the library `paramiko <https://www.paramiko.org/>`_ that is installed as a required dependency of ``aiida-core``.
+The ``ssh_async`` transport provides an asynchronous SSH implementation based on ``asyncssh`` by default, with an optional ``openssh`` backend for cases such as SSH multiplexing.
+The ``ssh_async`` transport can also authenticate with a login password when using the ``asyncssh`` or ``openssh`` backend.
 
 .. _topics:transport:develop_plugin:
 

--- a/environment.yml
+++ b/environment.yml
@@ -37,3 +37,4 @@ dependencies:
 - upf_to_json~=0.9.2
 - wrapt~=1.11
 - chardet~=5.2.0
+- keyringrs~=0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ dependencies = [
   'typing-extensions~=4.13',
   'upf_to_json~=0.9.2',
   'wrapt~=1.11',
-  'chardet~=5.2.0;platform_system=="Windows"'
+  'chardet~=5.2.0;platform_system=="Windows"',
+  'keyringrs~=0.4.0'
 ]
 description = 'AiiDA is a workflow manager for computational science with a strong focus on provenance, performance and extensibility.'
 dynamic = ['version']  # read from aiida/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -444,7 +444,8 @@ markers = [
   'requires_rmq: requires RabbitMQ specifically (not compatible with ZeroMQ broker)',
   'requires_broker: requires a message broker (RabbitMQ or ZeroMQ)',
   'requires_psql: requires a connection to PostgreSQL DB',
-  'presto: automatic marker for tests needing no external services (not requires_rmq, not requires_psql)',
+  'requires_secure_storage: requires a system secure storage backend',
+  'presto: automatic marker for tests needing no external services (not requires_rmq, not requires_psql, not requires_secure_storage)',
   'sphinx: set parameters for the sphinx `app` fixture'
 ]
 minversion = '7.0'

--- a/src/aiida/cmdline/params/options/interactive.py
+++ b/src/aiida/cmdline/params/options/interactive.py
@@ -58,6 +58,7 @@ class InteractiveOption(ConditionalOption):
         param_decls: Sequence[str] | None = None,
         prompt_fn: t.Callable[[click.Context], bool] | None = None,
         contextual_default: t.Any | None = None,
+        accept_none_default: bool = False,
         **kwargs: t.Any,
     ):
         """Construct a new instance.
@@ -65,10 +66,15 @@ class InteractiveOption(ConditionalOption):
         :param param_decls: relayed to :class:`click.Option`
         :param prompt_fn: callable(ctx) -> Bool, returns True if the option should be prompted for in interactive mode.
         :param contextual_default: An optional callback function to get a default which is passed the click context.
+        :param accept_none_default: if True, a ``None`` default can be accepted by pressing enter at the prompt. By
+            default click refuses empty input when the default is ``None``, forcing the user to type ``!`` to set no
+            value; enabling this presents the ``None`` default as an empty string while prompting and maps the empty
+            input back to ``None``.
         """
         super().__init__(param_decls=param_decls, **kwargs)
         self._prompt_fn = prompt_fn
         self._contextual_default = contextual_default
+        self._accept_none_default = accept_none_default
 
     @property
     def prompt(self) -> str | None:
@@ -131,6 +137,11 @@ class InteractiveOption(ConditionalOption):
             # raised further down below, forcing the user to specify a valid value.
             value = None
 
+        if self._accept_none_default and value == '' and source is click.core.ParameterSource.PROMPT:
+            # The user accepted the ``None`` default (presented as an empty string by ``get_default``) by pressing
+            # enter, which for this option means "no value": map the empty input back to ``None``.
+            value = None
+
         try:
             return super().process_value(ctx, value)
         except click.BadParameter as exception:
@@ -180,6 +191,13 @@ class InteractiveOption(ConditionalOption):
             default = self.type.deconvert_default(default)  # type: ignore[attr-defined]
         except AttributeError:
             pass
+
+        # When ``accept_none_default`` is set, present a ``None`` default as an empty string while prompting so the
+        # user can accept it by pressing enter (click's prompt loop refuses empty input when the default is ``None``).
+        # The empty value is mapped back to ``None`` in ``process_value``. Only applies in interactive mode, so the
+        # non-interactive default remains ``None``.
+        if self._accept_none_default and default is None and self.is_interactive(ctx):
+            return ''
 
         return default
 

--- a/src/aiida/common/__init__.py
+++ b/src/aiida/common/__init__.py
@@ -73,6 +73,7 @@ __all__ = (
     'ProfileConfigurationError',
     'ProgressReporterAbstract',
     'RemoteOperationError',
+    'SecureStorage',
     'StashMode',
     'StorageBackupError',
     'StorageMigrationError',

--- a/src/aiida/common/datastructures.py
+++ b/src/aiida/common/datastructures.py
@@ -10,12 +10,85 @@
 
 from __future__ import annotations
 
+import sys
+from collections.abc import Mapping
 from enum import Enum, IntEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .extendeddicts import DefaultFieldsAttributeDict
 
-__all__ = ('CalcInfo', 'CalcJobState', 'CodeInfo', 'CodeRunMode', 'StashMode', 'UnstashTargetMode')
+__all__ = ('CalcInfo', 'CalcJobState', 'CodeInfo', 'CodeRunMode', 'SecureStorage', 'StashMode', 'UnstashTargetMode')
+
+if TYPE_CHECKING:
+    import keyringrs
+
+
+class SecureStorage:
+    """Manager for passwords stored in the system secure storage."""
+
+    _SERVICE_NAME = 'aiida.core.authinfo'
+    # Appends random string to reduce likelihood of collision with user password.
+    SECURE_STORAGE_PASSWORD_MARKER = 'REDACTED-KHOgfgbI3AVyNoJbkKuLxTl1P'
+
+    @classmethod
+    def contains_redacted_password(cls, auth_params: Mapping[str, Any]) -> bool:
+        """Return whether the auth params contain the secure-storage password marker."""
+        return auth_params.get('password') == cls.SECURE_STORAGE_PASSWORD_MARKER
+
+    def __init__(self, computer_uuid: str, user_pk: int | None) -> None:
+        self._computer_uuid = computer_uuid
+        self._user_pk = user_pk
+
+    @property
+    def _entry_name(self) -> str:
+        """Return the keyring entry name, unique per computer and user (i.e. per authinfo)."""
+        return f'{self._computer_uuid}-{self._user_pk}'
+
+    def _entry(self) -> keyringrs.Entry:  # type: ignore[name-defined]
+        """Return the keyring entry for this authinfo, importing ``keyringrs`` lazily."""
+        # Imported lazily to avoid loading the native extension on `import aiida.orm`.
+        import keyringrs
+
+        return keyringrs.Entry(self._SERVICE_NAME, self._entry_name)  # type: ignore[attr-defined]
+
+    def get_password(self) -> str | None:
+        """Return the stored password if available."""
+        try:
+            return self._entry().get_password()  # type: ignore[no-any-return]
+        except KeyError:
+            return None
+
+    @classmethod
+    def redact_auth_params(cls, auth_params: dict[str, Any]) -> None:
+        """Replace a password in auth params with the secure-storage marker."""
+        if auth_params.get('password') is not None:
+            auth_params['password'] = cls.SECURE_STORAGE_PASSWORD_MARKER
+
+    def set_password(self, password: str) -> None:
+        """Store a password in the system secure storage."""
+        self._entry().set_password(password)
+
+    def delete_password(self) -> None:
+        """Delete the stored password if available.
+
+        :raises OSError: if the system secure storage cannot be accessed
+        """
+        try:
+            self._entry().delete_credential()
+        except KeyError:
+            pass
+        except Exception as exception:
+            msg = f'Unable to delete password from secure storage for `{self._entry_name}`.'
+            raise OSError(msg) from exception
+
+    def get_cmd_stdout_password(self) -> str:
+        """Return a command that prints the stored password to stdout."""
+        python_command = (
+            'from keyringrs import Entry;'
+            f'entry = Entry("{self._SERVICE_NAME}", "{self._entry_name}");'
+            'print(entry.get_password(), end="")'
+        )
+        return f'"{sys.executable}" -c \'{python_command}\''
 
 
 class StashMode(Enum):

--- a/src/aiida/orm/authinfos.py
+++ b/src/aiida/orm/authinfos.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from aiida.common import exceptions
+from aiida.common.datastructures import SecureStorage
 from aiida.manage import get_manager
+from aiida.orm.implementation.authinfos import BackendAuthInfo
 from aiida.plugins import TransportFactory
 
 from . import entities, users
@@ -23,7 +25,6 @@ from .users import User
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import StorageBackend
-    from aiida.orm.implementation.authinfos import BackendAuthInfo
     from aiida.transports import Transport
 
 __all__ = ('AuthInfo',)
@@ -92,11 +93,22 @@ class AuthInfo(entities.Entity['BackendAuthInfo', AuthInfoCollection]):
         :param backend: the backend to use for the instance, or use the default backend if None
         """
         backend = backend or get_manager().get_profile_storage()
+        auth_params = {} if auth_params is None else auth_params.copy()
+
+        secure_storage = SecureStorage(computer.uuid, user.pk)
+        password = auth_params.get('password')
+        if password is not None:
+            if password == SecureStorage.SECURE_STORAGE_PASSWORD_MARKER:
+                msg = 'Password cannot be equal to the secure-storage redaction marker.'
+                raise ValueError(msg)
+            secure_storage.set_password(password)
+            SecureStorage.redact_auth_params(auth_params)
+
         model = backend.authinfos.create(
             computer=computer.backend_entity,
             user=user.backend_entity,
             enabled=enabled,
-            auth_params=auth_params or {},
+            auth_params=auth_params,
             metadata=metadata or {},
         )
         super().__init__(model)
@@ -158,12 +170,20 @@ class AuthInfo(entities.Entity['BackendAuthInfo', AuthInfoCollection]):
     def get_auth_params(self) -> dict[str, Any]:
         """Return the dictionary of authentication parameters
 
+        If a password is stored in secure storage, the ``password`` key holds a redaction marker instead of the
+        actual secret.
+
         :return: a dictionary with authentication parameters
         """
-        return self._backend_entity.get_auth_params()
+        return self._backend_entity.get_auth_params().copy()
 
     def set_auth_params(self, auth_params: dict[str, Any]) -> None:
-        """Set the dictionary of authentication parameters
+        """Set the dictionary of authentication parameters.
+
+        If a password is present, store it in secure storage and persist a redacted marker
+        instead. If the password equals the redaction marker, as returned by
+        ``get_auth_params``, the password currently in secure storage is left untouched, so that
+        round-tripping the auth params does not alter the stored password.
 
         :param auth_params: a dictionary with authentication parameters
         """
@@ -205,4 +225,15 @@ class AuthInfo(entities.Entity['BackendAuthInfo', AuthInfoCollection]):
         except exceptions.EntryPointError as exception:
             raise exceptions.ConfigurationError(f'transport type `{transport_type}` could not be loaded: {exception}')
 
-        return transport_class(machine=computer.hostname, **self.get_auth_params())
+        auth_params = self.get_auth_params()
+        if SecureStorage.contains_redacted_password(auth_params):
+            if (password := self._get_secure_storage().get_password()) is None:
+                msg = f'No registered password has been found in secure storage for host `{computer.hostname}`.'
+                raise ValueError(msg)
+            auth_params['password'] = password
+
+        return transport_class(machine=computer.hostname, **auth_params)
+
+    def _get_secure_storage(self) -> SecureStorage:
+        """Return the secure storage manager for this authinfo."""
+        return SecureStorage(self.computer.uuid, self.user.pk)

--- a/src/aiida/storage/psql_dos/orm/authinfos.py
+++ b/src/aiida/storage/psql_dos/orm/authinfos.py
@@ -9,11 +9,16 @@
 """Module for the SqlAlchemy backend implementation of the `AuthInfo` ORM class."""
 
 from aiida.common import exceptions
+from aiida.common.datastructures import SecureStorage
 from aiida.common.lang import type_check
+from aiida.common.log import AIIDA_LOGGER
 from aiida.orm.implementation.authinfos import BackendAuthInfo, BackendAuthInfoCollection
 from aiida.storage.psql_dos.models.authinfo import DbAuthInfo
 
 from . import computers, entities, users, utils
+
+# TODO check if this is a proper _LOGGER
+_LOGGER = AIIDA_LOGGER.getChild('storage.orm.authinfos')
 
 
 class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
@@ -91,6 +96,9 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
     def get_auth_params(self):
         """Return the dictionary of authentication parameters
 
+        If a password is stored in secure storage, the ``password`` key holds a redaction marker instead of the
+        actual secret.
+
         :return: a dictionary with authentication parameters
         """
         return self.model.auth_params
@@ -98,8 +106,20 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
     def set_auth_params(self, auth_params):
         """Set the dictionary of authentication parameters
 
+        If a password is present, store it in secure storage and persist a redacted marker
+        instead. If the password equals the redaction marker, as returned by
+        ``get_auth_params``, the password currently in secure storage is left untouched, so that
+        round-tripping the auth params does not alter the stored password.
+
         :param auth_params: a dictionary with authentication parameters
         """
+        auth_params = auth_params.copy()
+        password = auth_params.get('password')
+        # When round-tripping the result of ``get_auth_params``, the password is already represented by the
+        # redacted marker. Do not store that marker as the secure-storage password by accident.
+        if password is not None and not SecureStorage.contains_redacted_password(auth_params):
+            SecureStorage(self.model.dbcomputer.uuid, self.model.aiidauser_id).set_password(password)
+        SecureStorage.redact_auth_params(auth_params)
         self.model.auth_params = auth_params
 
     def get_metadata(self):
@@ -132,8 +152,19 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
         session = self.backend.get_session()
 
         try:
-            row = session.query(self.ENTITY_CLASS.MODEL_CLASS).filter_by(id=pk).one()
+            row: DbAuthInfo = session.query(self.ENTITY_CLASS.MODEL_CLASS).filter_by(id=pk).one()
+            dbcomputer_uuid = row.dbcomputer.uuid
+            user_pk = row.aiidauser_id
+            deleted_authinfo_had_password = SecureStorage.contains_redacted_password(row.auth_params)
             session.delete(row)
             session.commit()
         except NoResultFound:
             raise exceptions.NotExistent(f'AuthInfo<{pk}> does not exist')
+
+        # The password in secure storage is keyed per authinfo (computer and user), so it is removed together with the
+        # authinfo that stored it, if any.
+        if deleted_authinfo_had_password:
+            try:
+                SecureStorage(dbcomputer_uuid, user_pk).delete_password()
+            except OSError as exception:
+                _LOGGER.warning(f'Unable to delete password from secure storage for `{dbcomputer_uuid}`: {exception}')

--- a/src/aiida/storage/psql_dos/orm/computers.py
+++ b/src/aiida/storage/psql_dos/orm/computers.py
@@ -14,10 +14,14 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import make_transient
 
 from aiida.common import exceptions
+from aiida.common.datastructures import SecureStorage
+from aiida.common.log import AIIDA_LOGGER
 from aiida.orm.implementation.computers import BackendComputer, BackendComputerCollection
 from aiida.storage.psql_dos.models.computer import DbComputer
 
 from . import entities, utils
+
+_LOGGER = AIIDA_LOGGER.getChild('storage.orm.computers')
 
 
 class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
@@ -124,7 +128,24 @@ class SqlaComputerCollection(BackendComputerCollection):
             row = session.get(self.ENTITY_CLASS.MODEL_CLASS, pk)
             if row is None:
                 raise exceptions.NotExistent(f'Computer<{pk}> does not exist')
+            row_uuid = row.uuid
+            # Each authinfo that stores a password (i.e. carries the redaction marker) owns a separate credential,
+            # keyed per computer and user. Record the users before the cascade delete removes the authinfos.
+            users_with_password = [
+                authinfo.aiidauser_id
+                for authinfo in row.authinfos
+                if SecureStorage.contains_redacted_password(authinfo.auth_params)
+            ]
             session.delete(row)
             session.commit()
         except SQLAlchemyError as exc:
             raise exceptions.InvalidOperation(f'Unable to delete the requested computer: {exc}')
+
+        # We delete each stored password from the secure storage if available.
+        for user_pk in users_with_password:
+            try:
+                SecureStorage(row_uuid, user_pk).delete_password()
+            except OSError as exception:
+                _LOGGER.warning(
+                    f'Unable to delete password from secure storage for `{row_uuid}-{user_pk}`: {exception}'
+                )

--- a/src/aiida/storage/psql_dos/orm/computers.py
+++ b/src/aiida/storage/psql_dos/orm/computers.py
@@ -122,6 +122,8 @@ class SqlaComputerCollection(BackendComputerCollection):
         try:
             session = self.backend.get_session()
             row = session.get(self.ENTITY_CLASS.MODEL_CLASS, pk)
+            if row is None:
+                raise exceptions.NotExistent(f'Computer<{pk}> does not exist')
             session.delete(row)
             session.commit()
         except SQLAlchemyError as exc:

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -226,11 +226,18 @@ class _AsyncSSH(_AsynchronousSSHBackend):
     Note: This class is not part of the public API and should not be used directly.
     """
 
-    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+    def __init__(
+        self,
+        machine: str,
+        logger: logging.LoggerAdapter,
+        bash_command: str,
+        connection_options: asyncssh.SSHClientConnectionOptions | None = None,
+    ):
         super().__init__(machine, logger, bash_command)
+        self._connection_options = connection_options
 
     async def open(self):
-        self._conn = await asyncssh.connect(self.machine)
+        self._conn = await asyncssh.connect(self.machine, options=self._connection_options)
         self._sftp = await self._conn.start_sftp_client()
 
     async def close(self):

--- a/src/aiida/transports/plugins/async_backend.py
+++ b/src/aiida/transports/plugins/async_backend.py
@@ -18,6 +18,7 @@ while the `_OpenSSH` class uses the `ssh` command line client.
 import abc
 import asyncio
 import logging
+import os
 import posixpath
 import re
 import subprocess
@@ -462,8 +463,9 @@ class _OpenSSH(_AsynchronousSSHBackend):
     Note: This class is not part of the public API and should not be used directly.
     """
 
-    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str):
+    def __init__(self, machine: str, logger: logging.LoggerAdapter, bash_command: str, password: str | None = None):
         super().__init__(machine, logger, bash_command)
+        self._password = password
 
         # Check if the local OpenSSH client version is 9.0 or higher.
         # OpenSSH 9.0+ changed scp to use SFTP protocol by default instead of RCP.
@@ -477,6 +479,34 @@ class _OpenSSH(_AsynchronousSSHBackend):
             self.logger.debug(f'Detected OpenSSH version {openssh_version}, using RCP mode for scp commands.')
             self.is_openssh_9_or_higher = False
 
+    def _wrap_command_with_sshpass(self, commands: list[str]) -> tuple[list[str], int | None]:
+        """Wrap an OpenSSH command with ``sshpass`` if password authentication is configured.
+
+        The password is passed through a file descriptor to avoid exposing it in command-line arguments.
+        The caller is responsible for passing the file descriptor to the child process and closing it afterwards.
+        """
+        if self._password is None:
+            return commands, None
+
+        commands = [
+            commands[0],
+            '-o',
+            'PreferredAuthentications=password',
+            '-o',
+            'PubkeyAuthentication=no',
+            *commands[1:],
+        ]
+        read_fd, write_fd = os.pipe()
+        try:
+            os.write(write_fd, self._password.encode())
+        except Exception:
+            os.close(read_fd)
+            raise
+        finally:
+            os.close(write_fd)
+        os.set_inheritable(read_fd, True)
+        return ['sshpass', '-d', str(read_fd), *commands], read_fd
+
     async def openssh_execute(self, commands, stdin: str | None = None, timeout: float | None = None):
         """
         Execute a command using the _OpenSSH command line client.
@@ -484,9 +514,26 @@ class _OpenSSH(_AsynchronousSSHBackend):
         :param timeout: The timeout in seconds
         :return: The return code, stdout, and stderr
         """
-        process = await asyncio.create_subprocess_exec(
-            *commands, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-        )
+        commands, password_fd = self._wrap_command_with_sshpass(commands)
+        try:
+            if password_fd is None:
+                process = await asyncio.create_subprocess_exec(
+                    *commands,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            else:
+                process = await asyncio.create_subprocess_exec(
+                    *commands,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    pass_fds=(password_fd,),
+                )
+        finally:
+            if password_fd is not None:
+                os.close(password_fd)
 
         if stdin:
             process.stdin.write(stdin.encode())  # type: ignore[union-attr]

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -13,11 +13,14 @@
 import asyncio
 import glob
 import os
+import shutil
 import subprocess
 from pathlib import Path, PurePath
 
 import click
+from asyncssh import SSHClientConnectionOptions
 
+from aiida.common.datastructures import SecureStorage
 from aiida.common.escaping import escape_for_bash
 from aiida.common.exceptions import InvalidOperation
 from aiida.transports.transport import (
@@ -29,6 +32,88 @@ from aiida.transports.transport import (
 )
 
 __all__ = ('AsyncSshTransport',)
+
+
+def validate_password_is_not_redacted_marker(ctx, param, value: str | None):
+    """Validate the password is not the secure-storage redaction marker.
+
+    :param ctx: the click context
+    :param param: the click parameter
+    :param value: the password value to validate
+    :return: the unchanged password value
+    :raises click.BadParameter: if the password equals the redaction marker
+    """
+    if value == SecureStorage.SECURE_STORAGE_PASSWORD_MARKER:
+        msg = 'Password cannot be equal to the secure-storage redaction marker.'
+        raise click.BadParameter(msg)
+
+    return value
+
+
+def validate_os_supports_secure_storage(ctx, param, value: str | None):
+    """Validate secure storage is available when configuring a password.
+
+    :param ctx: the click context
+    :param param: the click parameter
+    :param value: the password value to validate
+    :return: the unchanged password value
+    :raises OSError: if the system secure storage cannot be accessed
+    """
+    # ``None`` means no password authentication; only an actual password (including an
+    # intentionally empty string) needs to be stored and therefore requires secure storage.
+    if value is None:
+        return value
+
+    import keyringrs
+
+    try:
+        entry = keyringrs.Entry(  # type: ignore[attr-defined]
+            'aiida.transports.ssh_async', 'VALIDATE_OS_SUPPORTS_SECURE_STORAGE'
+        )
+        entry.set_password('DUMMY')
+        entry.delete_credential()
+    except Exception as exception:
+        msg = (
+            'Could not access secure storage on your system for storing the password. '
+            'Cannot use password authentication without secure storage.'
+        )
+        raise OSError(msg) from exception
+
+    return value
+
+
+def validate_os_supports_sshpass(ctx, param, value: str | None):
+    """Validate ``sshpass`` is available when configuring a password.
+
+    :param ctx: the click context
+    :param param: the click parameter
+    :param value: the password value to validate
+    :return: the unchanged password value
+    :raises OSError: if ``sshpass`` cannot be found
+    """
+    # ``None`` means no password authentication; an empty string is still a password.
+    if value is None:
+        return value
+
+    if shutil.which('sshpass') is None:
+        msg = 'Command line tool `sshpass` was not found. Cannot use password authentication without `sshpass`.'
+        raise OSError(msg)
+
+    return value
+
+
+def validate_os_supports_password_authentication(ctx, param, value: str | None):
+    """Validate the system supports password authentication for the transport.
+
+    :param ctx: the click context
+    :param param: the click parameter
+    :param value: the password value to validate
+    :return: the unchanged password value
+    """
+    value = validate_password_is_not_redacted_marker(ctx, param, value)
+    value = validate_os_supports_secure_storage(ctx, param, value)
+    value = validate_os_supports_sshpass(ctx, param, value)
+    return value
 
 
 def validate_script(ctx, param, value: str):
@@ -71,6 +156,18 @@ class AsyncSshTransport(AsyncTransport):
                     " Note, if not provided, we will use the 'hostname' that was set by you during setup."
                 ),
                 'non_interactive_default': True,
+            },
+        ),
+        (
+            'password',
+            {
+                'type': str,
+                'default': None,
+                'prompt': 'Password',
+                'hide_input': True,
+                'help': 'Login password for the remote machine.',
+                'non_interactive_default': True,
+                'callback': validate_os_supports_password_authentication,
             },
         ),
         (
@@ -142,6 +239,24 @@ class AsyncSshTransport(AsyncTransport):
             # for backward compatibility
             self.auth_script = kwargs.pop('script_before', 'None')
 
+        self._password: str | None = kwargs.pop('password', None)
+        self._sshpass_password_fds: list[int] = []
+
+        if self._password is not None and kwargs.get('backend') == 'openssh':
+            msg = (
+                'Password authentication is not supported by the `openssh` backend. '
+                'Use the default `asyncssh` backend or configure key-based authentication.'
+            )
+            raise ValueError(msg)
+
+        connection_options = None
+        if self._password is not None:
+            connection_options = SSHClientConnectionOptions(
+                password=self._password,
+                preferred_auth='password',
+                public_key_auth=False,
+            )
+
         if kwargs.get('backend') == 'openssh':
             from .async_backend import _OpenSSH
 
@@ -150,7 +265,12 @@ class AsyncSshTransport(AsyncTransport):
             # default backend is asyncssh
             from .async_backend import _AsyncSSH
 
-            self.async_backend = _AsyncSSH(self.machine, self.logger, self._bash_command_str)  # type: ignore[assignment]
+            self.async_backend = _AsyncSSH(
+                self.machine,
+                self.logger,
+                self._bash_command_str,
+                connection_options=connection_options,
+            )  # type: ignore[assignment]
 
     @property
     def max_io_allowed(self):
@@ -1302,4 +1422,20 @@ class AsyncSshTransport(AsyncTransport):
         """
         connect_string = self._gotocomputer_string(remotedir=remotedir)
         cmd = f'ssh -t {self.machine} {connect_string}'
+
+        if self._password is not None:
+            if shutil.which('sshpass') is None:
+                msg = 'Command line tool `sshpass` was not found. Cannot use password authentication.'
+                raise InvalidOperation(msg)
+            cmd = (
+                f'ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no '
+                f'-t {self.machine} {connect_string}'
+            )
+            read_fd, write_fd = os.pipe()
+            os.write(write_fd, self._password.encode())
+            os.close(write_fd)
+            os.set_inheritable(read_fd, True)
+            self._sshpass_password_fds.append(read_fd)
+            cmd = f'sshpass -d {read_fd} {cmd}'
+
         return cmd

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -245,13 +245,6 @@ class AsyncSshTransport(AsyncTransport):
         self._password: str | None = kwargs.pop('password', None)
         self._sshpass_password_fds: list[int] = []
 
-        if self._password is not None and kwargs.get('backend') == 'openssh':
-            msg = (
-                'Password authentication is not supported by the `openssh` backend. '
-                'Use the default `asyncssh` backend or configure key-based authentication.'
-            )
-            raise ValueError(msg)
-
         connection_options = None
         if self._password is not None:
             connection_options = SSHClientConnectionOptions(
@@ -263,7 +256,7 @@ class AsyncSshTransport(AsyncTransport):
         if kwargs.get('backend') == 'openssh':
             from .async_backend import _OpenSSH
 
-            self.async_backend = _OpenSSH(self.machine, self.logger, self._bash_command_str)
+            self.async_backend = _OpenSSH(self.machine, self.logger, self._bash_command_str, password=self._password)
         else:
             # default backend is asyncssh
             from .async_backend import _AsyncSSH

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -165,8 +165,11 @@ class AsyncSshTransport(AsyncTransport):
                 'default': None,
                 'prompt': 'Password',
                 'hide_input': True,
+                'show_default': False,
                 'help': 'Login password for the remote machine.',
                 'non_interactive_default': True,
+                # Allow accepting the ``None`` default (no password) by pressing enter at the prompt.
+                'accept_none_default': True,
                 'callback': validate_os_supports_password_authentication,
             },
         ),

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -106,31 +106,47 @@ class Transport(abc.ABC):
         ),
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,
+        machine: str | None = None,
+        safe_interval: float | None = None,
+        use_login_shell: bool | None = None,
+        **_,
+    ):
         """__init__ method of the Transport base class.
 
+        :param machine: the machine to connect to
         :param safe_interval: (optional, default self._DEFAULT_SAFE_OPEN_INTERVAL)
            Minimum time interval in seconds between opening new connections.
         :param use_login_shell: (optional, default True)
            if False, do not use a login shell when executing command
         """
         from aiida.common import AIIDA_LOGGER
+        from aiida.common.warnings import warn_deprecation
 
-        self._safe_open_interval = kwargs.pop('safe_interval', self._DEFAULT_SAFE_OPEN_INTERVAL)
-        self._use_login_shell = kwargs.pop('use_login_shell', True)
+        if args:
+            warn_deprecation(
+                'Passing positional arguments to `Transport.__init__` is deprecated and they are ignored; '
+                'pass all arguments as keyword arguments instead.',
+                version=3,
+            )
+
+        self._safe_open_interval = self._DEFAULT_SAFE_OPEN_INTERVAL if safe_interval is None else safe_interval
+        self._use_login_shell = True if use_login_shell is None else use_login_shell
         if self._use_login_shell:
             self._bash_command_str = 'bash -l '
         else:
             self._bash_command_str = 'bash '
 
         self._logger = AIIDA_LOGGER.getChild('transport').getChild(self.__class__.__name__)
-        self._logger_extra = None
+        self._logger_extra: dict[str, object] | None = None
         self._is_open = False
         self._enters = 0
         self._open_lock = asyncio.Lock()
 
         # for accessing the identity of the underlying machine
-        self.hostname = kwargs.get('machine')
+        self.hostname = machine
 
     def __repr__(self):
         return f'<{self.__class__.__name__}: {self!s}>'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def pytest_collection_modifyitems(items, config):
     """Automatically generate markers for certain tests.
 
     Most notably, we add the 'presto' marker for all tests that
-    are not marked with requires_rmq, requires_psql, or nightly.
+    are not marked with requires_rmq, requires_psql, requires_secure_storage, or nightly.
     Tests marked requires_broker are included in presto since ZeroMQ
     broker is available without external services.
     """
@@ -118,11 +118,17 @@ def pytest_collection_modifyitems(items, config):
         if filepath_item.is_relative_to(filepath_psqldos):
             item.add_marker('requires_psql')
 
+        markers = [marker.name for marker in item.iter_markers()]
+
         # Add 'presto' marker to tests that don't need external services.
         # Tests with requires_broker ARE included (ZeroMQ broker needs no external service).
-        # Tests with requires_rmq, requires_psql, or nightly are excluded.
-        markers = [marker.name for marker in item.iter_markers()]
-        if 'requires_rmq' not in markers and 'requires_psql' not in markers and 'nightly' not in markers:
+        # Tests with requires_rmq, requires_psql, requires_secure_storage, or nightly are excluded.
+        if (
+            'requires_rmq' not in markers
+            and 'requires_psql' not in markers
+            and 'requires_secure_storage' not in markers
+            and 'nightly' not in markers
+        ):
             item.add_marker('presto')
 
 

--- a/tests/orm/test_authinfos.py
+++ b/tests/orm/test_authinfos.py
@@ -117,6 +117,7 @@ def test_delete_authinfo_removes_only_its_own_secure_password(aiida_profile_clea
     assert list(store.values()) == ['pw-default']
 
 
+@pytest.mark.requires_secure_storage
 class TestAuthinfo:
     """Unit tests for the AuthInfo ORM class."""
 

--- a/tests/orm/test_authinfos.py
+++ b/tests/orm/test_authinfos.py
@@ -8,10 +8,113 @@
 ###########################################################################
 """Unit tests for the AuthInfo ORM class."""
 
+import shlex
+import subprocess
+
 import pytest
 
 from aiida.common import exceptions
-from aiida.orm import authinfos, computers
+from aiida.common.datastructures import SecureStorage
+from aiida.orm import authinfos, computers, users
+
+
+class MockEntry:
+    """Mock keyring entry for testing secure-storage cleanup."""
+
+    def __init__(self, exception: Exception | None) -> None:
+        self.exception = exception
+
+    def set_password(self, password: str):
+        """Accept storing the password."""
+
+    def delete_credential(self):
+        """Raise the configured exception."""
+        if self.exception is not None:
+            raise self.exception
+
+
+def test_init_auth_params_stores_password_in_secure_storage(aiida_profile_clean, aiida_localhost, monkeypatch):
+    """Passing auth params to the constructor should not persist plaintext passwords."""
+    monkeypatch.setattr(SecureStorage, '_entry', lambda _: MockEntry(None))
+    user = users.User(email='constructor@localhost').store()
+
+    auth_info = authinfos.AuthInfo(computer=aiida_localhost, user=user, auth_params={'password': 'pw'}).store()
+
+    assert SecureStorage.contains_redacted_password(auth_info.get_auth_params())
+    assert auth_info.get_auth_params()['password'] != 'pw'
+
+
+@pytest.mark.parametrize('entity', ('authinfo', 'computer'))
+@pytest.mark.parametrize('has_password', (False, True))
+def test_delete_cleans_secure_storage_best_effort(
+    aiida_profile_clean, aiida_localhost, monkeypatch, entity, has_password
+):
+    """Deleting an authinfo or computer only cleans up secure storage if a password was stored."""
+    auth_info = aiida_localhost.configure()
+    if has_password:
+        monkeypatch.setattr(SecureStorage, '_entry', lambda _: MockEntry(None))
+        auth_info.set_auth_params({'password': 'pw'})
+
+    exception = (
+        OSError('No secure-storage backend available.')
+        if has_password
+        else AssertionError('Secure-storage cleanup should not have been attempted.')
+    )
+    monkeypatch.setattr(SecureStorage, '_entry', lambda _: MockEntry(exception))
+
+    if entity == 'authinfo':
+        authinfos.AuthInfo.collection.delete(auth_info.pk)
+        assert len(authinfos.AuthInfo.collection.all()) == 0
+    else:
+        computers.Computer.collection.delete(aiida_localhost.pk)
+        assert len(computers.Computer.collection.all()) == 0
+
+
+def test_delete_authinfo_removes_only_its_own_secure_password(aiida_profile_clean, aiida_localhost, monkeypatch):
+    """Each authinfo owns a separate credential (keyed per computer and user); deleting one must not remove another's.
+
+    A computer can have multiple authinfos, one per user. Since each stores its password under its own keyring
+    entry, deleting one authinfo cleans up only that entry, leaving other users' passwords intact.
+    """
+    store: dict[str, str] = {}
+
+    class DictEntry:
+        """Mock keyring entry backed by ``store``, keyed by the secure-storage entry name."""
+
+        def __init__(self, secure_storage: SecureStorage) -> None:
+            self._name = secure_storage._entry_name
+
+        def set_password(self, password: str) -> None:
+            store[self._name] = password
+
+        def get_password(self) -> str:
+            if self._name not in store:
+                raise KeyError(self._name)
+            return store[self._name]
+
+        def delete_credential(self) -> None:
+            if self._name not in store:
+                raise KeyError(self._name)
+            del store[self._name]
+
+    def get_dict_entry(secure_storage: SecureStorage) -> DictEntry:
+        return DictEntry(secure_storage)
+
+    monkeypatch.setattr(SecureStorage, '_entry', get_dict_entry)
+
+    default_auth_info = aiida_localhost.configure()
+    default_auth_info.set_auth_params({'password': 'pw-default'})
+    other_user = users.User(email='other@localhost').store()
+    other_auth_info = authinfos.AuthInfo(
+        computer=aiida_localhost, user=other_user, auth_params={'password': 'pw-other'}
+    ).store()
+
+    # The two authinfos store their passwords under distinct entries.
+    assert len(store) == 2
+
+    # Deleting one authinfo removes only its own credential; the other user's password is untouched.
+    authinfos.AuthInfo.collection.delete(other_auth_info.pk)
+    assert list(store.values()) == ['pw-default']
 
 
 class TestAuthinfo:
@@ -30,9 +133,46 @@ class TestAuthinfo:
         self.auth_info.set_auth_params(auth_params)
         assert self.auth_info.get_auth_params() == auth_params
 
+        secure_storage = SecureStorage(self.computer.uuid, self.auth_info.user.pk)
+        try:
+            auth_params['password'] = 'pw'
+            self.auth_info.set_auth_params(auth_params)
+            assert SecureStorage.contains_redacted_password(self.auth_info.get_auth_params())
+            assert secure_storage.get_password() == 'pw'
+
+            # Round-tripping the auth params must not alter the password in secure storage
+            self.auth_info.set_auth_params(self.auth_info.get_auth_params())
+            assert SecureStorage.contains_redacted_password(self.auth_info.get_auth_params())
+            assert secure_storage.get_password() == 'pw'
+        finally:
+            secure_storage.delete_password()
+
+    def test_secure_storage(self):
+        secure_storage = SecureStorage(self.computer.uuid, self.auth_info.user.pk)
+        # Check get_password
+        assert secure_storage.get_password() is None
+        try:
+            # Check set_password
+            secure_storage.set_password('password')
+            assert secure_storage.get_password() == 'password'
+
+            # The generated command must print the stored password to stdout
+            cmd_stdout_password = secure_storage.get_cmd_stdout_password()
+            result = subprocess.run(shlex.split(cmd_stdout_password), capture_output=True, text=True, check=False)
+            assert result.stdout == 'password'
+        finally:
+            secure_storage.delete_password()
+
+        # Check delete_password
+        assert secure_storage.get_password() is None
+
     def test_delete_authinfo(self):
         """Test deleting a single AuthInfo."""
         pk = self.auth_info.pk
+        user_pk = self.auth_info.user.pk
+        # Storing a password marks the authinfo and persists the credential in secure storage.
+        self.auth_info.set_auth_params({'password': 'pw'})
+        assert SecureStorage(self.computer.uuid, user_pk).get_password() == 'pw'
 
         assert len(authinfos.AuthInfo.collection.all()) == 1
         authinfos.AuthInfo.collection.delete(pk)
@@ -41,10 +181,37 @@ class TestAuthinfo:
         with pytest.raises(exceptions.NotExistent):
             authinfos.AuthInfo.collection.delete(pk)
 
+        # Check password has been also deleted
+        # We have to create a new SecureStorage as auth_info is now invalid
+        assert SecureStorage(self.computer.uuid, user_pk).get_password() is None
+
+    def test_delete_authinfo_keeps_other_users_password(self):
+        """Deleting one authinfo must keep another user's password, as each authinfo owns a separate credential."""
+        other_user = users.User(email='other@localhost').store()
+        other_auth_info = authinfos.AuthInfo(computer=self.computer, user=other_user).store()
+
+        secure_storage = SecureStorage(self.computer.uuid, self.auth_info.user.pk)
+        try:
+            self.auth_info.set_auth_params({'password': 'pw'})
+            other_auth_info.set_auth_params({'password': 'pw'})
+            authinfos.AuthInfo.collection.delete(other_auth_info.pk)
+            assert secure_storage.get_password() == 'pw'
+        finally:
+            secure_storage.delete_password()
+
     def test_delete_computer(self):
         """Test that deleting a computer also deletes the associated Authinfo."""
         pk = self.auth_info.pk
+        user_pk = self.auth_info.user.pk
+
+        # Storing a password marks the authinfo and persists the credential in secure storage.
+        self.auth_info.set_auth_params({'password': 'pw'})
+        assert SecureStorage(self.computer.uuid, user_pk).get_password() == 'pw'
 
         computers.Computer.collection.delete(self.computer.pk)
         with pytest.raises(exceptions.NotExistent):
             authinfos.AuthInfo.collection.delete(pk)
+
+        # Check password has been also deleted
+        # We have to create a new SecureStorage as auth_info is now invalid
+        assert SecureStorage(self.computer.uuid, user_pk).get_password() is None

--- a/tests/orm/test_computers.py
+++ b/tests/orm/test_computers.py
@@ -61,6 +61,9 @@ class TestComputer:
         with pytest.raises(exceptions.NotExistent):
             Computer.collection.get(id=comp_pk)
 
+        with pytest.raises(exceptions.NotExistent, match=rf'Computer<{comp_pk}> does not exist'):
+            Computer.collection.delete(comp_pk)
+
     def test_get_minimum_job_poll_interval(self):
         """Test the :meth:`aiida.orm.Computer.get_minimum_job_poll_interval` method."""
         computer = Computer()

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -1612,10 +1612,28 @@ def test_gotocomputer_command(custom_transport):
         assert 'ssh' in goto_computer_cmd
 
 
-def test_openssh_backend_rejects_password():
-    """A password cannot be used with the ``openssh`` backend, which has no way to inject it."""
-    with pytest.raises(ValueError, match=r'Password authentication is not supported by the `openssh` backend'):
-        TransportFactory('core.ssh_async')(machine='localhost', backend='openssh', password='secret')
+def test_openssh_backend_accepts_password():
+    """A password can be configured for the ``openssh`` backend."""
+    transport = TransportFactory('core.ssh_async')(machine='localhost', backend='openssh', password='secret')
+
+    assert transport._password == 'secret'
+
+
+def test_openssh_backend_password_authentication():
+    """The ``openssh`` backend can authenticate with a password through ``sshpass``."""
+    if shutil.which('sshpass') is None:
+        pytest.skip('The `sshpass` command line tool is not installed.')
+
+    transport = TransportFactory('core.ssh_async')(machine='localhost', backend='openssh', password='password')
+
+    with transport:
+        returncode, stdout, stderr = transport.exec_command_wait('echo password-auth-ok')
+
+    if returncode == 255 and 'connect to host localhost' in stderr:
+        pytest.skip(f'Local SSH server is not reachable: {stderr}')
+
+    assert returncode == 0, stderr
+    assert stdout.strip() == 'password-auth-ok'
 
 
 def test_gotocomputer_command_uses_sshpass_fd(monkeypatch):

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -21,12 +21,17 @@ import time
 import uuid
 from pathlib import Path
 
+import click
 import psutil
 import pytest
 
+from aiida.common.datastructures import SecureStorage
+from aiida.common.exceptions import InvalidOperation
 from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.plugins import SchedulerFactory, TransportFactory
 from aiida.transports import Transport
+from aiida.transports.plugins import ssh_async
+from aiida.transports.plugins.local import LocalTransport
 
 # TODO : test for copy with pattern
 # TODO : test for copy with/without patterns, overwriting folder
@@ -64,23 +69,38 @@ def tmp_path_local(tmp_path_factory):
         ('core.ssh', None),
         ('core.ssh_async', 'asyncssh'),
         ('core.ssh_async', 'openssh'),
+        ('core.ssh_async', 'password-passed'),
+        ('core.ssh_async', 'password-from-keychain'),
     ],
 )
-def custom_transport(request, tmp_path_factory, monkeypatch) -> Transport:
+def custom_transport(request, aiida_localhost) -> Transport:
     """Fixture that parametrizes over all the registered implementations of the transport plugins."""
-    plugin = TransportFactory(request.param[0])
+    plugin_name, use_case = request.param
+    plugin = TransportFactory(plugin_name)
+    auth_info = None
 
-    if request.param[0] == 'core.ssh':
+    if plugin_name == 'core.ssh':
         kwargs = {'machine': 'localhost', 'timeout': 30, 'load_system_host_keys': True, 'key_policy': 'AutoAddPolicy'}
-    elif request.param[0] == 'core.ssh_async':
-        kwargs = {
-            'machine': 'localhost',
-            'backend': request.param[1],
-        }
+    elif plugin_name == 'core.ssh_async':
+        auth_info = aiida_localhost.configure()
+        kwargs = {'machine': 'localhost'}
+        if use_case in {'asyncssh', 'openssh'}:
+            kwargs['backend'] = use_case
+        elif use_case == 'password-passed':
+            kwargs['backend'] = 'asyncssh'
+            kwargs['password'] = 'password'
+        elif use_case == 'password-from-keychain':
+            auth_info.set_auth_params({'password': 'password'})
+            kwargs['backend'] = 'asyncssh'
+            kwargs['password'] = SecureStorage(auth_info.computer.uuid, auth_info.user.pk).get_password()
     else:
         kwargs = {}
 
-    return plugin(**kwargs)
+    try:
+        yield plugin(**kwargs)
+    finally:
+        if plugin_name == 'core.ssh_async' and use_case == 'password-from-keychain' and auth_info is not None:
+            SecureStorage(auth_info.computer.uuid, auth_info.user.pk).delete_password()
 
 
 def test_is_open(custom_transport):
@@ -1580,3 +1600,86 @@ def test_glob(custom_transport, tmp_path_local):
         g_list = transport.glob(str(tmp_path_local) + '/folder2/aiida.pdos*')
         paths = [str(tmp_path_local.joinpath('folder2/aiida.pdos_atm#2(Al)_wfc#2(p)'))]
         assert sorted(paths) == sorted(g_list)
+
+
+def test_gotocomputer_command(custom_transport):
+    """Test the generated go-to-computer command."""
+    goto_computer_cmd = custom_transport.gotocomputer_command(Path('/path'))
+
+    if isinstance(custom_transport, LocalTransport):
+        assert 'bash' in goto_computer_cmd
+    else:
+        assert 'ssh' in goto_computer_cmd
+
+
+def test_openssh_backend_rejects_password():
+    """A password cannot be used with the ``openssh`` backend, which has no way to inject it."""
+    with pytest.raises(ValueError, match=r'Password authentication is not supported by the `openssh` backend'):
+        TransportFactory('core.ssh_async')(machine='localhost', backend='openssh', password='secret')
+
+
+def test_gotocomputer_command_uses_sshpass_fd(monkeypatch):
+    """Password-assisted go-to-computer commands should not expose the password as a command argument."""
+    monkeypatch.setattr(ssh_async.shutil, 'which', lambda _: '/usr/bin/sshpass')
+    transport = TransportFactory('core.ssh_async')(machine='localhost', backend='asyncssh', password='secret')
+
+    command = transport.gotocomputer_command()
+
+    assert 'sshpass -d' in command
+    assert 'secret' not in command
+    match = re.search(r'sshpass -d (\d+)', command)
+    assert match is not None
+    os.close(int(match.group(1)))
+
+
+def test_gotocomputer_command_requires_sshpass_for_password(monkeypatch):
+    """Password-assisted go-to-computer commands require ``sshpass``."""
+    monkeypatch.setattr(ssh_async.shutil, 'which', lambda _: None)
+    transport = TransportFactory('core.ssh_async')(machine='localhost', backend='asyncssh', password='secret')
+
+    with pytest.raises(InvalidOperation, match='Cannot use password authentication'):
+        transport.gotocomputer_command()
+
+
+def test_validate_password_is_not_redacted_marker():
+    """Validate password configuration rejects the secure-storage redaction marker."""
+    with pytest.raises(click.BadParameter, match='Password cannot be equal to the secure-storage redaction marker'):
+        ssh_async.validate_password_is_not_redacted_marker(None, None, SecureStorage.SECURE_STORAGE_PASSWORD_MARKER)
+
+
+def test_validate_os_supports_secure_storage(monkeypatch):
+    """Validate password configuration fails if secure storage is unavailable."""
+    import keyringrs
+
+    class FailingEntry:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_password(self, _: str):
+            raise RuntimeError('Could not access secure storage.')
+
+    monkeypatch.setattr(keyringrs, 'Entry', FailingEntry)
+
+    with pytest.raises(OSError, match=r'.*Cannot use password authentication without secure storage.*'):
+        ssh_async.validate_os_supports_secure_storage(None, None, 'pw')
+
+
+def test_validate_os_supports_password_authentication_requires_sshpass(monkeypatch):
+    """Validate password authentication fails if ``sshpass`` is unavailable."""
+    import keyringrs
+
+    class Entry:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_password(self, _: str):
+            pass
+
+        def delete_credential(self):
+            pass
+
+    monkeypatch.setattr(keyringrs, 'Entry', Entry)
+    monkeypatch.setattr(ssh_async.shutil, 'which', lambda _: None)
+
+    with pytest.raises(OSError, match=r'.*Cannot use password authentication without `sshpass`.*'):
+        ssh_async.validate_os_supports_password_authentication(None, None, 'pw')

--- a/tests/transports/test_all_plugins.py
+++ b/tests/transports/test_all_plugins.py
@@ -70,7 +70,7 @@ def tmp_path_local(tmp_path_factory):
         ('core.ssh_async', 'asyncssh'),
         ('core.ssh_async', 'openssh'),
         ('core.ssh_async', 'password-passed'),
-        ('core.ssh_async', 'password-from-keychain'),
+        pytest.param(('core.ssh_async', 'password-from-keychain'), marks=pytest.mark.requires_secure_storage),
     ],
 )
 def custom_transport(request, aiida_localhost) -> Transport:

--- a/tests/transports/test_asyncssh_plugin.py
+++ b/tests/transports/test_asyncssh_plugin.py
@@ -174,9 +174,10 @@ def test_get_openssh_version():
 class _TestOpenSSH(_OpenSSH):
     """Minimal OpenSSH subclass for testing escape methods."""
 
-    def __init__(self):
+    def __init__(self, password=None):
         self.machine = 'localhost'
         self.bash_command = 'bash -c '
+        self._password = password
 
 
 def test_openssh_path_exists_raises_on_unexpected_return_code():

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,7 @@ dependencies = [
     { name = "ipython", version = "9.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jedi" },
     { name = "jinja2" },
+    { name = "keyringrs", version = "0.4.0", source = { registry = "https://pypi.org/simple" } },
     { name = "kiwipy", extra = ["rmq"] },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -222,6 +223,7 @@ requires-dist = [
     { name = "jinja2", specifier = "~=3.0" },
     { name = "jupyter", marker = "extra == 'notebook'", specifier = "~=1.0" },
     { name = "jupyter-client", marker = "extra == 'notebook'", specifier = "~=8.0" },
+    { name = "keyringrs", specifier = "~=0.4.0" },
     { name = "kiwipy", extras = ["rmq"], specifier = "~=0.9.0" },
     { name = "matplotlib", marker = "extra == 'atomic-tools'", specifier = "~=3.3,>=3.3.4" },
     { name = "mypy", marker = "extra == 'pre-commit'", specifier = "~=2.3.0" },
@@ -2403,6 +2405,28 @@ rmq = [
     { name = "aio-pika" },
     { name = "pamqp" },
     { name = "pytray" },
+]
+
+[[package]]
+name = "keyringrs"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/9e/6c73d08404518bbe81889dd48ca0494815b9790f031e83ebf382427ba6e0/keyringrs-0.4.0.tar.gz", hash = "sha256:4474fc294474a9e88746a1e5de3bd7249a9cea8f3668e722c9df7dd2b68cd77b", size = 31518 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/07/19237f4a5886525a1468a71dc860da7ceed6eba11968075db34f5eefd3c6/keyringrs-0.4.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:942084d562b754eef9ce4f5f84700530059baaa815de1aa9421ee1d9c566484e", size = 257467 },
+    { url = "https://files.pythonhosted.org/packages/a5/28/c49326f4794e3ca839b7e1a4c41f30e6a593131e42560c970195bd639617/keyringrs-0.4.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffce9bb7737e83c86b2e0fd3fa868f29a86ad7e275d3853755131d6aadc21a5e", size = 251546 },
+    { url = "https://files.pythonhosted.org/packages/77/57/8c16cb0053a5305398161bd8a8b7526a74c652fc2e794504d551b8feb62c/keyringrs-0.4.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a50370aac82f10a91365e5ac9be0bb74946ee064741eae9ae235773f9006a7a2", size = 724491 },
+    { url = "https://files.pythonhosted.org/packages/38/03/fba6a69192bc1054e2785337aedef3798a8c1cc6b7893cadabc8dfcaa3c6/keyringrs-0.4.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07f9fda5c4bf51cadddd4409c2bcfd7db4aa8f42c98e7f1c5125eb7230ba5598", size = 722183 },
+    { url = "https://files.pythonhosted.org/packages/4c/9d/49409d37e72c334a6a51d8e5c5ecc5033ac825f1c781836c23f85e29b072/keyringrs-0.4.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7d8c86c77fce368e60425313c5993edaa70fec6a51d525834eb663f1fb60e16c", size = 809595 },
+    { url = "https://files.pythonhosted.org/packages/5c/62/4dc4e976a10bb3619a45ab6f6ae6bc7e3eaa0e4693184b6f7072aaa1e525/keyringrs-0.4.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:067e4df8de97b4958c4c8676a8f53e424889b660fe5968e7360af5265c6c2b0c", size = 843601 },
+    { url = "https://files.pythonhosted.org/packages/33/b7/b8ae5d763f9902cfb68fe784c8d024b9a265ea4a00fb835448353aa23521/keyringrs-0.4.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75a64e393576310632c9c27bdbfbc75d4d8229453d4323a5255479eb00e300e3", size = 755171 },
+    { url = "https://files.pythonhosted.org/packages/0c/84/d9c2aca6b1a5ba844d06885bd0611460750514b0e1d75a4cd60c414e4fe4/keyringrs-0.4.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ed512b6f344b5550cc9178871f7f94c2b3c931202dce438defcb90b9dff4b289", size = 796531 },
+    { url = "https://files.pythonhosted.org/packages/86/03/badaed39a93528bb620ee15fc6e4d315b805b8b99af174e45fa5a51caac4/keyringrs-0.4.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3be0f3f4e627ce409e233e96dd84dd3564c6eafa2a8b01c7a9b3574a4e0ec7f0", size = 914455 },
+    { url = "https://files.pythonhosted.org/packages/f5/df/a38e3e63d3755250d9576368d98d4e2a195496f3551c35f9d9a727c53047/keyringrs-0.4.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e948c6b3e94ad0ccfe1e7108c20ceb99667b05c1e455733a466fc41be097a02b", size = 984575 },
+    { url = "https://files.pythonhosted.org/packages/35/8f/983fb0a4728cb97a8ae418d2da234afcb130ffb8c845d746b802e7ba530e/keyringrs-0.4.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1fd0f3fca90c4443669966d533a408f211a290e7483b9bf9ac1595cda9bc90dd", size = 951522 },
+    { url = "https://files.pythonhosted.org/packages/64/f4/b4798a08918281d7da3e94295d3e80cbfbc6e66ffbee455252fb58db01e1/keyringrs-0.4.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f4f09bcc1d4fb61cd7c1038150ee9309af3b51f0801c2a8f3a22cc542da0ed77", size = 926049 },
+    { url = "https://files.pythonhosted.org/packages/29/14/666630b5a5ff76663ad8e609f44ff02a9cb10b289a5f264af45262082f97/keyringrs-0.4.0-cp39-abi3-win32.whl", hash = "sha256:531c09db12cb319238a071fd50eaa1f0598de31341a3444a46c385f7f4fe43be", size = 139458 },
+    { url = "https://files.pythonhosted.org/packages/c6/b5/ffed5cdc3b6d56d90c84ef97a12569c0f21517c0f59dba4c61b4bd8da737/keyringrs-0.4.0-cp39-abi3-win_amd64.whl", hash = "sha256:e50fe42a9a12226acd39ff8cd3bbb5b3e5b316f26a3698e9dea445b0a9399fab", size = 145837 },
 ]
 
 [[package]]


### PR DESCRIPTION
Second round of PR #6761 after long rebase. Most review comments have been adapted or are now out-of-date so a new PR for a cleaner review will be helpful. The first two commits are not directly related to the PR but happen because the files are touched anyway.

The redacted logic for auth params required further rework. To not expose the function `AuthInfo.get_auth_params`  that is part of public API with the the password credentials we redact the password before returning the auth params. This is to prevent unintended password exposure through public api usage. Therefore one has to consider auth params that have redacted passwords, so round-trips: set auth params with real password, store password in secure storage but redact entry in database -> get auth params returns only redacted auth params -> update some auth params -> set with updated auth params --> oops password in secure storage is now set to redacted string. So to avoid this we do some checks if the auth params contain the redacted string value, to not store it in the secure storage overwriting the original password.

`SecureStorage` has been moved to `aiida.common.datastructures` to make it easier to import from the various authinfo-related layers (ORM, interface, implementation) and computer cleanup code.

The CLI logic had to be adapted so the password option can use `None` as an actual default value. Previously, a `None` default was interpreted by the CLI as “no default”, meaning the user could not simply press enter to select “no password”. An explicit option was added for this behavior (see commit "👌 Let the ssh_async password prompt accept no value via enter").

The secure-storage entry now also includes the user identifier. This is needed because there is a one-to-many relationship between a computer and its authinfos: a single computer can have authinfos for multiple users. By including the user in secure-storage entry, each one is unique per authinfo.

For `ssh_async`, passing the password directly as an SSH command-line option would expose it to other processes, since process arguments can be inspected. To avoid this, the implementation uses `sshpass` with a file descriptor. The password is written through a pipe/file descriptor rather than exposed in the command arguments, making it inaccessible to other processes via the process list. If there is interest in supporting password authentication without `sshpass`, we can consider adding a less secure fallback explicitly.

TODO:
- [ ] release on keyringrs to include stubs properly so mypy does not complain (pre-commit failure)
- [ ] release keyringrs on conda-forge. I am in the process of it