### PR TITLE
👌 Run only mypy in release and nightly checks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
 
-  pre-commit:
+  mypy:
 
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -39,10 +39,12 @@ jobs:
       with:
         python-version: '3.11'
         extras: pre-commit
+        # Full pre-commit runs in locked CI; run mypy additionally here
+        # with latest compatible dependencies for nightly validation.
         from-lock: 'false'
 
-    - name: Run pre-commit
-      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+    - name: Run mypy
+      run: pre-commit run mypy --all-files
 
   nightly-tests:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,12 @@ jobs:
       with:
         python-version: '3.11'
         extras: pre-commit
+        # Full pre-commit runs in locked CI; run mypy additionally here
+        # with latest compatible dependencies for release validation.
         from-lock: 'false'
 
-    - name: Run pre-commit
-      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+    - name: Run mypy
+      run: pre-commit run mypy --all-files
 
   tests:
     if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && contains(fromJson(toJson(github.event.pull_request.labels)).*.name, 'test-release'))


### PR DESCRIPTION
Formatting hooks are already covered by the locked pre-commit CI. The release workflow intentionally installs with from-lock=false to exercise latest compatible dependencies. Running formatting hooks in that environment can fail only because a newer formatter wants a different style, which is noise for release validation.

Keep the unlocked release check mypy, where changes in dependency types or stubs provide useful signal.

Note that because we only run mypy we do not need to check if the execution of pre-commit changed files with git diff, since mypy alread exits with a nonzero exit code.