### PR TITLE
Docs: remove outdated claim that 2FA requires installing AiiDA on the remote

### DIFF
--- a/docs/source/howto/faq.rst
+++ b/docs/source/howto/faq.rst
@@ -114,7 +114,7 @@ This will cause all calculations submitted on that computer to pause.
 To restart them, one needs to generate a new SSH key pair and play the paused processes using ``verdi process play --all``.
 Typically, this is all one needs to do - AiiDA will re-establish the connection to the computer and will continue following the calculations.
 
-This manual step can be avoided altogether with the ``core.ssh_async`` transport, which can run an authentication script that renews the credentials before each connection, see :ref:`how-to:ssh:2fa`.
+This manual step can be avoided altogether with the ``core.ssh_async`` transport and a configured ``authentication_script``, which renews the credentials before each connection; see :ref:`how-to:ssh:2fa`.
 
 How to back up AiiDA data?
 =============================================================================

--- a/docs/source/howto/faq.rst
+++ b/docs/source/howto/faq.rst
@@ -114,6 +114,8 @@ This will cause all calculations submitted on that computer to pause.
 To restart them, one needs to generate a new SSH key pair and play the paused processes using ``verdi process play --all``.
 Typically, this is all one needs to do - AiiDA will re-establish the connection to the computer and will continue following the calculations.
 
+This manual step can be avoided altogether with the ``core.ssh_async`` transport, which can run an authentication script that renews the credentials before each connection, see :ref:`how-to:ssh:2fa`.
+
 How to back up AiiDA data?
 =============================================================================
 

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -39,7 +39,7 @@ The second option allows managing multiple remote compute resources (including H
 .. note::
 
     The second option requires access through an SSH keypair.
-    If your compute resource demands two-factor authentication, the ``core.ssh_async`` transport can obtain fresh credentials before each connection, see :ref:`how-to:ssh:2fa`.
+    If your compute resource demands two-factor authentication, configure the ``authentication_script`` for the ``core.ssh_async`` transport to obtain fresh credentials before each connection; see :ref:`how-to:ssh:2fa`.
 
 
 Computer requirements

--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -39,7 +39,7 @@ The second option allows managing multiple remote compute resources (including H
 .. note::
 
     The second option requires access through an SSH keypair.
-    If your compute resource demands two-factor authentication, you may need to install AiiDA directly on the compute resource instead.
+    If your compute resource demands two-factor authentication, the ``core.ssh_async`` transport can obtain fresh credentials before each connection, see :ref:`how-to:ssh:2fa`.
 
 
 Computer requirements

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -9,7 +9,7 @@ There are three ways of setting up an SSH connection for AiiDA:
 
 #. Using a passwordless SSH key (easier, less safe)
 #. Using a password-protected SSH key through ``ssh-agent`` (one more step, safer)
-#. Using :ref:`two-factor authentication <how-to:ssh:2fa>` with the ``core.ssh_async`` transport, if your compute resource requires it, and allows automation
+#. Using :ref:`two-factor authentication <how-to:ssh:2fa>` with the ``core.ssh_async`` transport and a configured ``authentication_script``, if your compute resource requires it and allows automation
 
 .. _how-to:ssh:passwordless:
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -5,10 +5,11 @@ How to setup SSH connections
 ****************************
 
 AiiDA communicates with remote computers via the SSH protocol.
-There are two ways of setting up an SSH connection for AiiDA:
+There are three ways of setting up an SSH connection for AiiDA:
 
 #. Using a passwordless SSH key (easier, less safe)
 #. Using a password-protected SSH key through ``ssh-agent`` (one more step, safer)
+#. Using :ref:`two-factor authentication <how-to:ssh:2fa>` with the ``core.ssh_async`` transport, if your compute resource requires it, and allows automation
 
 .. _how-to:ssh:passwordless:
 


### PR DESCRIPTION
Since #7184, the `core.ssh_async` transport supports two-factor authentication through the `authentication_script` option, and `docs/source/howto/ssh.rst` documents the full workflow. However, a few older pages still state or imply that 2FA is unsupported and never link to that section.

- `howto/run_codes.rst`: the note claimed that with 2FA "you may need to install AiiDA directly on the compute resource instead". Replaced with a pointer to the 2FA how-to.
- `howto/ssh.rst`: the intro listed "two ways" of setting up an SSH connection. 2FA is now listed as a third.
- `howto/faq.rst`: the MFA key-expiry entry only described the manual workaround (regenerate keys, `verdi process play --all`). That is still valid, so it is kept, with an added pointer to the automated alternative.

All three cross-references resolve to `ssh.html#how-to-ssh-2fa`; the docs build produces no new warnings.
