### PR TITLE
Docs: update `core.ssh` references for its deprecation

### DIFF
--- a/docs/source/howto/run_codes.rst
+++ b/docs/source/howto/run_codes.rst
@@ -136,7 +136,12 @@ The second step configures private connection details using:
 
     $ verdi computer configure TRANSPORTTYPE COMPUTERLABEL
 
-Replace ``COMPUTERLABEL`` with the computer label chosen during the setup and replace ``TRANSPORTTYPE`` with the name of chosen transport type, i.e., ``core.local`` for the localhost computer and ``core.ssh`` for any remote computer.
+Replace ``COMPUTERLABEL`` with the computer label chosen during the setup and replace ``TRANSPORTTYPE`` with the name of chosen transport type, i.e., ``core.local`` for the localhost computer and ``core.ssh_async`` for any remote computer.
+
+.. deprecated:: 2.8
+
+    The ``core.ssh`` transport plugin is deprecated and will be removed in v3.0.
+    Use ``core.ssh_async`` instead, which is significantly faster and provides an easier configuration interface.
 
 After the setup and configuration have been completed, let's check that everything is working properly:
 
@@ -174,7 +179,7 @@ Some compute resources, particularly large supercomputing centers, may not toler
 
     .. code-block:: bash
 
-        verdi computer configure core.ssh --non-interactive --safe-interval <SECONDS> <COMPUTER_NAME>
+        verdi computer configure core.ssh_async --non-interactive --safe-interval <SECONDS> <COMPUTER_NAME>
 
 .. important::
 

--- a/docs/source/howto/ssh.rst
+++ b/docs/source/howto/ssh.rst
@@ -178,7 +178,9 @@ To instruct ssh to look in the OSX keychain for key passphrases, add the followi
 AiiDA configuration
 ^^^^^^^^^^^^^^^^^^^
 
-When :ref:`configuring the computer in AiiDA <how-to:run-codes:computer:configuration>`, simply make sure that ``Allow ssh agent`` is set to ``true`` (default).
+With the recommended ``core.ssh_async`` transport, no extra configuration is needed: the agent is picked up through the ``SSH_AUTH_SOCK`` environment variable, just like the ``ssh`` command does.
+
+With the deprecated ``core.ssh`` transport, when :ref:`configuring the computer in AiiDA <how-to:run-codes:computer:configuration>`, simply make sure that ``Allow ssh agent`` is set to ``true`` (default).
 
 .. _how-to:ssh:proxy:
 
@@ -245,23 +247,36 @@ In both cases, this should allow you to directly connect to the *TARGET* server 
 AiiDA configuration
 ^^^^^^^^^^^^^^^^^^^
 
-When :ref:`configuring the computer in AiiDA <how-to:run-codes:computer:configuration>`, AiiDA will automatically parse most of required information from your ``~/.ssh/config`` file. A notable exception to this is the ``proxy_jump`` directive, which **must** be specified manually.
-
-Simply copy & paste the same instructions as you have used for ``ProxyJump`` in your ``~/.ssh/config`` to the input for ``proxy_jump``:
+With the recommended ``core.ssh_async`` transport, nothing else is needed: the plugin connects as ``ssh SHORTNAME_TARGET`` would, so the ``ProxyJump``/``ProxyCommand`` directives of your ``~/.ssh/config`` are honoured directly.
 
 .. code-block:: console
 
-   $ verdi computer configure core.ssh SHORTNAME_TARGET
-   ...
-   Allow ssh agent [True]:
-   SSH proxy jump []: USER_PROXY@FULLHOSTNAME_PROXY
+   $ verdi computer configure core.ssh_async SHORTNAME_TARGET
 
-.. note:: A chain of proxies can be specified as a comma-separated list. If you need to specify a different username, you can so with ``USER_PROXY@...``. If no username is specified for the proxy the same username as for the *TARGET* is used.
+.. dropdown:: :fa:`plus-circle` With the deprecated ``core.ssh`` transport
 
-.. important:: Specifying the ``proxy_command`` manually
+   .. deprecated:: 2.8
 
-    When specifying or updating the ``proxy_command`` option via ``verdi computer configure ssh``, please **do not use placeholders** ``%h`` and ``%p`` but provide the *actual* hostname and port.
-    AiiDA replaces them only when parsing from the ``~/.ssh/config`` file.
+       The ``core.ssh`` transport plugin is deprecated and will be removed in v3.0.
+       Use ``core.ssh_async`` instead, which is significantly faster and provides an easier configuration interface.
+
+   When :ref:`configuring the computer in AiiDA <how-to:run-codes:computer:configuration>`, AiiDA will automatically parse most of required information from your ``~/.ssh/config`` file. A notable exception to this is the ``proxy_jump`` directive, which **must** be specified manually.
+
+   Simply copy & paste the same instructions as you have used for ``ProxyJump`` in your ``~/.ssh/config`` to the input for ``proxy_jump``:
+
+   .. code-block:: console
+
+      $ verdi computer configure core.ssh SHORTNAME_TARGET
+      ...
+      Allow ssh agent [True]:
+      SSH proxy jump []: USER_PROXY@FULLHOSTNAME_PROXY
+
+   .. note:: A chain of proxies can be specified as a comma-separated list. If you need to specify a different username, you can so with ``USER_PROXY@...``. If no username is specified for the proxy the same username as for the *TARGET* is used.
+
+   .. important:: Specifying the ``proxy_command`` manually
+
+       When specifying or updating the ``proxy_command`` option via ``verdi computer configure core.ssh``, please **do not use placeholders** ``%h`` and ``%p`` but provide the *actual* hostname and port.
+       AiiDA replaces them only when parsing from the ``~/.ssh/config`` file.
 
 
 .. _how-to:ssh:2fa:
@@ -486,12 +501,16 @@ Security considerations
 Using kerberos tokens
 =====================
 
-If the remote machine requires authentication through a Kerberos token (that you need to obtain before using ssh), you typically need to
+If the remote machine requires authentication through a Kerberos token (that you need to obtain before using ssh), the simplest option is to use the ``core.ssh_async`` transport with the ``openssh`` backend, which shells out to the ``ssh`` command and therefore honours the ``GSSAPI`` options of your ``~/.ssh/config`` directly.
 
-* install ``libffi`` (``sudo apt-get install libffi-dev`` under Ubuntu)
-* install the ``ssh_kerberos`` extra during the installation of aiida-core (see :ref:`installation:guide-complete:python-package:optional-requirements`).
+.. dropdown:: :fa:`plus-circle` With the deprecated ``core.ssh`` transport
 
-If you provide all necessary ``GSSAPI`` options in your ``~/.ssh/config`` file, ``verdi computer configure`` should already pick up the appropriate values for all the gss-related options.
+   You typically need to
+
+   * install ``libffi`` (``sudo apt-get install libffi-dev`` under Ubuntu)
+   * install the ``ssh_kerberos`` extra during the installation of aiida-core (see :ref:`installation:guide-complete:python-package:optional-requirements`).
+
+   If you provide all necessary ``GSSAPI`` options in your ``~/.ssh/config`` file, ``verdi computer configure`` should already pick up the appropriate values for all the gss-related options.
 
 For a real-world SSH troubleshooting walkthrough and a deep dive into secure SSH agent forwarding for cloud-based AiiDA deployments, see also these blog posts:
 

--- a/docs/source/reference/rest_api.rst
+++ b/docs/source/reference/rest_api.rst
@@ -711,7 +711,7 @@ Computers
                 "id": 3,
                 "name": "Alpha",
                 "scheduler_type": "core.slurm",
-                "transport_type": "core.ssh",
+                "transport_type": "core.ssh_async",
                 "uuid": "9b5c84bb-4575-4fbe-b18c-b23fc30ec55e"
               },
               {
@@ -720,7 +720,7 @@ Computers
                 "id": 4,
                 "name": "Beta",
                 "scheduler_type": "core.slurm",
-                "transport_type": "core.ssh",
+                "transport_type": "core.ssh_async",
                 "uuid": "5d490d77-638d-4d4b-8288-722f930783c8"
               },
               {
@@ -729,7 +729,7 @@ Computers
                 "id": 5,
                 "name": "Gamma",
                 "scheduler_type": "core.slurm",
-                "transport_type": "core.ssh",
+                "transport_type": "core.ssh_async",
                 "uuid": "7a0c3ff9-1caf-405c-8e89-2369cf91b634"
               }
             ]
@@ -764,7 +764,7 @@ Computers
                 "id": 4,
                 "name": "Beta",
                 "scheduler_type": "core.slurm",
-                "transport_type": "core.ssh",
+                "transport_type": "core.ssh_async",
                 "uuid": "5d490d77-638d-4d4b-8288-722f930783c8"
               }
             ]

--- a/docs/source/topics/plugins.rst
+++ b/docs/source/topics/plugins.rst
@@ -351,7 +351,8 @@ Usage: The scheduler is used in the familiar way by entering 'myscheduler' as th
 ``aiida.transports``
 --------------------
 
-``aiida-core`` ships with two modes of transporting files and folders to remote computers: ``core.ssh`` and ``core.local`` (stub for when the remote computer is actually the same).
+``aiida-core`` ships with two modes of transporting files and folders to remote computers: ``core.ssh_async`` and ``core.local`` (stub for when the remote computer is actually the same).
+(A third one, ``core.ssh``, is deprecated since v2.8 and will be removed in v3.0; use ``core.ssh_async`` instead.)
 We recommend naming the plugin package after the mode of transport (e.g. ``aiida-mytransport``), so that the entry point name can simply equal the name of the transport:
 
 Spec::
@@ -402,7 +403,7 @@ The module provides the following fixtures:
 * :ref:`postgres_cluster <topics:plugins:testfixtures:postgres-cluster>`: Create a temporary and isolated PostgreSQL cluster using ``pgtest`` and cleanup after the yielder
 * :ref:`aiida_computer <topics:plugins:testfixtures:aiida-computer>`: Setup a :class:`~aiida.orm.computers.Computer` instance
 * :ref:`aiida_computer_local <topics:plugins:testfixtures:aiida-computer-local>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using local transport
-* :ref:`aiida_computer_ssh <topics:plugins:testfixtures:aiida-computer-ssh>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using SSH transport
+* :ref:`aiida_computer_ssh <topics:plugins:testfixtures:aiida-computer-ssh>`: Setup the localhost as a :class:`~aiida.orm.computers.Computer` using SSH transport (``core.ssh`` is deprecated, prefer ``aiida_computer_ssh_async``)
 * :ref:`aiida_localhost <topics:plugins:testfixtures:aiida-localhost>`: Shortcut for <topics:plugins:testfixtures:aiida-computer-local> that immediately returns a :class:`~aiida.orm.computers.Computer` instance for the ``localhost`` computer instead of a factory
 * :ref:`aiida_code <topics:plugins:testfixtures:aiida-code>`: Setup a :class:`~aiida.orm.nodes.data.code.abstract.AbstractCode` instance
 * :ref:`aiida_code_installed <topics:plugins:testfixtures:aiida-code-installed>`: Setup a :class:`~aiida.orm.nodes.data.code.installed.InstalledCode` instance on a given computer
@@ -686,7 +687,16 @@ If you need a guarantee that the computer is not configured, make sure to clean 
 ``aiida_computer_ssh``
 ----------------------
 
-This fixture is a shortcut for ``aiida_computer`` to setup the localhost with SSH transport:
+This fixture is a shortcut for ``aiida_computer`` to setup the localhost with the (deprecated) ``core.ssh`` transport.
+For new tests use the ``aiida_computer_ssh_async`` fixture instead, which uses ``core.ssh_async``.
+
+.. code-block:: python
+
+    def test(aiida_computer_ssh_async):
+        localhost = aiida_computer_ssh_async(backend='asyncssh')
+        assert localhost.transport_type == 'core.ssh_async'
+
+The ``aiida_computer_ssh`` fixture itself is used as follows:
 
 .. code-block:: python
 

--- a/docs/source/topics/transport.rst
+++ b/docs/source/topics/transport.rst
@@ -7,9 +7,15 @@ Transport plugins
 The term `transport` in AiiDA refers to a class that the engine uses to perform operations on local or remote machines where its :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob` are submitted.
 The base class :py:class:`~aiida.transports.transport.Transport` defines an interface for these operations, such as copying files and executing commands.
 A `transport plugin` is a class that implements this base class for a specific connection method.
-The ``aiida-core`` package ships with two transport plugins: the :py:class:`~aiida.transports.plugins.local.LocalTransport` and :py:class:`~aiida.transports.plugins.ssh.SshTransport` classes.
-The ``local`` transport can be used to connect with the `localhost` and makes use only of some standard python modules like ``os`` and ``shutil``.
-The ``ssh`` transport, which can be used for machines that can be connected to over ssh, is simply a wrapper around the library `paramiko <https://www.paramiko.org/>`_ that is installed as a required dependency of ``aiida-core``.
+The ``aiida-core`` package ships with three transport plugins: the :py:class:`~aiida.transports.plugins.local.LocalTransport`, :py:class:`~aiida.transports.plugins.ssh_async.AsyncSshTransport` and :py:class:`~aiida.transports.plugins.ssh.SshTransport` classes.
+The ``core.local`` transport can be used to connect with the `localhost` and makes use only of some standard python modules like ``os`` and ``shutil``.
+The ``core.ssh_async`` transport is the recommended plugin for machines that can be connected to over ssh: its operations are asynchronous and the connection is configured through your ``~/.ssh/config`` file.
+The ``core.ssh`` transport is simply a wrapper around the library `paramiko <https://www.paramiko.org/>`_ that is installed as a required dependency of ``aiida-core``.
+
+.. deprecated:: 2.8
+
+    The ``core.ssh`` transport plugin is deprecated and will be removed in v3.0.
+    Use ``core.ssh_async`` instead, which is significantly faster and provides an easier configuration interface.
 
 .. _topics:transport:develop_plugin:
 


### PR DESCRIPTION
`core.ssh` was deprecated in v2.8 in favour of `core.ssh_async` (#7175), but the documentation was not updated and still presents `core.ssh` as *the* way to connect to a remote computer.

### Changes

- **Straight substitutions** where `core.ssh` was just a value/argument:
  - `howto/run_codes.rst`: the transport to choose for a remote computer, and the `verdi computer configure ... --safe-interval` example.
  - `reference/rest_api.rst`: the `transport_type` field in the example payloads.

- **Deprecation flagged where the content is paramiko-specific** and has no `core.ssh_async` equivalent. In these cases the `core.ssh_async` behaviour is documented first and the old instructions moved into a `.. dropdown::` marked as deprecated:
  - `howto/ssh.rst` proxy section — `core.ssh_async` honours `ProxyJump`/`ProxyCommand` from `~/.ssh/config` directly, so there is no `proxy_jump`/`proxy_command` option to fill in.
  - `howto/ssh.rst` ssh-agent section — `Allow ssh agent` does not exist for `core.ssh_async`, which picks up the agent through `SSH_AUTH_SOCK`.
  - `howto/ssh.rst` Kerberos section — the `openssh` backend shells out to `ssh`, so it honours the `GSSAPI` options of `~/.ssh/config` without the `ssh_kerberos` extra.

- **Plugin listings**:
  - `topics/transport.rst` and `topics/plugins.rst` now list `core.ssh_async` among the shipped transport plugins, with a `.. deprecated:: 2.8` note for `core.ssh`.
  - `topics/plugins.rst` test-fixture docs point at `aiida_computer_ssh_async` for new tests.

Docs-only, no source changes. `sphinx-build -W` passes (the only warning is the pre-existing `archive_profile.md` notebook execution failure).
