### PR TITLE
`DaemonClient`: add `wait` option to increase/decrease workers

### DIFF
--- a/src/aiida/engine/daemon/client.py
+++ b/src/aiida/engine/daemon/client.py
@@ -748,26 +748,37 @@ class DaemonClient:
 
         return DaemonEnvInfo(packages=packages, python_binary=python_binary)
 
-    def increase_workers(self, number: int, timeout: int | None = None) -> dict[str, t.Any]:
+    def increase_workers(self, number: int, timeout: int | None = None, wait: bool = False) -> dict[str, t.Any]:
         """Increase the number of workers.
 
         :param number: The number of workers to add.
         :param timeout: Optional timeout to set for trying to reach the circus daemon. Default is set on the client upon
             instantiation taken from the ``daemon.timeout`` config option.
+        :param wait: If ``False``, return as soon as the daemon acknowledged the command, i.e. before the workers have
+            been spawned. If ``True``, return only once they have and include the resulting ``numprocesses`` in the
+            response. Note that the workers still need to boot before they start consuming tasks.
         :return: The client call response.
+        :raises DaemonTimeoutException: If ``wait`` is ``True`` and spawning takes longer than ``timeout``. The workers
+            are still spawned in that case, only the response is not awaited.
         """
-        command = {'command': 'incr', 'properties': {'name': self.daemon_name, 'nb': number}}
+        command = {'command': 'incr', 'properties': {'name': self.daemon_name, 'nb': number, 'waiting': wait}}
         return self.call_client(command, timeout=timeout)
 
-    def decrease_workers(self, number: int, timeout: int | None = None) -> dict[str, t.Any]:
+    def decrease_workers(self, number: int, timeout: int | None = None, wait: bool = False) -> dict[str, t.Any]:
         """Decrease the number of workers.
 
         :param number: The number of workers to remove.
         :param timeout: Optional timeout to set for trying to reach the circus daemon. Default is set on the client upon
             instantiation taken from the ``daemon.timeout`` config option.
+        :param wait: If ``False``, return as soon as the daemon acknowledged the command, i.e. before the workers have
+            been stopped. If ``True``, return only once they have and include the resulting ``numprocesses`` in the
+            response. Since workers are shut down gracefully, this can take a while for a worker that is still running
+            processes, in which case ``timeout`` needs to be increased beyond the ``daemon.timeout`` default.
         :return: The client call response.
+        :raises DaemonTimeoutException: If ``wait`` is ``True`` and stopping takes longer than ``timeout``. The workers
+            are still stopped in that case, only the response is not awaited.
         """
-        command = {'command': 'decr', 'properties': {'name': self.daemon_name, 'nb': number}}
+        command = {'command': 'decr', 'properties': {'name': self.daemon_name, 'nb': number, 'waiting': wait}}
         return self.call_client(command, timeout=timeout)
 
     def start_daemon(

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -393,3 +393,60 @@ class TestDaemonEnvInfo:
             ),
         ):
             assert stopped_daemon_client.restart_daemon() == {'status': 'ok'}
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_change_workers_without_wait(started_daemon_client):
+    """Test that by default the calls return on acknowledgement, before the workers have been spawned or stopped."""
+    client = started_daemon_client
+    number_workers = client.get_numprocesses()['numprocesses']
+
+    def await_workers(target):
+        """Let the daemon settle, since while acting on a command it holds a lock that fails any concurrent one."""
+        client._await_condition(
+            lambda: client.get_number_of_workers() == target,
+            DaemonTimeoutException(f'The number of workers failed to reach {target}.'),
+            timeout=15,
+        )
+
+    # The acknowledgement carries no ``numprocesses``, as the daemon replies before having acted on the command
+    response = client.increase_workers(1)
+    assert response['status'] == 'ok'
+    assert 'numprocesses' not in response
+    await_workers(number_workers + 1)
+
+    response = client.decrease_workers(1)
+    assert response['status'] == 'ok'
+    assert 'numprocesses' not in response
+    await_workers(number_workers)
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_change_workers_with_wait(started_daemon_client):
+    """Test that with ``wait=True`` the workers have been spawned or stopped by the time the call returns."""
+    number_workers = started_daemon_client.get_numprocesses()['numprocesses']
+
+    response = started_daemon_client.increase_workers(1, timeout=10, wait=True)
+    assert response['numprocesses'] == number_workers + 1
+    assert started_daemon_client.get_number_of_workers() == number_workers + 1
+
+    response = started_daemon_client.decrease_workers(1, timeout=10, wait=True)
+    assert response['numprocesses'] == number_workers
+    assert started_daemon_client.get_number_of_workers() == number_workers
+
+
+@pytest.mark.parametrize('method', ('increase_workers', 'decrease_workers'))
+def test_change_workers_with_wait_timeout(stopped_daemon_client, method):
+    """Test that with ``wait=True`` a call that outlasts the timeout raises, since the response is only sent once the
+    daemon acted on the command."""
+    from circus.exc import CallError
+
+    with (
+        patch.object(DaemonClient, 'get_daemon_pid', return_value=1),
+        patch.object(DaemonClient, '_is_pid_file_stale', False),
+        patch.object(DaemonClient, 'get_client') as get_client,
+    ):
+        get_client.return_value.__enter__.return_value.call.side_effect = CallError('Timed out.')
+
+        with pytest.raises(DaemonTimeoutException, match='Connection to the daemon timed out.'):
+            getattr(stopped_daemon_client, method)(1, timeout=1, wait=True)

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -448,5 +448,5 @@ def test_change_workers_with_wait_timeout(stopped_daemon_client, method):
     ):
         get_client.return_value.__enter__.return_value.call.side_effect = CallError('Timed out.')
 
-        with pytest.raises(DaemonTimeoutException, match='Connection to the daemon timed out.'):
+        with pytest.raises(DaemonTimeoutException, match=r'Connection to the daemon timed out\.'):
             getattr(stopped_daemon_client, method)(1, timeout=1, wait=True)


### PR DESCRIPTION
The `increase_workers` and `decrease_workers` methods sent the circus
`incr`/`decr` command without the `waiting` property. Without it, the
daemon replies as soon as it acknowledged the command, which is before
the workers have actually been spawned or stopped, and the response does
not even contain the resulting `numprocesses`.

Add a `wait` keyword to both methods that is forwarded as the `waiting`
property. When set, the call returns only once the daemon acted on the
command and the response contains the resulting number of workers. It
defaults to `False` to keep the current behavior for existing callers.

Closes #7500
