### PR TITLE
🧪 Require Docker check for releases

### DIFF
--- a/.github/actions/docker-build-test/action.yml
+++ b/.github/actions/docker-build-test/action.yml
@@ -1,0 +1,61 @@
+name: Build and test Docker images
+description: Build AiiDA Docker images locally and run tests without publishing them.
+
+inputs:
+  platform:
+    description: Docker platform to build and test
+    default: amd64
+    required: false
+  python-version:
+    description: Python version used to run Docker image tests
+    default: '3.11'
+    required: false
+
+runs:
+  using: composite
+  steps:
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v3
+
+  - name: Build images
+    uses: docker/bake-action@v6.10.0
+    env:
+      BUILDKIT_PROGRESS: plain
+    with:
+      # Load to Docker engine for testing
+      load: true
+      workdir: .docker/
+      source: .
+      set: |
+        *.platform=${{ inputs.platform }}
+        *.cache-to=type=gha,scope=${{ github.workflow }},mode=min
+        *.cache-from=type=gha,scope=${{ github.workflow }}
+      files: |
+        docker-bake.hcl
+        build.json
+
+  - name: Set Up Python
+    uses: actions/setup-python@v6
+    with:
+      python-version: ${{ inputs.python-version }}
+      cache: pip
+
+  - name: Install dependencies
+    run: pip install -r requirements.txt
+    shell: bash
+    working-directory: .docker
+
+  - name: Test aiida-core-base
+    run: pytest -s --variant aiida-core-base tests/
+    shell: bash
+    working-directory: .docker
+
+  - name: Test aiida-core-with-services
+    run: pytest -s --variant aiida-core-with-services tests/
+    shell: bash
+    working-directory: .docker
+
+  - name: Test aiida-core-dev
+    run: pytest -s --variant aiida-core-dev tests/
+    shell: bash
+    working-directory: .docker

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,5 +1,5 @@
-# This workflow is only meant to be run on PRs from forked repositoritories.
-# The full workflow that is run on pushes to origin is in docker.yml
+# This workflow is only meant to be run on PRs from forked repositories.
+# The full workflow that is run on pushes to origin is in docker.yml.
 # The difference here is that we do not upload to ghcr.io,
 # and thus don't need a GITHUB_TOKEN secret.
 name: Build & Test Docker Images
@@ -28,47 +28,11 @@ jobs:
     name: build and test amd64 images
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    defaults:
-      run:
-        working-directory: .docker
 
     steps:
 
     - name: Checkout Repo
       uses: actions/checkout@v6
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build images
-      uses: docker/bake-action@v6.10.0
-      with:
-        # Load to Docker engine for testing
-        load: true
-        workdir: .docker/
-        source: .
-        set: |
-          *.platform=amd64
-          *.cache-to=type=gha,scope=${{ github.workflow }},mode=min
-          *.cache-from=type=gha,scope=${{ github.workflow }}
-        files: |
-          docker-bake.hcl
-          build.json
-
-    - name: Set Up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.11'
-        cache: pip
-
-    - name: Install dependencies
-      run: pip install -r requirements.txt
-
-    - name: Test aiida-core-base
-      run: pytest -s --variant aiida-core-base tests/
-
-    - name: Test aiida-core-with-services
-      run: pytest -s --variant aiida-core-with-services tests/
-
-    - name: Test aiida-core-dev
-      run: pytest -s --variant aiida-core-dev tests/
+    - name: Build and test Docker images
+      uses: ./.github/actions/docker-build-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: release
 # Automate publishing to PyPI and TestPyPI. When pushing a release tag vX.Y.Z,
 # the workflow will publish to PyPI. When the 'test-release' label is active on
 # a PR, the workflow will publish to TestPyPI on each update. In both cases it
-# is checked if pre-commit and the tests pass. When a release tag is pushed it
-# will in addition check if the tag and aiida-core version and tag match.
+# is checked if pre-commit, the tests, and a no-publish Docker build/test pass.
+# When a release tag is pushed it will in addition check if the tag and
+# aiida-core version match.
 
 on:
   # pull request event we use for test releases
@@ -76,12 +77,27 @@ jobs:
     - name: Run sub-set of test suite
       run: pytest -s -m requires_broker --broker-backend zmq --db-backend=sqlite tests/
 
+  docker:
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && contains(fromJson(toJson(github.event.pull_request.labels)).*.name, 'test-release'))
+
+    name: Build and test Docker images
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v6
+
+    - name: Build and test Docker images
+      uses: ./.github/actions/docker-build-test
+
   publish-pypi:
     if: startsWith(github.ref, 'refs/tags/')
 
     name: Publish to PyPI
 
-    needs: [check-release-tag, pre-commit, tests]
+    needs: [check-release-tag, pre-commit, tests, docker]
 
     runs-on: ubuntu-24.04
 
@@ -109,7 +125,7 @@ jobs:
 
     name: Publish to test PyPI
 
-    needs: [pre-commit, tests]
+    needs: [pre-commit, tests, docker]
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
Extract the no-publish Docker build/test steps into a composite action. Use it from both the fork PR Docker workflow and the release workflow so real and test releases must pass Docker image checks before publishing.