### PR TITLE
👌 Defer ORM Pydantic model rebuilding

### DIFF
--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -415,7 +415,6 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
         )
         model.__qualname__ = f'{cast(Any, cls).__name__}.Model'
         model.model_config = deepcopy(cls.ReadModel.model_config)
-        model.model_rebuild(force=True)
 
         cls._COMPAT_MODEL = model
 
@@ -601,8 +600,6 @@ class Entity(abc.ABC, Generic[BackendEntityType, CollectionType]):
             WriteModel.__pydantic_decorators__.field_serializers = serializers
             WriteModel.__pydantic_decorators__.field_validators = validators
             WriteModel.model_config = deepcopy(model_cls.model_config)
-
-            WriteModel.model_rebuild(force=True)
 
             return WriteModel
 

--- a/src/aiida/orm/nodes/data/code/abstract.py
+++ b/src/aiida/orm/nodes/data/code/abstract.py
@@ -227,7 +227,6 @@ class AbstractCode(Data, metaclass=abc.ABCMeta):
         )
         CliModel.__qualname__ = f'{cls.__name__}.CliModel'
         CliModel.model_config['arbitrary_types_allowed'] = True
-        CliModel.model_rebuild(force=True)
         cls._CliModel = CliModel
 
     @abc.abstractmethod

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -455,7 +455,6 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
         )
         model.__qualname__ = f'{cast(Any, cls).__name__}.Model'
         model.model_config = deepcopy(cls.ReadModel.model_config)
-        model.model_rebuild(force=True)
 
         cls._COMPAT_MODEL = model
 
@@ -1177,7 +1176,6 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             )
             AttributesModel.__qualname__ = f'{cls.__name__}.AttributesModel'
             cls.AttributesModel = AttributesModel  # type: ignore[misc]
-        cls.AttributesModel.model_rebuild(force=True)
 
     @classmethod
     def _get_patched_node_type_field(cls):
@@ -1236,7 +1234,6 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             ),
         )
         ReadModel.__qualname__ = f'{cls.__name__}.ReadModel'
-        ReadModel.model_rebuild(force=True)
 
         cls.ReadModel = ReadModel  # type: ignore[misc]
 
@@ -1265,7 +1262,6 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
             ),
         )
         ConstructorModel.__qualname__ = f'{cls.__name__}.ConstructorModel'
-        ConstructorModel.model_rebuild(force=True)
 
         cls._ConstructorModel = ConstructorModel
 

--- a/src/aiida/orm/pydantic.py
+++ b/src/aiida/orm/pydantic.py
@@ -86,8 +86,6 @@ class OrmModel(AiiDABaseModel):
                     field.default_factory = None
             MinimalModel.model_fields[key] = field
 
-        MinimalModel.model_rebuild(force=True)
-
         # Make subsequent calls idempotent for this specific class and the derived model
         cls._AIIDA_MINIMAL_MODEL = MinimalModel  # type: ignore[attr-defined]
         MinimalModel._AIIDA_MINIMAL_MODEL = MinimalModel  # type: ignore[attr-defined]

--- a/tests/orm/models/test_models.py
+++ b/tests/orm/models/test_models.py
@@ -13,6 +13,7 @@ from typing_extensions import NotRequired
 from aiida import orm
 from aiida.common.datastructures import StashMode
 from aiida.common.exceptions import UnsupportedSchemaError
+from aiida.orm.pydantic import OrmModel
 
 orm_to_test = (
     orm.AuthInfo,
@@ -517,6 +518,31 @@ def test_minimal_model_idempotency():
     assert RepeatedDynamicModel is DynamicModel
 
 
+def test_generated_orm_model_setup_defers_pydantic_rebuild(monkeypatch):
+    """Test generated ORM models are not rebuilt eagerly during class setup."""
+    rebuilt: list[type[OrmModel]] = []
+
+    def model_rebuild(cls, *args, **kwargs):
+        rebuilt.append(cls)
+        return True
+
+    with monkeypatch.context() as context:
+        context.setattr(OrmModel, 'model_rebuild', classmethod(model_rebuild))
+
+        class LazyModelData(orm.Data):
+            class AttributesModel(orm.Data.AttributesModel):
+                value: int
+
+            class ConstructorArgsModel(OrmModel):
+                value: int
+
+        assert rebuilt == []
+
+    model = LazyModelData.WriteModel(node_type=LazyModelData.class_node_type, attributes={'value': '1'})
+    assert model.attributes.value == 1
+    assert LazyModelData.ReadModel.model_json_schema()['title'] == 'LazyModelDataReadModel'
+
+
 @pytest.mark.parametrize(
     'required_arguments',
     orm_to_test,
@@ -527,10 +553,10 @@ def test_model_overrides(required_arguments: RequiredEntityArguments):
     name = cls.__name__
 
     assert cls.ReadModel.__qualname__ == f'{name}.ReadModel'
-    assert cls.ReadModel.model_config.get('title') == f'{name}ReadModel'
+    assert cls.ReadModel.model_json_schema()['title'] == f'{name}ReadModel'
 
     assert cls.WriteModel.__qualname__ == f'{name}.WriteModel'
-    assert cls.WriteModel.model_config.get('title') == f'{name}WriteModel'
+    assert cls.WriteModel.model_json_schema()['title'] == f'{name}WriteModel'
 
 
 def _clean_and_sort(dictionary: dict) -> dict:
@@ -616,11 +642,11 @@ def test_node_attributes_model_overrides(required_arguments: RequiredNodeArgumen
     AttributesModel = cls.ReadModel.model_fields['attributes'].annotation  # noqa: N806
     assert AttributesModel is cls.AttributesModel
     assert AttributesModel.__qualname__ == f'{name}.AttributesModel'
-    assert AttributesModel.model_config.get('title') == f'{name}AttributesModel'
+    assert AttributesModel.model_json_schema()['title'] == f'{name}AttributesModel'
 
     AttributesWriteModel = cls.WriteModel.model_fields['attributes'].annotation  # noqa: N806
     assert AttributesWriteModel.__qualname__ == f'{name}.AttributesWriteModel'
-    assert AttributesWriteModel.model_config.get('title') == f'{name}AttributesWriteModel'
+    assert AttributesWriteModel.model_json_schema()['title'] == f'{name}AttributesWriteModel'
 
 
 def _validate_value(value):

--- a/tests/orm/models/test_models.py
+++ b/tests/orm/models/test_models.py
@@ -529,7 +529,7 @@ def test_generated_orm_model_setup_defers_pydantic_rebuild(monkeypatch):
     with monkeypatch.context() as context:
         context.setattr(OrmModel, 'model_rebuild', classmethod(model_rebuild))
 
-        class TestModelData(orm.Data):
+        class TestData(orm.Data):
             class AttributesModel(orm.Data.AttributesModel):
                 value: int
 
@@ -538,9 +538,9 @@ def test_generated_orm_model_setup_defers_pydantic_rebuild(monkeypatch):
 
         assert rebuilt == []
 
-    model = TestModelData.WriteModel(node_type=TestModelData.class_node_type, attributes={'value': '1'})
+    model = TestData.WriteModel(node_type=TestData.class_node_type, attributes={'value': '1'})
     assert model.attributes.value == 1
-    assert TestModelData.ReadModel.model_json_schema()['title'] == 'TestModelDataReadModel'
+    assert TestData.ReadModel.model_json_schema()['title'] == 'TestDataReadModel'
 
 
 @pytest.mark.parametrize(

--- a/tests/orm/models/test_models.py
+++ b/tests/orm/models/test_models.py
@@ -529,7 +529,7 @@ def test_generated_orm_model_setup_defers_pydantic_rebuild(monkeypatch):
     with monkeypatch.context() as context:
         context.setattr(OrmModel, 'model_rebuild', classmethod(model_rebuild))
 
-        class LazyModelData(orm.Data):
+        class TestModelData(orm.Data):
             class AttributesModel(orm.Data.AttributesModel):
                 value: int
 
@@ -538,9 +538,9 @@ def test_generated_orm_model_setup_defers_pydantic_rebuild(monkeypatch):
 
         assert rebuilt == []
 
-    model = LazyModelData.WriteModel(node_type=LazyModelData.class_node_type, attributes={'value': '1'})
+    model = TestModelData.WriteModel(node_type=TestModelData.class_node_type, attributes={'value': '1'})
     assert model.attributes.value == 1
-    assert LazyModelData.ReadModel.model_json_schema()['title'] == 'LazyModelDataReadModel'
+    assert TestModelData.ReadModel.model_json_schema()['title'] == 'TestModelDataReadModel'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Avoid rebuilding generated ORM Pydantic models during class setup. Leave validator and schema construction to Pydantic's deferred build machinery until models are validated, serialized, or used for schema generation.

Add focused regression coverage to ensure generated node model setup does not force model rebuilds while explicit model use still works.