### PR TITLE
🐛 Distinguish missing vs unparsed detailed job info

### DIFF
--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -853,7 +853,12 @@ class CalcJob(Process):
         detailed_job_info = self.node.get_detailed_job_info()
 
         if detailed_job_info is None:
-            self.logger.warning('could not parse scheduler output: the `detailed_job_info` attribute is missing')
+            if scheduler.can_get_detailed_job_info():
+                self.logger.warning('could not parse scheduler output: raised exception during parsing')
+            else:
+                self.logger.info(
+                    f'could not parse scheduler output: scheduler `{scheduler}` does not parse detailed job info'
+                )
         elif detailed_job_info.get('retval', 0) != 0:
             self.logger.warning('could not parse scheduler output: return value of `detailed_job_info` is non-zero')
             detailed_job_info = None

--- a/src/aiida/schedulers/scheduler.py
+++ b/src/aiida/schedulers/scheduler.py
@@ -352,6 +352,13 @@ class Scheduler(metaclass=abc.ABCMeta):
         """
         raise exceptions.FeatureNotAvailable('Cannot get detailed job info')
 
+    def can_get_detailed_job_info(self) -> bool:
+        try:
+            self._get_detailed_job_info_command('')
+        except exceptions.FeatureNotAvailable:
+            return False
+        return True
+
     def get_detailed_job_info(self, job_id: str) -> dict[str, str | int]:
         """Return the detailed job info.
 

--- a/src/aiida/schedulers/scheduler.py
+++ b/src/aiida/schedulers/scheduler.py
@@ -354,7 +354,7 @@ class Scheduler(metaclass=abc.ABCMeta):
 
     def can_get_detailed_job_info(self) -> bool:
         try:
-            self._get_detailed_job_info_command('')
+            self._get_detailed_job_info_command('1')
         except exceptions.FeatureNotAvailable:
             return False
         return True

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -825,15 +825,17 @@ class TestCalcJob:
 
 
 @pytest.fixture
-def generate_process(aiida_code_installed):
+def generate_process(aiida_code_installed, aiida_localhost):
     """Instantiate a process with default inputs and return the `Process` instance."""
     from aiida.engine.utils import instantiate_process
     from aiida.manage import get_manager
 
-    def _generate_process(inputs=None):
+    def _generate_process(inputs=None, computer=None):
         base_inputs = {
             'code': aiida_code_installed(
-                default_calc_job_plugin='core.arithmetic.add', filepath_executable='/bin/bash'
+                default_calc_job_plugin='core.arithmetic.add',
+                filepath_executable='/bin/bash',
+                computer=computer or aiida_localhost,
             ),
             'x': orm.Int(1),
             'y': orm.Int(2),
@@ -857,12 +859,29 @@ def generate_process(aiida_code_installed):
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('override_logging')
-def test_parse_insufficient_data(generate_process):
+@pytest.mark.parametrize(
+    'scheduler_type, expected_log',
+    (
+        # The `core.direct` scheduler does not implement detailed job info parsing, so the missing
+        # `detailed_job_info` attribute is expected and is logged at `info` level instead of `warning`.
+        (
+            'core.direct',
+            'could not parse scheduler output: scheduler `DirectScheduler` does not parse detailed job info',
+        ),
+        # The `core.slurm` scheduler does implement it, so a missing attribute means the retrieval or parsing of the
+        # detailed job info failed, which is logged at `warning` level.
+        ('core.slurm', 'could not parse scheduler output: raised exception during parsing'),
+    ),
+)
+def test_parse_insufficient_data(generate_process, aiida_computer, scheduler_type, expected_log):
     """Test the scheduler output parsing logic in `CalcJob.parse`.
 
     Here we check explicitly that the parsing does not except even if the required information is not available.
     """
-    process = generate_process()
+    computer = aiida_computer(label=f'computer-{scheduler_type}', scheduler_type=scheduler_type)
+    computer.configure()
+
+    process = generate_process(computer=computer)
 
     retrieved = orm.FolderData().store()
     retrieved.base.links.add_incoming(process.node, link_label='retrieved', link_type=LinkType.CREATE)
@@ -877,7 +896,7 @@ def test_parse_insufficient_data(generate_process):
     # process but should log a warning, so here we check that those expected warnings are attached to the node
     logs = [log.message for log in orm.Log.collection.get_logs_for(process.node)]
     expected_logs = [
-        'could not parse scheduler output: the `detailed_job_info` attribute is missing',
+        expected_log,
         f'could not parse scheduler output: the `{filename_stderr}` file is missing',
         f'could not parse scheduler output: the `{filename_stdout}` file is missing',
     ]


### PR DESCRIPTION
In the parsing step we check if the `get_detailed_job_info` and set it to None if it excepts because it is not implemented. I added now that it also captures any exception when retrieving the detailed job info (most likely some transport error). Then when parsing in the CalcJob we use the new endpoint `can_get_detailed_job_info` to determine if the detailed job info could not be retrieved due the scheduler not implementing the feature or for some real exception.

Ideally I would have liked to decouple the scheduler logic more from calcjob by introducing an enum or an attribute that explicitly specifies that the get detailed job info is not implemented but then we would need to update the database schema to support this schema.