### PR TITLE
🐛 `aiida_localhost`: revert label to `localhost`

### DIFF
--- a/src/aiida/tools/pytest_fixtures/orm.py
+++ b/src/aiida/tools/pytest_fixtures/orm.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 import typing as t
 
@@ -291,12 +290,6 @@ def aiida_computer_ssh_async(aiida_computer) -> t.Callable[[], Computer]:
 def aiida_localhost(aiida_computer_local) -> Computer:
     """Return a :class:`aiida.orm.computers.Computer` instance representing localhost with ``core.local`` transport.
 
-    The computer's label is suffixed with the pytest-xdist worker id (e.g. ``localhost-gw0``,
-    or just ``localhost-master`` when not running under xdist). This keeps the fixture's row
-    distinct from any literal-``'localhost'`` Computer that ``verdi presto`` or other code
-    paths may create in the same profile, avoiding UNIQUE-constraint collisions on
-    ``Computer.label``.
-
     Usage::
 
         def test(aiida_localhost):
@@ -304,8 +297,7 @@ def aiida_localhost(aiida_computer_local) -> Computer:
 
     :return: The computer.
     """
-    worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
-    return aiida_computer_local(label=f'localhost-{worker_id}')
+    return aiida_computer_local(label='localhost')
 
 
 @pytest.fixture

--- a/tests/cmdline/commands/test_code.py
+++ b/tests/cmdline/commands/test_code.py
@@ -206,7 +206,7 @@ def test_code_delete_one_force(run_cli_command, code):
         load_code('code')
 
 
-def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, computer_label, hostname) -> str:
+def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, hostname) -> str:
     """Normalize dynamic values in CLI output for stable regression testing.
 
     Args:
@@ -214,9 +214,6 @@ def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, compute
         code_pk: The actual PK to be replaced with placeholder
         code_uuid: The actual UUID to be replaced with placeholder
         computer_pk: Optional computer PK to be replaced with placeholder
-        computer_label: Optional suffixed ``aiida_localhost`` label whose worker-id suffix should be
-            stripped (e.g. ``localhost-gw1`` -> ``localhost``), so the golden file can carry the
-            user-facing label without an xdist artefact
         hostname: Optional hostname to be replaced with placeholder
 
     Returns:
@@ -235,13 +232,6 @@ def _normalize_code_show_output(output, code_pk, code_uuid, computer_pk, compute
 
     # Replace UUID first (before PK, as PK digits might appear in UUID)
     normalized = normalized.replace(code_uuid, '<UUID>')
-
-    # Strip the worker-id suffix from the ``aiida_localhost`` label so the golden file shows the
-    # user-facing ``localhost`` rather than ``localhost-gw1``. Done before hostname substitution
-    # because the suffixed label contains the hostname as a substring (matching ``localhost``
-    # first would leave a dangling ``-gw1``).
-    if computer_label and computer_label.startswith(f'{hostname}-'):
-        normalized = normalized.replace(computer_label, hostname)
 
     # Replace hostname if provided
     if hostname:
@@ -314,7 +304,6 @@ def test_code_show(run_cli_command, aiida_localhost, tmp_path, bash_path, aiida_
         code_pk=code.pk,
         code_uuid=code.uuid,
         computer_pk=computer.pk if computer else None,
-        computer_label=computer.label if computer else None,
         hostname=computer.hostname if computer else None,
     )
 
@@ -435,7 +424,7 @@ def test_code_duplicate_ignore(run_cli_command, aiida_code_installed, non_intera
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('sort_option', ('--sort', '--no-sort'))
-def test_code_export(run_cli_command, aiida_code_installed, aiida_localhost, tmp_path, file_regression, sort_option):
+def test_code_export(run_cli_command, aiida_code_installed, tmp_path, file_regression, sort_option):
     """Test export the code setup to str."""
     prepend_text = 'module load something\n    some command'
     code = aiida_code_installed(
@@ -449,10 +438,8 @@ def test_code_export(run_cli_command, aiida_code_installed, aiida_localhost, tmp
     options = [str(code.pk), str(filepath), sort_option]
     result = run_cli_command(cmd_code.export, options)
     assert str(filepath) in result.output, 'Filename should be in terminal output but was not found.'
-    # file regression check; strip the worker-id suffix from the computer label so the golden
-    # file carries the user-facing ``localhost`` rather than ``localhost-gw1`` (see
-    # ``aiida_localhost`` fixture).
-    content = filepath.read_text().replace(aiida_localhost.label, aiida_localhost.hostname)
+    # file regression check
+    content = filepath.read_text()
     file_regression.check(content, extension='.yml')
 
     # round trip test by create code from the config file
@@ -508,7 +495,7 @@ def test_code_export_overwrite(run_cli_command, aiida_code_installed, tmp_path):
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.usefixtures('chdir_tmp_path')
-def test_code_export_default_filename(run_cli_command, aiida_code_installed, aiida_localhost):
+def test_code_export_default_filename(run_cli_command, aiida_code_installed):
     """Test default filename being created if no argument passed."""
 
     prepend_text = 'module load something\n    some command'
@@ -522,7 +509,7 @@ def test_code_export_default_filename(run_cli_command, aiida_code_installed, aii
     options = [str(code.pk)]
     run_cli_command(cmd_code.export, options)
 
-    assert pathlib.Path(f'code@{aiida_localhost.label}.yaml').is_file()
+    assert pathlib.Path('code@localhost.yaml').is_file()
 
 
 @pytest.mark.parametrize('non_interactive_editor', ('vim -cwq',), indirect=True)

--- a/tests/tools/pytest_fixtures/test_orm.py
+++ b/tests/tools/pytest_fixtures/test_orm.py
@@ -18,6 +18,9 @@ pytest_plugins = ['aiida.tools.pytest_fixtures']
 def test_aiida_localhost(aiida_localhost):
     """Test the ``aiida_localhost`` fixture."""
     assert aiida_localhost.label == 'localhost'
+    assert aiida_localhost.hostname == 'localhost'
+    assert aiida_localhost.transport_type == 'core.local'
+    assert aiida_localhost.scheduler_type == 'core.direct'
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/pytest_fixtures/test_orm.py
+++ b/tests/tools/pytest_fixtures/test_orm.py
@@ -16,45 +16,8 @@ pytest_plugins = ['aiida.tools.pytest_fixtures']
 
 
 def test_aiida_localhost(aiida_localhost):
-    """Test the ``aiida_localhost`` fixture.
-
-    The label is suffixed with the pytest-xdist worker id to avoid collisions with literal
-    ``'localhost'`` Computers created by other tests or commands (e.g. ``verdi presto``).
-    """
-    # Assert at the contract level (the suffix exists) rather than coupling to the specific
-    # worker-id value, which depends on ``PYTEST_XDIST_WORKER`` at runtime.
-    assert aiida_localhost.label.startswith('localhost-')
-    assert aiida_localhost.hostname == 'localhost'
-    assert aiida_localhost.transport_type == 'core.local'
-    assert aiida_localhost.scheduler_type == 'core.direct'
-
-
-@pytest.mark.usefixtures('aiida_profile_clean')
-def test_aiida_localhost_no_literal_collision(request):
-    """The fixture's Computer must coexist with a pre-existing literal ``'localhost'`` Computer.
-
-    ``verdi presto`` and other code paths create a Computer with the literal ``'localhost'``
-    label in the same profile. This is the actual #7347 failure
-    order: the literal row is inserted first, then ``aiida_localhost`` is requested. Worker-
-    suffixing the fixture's label makes its row distinct from any literal-label row already in
-    the database, so no UNIQUE-constraint collision can fire.
-    """
-    Computer(
-        label='localhost',
-        hostname='localhost',
-        transport_type='core.ssh',
-        scheduler_type='core.direct',
-        workdir='/tmp',
-    ).store()
-
-    # Defer the fixture's creation until *after* the literal-``'localhost'`` row exists, mirroring
-    # the actual #7347 failure order. If we depended on ``aiida_localhost`` via the test signature,
-    # pytest would evaluate it before the test body runs and the literal row would not yet be
-    # present — we'd be testing the wrong direction of the race.
-    aiida_localhost = request.getfixturevalue('aiida_localhost')
-
-    assert aiida_localhost.label != 'localhost'
-    assert aiida_localhost.transport_type == 'core.local'
+    """Test the ``aiida_localhost`` fixture."""
+    assert aiida_localhost.label == 'localhost'
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -205,7 +205,7 @@ class TestVisGraph:
 
         expected = {
             'State: running" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]',
-            '@localhost" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]',
+            f'@{self.computer.label}" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]',
             'Exit Code: 200" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]',
             f'N{nodes.fd1.pk} [label="FolderData ({nodes.fd1.pk})" color=lightgray fillcolor=white penwidth=2 '
             'shape=ellipse style=filled]',
@@ -262,7 +262,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=rectangle style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @localhost" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
+                    @{computer_label}" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -276,7 +276,7 @@ class TestVisGraph:
                 N{rd1} -> N{calcf1} [color="#000000" style=solid]
                 N{calcf1} -> N{fd1} [color="#000000" style=solid]
                 N{calcf1} -> N{pd3} [color="#000000" style=solid]
-        }}""".format(**{k: v.pk for k, v in nodes.items()})
+        }}""".format(computer_label=self.computer.label, **{k: v.pk for k, v in nodes.items()})
 
         # dedent before comparison
         assert sorted([line.strip() for line in graph.graphviz.source.splitlines()]) == sorted(
@@ -301,7 +301,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=polygon sides=6 style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @localhost" pencolor=black shape=rectangle]
+                    @{computer_label}" pencolor=black shape=rectangle]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" pencolor=black shape=rectangle]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -315,7 +315,7 @@ class TestVisGraph:
                 N{rd1} -> N{calcf1} [color="#000000" style=solid]
                 N{calcf1} -> N{fd1} [color="#000000" style=solid]
                 N{calcf1} -> N{pd3} [color="#000000" style=solid]
-        }}""".format(**{k: v.pk for k, v in nodes.items()})
+        }}""".format(computer_label=self.computer.label, **{k: v.pk for k, v in nodes.items()})
 
         # dedent before comparison
         assert sorted([line.strip() for line in graph.graphviz.source.splitlines()]) == sorted(

--- a/tests/tools/visualization/test_graph.py
+++ b/tests/tools/visualization/test_graph.py
@@ -205,7 +205,7 @@ class TestVisGraph:
 
         expected = {
             'State: running" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]',
-            f'@{self.computer.label}" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]',
+            '@localhost" color=lightgray fillcolor=white penwidth=2 shape=ellipse style=filled]',
             'Exit Code: 200" color=lightgray fillcolor=white penwidth=2 shape=rectangle style=filled]',
             f'N{nodes.fd1.pk} [label="FolderData ({nodes.fd1.pk})" color=lightgray fillcolor=white penwidth=2 '
             'shape=ellipse style=filled]',
@@ -262,7 +262,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=rectangle style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @{computer_label}" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
+                    @localhost" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" fillcolor="#8cd499ff" penwidth=0 shape=ellipse style=filled]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -276,7 +276,7 @@ class TestVisGraph:
                 N{rd1} -> N{calcf1} [color="#000000" style=solid]
                 N{calcf1} -> N{fd1} [color="#000000" style=solid]
                 N{calcf1} -> N{pd3} [color="#000000" style=solid]
-        }}""".format(computer_label=self.computer.label, **{k: v.pk for k, v in nodes.items()})
+        }}""".format(**{k: v.pk for k, v in nodes.items()})
 
         # dedent before comparison
         assert sorted([line.strip() for line in graph.graphviz.source.splitlines()]) == sorted(
@@ -301,7 +301,7 @@ class TestVisGraph:
                     State: running" fillcolor="#e38851ff" penwidth=0 shape=polygon sides=6 style=filled]
                 N{pd0} -> N{wc1} [color="#000000" style=dashed]
                 N{rd1} [label="RemoteData ({rd1})
-                    @{computer_label}" pencolor=black shape=rectangle]
+                    @localhost" pencolor=black shape=rectangle]
                 N{calc1} -> N{rd1} [color="#000000" style=solid]
                 N{fd1} [label="FolderData ({fd1})" pencolor=black shape=rectangle]
                 N{wc1} -> N{fd1} [color="#000000" style=dashed]
@@ -315,7 +315,7 @@ class TestVisGraph:
                 N{rd1} -> N{calcf1} [color="#000000" style=solid]
                 N{calcf1} -> N{fd1} [color="#000000" style=solid]
                 N{calcf1} -> N{pd3} [color="#000000" style=solid]
-        }}""".format(computer_label=self.computer.label, **{k: v.pk for k, v in nodes.items()})
+        }}""".format(**{k: v.pk for k, v in nodes.items()})
 
         # dedent before comparison
         assert sorted([line.strip() for line in graph.graphviz.source.splitlines()]) == sorted(


### PR DESCRIPTION
Reverts the `aiida_localhost` label change from [#7363](https://github.com/aiidateam/aiida-core/pull/7363) (the pytest-xdist worker-id suffix, `localhost-master` / `localhost-gw0`, ...) back to `label='localhost'`, which the suffix broke for downstream test suites that hardcode it ([#7499](https://github.com/aiidateam/aiida-core/issues/7499), e.g. aiidalab-widgets-base). `aiida_localhost` is the one fixture that pins the computer's `label` to `localhost`; the others (`aiida_computer_local`, `aiida_computer_ssh`) only set `hostname` to `localhost` and leave `label` a random UUID.

The suffix was redundant: the get-or-create's `IntegrityError` retry recovers from a `UNIQUE(label)` collision regardless of the label. The two tests that created a `localhost` computer directly, `TestNode.setup_method` and `test_remote`'s factory, built the same four-field computer the fixture does and were routed through it in #7363, so nothing else uses the label. Neither the suffix nor that audit was the flakiness fix (the retry is); reverting is neutral. Keeps the audit and the retry, and reverts the test-side accommodations the suffix needed (`test_code.py` normalization, `test_graph.py`, `test_orm.py` assertions and the no-literal-collision regression test).

The root cause of the flake (why a committed row is intermittently not seen by the following `get`) is still unknown and tracked separately; the obvious SQLAlchemy session-snapshot explanation was tested and does not reproduce. It's orthogonal to the label.