### PR TITLE
Update to flit 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install flit
-      run: pip install flit~=4.0
+      run: pip install "flit>=4.0.2,<5"
     - name: Build
       run: flit build
     - name: Publish to PyPI
@@ -125,7 +125,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install flit
-      run: pip install flit~=4.0
+      run: pip install "flit>=4.0.2,<5"
     - name: Build
       run: flit build
     - name: Publish to TestPyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install flit
-      run: pip install flit~=3.8 flit-core~=3.8
+      run: pip install flit~=4.0
     - name: Build
       run: flit build
     - name: Publish to PyPI
@@ -125,7 +125,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install flit
-      run: pip install flit~=3.8 flit-core~=3.8
+      run: pip install flit~=4.0
     - name: Build
       run: flit build
     - name: Publish to TestPyPI

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -344,7 +344,7 @@ You have just created an ``aiida_diff_tutorial`` Python *package*!
 
     [build-system]
     # build the package with [flit](https://flit.readthedocs.io)
-    requires = ["flit_core >=3.4,<4"]
+    requires = ["flit_core ~=4.0"]
     build-backend = "flit_core.buildapi"
 
     [project]

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -344,7 +344,7 @@ You have just created an ``aiida_diff_tutorial`` Python *package*!
 
     [build-system]
     # build the package with [flit](https://flit.readthedocs.io)
-    requires = ["flit_core ~=4.0"]
+    requires = ["flit_core >=4.0.2,<5"]
     build-backend = "flit_core.buildapi"
 
     [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'flit_core.buildapi'
-requires = ['flit_core >=3.8,<5']
+requires = ['flit_core ~=4.0']
 
 # The "dev" dependency group is automatically synced by uv
 # and should thus contain all necessary deps for local development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'flit_core.buildapi'
-requires = ['flit_core ~=4.0']
+requires = ["flit_core >=4.0.2,<5"]
 
 # The "dev" dependency group is automatically synced by uv
 # and should thus contain all necessary deps for local development.


### PR DESCRIPTION
The main advantage support for [PEP-794](https://peps.python.org/pep-0794/) (quoting from [flit 4 CHANGELOG](https://flit.pypa.io/en/stable/history.html#version-4-0)

> The new Import-Name and Import-Namespace metadata fields (metadata 2.5) are now supported ([PR #774](https://github.com/pypa/flit/pull/774/)). In most cases no new input is required, as Flit will create this metadata automatically.

### Test plan

I checked the output of `uvx flit@4.0.2 build` and `uvx flit@3.12 build`, specifically checking the `RECORD` and `METADATA` wheel files

```console
❯ diff -w RECORD ../../dist-flit4/aiida_core-2.9.0.dev0.dist-info/RECORD 
646a647
> aiida_core-2.9.0.dev0.dist-info/licenses/AUTHORS.txt,sha256=a0eikdCV3Hw-90ILnCoPMKjoMOao0AX3cGSW5xClkdQ,1746
648,649c649,650
< aiida_core-2.9.0.dev0.dist-info/WHEEL,sha256=G2gURzTEtmeR8nrdXUJfNiB3VYVxigPQ-bEQujpNiNs,82
< aiida_core-2.9.0.dev0.dist-info/METADATA,sha256=11GDgjC9bRuUarX4SXzPRGVM5e5slL_awUbAbKUl5ug,12192
---
> aiida_core-2.9.0.dev0.dist-info/WHEEL,sha256=_yMHPaBV-s6fQMwUoo83NSdTCM3c8xXWFXRhqafN-7Y,81
> aiida_core-2.9.0.dev0.dist-info/METADATA,sha256=Sl0Q1GkgkEsYBMXzANcQXMpV27L_LjvP9SkPvM0NaWs,12237
aiida-core/dist/aiida_core-2.9.0.dev0.dist-info on  flit4 [!?] 


❯ diff -w METADATA ../../dist-flit4/aiida_core-2.9.0.dev0.dist-info/METADATA 
1c1
< Metadata-Version: 2.4
---
> Metadata-Version: 2.5
20a21
> License-File: AUTHORS.txt
128a130
> Import-Name: aiida
```