### PR TITLE
🔧 Exclude development-only files from the sdist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install flit
-      run: pip install flit~=3.4
+      run: pip install flit~=3.8 flit-core~=3.8
     - name: Build
       run: flit build
     - name: Publish to PyPI
@@ -125,7 +125,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install flit
-      run: pip install flit~=3.4
+      run: pip install flit~=3.8 flit-core~=3.8
     - name: Build
       run: flit build
     - name: Publish to TestPyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'flit_core.buildapi'
-requires = ['flit_core >=3.4,<4']
+requires = ['flit_core >=3.8,<5']
 
 # The "dev" dependency group is automatically synced by uv
 # and should thus contain all necessary deps for local development.
@@ -321,8 +321,26 @@ name = 'aiida'
 
 [tool.flit.sdist]
 exclude = [
+  '**/.mypy_cache/',
+  '.claude/',
+  '.devcontainer/',
+  '.docker/',
+  '.git-blame-ignore-revs',
+  '.github/',
+  '.gitignore',
+  '.molecule/',
+  '.pre-commit-config.yaml',
+  '.readthedocs.yml',
+  'AGENTS.md',
+  'AI_POLICY.md',
+  'CLAUDE.md',
+  'CODE_OF_CONDUCT.md',
+  'codecov.yml',
   'docs/',
-  'tests/'
+  'environment.yml',
+  'tests/',
+  'utils/',
+  'uv.lock'
 ]
 
 [tool.mypy]


### PR DESCRIPTION
The source distribution shipped a number of files that are not needed to build, install or use the package, such as CI workflows, dev container and docker setups, agent instructions, linter configuration and the uv lockfile. Extend `tool.flit.sdist.exclude` to drop them, including `**/.mypy_cache/` directories that may be present in a working tree.

Recursive glob patterns such as `**/.mypy_cache/` need a newer flit_core, so bump the build requirement to `>=3.8,<5` and install a matching flit version in the release workflow. Installing flit `~=3.8` installs `flit-core>=4.0` which causes issues when building sdist so it is also pinned it to `~=3.8`.