### PR TITLE
🐛 `verdi bug-report`: store log files by log type

### DIFF
--- a/src/aiida/cmdline/commands/cmd_bug_report.py
+++ b/src/aiida/cmdline/commands/cmd_bug_report.py
@@ -205,30 +205,33 @@ def _collect_diagnostics() -> dict[str, Any]:
     return diagnostics
 
 
-def _get_log_files() -> list[pathlib.Path]:
-    """Return the log files to include."""
+def _get_log_files() -> dict[str, pathlib.Path]:
+    """Return the log files to include, keyed by log type.
+
+    The log type is used as the name in the archive since the log files of a profile can share the same basename.
+    """
     from aiida.manage import get_manager
     from aiida.manage.configuration import get_config
 
     profile = get_manager().get_profile()
 
     if profile is None:
-        return []
+        return {}
 
     filepaths = get_config().filepaths(profile)
-    files = []
+    files = {}
 
-    log_filepaths = [
-        filepaths['profile']['log'],
-        filepaths['circus']['log'],
-        filepaths['daemon']['log'],
-        filepaths['broker_service']['log'],
-    ]
+    log_filepaths = {
+        'profile': filepaths['profile']['log'],
+        'circus': filepaths['circus']['log'],
+        'daemon': filepaths['daemon']['log'],
+        'broker_service': filepaths['broker_service']['log'],
+    }
 
-    for log_filepath in log_filepaths:
+    for log_type, log_filepath in log_filepaths.items():
         path = pathlib.Path(log_filepath)
         if path.exists():
-            files.append(path)
+            files[log_type] = path
 
     return files
 
@@ -292,10 +295,11 @@ def verdi_bug_report(output: str | None) -> None:
     try:
         with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
             zf.writestr('diagnostics.json', json.dumps(diagnostics, indent=2, sort_keys=True, default=str))
-            for filepath in log_files:
+            for log_type, filepath in log_files.items():
                 data = _read_log_tail(filepath)
-                zf.writestr(filepath.name, data)
-                contents.append((filepath.name, len(data)))
+                archive_name = f'{log_type}.log'
+                zf.writestr(archive_name, data)
+                contents.append((archive_name, len(data)))
     except OSError as exception:
         if output_path.exists():
             try:

--- a/tests/cmdline/commands/test_bug_report.py
+++ b/tests/cmdline/commands/test_bug_report.py
@@ -265,7 +265,7 @@ def test_collect_diagnostics_invalid_config(monkeypatch, tmp_path):
 
 
 def test_get_log_files(monkeypatch, tmp_path):
-    """Test ``_get_log_files`` returns the existing log files from the profile filepaths."""
+    """Test ``_get_log_files`` returns the existing log files from the profile filepaths, keyed by log type."""
     profile_log = tmp_path / 'profile.log'
     profile_log.write_text('profile', encoding='utf-8')
 
@@ -285,7 +285,12 @@ def test_get_log_files(monkeypatch, tmp_path):
     _patch_config(monkeypatch, tmp_path)
     monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
 
-    assert cmd_bug_report._get_log_files() == [profile_log, circus_log, daemon_log, broker_log]
+    assert cmd_bug_report._get_log_files() == {
+        'profile': profile_log,
+        'circus': circus_log,
+        'daemon': daemon_log,
+        'broker_service': broker_log,
+    }
 
 
 def test_get_log_files_skips_missing(monkeypatch, tmp_path):
@@ -299,7 +304,7 @@ def test_get_log_files_skips_missing(monkeypatch, tmp_path):
     _patch_config(monkeypatch, tmp_path)
     monkeypatch.setattr('aiida.manage.get_manager', lambda: manager)
 
-    assert cmd_bug_report._get_log_files() == [daemon_log]
+    assert cmd_bug_report._get_log_files() == {'daemon': daemon_log}
 
 
 def test_read_log_tail(tmp_path):
@@ -425,7 +430,23 @@ def test_check_storage_does_not_reset_preloaded_storage(monkeypatch):
 
 
 def test_bug_report_command(run_cli_command, tmp_path):
-    """Test the ``verdi bug-report`` command creates a zip file with diagnostics."""
+    """Test the ``verdi bug-report`` command creates a zip file with diagnostics and all log files.
+
+    The client log and the daemon log of a profile are both named ``aiida-<profile_name>.log``, so they have to be
+    stored under their log type in the archive to keep them from shadowing each other.
+    """
+    from aiida.manage import get_manager
+    from aiida.manage.configuration import get_config
+
+    logs = {
+        log_type: pathlib.Path(paths['log'])
+        for log_type, paths in get_config().filepaths(get_manager().get_profile()).items()
+    }
+
+    for log_type, log in logs.items():
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(f'contents of the {log_type} log', encoding='utf-8')
+
     output = tmp_path / 'report.zip'
     result = run_cli_command(cmd_bug_report.verdi_bug_report, ['-o', str(output)], use_subprocess=False)
 
@@ -433,8 +454,16 @@ def test_bug_report_command(run_cli_command, tmp_path):
     assert 'Bug report written to' in result.output
 
     with zipfile.ZipFile(output) as zf:
-        assert 'diagnostics.json' in zf.namelist()
+        namelist = zf.namelist()
         diagnostics = json.loads(zf.read('diagnostics.json'))
+        contents = {name: zf.read(name).decode('utf-8') for name in namelist if name.endswith('.log')}
+
+    assert set(namelist) == {'broker_service.log', 'circus.log', 'daemon.log', 'diagnostics.json', 'profile.log'}
+    assert len(namelist) == len(set(namelist))
+
+    # The command may log to the profile log while it runs, so only assert that each entry holds its own log
+    for log_type in logs:
+        assert f'contents of the {log_type} log' in contents[f'{log_type}.log']
 
     assert diagnostics['aiida_version'] == aiida.__version__
     assert diagnostics['profile'] is not None


### PR DESCRIPTION
The client log and the daemon log of a profile are both named `aiida-<profile_name>.log`, but each log file was added to the archive under its basename. `zipfile` happily writes both members, so the shadowed entry was no longer readable and the report effectively lost one of the two logs.

Key the log files returned by `_get_log_files` on their log type and use that as the name in the archive, so every log gets its own entry. The summary printed at the end now lists these archive names instead of the colliding basenames.