### PR TITLE
✨ Add per-worker task prefetch limits to ZeroMQ broker

### DIFF
--- a/docs/source/internals/broker.rst
+++ b/docs/source/internals/broker.rst
@@ -172,6 +172,7 @@ Message types
    * - ``SUBSCRIBE_TASK``
      - worker → broker
      - Register as a task consumer. Broker adds worker to dispatch pool.
+       Carries the worker's ``prefetch_count`` (see :ref:`task dispatch <internal_architecture:broker:dispatch>`).
    * - ``UNSUBSCRIBE_TASK``
      - worker → broker
      - Deregister as a task consumer.
@@ -198,6 +199,7 @@ The protocol maps AMQP concepts to ZeroMQ message types:
     basic.ack                 TASK_ACK
     basic.nack                TASK_NACK
     consumer with prefetch    TASK dispatch to available workers
+    basic.qos                 prefetch_count in SUBSCRIBE_TASK
     fanout exchange           BROADCAST via ROUTER fan-out
     direct exchange           RPC routed to named recipient
     durable queue             PersistentQueue (file-based)
@@ -254,16 +256,25 @@ With ``no_reply=True`` the task stays fully fire-and-forget: the broker sends no
 ``submit()`` always uses this mode while RPC messages do send a completion response.
 
 
+.. _internal_architecture:broker:dispatch:
+
 Task dispatch strategy
 ======================
 
-The broker keeps a deque of available workers, ``_available_workers``.
+The broker keeps a deque (double-ended queue) of available workers, ``available_workers``.
 A worker joins the pool when it sends ``SUBSCRIBE_TASK``.
 Since the ROUTER socket routes by identity, dispatching a task is just picking the next worker from the deque and sending to its identity.
 
-After dispatching, the worker goes straight back into the pool; the broker does not wait for the ACK.
-A single worker can therefore have several tasks in flight at once, which matches RabbitMQ's multi-prefetch behavior.
-The ACK only affects the ``PersistentQueue`` (removing the task from disk), never worker availability.
+After dispatching, the broker puts the worker back into the deque without waiting for an ACK if the limit of unacknowledged messages has not been reached.
+A single worker can therefore have several tasks in flight (dispatched but unacknowledged) at once, which is equivalent to AMQP's ``basic.qos`` mechanism.
+How many in flight tasks can be send to a worker is governed by the worker's prefetch limit, the equivalent of AMQP's ``basic.qos``.
+A worker declares it in ``SUBSCRIBE_TASK`` as ``prefetch_count``; the communicator takes the value from ``daemon.worker_process_slots``, the same option the RabbitMQ broker passes to kiwipy as ``task_prefetch_count``.
+The broker counts in flight tasks per worker in ``worker_load`` and only returns a worker to the pool while that count is below its limit.
+A worker that declares no limit (``prefetch_count`` of ``None`` or ``0``) is never held back.
+The worker acknowledges tasks once the corresponding AiiDA process has terminated.
+
+The ACK therefore does two things: it removes the task from the ``PersistentQueue`` on disk, and it frees the slot the task occupied so the worker can be handed another one.
+A ``NACK``, and the requeueing of tasks belonging to a worker that died, free the slot in the same way.
 
 .. code-block:: text
 
@@ -273,9 +284,13 @@ The ACK only affects the ``PersistentQueue`` (removing the task from disk), neve
         worker = available_workers.popleft()
         if worker no longer subscribed:      # stale entry
             continue
+        if worker is at its prefetch limit:  # stale entry
+            continue
         task   = task_queue.pop()           # pending → processing
         send task to worker                  # on failure: requeue + remove dead worker
-        available_workers.append(worker)     # immediately re-available
+        worker_load[worker] += 1
+        if worker_load[worker] < prefetch:   # else it waits for an ACK
+            available_workers.append(worker)
 
 
 .. _internal_architecture:broker:deferred_ack:

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -184,6 +184,7 @@ class ZeromqBroker(Broker):
             self._communicator = ZeromqCommunicator(
                 router_endpoint=router_endpoint,
                 task_timeout=get_config_option('broker.task_timeout'),
+                task_prefetch_count=get_config_option('daemon.worker_process_slots'),
             )
             self._communicator.start()
 

--- a/src/aiida/brokers/zeromq/communicator.py
+++ b/src/aiida/brokers/zeromq/communicator.py
@@ -69,10 +69,14 @@ class ZeromqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
         router_endpoint: str,
         client_id: str | None = None,
         task_timeout: float | None = None,
+        task_prefetch_count: int | None = None,
     ):
         self._router_endpoint = router_endpoint
         self._client_id = client_id or f'client-{uuid.uuid4().hex[:8]}'
         self._task_timeout = task_timeout
+        # Maximum number of tasks the broker may keep in flight on this client
+        # (``None`` = unlimited). Declared to the broker on every SUBSCRIBE_TASK.
+        self._task_prefetch_count = task_prefetch_count
 
         # ZeroMQ sockets (created on the event loop thread)
         self._context: zmq.asyncio.Context | None = None
@@ -343,7 +347,12 @@ class ZeromqCommunicator(kiwipy.Communicator):  # type: ignore[misc]
         def _do() -> str:
             ident = identifier or f'task-{uuid.uuid4().hex[:8]}'
             self._task_subscribers[ident] = subscriber
-            msg = make_subscribe_message(MessageType.SUBSCRIBE_TASK, self._client_id, ident)
+            msg = make_subscribe_message(
+                MessageType.SUBSCRIBE_TASK,
+                self._client_id,
+                ident,
+                prefetch_count=self._task_prefetch_count,
+            )
             self._send(msg)
             _LOGGER.info('Added task subscriber: %s', ident)
             return ident

--- a/src/aiida/brokers/zeromq/protocol.py
+++ b/src/aiida/brokers/zeromq/protocol.py
@@ -40,6 +40,7 @@ AMQP concepts mapped to message types:
     ``basic.ack``             ``TASK_ACK``
     ``basic.nack``            ``TASK_NACK``
     consumer with prefetch    ``TASK`` dispatch to workers
+    ``basic.qos``             ``prefetch_count`` in ``SUBSCRIBE_TASK``
     fanout exchange           ``BROADCAST`` via ROUTER fan-out
     direct exchange           ``RPC`` to specific recipient
     durable queue             ``PersistentQueue`` (file-based)
@@ -192,11 +193,27 @@ def make_broadcast_message(
     }
 
 
-def make_subscribe_message(msg_type: MessageType, sender: str, identifier: str | None = None) -> dict[str, Any]:
-    """Create a subscription message dictionary."""
+def make_subscribe_message(
+    msg_type: MessageType,
+    sender: str,
+    identifier: str | None = None,
+    prefetch_count: int | None = None,
+) -> dict[str, Any]:
+    """Create a subscription message dictionary.
+
+    :param msg_type: Type of subscription message (e.g., ``SUBSCRIBE_TASK``, ``SUBSCRIBE_RPC``).
+    :param sender: Identifier of the client sending the subscription.
+    :param identifier: Unique identifier for this subscription. If not provided, a UUID is generated
+        in the message itself.
+    :param prefetch_count: Maximum number of tasks the subscriber accepts in flight at once.
+        ``None`` or a non-positive value means unlimited. Only meaningful for ``SUBSCRIBE_TASK``;
+        ignored for other message types.
+    :return: Dictionary containing the subscription message.
+    """
     return {
         'type': msg_type.value,
         'id': uuid.uuid4().hex,
         'sender': sender,
         'identifier': identifier,
+        'prefetch_count': prefetch_count,
     }

--- a/src/aiida/brokers/zeromq/server.py
+++ b/src/aiida/brokers/zeromq/server.py
@@ -41,6 +41,7 @@ class ZeromqBrokerServer:
     - A persistent task queue for reliable task delivery
     - RPC subscriber registry for routing RPC calls
     - Task subscriber registry for distributing tasks
+    - Per-worker prefetch limits and in flight task counts, which throttle dispatch
 
     Socket architecture:
         ROUTER - Receives all client messages, routes replies and broadcasts
@@ -92,6 +93,11 @@ class ZeromqBrokerServer:
         # Task-worker assignments: task_id -> worker_identity
         # Used to requeue tasks when a worker dies
         self._task_worker_assignments: dict[str, bytes] = {}
+
+        # Prefetch limit declared by each worker on SUBSCRIBE_TASK (None = unlimited)
+        self._worker_prefetch: dict[bytes, int | None] = {}
+        # Number of dispatched but not yet acknowledged tasks per worker identity
+        self._worker_load: dict[bytes, int] = {}
 
         # Server state
         self._running = False
@@ -343,10 +349,10 @@ class ZeromqBrokerServer:
                 )
                 return
             self._task_queue.ack(task_id)
-            self._task_worker_assignments.pop(task_id, None)
+            self._release_task(task_id)
             _LOGGER.debug('Task acknowledged: %s', task_id)
 
-        # Worker is available for more tasks
+        # Worker has freed a slot and is available for more tasks
         self._mark_worker_available(identity)
 
     def _handle_task_nack(self, identity: bytes, msg: dict[str, Any]) -> None:
@@ -363,9 +369,10 @@ class ZeromqBrokerServer:
                 )
                 return
             self._task_queue.nack(task_id, requeue=True)
+            self._release_task(task_id)
             _LOGGER.debug('Task nacked and requeued: %s', task_id)
 
-        # Worker is available for more tasks
+        # Worker has freed a slot and is available for more tasks
         self._mark_worker_available(identity)
 
     def _handle_rpc(self, identity: bytes, msg: dict[str, Any]) -> None:
@@ -448,8 +455,12 @@ class ZeromqBrokerServer:
             return
 
         self._task_subscribers[identifier] = identity
+        # The prefetch limit applies to the connection, like AMQP's channel-level
+        # ``basic.qos``, so the most recent declaration for this identity wins.
+        prefetch = msg.get('prefetch_count')
+        self._worker_prefetch[identity] = prefetch if prefetch and prefetch > 0 else None
         self._mark_worker_available(identity)
-        _LOGGER.info('Task subscriber registered: %s', identifier)
+        _LOGGER.info('Task subscriber registered: %s (prefetch: %s)', identifier, self._worker_prefetch[identity])
 
         # Try to dispatch any pending tasks
         self._dispatch_pending_tasks()
@@ -468,7 +479,10 @@ class ZeromqBrokerServer:
         """Handle task subscriber removal."""
         identifier = msg.get('identifier') or msg.get('sender')
         if identifier and identifier in self._task_subscribers:
-            del self._task_subscribers[identifier]
+            worker_identity = self._task_subscribers.pop(identifier)
+            # Forget the prefetch limit once the connection has no task subscriptions left
+            if worker_identity not in self._task_subscribers.values():
+                self._worker_prefetch.pop(worker_identity, None)
             _LOGGER.info('Task subscriber removed: %s', identifier)
 
     def _handle_unsubscribe_rpc(self, identity: bytes, msg: dict[str, Any]) -> None:
@@ -479,12 +493,16 @@ class ZeromqBrokerServer:
             _LOGGER.info('RPC subscriber removed: %s', identifier)
 
     def _dispatch_pending_tasks(self) -> None:
-        """Dispatch pending tasks to available workers."""
+        """Dispatch pending tasks to workers that have a free slot."""
         while self._available_workers and not self._task_queue.is_empty():
             worker_identity = self._available_workers.popleft()
 
             # Verify worker is still subscribed
             if worker_identity not in self._task_subscribers.values():
+                continue
+
+            # Guard against stale entries for a worker that has since filled up
+            if not self._has_capacity(worker_identity):
                 continue
 
             # Get next task
@@ -511,10 +529,10 @@ class ZeromqBrokerServer:
                 self._task_queue.nack(task_id, requeue=True)
                 self._remove_dead_worker(worker_identity)
                 continue
-            self._task_worker_assignments[task_id] = worker_identity
-            # Re-add worker so it can receive more tasks concurrently
-            # (matching RMQ's multi-prefetch behaviour).  The ACK only
-            # affects the PersistentQueue, not worker availability.
+            self._assign_task(task_id, worker_identity)
+            # Re-add the worker so it can receive more tasks concurrently, but
+            # only while it stays below its declared prefetch limit (matching
+            # RMQ's multi-prefetch behaviour).  The ACK frees the slot again.
             self._mark_worker_available(worker_identity)
             _LOGGER.debug('Dispatched task %s to worker', task_id)
 
@@ -523,9 +541,12 @@ class ZeromqBrokerServer:
         # Requeue all tasks assigned to this worker
         dead_tasks = [tid for tid, wid in self._task_worker_assignments.items() if wid == identity]
         for task_id in dead_tasks:
-            self._task_worker_assignments.pop(task_id, None)
+            self._release_task(task_id)
             self._task_queue.nack(task_id, requeue=True)
             _LOGGER.warning('Requeued task %s from dead worker %s', task_id, identity.hex()[:8])
+
+        self._worker_prefetch.pop(identity, None)
+        self._worker_load.pop(identity, None)
 
         # Remove from task subscribers
         dead_keys = [k for k, v in self._task_subscribers.items() if v == identity]
@@ -586,8 +607,44 @@ class ZeromqBrokerServer:
                 _LOGGER.warning('Worker %s is dead, removing', identity.hex()[:8])
                 self._remove_dead_worker(identity)
 
+    def _assign_task(self, task_id: str, identity: bytes) -> None:
+        """Record a task as in flight on a worker, occupying one of its slots."""
+        if task_id in self._task_worker_assignments:
+            _LOGGER.warning('Task %s already assigned to worker, skipping', task_id)
+            return
+        self._task_worker_assignments[task_id] = identity
+        self._worker_load[identity] = self._worker_load.get(identity, 0) + 1
+
+    def _release_task(self, task_id: str) -> None:
+        """Drop a task's worker assignment, freeing the slot it occupied."""
+        identity = self._task_worker_assignments.pop(task_id, None)
+        if identity is None:
+            _LOGGER.debug('Tried to release task %s but it was not assigned', task_id)
+            return
+
+        remaining = self._worker_load.get(identity, 0) - 1
+        if remaining > 0:
+            self._worker_load[identity] = remaining
+        else:
+            self._worker_load.pop(identity, None)
+
+    def _has_capacity(self, identity: bytes) -> bool:
+        """Return whether a worker has a free slot for another task.
+
+        This is the equivalent of AMQP's ``basic.qos``: a worker declares a
+        prefetch count when it subscribes and is only handed further tasks while
+        its dispatched-but-unacknowledged count stays below it. A
+        worker that declared no limit is always considered to have capacity.
+        """
+        prefetch = self._worker_prefetch.get(identity)
+        if prefetch is None:
+            return True
+        return self._worker_load.get(identity, 0) < prefetch
+
     def _mark_worker_available(self, identity: bytes) -> None:
-        """Mark a worker as available for tasks."""
+        """Mark a worker as available for tasks, unless it is at its prefetch limit."""
+        if not self._has_capacity(identity):
+            return
         if identity not in self._available_workers:
             self._available_workers.append(identity)
 
@@ -622,6 +679,7 @@ class ZeromqBrokerServer:
             'task_subscribers': len(self._task_subscribers),
             'rpc_subscribers': len(self._rpc_subscribers),
             'available_workers': len(self._available_workers),
+            'in_flight_tasks': len(self._task_worker_assignments),
             'pending_rpc_responses': len(self._pending_rpc_responses),
         }
 

--- a/src/aiida/brokers/zeromq/server.py
+++ b/src/aiida/brokers/zeromq/server.py
@@ -333,6 +333,15 @@ class ZeromqBrokerServer:
         """Handle task acknowledgment from worker."""
         task_id = msg.get('task_id')
         if task_id:
+            # Verify this worker owns the task
+            owner = self._task_worker_assignments.get(task_id)
+            if owner != identity:
+                _LOGGER.warning(
+                    'Worker %s tried to ack task %s owned by another worker',
+                    identity.hex()[:8],
+                    task_id,
+                )
+                return
             self._task_queue.ack(task_id)
             self._task_worker_assignments.pop(task_id, None)
             _LOGGER.debug('Task acknowledged: %s', task_id)
@@ -344,6 +353,15 @@ class ZeromqBrokerServer:
         """Handle task negative acknowledgment from worker."""
         task_id = msg.get('task_id')
         if task_id:
+            # Verify this worker owns the task
+            owner = self._task_worker_assignments.get(task_id)
+            if owner != identity:
+                _LOGGER.warning(
+                    'Worker %s tried to nack task %s owned by another worker',
+                    identity.hex()[:8],
+                    task_id,
+                )
+                return
             self._task_queue.nack(task_id, requeue=True)
             _LOGGER.debug('Task nacked and requeued: %s', task_id)
 

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -164,7 +164,9 @@ class TestZeromqBrokerCommunicator:
 
             assert result is communicator
             sleep.assert_called_once_with(0.2)
-            communicator_cls.assert_called_once_with(router_endpoint=endpoint, task_timeout=None)
+            communicator_cls.assert_called_once_with(
+                router_endpoint=endpoint, task_timeout=None, task_prefetch_count=None
+            )
             communicator.start.assert_called_once()
 
     def test_get_communicator_warns_while_waiting_for_endpoint(self, zeromq_broker, monkeypatch):
@@ -189,7 +191,9 @@ class TestZeromqBrokerCommunicator:
             assert result is communicator
             assert sleep.call_count == 2
             warning.assert_called_once_with('Still waiting for broker to become ready...')
-            communicator_cls.assert_called_once_with(router_endpoint=endpoint, task_timeout=None)
+            communicator_cls.assert_called_once_with(
+                router_endpoint=endpoint, task_timeout=None, task_prefetch_count=None
+            )
             communicator.start.assert_called_once()
 
     def test_get_communicator(self, aiida_broker, monkeypatch):

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -19,6 +19,7 @@ import pytest
 
 from aiida.brokers.zeromq.broker import ZeromqBroker
 from aiida.brokers.zeromq.communicator import ZeromqCommunicator
+from aiida.brokers.zeromq.protocol import MessageType
 
 
 @pytest.fixture(scope='module')
@@ -76,6 +77,42 @@ class TestZeromqCommunicatorLifecycle:
         comm = ZeromqCommunicator(router_endpoint='ipc:///tmp/fake')
         with pytest.raises(RuntimeError, match='closed'):
             comm.task_send({'x': 1})
+
+
+class TestZeromqCommunicatorPrefetch:
+    """Tests that the communicator declares its prefetch count when subscribing."""
+
+    @staticmethod
+    def make_offline_communicator(**kwargs) -> ZeromqCommunicator:
+        """Return a communicator whose sends are captured instead of hitting a socket.
+
+        Pretending the current thread is the loop thread makes ``_run_on_loop``
+        execute inline, so no event loop or broker is needed.
+        """
+        import threading
+        from unittest.mock import MagicMock
+
+        comm = ZeromqCommunicator(router_endpoint='ipc://test', **kwargs)
+        comm._loop_thread = threading.current_thread()
+        comm._send = MagicMock()
+        comm._closed = False
+        return comm
+
+    def test_subscribe_declares_prefetch_count(self):
+        """Test the configured prefetch count is sent on SUBSCRIBE_TASK."""
+        comm = self.make_offline_communicator(task_prefetch_count=15)
+        comm.add_task_subscriber(lambda c, t: None, identifier='worker')
+
+        msg = comm._send.call_args[0][0]
+        assert msg['type'] == MessageType.SUBSCRIBE_TASK.value
+        assert msg['prefetch_count'] == 15
+
+    def test_subscribe_without_prefetch_count(self):
+        """Test no prefetch count is declared when none is configured."""
+        comm = self.make_offline_communicator()
+        comm.add_task_subscriber(lambda c, t: None, identifier='worker')
+
+        assert comm._send.call_args[0][0]['prefetch_count'] is None
 
 
 class TestZeromqCommunicatorMessaging:

--- a/tests/brokers/test_zeromq_server.py
+++ b/tests/brokers/test_zeromq_server.py
@@ -160,6 +160,8 @@ class TestZeromqBrokerServerMessageHandling:
         """Test _handle_task_nack requeues task and marks worker available."""
         server._task_queue.push('task-300', {'body': 'x'})
         server._task_queue.pop()
+        # Assign task to worker so NACK can find the owner
+        server._task_worker_assignments['task-300'] = b'worker-1'
 
         msg = {'type': MessageType.TASK_NACK.value, 'task_id': 'task-300'}
         server._handle_task_nack(b'worker-1', msg)
@@ -374,6 +376,37 @@ class TestZeromqBrokerServerMessageHandling:
         status = server.get_status()
         assert status['running'] is False
         assert status['pending_tasks'] == 0
+
+    def test_mismatched_ack_is_rejected(self, server):
+        """Test that a worker cannot ACK a task owned by another worker."""
+        # Set up: task assigned to worker-1
+        server._task_queue.push('task-1', {'body': 'data'})
+        server._task_queue.pop()
+        server._task_worker_assignments['task-1'] = b'worker-1'
+
+        # Worker-2 tries to ACK worker-1's task (should be rejected)
+        server._handle_task_ack(b'worker-2', {'type': MessageType.TASK_ACK.value, 'task_id': 'task-1'})
+
+        # Verify rejection: task still assigned and still processing
+        assert 'task-1' in server._task_worker_assignments
+        assert server._task_worker_assignments['task-1'] == b'worker-1'
+        assert server._task_queue.processing_count() == 1  # task not removed from processing
+
+    def test_mismatched_nack_is_rejected(self, server):
+        """Test that a worker cannot NACK a task owned by another worker."""
+        # Set up: task assigned to worker-1
+        server._task_queue.push('task-1', {'body': 'data'})
+        server._task_queue.pop()
+        server._task_worker_assignments['task-1'] = b'worker-1'
+
+        # Worker-2 tries to NACK worker-1's task (should be rejected)
+        server._handle_task_nack(b'worker-2', {'type': MessageType.TASK_NACK.value, 'task_id': 'task-1'})
+
+        # Verify rejection: task still assigned and not requeued
+        assert 'task-1' in server._task_worker_assignments
+        assert server._task_worker_assignments['task-1'] == b'worker-1'
+        assert server._task_queue.processing_count() == 1  # task not removed from processing
+        assert server._task_queue.size() == 0  # task was not requeued to pending
 
 
 class TestZeromqBrokerServerWithSockets:

--- a/tests/brokers/test_zeromq_server.py
+++ b/tests/brokers/test_zeromq_server.py
@@ -409,6 +409,168 @@ class TestZeromqBrokerServerMessageHandling:
         assert server._task_queue.size() == 0  # task was not requeued to pending
 
 
+class TestZeromqBrokerServerPrefetch:
+    """Tests for the per-worker prefetch limit (``daemon.worker_process_slots``).
+
+    Workers declare the limit on ``SUBSCRIBE_TASK``; the broker must not keep more
+    than that many tasks in flight on a worker until they are acknowledged.
+    """
+
+    @pytest.fixture
+    def server(self, tmp_path):
+        server = ZeromqBrokerServer(storage_path=tmp_path / 'storage', sockets_path=tmp_path / 'sockets')
+        server._send_to_client = MagicMock()
+        return server
+
+    @staticmethod
+    def subscribe(server, identity: bytes, identifier: str, prefetch_count: int | None = None) -> None:
+        """Register ``identity`` as a task subscriber with the given prefetch limit."""
+        server._handle_subscribe_task(
+            identity,
+            {
+                'type': MessageType.SUBSCRIBE_TASK.value,
+                'identifier': identifier,
+                'prefetch_count': prefetch_count,
+            },
+        )
+
+    @staticmethod
+    def push_tasks(server, count: int, prefix: str = 'task') -> None:
+        """Queue ``count`` tasks without dispatching them."""
+        for index in range(count):
+            server._task_queue.push(f'{prefix}-{index}', {'body': index, 'no_reply': True})
+
+    def test_subscribe_records_prefetch(self, server):
+        """Test the prefetch count declared on subscription is stored per identity."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=3)
+        assert server._worker_prefetch[b'worker-1'] == 3
+
+    def test_subscribe_without_prefetch_is_unlimited(self, server):
+        """Test a subscription that declares no prefetch count is unlimited."""
+        self.subscribe(server, b'worker-1', 'w1')
+        assert server._worker_prefetch[b'worker-1'] is None
+
+    def test_subscribe_with_nonpositive_prefetch_is_unlimited(self, server):
+        """Test a prefetch count of zero means unlimited, as it does in AMQP."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=0)
+        assert server._worker_prefetch[b'worker-1'] is None
+
+    def test_dispatch_stops_at_prefetch_limit(self, server):
+        """Test dispatch hands out at most ``prefetch_count`` tasks before an ACK."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=2)
+        self.push_tasks(server, 5)
+
+        server._dispatch_pending_tasks()
+
+        assert server._send_to_client.call_count == 2
+        assert len(server._task_worker_assignments) == 2
+        assert server._task_queue.size() == 3
+        assert b'worker-1' not in server._available_workers
+
+    def test_dispatch_unlimited_without_prefetch(self, server):
+        """Test a worker that declared no limit still receives every pending task."""
+        self.subscribe(server, b'worker-1', 'w1')
+        self.push_tasks(server, 5)
+
+        server._dispatch_pending_tasks()
+
+        assert server._send_to_client.call_count == 5
+        assert server._task_queue.size() == 0
+
+    def test_ack_frees_a_slot(self, server):
+        """Test acknowledging a task lets the next pending task through."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=2)
+        self.push_tasks(server, 5)
+        server._dispatch_pending_tasks()
+
+        acked = next(iter(server._task_worker_assignments))
+        server._handle_task_ack(b'worker-1', {'type': MessageType.TASK_ACK.value, 'task_id': acked})
+        server._dispatch_pending_tasks()
+
+        assert server._send_to_client.call_count == 3
+        assert len(server._task_worker_assignments) == 2
+        assert server._task_queue.size() == 2
+
+    def test_nack_frees_a_slot(self, server):
+        """Test a negative acknowledgment also releases the slot it occupied."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=1)
+        self.push_tasks(server, 2)
+        server._dispatch_pending_tasks()
+
+        nacked = next(iter(server._task_worker_assignments))
+        server._handle_task_nack(b'worker-1', {'type': MessageType.TASK_NACK.value, 'task_id': nacked})
+
+        assert server._worker_load.get(b'worker-1', 0) == 0
+        assert nacked not in server._task_worker_assignments
+        assert b'worker-1' in server._available_workers
+
+    def test_limit_is_per_worker(self, server):
+        """Test each worker gets its own allowance rather than a global one."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=1)
+        self.subscribe(server, b'worker-2', 'w2', prefetch_count=1)
+        self.push_tasks(server, 5)
+
+        server._dispatch_pending_tasks()
+
+        assert server._send_to_client.call_count == 2
+        assert sorted(server._worker_load) == [b'worker-1', b'worker-2']
+        assert all(load == 1 for load in server._worker_load.values())
+        assert server._task_queue.size() == 3
+
+    def test_capped_and_uncapped_workers_coexist(self, server):
+        """Test a capped worker stops while an unlimited one drains the queue."""
+        self.subscribe(server, b'capped', 'w1', prefetch_count=1)
+        self.subscribe(server, b'uncapped', 'w2')
+        self.push_tasks(server, 6)
+
+        server._dispatch_pending_tasks()
+
+        assert server._task_queue.size() == 0
+        assert server._worker_load[b'capped'] == 1
+        assert server._worker_load[b'uncapped'] == 5
+
+    def test_dead_worker_releases_its_slots(self, server):
+        """Test removing a dead worker clears its load so requeued tasks can move on."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=2)
+        self.push_tasks(server, 3)
+        server._dispatch_pending_tasks()
+
+        server._remove_dead_worker(b'worker-1')
+
+        assert b'worker-1' not in server._worker_load
+        assert b'worker-1' not in server._worker_prefetch
+        assert server._task_queue.size() == 3  # both in-flight tasks requeued
+
+    def test_unsubscribe_forgets_prefetch(self, server):
+        """Test the prefetch limit is dropped once the connection has no task subscription."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=2)
+        server._handle_unsubscribe_task(b'worker-1', {'type': MessageType.UNSUBSCRIBE_TASK.value, 'identifier': 'w1'})
+
+        assert b'worker-1' not in server._worker_prefetch
+
+    def test_unsubscribe_keeps_prefetch_while_other_subscriptions_remain(self, server):
+        """Test the limit survives while the same connection still has a task subscription."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=2)
+        self.subscribe(server, b'worker-1', 'w2', prefetch_count=2)
+        server._handle_unsubscribe_task(b'worker-1', {'type': MessageType.UNSUBSCRIBE_TASK.value, 'identifier': 'w1'})
+
+        assert server._worker_prefetch[b'worker-1'] == 2
+
+    def test_load_does_not_leak_on_repeated_ack(self, server):
+        """Test acknowledging an unknown task does not free a slot that was never taken."""
+        self.subscribe(server, b'worker-1', 'w1', prefetch_count=1)
+        self.push_tasks(server, 2)
+        server._dispatch_pending_tasks()
+
+        acked = next(iter(server._task_worker_assignments))
+        ack_msg = {'type': MessageType.TASK_ACK.value, 'task_id': acked}
+        server._handle_task_ack(b'worker-1', ack_msg)
+        server._handle_task_ack(b'worker-1', ack_msg)  # duplicate
+
+        server._dispatch_pending_tasks()
+        assert server._worker_load[b'worker-1'] == 1
+
+
 class TestZeromqBrokerServerWithSockets:
     """Tests using a real running server with ZeroMQ sockets."""
 
@@ -475,6 +637,71 @@ class TestZeromqBrokerServerWithSockets:
             received = decode_message(frames[1] if frames[0] == b'' else frames[0])
             assert received['type'] == MessageType.TASK.value
             assert received['id'] == 'live-task-1'
+
+        finally:
+            dealer.close()
+            ctx.term()
+
+    def test_prefetch_limit_over_the_wire(self, running_server):
+        """Test a worker declaring ``prefetch_count=1`` receives one task at a time."""
+        import zmq
+
+        ctx = zmq.Context()
+        dealer = ctx.socket(zmq.DEALER)
+        try:
+            dealer.setsockopt_string(zmq.IDENTITY, 'capped-client')
+            dealer.connect(running_server.router_endpoint)
+            time.sleep(0.1)
+
+            subscribe = {
+                'type': MessageType.SUBSCRIBE_TASK.value,
+                'identifier': 'capped-subscriber',
+                'sender': 'capped-client',
+                'prefetch_count': 1,
+            }
+            dealer.send_multipart([b'', encode_message(subscribe)])
+            running_server.run_once(timeout=1.0)
+
+            for index in range(3):
+                task = {
+                    'type': MessageType.TASK.value,
+                    'id': f'capped-task-{index}',
+                    'sender': 'capped-client',
+                    'body': {'index': index},
+                    'no_reply': True,
+                }
+                dealer.send_multipart([b'', encode_message(task)])
+                running_server.run_once(timeout=1.0)
+
+            def receive_task(timeout: int) -> dict | None:
+                """Return the next task delivered to the worker, or None if none arrives."""
+                poller = zmq.Poller()
+                poller.register(dealer, zmq.POLLIN)
+                if dealer not in dict(poller.poll(timeout=timeout)):
+                    return None
+                frames = dealer.recv_multipart()
+                return decode_message(frames[1] if frames[0] == b'' else frames[0])
+
+            first = receive_task(2000)
+            assert first is not None, 'Worker did not receive the first task'
+            assert first['id'] == 'capped-task-0'
+
+            # The remaining two must be withheld until the first one is acknowledged
+            running_server.run_once(timeout=0.5)
+            assert receive_task(500) is None, 'Broker exceeded the declared prefetch limit'
+            assert running_server._task_queue.size() == 2
+
+            ack = {
+                'type': MessageType.TASK_ACK.value,
+                'task_id': 'capped-task-0',
+                'sender': 'capped-client',
+            }
+            dealer.send_multipart([b'', encode_message(ack)])
+            running_server.run_once(timeout=1.0)
+
+            second = receive_task(2000)
+            assert second is not None, 'Worker did not receive the next task after the ACK'
+            assert second['id'] == 'capped-task-1'
 
         finally:
             dealer.close()


### PR DESCRIPTION
Implements logic that limits the number of in flight tasks (dispatched to the client but not yet unacknowledged). When the limit is reached the broker holds out dispatching further tasks. This mechanism is used by aiida to limit the number of tasks a worker works at the same time. The logic is the same as in RabbitMQ (kiwipy passes ``task_prefetch_count` later to `basic.qos`) This allows the ZMQ broker to now take the config option `daemon.worker_process_slots` into account.