### PR TITLE
Cache derived minimal model on specific class

### DIFF
--- a/src/aiida/orm/pydantic.py
+++ b/src/aiida/orm/pydantic.py
@@ -65,7 +65,7 @@ class OrmModel(AiiDABaseModel):
         if cls.__name__.startswith('Minimal'):
             return cls
 
-        cached = cls._AIIDA_MINIMAL_MODEL
+        cached = vars(cls).get('_AIIDA_MINIMAL_MODEL')
         if isinstance(cached, type) and issubclass(cached, OrmModel):
             return cached
 

--- a/tests/orm/models/test_models.py
+++ b/tests/orm/models/test_models.py
@@ -518,6 +518,12 @@ def test_minimal_model_idempotency():
     assert RepeatedDynamicModel is DynamicModel
 
 
+def test_minimal_model_idempotency_with_submodels():
+    ParentMinimalModel = orm.Node.ReadModel._as_minimal_model()  # noqa: N806
+    ChildMinimalModel = orm.Data.ReadModel._as_minimal_model()  # noqa: N806
+    assert ChildMinimalModel is not ParentMinimalModel
+
+
 def test_generated_orm_model_setup_defers_pydantic_rebuild(monkeypatch):
     """Test generated ORM models are not rebuilt eagerly during class setup."""
     rebuilt: list[type[OrmModel]] = []


### PR DESCRIPTION
The previous mechanism caused subclasses to end up with the same cached minimal model as their parent class.