### PR TITLE
🔧 `__version__`: roll back to 2.10.0.dev0

### DIFF
--- a/src/aiida/__init__.py
+++ b/src/aiida/__init__.py
@@ -27,7 +27,7 @@ __copyright__ = (
     'For further information please visit http://www.aiida.net/. All rights reserved.'
 )
 __license__ = 'MIT license, see LICENSE.txt file.'
-__version__ = '3.0.0.dev0'
+__version__ = '2.10.0.dev0'
 __authors__ = 'The AiiDA team.'
 __paper__ = (
     'S. P. Huber et al., "AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and '


### PR DESCRIPTION
Downstream packages pin a `<3.0` ceiling on `aiida-core`, so publishing development releases under `3.0.0.dev0` makes them uninstallable alongside the development version. Roll the development version back to `2.10.0.dev0` until the ecosystem is ready for a major bump.