### PR TITLE
Fix warning on resource leakage

### DIFF
--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import functools
-import sys
 import typing as t
+import weakref
 from collections.abc import Iterator
 
 from aiida.brokers.broker import Broker, BrokerConfigField, BrokerServiceStatus, JsonValue
@@ -23,6 +23,30 @@ if t.TYPE_CHECKING:
 LOGGER = AIIDA_LOGGER.getChild('broker.rabbitmq')
 
 __all__ = ('RabbitmqBroker',)
+
+
+class _BrokerResources:
+    """Resources owned by a :class:`RabbitmqBroker`."""
+
+    def __init__(self) -> None:
+        self.communicator: RmqThreadCommunicator | None = None
+
+    def release(self) -> None:
+        """Release the resources."""
+        if self.communicator is not None:
+            self.communicator.close()
+            self.communicator = None
+
+    @property
+    def has_pending_release(self) -> bool:
+        return self.communicator is not None
+
+
+def _finalize_broker(resources: _BrokerResources, broker_repr: str) -> None:
+    """Close resources held by a broker that was not closed explicitly."""
+    if resources.has_pending_release:
+        LOGGER.warning(f'RabbitmqBroker {broker_repr} was not closed explicitly.')
+        resources.release()
 
 
 class RabbitmqBroker(Broker):
@@ -87,7 +111,8 @@ class RabbitmqBroker(Broker):
         :param profile: The profile.
         """
         self._profile = profile
-        self._communicator: RmqThreadCommunicator | None = None
+        self._resources = _BrokerResources()
+        self._finalizer = weakref.finalize(self, _finalize_broker, self._resources, repr(self))
         self._prefix = f'aiida-{self._profile.uuid}'
 
     def __str__(self) -> str:
@@ -100,7 +125,7 @@ class RabbitmqBroker(Broker):
 
     def probe_service_status(self) -> BrokerServiceStatus:
         """Return status information reported by the RabbitMQ server."""
-        had_communicator = self._communicator is not None
+        had_communicator = self._resources.communicator is not None
 
         try:
             properties = self.get_communicator().server_properties
@@ -122,7 +147,7 @@ class RabbitmqBroker(Broker):
 
     def check_service_reachable(self) -> bool:
         """Return whether the RabbitMQ service is reachable."""
-        had_communicator = self._communicator is not None
+        had_communicator = self._resources.communicator is not None
 
         try:
             self.get_communicator()
@@ -136,27 +161,19 @@ class RabbitmqBroker(Broker):
 
     def close(self) -> None:
         """Close the broker."""
-        if self._communicator is not None:
-            self._communicator.close()
-            self._communicator = None
-
-    def __del__(self) -> None:
-        if self._communicator is not None:
-            LOGGER.warning(f'RabbitmqBroker {self!r} was not closed explicitly.')
-            if not sys.is_finalizing():
-                self.close()
+        self._resources.release()
 
     def iterate_tasks(self) -> Iterator[t.Any]:
         """Return an iterator over the tasks in the launch queue."""
         yield from self.get_communicator().task_queue(get_launch_queue_name(self._prefix))
 
     def get_communicator(self) -> RmqThreadCommunicator:
-        if self._communicator is None:
-            self._communicator = self._create_communicator()
+        if self._resources.communicator is None:
+            self._resources.communicator = self._create_communicator()
             # Check whether a compatible version of RabbitMQ is being used.
             self.check_rabbitmq_version()
 
-        return self._communicator
+        return self._resources.communicator
 
     def _create_communicator(self) -> RmqThreadCommunicator:
         """Return an instance of :class:`kiwipy.Communicator`."""
@@ -164,7 +181,7 @@ class RabbitmqBroker(Broker):
 
         from aiida.orm.utils import serialize
 
-        self._communicator = RmqThreadCommunicator.connect(
+        communicator = RmqThreadCommunicator.connect(
             connection_params={'url': self.get_url()},
             message_exchange=get_message_exchange_name(self._prefix),
             encoder=functools.partial(serialize.serialize, encoding='utf-8'),
@@ -178,7 +195,7 @@ class RabbitmqBroker(Broker):
             testing_mode=self._profile.is_test_profile,
         )
 
-        return self._communicator
+        return communicator
 
     def check_rabbitmq_version(self) -> tuple[Version, bool]:
         """Check the version of RabbitMQ that is being connected to and emit warning if it is not compatible."""

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -45,7 +45,7 @@ class _BrokerResources:
 def _finalize_broker(resources: _BrokerResources, broker_repr: str) -> None:
     """Close resources held by a broker that was not closed explicitly."""
     if resources.has_pending_release:
-        LOGGER.warning(f'RabbitmqBroker {broker_repr} was not closed explicitly.')
+        LOGGER.info(f'RabbitmqBroker {broker_repr} was not closed explicitly.')
         resources.release()
 
 

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 import typing as t
+import weakref
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -25,6 +26,26 @@ if t.TYPE_CHECKING:
 __all__ = ('ZeromqBroker',)
 
 LOGGER = AIIDA_LOGGER.getChild('broker.zeromq')
+
+
+class _BrokerResources:
+    """Resources owned by a :class:`ZeromqBroker`."""
+
+    def __init__(self) -> None:
+        self.communicator: ZeromqCommunicator | None = None
+
+    def release(self) -> None:
+        """Release the resources."""
+        if self.communicator is not None:
+            self.communicator.close()
+            self.communicator = None
+
+
+def _finalize_broker(resources: _BrokerResources, broker_repr: str) -> None:
+    """Cleanup resources held by a broker that was not closed explicitly."""
+    if resources.communicator is not None:
+        LOGGER.warning(f'ZeromqBroker {broker_repr} was not closed explicitly.')
+        resources.release()
 
 
 class ZeromqBroker(Broker):
@@ -61,7 +82,8 @@ class ZeromqBroker(Broker):
             )
             raise ConfigurationError(msg)
 
-        self._communicator: ZeromqCommunicator | None = None
+        self._resources = _BrokerResources()
+        self._finalizer = weakref.finalize(self, _finalize_broker, self._resources, repr(self))
 
         from aiida.manage.configuration import get_config
 
@@ -159,7 +181,7 @@ class ZeromqBroker(Broker):
 
     def get_communicator(self) -> ZeromqCommunicator:
         """Get or create a communicator connected to the broker."""
-        if self._communicator is None:
+        if self._resources.communicator is None:
             router_endpoint = self._router_endpoint
 
             if router_endpoint is None:
@@ -181,14 +203,14 @@ class ZeromqBroker(Broker):
 
             from aiida.manage.configuration import get_config_option
 
-            self._communicator = ZeromqCommunicator(
+            self._resources.communicator = ZeromqCommunicator(
                 router_endpoint=router_endpoint,
                 task_timeout=get_config_option('broker.task_timeout'),
                 task_prefetch_count=get_config_option('daemon.worker_process_slots'),
             )
-            self._communicator.start()
+            self._resources.communicator.start()
 
-        return self._communicator
+        return self._resources.communicator
 
     def iterate_tasks(self) -> t.Iterator[t.Any]:
         queue_path = self._storage_path / 'tasks'
@@ -200,9 +222,7 @@ class ZeromqBroker(Broker):
             yield ZeromqIncomingTask(task_id, task_data, queue)
 
     def close(self) -> None:
-        if self._communicator is not None:
-            self._communicator.close()
-            self._communicator = None
+        self._resources.release()
 
     def __enter__(self) -> ZeromqBroker:
         return self

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -44,7 +44,7 @@ class _BrokerResources:
 def _finalize_broker(resources: _BrokerResources, broker_repr: str) -> None:
     """Cleanup resources held by a broker that was not closed explicitly."""
     if resources.communicator is not None:
-        LOGGER.warning(f'ZeromqBroker {broker_repr} was not closed explicitly.')
+        LOGGER.info(f'ZeromqBroker {broker_repr} was not closed explicitly.')
         resources.release()
 
 

--- a/src/aiida/cmdline/utils/log.py
+++ b/src/aiida/cmdline/utils/log.py
@@ -1,7 +1,6 @@
 """Utilities for logging in the command line interface context."""
 
 import logging
-import sys
 
 import click
 
@@ -11,9 +10,7 @@ from .echo import COLORS
 class CliHandler(logging.Handler):
     """Handler for writing to the console using click."""
 
-    # Capture `sys` as a default since module globals may be cleared during interpreter shutdown.
-    # See https://stackoverflow.com/questions/67902926/python-importerror-in-del-how-to-solve-this
-    def emit(self, record, _sys=sys):
+    def emit(self, record):
         """Emit log record via click.
 
         Can make use of special attributes 'nl' (whether to add newline) and 'err' (whether to print to stderr), which
@@ -40,21 +37,6 @@ class CliHandler(logging.Handler):
             msg = self.format(record)
             click.echo(msg, err=err, nl=nl)
         except Exception:
-            # if errored out and python finalizes, click resources have been
-            # most likely destructed so we emit with minimal formatting
-            if _sys.is_finalizing():
-                try:
-                    msg = record.getMessage()
-                    if prefix:
-                        msg = f'{record.levelname.capitalize()}: {msg}'
-                    stream = _sys.__stderr__ if err else _sys.__stdout__
-                    if stream is not None:
-                        stream.write(f'{msg}\n' if nl else msg)
-                        stream.flush()
-                except Exception:
-                    pass
-                return
-
             self.handleError(record)
 
 

--- a/src/aiida/orm/implementation/storage_backend.py
+++ b/src/aiida/orm/implementation/storage_backend.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import abc
-import sys
 from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -140,18 +139,6 @@ class StorageBackend(abc.ABC):
     @abc.abstractmethod
     def close(self) -> None:
         """Close the storage access."""
-
-    def __del__(self) -> None:
-        try:
-            closed = self.is_closed
-        except AttributeError:
-            # covers cases where the backend implementation is not yet initialized but object is deleted
-            return
-
-        if not closed:
-            LOGGER.warning(f'StorageBackend {self!r} was not closed explicitly.')
-            if not sys.is_finalizing():
-                self.close()
 
     @property
     @abc.abstractmethod

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -97,7 +97,7 @@ class _PsqlDosResources:
 def _finalize_backend(resources: _PsqlDosResources, backend_repr: str) -> None:
     """Release resources held by a backend that was not closed explicitly."""
     if resources.has_pending_release:
-        LOGGER.warning(f'StorageBackend {backend_repr} was not closed explicitly.')
+        LOGGER.info('StorageBackend {backend_repr} was not closed explicitly.')
         resources.release()
 
 

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import functools
 import pathlib
+import weakref
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING, Any
@@ -70,6 +71,34 @@ def get_filepath_container(profile: Profile) -> pathlib.Path:
         raise ConfigurationError(f'invalid profile {profile.name}: `storage.config.repository_uri` is not absolute')
 
     return filepath.expanduser() / 'container'
+
+
+class _PsqlDosResources:
+    """Resources owned by a :class:`PsqlDosBackend`."""
+
+    def __init__(self) -> None:
+        self.session_factory: scoped_session | None = None
+
+    def release(self) -> None:
+        """Release the resources."""
+        if self.session_factory is not None:
+            engine = self.session_factory.bind
+            if engine is not None:
+                engine.dispose()  # type: ignore[union-attr]
+            self.session_factory.expunge_all()
+            self.session_factory.remove()
+            self.session_factory = None
+
+    @property
+    def has_pending_release(self) -> bool:
+        return self.session_factory is not None
+
+
+def _finalize_backend(resources: _PsqlDosResources, backend_repr: str) -> None:
+    """Release resources held by a backend that was not closed explicitly."""
+    if resources.has_pending_release:
+        LOGGER.warning(f'StorageBackend {backend_repr} was not closed explicitly.')
+        resources.release()
 
 
 class PsqlDosBackend(StorageBackend):
@@ -135,7 +164,8 @@ class PsqlDosBackend(StorageBackend):
         with self.migrator(profile) as migrator:
             migrator.validate_storage()
 
-        self._session_factory: scoped_session | None = None
+        self._resources = _PsqlDosResources()
+        self._finalizer = weakref.finalize(self, _finalize_backend, self._resources, repr(self))
         self._initialise_session()
         # save the URL of the database, for use in the __str__ method
         self._db_url = self.get_session().get_bind().url  # type: ignore[union-attr]
@@ -150,7 +180,15 @@ class PsqlDosBackend(StorageBackend):
 
     @property
     def is_closed(self) -> bool:
-        return self._session_factory is None
+        return self._resources.session_factory is None
+
+    @property
+    def _session_factory(self) -> scoped_session | None:
+        return self._resources.session_factory
+
+    @_session_factory.setter
+    def _session_factory(self, value: scoped_session | None) -> None:
+        self._resources.session_factory = value
 
     def __str__(self) -> str:
         state = 'closed' if self.is_closed else 'open'
@@ -168,26 +206,24 @@ class PsqlDosBackend(StorageBackend):
         """
         from aiida.storage.psql_dos.utils import create_sqlalchemy_engine
 
-        engine = create_sqlalchemy_engine(self._profile.storage_config)  # type: ignore[arg-type]
-        self._session_factory = scoped_session(sessionmaker(bind=engine, future=True, expire_on_commit=True))
+        self._resources.session_factory = scoped_session(
+            sessionmaker(
+                bind=create_sqlalchemy_engine(self._profile.storage_config),  # type: ignore[arg-type]
+                future=True,
+                expire_on_commit=True,
+            )
+        )
 
     def get_session(self) -> Session:
         """Return an SQLAlchemy session bound to the current thread."""
-        if self._session_factory is None:
+        if self._resources.session_factory is None:
             raise ClosedStorage(str(self))
-        return self._session_factory()
+        return self._resources.session_factory()
 
     def close(self) -> None:
-        if self._session_factory is None:
+        if self._resources.session_factory is None:
             return  # the instance is already closed, and so this is a no-op
-        # close the connection
-
-        engine = self._session_factory.bind
-        if engine is not None:
-            engine.dispose()  # type: ignore[union-attr]
-        self._session_factory.expunge_all()
-        self._session_factory.remove()
-        self._session_factory = None
+        self._resources.release()
 
     def _clear(self) -> None:
         from aiida.storage.psql_dos.models.settings import DbSetting

--- a/src/aiida/storage/sqlite_temp/backend.py
+++ b/src/aiida/storage/sqlite_temp/backend.py
@@ -14,6 +14,7 @@ import functools
 import hashlib
 import os
 import shutil
+import weakref
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
@@ -24,6 +25,7 @@ from sqlalchemy import column, insert, update
 from sqlalchemy.orm import Session
 
 from aiida.common.exceptions import ClosedStorage, IntegrityError
+from aiida.common.log import AIIDA_LOGGER
 from aiida.common.pydantic import AiiDABaseModel, MetadataField
 from aiida.manage.configuration import Profile
 from aiida.orm.entities import EntityTypes
@@ -37,6 +39,36 @@ if TYPE_CHECKING:
     from aiida.repository.backend.abstract import InfoDictType
 
 __all__ = ('SqliteTempBackend',)
+
+LOGGER = AIIDA_LOGGER.getChild(__file__)
+
+
+class _TempBackendResources:
+    """Resources owned by a :class:`SqliteTempBackend`."""
+
+    def __init__(self) -> None:
+        self.session: Session | None = None
+        self.repo: SandboxShaRepositoryBackend | None = None
+
+    def release(self) -> None:
+        """Release the resources."""
+        if self.session is not None:
+            self.session.close()
+            self.session = None
+        if self.repo is not None:
+            self.repo.erase()
+            self.repo = None
+
+    @property
+    def has_pending_release(self) -> bool:
+        return self.session is not None or self.repo is not None
+
+
+def _finalize_backend(resources: _TempBackendResources, backend_repr: str) -> None:
+    """Release resources held by a backend that was not closed explicitly."""
+    if resources.has_pending_release:
+        LOGGER.warning(f'SqliteTempBackend {backend_repr} was not closed explicitly.')
+        resources.release()
 
 
 class SqliteTempBackend(StorageBackend):
@@ -100,8 +132,9 @@ class SqliteTempBackend(StorageBackend):
 
     def __init__(self, profile: Profile):
         super().__init__(profile)
-        self._session: Session | None = None
-        self._repo: SandboxShaRepositoryBackend | None = SandboxShaRepositoryBackend(profile.storage_config['filepath'])
+        self._resources = _TempBackendResources()
+        self._resources.repo = SandboxShaRepositoryBackend(profile.storage_config['filepath'])
+        self._finalizer = weakref.finalize(self, _finalize_backend, self._resources, repr(self))
         self._globals: dict[str, tuple[Any, str | None]] = {}
         self._closed = False
         self.get_session()  # load the database on initialization
@@ -114,13 +147,24 @@ class SqliteTempBackend(StorageBackend):
     def is_closed(self) -> bool:
         return self._closed
 
+    @property
+    def _session(self) -> Session | None:
+        return self._resources.session
+
+    @_session.setter
+    def _session(self, value: Session | None) -> None:
+        self._resources.session = value
+
+    @property
+    def _repo(self) -> SandboxShaRepositoryBackend | None:
+        return self._resources.repo
+
+    @_repo.setter
+    def _repo(self, value: SandboxShaRepositoryBackend | None) -> None:
+        self._resources.repo = value
+
     def close(self) -> None:
-        if self._session:
-            self._session.close()
-        if self._repo:
-            self._repo.erase()
-        self._session = None
-        self._repo = None
+        self._resources.release()
         self._globals = {}
         self._closed = True
 

--- a/src/aiida/storage/sqlite_temp/backend.py
+++ b/src/aiida/storage/sqlite_temp/backend.py
@@ -67,7 +67,7 @@ class _TempBackendResources:
 def _finalize_backend(resources: _TempBackendResources, backend_repr: str) -> None:
     """Release resources held by a backend that was not closed explicitly."""
     if resources.has_pending_release:
-        LOGGER.warning(f'SqliteTempBackend {backend_repr} was not closed explicitly.')
+        LOGGER.info(f'SqliteTempBackend {backend_repr} was not closed explicitly.')
         resources.release()
 
 

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -14,6 +14,7 @@ import json
 import shutil
 import tarfile
 import tempfile
+import weakref
 import zipfile
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
@@ -72,6 +73,38 @@ def validate_sqlite_version() -> None:
             f' But you have {sqlite_installed_version} installed.'
         )
         raise IncompatibleExternalDependencies(message)
+
+
+class _ZipBackendResources:
+    """Resources owned by a :class:`SqliteZipBackend`."""
+
+    def __init__(self) -> None:
+        self.db_file: Path | None = None
+        self.session: Session | None = None
+        self.repo: _RoBackendRepository | None = None
+
+    def release(self) -> None:
+        """Release the resources."""
+        if self.session is not None:
+            self.session.close()
+            self.session = None
+        if self.db_file is not None and self.db_file.exists():
+            self.db_file.unlink(missing_ok=True)
+            self.db_file = None
+        if self.repo is not None:
+            self.repo.close()
+            self.repo = None
+
+    @property
+    def has_pending_release(self) -> bool:
+        return self.session is not None or self.db_file is not None or self.repo is not None
+
+
+def _finalize_backend(resources: _ZipBackendResources, backend_repr: str) -> None:
+    """Release resources held by a backend that was not closed explicitly."""
+    if resources.has_pending_release:
+        LOGGER.warning(f'SqliteZipBackend {backend_repr} was not closed explicitly.')
+        resources.release()
 
 
 class SqliteZipBackend(StorageBackend):
@@ -212,10 +245,8 @@ class SqliteZipBackend(StorageBackend):
         super().__init__(profile)
         self._path = Path(profile.storage_config['filepath'])
         validate_storage(self._path)
-        # lazy open the archive zipfile and extract the database file
-        self._db_file: Path | None = None
-        self._session: Session | None = None
-        self._repo: _RoBackendRepository | None = None
+        self._resources = _ZipBackendResources()
+        self._finalizer = weakref.finalize(self, _finalize_backend, self._resources, repr(self))
         self._closed = False
 
     def __str__(self) -> str:
@@ -228,15 +259,7 @@ class SqliteZipBackend(StorageBackend):
 
     def close(self) -> None:
         """Close the backend"""
-        if self._session:
-            self._session.close()
-        if self._db_file and self._db_file.exists():
-            self._db_file.unlink()
-        if self._repo:
-            self._repo.close()
-        self._session = None
-        self._db_file = None
-        self._repo = None
+        self._resources.release()
         self._closed = True
 
     def get_session(self) -> Session:
@@ -245,10 +268,10 @@ class SqliteZipBackend(StorageBackend):
 
         if self._closed:
             raise ClosedStorage(str(self))
-        if self._session is None:
+        if self._resources.session is None:
             if is_zipfile(self._path):
                 _, path = tempfile.mkstemp()
-                db_file = self._db_file = Path(path)
+                db_file = self._resources.db_file = Path(path)
                 with db_file.open('wb') as handle:
                     try:
                         extract_file_in_zip(self._path, DB_FILENAME, handle, search_limit=4)
@@ -258,20 +281,20 @@ class SqliteZipBackend(StorageBackend):
                 db_file = self._path / DB_FILENAME
                 if not db_file.exists():
                     raise CorruptStorage(f'database could not be read: non-existent {db_file}')
-            self._session = Session(create_sqla_engine(db_file), future=True)
-        return self._session
+            self._resources.session = Session(create_sqla_engine(db_file), future=True)
+        return self._resources.session
 
     def get_repository(self) -> _RoBackendRepository:
         if self._closed:
             raise ClosedStorage(str(self))
-        if self._repo is None:
+        if self._resources.repo is None:
             if is_zipfile(self._path):
-                self._repo = ZipfileBackendRepository(self._path)
+                self._resources.repo = ZipfileBackendRepository(self._path)
             elif (self._path / REPO_FOLDER).exists():
-                self._repo = FolderBackendRepository(self._path / REPO_FOLDER)
+                self._resources.repo = FolderBackendRepository(self._path / REPO_FOLDER)
             else:
                 raise CorruptStorage(f'repository could not be read: non-existent {self._path / REPO_FOLDER}')
-        return self._repo
+        return self._resources.repo
 
     def query(self) -> orm.SqliteQueryBuilder:
         return orm.SqliteQueryBuilder(self)

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -103,7 +103,7 @@ class _ZipBackendResources:
 def _finalize_backend(resources: _ZipBackendResources, backend_repr: str) -> None:
     """Release resources held by a backend that was not closed explicitly."""
     if resources.has_pending_release:
-        LOGGER.warning(f'SqliteZipBackend {backend_repr} was not closed explicitly.')
+        LOGGER.info(f'SqliteZipBackend {backend_repr} was not closed explicitly.')
         resources.release()
 
 

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -122,7 +122,7 @@ def test_finalize_ignores_closed_broker(aiida_profile, caplog):
     broker_repr = repr(broker)
     broker_reference = weakref.ref(broker)
 
-    with caplog.at_level(logging.WARNING, logger='aiida.broker.rabbitmq'):
+    with caplog.at_level(logging.INFO, logger='aiida.broker.rabbitmq'):
         del broker
         gc.collect()
 

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -8,9 +8,14 @@
 ###########################################################################
 """Tests for the `aiida.brokers.rabbitmq` module."""
 
+import gc
 import logging
 import pathlib
+import subprocess
+import sys
+import textwrap
 import uuid
+import weakref
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -108,47 +113,54 @@ def test_check_service_reachable_false(monkeypatch, manager):
     close.assert_called_once_with()
 
 
-def test_del_closes_broker_when_not_finalizing(aiida_profile, monkeypatch, caplog):
-    """Test `__del__` closes the broker when Python is not finalizing."""
+def test_finalize_ignores_closed_broker(aiida_profile, caplog):
+    """Test the finalizer does nothing when the broker was closed explicitly."""
     broker = RabbitmqBroker(aiida_profile)
-    broker._communicator = MagicMock()
-    close = MagicMock()
-    monkeypatch.setattr(broker, 'close', close)
+    communicator = MagicMock()
+    broker._resources.communicator = communicator
+    broker.close()
+    broker_repr = repr(broker)
+    broker_reference = weakref.ref(broker)
 
     with caplog.at_level(logging.WARNING, logger='aiida.broker.rabbitmq'):
-        broker.__del__()
+        del broker
+        gc.collect()
 
-    # Note: we do an in assert because it might be that a broker instance of a
-    # previous test got deleted during the log capture
-    assert (
-        'aiida.broker.rabbitmq',
-        logging.WARNING,
-        f'RabbitmqBroker {broker!r} was not closed explicitly.',
-    ) in caplog.record_tuples
-
-    close.assert_called_once_with()
+    assert broker_reference() is None
+    assert f'RabbitmqBroker {broker_repr} was not closed explicitly.' not in caplog.messages
+    communicator.close.assert_called_once_with()
 
 
-def test_del_logs_but_skips_close_when_finalizing(aiida_profile, monkeypatch, caplog):
-    """Test ``__del__`` logs but skips close when Python is finalizing."""
-    broker = RabbitmqBroker(aiida_profile)
-    close = MagicMock()
-    broker._communicator = MagicMock()
-    monkeypatch.setattr(broker, 'close', close)
-    monkeypatch.setattr('sys.is_finalizing', lambda: True)
+def test_finalize_runs_at_interpreter_shutdown(tmp_path):
+    """Test the broker finalizer runs when the interpreter exits."""
+    marker = tmp_path / 'broker-finalized'
+    config_dir = tmp_path / 'config'
+    code = textwrap.dedent(
+        f"""
+        import os
+        from pathlib import Path
+        from types import SimpleNamespace
 
-    with caplog.at_level(logging.WARNING, logger='aiida.broker.rabbitmq'):
-        broker.__del__()
+        os.environ['AIIDA_PATH'] = {str(config_dir)!r}
 
-    # Note: we do an in assert because it might be that a broker instance of a
-    # previous test got deleted during the log capture
-    assert (
-        'aiida.broker.rabbitmq',
-        logging.WARNING,
-        f'RabbitmqBroker {broker!r} was not closed explicitly.',
-    ) in caplog.record_tuples
+        from aiida.brokers.rabbitmq.broker import RabbitmqBroker
 
-    close.assert_not_called()
+        class DummyCommunicator:
+            def __init__(self, marker_path):
+                self._marker_path = Path(marker_path)
+
+            def close(self):
+                self._marker_path.write_text('closed')
+
+        broker = RabbitmqBroker(SimpleNamespace(uuid='00000000-0000-0000-0000-000000000000'))
+        broker._resources.communicator = DummyCommunicator({str(marker)!r})
+        """
+    )
+
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == 'closed'
 
 
 @pytest.mark.parametrize(

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -11,7 +11,13 @@
 from __future__ import annotations
 
 import copy
+import gc
 import json
+import logging
+import subprocess
+import sys
+import textwrap
+import weakref
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import psutil
@@ -38,8 +44,8 @@ def aiida_broker():
 
 
 @pytest.fixture
-def zeromq_broker(tmp_path):
-    """Create a ZMQ broker instance rooted in ``tmp_path``."""
+def zeromq_broker_factory(tmp_path):
+    """Return a factory for ZMQ broker instances rooted in ``tmp_path``."""
     profile = MagicMock()
     profile.name = 'test-profile'
     profile.process_control_backend = 'core.zeromq'
@@ -56,7 +62,15 @@ def zeromq_broker(tmp_path):
         return result
 
     with patch.object(config, 'filepaths', side_effect=filepaths):
-        yield ZeromqBroker(profile)
+        yield lambda: ZeromqBroker(profile)
+
+
+@pytest.fixture
+def zeromq_broker(zeromq_broker_factory):
+    """Create a ZMQ broker instance rooted in ``tmp_path``."""
+    broker = zeromq_broker_factory()
+    yield broker
+    broker.close()
 
 
 def test_get_default_config():
@@ -71,6 +85,67 @@ def test_init_invalid_backend():
 
     with pytest.raises(ConfigurationError, match=r'should be `core\.zeromq`'):
         ZeromqBroker(profile)
+
+
+def test_finalize_ignores_closed_broker(zeromq_broker_factory, caplog):
+    """Test the finalizer does nothing when the broker was closed explicitly."""
+    broker = zeromq_broker_factory()
+    communicator = MagicMock()
+    broker._resources.communicator = communicator
+    broker.close()
+    broker_repr = repr(broker)
+    broker_reference = weakref.ref(broker)
+
+    with caplog.at_level(logging.WARNING, logger='aiida.broker.zeromq'):
+        del broker
+        gc.collect()
+
+    assert broker_reference() is None
+    assert f'ZeromqBroker {broker_repr} was not closed explicitly.' not in caplog.messages
+    communicator.close.assert_called_once_with()
+
+
+def test_finalize_runs_at_interpreter_shutdown(tmp_path):
+    """Test the broker finalizer runs when the interpreter exits."""
+    marker = tmp_path / 'zeromq-broker-finalized'
+    config_dir = tmp_path / 'config'
+    service_dir = tmp_path / 'service'
+    log_path = tmp_path / 'broker.log'
+    code = textwrap.dedent(
+        f"""
+        import os
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        os.environ['AIIDA_PATH'] = {str(config_dir)!r}
+
+        from aiida.brokers.zeromq.broker import ZeromqBroker
+
+        profile = SimpleNamespace(name='test-profile', process_control_backend='core.zeromq')
+        config = SimpleNamespace(
+            filepaths=lambda current_profile: {{
+                'broker_service': {{'dir': {str(service_dir)!r}, 'log': {str(log_path)!r}}}
+            }},
+        )
+
+        class DummyCommunicator:
+            def __init__(self, marker_path):
+                self._marker_path = Path(marker_path)
+
+            def close(self):
+                self._marker_path.write_text('closed')
+
+        with patch('aiida.manage.configuration.get_config', return_value=config):
+            broker = ZeromqBroker(profile)
+            broker._resources.communicator = DummyCommunicator({str(marker)!r})
+        """
+    )
+
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == 'closed'
 
 
 class TestZeromqBrokerStatusQueries:

--- a/tests/brokers/test_zeromq_broker.py
+++ b/tests/brokers/test_zeromq_broker.py
@@ -96,7 +96,7 @@ def test_finalize_ignores_closed_broker(zeromq_broker_factory, caplog):
     broker_repr = repr(broker)
     broker_reference = weakref.ref(broker)
 
-    with caplog.at_level(logging.WARNING, logger='aiida.broker.zeromq'):
+    with caplog.at_level(logging.INFO, logger='aiida.broker.zeromq'):
         del broker
         gc.collect()
 

--- a/tests/cmdline/utils/test_log.py
+++ b/tests/cmdline/utils/test_log.py
@@ -9,7 +9,6 @@
 """Tests for the :mod:`aiida.cmdline.utils.log` module."""
 
 import logging
-from io import StringIO
 
 from aiida.cmdline.utils import log
 
@@ -54,18 +53,3 @@ def test_cli_formatter_prefix():
     record = logging.LogRecord('name', logging.INFO, 'pathname', 0, 'Some %s', ('value',), None)
     record.prefix = True
     assert log.CliFormatter().format(record) == '\x1b[34m\x1b[1mInfo\x1b[0m: Some value'
-
-
-def test_cli_handler_emit_when_globals_are_finalized(monkeypatch):
-    """Test ``CliHandler.emit`` falls back to a plain stream write during finalization."""
-    record = logging.LogRecord('name', logging.WARNING, 'pathname', 0, 'Some %s', ('value',), None)
-    handler = log.CliHandler()
-    stream = StringIO()
-    monkeypatch.setattr(log.sys, 'is_finalizing', lambda: True)
-    monkeypatch.setattr(log.sys, '__stdout__', stream)
-    monkeypatch.setattr(log, 'sys', None)
-    monkeypatch.setattr(log, 'click', None)
-
-    handler.emit(record)
-
-    assert stream.getvalue() == 'Warning: Some value\n'

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -10,10 +10,15 @@
 
 from __future__ import annotations
 
+import gc
 import json
 import logging
 import pathlib
+import subprocess
+import sys
+import textwrap
 import uuid
+import weakref
 from unittest.mock import MagicMock
 
 import pytest
@@ -171,45 +176,53 @@ class TestBackend:
         assert len(group.nodes) == 0
 
 
-def test_del_closes_backend_when_not_finalizing(aiida_profile, monkeypatch, caplog):
-    """Test ``__del__`` closes the backend when Python is not finalizing."""
+def test_finalize_ignores_closed_backend(aiida_profile, caplog):
+    """Test the finalizer does nothing when the backend was closed explicitly."""
     backend = aiida_profile.storage_cls(aiida_profile)
-    close = MagicMock()
-    monkeypatch.setattr(backend, 'close', close)
+    release = MagicMock(wraps=backend._resources.release)
+    backend._resources.release = release
+    backend.close()
+    release.assert_called_once_with()
+    backend_repr = repr(backend)
+    backend_reference = weakref.ref(backend)
 
     with caplog.at_level(logging.WARNING, logger=storage_backend_module.LOGGER.name):
-        backend.__del__()
+        del backend
+        gc.collect()
 
-    # Note: we do an ``in`` assert because it might be that a backend instance of a
-    # previous test got deleted during the log capture
-    assert (
-        storage_backend_module.LOGGER.name,
-        logging.WARNING,
-        f'StorageBackend {backend!r} was not closed explicitly.',
-    ) in caplog.record_tuples
-
-    close.assert_called_once_with()
+    assert backend_reference() is None
+    release.assert_called_once_with()
+    assert f'StorageBackend {backend_repr} was not closed explicitly.' not in caplog.messages
 
 
-def test_del_logs_but_skips_close_when_finalizing(aiida_profile, monkeypatch, caplog):
-    """Test ``__del__`` logs but skips close when Python is finalizing."""
-    backend = aiida_profile.storage_cls(aiida_profile)
-    close = MagicMock()
-    monkeypatch.setattr(backend, 'close', close)
-    monkeypatch.setattr('sys.is_finalizing', lambda: True)
+def test_finalize_runs_at_interpreter_shutdown(tmp_path):
+    """Test the backend finalizer runs when the interpreter exits."""
+    marker = tmp_path / 'backend-finalized'
+    storage_path = tmp_path / 'storage'
+    config_dir = tmp_path / 'config'
+    code = textwrap.dedent(
+        f"""
+        import os
+        from pathlib import Path
 
-    with caplog.at_level(logging.WARNING, logger=storage_backend_module.LOGGER.name):
-        backend.__del__()
+        os.environ['AIIDA_PATH'] = {str(config_dir)!r}
 
-    # Note: we do an ``in`` assert because it might be that a backend instance of a
-    # previous test got deleted during the log capture
-    assert (
-        storage_backend_module.LOGGER.name,
-        logging.WARNING,
-        f'StorageBackend {backend!r} was not closed explicitly.',
-    ) in caplog.record_tuples
+        from aiida.storage.sqlite_temp.backend import SqliteTempBackend
 
-    close.assert_not_called()
+        backend = SqliteTempBackend(SqliteTempBackend.create_profile(filepath={str(storage_path)!r}))
+
+        class DummyRepo:
+            def erase(self):
+                Path({str(marker)!r}).write_text('closed')
+
+        backend._resources.repo = DummyRepo()
+        """
+    )
+
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == 'closed'
 
 
 def test_backup_not_implemented(aiida_config, backend, monkeypatch, tmp_path):

--- a/tests/orm/implementation/test_backend.py
+++ b/tests/orm/implementation/test_backend.py
@@ -186,7 +186,7 @@ def test_finalize_ignores_closed_backend(aiida_profile, caplog):
     backend_repr = repr(backend)
     backend_reference = weakref.ref(backend)
 
-    with caplog.at_level(logging.WARNING, logger=storage_backend_module.LOGGER.name):
+    with caplog.at_level(logging.INFO, logger=storage_backend_module.LOGGER.name):
         del backend
         gc.collect()
 


### PR DESCRIPTION
I know the fix in the first commit seems like a workaround hack but this is the recommended way by python.

> A finalizer will never invoke its callback during the later part of the [interpreter shutdown](https://docs.python.org/3/glossary.html#term-interpreter-shutdown) when module globals are liable to have been replaced by [None](https://docs.python.org/3/library/constants.html#None).

*https://docs.python.org/3/library/weakref.html#weakref.finalize*

> It is not guaranteed that `__del__()` methods are called for objects that still exist when the interpreter exits. [weakref.finalize](https://docs.python.org/3/library/weakref.html#weakref.finalize) provides a straightforward way to register a cleanup function to be called when an object is garbage collected.

*[https://docs.python.org/3/reference/datamodel.html#object.\_\_del\_\_](https://docs.python.org/3/reference/datamodel.html#object.__del__)*

See also for additional background this https://stackoverflow.com/a/43881370 and the email communication linked there.

One could make the _Resource classes more generic adding resources with an ID and a callback to release them, but I think that makes the logic actually harder to read rather than just implementing it for every class that has resources that need to be released on deletion.

The `__del__` was a bit buggy with python finalization. This problem did not occur when using `gc.collect`  so I hardened the tests to a new python process to properly tests it. It makes the test a bit heavier but so be it.