### PR TITLE
🐛 Close broker and storage backend when verdi commands exit

### DIFF
--- a/src/aiida/cmdline/commands/cmd_archive.py
+++ b/src/aiida/cmdline/commands/cmd_archive.py
@@ -23,6 +23,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.types import GroupParamType, PathOrUrl
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_codes, load_computers, load_group, load_groups, load_nodes
 from aiida.common.exceptions import CorruptStorage, IncompatibleStorageSchema, UnreachableStorage
 from aiida.common.links import GraphTraversalRules
 from aiida.common.log import AIIDA_LOGGER
@@ -192,16 +193,16 @@ def create(
         entities = []
 
         if codes:
-            entities.extend(codes)
+            entities.extend(load_codes(codes))
 
         if computers:
-            entities.extend(computers)
+            entities.extend(load_computers(computers))
 
         if groups:
-            entities.extend(groups)
+            entities.extend(load_groups(groups))
 
         if nodes:
-            entities.extend(nodes)
+            entities.extend(load_nodes(nodes))
 
     kwargs = {
         'input_calc_forward': input_calc_forward,
@@ -396,6 +397,7 @@ def import_archive(
     else:
         set_progress_reporter(None)
 
+    group = load_group(group) if group is not None else None
     all_archives = _gather_imports(archives, webpages)
 
     # Preliminary sanity check

--- a/src/aiida/cmdline/commands/cmd_calcjob.py
+++ b/src/aiida/cmdline/commands/cmd_calcjob.py
@@ -19,6 +19,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.types import CalculationParamType
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_calculation, load_calculations, load_computers
 
 if t.TYPE_CHECKING:
     from aiida import orm
@@ -31,6 +32,7 @@ def verdi_calcjob():
 
 @verdi_calcjob.command('gotocomputer')
 @arguments.CALCULATION('calcjob', type=CalculationParamType(sub_classes=('aiida.node:process.calculation.calcjob',)))
+@decorators.with_dbenv()
 def calcjob_gotocomputer(calcjob):
     """Open a shell in the remote folder on the calcjob.
 
@@ -38,6 +40,8 @@ def calcjob_gotocomputer(calcjob):
     computer on which the calcjob is being/has been executed.
     """
     from aiida.common.exceptions import NotExistent
+
+    calcjob = load_calculation(calcjob, param_name='calcjob')
 
     try:
         transport = calcjob.get_transport()
@@ -66,6 +70,8 @@ def calcjob_gotocomputer(calcjob):
 def calcjob_res(calcjob, fmt, keys):
     """Print data from the result output Dict node of a calcjob."""
     from aiida.cmdline.utils.echo import echo_dictionary
+
+    calcjob = load_calculation(calcjob, param_name='calcjob')
 
     try:
         results = calcjob.res.get_results()
@@ -97,6 +103,8 @@ def calcjob_inputcat(calcjob, path):
     import errno
     import sys
     from shutil import copyfileobj
+
+    calcjob = load_calculation(calcjob, param_name='calcjob')
 
     # Get path from the given CalcJobNode if not defined by user
     if path is None:
@@ -143,6 +151,8 @@ def calcjob_remotecat(calcjob: orm.CalcJobNode, path: str | None):
     import sys
     import tempfile
 
+    calcjob = load_calculation(calcjob, param_name='calcjob')
+
     remote_folder, path = get_remote_and_path(calcjob, path)
 
     with tempfile.NamedTemporaryFile() as tmp_path:
@@ -168,6 +178,8 @@ def calcjob_outputcat(calcjob, path):
     """
     import errno
     import sys
+
+    calcjob = load_calculation(calcjob, param_name='calcjob')
     from shutil import copyfileobj
 
     try:
@@ -220,6 +232,8 @@ def calcjob_inputls(calcjob, path, color):
     """
     from aiida.cmdline.utils.repository import list_repository_contents
 
+    calcjob = load_calculation(calcjob, param_name='calcjob')
+
     try:
         list_repository_contents(calcjob, path, color)
     except FileNotFoundError:
@@ -240,6 +254,8 @@ def calcjob_outputls(calcjob, path, color):
     Content can only be shown after the daemon has retrieved the remote files.
     """
     from aiida.cmdline.utils.repository import list_repository_contents
+
+    calcjob = load_calculation(calcjob, param_name='calcjob')
 
     try:
         retrieved = calcjob.outputs.retrieved
@@ -267,6 +283,8 @@ def calcjob_cleanworkdir(calcjobs, past_days, older_than, computers, force, exit
     If both are specified, a logical AND is done between the two, i.e. the calcjobs that will be cleaned have been
     modified AFTER [-p option] days from now, but BEFORE [-o option] days from now.
     """
+    calcjobs = load_calculations(calcjobs, param_name='calcjobs')
+    computers = load_computers(computers) if computers else computers
     from aiida.orm.utils.remote import clean_mapping_remote_paths, get_calcjob_remote_paths
 
     if calcjobs:

--- a/src/aiida/cmdline/commands/cmd_code.py
+++ b/src/aiida/cmdline/commands/cmd_code.py
@@ -26,6 +26,7 @@ from aiida.cmdline.params.options.commands import code as options_code
 from aiida.cmdline.utils import echo, echo_tabulate
 from aiida.cmdline.utils.common import validate_output_filename
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_code, load_codes, load_computer, load_entity
 from aiida.common import exceptions
 
 if TYPE_CHECKING:
@@ -90,13 +91,21 @@ def get_on_computer(ctx: click.Context) -> bool:
 
 
 def set_code_builder(ctx: click.Context, _param: Any, value: Any) -> Any:
-    """Set the code spec for defaults of following options."""
+    """Set the code spec for defaults of following options.
+
+    This callback seeds the defaults that the following options prompt with, so unlike a command body it has to
+    resolve the identifier while the command line is still being parsed, and loads the backend itself.
+    """
+    from aiida.cmdline.utils.decorators import load_backend_if_not_loaded
     from aiida.orm.utils.builders.code import CodeBuilder
+
+    load_backend_if_not_loaded()
+    code = load_entity(value, param_name=_param.name)
 
     # TODO(danielhollas): CodeBuilder is deprecated, rewrite this somehow?
     with warnings.catch_warnings(record=True):
-        ctx.code_builder = CodeBuilder.from_code(value)  # type: ignore[attr-defined]
-    return value
+        ctx.code_builder = CodeBuilder.from_code(code)  # type: ignore[attr-defined]
+    return code
 
 
 # Defining the ``COMPUTER`` option first guarantees that the user is prompted for the computer first. This is necessary
@@ -233,6 +242,7 @@ def show(code: Code):
     """Display detailed information for a code."""
     from aiida.cmdline import is_verbose
 
+    code = load_code(code)
     table = []
 
     # These are excluded from the CLI, so we add them manually
@@ -265,6 +275,7 @@ def show(code: Code):
 @with_dbenv()
 def export(code, output_file, overwrite, sort):
     """Export code to a yaml file. If no output file is given, default name is created based on the code label."""
+    code = load_code(code)
     other_args = {'sort': sort}
     fileformat = 'yaml'
 
@@ -309,6 +320,7 @@ def delete(codes, dry_run, force):
     """
     from aiida.tools import delete_nodes
 
+    codes = load_codes(codes)
     node_pks_to_delete = [code.pk for code in codes]
 
     def _dry_run_callback(pks):
@@ -328,7 +340,7 @@ def delete(codes, dry_run, force):
 @with_dbenv()
 def hide(codes):
     """Hide one or more codes from `verdi code list`."""
-    for code in codes:
+    for code in load_codes(codes):
         code.is_hidden = True
         echo.echo_success(f'Code<{code.pk}> {code.full_label} hidden')
 
@@ -338,7 +350,7 @@ def hide(codes):
 @with_dbenv()
 def reveal(codes):
     """Reveal one or more hidden codes in `verdi code list`."""
-    for code in codes:
+    for code in load_codes(codes):
         code.is_hidden = False
         echo.echo_success(f'Code<{code.pk}> {code.full_label} revealed')
 
@@ -349,6 +361,7 @@ def reveal(codes):
 @with_dbenv()
 def relabel(code, label):
     """Relabel a code."""
+    code = load_code(code)
     old_label = code.full_label
 
     try:
@@ -389,6 +402,8 @@ def code_list(computer, default_calc_job_plugin, all_entries, all_users, raw, sh
     """List the available codes."""
     from aiida import orm
     from aiida.orm.utils.node import load_node_class
+
+    computer = load_computer(computer) if computer is not None else None
 
     if show_owner:
         echo.echo_deprecated(

--- a/src/aiida/cmdline/commands/cmd_computer.py
+++ b/src/aiida/cmdline/commands/cmd_computer.py
@@ -24,6 +24,7 @@ from aiida.cmdline.params.options.commands import computer as options_computer
 from aiida.cmdline.utils import echo, echo_tabulate
 from aiida.cmdline.utils.common import validate_output_filename
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_computer, load_entity, load_user
 from aiida.common.exceptions import EntryPointError, ValidationError
 from aiida.plugins.entry_point import get_entry_point_names
 
@@ -265,11 +266,18 @@ def get_parameter_default(parameter, ctx):
 
 
 def set_computer_builder(ctx, param, value):
-    """Set the computer spec for defaults of following options."""
+    """Set the computer spec for defaults of following options.
+
+    This callback seeds the defaults that the following options prompt with, so unlike a command body it has to
+    resolve the identifier while the command line is still being parsed. It therefore loads the backend itself.
+    """
+    from aiida.cmdline.utils.decorators import load_backend_if_not_loaded
     from aiida.orm.utils.builders.computer import ComputerBuilder
 
-    ctx.computer_builder = ComputerBuilder.from_computer(value)
-    return value
+    load_backend_if_not_loaded()
+    computer = load_entity(value, param_name=param.name)
+    ctx.computer_builder = ComputerBuilder.from_computer(computer)
+    return computer
 
 
 @verdi_computer.command('setup')
@@ -386,6 +394,9 @@ def computer_enable(computer, user):
     """Enable the computer for the given user."""
     from aiida.common.exceptions import NotExistent
 
+    computer = load_computer(computer)
+    user = load_user(user)
+
     try:
         authinfo = computer.get_authinfo(user)
     except NotExistent:
@@ -410,6 +421,9 @@ def computer_disable(computer, user):
     Thi can be useful, for example, when a computer is under maintenance.
     """
     from aiida.common.exceptions import NotExistent
+
+    computer = load_computer(computer)
+    user = load_user(user)
 
     try:
         authinfo = computer.get_authinfo(user)
@@ -451,6 +465,7 @@ def computer_list(all_entries, raw):
 
 @verdi_computer.command('goto')
 @arguments.COMPUTER()
+@with_dbenv()
 def computer_goto(computer):
     """Open a shell connecting to the remote computer.
 
@@ -458,6 +473,8 @@ def computer_goto(computer):
     computer specified on the command line.
     """
     from aiida.common.exceptions import NotExistent
+
+    computer = load_computer(computer)
 
     try:
         transport = computer.get_transport()
@@ -477,6 +494,7 @@ def computer_goto(computer):
 @with_dbenv()
 def computer_show(computer):
     """Show detailed information for a computer."""
+    computer = load_computer(computer)
     table = [
         ['Label', computer.label],
         ['PK', computer.pk],
@@ -504,6 +522,7 @@ def computer_relabel(computer, label):
     """Relabel a computer."""
     from aiida.common.exceptions import UniquenessError
 
+    computer = load_computer(computer)
     old_label = computer.label
 
     if old_label == label:
@@ -542,9 +561,13 @@ def computer_test(user, print_traceback, computer):
     from aiida import orm
     from aiida.common.exceptions import NotExistent
 
+    computer = load_computer(computer)
+
     # Set a user automatically if one is not specified in the command line
     if user is None:
         user = orm.User.collection.get_default()
+    else:
+        user = load_user(user)
 
     echo.echo_report(f'Testing computer<{computer.label}> for user<{user.email}>...')
 
@@ -647,6 +670,7 @@ def computer_delete(computer, dry_run):
     from aiida.orm.querybuilder import QueryBuilder
     from aiida.tools import delete_nodes
 
+    computer = load_computer(computer)
     label = computer.label
 
     # Sofar, we can only get this info with QueryBuilder
@@ -716,10 +740,14 @@ def computer_configure():
     help='Email address of the AiiDA user for whom to configure this computer (if different from default user).'
 )
 @arguments.COMPUTER()
+@with_dbenv()
 def computer_config_show(computer, user, defaults, as_option_string):
     """Show the current configuration for a computer."""
     from aiida.common.escaping import escape_for_bash
     from aiida.transports import cli as transport_cli
+
+    computer = load_computer(computer)
+    user = load_user(user) if user is not None else None
 
     transport_cls = computer.get_transport_class()
     option_list = [
@@ -778,6 +806,7 @@ def computer_export_setup(computer, output_file, overwrite, sort):
     """Export computer setup to a YAML file."""
     import yaml
 
+    computer = load_computer(computer)
     computer_setup = {
         'label': computer.label,
         'hostname': computer.hostname,
@@ -825,6 +854,9 @@ def computer_export_setup(computer, output_file, overwrite, sort):
 def computer_export_config(computer, output_file, user, overwrite, sort):
     """Export computer transport configuration for a user to a YAML file."""
     import yaml
+
+    computer = load_computer(computer)
+    user = load_user(user) if user is not None else None
 
     if not computer.is_configured:
         echo.echo_critical(

--- a/src/aiida/cmdline/commands/cmd_data/cmd_array.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_array.py
@@ -10,6 +10,8 @@
 
 from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, options, types
+from aiida.cmdline.utils import decorators
+from aiida.cmdline.utils.loaders import load_data
 
 
 @verdi_data.group('core.array')
@@ -20,11 +22,12 @@ def array():
 @array.command('show')
 @arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:core.array',)))
 @options.DICT_FORMAT()
+@decorators.with_dbenv()
 def array_show(data, fmt):
     """Visualize ArrayData objects."""
     from aiida.cmdline.utils.echo import echo_dictionary
 
-    for node in data:
+    for node in load_data(data):
         the_dict = {}
         for arrayname in node.get_arraynames():
             the_dict[arrayname] = node.get_array(arrayname).tolist()

--- a/src/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -15,7 +15,7 @@ from aiida.cmdline.commands.cmd_data.cmd_export import data_export
 from aiida.cmdline.commands.cmd_data.cmd_list import list_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
-from aiida.cmdline.utils.loaders import load_data, load_datum
+from aiida.cmdline.utils.loaders import load_data, load_datum, load_groups
 from aiida.common.utils import Prettifier
 
 LIST_PROJECT_HEADERS = ['ID', 'Formula', 'Ctime', 'Label']
@@ -60,7 +60,7 @@ def bands_list(elements, elements_exclusive, raw, formula_mode, past_days, group
     args.past_days = past_days
     args.group_name = None
     if groups is not None:
-        args.group_pk = [group.pk for group in groups]
+        args.group_pk = [group.pk for group in load_groups(groups)]
     else:
         args.group_pk = None
     args.all_users = all_users

--- a/src/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -15,6 +15,7 @@ from aiida.cmdline.commands.cmd_data.cmd_export import data_export
 from aiida.cmdline.commands.cmd_data.cmd_list import list_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_data, load_datum
 from aiida.common.utils import Prettifier
 
 LIST_PROJECT_HEADERS = ['ID', 'Formula', 'Ctime', 'Label']
@@ -91,6 +92,8 @@ def bands_list(elements, elements_exclusive, raw, formula_mode, past_days, group
 @decorators.with_dbenv()
 def bands_show(data, fmt):
     """Visualize BandsData objects."""
+    data = load_data(data)
+
     try:
         show_function = getattr(cmd_show, f'_show_{fmt}')
     except AttributeError:
@@ -133,6 +136,7 @@ def bands_show(data, fmt):
 @decorators.with_dbenv()
 def bands_export(fmt, y_min_lim, y_max_lim, output, force, prettify_format, datum):
     """Export BandsData objects."""
+    datum = load_datum(datum)
     args = {}
     if y_min_lim is not None:
         args['y_min_lim'] = y_min_lim

--- a/src/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -15,6 +15,7 @@ from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_optio
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_data, load_datum
 
 LIST_PROJECT_HEADERS = ['Id', 'Formulae', 'Source.URI']
 EXPORT_FORMATS = ['cif']
@@ -75,6 +76,8 @@ def cif_list(raw, formula_mode, past_days, groups, all_users):
 @decorators.with_dbenv()
 def cif_show(data, fmt):
     """Visualize CifData objects."""
+    data = load_data(data)
+
     try:
         show_function = getattr(cmd_show, f'_show_{fmt}')
     except AttributeError:
@@ -88,7 +91,7 @@ def cif_show(data, fmt):
 @decorators.with_dbenv()
 def cif_content(data):
     """Show the content of the CIF file."""
-    for node in data:
+    for node in load_data(data):
         try:
             echo.echo(node.get_content())
         except OSError as exception:
@@ -102,7 +105,7 @@ def cif_content(data):
 @decorators.with_dbenv()
 def cif_export(**kwargs):
     """Export CifData object."""
-    node = kwargs.pop('datum')
+    node = load_datum(kwargs.pop('datum'))
     output = kwargs.pop('output')
     fmt = kwargs.pop('fmt')
     force = kwargs.pop('force')

--- a/src/aiida/cmdline/commands/cmd_data/cmd_dict.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_dict.py
@@ -10,6 +10,8 @@
 
 from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, options, types
+from aiida.cmdline.utils import decorators
+from aiida.cmdline.utils.loaders import load_data
 
 
 @verdi_data.group('core.dict')
@@ -20,9 +22,10 @@ def dictionary():
 @dictionary.command('show')
 @arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:core.dict',)))
 @options.DICT_FORMAT()
+@decorators.with_dbenv()
 def dictionary_show(data, fmt):
     """Show contents of Dict nodes."""
     from aiida.cmdline.utils.echo import echo_dictionary
 
-    for node in data:
+    for node in load_data(data):
         echo_dictionary(node.get_dict(), fmt)

--- a/src/aiida/cmdline/commands/cmd_data/cmd_list.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_list.py
@@ -9,6 +9,7 @@
 """This module provides list functionality to all data types."""
 
 from aiida.cmdline.params import options
+from aiida.cmdline.utils.loaders import load_groups
 
 LIST_OPTIONS = [
     options.GROUPS,
@@ -95,5 +96,5 @@ def data_list(datatype, columns, elements, elements_only, formula_mode, past_day
     project = [columns_dict[k] for k in columns]
     group_pks = None
     if groups is not None:
-        group_pks = [g.pk for g in groups]
+        group_pks = [g.pk for g in load_groups(groups)]
     return query(datatype, project, past_days, group_pks, all_users)

--- a/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -16,6 +16,8 @@ import click
 from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, types
 from aiida.cmdline.utils import echo
+from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_datum, load_node
 
 
 @verdi_data.group('core.remote')
@@ -34,9 +36,12 @@ def remote():
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:core.remote',)))
 @click.option('-l', '--long', 'ls_long', is_flag=True, default=False, help='Display also file metadata.')
 @click.option('-p', '--path', type=click.STRING, default='.', help='The folder to list.')
+@with_dbenv()
 def remote_ls(ls_long, path, datum):
     """List content of a (sub)directory in a RemoteData object."""
     import datetime
+
+    datum = load_datum(datum)
 
     try:
         content = datum.listdir_withattributes(path=path)
@@ -60,11 +65,14 @@ def remote_ls(ls_long, path, datum):
 @remote.command('cat')
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:core.remote',)))
 @click.argument('path', type=click.STRING)
+@with_dbenv()
 def remote_cat(datum, path):
     """Show content of a file in a RemoteData object."""
     import os
     import sys
     import tempfile
+
+    datum = load_datum(datum)
 
     try:
         with tempfile.NamedTemporaryFile(delete=False) as tmpf:
@@ -84,8 +92,10 @@ def remote_cat(datum, path):
 
 @remote.command('show')
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:core.remote',)))
+@with_dbenv()
 def remote_show(datum):
     """Show information for a RemoteData object."""
+    datum = load_datum(datum)
     echo.echo(f'- Remote computer name: {datum.computer.label}')
     echo.echo(f'- Remote folder full path: {datum.get_remote_path()}')
 
@@ -115,8 +125,11 @@ def remote_show(datum):
     default=False,
     help='Return the size in bytes or human-readable format?',
 )
+@with_dbenv()
 def remote_size(node, method, path, return_bytes):
     """Obtain the total size of a file or directory at a given path that is stored via a ``RemoteData`` object."""
+    node = load_node(node)
+
     try:
         # `method` might change, if `du` fails, so assigning to new variable here
         total_size, used_method = node.get_size_on_disk(relpath=path, method=method, return_bytes=return_bytes)

--- a/src/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_singlefile.py
@@ -11,6 +11,7 @@
 from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_datum
 
 
 @verdi_data.group('core.singlefile')
@@ -23,6 +24,8 @@ def singlefile():
 @decorators.with_dbenv()
 def singlefile_content(datum):
     """Show the content of the file."""
+    datum = load_datum(datum)
+
     try:
         echo.echo(datum.get_content())
     except OSError as exception:

--- a/src/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -15,6 +15,7 @@ from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_optio
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_data, load_datum, load_group
 from aiida.cmdline.utils.pluginable import Pluginable
 
 LIST_PROJECT_HEADERS = ['Id', 'Label', 'Formula']
@@ -127,6 +128,8 @@ def structure_list(elements, raw, formula_mode, past_days, groups, all_users):
 @decorators.with_dbenv()
 def structure_show(data, fmt):
     """Visualize StructureData objects."""
+    data = load_data(data)
+
     try:
         show_function = getattr(cmd_show, f'_show_{fmt}')
     except AttributeError:
@@ -145,7 +148,7 @@ def structure_show(data, fmt):
 @decorators.with_dbenv()
 def structure_export(**kwargs):
     """Export StructureData object to file."""
-    node = kwargs.pop('datum')
+    node = load_datum(kwargs.pop('datum'))
     output = kwargs.pop('output')
     fmt = kwargs.pop('fmt')
     force = kwargs.pop('force')
@@ -218,7 +221,7 @@ def import_aiida_xyz(filename, vacuum_factor, vacuum_addition, pbc, label, group
     _store_structure(new_structure, dry_run)
 
     if group:
-        group.add_nodes(new_structure)
+        load_group(group).add_nodes(new_structure)
 
 
 @structure_import.command('ase')
@@ -248,4 +251,4 @@ def import_ase(filename, label, group, dry_run):
     _store_structure(new_structure, dry_run)
 
     if group:
-        group.add_nodes(new_structure)
+        load_group(group).add_nodes(new_structure)

--- a/src/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -15,6 +15,7 @@ from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_optio
 from aiida.cmdline.commands.cmd_data.cmd_list import data_list, list_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_data, load_datum
 
 LIST_PROJECT_HEADERS = ['Id', 'Label']
 EXPORT_FORMATS = ['cif', 'xsf']
@@ -90,6 +91,8 @@ def trajectory_list(raw, past_days, groups, all_users):
 @decorators.with_dbenv()
 def trajectory_show(data, fmt, **kwargs):
     """Visualize a trajectory."""
+    data = load_data(data)
+
     try:
         show_function = getattr(cmd_show, f'_show_{fmt}')
     except AttributeError:
@@ -106,7 +109,7 @@ def trajectory_show(data, fmt, **kwargs):
 @decorators.with_dbenv()
 def trajectory_export(**kwargs):
     """Export trajectory to file."""
-    node = kwargs.pop('datum')
+    node = load_datum(kwargs.pop('datum'))
     output = kwargs.pop('output')
     fmt = kwargs.pop('fmt')
     force = kwargs.pop('force')

--- a/src/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/src/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -16,6 +16,7 @@ from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.commands.cmd_data.cmd_export import data_export, export_options
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_datum, load_group
 
 
 @verdi_data.group('core.upf')
@@ -107,6 +108,8 @@ def upf_exportfamily(folder, group):
     """Export a pseudopotential family into a folder.
     Call without parameters to get some help.
     """
+    group = load_group(group)
+
     if group.is_empty:
         echo.echo_critical(f'Group<{group.label}> contains no pseudos')
 
@@ -146,7 +149,7 @@ def upf_import(filename):
 @decorators.with_dbenv()
 def upf_export(**kwargs):
     """Export `UpfData` object to file."""
-    node = kwargs.pop('datum')
+    node = load_datum(kwargs.pop('datum'))
     output = kwargs.pop('output')
     fmt = kwargs.pop('fmt')
     force = kwargs.pop('force')

--- a/src/aiida/cmdline/commands/cmd_devel.py
+++ b/src/aiida/cmdline/commands/cmd_devel.py
@@ -15,7 +15,7 @@ import click
 from aiida import get_profile
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options, types
-from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils import decorators, echo, loaders
 from aiida.common import exceptions
 
 
@@ -162,7 +162,9 @@ def devel_launch_arithmetic_add(code, daemon, sleep):
 
     default_calc_job_plugin = 'core.arithmetic.add'
 
-    if not code:
+    if code:
+        code = loaders.load_code(code)
+    else:
         try:
             code = load_code('bash@localhost')
         except exceptions.NotExistent:
@@ -214,7 +216,9 @@ def devel_launch_multiply_add(code, daemon):
 
     default_calc_job_plugin = 'core.arithmetic.add'
 
-    if not code:
+    if code:
+        code = loaders.load_code(code)
+    else:
         try:
             code = load_code('bash@localhost')
         except exceptions.NotExistent:

--- a/src/aiida/cmdline/commands/cmd_group.py
+++ b/src/aiida/cmdline/commands/cmd_group.py
@@ -16,6 +16,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_group, load_groups, load_node, load_nodes, load_user
 from aiida.common.exceptions import UniquenessError
 from aiida.common.links import GraphTraversalRules
 
@@ -32,6 +33,9 @@ def verdi_group():
 @with_dbenv()
 def group_add_nodes(group, force, nodes):
     """Add nodes to a group."""
+    group = load_group(group)
+    nodes = load_nodes(nodes)
+
     if not force:
         click.confirm(f'Do you really want to add {len(nodes)} nodes to {group}?', abort=True)
 
@@ -47,6 +51,9 @@ def group_add_nodes(group, force, nodes):
 def group_remove_nodes(group, nodes, clear, force):
     """Remove nodes from a group."""
     from aiida.orm import Group, Node, QueryBuilder
+
+    group = load_group(group)
+    nodes = load_nodes(nodes)
 
     if nodes and clear:
         echo.echo_critical(
@@ -97,6 +104,10 @@ def group_remove_nodes(group, nodes, clear, force):
 def group_move_nodes(source_group, target_group, force, nodes, all_entries):
     """Move the specified NODES from one group to another."""
     from aiida.orm import Group, Node, QueryBuilder
+
+    source_group = load_group(source_group, param_name='source_group')
+    target_group = load_group(target_group, param_name='target_group')
+    nodes = load_nodes(nodes)
 
     if source_group.pk == target_group.pk:
         echo.echo_critical(f'Source and target group are the same: {source_group}.')
@@ -201,6 +212,10 @@ def group_delete(
 
     from aiida import orm
     from aiida.tools import delete_group_nodes
+
+    groups = load_groups(groups)
+    user = load_user(user) if user is not None else None
+    node = load_node(node) if node is not None else None
 
     filters_provided = any(
         [all_users or user or past_days or startswith or endswith or contains or node or type_string]
@@ -323,6 +338,8 @@ def group_delete(
 @with_dbenv()
 def group_relabel(group, label):
     """Change the label of a group."""
+    group = load_group(group)
+
     try:
         group.label = label
     except UniquenessError as exception:
@@ -340,6 +357,8 @@ def group_description(group, description):
 
     If no description is defined, the current description will simply be echoed.
     """
+    group = load_group(group)
+
     if description:
         group.description = description
         echo.echo_success(f'Changed the description of {group}.')
@@ -365,6 +384,8 @@ def group_show(group, raw, limit, uuid):
 
     from aiida.common import timezone
     from aiida.common.utils import str_timedelta
+
+    group = load_group(group)
 
     if limit:
         node_iterator = group.nodes[:limit]
@@ -456,6 +477,9 @@ def group_list(
 ):
     """Show a list of existing groups."""
     import datetime
+
+    user = load_user(user) if user is not None else None
+    node = load_node(node) if node is not None else None
 
     from tabulate import tabulate
 
@@ -566,6 +590,7 @@ def group_copy(source_group, destination_group):
     """
     from aiida import orm
 
+    source_group = load_group(source_group, param_name='source_group')
     dest_group, created = orm.Group.collection.get_or_create(label=destination_group)
 
     # Issue warning if destination group is not empty and get user confirmation to continue
@@ -686,6 +711,8 @@ def group_dump(
 
     import traceback
     from pathlib import Path
+
+    group = load_group(group)
 
     from aiida.cmdline.utils import echo
     from aiida.tools._dumping.utils import DumpPaths

--- a/src/aiida/cmdline/commands/cmd_node.py
+++ b/src/aiida/cmdline/commands/cmd_node.py
@@ -22,6 +22,7 @@ from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.params.types.plugin import PluginParamType
 from aiida.cmdline.utils import decorators, echo, echo_tabulate, multi_line_input
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_node, load_nodes, load_user
 from aiida.common import exceptions, timezone
 from aiida.common.links import GraphTraversalRules
 
@@ -94,6 +95,8 @@ def repo_cat(node, relative_path):
 
     from aiida.orm import SinglefileData
 
+    node = load_node(node)
+
     if not relative_path:
         if not isinstance(node, SinglefileData):
             raise click.BadArgumentUsage("Missing argument 'RELATIVE_PATH'.")
@@ -119,6 +122,8 @@ def repo_ls(node, relative_path, color):
     """List files in the node repository folder."""
     from aiida.cmdline.utils.repository import list_repository_contents
 
+    node = load_node(node)
+
     try:
         list_repository_contents(node, relative_path, color)
     except FileNotFoundError:
@@ -143,6 +148,7 @@ def repo_dump(node, output_directory):
 
     from aiida.repository import FileType
 
+    node = load_node(node)
     output_directory = pathlib.Path(output_directory)
 
     try:
@@ -183,6 +189,7 @@ def repo_dump(node, output_directory):
 @with_dbenv()
 def node_label(nodes, label, raw, force):
     """View or set the label of one or more nodes."""
+    nodes = load_nodes(nodes)
     table = []
 
     if label is None:
@@ -216,6 +223,7 @@ def node_label(nodes, label, raw, force):
 @with_dbenv()
 def node_description(nodes, description, force, raw):
     """View or set the description of one or more nodes."""
+    nodes = load_nodes(nodes)
     table = []
 
     if description is None:
@@ -248,6 +256,8 @@ def node_description(nodes, description, force, raw):
 def node_show(nodes, print_groups):
     """Show generic information on one or more nodes."""
     from aiida.cmdline.utils.common import get_node_info
+
+    nodes = load_nodes(nodes)
 
     for node in nodes:
         # TODO: Add a check here on the node type, otherwise it might try to access
@@ -315,7 +325,7 @@ def echo_node_dict(nodes: list[Node], keys: list, fmt: str, identifier: str, raw
 @with_dbenv()
 def attributes(nodes, keys, fmt, identifier, raw):
     """Show the attributes of one or more nodes."""
-    echo_node_dict(nodes, keys, fmt, identifier, raw)
+    echo_node_dict(load_nodes(nodes), keys, fmt, identifier, raw)
 
 
 @verdi_node.command('extras')
@@ -327,7 +337,7 @@ def attributes(nodes, keys, fmt, identifier, raw):
 @with_dbenv()
 def extras(nodes, keys, fmt, identifier, raw):
     """Show the extras of one or more nodes."""
-    echo_node_dict(nodes, keys, fmt, identifier, raw, use_attrs=False)
+    echo_node_dict(load_nodes(nodes), keys, fmt, identifier, raw, use_attrs=False)
 
 
 def _warn_about_stash_nodes(pks_to_delete: set[int]) -> None:
@@ -482,6 +492,8 @@ def rehash(nodes, entry_point, force):
     """
     from aiida.orm import Data, ProcessNode, QueryBuilder
 
+    nodes = load_nodes(nodes)
+
     # If no explicit entry point is defined, rehash all nodes, which are either Data nodes or ProcessNodes
     if entry_point is None:
         classes: tuple = (Data, ProcessNode)
@@ -606,6 +618,8 @@ def graph_generate(
     if not root_nodes:
         echo.echo_critical('No root node(s) specified.')
 
+    root_nodes = load_nodes(root_nodes, param_name='root_nodes')
+
     if not output_file:
         pks = '.'.join(str(n.pk) for n in root_nodes)
         output_file = pathlib.Path(f'{pks}.{engine}.{output_format}')
@@ -650,6 +664,8 @@ def verdi_comment():
 @decorators.with_dbenv()
 def comment_add(nodes, content):
     """Add a comment to one or more nodes."""
+    nodes = load_nodes(nodes)
+
     if not content:
         content = multi_line_input.edit_comment()
 
@@ -686,7 +702,9 @@ def comment_update(comment_id, content):
 @decorators.with_dbenv()
 def comment_show(user, nodes):
     """Show the comments of one or multiple nodes."""
-    for node in nodes:
+    user = load_user(user) if user is not None else None
+
+    for node in load_nodes(nodes):
         msg = f'* Comments for Node<{node.pk}>'
         echo.echo('*' * len(msg))
         echo.echo(msg)

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -497,10 +497,6 @@ def process_watch(broker, processes, most_recent_node):
     except (SystemExit, KeyboardInterrupt):
         echo.echo('')  # add a new line after the interrupt character
         echo.echo_report('received interrupt, exiting...')
-        try:
-            communicator.close()
-        except RuntimeError:
-            pass
 
         # Reraise to trigger clicks builtin abort sequence
         raise

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -15,6 +15,7 @@ from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.params.options.overridable import OverridableOption
 from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_group, load_process, load_processes
 from aiida.common.log import LOG_LEVELS, capture_logging
 
 REPAIR_INSTRUCTIONS = """\
@@ -122,7 +123,7 @@ def process_list(
     relationships = {}
 
     if group:
-        relationships['with_node'] = group
+        relationships['with_node'] = load_group(group)
 
     builder = CalculationQueryBuilder()
     filters = builder.get_filters(all_entries, process_state, process_label, paused, exit_status, failed)
@@ -203,6 +204,8 @@ def process_show(processes, most_recent_node):
     Show details for one or multiple processes."""
     from aiida.cmdline.utils.common import get_node_info
 
+    processes = load_processes(processes)
+
     if not processes and not most_recent_node:
         raise click.UsageError(
             'Please specify one or multiple processes by their identifier (PK, UUID or label) or use an option.'
@@ -228,6 +231,8 @@ def process_call_root(processes):
     """Show root process of processes.
 
     Show root process(es) of the call stack for one or multiple processes."""
+    processes = load_processes(processes)
+
     if not processes:
         raise click.UsageError('Please specify one or multiple processes by their identifier (PK, UUID or label).')
     for process in processes:
@@ -270,6 +275,8 @@ def process_report(processes, most_recent_node, levelname, indent_size, max_dept
     from aiida.cmdline.utils.common import get_calcjob_report, get_process_function_report, get_workchain_report
     from aiida.orm import CalcFunctionNode, CalcJobNode, WorkChainNode, WorkFunctionNode
 
+    processes = load_processes(processes)
+
     if not processes and not most_recent_node:
         raise click.UsageError(
             'Please specify one or multiple processes by their identifier (PK, UUID or label) or use an option.'
@@ -308,6 +315,8 @@ def process_status(call_link_label, most_recent_node, max_depth, processes):
     Show the status of one or multiple processes."""
     from aiida.cmdline.utils.ascii_vis import format_call_graph
 
+    processes = load_processes(processes)
+
     if not processes and not most_recent_node:
         raise click.UsageError(
             'Please specify one or multiple processes by their identifier (PK, UUID or label) or use an option.'
@@ -345,6 +354,8 @@ def process_kill(processes, all_entries, timeout, force):
 
     Kill one or multiple running processes."""
     from aiida.engine.processes import control
+
+    processes = load_processes(processes)
 
     if not processes and not all_entries:
         raise click.UsageError(
@@ -389,6 +400,8 @@ def process_pause(processes, all_entries, timeout):
     Pause one or multiple running processes."""
     from aiida.engine.processes import control
 
+    processes = load_processes(processes)
+
     if not processes and not all_entries:
         raise click.UsageError(
             'Please specify one or multiple processes by their identifier (PK, UUID or label) or use an option.'
@@ -422,6 +435,8 @@ def process_play(processes, all_entries, timeout):
 
     Play (unpause) one or multiple paused processes."""
     from aiida.engine.processes import control
+
+    processes = load_processes(processes)
 
     if not processes and not all_entries:
         raise click.UsageError(
@@ -482,6 +497,8 @@ def process_watch(broker, processes, most_recent_node):
 
     if most_recent_node:
         processes = [get_most_recent_node()]
+    else:
+        processes = load_processes(processes)
 
     for process in processes:
         if process.is_terminated:
@@ -668,6 +685,8 @@ def process_dump(
     """
     import traceback
     from pathlib import Path
+
+    process = load_process(process)
 
     from aiida.cmdline.utils import echo
     from aiida.tools._dumping.utils import DumpPaths

--- a/src/aiida/cmdline/commands/cmd_profile.py
+++ b/src/aiida/cmdline/commands/cmd_profile.py
@@ -19,6 +19,7 @@ from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.commands import setup
 from aiida.cmdline.utils import defaults, echo
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.loaders import load_codes, load_computers, load_groups, load_user
 from aiida.common import exceptions
 from aiida.manage.configuration import Profile, create_profile, get_config
 
@@ -516,6 +517,11 @@ def profile_dump(
 
     import traceback
     from pathlib import Path
+
+    codes = load_codes(codes) if codes else codes
+    computers = load_computers(computers) if computers else computers
+    groups = load_groups(groups) if groups else groups
+    user = load_user(user) if user is not None else None
 
     from aiida.cmdline.utils import echo
     from aiida.tools._dumping.utils import DumpPaths

--- a/src/aiida/cmdline/commands/cmd_rabbitmq.py
+++ b/src/aiida/cmdline/commands/cmd_rabbitmq.py
@@ -20,6 +20,7 @@ import wrapt
 from aiida.cmdline.commands.cmd_devel import verdi_devel
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import decorators, echo, echo_tabulate
+from aiida.cmdline.utils.loaders import load_processes
 
 if t.TYPE_CHECKING:
     import requests
@@ -264,6 +265,8 @@ def cmd_tasks_revive(processes, force):
     multiple instances of the task being executed and should thus be used with caution.
     """
     from aiida.engine.processes.control import revive_processes
+
+    processes = load_processes(processes)
 
     if not force:
         echo.echo_warning('This command should only be used if you are absolutely sure the process task was lost.')

--- a/src/aiida/cmdline/commands/cmd_user.py
+++ b/src/aiida/cmdline/commands/cmd_user.py
@@ -14,6 +14,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.params.options.commands import setup as options_setup
 from aiida.cmdline.utils import decorators, echo
+from aiida.cmdline.utils.loaders import load_user, resolve_callback
 
 
 @verdi.group('user')
@@ -53,6 +54,8 @@ def user_list():
     help='Email address that serves as the user name and a way to identify data created by it.',
     type=types.UserParamType(create=True),
     cls=options.interactive.InteractiveOption,
+    # The contextual defaults below read attributes off the user, so it has to be resolved while parsing.
+    callback=resolve_callback,
 )
 @options_setup.SETUP_USER_FIRST_NAME(contextual_default=lambda ctx: ctx.params['user'].first_name)
 @options_setup.SETUP_USER_LAST_NAME(contextual_default=lambda ctx: ctx.params['user'].last_name)
@@ -91,6 +94,8 @@ def user_configure(ctx, user, first_name, last_name, institution, set_default):
 def user_set_default(ctx, user):
     """Set a user as the default user for the profile."""
     from aiida.manage import get_manager
+
+    user = load_user(user) if isinstance(user, str) else user
 
     get_manager().set_default_user_email(ctx.obj.profile, user.email)
     echo.echo_success(f'Set `{user.email}` as the default user for profile `{ctx.obj.profile.name}.`')

--- a/src/aiida/cmdline/params/options/commands/code.py
+++ b/src/aiida/cmdline/params/options/commands/code.py
@@ -13,6 +13,7 @@ import click
 from aiida.cmdline.params import options, types
 from aiida.cmdline.params.options.interactive import InteractiveOption, TemplateInteractiveOption
 from aiida.cmdline.params.options.overridable import OverridableOption
+from aiida.cmdline.utils.loaders import resolve_callback
 
 
 def is_on_computer(ctx: click.Context) -> bool:
@@ -144,6 +145,8 @@ COMPUTER = options.COMPUTER.clone(
     cls=InteractiveOption,
     required_fn=is_on_computer,
     prompt_fn=is_on_computer,
+    # ``validate_label_uniqueness`` reads the computer while parsing, so it has to be resolved by then.
+    callback=resolve_callback,
     help='Name of the computer, on which the code is installed.',
 )
 

--- a/src/aiida/cmdline/params/types/code.py
+++ b/src/aiida/cmdline/params/types/code.py
@@ -58,8 +58,8 @@ class CodeParamType(IdentifierParamType):
         """
         return [CompletionItem(option) for (option,) in self.orm_class_loader.get_options(incomplete, project='label')]  # type: ignore[no-untyped-call]
 
-    def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None) -> t.Any:
-        code = super().convert(value, param, ctx)
+    def resolve(self, identifier: str) -> t.Any:
+        code = super().resolve(identifier)
 
         if code and self._entry_point is not None:
             entry_point = code.default_calc_job_plugin

--- a/src/aiida/cmdline/params/types/group.py
+++ b/src/aiida/cmdline/params/types/group.py
@@ -79,16 +79,17 @@ class GroupParamType(IdentifierParamType):
             for (option,) in self.orm_class_loader.get_options(incomplete, project='label')  # type: ignore[no-untyped-call]
         ]
 
-    @decorators.with_dbenv()
-    def convert(self, value: t.Any, param: click.Parameter, ctx: click.Context) -> t.Any:
+    def resolve(self, identifier: str) -> t.Any:
+        from aiida.common import exceptions
+
         try:
-            group = super().convert(value, param, ctx)
-        except click.BadParameter:
-            if self._create_if_not_exist:
-                # The particular subclass to load will be stored in `_sub_classes` as loaded by `convert` of the super.
-                cls = self._sub_classes[0]  # type: ignore[index]
-                group = cls(label=value).store()
-            else:
+            group = super().resolve(identifier)
+        except (exceptions.NotExistent, exceptions.MultipleObjectsError, ValueError):
+            if not self._create_if_not_exist:
                 raise
+
+            # ``sub_classes`` declares the particular subclass to create.
+            cls = self.sub_classes[0]  # type: ignore[index]
+            group = cls(label=identifier).store()
 
         return group

--- a/src/aiida/cmdline/params/types/identifier.py
+++ b/src/aiida/cmdline/params/types/identifier.py
@@ -16,7 +16,6 @@ from functools import cached_property
 
 import click
 
-from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.plugins.entry_point import get_entry_point_from_string
 
 if t.TYPE_CHECKING:
@@ -76,7 +75,6 @@ class IdentifierParamType(click.ParamType, ABC):
 
     @property
     @abstractmethod
-    @with_dbenv()
     def orm_class_loader(self) -> OrmEntityLoader:
         """Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
         to be used to load the entity for a given identifier
@@ -84,32 +82,18 @@ class IdentifierParamType(click.ParamType, ABC):
         :return: the orm entity loader class for this ParamType
         """
 
-    @with_dbenv()
-    def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context) -> t.Any:
-        """Attempt to convert the given value to an instance of the orm class using the orm class loader.
+    @property
+    def sub_classes(self) -> tuple[t.Any, ...] | None:
+        """Return the orm classes that an identifier for this parameter is allowed to map onto.
 
-        :return: the loaded orm entity
-        :raises click.BadParameter: if the value is ambiguous and leads to multiple entities
-        :raises click.BadParameter: if the value cannot be mapped onto any existing instance
-        :raises RuntimeError: if the defined orm class loader is not a subclass of the OrmEntityLoader class
+        The entry points given to the constructor are resolved on first access. Resolving them only imports the classes
+        they point to, so this does not require a storage backend.
+
+        :return: the allowed sub classes, or ``None`` if the parameter does not restrict them.
+        :raises RuntimeError: if an entry point cannot be loaded or does not point to a valid sub class.
         """
-        from aiida.common import exceptions
-        from aiida.orm.utils.loaders import OrmEntityLoader
-
-        value = super().convert(value, param, ctx)
-
-        if not value:
-            raise click.BadParameter('the value for the identifier cannot be empty')
-
-        loader = self.orm_class_loader
-
-        if not issubclass(loader, OrmEntityLoader):
-            raise RuntimeError('the orm class loader should be a subclass of OrmEntityLoader')
-
-        # If entry points were in the constructor, we load their corresponding classes, validate that they are valid
-        # sub classes of the orm class loader and then pass it as the sub_class parameter to the load_entity call.
-        # We store the loaded entry points in an instance variable, such that the loading only has to be done once.
-        if self._entry_points and self._sub_classes is None:
+        if self._sub_classes is None and self._entry_points:
+            loader = self.orm_class_loader
             sub_classes = []
 
             for entry_point in self._entry_points:
@@ -128,9 +112,40 @@ class IdentifierParamType(click.ParamType, ABC):
 
             self._sub_classes = tuple(sub_classes)
 
-        try:
-            entity = loader.load_entity(value, sub_classes=self._sub_classes)
-        except (exceptions.MultipleObjectsError, exceptions.NotExistent, ValueError) as exception:
-            raise click.BadParameter(str(exception))
+        return self._sub_classes
 
-        return entity
+    def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None) -> str:
+        """Validate the identifier and return it unchanged.
+
+        Resolving the identifier into an orm entity requires a storage backend, which parsing a command line must not
+        need. Commands therefore resolve the identifier in their body through
+        :mod:`aiida.cmdline.utils.loaders`, which calls :meth:`resolve`.
+
+        :return: the identifier
+        :raises click.BadParameter: if the value is empty
+        """
+        value = super().convert(value, param, ctx)
+
+        if not value:
+            raise click.BadParameter('the value for the identifier cannot be empty', ctx=ctx, param=param)
+
+        return t.cast(str, value)
+
+    def resolve(self, identifier: str) -> t.Any:
+        """Return the orm entity that the identifier maps onto.
+
+        Requires a loaded storage backend. Subclasses override this to apply checks that need the loaded entity.
+
+        :param identifier: PK, UUID or label of the entity.
+        :raises aiida.common.NotExistent: if the identifier maps onto no entity.
+        :raises aiida.common.MultipleObjectsError: if the identifier is ambiguous.
+        :raises RuntimeError: if the defined orm class loader is not a subclass of the OrmEntityLoader class.
+        """
+        from aiida.orm.utils.loaders import OrmEntityLoader
+
+        loader = self.orm_class_loader
+
+        if not issubclass(loader, OrmEntityLoader):
+            raise RuntimeError('the orm class loader should be a subclass of OrmEntityLoader')
+
+        return loader.load_entity(identifier, sub_classes=self.sub_classes)

--- a/src/aiida/cmdline/params/types/multiple.py
+++ b/src/aiida/cmdline/params/types/multiple.py
@@ -34,6 +34,11 @@ class MultipleValueParamType(click.ParamType):
         else:
             self.name = ''
 
+    @property
+    def param_type(self) -> click.ParamType:
+        """Return the parameter type that each of the values is parsed with."""
+        return self._param_type
+
     @shim_add_ctx
     def get_metavar(self, param: click.Parameter, ctx: click.Context | None) -> str | None:
         try:

--- a/src/aiida/cmdline/params/types/user.py
+++ b/src/aiida/cmdline/params/types/user.py
@@ -32,20 +32,34 @@ class UserParamType(click.ParamType):
         """:param create: If the user does not exist, create a new instance (unstored)."""
         self._create = create
 
-    @with_dbenv()
-    def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None) -> orm.User:
-        from aiida import orm
+    def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None) -> str:
+        """Validate the email and return it unchanged.
 
-        results = orm.User.collection.find({'email': value})
+        Looking the user up requires a storage backend, which parsing a command line must not need. Commands resolve
+        the email in their body through :mod:`aiida.cmdline.utils.loaders`, which calls :meth:`resolve`.
+        """
+        return t.cast(str, super().convert(value, param, ctx))
+
+    def resolve(self, identifier: str) -> orm.User:
+        """Return the user with the given email address.
+
+        :param identifier: email address of the user.
+        :raises aiida.common.NotExistent: if no user has this email and the parameter does not create one.
+        :raises aiida.common.MultipleObjectsError: if more than one user has this email.
+        """
+        from aiida import orm
+        from aiida.common import exceptions
+
+        results = orm.User.collection.find({'email': identifier})
 
         if not results:
             if self._create:
-                return orm.User(email=value)
+                return orm.User(email=identifier)
 
-            self.fail(f"User '{value}' not found", param, ctx)
+            raise exceptions.NotExistent(f"User '{identifier}' not found")
 
         if len(results) > 1:
-            self.fail(f"Multiple users found with email '{value}': {results}")
+            raise exceptions.MultipleObjectsError(f"Multiple users found with email '{identifier}': {results}")
 
         return results[0]
 

--- a/src/aiida/cmdline/utils/decorators.py
+++ b/src/aiida/cmdline/utils/decorators.py
@@ -21,7 +21,7 @@ Provides:
 from __future__ import annotations
 
 import typing as t
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 from click_spinner import spinner
 from wrapt import decorator
@@ -46,13 +46,17 @@ def with_manager(wrapped, _, args, kwargs):
 def with_broker(wrapped, _, args, kwargs):
     """Decorate a function injecting a :class:`aiida.brokers.broker.Broker` instance.
 
-    If the currently loaded profile does not define a broker, the command is aborted.
+    The broker is reset after the Click context closes. If the currently loaded profile does not define a broker, the
+    command is aborted.
     """
+    import click
+
     from aiida.common.docs import URL_NO_BROKER
     from aiida.manage import get_manager
 
-    broker = get_manager().get_broker()
-    profile = get_manager().get_profile()
+    manager = get_manager()
+    broker = manager.get_broker()
+    profile = manager.get_profile()
     assert profile is not None
 
     if broker is None:
@@ -62,7 +66,21 @@ def with_broker(wrapped, _, args, kwargs):
         )
 
     kwargs['broker'] = broker
-    return wrapped(*args, **kwargs)
+    context = click.get_current_context(silent=True)
+
+    def reset_broker() -> None:
+        """Reset the broker, ignoring communicators already closed by the command or an interrupt handler."""
+        with suppress(RuntimeError):
+            manager.reset_broker()
+
+    if context is not None:
+        context.call_on_close(reset_broker)
+
+    try:
+        return wrapped(*args, **kwargs)
+    finally:
+        if context is None:
+            reset_broker()
 
 
 def load_backend_if_not_loaded():
@@ -97,14 +115,28 @@ def with_dbenv() -> t.Callable:
     @decorator
     def wrapper(wrapped, _, args, kwargs):
         """The wrapped function that should be called after having loaded the backend."""
+        import click
+
         from aiida.common.exceptions import ConfigurationError, IntegrityError, LockedProfileError
+        from aiida.manage import get_manager
+
+        manager = get_manager()
+        storage_was_loaded = manager.profile_storage_loaded
+        context = click.get_current_context(silent=True)
+
+        if not storage_was_loaded and context is not None:
+            context.call_on_close(manager.reset_profile_storage)
 
         try:
-            load_backend_if_not_loaded()
-        except (IntegrityError, ConfigurationError, LockedProfileError) as exception:
-            echo.echo_critical(str(exception))
+            try:
+                load_backend_if_not_loaded()
+            except (IntegrityError, ConfigurationError, LockedProfileError) as exception:
+                echo.echo_critical(str(exception))
 
-        return wrapped(*args, **kwargs)
+            return wrapped(*args, **kwargs)
+        finally:
+            if not storage_was_loaded and context is None:
+                manager.reset_profile_storage()
 
     return wrapper
 

--- a/src/aiida/cmdline/utils/decorators.py
+++ b/src/aiida/cmdline/utils/decorators.py
@@ -55,6 +55,7 @@ def with_broker(wrapped, _, args, kwargs):
     from aiida.manage import get_manager
 
     manager = get_manager()
+    broker_was_loaded = manager.broker_loaded
     broker = manager.get_broker()
     profile = manager.get_profile()
     assert profile is not None
@@ -73,13 +74,13 @@ def with_broker(wrapped, _, args, kwargs):
         with suppress(RuntimeError):
             manager.reset_broker()
 
-    if context is not None:
+    if not broker_was_loaded and context is not None:
         context.call_on_close(reset_broker)
 
     try:
         return wrapped(*args, **kwargs)
     finally:
-        if context is None:
+        if not broker_was_loaded and context is None:
             reset_broker()
 
 

--- a/src/aiida/cmdline/utils/loaders.py
+++ b/src/aiida/cmdline/utils/loaders.py
@@ -1,0 +1,208 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Helpers to resolve command line identifiers into ORM entities from within a command body.
+
+Command parameters carry identifiers as plain strings so that parsing a ``verdi`` command line does not require a
+storage backend. Resolving them is the responsibility of the command, which does so through the helpers in this module
+once the backend has been loaded.
+
+The parameter declaration stays the single source of truth: the helpers look up the parameter that supplied the
+identifier and delegate to its ``resolve`` method, so restrictions such as ``sub_classes`` are declared once on the
+parameter rather than repeated in every command body.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import click
+
+if t.TYPE_CHECKING:
+    from aiida.orm import Computer, Group, Node, User
+
+__all__ = (
+    'load_calculation',
+    'load_calculations',
+    'load_code',
+    'load_codes',
+    'load_computer',
+    'load_computers',
+    'load_data',
+    'load_datum',
+    'load_entities',
+    'load_entity',
+    'load_group',
+    'load_groups',
+    'load_node',
+    'load_nodes',
+    'load_process',
+    'load_processes',
+    'load_user',
+    'resolve_callback',
+)
+
+
+class _Resolvable(t.Protocol):
+    """A click parameter type that can resolve an identifier into an ORM entity."""
+
+    def resolve(self, identifier: str) -> t.Any: ...
+
+
+def _find_param(param_name: str) -> click.Parameter | None:
+    """Return the parameter of the command currently being invoked, if it can be determined."""
+    context = click.get_current_context(silent=True)
+
+    if context is None:
+        return None
+
+    return next((each for each in context.command.params if each.name == param_name), None)
+
+
+def _resolvable_type(param: click.Parameter | None) -> _Resolvable | None:
+    """Return the type of the parameter that resolves identifiers, unwrapping multi-value parameters."""
+    from aiida.cmdline.params.types.multiple import MultipleValueParamType
+
+    if param is None:
+        return None
+
+    param_type = param.type
+
+    if isinstance(param_type, MultipleValueParamType):
+        param_type = param_type.param_type
+
+    return t.cast('_Resolvable', param_type) if hasattr(param_type, 'resolve') else None
+
+
+def load_entity(identifier: str, *, param_name: str) -> t.Any:
+    """Return the ORM entity that the identifier maps onto.
+
+    The parameter named ``param_name`` supplies the type that performs the lookup, so any restriction declared on it
+    is applied here.
+
+    :param identifier: PK, UUID or label of the entity, as given on the command line.
+    :param param_name: Name of the command parameter that supplied the identifier.
+    :raises click.BadParameter: if the identifier is ambiguous or maps onto no entity.
+    :raises RuntimeError: if ``param_name`` does not name a parameter that can resolve identifiers.
+    """
+    from aiida.common import exceptions
+
+    param = _find_param(param_name)
+    param_type = _resolvable_type(param)
+
+    if param_type is None:
+        msg = f'parameter `{param_name}` does not declare a type that can resolve identifiers'
+        raise RuntimeError(msg)
+
+    try:
+        return param_type.resolve(identifier)
+    except (exceptions.MultipleObjectsError, exceptions.NotExistent, ValueError) as exception:
+        raise click.BadParameter(str(exception), ctx=click.get_current_context(silent=True), param=param) from exception
+
+
+def resolve_callback(ctx: click.Context, param: click.Parameter, value: t.Any) -> t.Any:
+    """Click callback that resolves an identifier while the command line is still being parsed.
+
+    Command bodies should call :func:`load_entity` instead. Use this only for parameters whose loaded entity is needed
+    during parsing itself, such as when a later parameter derives its interactive default or its validation from it.
+    Because it runs before the command body, it loads the storage backend itself.
+    """
+    from aiida.cmdline.utils.decorators import load_backend_if_not_loaded
+
+    if value is None:
+        return None
+
+    load_backend_if_not_loaded()
+    return load_entity(value, param_name=t.cast(str, param.name))
+
+
+def load_entities(identifiers: t.Sequence[str], *, param_name: str) -> list[t.Any]:
+    """Return the ORM entities that the identifiers map onto.
+
+    All identifiers are resolved before returning, so a command never acts on a partially resolved selection.
+
+    :param identifiers: PKs, UUIDs or labels of the entities, as given on the command line.
+    :param param_name: Name of the command parameter that supplied the identifiers.
+    :raises click.BadParameter: if an identifier is ambiguous or maps onto no entity.
+    """
+    return [load_entity(identifier, param_name=param_name) for identifier in identifiers]
+
+
+def load_node(identifier: str, *, param_name: str = 'node') -> Node:
+    """Return the node that the identifier maps onto. See :func:`load_entity`."""
+    return t.cast('Node', load_entity(identifier, param_name=param_name))
+
+
+def load_nodes(identifiers: t.Sequence[str], *, param_name: str = 'nodes') -> list[Node]:
+    """Return the nodes that the identifiers map onto. See :func:`load_entities`."""
+    return t.cast('list[Node]', load_entities(identifiers, param_name=param_name))
+
+
+def load_group(identifier: str, *, param_name: str = 'group') -> Group:
+    """Return the group that the identifier maps onto. See :func:`load_entity`."""
+    return t.cast('Group', load_entity(identifier, param_name=param_name))
+
+
+def load_groups(identifiers: t.Sequence[str], *, param_name: str = 'groups') -> list[Group]:
+    """Return the groups that the identifiers map onto. See :func:`load_entities`."""
+    return t.cast('list[Group]', load_entities(identifiers, param_name=param_name))
+
+
+def load_computer(identifier: str, *, param_name: str = 'computer') -> Computer:
+    """Return the computer that the identifier maps onto. See :func:`load_entity`."""
+    return t.cast('Computer', load_entity(identifier, param_name=param_name))
+
+
+def load_computers(identifiers: t.Sequence[str], *, param_name: str = 'computers') -> list[Computer]:
+    """Return the computers that the identifiers map onto. See :func:`load_entities`."""
+    return t.cast('list[Computer]', load_entities(identifiers, param_name=param_name))
+
+
+def load_user(identifier: str, *, param_name: str = 'user') -> User:
+    """Return the user with the given email address. See :func:`load_entity`."""
+    return t.cast('User', load_entity(identifier, param_name=param_name))
+
+
+def load_code(identifier: str, *, param_name: str = 'code') -> t.Any:
+    """Return the code that the identifier maps onto. See :func:`load_entity`."""
+    return load_entity(identifier, param_name=param_name)
+
+
+def load_codes(identifiers: t.Sequence[str], *, param_name: str = 'codes') -> list[t.Any]:
+    """Return the codes that the identifiers map onto. See :func:`load_entities`."""
+    return load_entities(identifiers, param_name=param_name)
+
+
+def load_process(identifier: str, *, param_name: str = 'process') -> t.Any:
+    """Return the process node that the identifier maps onto. See :func:`load_entity`."""
+    return load_entity(identifier, param_name=param_name)
+
+
+def load_processes(identifiers: t.Sequence[str], *, param_name: str = 'processes') -> list[t.Any]:
+    """Return the process nodes that the identifiers map onto. See :func:`load_entities`."""
+    return load_entities(identifiers, param_name=param_name)
+
+
+def load_calculation(identifier: str, *, param_name: str = 'calculation') -> t.Any:
+    """Return the calculation node that the identifier maps onto. See :func:`load_entity`."""
+    return load_entity(identifier, param_name=param_name)
+
+
+def load_calculations(identifiers: t.Sequence[str], *, param_name: str = 'calculations') -> list[t.Any]:
+    """Return the calculation nodes that the identifiers map onto. See :func:`load_entities`."""
+    return load_entities(identifiers, param_name=param_name)
+
+
+def load_datum(identifier: str, *, param_name: str = 'datum') -> t.Any:
+    """Return the data node that the identifier maps onto. See :func:`load_entity`."""
+    return load_entity(identifier, param_name=param_name)
+
+
+def load_data(identifiers: t.Sequence[str], *, param_name: str = 'data') -> list[t.Any]:
+    """Return the data nodes that the identifiers map onto. See :func:`load_entities`."""
+    return load_entities(identifiers, param_name=param_name)

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -257,6 +257,14 @@ class Manager:
         """
         return self._profile_storage is not None
 
+    @property
+    def broker_loaded(self) -> bool:
+        """Return whether a broker has been loaded.
+
+        :return: boolean, True if a broker is currently loaded, False otherwise
+        """
+        return self._broker is not None
+
     def get_option(self, option_name: str) -> Any:
         """Return the value of a configuration option.
 

--- a/src/aiida/transports/cli.py
+++ b/src/aiida/transports/cli.py
@@ -15,14 +15,22 @@ import click
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.params.options.interactive import InteractiveOption
 from aiida.cmdline.utils import echo
-from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.cmdline.utils.decorators import load_backend_if_not_loaded, with_dbenv
+from aiida.cmdline.utils.loaders import load_entity, load_user
 from aiida.common.exceptions import NotExistent
 
 TRANSPORT_PARAMS = []
 
 
-def match_comp_transport(ctx, param, computer, transport_type):
-    """Check the computer argument against the transport type."""
+def match_comp_transport(ctx, param, identifier, transport_type):
+    """Check the computer argument against the transport type.
+
+    The interactive defaults of the following options are derived from the computer, so unlike a command body this
+    callback has to resolve the identifier while the command line is still being parsed, and loads the backend itself.
+    """
+    load_backend_if_not_loaded()
+    computer = load_entity(identifier, param_name=param.name)
+
     if computer.transport_type != transport_type:
         echo.echo_critical(
             f'Computer {computer.label} has transport of type "{computer.transport_type}", not {transport_type}!'
@@ -41,6 +49,7 @@ def configure_computer_main(computer, user, **kwargs):
     """Configure a computer via the CLI."""
     from aiida import orm
 
+    user = load_user(user) if isinstance(user, str) else user
     user = user or orm.User.collection.get_default()
 
     echo.echo_report(f'Configuring computer {computer.label} for user {user.email}.')
@@ -91,7 +100,8 @@ def interactive_default(key, also_non_interactive=False):
         if not also_non_interactive and ctx.params['non_interactive']:
             raise click.MissingParameter()
 
-        user = ctx.params.get('user', None) or orm.User.collection.get_default()
+        user = ctx.params.get('user', None)
+        user = load_user(user) if user is not None else orm.User.collection.get_default()
         computer = ctx.params.get('computer', None)
 
         if computer is None:

--- a/tests/cmdline/params/types/test_calculation.py
+++ b/tests/cmdline/params/types/test_calculation.py
@@ -35,7 +35,7 @@ def test_get_by_id(entities):
     """Verify that using the ID will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = entities
     identifier = str(entity_01.pk)
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -43,7 +43,7 @@ def test_get_by_uuid(entities):
     """Verify that using the UUID will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = entities
     identifier = str(entity_01.uuid)
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -51,7 +51,7 @@ def test_get_by_label(entities):
     """Verify that using the LABEL will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = entities
     identifier = str(entity_01.label)
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -63,11 +63,11 @@ def test_ambiguous_label_pk(entities):
     """
     entity_01, entity_02, _entity_03 = entities
     identifier = str(entity_02.label)
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_02.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_02.uuid
 
 
@@ -79,9 +79,9 @@ def test_ambiguous_label_uuid(entities):
     """
     entity_01, _entity_02, entity_03 = entities
     identifier = str(entity_03.label)
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_03.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = CalculationParamType().convert(identifier, None, None)
+    result = CalculationParamType().resolve(identifier)
     assert result.uuid == entity_03.uuid

--- a/tests/cmdline/params/types/test_code.py
+++ b/tests/cmdline/params/types/test_code.py
@@ -51,7 +51,7 @@ def test_get_by_id(setup_codes, parameter_type):
     """Verify that using the ID will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_codes
     identifier = f'{entity_01.pk}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -59,7 +59,7 @@ def test_get_by_uuid(setup_codes, parameter_type):
     """Verify that using the UUID will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_codes
     identifier = f'{entity_01.uuid}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -67,7 +67,7 @@ def test_get_by_label(setup_codes, parameter_type):
     """Verify that using the LABEL will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_codes
     identifier = f'{entity_01.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -75,7 +75,7 @@ def test_get_by_fullname(setup_codes, parameter_type):
     """Verify that using the LABEL@machinename will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_codes
     identifier = f'{entity_01.label}@{entity_01.computer.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -87,11 +87,11 @@ def test_ambiguous_label_pk(setup_codes, parameter_type):
     """
     entity_01, entity_02, _entity_03 = setup_codes
     identifier = f'{entity_02.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_02.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_02.uuid
 
 
@@ -103,11 +103,11 @@ def test_ambiguous_label_uuid(setup_codes, parameter_type):
     """
     entity_01, _entity_02, entity_03 = setup_codes
     identifier = f'{entity_03.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_03.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_03.uuid
 
 
@@ -116,12 +116,12 @@ def test_entry_point_validation(setup_codes):
     _entity_01, entity_02, entity_03 = setup_codes
     parameter_type = CodeParamType(entry_point='core.arithmetic.add')
     identifier = f'{entity_02.pk}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_02.uuid
 
     with pytest.raises(click.BadParameter):
         identifier = f'{entity_03.pk}'
-        result = parameter_type.convert(identifier, None, None)
+        result = parameter_type.resolve(identifier)
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')

--- a/tests/cmdline/params/types/test_computer.py
+++ b/tests/cmdline/params/types/test_computer.py
@@ -69,7 +69,7 @@ def test_get_by_id(setup_computers, parameter_type):
     """Verify that using the ID will retrieve the correct entity"""
     entity_01, _, _ = setup_computers
     identifier = f'{entity_01.pk}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -77,7 +77,7 @@ def test_get_by_uuid(setup_computers, parameter_type):
     """Verify that using the UUID will retrieve the correct entity"""
     entity_01, _, _ = setup_computers
     identifier = f'{entity_01.uuid}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -85,7 +85,7 @@ def test_get_by_label(setup_computers, parameter_type):
     """Verify that using the LABEL will retrieve the correct entity"""
     entity_01, _, _ = setup_computers
     identifier = f'{entity_01.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -97,11 +97,11 @@ def test_ambiguous_label_pk(setup_computers, parameter_type):
     """
     entity_01, entity_02, _ = setup_computers
     identifier = f'{entity_02.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_02.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_02.uuid
 
 
@@ -113,9 +113,9 @@ def test_ambiguous_label_uuid(setup_computers, parameter_type):
     """
     entity_01, _, entity_03 = setup_computers
     identifier = f'{entity_03.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_03.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_03.uuid

--- a/tests/cmdline/params/types/test_data.py
+++ b/tests/cmdline/params/types/test_data.py
@@ -39,19 +39,19 @@ class TestDataParamType:
     def test_get_by_id(self):
         """Verify that using the ID will retrieve the correct entity"""
         identifier = f'{self.entity_01.pk}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
     def test_get_by_uuid(self):
         """Verify that using the UUID will retrieve the correct entity"""
         identifier = f'{self.entity_01.uuid}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
     def test_get_by_label(self):
         """Verify that using the LABEL will retrieve the correct entity"""
         identifier = f'{self.entity_01.label}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
     def test_ambiguous_label_pk(self):
@@ -61,11 +61,11 @@ class TestDataParamType:
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
         identifier = f'{self.entity_02.label}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
         identifier = f'{self.entity_02.label}{OrmEntityLoader.label_ambiguity_breaker}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_02.uuid
 
     def test_ambiguous_label_uuid(self):
@@ -75,9 +75,9 @@ class TestDataParamType:
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
         identifier = f'{self.entity_03.label}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
         identifier = f'{self.entity_03.label}{OrmEntityLoader.label_ambiguity_breaker}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_03.uuid

--- a/tests/cmdline/params/types/test_group.py
+++ b/tests/cmdline/params/types/test_group.py
@@ -10,10 +10,10 @@
 
 import uuid
 
-import click
 import pytest
 
 from aiida.cmdline.params.types import GroupParamType
+from aiida.common import exceptions
 from aiida.orm import AutoGroup, Group, ImportGroup
 from aiida.orm.utils.loaders import OrmEntityLoader
 
@@ -42,7 +42,7 @@ def test_get_by_id(setup_groups, parameter_type):
     """Verify that using the ID will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_groups
     identifier = f'{entity_01.pk}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -50,7 +50,7 @@ def test_get_by_uuid(setup_groups, parameter_type):
     """Verify that using the UUID will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_groups
     identifier = f'{entity_01.uuid}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -58,7 +58,7 @@ def test_get_by_label(setup_groups, parameter_type):
     """Verify that using the LABEL will retrieve the correct entity."""
     entity_01, _entity_02, _entity_03 = setup_groups
     identifier = f'{entity_01.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
 
@@ -70,11 +70,11 @@ def test_ambiguous_label_pk(setup_groups, parameter_type):
     """
     entity_01, entity_02, _entity_03 = setup_groups
     identifier = f'{entity_02.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_02.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_02.uuid
 
 
@@ -86,11 +86,11 @@ def test_ambiguous_label_uuid(setup_groups, parameter_type):
     """
     entity_01, _entity_02, entity_03 = setup_groups
     identifier = f'{entity_03.label}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_01.uuid
 
     identifier = f'{entity_03.label}{OrmEntityLoader.label_ambiguity_breaker}'
-    result = parameter_type.convert(identifier, None, None)
+    result = parameter_type.resolve(identifier)
     assert result.uuid == entity_03.uuid
 
 
@@ -98,13 +98,13 @@ def test_create_if_not_exist():
     """Test the `create_if_not_exist` constructor argument."""
     label = 'non-existing-label-01'
     parameter_type = GroupParamType(create_if_not_exist=True)
-    result = parameter_type.convert(label, None, None)
+    result = parameter_type.resolve(label)
     assert isinstance(result, Group)
     assert result.is_stored
 
     label = 'non-existing-label-02'
     parameter_type = GroupParamType(create_if_not_exist=True, sub_classes=('aiida.groups:core.auto',))
-    result = parameter_type.convert(label, None, None)
+    result = parameter_type.resolve(label)
     assert isinstance(result, AutoGroup)
 
     # Specifying more than one subclass when `create_if_not_exist=True` is not allowed.
@@ -129,8 +129,8 @@ def test_sub_classes(setup_groups, sub_classes, expected):
 
     for group in [entity_01, entity_02, entity_03]:
         try:
-            parameter_type.convert(str(group.pk), None, None)
-        except click.BadParameter:
+            parameter_type.resolve(str(group.pk))
+        except exceptions.NotExistent:
             results.append(False)
         else:
             results.append(True)

--- a/tests/cmdline/params/types/test_identifier.py
+++ b/tests/cmdline/params/types/test_identifier.py
@@ -8,10 +8,10 @@
 ###########################################################################
 """Tests for the `IdentifierParamType`."""
 
-import click
 import pytest
 
 from aiida.cmdline.params.types import IdentifierParamType, NodeParamType
+from aiida.common import exceptions
 from aiida.orm import Bool, Float, Int
 
 
@@ -54,14 +54,14 @@ class TestIdentifierParamType:
         param_type_scoped = NodeParamType(sub_classes=('aiida.data:core.bool', 'aiida.data:core.float'))
 
         # For the base NodeParamType all node types should be matched
-        assert param_type_normal.convert(str(node_bool.pk), None, None).uuid == node_bool.uuid
-        assert param_type_normal.convert(str(node_float.pk), None, None).uuid == node_float.uuid
-        assert param_type_normal.convert(str(node_int.pk), None, None).uuid == node_int.uuid
+        assert param_type_normal.resolve(str(node_bool.pk)).uuid == node_bool.uuid
+        assert param_type_normal.resolve(str(node_float.pk)).uuid == node_float.uuid
+        assert param_type_normal.resolve(str(node_int.pk)).uuid == node_int.uuid
 
         # The scoped NodeParamType should only match Bool and Float
-        assert param_type_scoped.convert(str(node_bool.pk), None, None).uuid == node_bool.uuid
-        assert param_type_scoped.convert(str(node_float.pk), None, None).uuid == node_float.uuid
+        assert param_type_scoped.resolve(str(node_bool.pk)).uuid == node_bool.uuid
+        assert param_type_scoped.resolve(str(node_float.pk)).uuid == node_float.uuid
 
         # The Int should not be found and raise
-        with pytest.raises(click.BadParameter):
-            param_type_scoped.convert(str(node_int.pk), None, None)
+        with pytest.raises(exceptions.NotExistent):
+            param_type_scoped.resolve(str(node_int.pk))

--- a/tests/cmdline/params/types/test_node.py
+++ b/tests/cmdline/params/types/test_node.py
@@ -39,19 +39,19 @@ class TestNodeParamType:
     def test_get_by_id(self):
         """Verify that using the ID will retrieve the correct entity"""
         identifier = f'{self.entity_01.pk}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
     def test_get_by_uuid(self):
         """Verify that using the UUID will retrieve the correct entity"""
         identifier = f'{self.entity_01.uuid}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
     def test_get_by_label(self):
         """Verify that using the LABEL will retrieve the correct entity"""
         identifier = f'{self.entity_01.label}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
     def test_ambiguous_label_pk(self):
@@ -61,11 +61,11 @@ class TestNodeParamType:
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
         identifier = f'{self.entity_02.label}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
         identifier = f'{self.entity_02.label}{OrmEntityLoader.label_ambiguity_breaker}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_02.uuid
 
     def test_ambiguous_label_uuid(self):
@@ -75,9 +75,9 @@ class TestNodeParamType:
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
         identifier = f'{self.entity_03.label}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_01.uuid
 
         identifier = f'{self.entity_03.label}{OrmEntityLoader.label_ambiguity_breaker}'
-        result = self.param.convert(identifier, None, None)
+        result = self.param.resolve(identifier)
         assert result.uuid == self.entity_03.uuid

--- a/tests/cmdline/utils/test_decorators.py
+++ b/tests/cmdline/utils/test_decorators.py
@@ -57,6 +57,7 @@ def test_with_broker_resets_after_group_closes(config, manager, monkeypatch):
     manager.load_profile()
     expected_broker = mock.Mock()
     reset_broker = mock.Mock()
+    monkeypatch.setattr(manager, '_broker', None)
     monkeypatch.setattr(manager, 'get_broker', lambda: expected_broker)
     monkeypatch.setattr(manager, 'reset_broker', reset_broker)
 
@@ -74,6 +75,26 @@ def test_with_broker_resets_after_group_closes(config, manager, monkeypatch):
 
     assert result.exception is None
     reset_broker.assert_called_once_with()
+
+
+def test_with_broker_preserves_loaded_broker(config, manager, monkeypatch):
+    """Test ``with_broker`` does not close a broker that was already loaded."""
+    manager.load_profile()
+    expected_broker = mock.Mock()
+    reset_broker = mock.Mock()
+    monkeypatch.setattr(manager, '_broker', expected_broker)
+    monkeypatch.setattr(manager, 'get_broker', lambda: expected_broker)
+    monkeypatch.setattr(manager, 'reset_broker', reset_broker)
+
+    @click.command()
+    @with_broker
+    def command(broker):
+        assert broker is expected_broker
+
+    result = CliRunner().invoke(command)
+
+    assert result.exception is None
+    reset_broker.assert_not_called()
 
 
 def test_with_dbenv_preserves_loaded_storage(config, manager):

--- a/tests/cmdline/utils/test_decorators.py
+++ b/tests/cmdline/utils/test_decorators.py
@@ -10,9 +10,11 @@
 
 from unittest import mock
 
+import click
 import pytest
+from click.testing import CliRunner
 
-from aiida.cmdline.utils.decorators import load_backend_if_not_loaded
+from aiida.cmdline.utils.decorators import load_backend_if_not_loaded, with_broker, with_dbenv
 from aiida.common.exceptions import InvalidOperation
 from aiida.manage import get_manager
 
@@ -48,6 +50,45 @@ def manager(monkeypatch):
     monkeypatch.setattr(manager, '_profile_storage', None)
     monkeypatch.setattr(manager.__class__, 'get_profile_storage', get_profile_storage)
     yield manager
+
+
+def test_with_broker_resets_after_group_closes(config, manager, monkeypatch):
+    """Test ``with_broker`` keeps the broker open for subcommands and then resets it."""
+    manager.load_profile()
+    expected_broker = mock.Mock()
+    reset_broker = mock.Mock()
+    monkeypatch.setattr(manager, 'get_broker', lambda: expected_broker)
+    monkeypatch.setattr(manager, 'reset_broker', reset_broker)
+
+    @click.group()
+    @with_broker
+    def command_group(broker):
+        assert broker is expected_broker
+        reset_broker.assert_not_called()
+
+    @command_group.command()
+    def command():
+        reset_broker.assert_not_called()
+
+    result = CliRunner().invoke(command_group, ['command'])
+
+    assert result.exception is None
+    reset_broker.assert_called_once_with()
+
+
+def test_with_dbenv_preserves_loaded_storage(config, manager):
+    """Test ``with_dbenv`` does not close storage that was already loaded."""
+    manager.load_profile()
+    manager.get_profile_storage()
+
+    @with_dbenv()
+    def wrapped():
+        assert manager.profile_storage_loaded
+
+    wrapped()
+
+    assert manager.profile_storage_loaded
+    manager.reset_profile_storage()
 
 
 def test_load_backend_if_not_loaded(config, manager):


### PR DESCRIPTION
Implements a general mechanism into verdi commands using `with_broker` or `with_dbenv` decorator to also close the opened resources.

Requires some API break to do it cleanly because `with_dbenv` keeps the database open without closing it at the end. It is needed the way it is designed because we use it to resolve CLI parameter that resolve to database nodes. The change of `with_dbenv` alone would result in every parameter opening and closing the database connection. Therefore we just move the process of resolving the CLI parameter to a ORM node in the parameter logic into the actual CLI command function. For CLI command functions the new `with_dbenv` logic is okay since the python interpreter process should close after calling one command. This requires some bigger refactor of command line utilities. I still need to iterate on the current implementation, but there will be a lot of added lines of code that move the loading of the node to the verdi command function