### PR TITLE
🐛 Failed `COPY` stash deletes sibling stashes

### DIFF
--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -533,11 +533,11 @@ async def stash_calculation(calculation: CalcJobNode, transport: Transport) -> N
         try:
             await _do_copy()
         except exceptions.StashingError as exception:
-            # try to clean up in case of a failure
-            await transport.rmtree_async(target_base / uuid[:2])
+            # Only remove this calculation's stash: ``target_base / uuid[:2]`` is a shard shared with other stashes.
+            await transport.rmtree_async(target_basepath)
             raise exception
         else:
-            EXEC_LOGGER.debug(f'All files succesfully {source_list} stashed to {target_base / uuid[:2]}')
+            EXEC_LOGGER.debug(f'All files succesfully {source_list} stashed to {target_basepath}')
 
         remote_stash = RemoteStashFolderData(
             computer=calculation.computer,

--- a/src/aiida/engine/daemon/execmanager.py
+++ b/src/aiida/engine/daemon/execmanager.py
@@ -533,7 +533,6 @@ async def stash_calculation(calculation: CalcJobNode, transport: Transport) -> N
         try:
             await _do_copy()
         except exceptions.StashingError as exception:
-            # Only remove this calculation's stash: ``target_base / uuid[:2]`` is a shard shared with other stashes.
             await transport.rmtree_async(target_basepath)
             raise exception
         else:

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -8,6 +8,7 @@
 ###########################################################################
 """Tests for the :mod:`aiida.engine.daemon.execmanager` module."""
 
+import contextlib
 import io
 import pathlib
 
@@ -755,6 +756,15 @@ async def test_stashing(
     dest_path_error = tmp_path / 'stash_path_error'
     dest_path_error.mkdir()
 
+    # A failed stash must leave pre-existing content in the destination untouched, for all modes.
+    if stash_mode == StashMode.COPY.value:
+        other_stash = dest_path_error / uuid[:2] / 'ab' / 'other-calculation'
+        other_stash.mkdir(parents=True)
+        (other_stash / 'aiida.out').write_text('other')
+    else:
+        other_stash = dest_path_error / ('other-calculation.' + stash_mode)
+        other_stash.write_text('other')
+
     if stash_mode == StashMode.COPY.value:
         node.set_option(
             'stash',
@@ -797,39 +807,31 @@ async def test_stashing(
                 await execmanager.stash_calculation(node, transport)
                 assert any('Failed to stash' in message for message in caplog.messages)
 
-    # Ensure no files were created in the destination path after the error
+    # The failed stash must not have created its own target, nor touched the sibling stash
     if stash_mode == StashMode.COPY.value:
         assert not (dest_path_error / uuid[:2] / uuid[2:4] / uuid[4:]).exists()
+        assert (other_stash / 'aiida.out').read_text() == 'other'
     else:
-        assert not any(dest_path_error.iterdir())
+        assert list(dest_path_error.iterdir()) == [other_stash]
+        assert other_stash.read_text() == 'other'
 
+    ## 3) test that an existing stash target is never overwritten (see #7564)
+    if stash_mode != StashMode.COPY.value:
+        existing_archive = pathlib.Path(str(dest_path / uuid) + '.' + stash_mode)
+        existing_archive.write_text('tampered')
 
-@pytest.mark.asyncio
-async def test_stashing_copy_failure_keeps_other_stashes(generate_calcjob_node, tmp_path, monkeypatch):
-    """A failed ``COPY`` stash must only remove its own directory, not the whole ``uuid[:2]`` shard."""
-    node = generate_calcjob_node()
-    uuid = node.uuid
-    workdir = tmp_path / 'workdir'
-    workdir.mkdir()
-    (workdir / 'aiida.out').write_text('out')
-    node.set_remote_workdir(str(workdir))
+        node.set_option(
+            'stash',
+            {
+                'source_list': ['*'],
+                'target_base': str(dest_path),
+                'stash_mode': stash_mode,
+                'dereference': True,
+            },
+        )
 
-    target_base = tmp_path / 'stash'
-    node.set_option(
-        'stash', {'source_list': ['*'], 'target_base': str(target_base), 'stash_mode': StashMode.COPY.value}
-    )
+        with LocalTransport() as transport:
+            with contextlib.suppress(StashingError):
+                await execmanager.stash_calculation(node, transport)
 
-    other_stash = target_base / uuid[:2] / 'ab' / 'other-calculation'
-    other_stash.mkdir(parents=True)
-    (other_stash / 'aiida.out').write_text('other')
-
-    async def mock_copy_async(*args, **kwargs):
-        raise OSError('copy mocked error')
-
-    with LocalTransport() as transport:
-        monkeypatch.setattr(transport, 'copy_async', mock_copy_async)
-        with pytest.raises(StashingError, match='Failed to copy'):
-            await execmanager.stash_calculation(node, transport)
-
-    assert not (target_base / uuid[:2] / uuid[2:4] / uuid[4:]).exists()
-    assert (other_stash / 'aiida.out').read_text() == 'other'
+        assert existing_archive.read_text() == 'tampered'

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -8,7 +8,6 @@
 ###########################################################################
 """Tests for the :mod:`aiida.engine.daemon.execmanager` module."""
 
-import contextlib
 import io
 import pathlib
 
@@ -756,14 +755,17 @@ async def test_stashing(
     dest_path_error = tmp_path / 'stash_path_error'
     dest_path_error.mkdir()
 
-    # A failed stash must leave pre-existing content in the destination untouched, for all modes.
+    # a calculation already stashed in the same shard, i.e. its UUID shares the first four characters
     if stash_mode == StashMode.COPY.value:
-        other_stash = dest_path_error / uuid[:2] / 'ab' / 'other-calculation'
+        other_uuid = uuid[:4] + 'beef-0000-0000-0000-000000000000'
+        other_stash = dest_path_error / other_uuid[:2] / other_uuid[2:4] / other_uuid[4:]
         other_stash.mkdir(parents=True)
         (other_stash / 'aiida.out').write_text('other')
     else:
         other_stash = dest_path_error / ('other-calculation.' + stash_mode)
         other_stash.write_text('other')
+
+    existing_paths = set(tmp_path.rglob('*'))
 
     if stash_mode == StashMode.COPY.value:
         node.set_option(
@@ -807,13 +809,13 @@ async def test_stashing(
                 await execmanager.stash_calculation(node, transport)
                 assert any('Failed to stash' in message for message in caplog.messages)
 
-    # The failed stash must not have created its own target, nor touched the sibling stash
+    # A failed stash must not remove anything that was already on disk, in any mode
+    removed = existing_paths - set(tmp_path.rglob('*'))
+    assert not removed, f'failed stash removed pre-existing paths: {sorted(str(path) for path in removed)}'
+
+    # COPY also cleans up its own half-written target; the compress modes will do that in #7564
     if stash_mode == StashMode.COPY.value:
         assert not (dest_path_error / uuid[:2] / uuid[2:4] / uuid[4:]).exists()
-        assert (other_stash / 'aiida.out').read_text() == 'other'
-    else:
-        assert list(dest_path_error.iterdir()) == [other_stash]
-        assert other_stash.read_text() == 'other'
 
     ## 3) test that an existing stash target is never overwritten (see #7564)
     if stash_mode != StashMode.COPY.value:
@@ -830,8 +832,8 @@ async def test_stashing(
             },
         )
 
-        with LocalTransport() as transport:
-            with contextlib.suppress(StashingError):
-                await execmanager.stash_calculation(node, transport)
+        with LocalTransport() as transport, caplog.at_level(logging.WARNING):
+            await execmanager.stash_calculation(node, transport)
 
         assert existing_archive.read_text() == 'tampered'
+        assert any('already exists' in message for message in caplog.messages)

--- a/tests/engine/daemon/test_execmanager.py
+++ b/tests/engine/daemon/test_execmanager.py
@@ -798,4 +798,38 @@ async def test_stashing(
                 assert any('Failed to stash' in message for message in caplog.messages)
 
     # Ensure no files were created in the destination path after the error
-    assert not any(dest_path_error.iterdir())
+    if stash_mode == StashMode.COPY.value:
+        assert not (dest_path_error / uuid[:2] / uuid[2:4] / uuid[4:]).exists()
+    else:
+        assert not any(dest_path_error.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_stashing_copy_failure_keeps_other_stashes(generate_calcjob_node, tmp_path, monkeypatch):
+    """A failed ``COPY`` stash must only remove its own directory, not the whole ``uuid[:2]`` shard."""
+    node = generate_calcjob_node()
+    uuid = node.uuid
+    workdir = tmp_path / 'workdir'
+    workdir.mkdir()
+    (workdir / 'aiida.out').write_text('out')
+    node.set_remote_workdir(str(workdir))
+
+    target_base = tmp_path / 'stash'
+    node.set_option(
+        'stash', {'source_list': ['*'], 'target_base': str(target_base), 'stash_mode': StashMode.COPY.value}
+    )
+
+    other_stash = target_base / uuid[:2] / 'ab' / 'other-calculation'
+    other_stash.mkdir(parents=True)
+    (other_stash / 'aiida.out').write_text('other')
+
+    async def mock_copy_async(*args, **kwargs):
+        raise OSError('copy mocked error')
+
+    with LocalTransport() as transport:
+        monkeypatch.setattr(transport, 'copy_async', mock_copy_async)
+        with pytest.raises(StashingError, match='Failed to copy'):
+            await execmanager.stash_calculation(node, transport)
+
+    assert not (target_base / uuid[:2] / uuid[2:4] / uuid[4:]).exists()
+    assert (other_stash / 'aiida.out').read_text() == 'other'


### PR DESCRIPTION
In `COPY` mode, `stash_calculation` writes to `target_base/uuid[:2]/uuid[2:4]/uuid[4:]`, but on a `StashingError` it cleaned up with

```python
await transport.rmtree_async(target_base / uuid[:2])
```

which removes the whole two-character shard, i.e. every previously stashed calculation whose UUID shares that prefix (~1/256 of the stash area). Introduced in ae49af6c3, shipped since v2.7.0.

This PR removes only the failed calculation's own `target_basepath`, and generalizes the regression coverage into the parametrized `test_stashing`: a failed stash must leave pre-existing destination content untouched in *every* stash mode (a sibling directory in the same shard for `COPY`, a sibling archive for the compress modes).

Compress modes are unaffected by the rmtree bug itself (single tarball, no rmtree cleanup).

Remaining sharp edge, deliberately out of scope: for `core.stash` jobs the target path is keyed by the *source node's* UUID, so two stash jobs of the same node share it, and a failed one can still remove its sibling's completed stash. #7564 closes that by making the target unique per stash job; this PR stays minimal because it has to go to the patch releases: 2.7.x, 2.8.x, 2.9.x.


*(Disclaimer: I'm @khsrali's AI assistant, I'm posting with his instructions)*
