### PR TITLE
Make root verdi group pluginable

### DIFF
--- a/src/aiida/cmdline/commands/cmd_verdi.py
+++ b/src/aiida/cmdline/commands/cmd_verdi.py
@@ -12,12 +12,14 @@ import click
 
 from aiida import __version__
 
-from ..groups import VerdiCommandGroup
 from ..params import options, types
+from ..utils.pluginable import Pluginable
 
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
-@click.group(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
+@click.group(
+    cls=Pluginable, entry_point_group='aiida.cmdline.verdi', context_settings={'help_option_names': ['--help', '-h']}
+)
 @options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
 @options.VERBOSITY()
 @click.version_option(__version__, package_name='aiida_core', message='AiiDA version %(version)s')

--- a/src/aiida/plugins/entry_point.py
+++ b/src/aiida/plugins/entry_point.py
@@ -85,6 +85,7 @@ ENTRY_POINT_GROUP_TO_MODULE_PATH_MAP = {
     'aiida.cmdline.computer.configure': 'aiida.cmdline.computer.configure',
     'aiida.cmdline.data': 'aiida.cmdline.data',
     'aiida.cmdline.data.structure.import': 'aiida.cmdline.data.structure.import',
+    'aiida.cmdline.verdi': 'aiida.cmdline.verdi',
     'aiida.data': 'aiida.orm.nodes.data',
     'aiida.groups': 'aiida.orm.groups',
     'aiida.orm': 'aiida.orm',

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -23,6 +23,25 @@ def test_verdi_version(run_cli_command):
 
 
 @pytest.mark.usefixtures('config_with_profile')
+def test_verdi_external_command(run_cli_command, monkeypatch):
+    """Verify that a command registered through an entry point can be invoked."""
+
+    @click.command()
+    def external():
+        click.echo('external command')
+
+    def load_entry_point(group, name):
+        assert group == 'aiida.cmdline.verdi'
+        assert name == 'external'
+        return external
+
+    monkeypatch.setattr('aiida.cmdline.utils.pluginable.load_entry_point', load_entry_point)
+
+    result = run_cli_command(cmd_verdi.verdi, ['external'], use_subprocess=False)
+    assert result.output == 'external command\n'
+
+
+@pytest.mark.usefixtures('config_with_profile')
 def test_verdi_with_empty_profile_list(run_cli_command):
     """Regression test for #2424: verify that verdi remains operable even if profile list is empty"""
     from aiida.manage.configuration import CONFIG

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -879,8 +879,7 @@ def run_cli_command_runner(command, parameters, user_input, initialize_ctx_obj, 
     """Run CLI command through ``click.testing.CliRunner``."""
     from click.testing import CliRunner
 
-    from aiida.cmdline.commands.cmd_verdi import VerdiCommandGroup
-    from aiida.cmdline.groups.verdi import LazyVerdiObjAttributeDict
+    from aiida.cmdline.groups.verdi import LazyVerdiObjAttributeDict, VerdiCommandGroup
 
     if initialize_ctx_obj:
         config = get_config()


### PR DESCRIPTION
Recreation of #7053 (I cannot push to the branch because of permission restrictions because its so out of date that I would push a new GitHub workflow)

Load top-level verdi commands from the aiida.cmdline.verdi entry point group while retaining the existing built-in commands. Add regression coverage for invoking an external command.