### PR TITLE
🐛 Stash failures are not logged to the process node

### DIFF
--- a/src/aiida/engine/processes/calcjobs/tasks.py
+++ b/src/aiida/engine/processes/calcjobs/tasks.py
@@ -383,8 +383,10 @@ async def task_stash_job(node: CalcJobNode, transport_queue: TransportQueue, can
         )
     except plumpy.process_states.Interruption:
         raise
-    except StashingError:
-        # Re-raise StashingError so it can be handled in the Waiting state with an exit code
+    except StashingError as exception:
+        # Log to the node so the failure shows up in ``verdi process report``, then re-raise so the ``Waiting`` state
+        # terminates the process with an exit code
+        node.logger.error(f'stashing calculation<{node.pk}> failed: {exception}')
         raise
     except Exception as exception:
         logger.warning(f'stashing calculation<{node.pk}> failed')

--- a/tests/calculations/test_stash.py
+++ b/tests/calculations/test_stash.py
@@ -641,3 +641,10 @@ def test_fail_on_missing_with_missing_file(aiida_localhost, tmp_path, stash_mode
     else:
         assert node.is_failed
         assert node.exit_status == 160  # ERROR_STASHING_FAILED
+        logs = orm.Log.collection.get_logs_for(node)
+        assert any(
+            log.levelname == 'ERROR'
+            and f'stashing calculation<{node.pk}> failed' in log.message
+            and 'missing.txt' in log.message
+            for log in logs
+        )


### PR DESCRIPTION
Follow-up to #7563, addressing a point raised there by @npaulish.

Log an error through `node.logger` (which writes to the DB log) before re-raising. Error rather than warning: a transient failure outside the `StashingError` paths is retried by `exponential_backoff_retry` and already lands at ERROR on the node, so the run that failed for good must not rank below the one that recovered. The existing end-to-end test `test_fail_on_missing_with_missing_file` asserts the ERROR entry for both `COPY` and `COMPRESS_TARGZ`
