### PR TITLE
🧪 `docker-bake`: replace `workdir` with `source`

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -45,8 +45,7 @@ jobs:
       with:
         # Load to Docker engine for testing
         load: true
-        workdir: .docker/
-        source: .
+        source: .docker/
         set: |
           *.platform=amd64
           *.cache-to=type=gha,scope=${{ github.workflow }},mode=min

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,8 +61,7 @@ jobs:
       uses: docker/bake-action@v7.3.0
       with:
         push: true
-        workdir: .docker/
-        source: .
+        source: .docker/
         # Using provenance to disable default attestation so it will build only desired images:
         # https://github.com/orgs/community/discussions/45969
         provenance: false


### PR DESCRIPTION
The Docker jobs started failing since [#7570](https://github.com/aiidateam/aiida-core/pull/7570) bumped `docker/bake-action` to v7.

v7 merged the `workdir` input into `source`, so bake resolved the definition files against the repository root instead of `.docker/` and no longer found them. Point `source` at `.docker/`, from which bake resolves every relative path as `workdir` used to.