### PR TITLE
👌 Progress bars: hide when not on a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Behavior changes
 
+#### Progress bars: hidden when the output stream is not a terminal ([#7577](https://github.com/aiidateam/aiida-core/pull/7577))
+
+Progress bars animate by rewriting a single line, so a stream that cannot be rewritten collects every redraw instead, burying the real output of a command such as `verdi archive create` under hundreds of frames.
+They are now hidden whenever `stderr`, the stream they are written to, is not a terminal, so `verdi archive create 2> log.txt` no longer fills the log with frames while `verdi archive create > out.txt` still shows them.
+A Jupyter kernel is treated as a terminal, since it renders the redraws as an animation.
+Pass `disable=False` to `set_progress_bar_tqdm` to show a bar regardless.
+
 ### Fixes
 
 ### Deprecations

--- a/src/aiida/common/progress_reporter.py
+++ b/src/aiida/common/progress_reporter.py
@@ -18,6 +18,7 @@ and indeed a valid implementation is::
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from functools import partial
 from types import TracebackType
@@ -172,9 +173,18 @@ def set_progress_reporter(
         PROGRESS_REPORTER = reporter
 
 
+def _in_jupyter_kernel() -> bool:
+    """Return whether this process is an IPython kernel, as used by Jupyter."""
+    ipython = sys.modules.get('IPython')
+    if ipython is None:
+        return False
+    return hasattr(ipython.get_ipython(), 'kernel')
+
+
 def set_progress_bar_tqdm(
     bar_format: str | None = TQDM_BAR_FORMAT,
     leave: bool | None = False,
+    *,
     disable: bool | None = None,
     **kwargs: Any,
 ) -> None:
@@ -186,13 +196,18 @@ def set_progress_bar_tqdm(
         bar with ``total=None``, since this format's percentage would sit frozen at 0%.
     :param leave: If True, keeps all traces of the progressbar upon termination of iteration.
             If `None`, will leave only if `position` is `0`.
-    :param disable: If True, hide the bar entirely. The default `None` hides it whenever the output
-            stream is not a terminal, so redirecting to a log file does not fill it with the
-            redraw frames a bar emits.
+    :param disable: If ``True``, hide the bar entirely; if ``False``, always show it. The default
+            ``None`` hides it whenever the output stream is not a terminal, so redirecting to a
+            log file does not fill it with the redraw frames a bar emits. A Jupyter kernel is treated
+            as a terminal, since it renders those redraws as an animation.
     :param kwargs: pass to the tqdm init
 
     """
     from tqdm import tqdm
+
+    # A kernel's stderr is not a terminal, so tqdm's own check would hide the bar there.
+    if disable is None and _in_jupyter_kernel():
+        disable = False
 
     set_progress_reporter(tqdm, bar_format=bar_format, leave=leave, disable=disable, **kwargs)
 

--- a/src/aiida/common/progress_reporter.py
+++ b/src/aiida/common/progress_reporter.py
@@ -172,7 +172,12 @@ def set_progress_reporter(
         PROGRESS_REPORTER = reporter
 
 
-def set_progress_bar_tqdm(bar_format: str | None = TQDM_BAR_FORMAT, leave: bool | None = False, **kwargs: Any) -> None:
+def set_progress_bar_tqdm(
+    bar_format: str | None = TQDM_BAR_FORMAT,
+    leave: bool | None = False,
+    disable: bool | None = None,
+    **kwargs: Any,
+) -> None:
     """Set a `tqdm <https://github.com/tqdm/tqdm>`__ implementation of the progress reporter interface.
 
     See :func:`~aiida.common.progress_reporter.set_progress_reporter` for details.
@@ -181,12 +186,15 @@ def set_progress_bar_tqdm(bar_format: str | None = TQDM_BAR_FORMAT, leave: bool 
         bar with ``total=None``, since this format's percentage would sit frozen at 0%.
     :param leave: If True, keeps all traces of the progressbar upon termination of iteration.
             If `None`, will leave only if `position` is `0`.
+    :param disable: If True, hide the bar entirely. The default `None` hides it whenever the output
+            stream is not a terminal, so redirecting to a log file does not fill it with the
+            redraw frames a bar emits.
     :param kwargs: pass to the tqdm init
 
     """
     from tqdm import tqdm
 
-    set_progress_reporter(tqdm, bar_format=bar_format, leave=leave, **kwargs)
+    set_progress_reporter(tqdm, bar_format=bar_format, leave=leave, disable=disable, **kwargs)
 
 
 def create_callback(progress_reporter: ProgressReporterAbstract | tqdm[Any]) -> Callable[[str, Any], None]:

--- a/tests/common/test_progress_reporter.py
+++ b/tests/common/test_progress_reporter.py
@@ -9,10 +9,23 @@
 """Tests for the progress reporter."""
 
 import io
+import sys
+from types import SimpleNamespace
 
 import pytest
 
 from aiida.common.progress_reporter import get_progress_reporter, set_progress_bar_tqdm, set_progress_reporter
+
+
+class Stream(io.StringIO):
+    """A stream whose terminal-ness is settable, since ``io.StringIO`` is never a terminal."""
+
+    def __init__(self, *, isatty: bool):
+        super().__init__()
+        self._isatty = isatty
+
+    def isatty(self) -> bool:
+        return self._isatty
 
 
 @pytest.fixture
@@ -20,6 +33,7 @@ def tqdm_reporter():
     """Install the tqdm reporter and restore the default afterwards."""
 
     def _install(**kwargs):
+        """Install the tqdm reporter with ``kwargs`` and return the installed reporter."""
         set_progress_bar_tqdm(**kwargs)
         return get_progress_reporter()
 
@@ -30,19 +44,39 @@ def tqdm_reporter():
 
 
 def _run_bar(reporter, stream):
+    """Run a short progress bar to completion on ``stream``."""
     with reporter(total=10, desc='Doing something', file=stream) as progress:
         progress.update(5)
 
 
-def test_disabled_when_stream_is_not_a_terminal(tqdm_reporter):
-    """A redirected stream must get no output at all, so log files do not fill with redraw frames."""
-    stream = io.StringIO()
+@pytest.mark.parametrize(
+    'kwargs, isatty, expect_bar',
+    (
+        pytest.param({}, False, False, id='default-hidden-on-redirected-stream'),
+        pytest.param({}, True, True, id='default-shown-on-terminal'),
+        pytest.param({'disable': False}, False, True, id='explicit-false-shows-on-redirected-stream'),
+        pytest.param({'disable': True}, True, False, id='explicit-true-hides-on-terminal'),
+    ),
+)
+def test_bar_visibility(tqdm_reporter, kwargs, isatty, expect_bar):
+    """The stream's terminal-ness decides by default, and an explicit ``disable`` overrides it."""
+    stream = Stream(isatty=isatty)
+
+    _run_bar(tqdm_reporter(**kwargs), stream)
+
+    written = stream.getvalue()
+    # A hidden bar has to leave the stream untouched, so a log file does not fill with redraw frames.
+    assert (written != '') is expect_bar
+    assert ('Doing something' in written) is expect_bar
+
+
+def test_shown_in_jupyter_kernel(tqdm_reporter, monkeypatch):
+    """A Jupyter kernel's stderr is not a terminal, but it renders the redraws as an animation."""
+    shell = SimpleNamespace(kernel=object())
+    monkeypatch.setitem(sys.modules, 'IPython', SimpleNamespace(get_ipython=lambda: shell))
+
+    stream = Stream(isatty=False)
+
     _run_bar(tqdm_reporter(), stream)
-    assert stream.getvalue() == ''
 
-
-def test_enabled_when_disable_is_explicitly_false(tqdm_reporter):
-    """Passing ``disable=False`` must still write, so the default is what silences a redirected stream."""
-    stream = io.StringIO()
-    _run_bar(tqdm_reporter(disable=False), stream)
     assert 'Doing something' in stream.getvalue()

--- a/tests/common/test_progress_reporter.py
+++ b/tests/common/test_progress_reporter.py
@@ -1,0 +1,48 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the progress reporter."""
+
+import io
+
+import pytest
+
+from aiida.common.progress_reporter import get_progress_reporter, set_progress_bar_tqdm, set_progress_reporter
+
+
+@pytest.fixture
+def tqdm_reporter():
+    """Install the tqdm reporter and restore the default afterwards."""
+
+    def _install(**kwargs):
+        set_progress_bar_tqdm(**kwargs)
+        return get_progress_reporter()
+
+    try:
+        yield _install
+    finally:
+        set_progress_reporter(None)
+
+
+def _run_bar(reporter, stream):
+    with reporter(total=10, desc='Doing something', file=stream) as progress:
+        progress.update(5)
+
+
+def test_disabled_when_stream_is_not_a_terminal(tqdm_reporter):
+    """A redirected stream must get no output at all, so log files do not fill with redraw frames."""
+    stream = io.StringIO()
+    _run_bar(tqdm_reporter(), stream)
+    assert stream.getvalue() == ''
+
+
+def test_enabled_when_disable_is_explicitly_false(tqdm_reporter):
+    """Passing ``disable=False`` must still write, so the default is what silences a redirected stream."""
+    stream = io.StringIO()
+    _run_bar(tqdm_reporter(disable=False), stream)
+    assert 'Doing something' in stream.getvalue()

--- a/tests/integration/notebook/test_notebook_integration.py
+++ b/tests/integration/notebook/test_notebook_integration.py
@@ -60,3 +60,13 @@ def test_separate_cell_passes():
 def test_magic_cells_passes():
     """Test that magic commands work correctly after greenback portal is installed."""
     _execute_notebook('test_magic_cells.ipynb')
+
+
+@pytest.mark.timeout(180)
+def test_progress_bar_shown_in_notebook():
+    """Test that a progress bar is shown in a kernel, whose stderr is not a terminal."""
+    nb = _execute_notebook('test_progress_bar.ipynb')
+
+    code_cell = nb.cells[1]  # Cell index 1, after the markdown cell
+    stderr = _get_cell_outputs(code_cell, name='stderr')
+    assert 'Doing something' in stderr

--- a/tests/integration/notebook/test_progress_bar.ipynb
+++ b/tests/integration/notebook/test_progress_bar.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test: progress bars are shown in a notebook\n",
+    "\n",
+    "A kernel replaces `sys.stderr` with a stream that reports `isatty() == False`, which is what\n",
+    "`tqdm`'s `disable=None` uses to hide a bar. The kernel renders the redraws as an animation, so\n",
+    "the bar must be shown here anyway."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "from aiida.common.progress_reporter import get_progress_reporter, set_progress_bar_tqdm\n",
+    "\n",
+    "assert not sys.stderr.isatty(), 'the kernel stderr is expected not to be a terminal'\n",
+    "\n",
+    "set_progress_bar_tqdm()\n",
+    "with get_progress_reporter()(total=3, desc='Doing something') as progress:\n",
+    "    for _ in range(3):\n",
+    "        progress.update()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Progress bars animate by rewriting a single line. A stream that cannot be rewritten collects every redraw instead, so piping `verdi archive create` to a log file buries the real output under hundreds of frames. One 251k-node export writes ~180 of them today, and [#7414](https://github.com/aiidateam/aiida-core/pull/7414) adds another 220 for the graph traversal.

`tqdm` already solves this: `disable=None` means hide unless the stream is a terminal. `set_progress_bar_tqdm` never passed it, so bars were written unconditionally. This makes it the default, with `disable=False` available for callers who want a bar regardless.

Only the stream tqdm writes to (stderr) is inspected, so `verdi archive create > out.txt` still shows bars, while `2>` or `&>` silences them.

Raised by @agoscinski in [#7414](https://github.com/aiidateam/aiida-core/pull/7414/files#r3849960916).

`progress_reporter.py` had no test module at all; this adds one covering both directions.