### PR TITLE
Add TID lint rules to avoid relative imports

### DIFF
--- a/.molecule/default/files/polish/lib/workchain.py
+++ b/.molecule/default/files/polish/lib/workchain.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from string import Template
 
-from .expression import OPERATORS
+from .expression import OPERATORS  # noqa: TID252
 
 INDENTATION_WIDTH = 4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -514,8 +514,12 @@ select = [
   'PLW',  # pylint-warning
   'RUF',  # ruff
   'FLY',  # flynt
-  'NPY201'  # numpy compatibility
+  'NPY201',  # numpy compatibility
+  'TID'  # flake8-tidy-imports
 ]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 # Mark some classes as generic, per https://docs.astral.sh/ruff/settings/#lint_pyflakes_extend-generics
 # Needed due to https://github.com/astral-sh/ruff/issues/9298

--- a/src/aiida/brokers/__init__.py
+++ b/src/aiida/brokers/__init__.py
@@ -4,9 +4,9 @@
 
 # fmt: off
 
-from .broker import *
-from .rabbitmq import *
-from .zeromq import *
+from aiida.brokers.broker import *
+from aiida.brokers.rabbitmq import *
+from aiida.brokers.zeromq import *
 
 __all__ = (
     'Broker',

--- a/src/aiida/brokers/rabbitmq/__init__.py
+++ b/src/aiida/brokers/rabbitmq/__init__.py
@@ -4,7 +4,7 @@
 
 # fmt: off
 
-from .broker import *
+from aiida.brokers.rabbitmq.broker import *
 
 __all__ = (
     'RabbitmqBroker',

--- a/src/aiida/brokers/rabbitmq/broker.py
+++ b/src/aiida/brokers/rabbitmq/broker.py
@@ -9,10 +9,9 @@ from collections.abc import Iterator
 
 from aiida.brokers.broker import Broker, BrokerConfigField, BrokerServiceStatus, JsonValue
 from aiida.brokers.rabbitmq import defaults
+from aiida.brokers.rabbitmq.utils import get_launch_queue_name, get_message_exchange_name, get_task_exchange_name
 from aiida.common.log import AIIDA_LOGGER
 from aiida.manage.configuration import get_config_option
-
-from .utils import get_launch_queue_name, get_message_exchange_name, get_task_exchange_name
 
 if t.TYPE_CHECKING:
     from kiwipy.rmq import RmqThreadCommunicator
@@ -217,7 +216,7 @@ class RabbitmqBroker(Broker):
         """
         from urllib.parse import urlsplit, urlunsplit
 
-        from .utils import get_rmq_url
+        from aiida.brokers.rabbitmq.utils import get_rmq_url
 
         kwargs = {
             key[7:]: val for key, val in self._profile.process_control_config.items() if key.startswith('broker_')

--- a/src/aiida/brokers/rabbitmq/utils.py
+++ b/src/aiida/brokers/rabbitmq/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from . import defaults
+from aiida.brokers.rabbitmq import defaults
 
 
 def get_rmq_url(

--- a/src/aiida/brokers/zeromq/__init__.py
+++ b/src/aiida/brokers/zeromq/__init__.py
@@ -4,7 +4,7 @@
 
 # fmt: off
 
-from .broker import *
+from aiida.brokers.zeromq.broker import *
 
 __all__ = (
     'ZeromqBroker',

--- a/src/aiida/brokers/zeromq/broker.py
+++ b/src/aiida/brokers/zeromq/broker.py
@@ -12,13 +12,12 @@ from pathlib import Path
 import psutil
 
 from aiida.brokers.broker import Broker, BrokerConfigField, BrokerServiceStatus
+from aiida.brokers.zeromq.communicator import ZeromqCommunicator
+from aiida.brokers.zeromq.defaults import BROKER_READY_TIMEOUT
+from aiida.brokers.zeromq.queue import PersistentQueue
+from aiida.brokers.zeromq.service import PID_SENTINEL, ZeromqBrokerService
 from aiida.common.exceptions import ConfigurationError
 from aiida.common.log import AIIDA_LOGGER
-
-from .communicator import ZeromqCommunicator
-from .defaults import BROKER_READY_TIMEOUT
-from .queue import PersistentQueue
-from .service import PID_SENTINEL, ZeromqBrokerService
 
 if t.TYPE_CHECKING:
     from aiida.manage.configuration.profile import Profile

--- a/src/aiida/brokers/zeromq/communicator.py
+++ b/src/aiida/brokers/zeromq/communicator.py
@@ -29,8 +29,8 @@ import kiwipy
 import zmq
 import zmq.asyncio
 
-from .defaults import LOOP_JOIN_TIMEOUT, LOOP_TIMEOUT
-from .protocol import (
+from aiida.brokers.zeromq.defaults import LOOP_JOIN_TIMEOUT, LOOP_TIMEOUT
+from aiida.brokers.zeromq.protocol import (
     MessageType,
     decode_message,
     encode_message,

--- a/src/aiida/brokers/zeromq/server.py
+++ b/src/aiida/brokers/zeromq/server.py
@@ -25,9 +25,9 @@ from typing import Any
 
 import zmq
 
-from .defaults import HEARTBEAT_IVL, HEARTBEAT_TIMEOUT, POLL_TIMEOUT
-from .protocol import MessageType, decode_message, encode_message
-from .queue import PersistentQueue
+from aiida.brokers.zeromq.defaults import HEARTBEAT_IVL, HEARTBEAT_TIMEOUT, POLL_TIMEOUT
+from aiida.brokers.zeromq.protocol import MessageType, decode_message, encode_message
+from aiida.brokers.zeromq.queue import PersistentQueue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -594,7 +594,7 @@ class ZeromqBrokerServer:
         if not self._task_worker_assignments:
             return
 
-        from .protocol import make_ping
+        from aiida.brokers.zeromq.protocol import make_ping
 
         # Get unique worker identities with assigned tasks
         worker_identities = set(self._task_worker_assignments.values())

--- a/src/aiida/brokers/zeromq/service.py
+++ b/src/aiida/brokers/zeromq/service.py
@@ -16,10 +16,9 @@ import time
 import typing as t
 from pathlib import Path
 
+from aiida.brokers.zeromq.defaults import POLL_TIMEOUT, STATUS_INTERVAL
+from aiida.brokers.zeromq.server import ZeromqBrokerServer
 from aiida.common.log import configure_logging
-
-from .defaults import POLL_TIMEOUT, STATUS_INTERVAL
-from .server import ZeromqBrokerServer
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/aiida/calculations/unstash.py
+++ b/src/aiida/calculations/unstash.py
@@ -12,11 +12,10 @@ import json
 from pathlib import Path
 
 from aiida import orm
+from aiida.calculations.stash import StashCalculation
 from aiida.common import AIIDA_LOGGER
 from aiida.common.datastructures import CalcInfo, CodeInfo, UnstashTargetMode
 from aiida.engine import CalcJob
-
-from .stash import StashCalculation
 
 EXEC_LOGGER = AIIDA_LOGGER.getChild('UnstashCalculation')
 

--- a/src/aiida/cmdline/__init__.py
+++ b/src/aiida/cmdline/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .groups import *
-from .params import *
-from .utils import *
+from aiida.cmdline.groups import *
+from aiida.cmdline.params import *
+from aiida.cmdline.utils import *
 
 __all__ = (
     'AbsolutePathParamType',

--- a/src/aiida/cmdline/commands/cmd_rabbitmq.py
+++ b/src/aiida/cmdline/commands/cmd_rabbitmq.py
@@ -238,7 +238,7 @@ def cmd_tasks_analyze(ctx, fix):
 
     Use ``-v INFO`` to be more verbose and print more information.
     """
-    from .cmd_process import process_repair
+    from aiida.cmdline.commands.cmd_process import process_repair
 
     ctx.invoke(process_repair, dry_run=not fix)
 

--- a/src/aiida/cmdline/commands/cmd_status.py
+++ b/src/aiida/cmdline/commands/cmd_status.py
@@ -18,11 +18,10 @@ import click
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import echo
+from aiida.cmdline.utils.echo import ExitCode
 from aiida.common.exceptions import CorruptStorage, IncompatibleStorageSchema, UnreachableStorage
 from aiida.common.log import override_log_level
 from aiida.common.warnings import warn_deprecation
-
-from ..utils.echo import ExitCode
 
 
 class ServiceStatus(enum.IntEnum):

--- a/src/aiida/cmdline/commands/cmd_verdi.py
+++ b/src/aiida/cmdline/commands/cmd_verdi.py
@@ -11,9 +11,8 @@
 import click
 
 from aiida import __version__
-
-from ..groups import VerdiCommandGroup
-from ..params import options, types
+from aiida.cmdline.groups import VerdiCommandGroup
+from aiida.cmdline.params import options, types
 
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number

--- a/src/aiida/cmdline/groups/__init__.py
+++ b/src/aiida/cmdline/groups/__init__.py
@@ -4,8 +4,8 @@
 
 # fmt: off
 
-from .dynamic import *
-from .verdi import *
+from aiida.cmdline.groups.dynamic import *
+from aiida.cmdline.groups.verdi import *
 
 __all__ = (
     'DynamicEntryPointCommandGroup',

--- a/src/aiida/cmdline/groups/dynamic.py
+++ b/src/aiida/cmdline/groups/dynamic.py
@@ -8,13 +8,12 @@ import typing as t
 
 import click
 
+from aiida.cmdline.groups.verdi import VerdiCommandGroup
+from aiida.cmdline.params import options
+from aiida.cmdline.params.options.interactive import InteractiveOption
 from aiida.common import exceptions
 from aiida.plugins.entry_point import ENTRY_POINT_GROUP_FACTORY_MAPPING, get_entry_point_names
 from aiida.plugins.factories import BaseFactory
-
-from ..params import options
-from ..params.options.interactive import InteractiveOption
-from .verdi import VerdiCommandGroup
 
 if t.TYPE_CHECKING:
     from click.decorators import FC

--- a/src/aiida/cmdline/groups/verdi.py
+++ b/src/aiida/cmdline/groups/verdi.py
@@ -9,12 +9,11 @@ import typing as t
 
 import click
 
+from aiida.cmdline.params import options
 from aiida.cmdline.utils.echo import echo_deprecated
 from aiida.common.exceptions import ConfigurationError
 from aiida.common.extendeddicts import AttributeDict
 from aiida.manage.configuration import get_config
-
-from ..params import options
 
 __all__ = ('VerdiCommandGroup',)
 

--- a/src/aiida/cmdline/params/__init__.py
+++ b/src/aiida/cmdline/params/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .types import *
+from aiida.cmdline.params.types import *
 
 __all__ = (
     'AbsolutePathParamType',

--- a/src/aiida/cmdline/params/arguments/__init__.py
+++ b/src/aiida/cmdline/params/arguments/__init__.py
@@ -11,8 +11,8 @@
 
 # fmt: off
 
-from .main import *
-from .overridable import *
+from aiida.cmdline.params.arguments.main import *
+from aiida.cmdline.params.arguments.overridable import *
 
 __all__ = (
     'CALCULATION',

--- a/src/aiida/cmdline/params/arguments/main.py
+++ b/src/aiida/cmdline/params/arguments/main.py
@@ -11,8 +11,8 @@
 
 import click
 
-from .. import types
-from .overridable import OverridableArgument
+from aiida.cmdline.params import types
+from aiida.cmdline.params.arguments.overridable import OverridableArgument
 
 __all__ = (
     'CALCULATION',

--- a/src/aiida/cmdline/params/options/__init__.py
+++ b/src/aiida/cmdline/params/options/__init__.py
@@ -12,11 +12,11 @@
 
 # fmt: off
 
-from .callable import *
-from .config import *
-from .main import *
-from .multivalue import *
-from .overridable import *
+from aiida.cmdline.params.options.callable import *
+from aiida.cmdline.params.options.config import *
+from aiida.cmdline.params.options.main import *
+from aiida.cmdline.params.options.multivalue import *
+from aiida.cmdline.params.options.overridable import *
 
 __all__ = (
     'ALL',

--- a/src/aiida/cmdline/params/options/config.py
+++ b/src/aiida/cmdline/params/options/config.py
@@ -23,7 +23,7 @@ import typing as t
 
 import click
 
-from .overridable import OverridableOption
+from aiida.cmdline.params.options.overridable import OverridableOption
 
 if t.TYPE_CHECKING:
     from click.decorators import FC

--- a/src/aiida/cmdline/params/options/interactive.py
+++ b/src/aiida/cmdline/params/options/interactive.py
@@ -15,9 +15,8 @@ import typing as t
 import click
 from click.shell_completion import CompletionItem
 
+from aiida.cmdline.params.options.conditional import ConditionalOption
 from aiida.cmdline.utils import echo
-
-from .conditional import ConditionalOption
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -16,15 +16,14 @@ import typing as t
 import click
 
 from aiida.brokers.rabbitmq.defaults import BROKER_DEFAULTS
+from aiida.cmdline.params import types
+from aiida.cmdline.params.options.callable import CallableDefaultOption
+from aiida.cmdline.params.options.config import ConfigFileOption
+from aiida.cmdline.params.options.multivalue import MultipleValueOption
+from aiida.cmdline.params.options.overridable import OverridableOption
+from aiida.cmdline.utils import defaults, echo
 from aiida.common.log import LOG_LEVELS, configure_logging
 from aiida.manage.external.postgres import DEFAULT_DBINFO  # type: ignore[attr-defined]
-
-from ...utils import defaults, echo
-from .. import types
-from .callable import CallableDefaultOption
-from .config import ConfigFileOption
-from .multivalue import MultipleValueOption
-from .overridable import OverridableOption
 
 if t.TYPE_CHECKING:
     from click.decorators import FC

--- a/src/aiida/cmdline/params/options/multivalue.py
+++ b/src/aiida/cmdline/params/options/multivalue.py
@@ -14,7 +14,7 @@ import typing as t
 
 import click
 
-from .. import types
+from aiida.cmdline.params import types
 
 __all__ = ('MultipleValueOption',)
 

--- a/src/aiida/cmdline/params/types/__init__.py
+++ b/src/aiida/cmdline/params/types/__init__.py
@@ -12,23 +12,23 @@
 
 # fmt: off
 
-from .calculation import *
-from .choice import *
-from .code import *
-from .computer import *
-from .config import *
-from .data import *
-from .group import *
-from .identifier import *
-from .multiple import *
-from .node import *
-from .path import *
-from .plugin import *
-from .process import *
-from .profile import *
-from .strings import *
-from .user import *
-from .workflow import *
+from aiida.cmdline.params.types.calculation import *
+from aiida.cmdline.params.types.choice import *
+from aiida.cmdline.params.types.code import *
+from aiida.cmdline.params.types.computer import *
+from aiida.cmdline.params.types.config import *
+from aiida.cmdline.params.types.data import *
+from aiida.cmdline.params.types.group import *
+from aiida.cmdline.params.types.identifier import *
+from aiida.cmdline.params.types.multiple import *
+from aiida.cmdline.params.types.node import *
+from aiida.cmdline.params.types.path import *
+from aiida.cmdline.params.types.plugin import *
+from aiida.cmdline.params.types.process import *
+from aiida.cmdline.params.types.profile import *
+from aiida.cmdline.params.types.strings import *
+from aiida.cmdline.params.types.user import *
+from aiida.cmdline.params.types.workflow import *
 
 __all__ = (
     'AbsolutePathParamType',

--- a/src/aiida/cmdline/params/types/calculation.py
+++ b/src/aiida/cmdline/params/types/calculation.py
@@ -10,7 +10,7 @@
 
 import typing as t
 
-from .identifier import IdentifierParamType
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 
 if t.TYPE_CHECKING:
     from aiida.orm.utils.loaders import CalculationEntityLoader

--- a/src/aiida/cmdline/params/types/choice.py
+++ b/src/aiida/cmdline/params/types/choice.py
@@ -14,7 +14,7 @@ import typing as t
 
 import click
 
-from .._shims import shim_add_ctx
+from aiida.cmdline.params._shims import shim_add_ctx
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/aiida/cmdline/params/types/code.py
+++ b/src/aiida/cmdline/params/types/code.py
@@ -18,9 +18,8 @@ if t.TYPE_CHECKING:
 import click
 from click.shell_completion import CompletionItem
 
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 from aiida.cmdline.utils import decorators
-
-from .identifier import IdentifierParamType
 
 __all__ = ('CodeParamType',)
 

--- a/src/aiida/cmdline/params/types/computer.py
+++ b/src/aiida/cmdline/params/types/computer.py
@@ -19,8 +19,8 @@ import click
 from click.shell_completion import CompletionItem
 from click.types import StringParamType
 
-from ...utils import decorators
-from .identifier import IdentifierParamType
+from aiida.cmdline.params.types.identifier import IdentifierParamType
+from aiida.cmdline.utils import decorators
 
 __all__ = ('ComputerParamType', 'MpirunCommandParamType', 'ShebangParamType')
 

--- a/src/aiida/cmdline/params/types/data.py
+++ b/src/aiida/cmdline/params/types/data.py
@@ -13,7 +13,7 @@ import typing as t
 if t.TYPE_CHECKING:
     from aiida.orm.utils.loaders import DataEntityLoader
 
-from .identifier import IdentifierParamType
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 
 __all__ = ('DataParamType',)
 

--- a/src/aiida/cmdline/params/types/group.py
+++ b/src/aiida/cmdline/params/types/group.py
@@ -17,10 +17,9 @@ if t.TYPE_CHECKING:
 
 import click
 
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 from aiida.cmdline.utils import decorators
 from aiida.common.lang import type_check
-
-from .identifier import IdentifierParamType
 
 __all__ = ('GroupParamType',)
 

--- a/src/aiida/cmdline/params/types/multiple.py
+++ b/src/aiida/cmdline/params/types/multiple.py
@@ -14,7 +14,7 @@ import typing as t
 
 import click
 
-from .._shims import shim_add_ctx
+from aiida.cmdline.params._shims import shim_add_ctx
 
 __all__ = ('MultipleValueParamType',)
 

--- a/src/aiida/cmdline/params/types/node.py
+++ b/src/aiida/cmdline/params/types/node.py
@@ -13,7 +13,7 @@ import typing as t
 if t.TYPE_CHECKING:
     from aiida.orm.utils.loaders import NodeEntityLoader
 
-from .identifier import IdentifierParamType
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 
 __all__ = ('NodeParamType',)
 

--- a/src/aiida/cmdline/params/types/plugin.py
+++ b/src/aiida/cmdline/params/types/plugin.py
@@ -15,6 +15,8 @@ import typing as t
 
 import click
 
+from aiida.cmdline.params._shims import shim_add_ctx
+from aiida.cmdline.params.types.strings import EntryPointType
 from aiida.common import exceptions
 from aiida.plugins import factories
 from aiida.plugins.entry_point import (
@@ -27,9 +29,6 @@ from aiida.plugins.entry_point import (
     get_entry_point_string_format,
     get_entry_points,
 )
-
-from .._shims import shim_add_ctx
-from .strings import EntryPointType
 
 if t.TYPE_CHECKING:
     from importlib_metadata import EntryPoint

--- a/src/aiida/cmdline/params/types/process.py
+++ b/src/aiida/cmdline/params/types/process.py
@@ -13,7 +13,7 @@ import typing as t
 if t.TYPE_CHECKING:
     from aiida.orm.utils.loaders import ProcessEntityLoader
 
-from .identifier import IdentifierParamType
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 
 __all__ = ('ProcessParamType',)
 

--- a/src/aiida/cmdline/params/types/profile.py
+++ b/src/aiida/cmdline/params/types/profile.py
@@ -15,7 +15,7 @@ import typing as t
 import click
 from click.shell_completion import CompletionItem
 
-from .strings import LabelStringType
+from aiida.cmdline.params.types.strings import LabelStringType
 
 if t.TYPE_CHECKING:
     from aiida.manage.configuration import Profile

--- a/src/aiida/cmdline/params/types/workflow.py
+++ b/src/aiida/cmdline/params/types/workflow.py
@@ -13,7 +13,7 @@ import typing as t
 if t.TYPE_CHECKING:
     from aiida.orm.utils.loaders import WorkflowEntityLoader
 
-from .identifier import IdentifierParamType
+from aiida.cmdline.params.types.identifier import IdentifierParamType
 
 __all__ = ('WorkflowParamType',)
 

--- a/src/aiida/cmdline/utils/__init__.py
+++ b/src/aiida/cmdline/utils/__init__.py
@@ -12,10 +12,10 @@
 
 # fmt: off
 
-from .ascii_vis import *
-from .common import *
-from .decorators import *
-from .echo import *
+from aiida.cmdline.utils.ascii_vis import *
+from aiida.cmdline.utils.common import *
+from aiida.cmdline.utils.decorators import *
+from aiida.cmdline.utils.echo import *
 
 __all__ = (
     'dbenv',

--- a/src/aiida/cmdline/utils/common.py
+++ b/src/aiida/cmdline/utils/common.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from click import style
 
-from . import echo
+from aiida.cmdline.utils import echo
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping

--- a/src/aiida/cmdline/utils/decorators.py
+++ b/src/aiida/cmdline/utils/decorators.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from click_spinner import spinner
 from wrapt import decorator
 
-from . import echo
+from aiida.cmdline.utils import echo
 
 DAEMON_NOT_RUNNING_DEFAULT_MESSAGE = 'daemon is not running'
 

--- a/src/aiida/cmdline/utils/log.py
+++ b/src/aiida/cmdline/utils/log.py
@@ -4,7 +4,7 @@ import logging
 
 import click
 
-from .echo import COLORS
+from aiida.cmdline.utils.echo import COLORS
 
 
 class CliHandler(logging.Handler):

--- a/src/aiida/common/__init__.py
+++ b/src/aiida/common/__init__.py
@@ -16,13 +16,13 @@
 
 # fmt: off
 
-from .datastructures import *
-from .exceptions import *
-from .extendeddicts import *
-from .links import *
-from .log import *
-from .progress_reporter import *
-from .utils import *
+from aiida.common.datastructures import *
+from aiida.common.exceptions import *
+from aiida.common.extendeddicts import *
+from aiida.common.links import *
+from aiida.common.log import *
+from aiida.common.progress_reporter import *
+from aiida.common.utils import *
 
 __all__ = (
     'AIIDA_LOGGER',

--- a/src/aiida/common/datastructures.py
+++ b/src/aiida/common/datastructures.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from enum import Enum, IntEnum
 from typing import TYPE_CHECKING
 
-from .extendeddicts import DefaultFieldsAttributeDict
+from aiida.common.extendeddicts import DefaultFieldsAttributeDict
 
 __all__ = ('CalcInfo', 'CalcJobState', 'CodeInfo', 'CodeRunMode', 'StashMode', 'UnstashTargetMode')
 

--- a/src/aiida/common/extendeddicts.py
+++ b/src/aiida/common/extendeddicts.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from typing_extensions import Self
 
-from . import exceptions
+from aiida.common import exceptions
 
 __all__ = ('AttributeDict', 'DefaultFieldsAttributeDict', 'FixedFieldsAttributeDict')
 

--- a/src/aiida/common/files.py
+++ b/src/aiida/common/files.py
@@ -11,7 +11,7 @@
 import hashlib
 from typing import BinaryIO
 
-from .typing import FilePath
+from aiida.common.typing import FilePath
 
 
 def md5_from_filelike(filelike: BinaryIO, block_size_factor: int = 128) -> str:

--- a/src/aiida/common/folders.py
+++ b/src/aiida/common/folders.py
@@ -22,9 +22,9 @@ from collections.abc import Iterator
 
 from typing_extensions import Self
 
-from . import timezone
-from .lang import type_check
-from .typing import FilePath
+from aiida.common import timezone
+from aiida.common.lang import type_check
+from aiida.common.typing import FilePath
 
 # If True, tries to make everything (dirs, files) group-writable.
 # Otherwise, tries to make everything only readable and writable by the user.

--- a/src/aiida/common/hashing.py
+++ b/src/aiida/common/hashing.py
@@ -23,9 +23,8 @@ from operator import itemgetter
 
 from aiida.common.constants import AIIDA_FLOAT_PRECISION
 from aiida.common.exceptions import HashingError
+from aiida.common.folders import Folder
 from aiida.common.utils import DatetimePrecision
-
-from .folders import Folder
 
 
 def get_random_string(length: int = 12) -> str:

--- a/src/aiida/common/links.py
+++ b/src/aiida/common/links.py
@@ -11,7 +11,7 @@
 from collections import namedtuple
 from enum import Enum
 
-from .lang import isidentifier, type_check
+from aiida.common.lang import isidentifier, type_check
 
 __all__ = ('GraphTraversalRule', 'GraphTraversalRules', 'LinkType', 'validate_link_label')
 

--- a/src/aiida/common/utils.py
+++ b/src/aiida/common/utils.py
@@ -25,7 +25,7 @@ from uuid import UUID
 
 from typing_extensions import Self
 
-from .lang import classproperty
+from aiida.common.lang import classproperty
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator

--- a/src/aiida/engine/__init__.py
+++ b/src/aiida/engine/__init__.py
@@ -12,13 +12,13 @@
 
 # fmt: off
 
-from .daemon import *
-from .exceptions import *
-from .launch import *
-from .persistence import *
-from .processes import *
-from .runners import *
-from .utils import *
+from aiida.engine.daemon import *
+from aiida.engine.exceptions import *
+from aiida.engine.launch import *
+from aiida.engine.persistence import *
+from aiida.engine.processes import *
+from aiida.engine.runners import *
+from aiida.engine.utils import *
 
 __all__ = (
     'PORT_NAMESPACE_SEPARATOR',

--- a/src/aiida/engine/daemon/__init__.py
+++ b/src/aiida/engine/daemon/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .client import *
+from aiida.engine.daemon.client import *
 
 __all__ = (
     'DaemonClient',

--- a/src/aiida/engine/launch.py
+++ b/src/aiida/engine/launch.py
@@ -16,14 +16,13 @@ import typing as t
 from aiida.common import InvalidOperation
 from aiida.common.lang import type_check
 from aiida.common.log import AIIDA_LOGGER
+from aiida.engine.processes.builder import ProcessBuilder
+from aiida.engine.processes.functions import FunctionProcess
+from aiida.engine.processes.process import Process
+from aiida.engine.runners import ResultAndPk
+from aiida.engine.utils import instantiate_process, is_process_scoped, prepare_inputs
 from aiida.manage import manager
 from aiida.orm import ProcessNode
-
-from .processes.builder import ProcessBuilder
-from .processes.functions import FunctionProcess
-from .processes.process import Process
-from .runners import ResultAndPk
-from .utils import instantiate_process, is_process_scoped, prepare_inputs
 
 __all__ = ('await_processes', 'run', 'run_get_node', 'run_get_pk', 'submit')
 

--- a/src/aiida/engine/processes/__init__.py
+++ b/src/aiida/engine/processes/__init__.py
@@ -12,15 +12,15 @@
 
 # fmt: off
 
-from .builder import *
-from .calcjobs import *
-from .exit_code import *
-from .functions import *
-from .futures import *
-from .ports import *
-from .process import *
-from .process_spec import *
-from .workchains import *
+from aiida.engine.processes.builder import *
+from aiida.engine.processes.calcjobs import *
+from aiida.engine.processes.exit_code import *
+from aiida.engine.processes.functions import *
+from aiida.engine.processes.futures import *
+from aiida.engine.processes.ports import *
+from aiida.engine.processes.process import *
+from aiida.engine.processes.process_spec import *
+from aiida.engine.processes.workchains import *
 
 __all__ = (
     'PORT_NAMESPACE_SEPARATOR',

--- a/src/aiida/engine/processes/builder.py
+++ b/src/aiida/engine/processes/builder.py
@@ -14,10 +14,9 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from aiida.engine.processes.ports import PortNamespace
+from aiida.engine.processes.utils import prune_mapping
 from aiida.orm import Dict, Node
 from aiida.orm.nodes.data.base import BaseType
-
-from .utils import prune_mapping
 
 if TYPE_CHECKING:
     from aiida.engine.processes.process import Process

--- a/src/aiida/engine/processes/calcjobs/__init__.py
+++ b/src/aiida/engine/processes/calcjobs/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .calcjob import *
-from .importer import *
-from .manager import *
+from aiida.engine.processes.calcjobs.calcjob import *
+from aiida.engine.processes.calcjobs.importer import *
+from aiida.engine.processes.calcjobs.manager import *
 
 __all__ = (
     'CalcJob',

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -28,14 +28,13 @@ from aiida.common.folders import Folder
 from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
 from aiida.common.typing import FilePath
-
-from ..exit_code import ExitCode
-from ..ports import PortNamespace
-from ..process import Process, ProcessState
-from ..process_spec import CalcJobProcessSpec
-from .importer import CalcJobImporter
-from .monitors import CalcJobMonitor
-from .tasks import UPLOAD_COMMAND, Waiting
+from aiida.engine.processes.calcjobs.importer import CalcJobImporter
+from aiida.engine.processes.calcjobs.monitors import CalcJobMonitor
+from aiida.engine.processes.calcjobs.tasks import UPLOAD_COMMAND, Waiting
+from aiida.engine.processes.exit_code import ExitCode
+from aiida.engine.processes.ports import PortNamespace
+from aiida.engine.processes.process import Process, ProcessState
+from aiida.engine.processes.process_spec import CalcJobProcessSpec
 
 __all__ = ('CalcJob',)
 

--- a/src/aiida/engine/processes/calcjobs/tasks.py
+++ b/src/aiida/engine/processes/calcjobs/tasks.py
@@ -27,18 +27,17 @@ from aiida.common.exceptions import FeatureNotAvailable, StashingError, Transpor
 from aiida.common.folders import SandboxFolder
 from aiida.engine import utils
 from aiida.engine.daemon import execmanager
+from aiida.engine.processes.calcjobs.monitors import CalcJobMonitorAction, CalcJobMonitorResult, CalcJobMonitors
 from aiida.engine.processes.exit_code import ExitCode
+from aiida.engine.processes.process import ProcessState
 from aiida.engine.transports import TransportQueue
 from aiida.engine.utils import InterruptableFuture, interruptable_task
 from aiida.manage.configuration import get_config_option
 from aiida.orm.nodes.process.calculation.calcjob import CalcJobNode
 from aiida.schedulers.datastructures import JobState
 
-from ..process import ProcessState
-from .monitors import CalcJobMonitorAction, CalcJobMonitorResult, CalcJobMonitors
-
 if TYPE_CHECKING:
-    from .calcjob import CalcJob
+    from aiida.engine.processes.calcjobs.calcjob import CalcJob
 
 UPLOAD_COMMAND = 'upload'
 SUBMIT_COMMAND = 'submit'

--- a/src/aiida/engine/processes/functions.py
+++ b/src/aiida/engine/processes/functions.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, ParamSpec
 import docstring_parser
 
 from aiida.common.lang import override
+from aiida.engine.processes.process import Process
+from aiida.engine.processes.process_spec import ProcessSpec
 from aiida.manage import get_manager
 from aiida.orm import (
     Bool,
@@ -39,11 +41,8 @@ from aiida.orm import (
 )
 from aiida.orm.utils.mixins import FunctionCalculationMixin
 
-from .process import Process
-from .process_spec import ProcessSpec
-
 if TYPE_CHECKING:
-    from .exit_code import ExitCode
+    from aiida.engine.processes.exit_code import ExitCode
 
 __all__ = ('FunctionProcess', 'calcfunction', 'workfunction')
 
@@ -525,7 +524,7 @@ class FunctionProcess(Process):
     @override
     async def run(self) -> ExitCode | None:
         """Run the process."""
-        from .exit_code import ExitCode
+        from aiida.engine.processes.exit_code import ExitCode
 
         # The following conditional is required for the caching to properly work. Even if the source node has a process
         # state of `Finished` the cached process will still enter the running state. The process state will have then

--- a/src/aiida/engine/processes/futures.py
+++ b/src/aiida/engine/processes/futures.py
@@ -40,7 +40,7 @@ class ProcessFuture(asyncio.Future):
         :param poll_interval: optional polling interval, if None, polling is not activated.
         :param communicator: optional communicator, if None, will not subscribe to broadcasts.
         """
-        from .process import ProcessState
+        from aiida.engine.processes.process import ProcessState
 
         # create future in specified event loop
         loop = loop if loop is not None else get_or_create_event_loop()

--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -43,16 +43,15 @@ from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
+from aiida.engine.processes.builder import ProcessBuilder
+from aiida.engine.processes.exit_code import ExitCode, ExitCodesNamespace
+from aiida.engine.processes.ports import PORT_NAMESPACE_SEPARATOR, InputPort, OutputPort, PortNamespace
+from aiida.engine.processes.process_spec import ProcessSpec
+from aiida.engine.processes.utils import prune_mapping
 from aiida.engine.utils import InterruptableFuture
 from aiida.orm.implementation.utils import clean_value
 from aiida.orm.nodes.process.calculation.calcjob import CalcJobNode
 from aiida.orm.utils import serialize
-
-from .builder import ProcessBuilder
-from .exit_code import ExitCode, ExitCodesNamespace
-from .ports import PORT_NAMESPACE_SEPARATOR, InputPort, OutputPort, PortNamespace
-from .process_spec import ProcessSpec
-from .utils import prune_mapping
 
 if TYPE_CHECKING:
     from aiida.engine.runners import Runner
@@ -348,7 +347,7 @@ class Process(PlumpyProcess):
                 self._cancelling_scheduler_job.cancel()
                 self.node.logger.report('Found active scheduler job cancelation that will be rescheduled.')
 
-            from .calcjobs.tasks import task_kill_job
+            from aiida.engine.processes.calcjobs.tasks import task_kill_job
 
             coro = self._launch_task(task_kill_job, self.node, self.runner.transport)
             self._cancelling_scheduler_job = asyncio.create_task(coro)

--- a/src/aiida/engine/processes/process_spec.py
+++ b/src/aiida/engine/processes/process_spec.py
@@ -10,10 +10,9 @@
 
 import plumpy.process_spec
 
+from aiida.engine.processes.exit_code import ExitCode, ExitCodesNamespace
+from aiida.engine.processes.ports import CalcJobOutputPort, InputPort, PortNamespace
 from aiida.orm import Dict
-
-from .exit_code import ExitCode, ExitCodesNamespace
-from .ports import CalcJobOutputPort, InputPort, PortNamespace
 
 __all__ = ('CalcJobProcessSpec', 'ProcessSpec')
 

--- a/src/aiida/engine/processes/workchains/__init__.py
+++ b/src/aiida/engine/processes/workchains/__init__.py
@@ -12,11 +12,11 @@
 
 # fmt: off
 
-from .awaitable import *
-from .context import *
-from .restart import *
-from .utils import *
-from .workchain import *
+from aiida.engine.processes.workchains.awaitable import *
+from aiida.engine.processes.workchains.context import *
+from aiida.engine.processes.workchains.restart import *
+from aiida.engine.processes.workchains.utils import *
+from aiida.engine.processes.workchains.workchain import *
 
 __all__ = (
     'Awaitable',

--- a/src/aiida/engine/processes/workchains/context.py
+++ b/src/aiida/engine/processes/workchains/context.py
@@ -8,9 +8,8 @@
 ###########################################################################
 """Convenience functions to add awaitables to the Context of a WorkChain."""
 
+from aiida.engine.processes.workchains.awaitable import Awaitable, AwaitableAction, construct_awaitable
 from aiida.orm import ProcessNode
-
-from .awaitable import Awaitable, AwaitableAction, construct_awaitable
 
 __all__ = ('ToContext', 'append_', 'assign_')
 

--- a/src/aiida/engine/processes/workchains/restart.py
+++ b/src/aiida/engine/processes/workchains/restart.py
@@ -20,10 +20,9 @@ from aiida import orm
 from aiida.common import AttributeDict
 from aiida.common.links import LinkType
 from aiida.common.warnings import warn_deprecation
-
-from .context import ToContext, append_
-from .utils import ProcessHandlerReport, process_handler
-from .workchain import WorkChain
+from aiida.engine.processes.workchains.context import ToContext, append_
+from aiida.engine.processes.workchains.utils import ProcessHandlerReport, process_handler
+from aiida.engine.processes.workchains.workchain import WorkChain
 
 if TYPE_CHECKING:
     from aiida.engine.processes import ExitCode, PortNamespace, Process, ProcessSpec
@@ -149,7 +148,7 @@ class BaseRestartWorkChain(WorkChain):
     @property
     def process_class(self) -> type[Process]:
         """Return the process class to run in the loop."""
-        from ..process import Process
+        from aiida.engine.processes.process import Process
 
         if self._process_class is None or not issubclass(self._process_class, Process):
             raise ValueError('no valid Process class defined for `_process_class` attribute')

--- a/src/aiida/engine/processes/workchains/utils.py
+++ b/src/aiida/engine/processes/workchains/utils.py
@@ -15,7 +15,7 @@ from typing import NamedTuple
 
 from wrapt import decorator
 
-from ..exit_code import ExitCode
+from aiida.engine.processes.exit_code import ExitCode
 
 __all__ = ('ProcessHandlerReport', 'process_handler')
 

--- a/src/aiida/engine/processes/workchains/workchain.py
+++ b/src/aiida/engine/processes/workchains/workchain.py
@@ -25,13 +25,12 @@ from plumpy.workchains import WorkChainSpec as PlumpyWorkChainSpec
 from aiida.common import exceptions
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import override
+from aiida.engine.processes.exit_code import ExitCode
+from aiida.engine.processes.process import Process, ProcessState
+from aiida.engine.processes.process_spec import ProcessSpec
+from aiida.engine.processes.workchains.awaitable import Awaitable, AwaitableAction, AwaitableTarget, construct_awaitable
 from aiida.orm import Node, ProcessNode, WorkChainNode
 from aiida.orm.utils import load_node
-
-from ..exit_code import ExitCode
-from ..process import Process, ProcessState
-from ..process_spec import ProcessSpec
-from .awaitable import Awaitable, AwaitableAction, AwaitableTarget, construct_awaitable
 
 if t.TYPE_CHECKING:
     from aiida.engine.runners import Runner
@@ -310,7 +309,7 @@ class WorkChain(Process, metaclass=Protect):
         will enter in the Wait state, otherwise it will go to Continue. When the stepper returns that it is done, the
         stepper result will be converted to None and returned, unless it is an integer or instance of ExitCode.
         """
-        from .context import ToContext
+        from aiida.engine.processes.workchains.context import ToContext
 
         self._awaitables = []
         result: t.Any = None

--- a/src/aiida/engine/runners.py
+++ b/src/aiida/engine/runners.py
@@ -27,12 +27,11 @@ from plumpy.persistence import Persister
 from plumpy.process_comms import RemoteProcessThreadController
 
 from aiida.common import exceptions
+from aiida.engine import transports, utils
+from aiida.engine.processes import Process, ProcessBuilder, ProcessState, futures
+from aiida.engine.processes.calcjobs import manager
 from aiida.orm import ProcessNode, load_node
 from aiida.plugins.utils import PluginVersionProvider
-
-from . import transports, utils
-from .processes import Process, ProcessBuilder, ProcessState, futures
-from .processes.calcjobs import manager
 
 __all__ = ('Runner',)
 
@@ -170,7 +169,7 @@ class Runner:
         self._closed = True
 
     def instantiate_process(self, process: TYPE_RUN_PROCESS, **inputs):
-        from .utils import instantiate_process
+        from aiida.engine.utils import instantiate_process
 
         return instantiate_process(self, process, **inputs)
 

--- a/src/aiida/engine/utils.py
+++ b/src/aiida/engine/utils.py
@@ -21,10 +21,9 @@ from typing import TYPE_CHECKING, Any
 from plumpy import get_or_create_event_loop
 
 if TYPE_CHECKING:
+    from aiida.engine.processes import Process, ProcessBuilder
+    from aiida.engine.runners import Runner
     from aiida.orm import ProcessNode
-
-    from .processes import Process, ProcessBuilder
-    from .runners import Runner
 
 __all__ = ('InterruptableFuture', 'interruptable_task', 'is_process_function')
 
@@ -66,7 +65,7 @@ def instantiate_process(runner: Runner, process: Process | type[Process] | Proce
     :param process: Process instance or class, CalcJobNode class or ProcessBuilder instance
     :param inputs: the inputs for the process to be instantiated with
     """
-    from .processes import Process, ProcessBuilder
+    from aiida.engine.processes import Process, ProcessBuilder
 
     if isinstance(process, Process):
         assert not inputs
@@ -242,7 +241,7 @@ def is_process_scoped() -> bool:
 
     :returns: True if the current scope is within a nested process, False otherwise
     """
-    from .processes.process import Process
+    from aiida.engine.processes.process import Process
 
     return Process.current() is not None
 

--- a/src/aiida/manage/__init__.py
+++ b/src/aiida/manage/__init__.py
@@ -22,9 +22,9 @@
 
 # fmt: off
 
-from .caching import *
-from .configuration import *
-from .manager import *
+from aiida.manage.caching import *
+from aiida.manage.configuration import *
+from aiida.manage.manager import *
 
 __all__ = (
     'CURRENT_CONFIG_VERSION',

--- a/src/aiida/manage/configuration/__init__.py
+++ b/src/aiida/manage/configuration/__init__.py
@@ -13,10 +13,10 @@
 
 # fmt: off
 
-from .migrations import *
-from .options import *
-from .profile import *
-from .settings import *
+from aiida.manage.configuration.migrations import *
+from aiida.manage.configuration.options import *
+from aiida.manage.configuration.profile import *
+from aiida.manage.configuration.settings import *
 
 __all__ = (
     'CURRENT_CONFIG_VERSION',
@@ -59,9 +59,8 @@ from typing import TYPE_CHECKING, Any, Optional
 from aiida.common.warnings import AiidaDeprecationWarning
 
 if TYPE_CHECKING:
+    from aiida.manage.configuration.config import Config
     from aiida.orm import User
-
-    from .config import Config
 
 # global variables for aiida
 CONFIG: Optional['Config'] = None
@@ -69,7 +68,7 @@ CONFIG: Optional['Config'] = None
 
 def get_config_path():
     """Returns path to aiida configuration file."""
-    from .settings import DEFAULT_CONFIG_FILE_NAME, AiiDAConfigDir
+    from aiida.manage.configuration.settings import DEFAULT_CONFIG_FILE_NAME, AiiDAConfigDir
 
     return os.path.join(AiiDAConfigDir.get(), DEFAULT_CONFIG_FILE_NAME)
 
@@ -88,8 +87,7 @@ def load_config(create=False) -> 'Config':
     :raises aiida.common.MissingConfigurationError: if the configuration file could not be found and create=False
     """
     from aiida.common import exceptions
-
-    from .config import Config
+    from aiida.manage.configuration.config import Config
 
     filepath = get_config_path()
 

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -34,9 +34,14 @@ from pydantic import (
 
 from aiida.common.exceptions import ConfigurationError, EntryPointError, StorageMigrationError
 from aiida.common.log import AIIDA_LOGGER, AdvancedLogLevels, LogLevels
-
-from .options import Option, get_option, get_option_names, parse_option, resolve_deprecated_option_name
-from .profile import Profile
+from aiida.manage.configuration.options import (
+    Option,
+    get_option,
+    get_option_names,
+    parse_option,
+    resolve_deprecated_option_name,
+)
+from aiida.manage.configuration.profile import Profile
 
 LOGGER = AIIDA_LOGGER.getChild('manage.configuration.config')
 
@@ -370,8 +375,7 @@ class Config:
         :return: `Config` instance
         """
         from aiida.cmdline.utils import echo
-
-        from .migrations import check_and_migrate_config, config_needs_migrating
+        from aiida.manage.configuration.migrations import check_and_migrate_config, config_needs_migrating
 
         try:
             with open(filepath, 'rb') as handle:
@@ -438,7 +442,7 @@ class Config:
         :param config: the content of the configuration file in dictionary form
         :param validate: validate the dictionary against the schema
         """
-        from .migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
+        from aiida.manage.configuration.migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
 
         if validate:
             self.validate(config, filepath)
@@ -951,8 +955,7 @@ class Config:
         import tempfile
 
         from aiida.common.files import md5_file, md5_from_filelike
-
-        from .settings import DEFAULT_CONFIG_INDENT_SIZE
+        from aiida.manage.configuration.settings import DEFAULT_CONFIG_INDENT_SIZE
 
         # If the filepath of this configuration does not yet exist, simply write it.
         if not os.path.isfile(self.filepath):
@@ -984,7 +987,7 @@ class Config:
         """
         import tempfile
 
-        from .settings import DEFAULT_CONFIG_INDENT_SIZE, DEFAULT_UMASK
+        from aiida.manage.configuration.settings import DEFAULT_CONFIG_INDENT_SIZE, DEFAULT_UMASK
 
         umask = os.umask(DEFAULT_UMASK)
 

--- a/src/aiida/manage/configuration/migrations/__init__.py
+++ b/src/aiida/manage/configuration/migrations/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .migrations import *
+from aiida.manage.configuration.migrations.migrations import *
 
 __all__ = (
     'CURRENT_CONFIG_VERSION',

--- a/src/aiida/manage/configuration/options.py
+++ b/src/aiida/manage/configuration/options.py
@@ -55,7 +55,7 @@ class Option:
 
     @property
     def global_only(self) -> bool:
-        from .config import ProfileOptionsSchema
+        from aiida.manage.configuration.config import ProfileOptionsSchema
 
         return self._name.replace('.', '__') not in ProfileOptionsSchema.model_fields
 
@@ -82,7 +82,7 @@ class Option:
         """
         from pydantic import ValidationError
 
-        from .config import GlobalOptionsSchema
+        from aiida.manage.configuration.config import GlobalOptionsSchema
 
         attribute = self.name.replace('.', '__')
 
@@ -108,7 +108,7 @@ class Option:
 
 def get_option_names() -> list[str]:
     """Return a list of available option names."""
-    from .config import GlobalOptionsSchema
+    from aiida.manage.configuration.config import GlobalOptionsSchema
 
     return [key.replace('__', '.') for key in GlobalOptionsSchema.model_fields]
 
@@ -116,14 +116,14 @@ def get_option_names() -> list[str]:
 @lru_cache(maxsize=1)
 def _get_options_schema_properties() -> dict[str, Any]:
     """Return the JSON schema properties for the global options schema."""
-    from .config import GlobalOptionsSchema
+    from aiida.manage.configuration.config import GlobalOptionsSchema
 
     return GlobalOptionsSchema.model_json_schema()['properties']
 
 
 def get_option(name: str) -> Option:
     """Return option."""
-    from .config import GlobalOptionsSchema
+    from aiida.manage.configuration.config import GlobalOptionsSchema
 
     options = GlobalOptionsSchema.model_fields
     option_name = name.replace('.', '__')

--- a/src/aiida/manage/configuration/profile.py
+++ b/src/aiida/manage/configuration/profile.py
@@ -20,8 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from aiida.common import exceptions
-
-from .options import parse_option
+from aiida.manage.configuration.options import parse_option
 
 if TYPE_CHECKING:
     from aiida.orm import Code, Computer, Group, User

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -88,7 +88,7 @@ class Manager:
         :raises aiida.common.ConfigurationError: if the configuration file could not be found, read or deserialized
 
         """
-        from .configuration import get_config
+        from aiida.manage.configuration import get_config
 
         return get_config(create=create)
 

--- a/src/aiida/orm/__init__.py
+++ b/src/aiida/orm/__init__.py
@@ -12,19 +12,19 @@
 
 # fmt: off
 
-from .authinfos import *
-from .comments import *
-from .computers import *
-from .entities import *
-from .extras import *
-from .fields import *
-from .groups import *
-from .logs import *
-from .nodes import *
-from .pydantic import *
-from .querybuilder import *
-from .users import *
-from .utils import *
+from aiida.orm.authinfos import *
+from aiida.orm.comments import *
+from aiida.orm.computers import *
+from aiida.orm.entities import *
+from aiida.orm.extras import *
+from aiida.orm.fields import *
+from aiida.orm.groups import *
+from aiida.orm.logs import *
+from aiida.orm.nodes import *
+from aiida.orm.pydantic import *
+from aiida.orm.querybuilder import *
+from aiida.orm.users import *
+from aiida.orm.utils import *
 
 __all__ = (
     'ASCENDING',

--- a/src/aiida/orm/authinfos.py
+++ b/src/aiida/orm/authinfos.py
@@ -14,12 +14,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from aiida.common import exceptions
 from aiida.manage import get_manager
+from aiida.orm import entities, users
+from aiida.orm.computers import Computer
+from aiida.orm.pydantic import OrmMetadataField
+from aiida.orm.users import User
 from aiida.plugins import TransportFactory
-
-from . import entities, users
-from .computers import Computer
-from .pydantic import OrmMetadataField
-from .users import User
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import StorageBackend
@@ -138,7 +137,7 @@ class AuthInfo(entities.Entity['BackendAuthInfo', AuthInfoCollection]):
     @property
     def computer(self) -> Computer:
         """Return the computer associated with this instance."""
-        from . import computers
+        from aiida.orm import computers
 
         return entities.from_backend_entity(computers.Computer, self._backend_entity.computer)
 

--- a/src/aiida/orm/comments.py
+++ b/src/aiida/orm/comments.py
@@ -15,15 +15,13 @@ from typing import TYPE_CHECKING, ClassVar, cast
 from uuid import UUID
 
 from aiida.manage import get_manager
-
-from . import entities
-from .pydantic import OrmMetadataField
+from aiida.orm import entities
+from aiida.orm.pydantic import OrmMetadataField
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import BackendComment, BackendNode, StorageBackend
-
-    from .nodes.node import Node
-    from .users import User
+    from aiida.orm.nodes.node import Node
+    from aiida.orm.users import User
 
 __all__ = ('Comment',)
 

--- a/src/aiida/orm/computers.py
+++ b/src/aiida/orm/computers.py
@@ -17,10 +17,9 @@ from uuid import UUID
 from aiida.common import exceptions
 from aiida.common.log import AIIDA_LOGGER, AiidaLoggerType
 from aiida.manage import get_manager
+from aiida.orm import entities, users
+from aiida.orm.pydantic import OrmMetadataField
 from aiida.plugins import SchedulerFactory, TransportFactory
-
-from . import entities, users
-from .pydantic import OrmMetadataField
 
 if TYPE_CHECKING:
     from aiida.orm import AuthInfo, User
@@ -573,7 +572,7 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
         :raise aiida.common.NotExistent: if the computer is not configured for the given
             user.
         """
-        from . import authinfos
+        from aiida.orm import authinfos
 
         try:
             authinfo = authinfos.AuthInfo.get_collection(self.backend).get(dbcomputer_id=self.pk, aiidauser_id=user.pk)
@@ -638,7 +637,7 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
             parameters to the supercomputer, as configured with ``verdi computer configure``
             for the user specified as a parameter ``user``.
         """
-        from . import authinfos
+        from aiida.orm import authinfos
 
         user = user or users.User.get_collection(self.backend).get_default()
         assert user is not None
@@ -672,7 +671,7 @@ class Computer(entities.Entity['BackendComputer', ComputerCollection]):
         :kwargs: the configuration keywords with corresponding values
         :return: the authinfo object for the configured user
         """
-        from . import authinfos
+        from aiida.orm import authinfos
 
         transport_cls = self.get_transport_class()
         user = user or users.User.get_collection(self.backend).get_default()

--- a/src/aiida/orm/convert.py
+++ b/src/aiida/orm/convert.py
@@ -70,7 +70,7 @@ def _(backend_entity):
 
 @get_orm_entity.register(BackendGroup)
 def _(backend_entity):
-    from .groups import load_group_class
+    from aiida.orm.groups import load_group_class
 
     group_class = load_group_class(backend_entity.type_string)
     return from_backend_entity(group_class, backend_entity)
@@ -78,42 +78,42 @@ def _(backend_entity):
 
 @get_orm_entity.register(BackendComputer)
 def _(backend_entity):
-    from . import computers
+    from aiida.orm import computers
 
     return from_backend_entity(computers.Computer, backend_entity)
 
 
 @get_orm_entity.register(BackendUser)
 def _(backend_entity):
-    from . import users
+    from aiida.orm import users
 
     return from_backend_entity(users.User, backend_entity)
 
 
 @get_orm_entity.register(BackendAuthInfo)
 def _(backend_entity):
-    from . import authinfos
+    from aiida.orm import authinfos
 
     return from_backend_entity(authinfos.AuthInfo, backend_entity)
 
 
 @get_orm_entity.register(BackendLog)
 def _(backend_entity):
-    from . import logs
+    from aiida.orm import logs
 
     return from_backend_entity(logs.Log, backend_entity)
 
 
 @get_orm_entity.register(BackendComment)
 def _(backend_entity):
-    from . import comments
+    from aiida.orm import comments
 
     return from_backend_entity(comments.Comment, backend_entity)
 
 
 @get_orm_entity.register(BackendNode)
 def _(backend_entity):
-    from .utils.node import load_node_class
+    from aiida.orm.utils.node import load_node_class
 
     node_class = load_node_class(backend_entity.node_type)
     return from_backend_entity(node_class, backend_entity)

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -36,9 +36,8 @@ from aiida.common.lang import classproperty, type_check
 from aiida.common.pydantic import get_metadata
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
-
-from .fields import QbFields, add_field
-from .pydantic import OrmFieldsAsModelDump, OrmMetadataField, OrmModel
+from aiida.orm.fields import QbFields, add_field
+from aiida.orm.pydantic import OrmFieldsAsModelDump, OrmMetadataField, OrmModel
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import BackendEntity, StorageBackend
@@ -134,7 +133,7 @@ class Collection(abc.ABC, Generic[EntityType]):
         :param offset: number of initial results to be skipped
         :param subclassing: whether to match subclasses of the type as well.
         """
-        from . import querybuilder
+        from aiida.orm import querybuilder
 
         filters = filters or {}
         order_by = {self.entity_type: order_by} if order_by else {}
@@ -721,7 +720,7 @@ def from_backend_entity(cls: type[EntityType], backend_entity: BackendEntity) ->
 
     :return: an AiiDA entity instance
     """
-    from .implementation.entities import BackendEntity
+    from aiida.orm.implementation.entities import BackendEntity
 
     type_check(backend_entity, BackendEntity)
     entity = cls.__new__(cls)

--- a/src/aiida/orm/extras.py
+++ b/src/aiida/orm/extras.py
@@ -13,8 +13,8 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
-    from .groups import Group
-    from .nodes.node import Node
+    from aiida.orm.groups import Group
+    from aiida.orm.nodes.node import Node
 
 __all__ = ('EntityExtras',)
 

--- a/src/aiida/orm/groups.py
+++ b/src/aiida/orm/groups.py
@@ -24,9 +24,8 @@ from aiida.common import exceptions
 from aiida.common.lang import classproperty, type_check
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
-
-from . import convert, entities, extras, users
-from .pydantic import OrmMetadataField
+from aiida.orm import convert, entities, extras, users
+from aiida.orm.pydantic import OrmMetadataField
 
 if TYPE_CHECKING:
     from importlib_metadata import EntryPoint
@@ -347,7 +346,7 @@ class Group(entities.Entity['BackendGroup', GroupCollection]):
 
         :param nodes: a single `Node` or a list of `Nodes`
         """
-        from .nodes import Node
+        from aiida.orm.nodes import Node
 
         if not self.is_stored:
             raise exceptions.ModificationNotAllowed('cannot add nodes to an unstored group')
@@ -368,7 +367,7 @@ class Group(entities.Entity['BackendGroup', GroupCollection]):
 
         :param nodes: a single `Node` or a list of `Nodes`
         """
-        from .nodes import Node
+        from aiida.orm.nodes import Node
 
         if not self.is_stored:
             raise exceptions.ModificationNotAllowed('cannot add nodes to an unstored group')

--- a/src/aiida/orm/implementation/__init__.py
+++ b/src/aiida/orm/implementation/__init__.py
@@ -12,17 +12,17 @@
 
 # fmt: off
 
-from .authinfos import *
-from .comments import *
-from .computers import *
-from .entities import *
-from .groups import *
-from .logs import *
-from .nodes import *
-from .querybuilder import *
-from .storage_backend import *
-from .users import *
-from .utils import *
+from aiida.orm.implementation.authinfos import *
+from aiida.orm.implementation.comments import *
+from aiida.orm.implementation.computers import *
+from aiida.orm.implementation.entities import *
+from aiida.orm.implementation.groups import *
+from aiida.orm.implementation.logs import *
+from aiida.orm.implementation.nodes import *
+from aiida.orm.implementation.querybuilder import *
+from aiida.orm.implementation.storage_backend import *
+from aiida.orm.implementation.users import *
+from aiida.orm.implementation.utils import *
 
 __all__ = (
     'BackendAuthInfo',

--- a/src/aiida/orm/implementation/authinfos.py
+++ b/src/aiida/orm/implementation/authinfos.py
@@ -11,11 +11,11 @@
 import abc
 from typing import TYPE_CHECKING, Any
 
-from .entities import BackendCollection, BackendEntity
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity
 
 if TYPE_CHECKING:
-    from .computers import BackendComputer
-    from .users import BackendUser
+    from aiida.orm.implementation.computers import BackendComputer
+    from aiida.orm.implementation.users import BackendUser
 
 __all__ = ('BackendAuthInfo', 'BackendAuthInfoCollection')
 

--- a/src/aiida/orm/implementation/comments.py
+++ b/src/aiida/orm/implementation/comments.py
@@ -12,11 +12,11 @@ import abc
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from .entities import BackendCollection, BackendEntity
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity
 
 if TYPE_CHECKING:
-    from .nodes import BackendNode
-    from .users import BackendUser
+    from aiida.orm.implementation.nodes import BackendNode
+    from aiida.orm.implementation.users import BackendUser
 
 __all__ = ('BackendComment', 'BackendCommentCollection')
 

--- a/src/aiida/orm/implementation/computers.py
+++ b/src/aiida/orm/implementation/computers.py
@@ -12,7 +12,7 @@ import abc
 import logging
 from typing import Any
 
-from .entities import BackendCollection, BackendEntity
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendComputer', 'BackendComputerCollection')
 

--- a/src/aiida/orm/implementation/groups.py
+++ b/src/aiida/orm/implementation/groups.py
@@ -13,11 +13,11 @@ import datetime
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Protocol
 
-from .entities import BackendCollection, BackendEntity, BackendEntityExtrasMixin
-from .nodes import BackendNode
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity, BackendEntityExtrasMixin
+from aiida.orm.implementation.nodes import BackendNode
 
 if TYPE_CHECKING:
-    from .users import BackendUser
+    from aiida.orm.implementation.users import BackendUser
 
 __all__ = ('BackendGroup', 'BackendGroupCollection')
 

--- a/src/aiida/orm/implementation/logs.py
+++ b/src/aiida/orm/implementation/logs.py
@@ -12,7 +12,7 @@ import abc
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from .entities import BackendCollection, BackendEntity
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendLog', 'BackendLogCollection')
 

--- a/src/aiida/orm/implementation/nodes.py
+++ b/src/aiida/orm/implementation/nodes.py
@@ -13,12 +13,12 @@ from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
-from .entities import BackendCollection, BackendEntity, BackendEntityExtrasMixin
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity, BackendEntityExtrasMixin
 
 if TYPE_CHECKING:
-    from ..utils import LinkTriple
-    from .computers import BackendComputer
-    from .users import BackendUser
+    from aiida.orm.implementation.computers import BackendComputer
+    from aiida.orm.implementation.users import BackendUser
+    from aiida.orm.utils import LinkTriple
 
 __all__ = ('BackendNode', 'BackendNodeCollection')
 

--- a/src/aiida/orm/implementation/querybuilder.py
+++ b/src/aiida/orm/implementation/querybuilder.py
@@ -92,7 +92,7 @@ class BackendQueryBuilder(abc.ABC):
 
     def __init__(self, backend: 'StorageBackend'):
         """:param backend: the backend"""
-        from .storage_backend import StorageBackend
+        from aiida.orm.implementation.storage_backend import StorageBackend
 
         type_check(backend, StorageBackend)
         self._backend = backend

--- a/src/aiida/orm/implementation/users.py
+++ b/src/aiida/orm/implementation/users.py
@@ -10,7 +10,7 @@
 
 import abc
 
-from .entities import BackendCollection, BackendEntity
+from aiida.orm.implementation.entities import BackendCollection, BackendEntity
 
 __all__ = ('BackendUser', 'BackendUserCollection')
 

--- a/src/aiida/orm/logs.py
+++ b/src/aiida/orm/logs.py
@@ -17,9 +17,8 @@ from uuid import UUID
 
 from aiida.common import timezone
 from aiida.manage import get_manager
-
-from . import entities
-from .pydantic import OrmMetadataField
+from aiida.orm import entities
+from aiida.orm.pydantic import OrmMetadataField
 
 if TYPE_CHECKING:
     from aiida.orm import Node
@@ -94,7 +93,7 @@ class LogCollection(entities.Collection['Log']):
 
         :return: the list of log entries
         """
-        from . import nodes
+        from aiida.orm import nodes
 
         if not isinstance(entity, nodes.Node):
             raise Exception('Only node logs are stored')
@@ -259,7 +258,7 @@ class Log(entities.Entity['BackendLog', LogCollection]):
 
     @property
     def node(self) -> Node:
-        from .utils.loaders import load_node
+        from aiida.orm.utils.loaders import load_node
 
         return load_node(self.dbnode_id)
 

--- a/src/aiida/orm/nodes/__init__.py
+++ b/src/aiida/orm/nodes/__init__.py
@@ -12,11 +12,11 @@
 
 # fmt: off
 
-from .attributes import *
-from .data import *
-from .node import *
-from .process import *
-from .repository import *
+from aiida.orm.nodes.attributes import *
+from aiida.orm.nodes.data import *
+from aiida.orm.nodes.node import *
+from aiida.orm.nodes.process import *
+from aiida.orm.nodes.repository import *
 
 __all__ = (
     'AbstractCode',

--- a/src/aiida/orm/nodes/attributes.py
+++ b/src/aiida/orm/nodes/attributes.py
@@ -13,7 +13,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .node import Node
+    from aiida.orm.nodes.node import Node
 
 __all__ = ('NodeAttributes',)
 

--- a/src/aiida/orm/nodes/caching.py
+++ b/src/aiida/orm/nodes/caching.py
@@ -8,11 +8,10 @@ from aiida.common import exceptions
 from aiida.common.hashing import make_hash
 from aiida.common.lang import type_check
 from aiida.common.warnings import warn_deprecation
-
-from ..querybuilder import QueryBuilder
+from aiida.orm.querybuilder import QueryBuilder
 
 if t.TYPE_CHECKING:
-    from .node import Node
+    from aiida.orm.nodes.node import Node
 
 
 class NodeCaching:

--- a/src/aiida/orm/nodes/comments.py
+++ b/src/aiida/orm/nodes/comments.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import typing as t
 
-from ..comments import Comment
-from ..users import User
+from aiida.orm.comments import Comment
+from aiida.orm.users import User
 
 if t.TYPE_CHECKING:
-    from .node import Node
+    from aiida.orm.nodes.node import Node
 
 
 class NodeComments:

--- a/src/aiida/orm/nodes/data/__init__.py
+++ b/src/aiida/orm/nodes/data/__init__.py
@@ -12,26 +12,26 @@
 
 # fmt: off
 
-from .array import *
-from .base import *
-from .bool import *
-from .cif import *
-from .code import *
-from .data import *
-from .dict import *
-from .enum import *
-from .float import *
-from .folder import *
-from .int import *
-from .jsonable import *
-from .list import *
-from .numeric import *
-from .orbital import *
-from .remote import *
-from .singlefile import *
-from .str import *
-from .structure import *
-from .upf import *
+from aiida.orm.nodes.data.array import *
+from aiida.orm.nodes.data.base import *
+from aiida.orm.nodes.data.bool import *
+from aiida.orm.nodes.data.cif import *
+from aiida.orm.nodes.data.code import *
+from aiida.orm.nodes.data.data import *
+from aiida.orm.nodes.data.dict import *
+from aiida.orm.nodes.data.enum import *
+from aiida.orm.nodes.data.float import *
+from aiida.orm.nodes.data.folder import *
+from aiida.orm.nodes.data.int import *
+from aiida.orm.nodes.data.jsonable import *
+from aiida.orm.nodes.data.list import *
+from aiida.orm.nodes.data.numeric import *
+from aiida.orm.nodes.data.orbital import *
+from aiida.orm.nodes.data.remote import *
+from aiida.orm.nodes.data.singlefile import *
+from aiida.orm.nodes.data.str import *
+from aiida.orm.nodes.data.structure import *
+from aiida.orm.nodes.data.upf import *
 
 __all__ = (
     'AbstractCode',

--- a/src/aiida/orm/nodes/data/array/__init__.py
+++ b/src/aiida/orm/nodes/data/array/__init__.py
@@ -12,12 +12,12 @@
 
 # fmt: off
 
-from .array import *
-from .bands import *
-from .kpoints import *
-from .projection import *
-from .trajectory import *
-from .xy import *
+from aiida.orm.nodes.data.array.array import *
+from aiida.orm.nodes.data.array.bands import *
+from aiida.orm.nodes.data.array.kpoints import *
+from aiida.orm.nodes.data.array.projection import *
+from aiida.orm.nodes.data.array.trajectory import *
+from aiida.orm.nodes.data.array.xy import *
 
 __all__ = (
     'ArrayData',

--- a/src/aiida/orm/nodes/data/array/array.py
+++ b/src/aiida/orm/nodes/data/array/array.py
@@ -18,10 +18,9 @@ from typing import Any, BinaryIO
 import numpy as np
 from pydantic import ConfigDict, field_validator
 
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmFieldsAsModelDump, OrmMetadataField, OrmModel
-
-from ..base import to_aiida_type
-from ..data import Data
 
 __all__ = ('ArrayData',)
 

--- a/src/aiida/orm/nodes/data/array/bands.py
+++ b/src/aiida/orm/nodes/data/array/bands.py
@@ -21,9 +21,8 @@ import numpy
 
 from aiida.common.exceptions import ValidationError
 from aiida.common.utils import join_labels, prettify_labels
+from aiida.orm.nodes.data.array.kpoints import KpointsData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .kpoints import KpointsData
 
 __all__ = ('BandsData', 'find_bandgap')
 

--- a/src/aiida/orm/nodes/data/array/kpoints.py
+++ b/src/aiida/orm/nodes/data/array/kpoints.py
@@ -17,9 +17,8 @@ import typing as t
 
 import numpy
 
+from aiida.orm.nodes.data.array.array import ArrayData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .array import ArrayData
 
 __all__ = ('KpointsData',)
 

--- a/src/aiida/orm/nodes/data/array/projection.py
+++ b/src/aiida/orm/nodes/data/array/projection.py
@@ -13,11 +13,10 @@ import copy
 import numpy as np
 
 from aiida.common import exceptions
+from aiida.orm.nodes.data.array.array import ArrayData
+from aiida.orm.nodes.data.array.bands import BandsData
+from aiida.orm.nodes.data.orbital import OrbitalData
 from aiida.plugins import OrbitalFactory
-
-from ..orbital import OrbitalData
-from .array import ArrayData
-from .bands import BandsData
 
 __all__ = ('ProjectionData',)
 

--- a/src/aiida/orm/nodes/data/array/trajectory.py
+++ b/src/aiida/orm/nodes/data/array/trajectory.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 import typing as t
 
 from aiida.common.warnings import warn_deprecation
+from aiida.orm.nodes.data.array.array import ArrayData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .array import ArrayData
 
 if t.TYPE_CHECKING:
     import numpy as np

--- a/src/aiida/orm/nodes/data/array/xy.py
+++ b/src/aiida/orm/nodes/data/array/xy.py
@@ -20,9 +20,8 @@ import numpy as np
 from pydantic import ConfigDict, field_validator
 
 from aiida.common.exceptions import NotExistent
+from aiida.orm.nodes.data.array.array import ArrayData
 from aiida.orm.pydantic import OrmMetadataField, OrmModel
-
-from .array import ArrayData
 
 __all__ = ('XyData',)
 

--- a/src/aiida/orm/nodes/data/base.py
+++ b/src/aiida/orm/nodes/data/base.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 import typing as t
 from functools import singledispatch
 
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField
-
-from .data import Data
 
 __all__ = ('BaseType', 'to_aiida_type')
 

--- a/src/aiida/orm/nodes/data/bool.py
+++ b/src/aiida/orm/nodes/data/bool.py
@@ -10,9 +10,8 @@
 
 import numpy
 
+from aiida.orm.nodes.data.base import BaseType, to_aiida_type
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import BaseType, to_aiida_type
 
 __all__ = ('Bool',)
 

--- a/src/aiida/orm/nodes/data/cif.py
+++ b/src/aiida/orm/nodes/data/cif.py
@@ -14,9 +14,8 @@ import re
 from typing import Literal
 
 from aiida.common.utils import Capturing
+from aiida.orm.nodes.data.singlefile import SinglefileData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .singlefile import SinglefileData
 
 __all__ = ('CifData', 'cif_from_ase', 'has_pycifrw', 'pycifrw_from_cif')
 

--- a/src/aiida/orm/nodes/data/code/__init__.py
+++ b/src/aiida/orm/nodes/data/code/__init__.py
@@ -4,11 +4,11 @@
 
 # fmt: off
 
-from .abstract import *
-from .containerized import *
-from .installed import *
-from .legacy import *
-from .portable import *
+from aiida.orm.nodes.data.code.abstract import *
+from aiida.orm.nodes.data.code.containerized import *
+from aiida.orm.nodes.data.code.installed import *
+from aiida.orm.nodes.data.code.legacy import *
+from aiida.orm.nodes.data.code.portable import *
 
 __all__ = (
     'AbstractCode',

--- a/src/aiida/orm/nodes/data/code/abstract.py
+++ b/src/aiida/orm/nodes/data/code/abstract.py
@@ -23,10 +23,9 @@ from aiida.common import exceptions
 from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.orm import Computer
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField, OrmModel
 from aiida.plugins import CalculationFactory
-
-from ..data import Data
 
 if t.TYPE_CHECKING:
     from aiida.engine import ProcessBuilder

--- a/src/aiida/orm/nodes/data/code/containerized.py
+++ b/src/aiida/orm/nodes/data/code/containerized.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 import pathlib
 
 from aiida.common.lang import type_check
+from aiida.orm.nodes.data.code.installed import InstalledCode
 from aiida.orm.pydantic import OrmMetadataField
-
-from .installed import InstalledCode
 
 __all__ = ('ContainerizedCode',)
 

--- a/src/aiida/orm/nodes/data/code/installed.py
+++ b/src/aiida/orm/nodes/data/code/installed.py
@@ -24,11 +24,10 @@ from aiida.common.lang import type_check
 from aiida.common.log import override_log_level
 from aiida.orm import Computer
 from aiida.orm.entities import from_backend_entity
+from aiida.orm.nodes.data.code.abstract import AbstractCode
+from aiida.orm.nodes.data.code.legacy import Code
 from aiida.orm.pydantic import OrmMetadataField
-
-from ....utils.loaders import load_computer
-from .abstract import AbstractCode
-from .legacy import Code
+from aiida.orm.utils.loaders import load_computer
 
 __all__ = ('InstalledCode',)
 

--- a/src/aiida/orm/nodes/data/code/legacy.py
+++ b/src/aiida/orm/nodes/data/code/legacy.py
@@ -15,9 +15,8 @@ from aiida.common import exceptions
 from aiida.common.log import override_log_level
 from aiida.common.warnings import warn_deprecation
 from aiida.orm import Computer
+from aiida.orm.nodes.data.code.abstract import AbstractCode
 from aiida.orm.pydantic import OrmMetadataField
-
-from .abstract import AbstractCode
 
 __all__ = ('Code',)
 

--- a/src/aiida/orm/nodes/data/code/portable.py
+++ b/src/aiida/orm/nodes/data/code/portable.py
@@ -29,10 +29,9 @@ from aiida.common.folders import Folder
 from aiida.common.lang import type_check
 from aiida.common.typing import FilePath
 from aiida.orm import Computer
+from aiida.orm.nodes.data.code.abstract import AbstractCode
+from aiida.orm.nodes.data.code.legacy import Code
 from aiida.orm.pydantic import OrmMetadataField
-
-from .abstract import AbstractCode
-from .legacy import Code
 
 __all__ = ('PortableCode',)
 _LOGGER = logging.getLogger(__name__)

--- a/src/aiida/orm/nodes/data/data.py
+++ b/src/aiida/orm/nodes/data/data.py
@@ -14,9 +14,8 @@ from aiida.common import exceptions
 from aiida.common.lang import override
 from aiida.common.links import LinkType
 from aiida.orm.entities import from_backend_entity
+from aiida.orm.nodes.node import Node
 from aiida.orm.pydantic import OrmMetadataField
-
-from ..node import Node
 
 __all__ = ('Data',)
 

--- a/src/aiida/orm/nodes/data/dict.py
+++ b/src/aiida/orm/nodes/data/dict.py
@@ -17,10 +17,9 @@ import typing as t
 import pydantic as pdt
 
 from aiida.common import exceptions
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmFieldsAsModelDump, OrmMetadataField, OrmModel
-
-from .base import to_aiida_type
-from .data import Data
 
 __all__ = ('Dict',)
 

--- a/src/aiida/orm/nodes/data/enum.py
+++ b/src/aiida/orm/nodes/data/enum.py
@@ -23,10 +23,9 @@ from enum import Enum
 from plumpy.loaders import get_object_loader
 
 from aiida.common.lang import type_check
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField, OrmModel
-
-from .base import to_aiida_type
-from .data import Data
 
 __all__ = ('EnumData',)
 

--- a/src/aiida/orm/nodes/data/float.py
+++ b/src/aiida/orm/nodes/data/float.py
@@ -10,10 +10,9 @@
 
 import numbers
 
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.orm.nodes.data.numeric import NumericType
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import to_aiida_type
-from .numeric import NumericType
 
 __all__ = ('Float',)
 

--- a/src/aiida/orm/nodes/data/folder.py
+++ b/src/aiida/orm/nodes/data/folder.py
@@ -15,9 +15,8 @@ import io
 import pathlib
 import typing as t
 
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField, OrmModel
-
-from .data import Data
 
 if t.TYPE_CHECKING:
     from aiida.common.typing import FilePath

--- a/src/aiida/orm/nodes/data/int.py
+++ b/src/aiida/orm/nodes/data/int.py
@@ -12,10 +12,9 @@ from __future__ import annotations
 
 import numbers
 
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.orm.nodes.data.numeric import NumericType
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import to_aiida_type
-from .numeric import NumericType
 
 __all__ = ('Int',)
 

--- a/src/aiida/orm/nodes/data/jsonable.py
+++ b/src/aiida/orm/nodes/data/jsonable.py
@@ -8,9 +8,8 @@ import typing
 
 from pydantic import ConfigDict, WithJsonSchema
 
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmFieldsAsModelDump, OrmMetadataField, OrmModel
-
-from .data import Data
 
 __all__ = ('JsonableData',)
 

--- a/src/aiida/orm/nodes/data/list.py
+++ b/src/aiida/orm/nodes/data/list.py
@@ -14,10 +14,9 @@ from typing import Any
 
 import pydantic as pdt
 
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import to_aiida_type
-from .data import Data
 
 __all__ = ('List',)
 

--- a/src/aiida/orm/nodes/data/numeric.py
+++ b/src/aiida/orm/nodes/data/numeric.py
@@ -8,9 +8,8 @@
 ###########################################################################
 """Module for defintion of base `Data` sub class for numeric based data types."""
 
+from aiida.orm.nodes.data.base import BaseType, to_aiida_type
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import BaseType, to_aiida_type
 
 __all__ = ('NumericType',)
 

--- a/src/aiida/orm/nodes/data/orbital.py
+++ b/src/aiida/orm/nodes/data/orbital.py
@@ -11,9 +11,8 @@
 import copy
 
 from aiida.common.exceptions import ValidationError
+from aiida.orm.nodes.data.data import Data
 from aiida.plugins import OrbitalFactory
-
-from .data import Data
 
 __all__ = ('OrbitalData',)
 

--- a/src/aiida/orm/nodes/data/remote/__init__.py
+++ b/src/aiida/orm/nodes/data/remote/__init__.py
@@ -4,8 +4,8 @@
 
 # fmt: off
 
-from .base import *
-from .stash import *
+from aiida.orm.nodes.data.remote.base import *
+from aiida.orm.nodes.data.remote.stash import *
 
 __all__ = (
     'RemoteData',

--- a/src/aiida/orm/nodes/data/remote/base.py
+++ b/src/aiida/orm/nodes/data/remote/base.py
@@ -17,10 +17,9 @@ from typing import cast
 
 from aiida.orm import AuthInfo
 from aiida.orm.computers import Computer
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField
 from aiida.transports import Transport
-
-from ..data import Data
 
 _logger = logging.getLogger(__name__)
 

--- a/src/aiida/orm/nodes/data/remote/stash/__init__.py
+++ b/src/aiida/orm/nodes/data/remote/stash/__init__.py
@@ -4,10 +4,10 @@
 
 # fmt: off
 
-from .base import *
-from .compress import *
-from .custom import *
-from .folder import *
+from aiida.orm.nodes.data.remote.stash.base import *
+from aiida.orm.nodes.data.remote.stash.compress import *
+from aiida.orm.nodes.data.remote.stash.custom import *
+from aiida.orm.nodes.data.remote.stash.folder import *
 
 __all__ = (
     'RemoteStashCompressedData',

--- a/src/aiida/orm/nodes/data/remote/stash/base.py
+++ b/src/aiida/orm/nodes/data/remote/stash/base.py
@@ -10,9 +10,8 @@
 
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField
-
-from ...data import Data
 
 __all__ = ('RemoteStashData',)
 

--- a/src/aiida/orm/nodes/data/remote/stash/compress.py
+++ b/src/aiida/orm/nodes/data/remote/stash/compress.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check
+from aiida.orm.nodes.data.remote.stash.base import RemoteStashData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import RemoteStashData
 
 __all__ = ('RemoteStashCompressedData',)
 

--- a/src/aiida/orm/nodes/data/remote/stash/custom.py
+++ b/src/aiida/orm/nodes/data/remote/stash/custom.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check
+from aiida.orm.nodes.data.remote.stash.base import RemoteStashData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import RemoteStashData
 
 __all__ = ('RemoteStashCustomData',)
 

--- a/src/aiida/orm/nodes/data/remote/stash/folder.py
+++ b/src/aiida/orm/nodes/data/remote/stash/folder.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 from aiida.common.datastructures import StashMode
 from aiida.common.lang import type_check
+from aiida.orm.nodes.data.remote.stash.base import RemoteStashData
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import RemoteStashData
 
 __all__ = ('RemoteStashFolderData',)
 

--- a/src/aiida/orm/nodes/data/singlefile.py
+++ b/src/aiida/orm/nodes/data/singlefile.py
@@ -18,9 +18,8 @@ import typing as t
 
 from aiida.common import exceptions
 from aiida.common.typing import FilePath
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField, OrmModel
-
-from .data import Data
 
 __all__ = ('SinglefileData',)
 

--- a/src/aiida/orm/nodes/data/str.py
+++ b/src/aiida/orm/nodes/data/str.py
@@ -8,9 +8,8 @@
 ###########################################################################
 """`Data` sub class to represent a string value."""
 
+from aiida.orm.nodes.data.base import BaseType, to_aiida_type
 from aiida.orm.pydantic import OrmMetadataField
-
-from .base import BaseType, to_aiida_type
 
 __all__ = ('Str',)
 

--- a/src/aiida/orm/nodes/data/structure.py
+++ b/src/aiida/orm/nodes/data/structure.py
@@ -22,9 +22,8 @@ from pydantic import field_validator
 
 from aiida.common.constants import elements
 from aiida.common.exceptions import UnsupportedSpeciesError
+from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField
-
-from .data import Data
 
 __all__ = ('Kind', 'Site', 'StructureData')
 
@@ -1772,9 +1771,8 @@ class StructureData(Data):
             AiiDA database for record. Default False.
         :return: :py:class:`aiida.orm.nodes.data.cif.CifData` node.
         """
+        from aiida.orm.nodes.data.dict import Dict
         from aiida.tools.data import structure as structure_tools
-
-        from .dict import Dict
 
         param = Dict(kwargs)
         try:

--- a/src/aiida/orm/nodes/data/upf.py
+++ b/src/aiida/orm/nodes/data/upf.py
@@ -14,8 +14,7 @@ import re
 from upf_to_json import upf_to_json
 
 from aiida.common.warnings import warn_deprecation
-
-from .singlefile import SinglefileData
+from aiida.orm.nodes.data.singlefile import SinglefileData
 
 __all__ = ('UpfData',)
 

--- a/src/aiida/orm/nodes/links.py
+++ b/src/aiida/orm/nodes/links.py
@@ -9,12 +9,11 @@ from aiida.common import exceptions
 from aiida.common.escaping import sql_string_match
 from aiida.common.lang import type_check
 from aiida.common.links import LinkType
-
-from ..querybuilder import QueryBuilder
-from ..utils.links import LinkManager, LinkTriple
+from aiida.orm.querybuilder import QueryBuilder
+from aiida.orm.utils.links import LinkManager, LinkTriple
 
 if t.TYPE_CHECKING:
-    from .node import Node
+    from aiida.orm.nodes.node import Node
 
 
 class NodeLinks:
@@ -77,9 +76,8 @@ class NodeLinks:
         :raise TypeError: if `source` is not a Node instance or `link_type` is not a `LinkType` enum
         :raise ValueError: if the proposed link is invalid
         """
+        from aiida.orm.nodes.node import Node
         from aiida.orm.utils.links import validate_link
-
-        from .node import Node
 
         validate_link(source, self._node, link_type, link_label, backend=self._node.backend)
 
@@ -106,7 +104,7 @@ class NodeLinks:
         :raise TypeError: if `target` is not a Node instance or `link_type` is not a `LinkType` enum
         :raise ValueError: if the proposed link is invalid
         """
-        from .node import Node
+        from aiida.orm.nodes.node import Node
 
         type_check(link_type, LinkType, f'link_type should be a LinkType enum but got: {type(link_type)}')
         type_check(target, Node, f'target should be a `Node` instance but got: {type(target)}')
@@ -130,7 +128,7 @@ class NodeLinks:
         :param link_direction: `incoming` or `outgoing` to get the incoming or outgoing links, respectively.
         :param only_uuid: project only the node UUID instead of the instance onto the `NodeTriple.node` entries
         """
-        from .node import Node
+        from aiida.orm.nodes.node import Node
 
         if not isinstance(link_type, (tuple, list)):
             link_type = cast(t.Sequence[LinkType], (link_type,))

--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -38,33 +38,31 @@ from aiida.common.log import AIIDA_LOGGER
 from aiida.common.pydantic import get_metadata
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
+from aiida.orm.computers import Computer
+from aiida.orm.entities import Collection as EntityCollection
+from aiida.orm.entities import Entity, from_backend_entity
+from aiida.orm.extras import EntityExtras
 from aiida.orm.fields import QbAttributesField, QbFields, add_field
+from aiida.orm.nodes.attributes import NodeAttributes
+from aiida.orm.nodes.caching import NodeCaching
+from aiida.orm.nodes.comments import NodeComments
+from aiida.orm.nodes.links import NodeLinks
+from aiida.orm.pydantic import OrmMetadataField, OrmModel
+from aiida.orm.querybuilder import QueryBuilder
+from aiida.orm.users import User
 from aiida.orm.utils.node import (
     AbstractNodeMeta,
     get_query_type_from_type_string,
     get_type_string_from_class,
 )
 
-from ..computers import Computer
-from ..entities import Collection as EntityCollection
-from ..entities import Entity, from_backend_entity
-from ..extras import EntityExtras
-from ..pydantic import OrmMetadataField, OrmModel
-from ..querybuilder import QueryBuilder
-from ..users import User
-from .attributes import NodeAttributes
-from .caching import NodeCaching
-from .comments import NodeComments
-from .links import NodeLinks
-
 if TYPE_CHECKING:
     from importlib_metadata import EntryPoint
 
     from aiida.common.log import AiidaLoggerType
-
-    from ..implementation import StorageBackend
-    from ..implementation.nodes import BackendNode
-    from .repository import NodeRepository
+    from aiida.orm.implementation import StorageBackend
+    from aiida.orm.implementation.nodes import BackendNode
+    from aiida.orm.nodes.repository import NodeRepository
 
 __all__ = ('Node',)
 
@@ -129,7 +127,7 @@ class NodeBase:
     @cached_property
     def repository(self) -> NodeRepository:
         """Return the repository for this node."""
-        from .repository import NodeRepository
+        from aiida.orm.nodes.repository import NodeRepository
 
         return NodeRepository(self._node)
 

--- a/src/aiida/orm/nodes/process/__init__.py
+++ b/src/aiida/orm/nodes/process/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .calculation import *
-from .process import *
-from .workflow import *
+from aiida.orm.nodes.process.calculation import *
+from aiida.orm.nodes.process.process import *
+from aiida.orm.nodes.process.workflow import *
 
 __all__ = (
     'CalcFunctionNode',

--- a/src/aiida/orm/nodes/process/calculation/__init__.py
+++ b/src/aiida/orm/nodes/process/calculation/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .calcfunction import *
-from .calcjob import *
-from .calculation import *
+from aiida.orm.nodes.process.calculation.calcfunction import *
+from aiida.orm.nodes.process.calculation.calcjob import *
+from aiida.orm.nodes.process.calculation.calculation import *
 
 __all__ = (
     'CalcFunctionNode',

--- a/src/aiida/orm/nodes/process/calculation/calcfunction.py
+++ b/src/aiida/orm/nodes/process/calculation/calcfunction.py
@@ -11,10 +11,9 @@
 from typing import TYPE_CHECKING
 
 from aiida.common.links import LinkType
+from aiida.orm.nodes.process.calculation.calculation import CalculationNode
+from aiida.orm.nodes.process.process import ProcessNodeLinks
 from aiida.orm.utils.mixins import FunctionCalculationMixin
-
-from ..process import ProcessNodeLinks
-from .calculation import CalculationNode
 
 if TYPE_CHECKING:
     from aiida.orm import Node

--- a/src/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/src/aiida/orm/nodes/process/calculation/calcjob.py
@@ -19,10 +19,9 @@ from pydantic import field_validator
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcJobState
 from aiida.common.lang import classproperty
+from aiida.orm.nodes.process.calculation.calculation import CalculationNode
+from aiida.orm.nodes.process.process import ProcessNodeCaching
 from aiida.orm.pydantic import OrmMetadataField
-
-from ..process import ProcessNodeCaching
-from .calculation import CalculationNode
 
 if TYPE_CHECKING:
     from aiida.orm import FolderData

--- a/src/aiida/orm/nodes/process/calculation/calculation.py
+++ b/src/aiida/orm/nodes/process/calculation/calculation.py
@@ -9,9 +9,8 @@
 """Module with `Node` sub class for calculation processes."""
 
 from aiida.common.links import LinkType
+from aiida.orm.nodes.process.process import ProcessNode
 from aiida.orm.utils.managers import NodeLinksManager
-
-from ..process import ProcessNode
 
 __all__ = ('CalculationNode',)
 

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -19,12 +19,11 @@ from plumpy.process_states import ProcessState
 from aiida.common import exceptions
 from aiida.common.lang import classproperty
 from aiida.common.links import LinkType
+from aiida.orm.nodes.caching import NodeCaching
+from aiida.orm.nodes.links import NodeLinks
+from aiida.orm.nodes.node import Node
 from aiida.orm.pydantic import OrmMetadataField
 from aiida.orm.utils.mixins import Sealable
-
-from ..caching import NodeCaching
-from ..links import NodeLinks
-from ..node import Node
 
 if TYPE_CHECKING:
     from aiida.engine.processes import ExitCode, Process

--- a/src/aiida/orm/nodes/process/workflow/__init__.py
+++ b/src/aiida/orm/nodes/process/workflow/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .workchain import *
-from .workflow import *
-from .workfunction import *
+from aiida.orm.nodes.process.workflow.workchain import *
+from aiida.orm.nodes.process.workflow.workflow import *
+from aiida.orm.nodes.process.workflow.workfunction import *
 
 __all__ = (
     'WorkChainNode',

--- a/src/aiida/orm/nodes/process/workflow/workchain.py
+++ b/src/aiida/orm/nodes/process/workflow/workchain.py
@@ -12,8 +12,7 @@ from typing import TYPE_CHECKING
 
 from aiida.common import exceptions
 from aiida.common.lang import classproperty
-
-from .workflow import WorkflowNode
+from aiida.orm.nodes.process.workflow.workflow import WorkflowNode
 
 if TYPE_CHECKING:
     from aiida.tools.workflows import WorkflowTools

--- a/src/aiida/orm/nodes/process/workflow/workflow.py
+++ b/src/aiida/orm/nodes/process/workflow/workflow.py
@@ -11,9 +11,8 @@
 from typing import TYPE_CHECKING
 
 from aiida.common.links import LinkType
+from aiida.orm.nodes.process.process import ProcessNode, ProcessNodeLinks
 from aiida.orm.utils.managers import NodeLinksManager
-
-from ..process import ProcessNode, ProcessNodeLinks
 
 if TYPE_CHECKING:
     from aiida.orm import Node

--- a/src/aiida/orm/nodes/process/workflow/workfunction.py
+++ b/src/aiida/orm/nodes/process/workflow/workfunction.py
@@ -11,9 +11,8 @@
 from typing import TYPE_CHECKING
 
 from aiida.common.links import LinkType
+from aiida.orm.nodes.process.workflow.workflow import WorkflowNode, WorkflowNodeLinks
 from aiida.orm.utils.mixins import FunctionCalculationMixin
-
-from .workflow import WorkflowNode, WorkflowNodeLinks
 
 if TYPE_CHECKING:
     from aiida.orm import Node

--- a/src/aiida/orm/nodes/repository.py
+++ b/src/aiida/orm/nodes/repository.py
@@ -16,9 +16,8 @@ from aiida.manage import get_config_option
 
 if t.TYPE_CHECKING:
     from aiida.common.typing import FilePath
+    from aiida.orm.nodes.node import Node
     from aiida.repository import File, Repository
-
-    from .node import Node
 
 __all__ = ('NodeRepository',)
 

--- a/src/aiida/orm/querybuilder.py
+++ b/src/aiida/orm/querybuilder.py
@@ -36,6 +36,7 @@ from typing import (
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager
+from aiida.orm import authinfos, comments, computers, convert, entities, fields, groups, logs, nodes, users
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation.querybuilder import (
     GROUP_ENTITY_TYPE_PREFIX,
@@ -44,8 +45,6 @@ from aiida.orm.implementation.querybuilder import (
     PathItemType,
     QueryDictType,
 )
-
-from . import authinfos, comments, computers, convert, entities, fields, groups, logs, nodes, users
 
 if TYPE_CHECKING:
     from aiida.engine import Process

--- a/src/aiida/orm/users.py
+++ b/src/aiida/orm/users.py
@@ -14,9 +14,8 @@ from typing import TYPE_CHECKING, ClassVar
 
 from aiida.common import exceptions
 from aiida.manage import get_manager
-
-from . import entities
-from .pydantic import OrmMetadataField
+from aiida.orm import entities
+from aiida.orm.pydantic import OrmMetadataField
 
 if TYPE_CHECKING:
     from aiida.orm.implementation import StorageBackend

--- a/src/aiida/orm/utils/__init__.py
+++ b/src/aiida/orm/utils/__init__.py
@@ -12,11 +12,11 @@
 
 # fmt: off
 
-from .calcjob import *
-from .links import *
-from .loaders import *
-from .managers import *
-from .node import *
+from aiida.orm.utils.calcjob import *
+from aiida.orm.utils.links import *
+from aiida.orm.utils.loaders import *
+from aiida.orm.utils.managers import *
+from aiida.orm.utils.node import *
 
 __all__ = (
     'AbstractNodeMeta',

--- a/src/aiida/orm/utils/mixins.py
+++ b/src/aiida/orm/utils/mixins.py
@@ -15,9 +15,7 @@ import inspect
 from aiida.common import exceptions
 from aiida.common.lang import classproperty, override, type_check
 from aiida.common.warnings import warn_deprecation
-from aiida.orm.pydantic import OrmMetadataField
-
-from ..pydantic import OrmModel
+from aiida.orm.pydantic import OrmMetadataField, OrmModel
 
 
 class FunctionCalculationMixin:

--- a/src/aiida/parsers/__init__.py
+++ b/src/aiida/parsers/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .parser import *
+from aiida.parsers.parser import *
 
 __all__ = (
     'Parser',

--- a/src/aiida/plugins/__init__.py
+++ b/src/aiida/plugins/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .entry_point import *
-from .factories import *
-from .utils import *
+from aiida.plugins.entry_point import *
+from aiida.plugins.factories import *
+from aiida.plugins.utils import *
 
 __all__ = (
     'BaseFactory',

--- a/src/aiida/plugins/entry_point.py
+++ b/src/aiida/plugins/entry_point.py
@@ -18,8 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiida.common.exceptions import LoadingEntryPointError, MissingEntryPointError, MultipleEntryPointError
 from aiida.common.warnings import warn_deprecation
-
-from . import factories
+from aiida.plugins import factories
 
 if TYPE_CHECKING:
     from importlib_metadata import EntryPoint, EntryPoints

--- a/src/aiida/plugins/factories.py
+++ b/src/aiida/plugins/factories.py
@@ -70,7 +70,7 @@ def BaseFactory(group: str, name: str, load: bool = True) -> EntryPoint | Any:
     :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
     :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
     """
-    from .entry_point import get_entry_point, load_entry_point
+    from aiida.plugins.entry_point import get_entry_point, load_entry_point
 
     if load is True:
         return load_entry_point(group, name)

--- a/src/aiida/plugins/utils.py
+++ b/src/aiida/plugins/utils.py
@@ -17,8 +17,7 @@ from types import FunctionType
 
 from aiida.common import AIIDA_LOGGER
 from aiida.common.exceptions import EntryPointError
-
-from .entry_point import load_entry_point_from_string
+from aiida.plugins.entry_point import load_entry_point_from_string
 
 __all__ = ('PluginVersionProvider',)
 

--- a/src/aiida/repository/__init__.py
+++ b/src/aiida/repository/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .backend import *
-from .common import *
-from .repository import *
+from aiida.repository.backend import *
+from aiida.repository.common import *
+from aiida.repository.repository import *
 
 __all__ = (
     'AbstractRepositoryBackend',

--- a/src/aiida/repository/backend/__init__.py
+++ b/src/aiida/repository/backend/__init__.py
@@ -4,9 +4,9 @@
 
 # fmt: off
 
-from .abstract import *
-from .disk_object_store import *
-from .sandbox import *
+from aiida.repository.backend.abstract import *
+from aiida.repository.backend.disk_object_store import *
+from aiida.repository.backend.sandbox import *
 
 __all__ = (
     'AbstractRepositoryBackend',

--- a/src/aiida/repository/backend/disk_object_store.py
+++ b/src/aiida/repository/backend/disk_object_store.py
@@ -6,9 +6,8 @@ import shutil
 import typing as t
 
 from aiida.common.lang import type_check
+from aiida.repository.backend.abstract import AbstractRepositoryBackend, InfoDictType
 from aiida.storage.log import STORAGE_LOGGER
-
-from .abstract import AbstractRepositoryBackend, InfoDictType
 
 if t.TYPE_CHECKING:
     from disk_objectstore import Container

--- a/src/aiida/repository/backend/sandbox.py
+++ b/src/aiida/repository/backend/sandbox.py
@@ -10,8 +10,7 @@ import typing as t
 import uuid
 
 from aiida.common.folders import SandboxFolder
-
-from .abstract import AbstractRepositoryBackend, InfoDictType
+from aiida.repository.backend.abstract import AbstractRepositoryBackend, InfoDictType
 
 __all__ = ('SandboxRepositoryBackend',)
 

--- a/src/aiida/repository/repository.py
+++ b/src/aiida/repository/repository.py
@@ -8,9 +8,8 @@ from typing import Any, BinaryIO
 from aiida.common.hashing import make_hash
 from aiida.common.lang import type_check
 from aiida.common.typing import FilePath
-
-from .backend import AbstractRepositoryBackend, SandboxRepositoryBackend
-from .common import File, FileType
+from aiida.repository.backend import AbstractRepositoryBackend, SandboxRepositoryBackend
+from aiida.repository.common import File, FileType
 
 __all__ = ('Repository',)
 

--- a/src/aiida/restapi/run_api.py
+++ b/src/aiida/restapi/run_api.py
@@ -14,8 +14,8 @@ import os
 
 from flask_cors import CORS
 
-from . import api as api_classes
-from .common.config import API_CONFIG, APP_CONFIG, CLI_DEFAULTS
+from aiida.restapi import api as api_classes
+from aiida.restapi.common.config import API_CONFIG, APP_CONFIG, CLI_DEFAULTS
 
 __all__ = ('configure_api', 'run_api')
 

--- a/src/aiida/restapi/translator/nodes/node.py
+++ b/src/aiida/restapi/translator/nodes/node.py
@@ -448,7 +448,7 @@ class NodeTranslator(BaseTranslator):
         # logic is cleaned where the correct translator sub class is instantiated based on the node type that is
         # referenced, this hack can be removed.
         if isinstance(node, Data):
-            from .data import DataTranslator
+            from aiida.restapi.translator.nodes.data import DataTranslator
 
             downloadable_data = DataTranslator.get_downloadable_data(node, download_format=download_format)
             return downloadable_data

--- a/src/aiida/schedulers/__init__.py
+++ b/src/aiida/schedulers/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .datastructures import *
-from .plugins import *
-from .scheduler import *
+from aiida.schedulers.datastructures import *
+from aiida.schedulers.plugins import *
+from aiida.schedulers.scheduler import *
 
 __all__ = (
     'BashCliScheduler',

--- a/src/aiida/schedulers/plugins/__init__.py
+++ b/src/aiida/schedulers/plugins/__init__.py
@@ -11,7 +11,7 @@
 
 # fmt: off
 
-from .bash import *
+from aiida.schedulers.plugins.bash import *
 
 __all__ = (
     'BashCliScheduler',

--- a/src/aiida/schedulers/plugins/direct.py
+++ b/src/aiida/schedulers/plugins/direct.py
@@ -18,8 +18,7 @@ from typing_extensions import override
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import Scheduler, SchedulerError
 from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, NodeNumberJobResource
-
-from .bash import BashCliScheduler
+from aiida.schedulers.plugins.bash import BashCliScheduler
 
 if t.TYPE_CHECKING:
     from aiida.engine.processes.exit_code import ExitCode

--- a/src/aiida/schedulers/plugins/lsf.py
+++ b/src/aiida/schedulers/plugins/lsf.py
@@ -25,8 +25,7 @@ from aiida.common.exceptions import ConfigurationError, FeatureNotAvailable
 from aiida.common.extendeddicts import AttributeDict
 from aiida.schedulers import SchedulerError, SchedulerParsingError
 from aiida.schedulers.datastructures import JobInfo, JobResource, JobState, JobTemplate
-
-from .bash import BashCliScheduler
+from aiida.schedulers.plugins.bash import BashCliScheduler
 
 if t.TYPE_CHECKING:
     from aiida.engine.processes.exit_code import ExitCode

--- a/src/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/src/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -23,8 +23,7 @@ from aiida.common import AttributeDict, FeatureNotAvailable
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import SchedulerError, SchedulerParsingError
 from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, MachineInfo, NodeNumberJobResource
-
-from .bash import BashCliScheduler
+from aiida.schedulers.plugins.bash import BashCliScheduler
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/aiida/schedulers/plugins/pbspro.py
+++ b/src/aiida/schedulers/plugins/pbspro.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 
-from .pbsbaseclasses import PbsBaseClass
+from aiida.schedulers.plugins.pbsbaseclasses import PbsBaseClass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/aiida/schedulers/plugins/sge.py
+++ b/src/aiida/schedulers/plugins/sge.py
@@ -27,8 +27,7 @@ import aiida.schedulers
 from aiida.common.escaping import escape_for_bash
 from aiida.schedulers import SchedulerError, SchedulerParsingError
 from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, ParEnvJobResource
-
-from .bash import BashCliScheduler
+from aiida.schedulers.plugins.bash import BashCliScheduler
 
 if t.TYPE_CHECKING:
     from aiida.engine.processes.exit_code import ExitCode

--- a/src/aiida/schedulers/plugins/slurm.py
+++ b/src/aiida/schedulers/plugins/slurm.py
@@ -24,8 +24,7 @@ from aiida.common.exceptions import FeatureNotAvailable
 from aiida.common.lang import type_check
 from aiida.schedulers import Scheduler, SchedulerError
 from aiida.schedulers.datastructures import JobInfo, JobState, JobTemplate, NodeNumberJobResource
-
-from .bash import BashCliScheduler
+from aiida.schedulers.plugins.bash import BashCliScheduler
 
 if t.TYPE_CHECKING:
     from aiida.common import AttributeDict

--- a/src/aiida/schedulers/plugins/torque.py
+++ b/src/aiida/schedulers/plugins/torque.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 
-from .pbsbaseclasses import PbsBaseClass
+from aiida.schedulers.plugins.pbsbaseclasses import PbsBaseClass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/aiida/sphinxext/__init__.py
+++ b/src/aiida/sphinxext/__init__.py
@@ -12,8 +12,7 @@
 def setup(app):
     """Setup function to add the extension classes / nodes to Sphinx."""
     import aiida
-
-    from . import calcjob, process, workchain
+    from aiida.sphinxext import calcjob, process, workchain
 
     process.setup_extension(app)
     workchain.setup_extension(app)

--- a/src/aiida/sphinxext/calcjob.py
+++ b/src/aiida/sphinxext/calcjob.py
@@ -11,8 +11,7 @@
 import inspect
 
 from aiida.engine import CalcJob
-
-from .process import AiidaProcessDirective, AiidaProcessDocumenter
+from aiida.sphinxext.process import AiidaProcessDirective, AiidaProcessDocumenter
 
 
 def setup_extension(app):

--- a/src/aiida/sphinxext/workchain.py
+++ b/src/aiida/sphinxext/workchain.py
@@ -11,8 +11,7 @@
 import inspect
 
 from aiida.engine import WorkChain
-
-from .process import AiidaProcessDirective, AiidaProcessDocumenter
+from aiida.sphinxext.process import AiidaProcessDirective, AiidaProcessDocumenter
 
 
 def setup_extension(app):

--- a/src/aiida/storage/__init__.py
+++ b/src/aiida/storage/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .sqlite_dos import *
+from aiida.storage.sqlite_dos import *
 
 __all__ = (
     'SqliteDosStorage',

--- a/src/aiida/storage/psql_dos/__init__.py
+++ b/src/aiida/storage/psql_dos/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .backend import *
+from aiida.storage.psql_dos.backend import *
 
 __all__ = (
     'PsqlDosBackend',

--- a/src/aiida/storage/psql_dos/backend.py
+++ b/src/aiida/storage/psql_dos/backend.py
@@ -31,9 +31,8 @@ from aiida.orm.implementation import BackendEntity, StorageBackend
 from aiida.storage.log import STORAGE_LOGGER
 from aiida.storage.psql_dos.migrator import REPOSITORY_UUID_KEY, PsqlDosMigrator
 from aiida.storage.psql_dos.models import base
+from aiida.storage.psql_dos.orm import authinfos, comments, computers, convert, groups, logs, nodes, querybuilder, users
 from aiida.storage.utils import _create_smarter_in_clause
-
-from .orm import authinfos, comments, computers, convert, groups, logs, nodes, querybuilder, users
 
 if TYPE_CHECKING:
     from aiida.repository.backend import DiskObjectStoreRepositoryBackend

--- a/src/aiida/storage/psql_dos/migrations/utils/__init__.py
+++ b/src/aiida/storage/psql_dos/migrations/utils/__init__.py
@@ -8,6 +8,6 @@
 ###########################################################################
 """Utilities to perform the migrations."""
 
-from .reflect import ReflectMigrations
+from aiida.storage.psql_dos.migrations.utils.reflect import ReflectMigrations
 
 __all__ = ('ReflectMigrations',)

--- a/src/aiida/storage/psql_dos/migrations/utils/dblog_update.py
+++ b/src/aiida/storage/psql_dos/migrations/utils/dblog_update.py
@@ -15,8 +15,7 @@ import click
 import sqlalchemy as sa
 
 from aiida.cmdline.utils import echo
-
-from .utils import dumps_json
+from aiida.storage.psql_dos.migrations.utils.utils import dumps_json
 
 
 def get_legacy_workflow_log_number(connection):

--- a/src/aiida/storage/psql_dos/migrations/utils/provenance_redesign.py
+++ b/src/aiida/storage/psql_dos/migrations/utils/provenance_redesign.py
@@ -13,8 +13,10 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import column, select, table, text
 
 from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR
-
-from .integrity import infer_calculation_entry_point, write_database_integrity_violation
+from aiida.storage.psql_dos.migrations.utils.integrity import (
+    infer_calculation_entry_point,
+    write_database_integrity_violation,
+)
 
 SELECT_CALCULATIONS_WITH_OUTGOING_CALL = """
     SELECT node_in.uuid, node_out.uuid, link.type, link.label

--- a/src/aiida/storage/psql_dos/migrator.py
+++ b/src/aiida/storage/psql_dos/migrator.py
@@ -193,7 +193,7 @@ class PsqlDosMigrator:
         """
         from disk_objectstore import Container
 
-        from .backend import get_filepath_container
+        from aiida.storage.psql_dos.backend import get_filepath_container
 
         return Container(get_filepath_container(self.profile))
 

--- a/src/aiida/storage/psql_dos/models/authinfo.py
+++ b/src/aiida/storage/psql_dos/models/authinfo.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import backref, relationship
 from sqlalchemy.schema import Column, UniqueConstraint
 from sqlalchemy.types import Boolean, Integer
 
-from .base import Base
+from aiida.storage.psql_dos.models.base import Base
 
 
 class DbAuthInfo(Base):

--- a/src/aiida/storage/psql_dos/models/group.py
+++ b/src/aiida/storage/psql_dos/models/group.py
@@ -15,8 +15,7 @@ from sqlalchemy.types import DateTime, Integer, String, Text
 
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-
-from .base import Base
+from aiida.storage.psql_dos.models.base import Base
 
 
 class DbGroupNode(Base):

--- a/src/aiida/storage/psql_dos/orm/authinfos.py
+++ b/src/aiida/storage/psql_dos/orm/authinfos.py
@@ -12,8 +12,7 @@ from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.orm.implementation.authinfos import BackendAuthInfo, BackendAuthInfoCollection
 from aiida.storage.psql_dos.models.authinfo import DbAuthInfo
-
-from . import computers, entities, users, utils
+from aiida.storage.psql_dos.orm import computers, entities, users, utils
 
 
 class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):

--- a/src/aiida/storage/psql_dos/orm/comments.py
+++ b/src/aiida/storage/psql_dos/orm/comments.py
@@ -15,8 +15,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from aiida.common import exceptions, lang
 from aiida.orm.implementation.comments import BackendComment, BackendCommentCollection
 from aiida.storage.psql_dos.models import comment as models
-
-from . import entities, users, utils
+from aiida.storage.psql_dos.orm import entities, users, utils
 
 
 class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):

--- a/src/aiida/storage/psql_dos/orm/computers.py
+++ b/src/aiida/storage/psql_dos/orm/computers.py
@@ -16,8 +16,7 @@ from sqlalchemy.orm.session import make_transient
 from aiida.common import exceptions
 from aiida.orm.implementation.computers import BackendComputer, BackendComputerCollection
 from aiida.storage.psql_dos.models.computer import DbComputer
-
-from . import entities, utils
+from aiida.storage.psql_dos.orm import entities, utils
 
 
 class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):

--- a/src/aiida/storage/psql_dos/orm/convert.py
+++ b/src/aiida/storage/psql_dos/orm/convert.py
@@ -34,7 +34,7 @@ def get_backend_entity(dbmodel, backend):
 @get_backend_entity.register(DbUser)
 def _(dbmodel, backend):
     """get_backend_entity for SQLA DbUser"""
-    from . import users
+    from aiida.storage.psql_dos.orm import users
 
     return users.SqlaUser.from_dbmodel(dbmodel, backend)
 
@@ -42,7 +42,7 @@ def _(dbmodel, backend):
 @get_backend_entity.register(DbGroup)
 def _(dbmodel, backend):
     """get_backend_entity for SQLA DbGroup"""
-    from . import groups
+    from aiida.storage.psql_dos.orm import groups
 
     return groups.SqlaGroup.from_dbmodel(dbmodel, backend)
 
@@ -50,7 +50,7 @@ def _(dbmodel, backend):
 @get_backend_entity.register(DbComputer)
 def _(dbmodel, backend):
     """get_backend_entity for SQLA DbGroup"""
-    from . import computers
+    from aiida.storage.psql_dos.orm import computers
 
     return computers.SqlaComputer.from_dbmodel(dbmodel, backend)
 
@@ -60,7 +60,7 @@ def _(dbmodel, backend):
     """get_backend_entity for SQLA DbNode. It will return an ORM instance since
     there is not Node backend entity yet.
     """
-    from . import nodes
+    from aiida.storage.psql_dos.orm import nodes
 
     return nodes.SqlaNode.from_dbmodel(dbmodel, backend)
 
@@ -68,7 +68,7 @@ def _(dbmodel, backend):
 @get_backend_entity.register(DbAuthInfo)
 def _(dbmodel, backend):
     """get_backend_entity for SQLA DbAuthInfo"""
-    from . import authinfos
+    from aiida.storage.psql_dos.orm import authinfos
 
     return authinfos.SqlaAuthInfo.from_dbmodel(dbmodel, backend)
 
@@ -76,7 +76,7 @@ def _(dbmodel, backend):
 @get_backend_entity.register(DbComment)
 def _(dbmodel, backend):
     """Get the comment from the model"""
-    from . import comments
+    from aiida.storage.psql_dos.orm import comments
 
     return comments.SqlaComment.from_dbmodel(dbmodel, backend)
 
@@ -84,7 +84,7 @@ def _(dbmodel, backend):
 @get_backend_entity.register(DbLog)
 def _(dbmodel, backend):
     """Get the comment from the model"""
-    from . import logs
+    from aiida.storage.psql_dos.orm import logs
 
     return logs.SqlaLog.from_dbmodel(dbmodel, backend)
 

--- a/src/aiida/storage/psql_dos/orm/entities.py
+++ b/src/aiida/storage/psql_dos/orm/entities.py
@@ -12,8 +12,7 @@ from typing import Generic, TypeVar
 
 from aiida.common.lang import type_check
 from aiida.storage.psql_dos.models.base import Base
-
-from . import utils
+from aiida.storage.psql_dos.orm import utils
 
 ModelType = TypeVar('ModelType')
 SelfType = TypeVar('SelfType', bound='SqlaModelEntity')
@@ -38,7 +37,7 @@ class SqlaModelEntity(Generic[ModelType]):
         :param backend: the corresponding storage backend
         :return: the AiiDA entity
         """
-        from ..backend import PsqlDosBackend
+        from aiida.storage.psql_dos.backend import PsqlDosBackend
 
         cls._class_check()
         type_check(dbmodel, cls.MODEL_CLASS)

--- a/src/aiida/storage/psql_dos/orm/groups.py
+++ b/src/aiida/storage/psql_dos/orm/groups.py
@@ -14,10 +14,9 @@ from aiida.common.exceptions import UniquenessError
 from aiida.common.lang import type_check
 from aiida.orm.implementation.groups import BackendGroup, BackendGroupCollection
 from aiida.storage.psql_dos.models.group import DbGroup, DbGroupNode
-
-from . import entities, users, utils
-from .extras_mixin import ExtrasMixin
-from .nodes import SqlaNode
+from aiida.storage.psql_dos.orm import entities, users, utils
+from aiida.storage.psql_dos.orm.extras_mixin import ExtrasMixin
+from aiida.storage.psql_dos.orm.nodes import SqlaNode
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/aiida/storage/psql_dos/orm/logs.py
+++ b/src/aiida/storage/psql_dos/orm/logs.py
@@ -13,8 +13,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from aiida.common import exceptions
 from aiida.orm.implementation import BackendLog, BackendLogCollection
 from aiida.storage.psql_dos.models import log as models
-
-from . import entities, utils
+from aiida.storage.psql_dos.orm import entities, utils
 
 
 class SqlaLog(entities.SqlaModelEntity[models.DbLog], BackendLog):

--- a/src/aiida/storage/psql_dos/orm/nodes.py
+++ b/src/aiida/storage/psql_dos/orm/nodes.py
@@ -20,12 +20,11 @@ from aiida.common.lang import type_check
 from aiida.orm.implementation import BackendNode, BackendNodeCollection
 from aiida.orm.implementation.utils import clean_value, validate_attribute_extra_key
 from aiida.storage.psql_dos.models import node as models
-
-from . import entities
-from . import utils as sqla_utils
-from .computers import SqlaComputer
-from .extras_mixin import ExtrasMixin
-from .users import SqlaUser
+from aiida.storage.psql_dos.orm import entities
+from aiida.storage.psql_dos.orm import utils as sqla_utils
+from aiida.storage.psql_dos.orm.computers import SqlaComputer
+from aiida.storage.psql_dos.orm.extras_mixin import ExtrasMixin
+from aiida.storage.psql_dos.orm.users import SqlaUser
 
 
 class SqlaNode(entities.SqlaModelEntity[models.DbNode], ExtrasMixin, BackendNode):

--- a/src/aiida/storage/psql_dos/orm/querybuilder/__init__.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/__init__.py
@@ -8,6 +8,6 @@
 ###########################################################################
 """Implementation of QueryBuilder backend."""
 
-from .main import SqlaQueryBuilder
+from aiida.storage.psql_dos.orm.querybuilder.main import SqlaQueryBuilder
 
 __all__ = ('SqlaQueryBuilder',)

--- a/src/aiida/storage/psql_dos/orm/querybuilder/main.py
+++ b/src/aiida/storage/psql_dos/orm/querybuilder/main.py
@@ -31,9 +31,8 @@ from sqlalchemy.types import Boolean, DateTime, Float, Integer, String
 from aiida.common.exceptions import NotExistent
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation.querybuilder import QUERYBUILD_LOGGER, BackendQueryBuilder, QueryDictType
+from aiida.storage.psql_dos.orm.querybuilder.joiner import JoinReturn, SqlaJoiner
 from aiida.storage.utils import _create_smarter_in_clause
-
-from .joiner import JoinReturn, SqlaJoiner
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator

--- a/src/aiida/storage/psql_dos/orm/users.py
+++ b/src/aiida/storage/psql_dos/orm/users.py
@@ -10,8 +10,7 @@
 
 from aiida.orm.implementation.users import BackendUser, BackendUserCollection
 from aiida.storage.psql_dos.models.user import DbUser
-
-from . import entities, utils
+from aiida.storage.psql_dos.orm import entities, utils
 
 
 class SqlaUser(entities.SqlaModelEntity[DbUser], BackendUser):

--- a/src/aiida/storage/sqlite_dos/__init__.py
+++ b/src/aiida/storage/sqlite_dos/__init__.py
@@ -4,7 +4,7 @@
 
 # fmt: off
 
-from .backend import *
+from aiida.storage.sqlite_dos.backend import *
 
 __all__ = (
     'SqliteDosStorage',

--- a/src/aiida/storage/sqlite_dos/backend.py
+++ b/src/aiida/storage/sqlite_dos/backend.py
@@ -30,14 +30,13 @@ from aiida.manage.configuration.profile import Profile
 from aiida.manage.configuration.settings import AiiDAConfigDir
 from aiida.orm.implementation import BackendEntity
 from aiida.storage.log import MIGRATE_LOGGER
+from aiida.storage.migrations import TEMPLATE_INVALID_SCHEMA_VERSION
+from aiida.storage.psql_dos import PsqlDosBackend
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 from aiida.storage.psql_dos.models.settings import DbSetting
 from aiida.storage.sqlite_zip import models, orm
 from aiida.storage.sqlite_zip.backend import validate_sqlite_version
 from aiida.storage.sqlite_zip.utils import create_sqla_engine
-
-from ..migrations import TEMPLATE_INVALID_SCHEMA_VERSION
-from ..psql_dos import PsqlDosBackend
-from ..psql_dos.migrator import PsqlDosMigrator
 
 if TYPE_CHECKING:
     from disk_objectstore import Container
@@ -330,7 +329,7 @@ class SqliteDosStorage(PsqlDosBackend):
         """
         from sqlalchemy import inspect
 
-        from ..sqlite_zip.models import MAP_ENTITY_TYPE_TO_MODEL
+        from aiida.storage.sqlite_zip.models import MAP_ENTITY_TYPE_TO_MODEL
 
         model = MAP_ENTITY_TYPE_TO_MODEL[entity_type]
         mapper = inspect(model).mapper  # type: ignore[union-attr]

--- a/src/aiida/storage/sqlite_temp/__init__.py
+++ b/src/aiida/storage/sqlite_temp/__init__.py
@@ -17,7 +17,7 @@ and destroys it when it is garbage collected.
 
 # fmt: off
 
-from .backend import *
+from aiida.storage.sqlite_temp.backend import *
 
 __all__ = (
     'SqliteTempBackend',

--- a/src/aiida/storage/sqlite_zip/__init__.py
+++ b/src/aiida/storage/sqlite_zip/__init__.py
@@ -35,7 +35,7 @@ and these revisions are handled by the `version_profile` and `migrate` backend m
 
 # fmt: off
 
-from .backend import *
+from aiida.storage.sqlite_zip.backend import *
 
 __all__ = (
     'SqliteZipBackend',

--- a/src/aiida/storage/sqlite_zip/backend.py
+++ b/src/aiida/storage/sqlite_zip/backend.py
@@ -40,9 +40,8 @@ from aiida.manage import Profile
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import StorageBackend
 from aiida.repository.backend.abstract import AbstractRepositoryBackend, InfoDictType
-
-from . import orm
-from .utils import (
+from aiida.storage.sqlite_zip import orm
+from aiida.storage.sqlite_zip.utils import (
     DB_FILENAME,
     META_FILENAME,
     REPO_FOLDER,
@@ -141,7 +140,7 @@ class SqliteZipBackend(StorageBackend):
 
     @classmethod
     def version_head(cls) -> str:
-        from .migrator import get_schema_version_head
+        from aiida.storage.sqlite_zip.migrator import get_schema_version_head
 
         return get_schema_version_head()
 
@@ -177,7 +176,7 @@ class SqliteZipBackend(StorageBackend):
         filepath_archive = Path(profile.storage_config['filepath'])
 
         if filepath_archive.exists() and not reset:
-            from .migrator import migrate
+            from aiida.storage.sqlite_zip.migrator import migrate
 
             # Check if migration is needed. If we are already at the desired version, then no migration is required
             target_version = cls.version_head()
@@ -203,7 +202,7 @@ class SqliteZipBackend(StorageBackend):
         # Here the original archive either doesn't exist or ``reset == True`` so we simply create an empty base archive
         # and move it to the path pointed to by the storage configuration of the profile.
         with tempfile.TemporaryDirectory() as dirpath:
-            from .models import SqliteBase
+            from aiida.storage.sqlite_zip.models import SqliteBase
 
             if reset:
                 LOGGER.report(f'Resetting existing {cls.__name__} at {filepath_archive}')
@@ -239,7 +238,7 @@ class SqliteZipBackend(StorageBackend):
         raise NotImplementedError('use the :func:`aiida.storage.sqlite_zip.migrator.migrate` function directly.')
 
     def __init__(self, profile: Profile):
-        from .migrator import validate_storage
+        from aiida.storage.sqlite_zip.migrator import validate_storage
 
         validate_sqlite_version()
         super().__init__(profile)
@@ -424,7 +423,7 @@ class SqliteZipBackend(StorageBackend):
     @staticmethod
     def validate_archive_versions(current_version: str, target_version: str) -> None:
         """Check if migration is needed, raising if legacy/unsupported/invalid."""
-        from .migrator import list_versions
+        from aiida.storage.sqlite_zip.migrator import list_versions
 
         if current_version in ('0.1', '0.2', '0.3') or target_version in ('0.1', '0.2', '0.3'):
             raise StorageMigrationError(

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/__init__.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/__init__.py
@@ -14,15 +14,15 @@ These migrations simply manipulate the metadata and data in-place.
 
 from collections.abc import Callable
 
-from .v04_to_v05 import migrate_v4_to_v5
-from .v05_to_v06 import migrate_v5_to_v6
-from .v06_to_v07 import migrate_v6_to_v7
-from .v07_to_v08 import migrate_v7_to_v8
-from .v08_to_v09 import migrate_v8_to_v9
-from .v09_to_v10 import migrate_v9_to_v10
-from .v10_to_v11 import migrate_v10_to_v11
-from .v11_to_v12 import migrate_v11_to_v12
-from .v12_to_v13 import migrate_v12_to_v13
+from aiida.storage.sqlite_zip.migrations.legacy.v04_to_v05 import migrate_v4_to_v5
+from aiida.storage.sqlite_zip.migrations.legacy.v05_to_v06 import migrate_v5_to_v6
+from aiida.storage.sqlite_zip.migrations.legacy.v06_to_v07 import migrate_v6_to_v7
+from aiida.storage.sqlite_zip.migrations.legacy.v07_to_v08 import migrate_v7_to_v8
+from aiida.storage.sqlite_zip.migrations.legacy.v08_to_v09 import migrate_v8_to_v9
+from aiida.storage.sqlite_zip.migrations.legacy.v09_to_v10 import migrate_v9_to_v10
+from aiida.storage.sqlite_zip.migrations.legacy.v10_to_v11 import migrate_v10_to_v11
+from aiida.storage.sqlite_zip.migrations.legacy.v11_to_v12 import migrate_v11_to_v12
+from aiida.storage.sqlite_zip.migrations.legacy.v12_to_v13 import migrate_v12_to_v13
 
 # version from -> version to, function which modifies metadata, data in-place
 LEGACY_MIGRATE_FUNCTIONS: dict[str, tuple[str, Callable[[dict, dict], None]]] = {

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v04_to_v05.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v04_to_v05.py
@@ -23,7 +23,7 @@ The individual SQLAlchemy database migrations may be found at:
 Where id is a SQLA id and migration-name is the name of the particular migration.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def remove_fields(metadata, data, entities, fields):

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v05_to_v06.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v05_to_v06.py
@@ -23,7 +23,7 @@ The individual SQLAlchemy database migrations may be found at:
 Where id is a SQLA id and migration-name is the name of the particular migration.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def migrate_deserialized_datetime(data, conversion):

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v06_to_v07.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v06_to_v07.py
@@ -23,7 +23,7 @@ The individual SQLAlchemy database migrations may be found at:
 Where id is a SQLA id and migration-name is the name of the particular migration.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def data_migration_legacy_process_attributes(data):

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v07_to_v08.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v07_to_v08.py
@@ -23,7 +23,7 @@ The individual SQLAlchemy database migrations may be found at:
 Where id is a SQLA id and migration-name is the name of the particular migration.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def migration_default_link_label(data: dict):

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v08_to_v09.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v08_to_v09.py
@@ -23,7 +23,7 @@ The individual SQLAlchemy database migrations may be found at:
 Where id is a SQLA id and migration-name is the name of the particular migration.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def migration_dbgroup_type_string(data):

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v09_to_v10.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v09_to_v10.py
@@ -8,7 +8,7 @@
 ###########################################################################
 """Migration from v0.9 to v0.10, used by `verdi export migrate` command."""
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def migrate_v9_to_v10(metadata: dict, data: dict) -> None:

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v10_to_v11.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v10_to_v11.py
@@ -11,7 +11,7 @@
 This migration applies the name change of the ``Computer`` attribute ``name`` to ``label``.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 
 def migrate_v10_to_v11(metadata: dict, data: dict) -> None:

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v11_to_v12.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v11_to_v12.py
@@ -11,7 +11,7 @@
 This migration is necessary after the `core.` prefix was added to entry points shipped with `aiida-core`.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 MAPPING_DATA = {
     'data.array.ArrayData.': 'data.core.array.ArrayData.',

--- a/src/aiida/storage/sqlite_zip/migrations/legacy/v12_to_v13.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy/v12_to_v13.py
@@ -12,7 +12,7 @@ This migration is necessary after the v0.11 to v0.12 migration did not add the c
 to transport entry points.
 """
 
-from ..utils import update_metadata, verify_metadata_version
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata, verify_metadata_version
 
 MAPPING_TRANSPORTS = {
     'local': 'core.local',

--- a/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -26,9 +26,8 @@ from aiida.common.hashing import chunked_file_hash
 from aiida.common.progress_reporter import get_progress_reporter
 from aiida.repository.common import File, FileType
 from aiida.storage.log import MIGRATE_LOGGER
-
-from ..utils import DB_FILENAME, REPO_FOLDER, create_sqla_engine
-from .utils import update_metadata
+from aiida.storage.sqlite_zip.migrations.utils import update_metadata
+from aiida.storage.sqlite_zip.utils import DB_FILENAME, REPO_FOLDER, create_sqla_engine
 
 _NODE_ENTITY_NAME = 'Node'
 _GROUP_ENTITY_NAME = 'Group'
@@ -133,8 +132,7 @@ def _json_to_sqlite(
 ) -> None:
     """Convert a JSON archive format to SQLite."""
     from aiida.common.utils import batch_iter
-
-    from . import v1_db_schema as v1_schema
+    from aiida.storage.sqlite_zip.migrations import v1_db_schema as v1_schema
 
     aiida_orm_to_backend = {
         _USER_ENTITY_NAME: v1_schema.DbUser,

--- a/src/aiida/storage/sqlite_zip/migrator.py
+++ b/src/aiida/storage/sqlite_zip/migrator.py
@@ -31,11 +31,17 @@ from aiida.common.exceptions import CorruptStorage, IncompatibleStorageSchema, S
 from aiida.common.progress_reporter import get_progress_reporter
 from aiida.storage.log import MIGRATE_LOGGER
 from aiida.storage.sqlite_zip.backend import SqliteZipBackend
-
-from .migrations.legacy import FINAL_LEGACY_VERSION, LEGACY_MIGRATE_FUNCTIONS
-from .migrations.legacy_to_main import LEGACY_TO_MAIN_REVISION, perform_v1_migration
-from .migrations.utils import copy_tar_to_zip, copy_zip_to_zip, update_metadata
-from .utils import DB_FILENAME, META_FILENAME, REPO_FOLDER, create_sqla_engine, extract_metadata, read_version
+from aiida.storage.sqlite_zip.migrations.legacy import FINAL_LEGACY_VERSION, LEGACY_MIGRATE_FUNCTIONS
+from aiida.storage.sqlite_zip.migrations.legacy_to_main import LEGACY_TO_MAIN_REVISION, perform_v1_migration
+from aiida.storage.sqlite_zip.migrations.utils import copy_tar_to_zip, copy_zip_to_zip, update_metadata
+from aiida.storage.sqlite_zip.utils import (
+    DB_FILENAME,
+    META_FILENAME,
+    REPO_FOLDER,
+    create_sqla_engine,
+    extract_metadata,
+    read_version,
+)
 
 
 def get_schema_version_head() -> str:

--- a/src/aiida/storage/sqlite_zip/orm.py
+++ b/src/aiida/storage/sqlite_zip/orm.py
@@ -34,10 +34,9 @@ from aiida.storage.psql_dos.orm.querybuilder.main import (
     String,
     get_column,
 )
+from aiida.storage.sqlite_zip import models
+from aiida.storage.sqlite_zip.utils import ReadOnlyError
 from aiida.storage.utils import _create_smarter_in_clause
-
-from . import models
-from .utils import ReadOnlyError
 
 
 class SqliteEntityOverride:

--- a/src/aiida/tools/__init__.py
+++ b/src/aiida/tools/__init__.py
@@ -22,13 +22,13 @@ What functionality should go directly in the ORM class in `aiida.orm` and what i
 
 # fmt: off
 
-from .archive import *
-from .calculations import *
-from .data import *
-from .graph import *
-from .groups import *
-from .visualization import *
-from .workflows import *
+from aiida.tools.archive import *
+from aiida.tools.calculations import *
+from aiida.tools.data import *
+from aiida.tools.graph import *
+from aiida.tools.groups import *
+from aiida.tools.visualization import *
+from aiida.tools.workflows import *
 
 __all__ = (
     'ArchiveExportError',

--- a/src/aiida/tools/_dumping/executors/__init__.py
+++ b/src/aiida/tools/_dumping/executors/__init__.py
@@ -1,7 +1,7 @@
-from .deletion import DeletionExecutor
-from .group import GroupDumpExecutor
-from .process import ProcessDumpExecutor
-from .profile import ProfileDumpExecutor
+from aiida.tools._dumping.executors.deletion import DeletionExecutor
+from aiida.tools._dumping.executors.group import GroupDumpExecutor
+from aiida.tools._dumping.executors.process import ProcessDumpExecutor
+from aiida.tools._dumping.executors.profile import ProfileDumpExecutor
 
 __all__ = (
     'DeletionExecutor',

--- a/src/aiida/tools/archive/__init__.py
+++ b/src/aiida/tools/archive/__init__.py
@@ -14,9 +14,9 @@ of subsets of the provenance graph, to a single file
 
 # fmt: off
 
-from .create import *
-from .exceptions import *
-from .imports import *
+from aiida.tools.archive.create import *
+from aiida.tools.archive.exceptions import *
+from aiida.tools.archive.imports import *
 
 __all__ = (
     'ArchiveExportError',

--- a/src/aiida/tools/archive/create.py
+++ b/src/aiida/tools/archive/create.py
@@ -31,12 +31,11 @@ from aiida.manage import get_manager
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import StorageBackend
 from aiida.orm.utils.links import LinkQuadruple
+from aiida.tools.archive.abstract import ArchiveFormatAbstract, ArchiveWriterAbstract
+from aiida.tools.archive.common import entity_type_to_orm
+from aiida.tools.archive.exceptions import ArchiveExportError, ExportValidationError
+from aiida.tools.archive.implementations.sqlite_zip.main import ArchiveFormatSqlZip
 from aiida.tools.graph.graph_traversers import get_nodes_export, validate_traversal_rules
-
-from .abstract import ArchiveFormatAbstract, ArchiveWriterAbstract
-from .common import entity_type_to_orm
-from .exceptions import ArchiveExportError, ExportValidationError
-from .implementations.sqlite_zip.main import ArchiveFormatSqlZip
 
 __all__ = ('create_archive',)
 

--- a/src/aiida/tools/archive/implementations/__init__.py
+++ b/src/aiida/tools/archive/implementations/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .sqlite_zip import *
+from aiida.tools.archive.implementations.sqlite_zip import *
 
 __all__ = ()
 

--- a/src/aiida/tools/archive/implementations/sqlite_zip/main.py
+++ b/src/aiida/tools/archive/implementations/sqlite_zip/main.py
@@ -14,9 +14,8 @@ from typing import Any, Literal, overload
 from aiida.storage.sqlite_zip.migrator import get_schema_version_head, migrate
 from aiida.storage.sqlite_zip.utils import read_version
 from aiida.tools.archive.abstract import ArchiveFormatAbstract
-
-from .reader import ArchiveReaderSqlZip
-from .writer import ArchiveAppenderSqlZip, ArchiveWriterSqlZip
+from aiida.tools.archive.implementations.sqlite_zip.reader import ArchiveReaderSqlZip
+from aiida.tools.archive.implementations.sqlite_zip.writer import ArchiveAppenderSqlZip, ArchiveWriterSqlZip
 
 
 class ArchiveFormatSqlZip(ArchiveFormatAbstract):

--- a/src/aiida/tools/archive/imports.py
+++ b/src/aiida/tools/archive/imports.py
@@ -27,11 +27,10 @@ from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import StorageBackend
 from aiida.orm.querybuilder import QueryBuilder
 from aiida.repository import Repository
-
-from .abstract import ArchiveFormatAbstract
-from .common import entity_type_to_orm
-from .exceptions import ImportTestRun, ImportUniquenessError, ImportValidationError
-from .implementations.sqlite_zip.main import ArchiveFormatSqlZip
+from aiida.tools.archive.abstract import ArchiveFormatAbstract
+from aiida.tools.archive.common import entity_type_to_orm
+from aiida.tools.archive.exceptions import ImportTestRun, ImportUniquenessError, ImportValidationError
+from aiida.tools.archive.implementations.sqlite_zip.main import ArchiveFormatSqlZip
 
 __all__ = ('import_archive',)
 

--- a/src/aiida/tools/calculations/__init__.py
+++ b/src/aiida/tools/calculations/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .base import *
+from aiida.tools.calculations.base import *
 
 __all__ = (
     'CalculationTools',

--- a/src/aiida/tools/data/__init__.py
+++ b/src/aiida/tools/data/__init__.py
@@ -12,9 +12,9 @@
 
 # fmt: off
 
-from .array import *
-from .orbital import *
-from .structure import *
+from aiida.tools.data.array import *
+from aiida.tools.data.orbital import *
+from aiida.tools.data.structure import *
 
 __all__ = (
     'Orbital',

--- a/src/aiida/tools/data/array/__init__.py
+++ b/src/aiida/tools/data/array/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .kpoints import *
+from aiida.tools.data.array.kpoints import *
 
 __all__ = (
     'get_explicit_kpoints_path',

--- a/src/aiida/tools/data/array/kpoints/__init__.py
+++ b/src/aiida/tools/data/array/kpoints/__init__.py
@@ -14,7 +14,7 @@
 
 # fmt: off
 
-from .main import *
+from aiida.tools.data.array.kpoints.main import *
 
 __all__ = (
     'get_explicit_kpoints_path',

--- a/src/aiida/tools/data/orbital/__init__.py
+++ b/src/aiida/tools/data/orbital/__init__.py
@@ -12,8 +12,8 @@
 
 # fmt: off
 
-from .orbital import *
-from .realhydrogen import *
+from aiida.tools.data.orbital.orbital import *
+from aiida.tools.data.orbital.realhydrogen import *
 
 __all__ = (
     'Orbital',

--- a/src/aiida/tools/data/orbital/realhydrogen.py
+++ b/src/aiida/tools/data/orbital/realhydrogen.py
@@ -11,8 +11,7 @@ complex-valued).
 """
 
 from aiida.common.exceptions import ValidationError
-
-from .orbital import Orbital, validate_float_or_none, validate_len3_list_or_none
+from aiida.tools.data.orbital.orbital import Orbital, validate_float_or_none, validate_len3_list_or_none
 
 __all__ = ('RealhydrogenOrbital',)
 

--- a/src/aiida/tools/dbimporters/__init__.py
+++ b/src/aiida/tools/dbimporters/__init__.py
@@ -8,6 +8,6 @@
 ###########################################################################
 """Module for plugins to import data from external databases into an AiiDA database."""
 
-from .baseclasses import DbImporter
+from aiida.tools.dbimporters.baseclasses import DbImporter
 
 __all__ = ('DbImporter',)

--- a/src/aiida/tools/graph/__init__.py
+++ b/src/aiida/tools/graph/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .deletions import *
+from aiida.tools.graph.deletions import *
 
 __all__ = (
     'delete_group_nodes',

--- a/src/aiida/tools/groups/__init__.py
+++ b/src/aiida/tools/groups/__init__.py
@@ -18,7 +18,7 @@
 
 # fmt: off
 
-from .paths import *
+from aiida.tools.groups.paths import *
 
 __all__ = (
     'GroupNotFoundError',

--- a/src/aiida/tools/pytest_fixtures/__init__.py
+++ b/src/aiida/tools/pytest_fixtures/__init__.py
@@ -3,8 +3,8 @@
 
 # fmt: off
 
-from .broker import run_aiida_broker_service, run_aiida_broker_service_for_profile
-from .configuration import (
+from aiida.tools.pytest_fixtures.broker import run_aiida_broker_service, run_aiida_broker_service_for_profile
+from aiida.tools.pytest_fixtures.configuration import (
     aiida_config,
     aiida_config_factory,
     aiida_config_tmp,
@@ -14,10 +14,15 @@ from .configuration import (
     aiida_profile_factory,
     aiida_profile_tmp,
 )
-from .daemon import daemon_client, started_daemon_client, stopped_daemon_client, submit_and_await
-from .entry_points import entry_points
-from .globals import aiida_manager
-from .orm import (
+from aiida.tools.pytest_fixtures.daemon import (
+    daemon_client,
+    started_daemon_client,
+    stopped_daemon_client,
+    submit_and_await,
+)
+from aiida.tools.pytest_fixtures.entry_points import entry_points
+from aiida.tools.pytest_fixtures.globals import aiida_manager
+from aiida.tools.pytest_fixtures.orm import (
     aiida_code,
     aiida_code_installed,
     aiida_computer,
@@ -27,7 +32,7 @@ from .orm import (
     aiida_localhost,
     ssh_key,
 )
-from .storage import config_psql_dos, config_sqlite_dos, postgres_cluster
+from aiida.tools.pytest_fixtures.storage import config_psql_dos, config_sqlite_dos, postgres_cluster
 
 __all__ = (
     'aiida_code',

--- a/src/aiida/tools/query/calculation.py
+++ b/src/aiida/tools/query/calculation.py
@@ -14,8 +14,7 @@ import typing as t
 from collections.abc import Iterable
 
 from aiida.common.lang import classproperty
-
-from .mapping import CalculationProjectionMapper, ProjectionMapper
+from aiida.tools.query.mapping import CalculationProjectionMapper, ProjectionMapper
 
 if t.TYPE_CHECKING:
     from aiida.orm import Node

--- a/src/aiida/tools/query/mapping.py
+++ b/src/aiida/tools/query/mapping.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from . import formatting
+from aiida.tools.query import formatting
 
 
 class ProjectionMapper:

--- a/src/aiida/tools/visualization/__init__.py
+++ b/src/aiida/tools/visualization/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .graph import *
+from aiida.tools.visualization.graph import *
 
 __all__ = (
     'Graph',

--- a/src/aiida/tools/workflows/__init__.py
+++ b/src/aiida/tools/workflows/__init__.py
@@ -12,7 +12,7 @@
 
 # fmt: off
 
-from .base import *
+from aiida.tools.workflows.base import *
 
 __all__ = (
     'WorkflowTools',

--- a/src/aiida/transports/__init__.py
+++ b/src/aiida/transports/__init__.py
@@ -12,8 +12,8 @@
 
 # fmt: off
 
-from .plugins import *
-from .transport import *
+from aiida.transports.plugins import *
+from aiida.transports.transport import *
 
 __all__ = (
     'AsyncSshTransport',

--- a/src/aiida/transports/plugins/__init__.py
+++ b/src/aiida/transports/plugins/__init__.py
@@ -12,8 +12,8 @@
 
 # fmt: off
 
-from .ssh import *
-from .ssh_async import *
+from aiida.transports.plugins.ssh import *
+from aiida.transports.plugins.ssh_async import *
 
 __all__ = (
     'AsyncSshTransport',

--- a/src/aiida/transports/plugins/ssh.py
+++ b/src/aiida/transports/plugins/ssh.py
@@ -20,8 +20,7 @@ from aiida.cmdline.params import options
 from aiida.cmdline.params.types.path import AbsolutePathOrEmptyParamType
 from aiida.common.escaping import escape_for_bash
 from aiida.common.warnings import warn_deprecation
-
-from ..transport import BlockingTransport, TransportInternalError, TransportPath, has_magic
+from aiida.transports.transport import BlockingTransport, TransportInternalError, TransportPath, has_magic
 
 __all__ = ('SshTransport', 'convert_to_bool', 'parse_sshconfig')
 

--- a/src/aiida/transports/plugins/ssh_async.py
+++ b/src/aiida/transports/plugins/ssh_async.py
@@ -174,7 +174,7 @@ class AsyncSshTransport(AsyncTransport):
             self.auth_script = kwargs.pop('script_before', 'None')
 
         if kwargs.get('backend') == 'openssh':
-            from .async_backend import _OpenSSH
+            from aiida.transports.plugins.async_backend import _OpenSSH
 
             self.async_backend = _OpenSSH(
                 self.machine,
@@ -185,7 +185,7 @@ class AsyncSshTransport(AsyncTransport):
             )
         else:
             # default backend is asyncssh
-            from .async_backend import _AsyncSSH
+            from aiida.transports.plugins.async_backend import _AsyncSSH
 
             self.async_backend = _AsyncSSH(  # type: ignore[assignment]
                 self.machine, self.data_machine, self.logger, self._bash_command_str

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -103,7 +103,7 @@ class TestCalcFunction:
         a different module, because we cannot define it in the same module (as the name clashes, on purpose) and we
         cannot inline the calcfunction in this test, since inlined process functions are not valid cache sources.
         """
-        from .calcfunctions import add_calcfunction
+        from tests.engine.calcfunctions import add_calcfunction
 
         result_original = self.test_calcfunction(self.default_int)
 

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -383,7 +383,7 @@ class TestProcess:
 
             @classmethod
             def define(cls, spec):
-                super(ChildProcess, cls).define(spec)
+                super().define(spec)
                 spec.input('input', valid_type=orm.Int)
                 spec.output('output', valid_type=orm.Int)
                 spec.output('name.space', valid_type=orm.Int)
@@ -395,7 +395,7 @@ class TestProcess:
 
             @classmethod
             def define(cls, spec):
-                super(ParentProcess, cls).define(spec)
+                super().define(spec)
                 spec.input('input', valid_type=orm.Int)
                 spec.expose_outputs(ChildProcess)
 
@@ -433,7 +433,7 @@ class TestProcess:
 
             @classmethod
             def define(cls, spec):
-                super(ChildProcess, cls).define(spec)
+                super().define(spec)
                 spec.input('input', valid_type=orm.Int)
                 spec.output('output', valid_type=orm.Int)
                 spec.output('name.space', valid_type=orm.Int)
@@ -445,7 +445,7 @@ class TestProcess:
 
             @classmethod
             def define(cls, spec):
-                super(ParentProcess, cls).define(spec)
+                super().define(spec)
                 spec.input('input', valid_type=orm.Int)
                 spec.expose_outputs(ChildProcess, namespace='child')
 

--- a/tests/tools/dumping/integration_tests.py
+++ b/tests/tools/dumping/integration_tests.py
@@ -17,8 +17,7 @@ import pytest
 from aiida import load_profile, orm
 from aiida.common import AIIDA_LOGGER, LinkType
 from aiida.tools._dumping.utils import DumpPaths
-
-from .utils import compare_tree
+from tests.tools.dumping.utils import compare_tree
 
 logger = AIIDA_LOGGER.getChild('tools._dumping.tests')
 


### PR DESCRIPTION
First merge #7579

I mainly want to avoid relative imports. With relative imports circular imports can easily happen. While I am okay to have circular in some parts of the code but it should be explicitly marked why. When absolute and relative imports are mixed it also reduces readability. Places where we load Processes from a relative import due to checkpoints, are okay in my opinion and I added `# noqa: TID252` at these places.