### PR TITLE
Integrate plumpy into aiida-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ docker-bake.override.json
 
 # dev files
 .dev
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+
+Process checkpoints created with earlier releases cannot be continued after upgrading because process state classes are now provided in-tree instead of by `plumpy`.
+Finish or terminate all active processes before upgrading.
+
 ### New features
 
 ### Behavior changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 Process checkpoints created with earlier releases cannot be continued after upgrading because process state classes are now provided in-tree instead of by `plumpy`.
 Finish or terminate all active processes before upgrading.
+The `logging.plumpy_loglevel` configuration option is removed because the Plumpy implementation is now part of aiida-core.
+Explicit values are migrated to `logging.aiida_core_loglevel` unless that option is already set, and all loggers under `aiida.engine` are governed by the aiida-core log level.
 
 ### New features
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,6 @@ intersphinx_mapping = {
     'flask_restful': ('https://flask-restful.readthedocs.io/en/latest/', None),
     'kiwipy': ('https://kiwipy.readthedocs.io/en/latest/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),
-    'plumpy': ('https://plumpy.readthedocs.io/en/latest/', None),
     'python': ('https://docs.python.org/3', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/14/', None),
 }

--- a/docs/source/howto/plugin_codes.rst
+++ b/docs/source/howto/plugin_codes.rst
@@ -93,7 +93,7 @@ For example:
 The first line of the method calls the |define| method of the |CalcJob| parent class.
 This necessary step defines the `inputs` and `outputs` that are common to all |CalcJob|'s.
 
-Next, we use the :py:meth:`~plumpy.process_spec.ProcessSpec.input` method in order to define our two input files ``file1`` and ``file2`` of type |SinglefileData|.
+Next, we use the :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.input` method in order to define our two input files ``file1`` and ``file2`` of type |SinglefileData|.
 
 .. admonition:: Further reading
 
@@ -102,7 +102,7 @@ Next, we use the :py:meth:`~plumpy.process_spec.ProcessSpec.input` method in ord
     :ref:`how-to:plugin-codes:cli-options` shows how to use the |Dict| class to represent the ``diff`` command line options as a python dictionary.
     The `aiida-diff`_ demo plugin goes further and adds automatic validation.
 
-We then use :py:meth:`~plumpy.process_spec.ProcessSpec.output` to define the only output of the calculation with the label ``diff``.
+We then use :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.output` to define the only output of the calculation with the label ``diff``.
 AiiDA will attach the outputs defined here to a (successfully) finished calculation using the link label provided.
 
 ..  I think the following is not really needed here at this point
@@ -112,7 +112,7 @@ AiiDA will attach the outputs defined here to a (successfully) finished calculat
 
 
 Finally, we set a few default ``options``, such as the name of the parser (which we will implement later), the name of input and output files, and the computational resources to use for such a calculation.
-These ``options`` have already been defined on the |spec| by the ``super().define(spec)`` call, and they can be accessed through the :py:attr:`~plumpy.process_spec.ProcessSpec.inputs` attribute, which behaves like a dictionary.
+These ``options`` have already been defined on the |spec| by the ``super().define(spec)`` call, and they can be accessed through the :py:attr:`~aiida.engine.processes.process_spec.ProcessSpec.inputs` attribute, which behaves like a dictionary.
 
 There is no ``return`` statement in ``define``: the ``define`` method directly modifies the |spec| object it receives.
 
@@ -144,7 +144,7 @@ For example:
     :pyobject: DiffCalculation.prepare_for_submission
 
 All inputs provided to the calculation are validated against the ``spec`` *before* |prepare_for_submission| is called.
-Therefore, when accessing the :py:attr:`~plumpy.processes.Process.inputs` attribute, you can safely assume that all required inputs have been set and that all inputs have a valid type.
+Therefore, when accessing the :py:attr:`~aiida.engine.processes.process.Process.inputs` attribute, you can safely assume that all required inputs have been set and that all inputs have a valid type.
 
 We start by creating a |CodeInfo| object that lets AiiDA know how to run the code, i.e. here:
 

--- a/docs/source/howto/workchains_restart.rst
+++ b/docs/source/howto/workchains_restart.rst
@@ -297,7 +297,7 @@ Exposing inputs and outputs
 Any base restart work chain *needs* to *expose* the inputs of the subprocess it wraps, and most likely *wants* to do the same for the outputs it produces, although the latter is not necessary.
 For the simple example presented in the previous section, simply copy-pasting the input and output port definitions of the subprocess ``ArithmeticAddCalculation`` was not too troublesome.
 However, this quickly becomes tedious, and more importantly, error-prone once you start to wrap processes with quite a few more inputs.
-To prevent the copy-pasting of input and output specifications, the :class:`~aiida.engine.processes.process_spec.ProcessSpec` class provides the :meth:`~plumpy.ProcessSpec.expose_inputs` and :meth:`~plumpy.ProcessSpec.expose_outputs` methods:
+To prevent the copy-pasting of input and output specifications, the :class:`~aiida.engine.processes.process_spec.ProcessSpec` class provides the :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_inputs` and :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_outputs` methods:
 
 .. code-block:: python
 

--- a/docs/source/howto/write_workflows.rst
+++ b/docs/source/howto/write_workflows.rst
@@ -183,8 +183,8 @@ In many cases it is convenient for work chains to expose the inputs of the subpr
 For the simple example presented in the previous section, simply copy-pasting the input and output port definitions of the subprocess ``MultiplyAddWorkChain`` was not too troublesome.
 However, this quickly becomes tedious and error-prone once you start to wrap processes with quite a few more inputs.
 
-To prevent the copy-pasting of input and output specifications, the :class:`~aiida.engine.processes.process_spec.ProcessSpec` class provides the :meth:`~plumpy.ProcessSpec.expose_inputs` and :meth:`~plumpy.ProcessSpec.expose_outputs` methods.
-Calling :meth:`~plumpy.ProcessSpec.expose_inputs` for a particular ``Process`` class, will automatically copy the inputs of the class into the inputs namespace of the process specification:
+To prevent the copy-pasting of input and output specifications, the :class:`~aiida.engine.processes.process_spec.ProcessSpec` class provides the :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_inputs` and :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_outputs` methods.
+Calling :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_inputs` for a particular ``Process`` class, will automatically copy the inputs of the class into the inputs namespace of the process specification:
 
 .. code-block:: python
 
@@ -260,7 +260,7 @@ After running the ``MultiplyAddIsEvenWorkChain``, you can see a hierarchical ove
 
 Note that this command also recursively shows the processes called by the subprocesses of the ``MultiplyAddIsEvenWorkChain`` work chain.
 
-As mentioned earlier, you can also expose the outputs of the ``MultiplyAddWorkChain`` using the :meth:`~plumpy.ProcessSpec.expose_outputs` method.
+As mentioned earlier, you can also expose the outputs of the ``MultiplyAddWorkChain`` using the :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_outputs` method.
 Say we want to add the ``result`` of the ``MultiplyAddWorkChain`` as one of the outputs of the extended work chain:
 
 .. code-block:: python

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -430,7 +430,7 @@ AiiDA provides separate options to control the verbosity of what is also directe
 
 With verdi commands adding the ``--verbosity`` flag the ``logging.aiida_loglevel`` and ``logging.terminal_handler`` option can be changed for execution of the command.
 
-By default, only messages from AiiDA's own loggers (``aiida-core``, ``plumpy``, ``kiwipy``, ``disk-objectstore``) are affected by ``logging.aiida_loglevel``.
+By default, only messages from AiiDA's own loggers (``aiida-core``, ``aiida.engine``, ``kiwipy``, ``disk-objectstore``) are affected by ``logging.aiida_loglevel``.
 To also include messages from third-party libraries, lower their log level as well.
 For example, to include SQLAlchemy messages:
 

--- a/docs/source/internals/broker.rst
+++ b/docs/source/internals/broker.rst
@@ -50,7 +50,7 @@ Module overview
 ===============
 
 ``ZeromqCommunicator`` implements ``kiwipy.Communicator``, the same interface that ``RmqThreadCommunicator`` implements for RabbitMQ.
-plumpy and the AiiDA engine only ever see this interface; they do not know which broker backend they are talking to.
+The AiiDA engine only ever sees this interface; they do not know which broker backend they are talking to.
 
 .. code-block:: text
 
@@ -220,7 +220,7 @@ The empty delimiter frame is the standard ZeroMQ convention for ROUTER/DEALER in
 The ROUTER socket prepends the sender's identity on receive and uses the first frame as the routing target on send.
 
 Payload fields like ``body`` and ``result`` are opaque to the broker.
-They are pre-encoded by the sender (typically as YAML strings by plumpy/kiwipy) and passed through without inspection.
+They are pre-encoded by the sender (typically as YAML strings by the engine/kiwipy) and passed through without inspection.
 
 
 Message flow: task submission
@@ -298,7 +298,7 @@ A ``NACK``, and the requeueing of tasks belonging to a worker that died, free th
 Deferred ACK pattern
 ====================
 
-kiwipy allows a task subscriber to return a ``Future`` instead of a result, and plumpy's process runner relies on this because AiiDA processes are long-running and asynchronous.
+kiwipy allows a task subscriber to return a ``Future`` instead of a result, and the process runner relies on this because AiiDA processes are long-running and asynchronous.
 Any compatible ``kiwipy.Communicator`` has to support it, so ours does too.
 
 When a task subscriber returns, there are two cases:
@@ -340,7 +340,7 @@ Receiving is purely client-local: ``add_broadcast_subscriber()`` sends nothing t
 The communicator just registers the callback and invokes it for any ``BROADCAST`` message that arrives on its DEALER socket.
 
 The catch is that a client only receives broadcasts if the broker knows about it, i.e. if it is registered as a task or RPC subscriber.
-That is enough for AiiDA: daemon workers always hold task and RPC subscriptions, and any client running a process holds an RPC subscription for it (registered by plumpy).
+That is enough for AiiDA: daemon workers always hold task and RPC subscriptions, and any client running a process holds an RPC subscription for it (registered by the engine).
 
 
 Dead worker detection

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -190,14 +190,13 @@ py:class Signature
 py:class ConfigDict
 py:class FieldInfo
 
-# These can be removed once they are properly included in the `__all__` in `plumpy`
-py:class plumpy.ports.PortNamespace
-py:class plumpy.utils.AttributesDict
-py:class plumpy.utils.AttributesFrozendict
-py:class plumpy.process_states.State
-py:class plumpy.workchains._If
-py:class plumpy.workchains._While
-py:class plumpy.processes.ProcessStateMachineMeta
+# These can be removed once they are properly included in the `__all__` of the engine process modules
+py:class aiida.engine.processes.generic.ports.PortNamespace
+py:class aiida.common.extendeddicts.AttributesFrozendict
+py:class aiida.engine.processes.states.State
+py:class aiida.engine.processes.workchains.outline._If
+py:class aiida.engine.processes.workchains.outline._While
+py:class aiida.engine.processes.generic.process.ProcessStateMachineMeta
 py:class PersistenceError
 py:class State
 py:class Stepper

--- a/docs/source/topics/calculations/usage.rst
+++ b/docs/source/topics/calculations/usage.rst
@@ -113,7 +113,7 @@ Next we should define what outputs we expect the calculation to produce:
 Just as for the inputs, one can specify what node type each output should have.
 By default a defined output will be 'required', which means that if the calculation job terminates and the output has not been attached, the process will be marked as failed.
 To indicate that an output is optional, one can use ``required=False`` in the ``spec.output`` call.
-Note that the process spec, and its :py:meth:`~plumpy.ProcessSpec.input` and :py:meth:`~plumpy.ProcessSpec.output` methods provide a lot more functionality.
+Note that the process spec, and its :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.input` and :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.output` methods provide a lot more functionality.
 Fore more details, please refer to the section on :ref:`process specifications<topics:processes:usage:spec>`.
 
 

--- a/docs/source/topics/processes/concepts.rst
+++ b/docs/source/topics/processes/concepts.rst
@@ -64,7 +64,7 @@ Process state
 =============
 Each instance of a ``Process`` class that is being executed has a process state.
 This property tells you about the current status of the process.
-It is stored in the instance of the ``Process`` itself and the workflow engine, the ``plumpy`` library, operates only on that value.
+It is stored in the instance of the ``Process`` itself and the workflow engine operates only on that value.
 However, the ``Process`` instance 'dies' as soon as it is terminated, therefore the process state is also written to the calculation node that the process uses as its database record, under the ``process_state`` attribute.
 The process can be in one of six states:
 

--- a/docs/source/topics/processes/functions.rst
+++ b/docs/source/topics/processes/functions.rst
@@ -258,7 +258,7 @@ In the case of the example above, it would look something like the following:
 .. code-block:: bash
 
     2019-03-21 15:12:25 [19]: [10|divide|on_except]: Traceback (most recent call last):
-      File "/home/sphuber/code/aiida/env/dev/plumpy/plumpy/process_states.py", line 220, in execute
+      File "/home/sphuber/code/aiida/env/dev/aiida-core/src/aiida/engine/processes/states.py", line 220, in execute
         result = self.run_fn(*self.args, **self.kwargs)
       File "/home/sphuber/code/aiida/env/dev/aiida-core/aiida/engine/processes/functions.py", line 319, in run
         result = self._func(*args, **kwargs)

--- a/docs/source/topics/processes/usage.rst
+++ b/docs/source/topics/processes/usage.rst
@@ -40,7 +40,7 @@ Through these attributes, one can define what inputs a process takes, what outpu
 Just by looking at a process specification then, one will know exactly *what* will happen, just not *how* it will happen.
 The ``inputs`` and ``outputs`` attributes are *namespaces* that contain so called *ports*, each one of which represents a specific input or output.
 The namespaces can be arbitrarily nested with ports and so are called *port namespaces*.
-The port and port namespace are implemented by the :py:class:`~plumpy.Port` and :py:class:`~aiida.engine.processes.ports.PortNamespace` class, respectively.
+The port and port namespace are implemented by the :py:class:`~aiida.engine.processes.generic.ports.Port` and :py:class:`~aiida.engine.processes.ports.PortNamespace` class, respectively.
 
 
 .. _topics:processes:usage:ports_portnamespaces:
@@ -54,15 +54,15 @@ To define an input for a process specification, we only need to add a port to th
     spec = ProcessSpec()
     spec.input('parameters')
 
-The ``input`` method, will create an instance of :py:class:`~aiida.engine.processes.ports.InputPort`, a sub class of the base :py:class:`~plumpy.Port`, and will add it to the ``inputs`` port namespace of the spec.
-Creating an output is just as easy, but one should use the :py:meth:`~plumpy.ProcessSpec.output` method instead:
+The ``input`` method, will create an instance of :py:class:`~aiida.engine.processes.ports.InputPort`, a sub class of the base :py:class:`~aiida.engine.processes.generic.ports.Port`, and will add it to the ``inputs`` port namespace of the spec.
+Creating an output is just as easy, but one should use the :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.output` method instead:
 
 .. code:: python
 
     spec = ProcessSpec()
     spec.output('result')
 
-This will cause an instance of :py:class:`~aiida.engine.processes.ports.CalcJobOutputPort`, also a sub class of the base :py:class:`~plumpy.Port`, to be created and to be added to the ``outputs`` specifcation attribute.
+This will cause an instance of :py:class:`~aiida.engine.processes.ports.CalcJobOutputPort`, also a sub class of the base :py:class:`~aiida.engine.processes.generic.ports.Port`, to be created and to be added to the ``outputs`` specifcation attribute.
 Recall, that the ``inputs`` and ``output`` are instances of a :py:class:`~aiida.engine.processes.ports.PortNamespace`, which means that they can contain any port.
 But the :py:class:`~aiida.engine.processes.ports.PortNamespace` itself is also a port itself, so it can be added to another port namespace, allowing one to create nested port namespaces.
 Creating a new namespace in for example the inputs namespace is as simple as:
@@ -105,7 +105,7 @@ Therefore the same concept of nesting through ``PortNamespaces`` applies to the 
 Validation and defaults
 ^^^^^^^^^^^^^^^^^^^^^^^
 In the previous section, we saw that the ``ProcessSpec`` uses the ``PortNamespace``, ``InputPort`` and ``OutputPort`` to define the inputs and outputs structure of the ``Process``.
-The underlying concept that allows this nesting of ports is that the ``PortNamespace``, ``InputPort`` and ``OutputPort``, are all a subclass of :py:class:`~plumpy.ports.Port`.
+The underlying concept that allows this nesting of ports is that the ``PortNamespace``, ``InputPort`` and ``OutputPort``, are all a subclass of :py:class:`~aiida.engine.processes.generic.ports.Port`.
 And as different subclasses of the same class, they have more properties and attributes in common, for example related to the concept of validation and default values.
 All three have the following attributes (with the exception of the ``OutputPort`` not having a ``default`` attribute):
 

--- a/docs/source/topics/workflows/usage.rst
+++ b/docs/source/topics/workflows/usage.rst
@@ -177,8 +177,8 @@ The third and final line is extremely important, as it will call the ``define`` 
 Inputs and outputs
 ------------------
 With those formalities out of the way, you can start defining the interesting properties of the work chain through the ``spec``.
-In the example you can see how the method :py:meth:`~plumpy.ProcessSpec.input` is used to define multiple input ports, which document exactly which inputs the work chain expects.
-Similarly, :py:meth:`~plumpy.ProcessSpec.output` is called to instruct that the work chain will produce an output with the label ``result``.
+In the example you can see how the method :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.input` is used to define multiple input ports, which document exactly which inputs the work chain expects.
+Similarly, :py:meth:`~aiida.engine.processes.process_spec.ProcessSpec.output` is called to instruct that the work chain will produce an output with the label ``result``.
 These two port creation methods support a lot more functionality, such as adding help string, validation and more, all of which is documented in detail in the section on :ref:`ports and port namespace<topics:processes:usage:ports_portnamespaces>`.
 
 
@@ -188,7 +188,7 @@ Outline
 -------
 The outline is what sets the work chain apart from other processes.
 It is a way of defining the higher-level logic that encodes the workflow that the work chain takes.
-The outline is defined in the ``define`` method through the :py:meth:`~plumpy.WorkChainSpec.outline`.
+The outline is defined in the ``define`` method through the :py:meth:`~aiida.engine.processes.workchains.workchain.WorkChainSpec.outline`.
 It takes a sequence of instructions that the work chain will execute, each of which is implemented as a method of the work chain class.
 In the simple example above, the outline consists of three simple instructions: ``add``, ``multiply``, ``results``.
 Since these are implemented as instance methods, they are prefixed with ``cls.`` to indicate that they are in fact methods of the work chain class.
@@ -551,7 +551,7 @@ As a first example, we will implement a thin wrapper workflow, which simply forw
 .. include:: include/snippets/expose_inputs/simple_parent.py
     :code: python
 
-In the ``define`` method of this simple parent work chain, we use the :meth:`~plumpy.process_spec.ProcessSpec.expose_inputs` and :meth:`~plumpy.process_spec.ProcessSpec.expose_outputs`.
+In the ``define`` method of this simple parent work chain, we use the :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_inputs` and :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_outputs`.
 This creates the corresponding input and output ports in the parent work chain.
 Additionally, AiiDA remembers which inputs and outputs were exposed from that particular work chain class.
 This is used when calling the child in the ``run_child`` method.
@@ -580,9 +580,9 @@ In the next section, we will explain each of the steps.
     :code: python
 
 First of all, we want to expose the ``a`` input and the ``e`` output at the top-level.
-For this, we again use :meth:`~plumpy.process_spec.ProcessSpec.expose_inputs` and :meth:`~plumpy.process_spec.ProcessSpec.expose_outputs`, but with the optional keyword ``include``.
+For this, we again use :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_inputs` and :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_outputs`, but with the optional keyword ``include``.
 This specifies a list of keys, and only inputs or outputs which are in that list will be exposed.
-So by passing ``include=['a']`` to :meth:`~plumpy.process_spec.ProcessSpec.expose_inputs`, only the input ``a`` is exposed.
+So by passing ``include=['a']`` to :meth:`~aiida.engine.processes.process_spec.ProcessSpec.expose_inputs`, only the input ``a`` is exposed.
 
 Additionally, we want to expose the inputs ``b`` and ``c`` (outputs ``d`` and ``f``), but in a namespace specific for each of the two children.
 For this purpose, we pass the ``namespace`` parameter to the expose functions.

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,9 @@ dependencies:
 - disk-objectstore~=1.5.0
 - docstring_parser
 - python-graphviz~=0.19
+- greenback~=1.0
+- greenlet>=3.2.4
 - importlib-metadata~=6.0
-- plumpy~=0.26.0
 - ipython>=7.6
 - jedi<0.19
 - jinja2~=3.0

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -4,6 +4,13 @@ projects:
 Python:
   * aiida/transports/transport.py
 
+Plumpy:
+  * aiida/common/lang.py
+  * aiida/common/loaders.py
+  * aiida/common/processes.py
+  * aiida/engine/persistence.py
+  * aiida/engine/processes/
+
 The respective copyright notices are reproduced below.
 
 --------------------------------------------------------------------------
@@ -286,3 +293,32 @@ FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+--------------------------------------------------------------------------
+
+Plumpy license:
+
+The MIT License (MIT)
+
+Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE
+(Theory and Simulation of Materials (THEOS) and National Centre for
+Computational Design and Discovery of Novel Materials (NCCR MARVEL)),
+Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -418,7 +418,6 @@ module = [
   'mayavi.*',
   'pgsu.*',
   'pgtest.*',
-  'tblib.*',
   'trogon.*',
   'wrapt.*'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,9 @@ dependencies = [
   'disk-objectstore~=1.5.0',
   'docstring-parser',
   'graphviz~=0.19',
+  'greenback~=1.0',
+  'greenlet>=3.2.4',
   'importlib-metadata~=6.0',
-  'plumpy~=0.26.0',
   'ipython>=7.6',
   'jedi<0.19',
   'jinja2~=3.0',
@@ -417,6 +418,7 @@ module = [
   'mayavi.*',
   'pgsu.*',
   'pgtest.*',
+  'tblib.*',
   'trogon.*',
   'wrapt.*'
 ]
@@ -443,8 +445,6 @@ filterwarnings = [
   'ignore:Identity map already had an identity for .* inside of an event handler within the flush?:sqlalchemy.exc.SAWarning',
   'ignore:The `aiida.orm.nodes.data.upf` module is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
   'ignore:The `Code` class is deprecated.*:aiida.common.warnings.AiidaDeprecationWarning',
-  # https://github.com/aiidateam/plumpy/issues/283
-  'ignore:There is no current event loop:DeprecationWarning:plumpy',
   "ignore:'asyncio.[sg]et_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio",
   "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:pytest_asyncio|kiwipy",
   # spglib deprecation

--- a/src/aiida/cmdline/commands/cmd_devel.py
+++ b/src/aiida/cmdline/commands/cmd_devel.py
@@ -74,7 +74,6 @@ def devel_check_undesired_imports():
 
     undesired_modules = [
         'requests',
-        'plumpy',
         'disk_objectstore',
         'paramiko',
         'seekpath',

--- a/src/aiida/cmdline/commands/cmd_process.py
+++ b/src/aiida/cmdline/commands/cmd_process.py
@@ -611,9 +611,8 @@ def process_repair(manager, broker, dry_run, force):
             # broker process and the timing issues that come with it.
             import uuid
 
-            from plumpy.process_comms import create_continue_body
-
             from aiida.brokers.zeromq.queue import PersistentQueue
+            from aiida.engine.processes.communications import create_continue_body
 
             queue_path = broker._storage_path / 'tasks'
             queue = PersistentQueue(queue_path)

--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -156,7 +156,7 @@ TRAVERSAL_RULE_HELP_STRING = {
 
 def valid_process_states() -> tuple[str, ...]:
     """Return a list of valid values for the ProcessState enum."""
-    from plumpy import ProcessState
+    from aiida.common.processes import ProcessState
 
     return tuple(state.value for state in ProcessState)
 
@@ -170,7 +170,7 @@ def valid_calc_job_states() -> tuple[str, ...]:
 
 def active_process_states() -> list[str]:
     """Return a list of process states that are considered active."""
-    from plumpy import ProcessState
+    from aiida.common.processes import ProcessState
 
     return [
         ProcessState.CREATED.value,

--- a/src/aiida/cmdline/utils/common.py
+++ b/src/aiida/cmdline/utils/common.py
@@ -26,9 +26,8 @@ if TYPE_CHECKING:
     from collections.abc import MutableMapping
     from datetime import datetime
 
-    import plumpy
-
     from aiida import engine, orm
+    from aiida.engine.processes.ports import PortNamespace
 
 __all__ = ('is_verbose',)
 
@@ -114,8 +113,7 @@ def get_node_summary(node: orm.Node) -> str:
     :param node: a Node instance
     :return: a string summary of the node
     """
-    from plumpy import ProcessState
-
+    from aiida.common.processes import ProcessState
     from aiida.orm import ProcessNode
 
     table_headers = ['Property', 'Value']
@@ -432,7 +430,7 @@ def print_process_spec(process_spec: engine.ProcessSpec) -> None:
     :param process_spec: a `ProcessSpec` instance
     """
 
-    def build_entries(ports: plumpy.PortNamespace) -> list[tuple]:
+    def build_entries(ports: PortNamespace) -> list[tuple]:
         """Build a list of entries to be printed for a `PortNamespace.
 
         :param ports: the port namespace

--- a/src/aiida/common/extendeddicts.py
+++ b/src/aiida/common/extendeddicts.py
@@ -10,14 +10,20 @@
 
 from __future__ import annotations
 
-from collections.abc import KeysView, Mapping
+from collections.abc import Iterator, KeysView, Mapping
 from typing import Any
 
 from typing_extensions import Self
 
 from aiida.common import exceptions
 
-__all__ = ('AttributeDict', 'DefaultFieldsAttributeDict', 'FixedFieldsAttributeDict')
+__all__ = (
+    'AttributeDict',
+    'AttributesFrozendict',
+    'DefaultFieldsAttributeDict',
+    'FixedFieldsAttributeDict',
+    'Frozendict',
+)
 
 
 class AttributeDict(dict[str, Any]):
@@ -96,6 +102,52 @@ class AttributeDict(dict[str, Any]):
 
     def __dir__(self) -> KeysView[str]:
         return self.keys()
+
+
+class Frozendict(Mapping[str, Any]):
+    """An immutable mapping backed by a dictionary."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._dict = dict(*args, **kwargs)
+        self._hash: int | None = None
+
+    def __getitem__(self, key: str) -> Any:
+        return self._dict[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._dict
+
+    def copy(self, **add_or_replace: Any) -> Frozendict:
+        return self.__class__(self, **add_or_replace)
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} {self._dict!r}>'
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._dict)
+
+    def __len__(self) -> int:
+        return len(self._dict)
+
+    def __hash__(self) -> int:
+        if self._hash is None:
+            self._hash = hash(frozenset(self._dict.items()))
+        return self._hash
+
+
+class AttributesFrozendict(Frozendict):
+    """An immutable mapping whose keys can also be accessed as attributes."""
+
+    def __getattr__(self, attr: str) -> Any:
+        if attr == '__setstate__':
+            raise AttributeError()
+        try:
+            return self[attr]
+        except KeyError as exception:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'") from exception
+
+    def __dir__(self) -> list[str]:
+        return list(self.keys())
 
 
 class FixedFieldsAttributeDict(AttributeDict):

--- a/src/aiida/common/lang.py
+++ b/src/aiida/common/lang.py
@@ -9,9 +9,10 @@
 """Utilities that extend the basic python language."""
 
 import functools
+import inspect
 import keyword
 from collections.abc import Callable
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 
 def isidentifier(identifier: str) -> bool:
@@ -51,12 +52,60 @@ def type_check(what: T, of_type: Any, msg: 'str | None' = None, allow_none: bool
 MethodType = TypeVar('MethodType', bound=Callable[..., Any])
 
 
+def super_check(wrapped: MethodType) -> MethodType:
+    """Decorate a method to require invocation through :func:`call_with_super_check`."""
+
+    @functools.wraps(wrapped)
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> None:
+        msg = f"The function '{wrapped.__name__}' was not called through call_with_super_check"
+        assert getattr(self, '_called', 0) >= 1, msg
+        wrapped(self, *args, **kwargs)
+        self._called -= 1
+
+    return wrapper  # type: ignore[return-value]
+
+
+def call_with_super_check(wrapped: MethodType, *args: Any, **kwargs: Any) -> None:
+    """Call a bound method and verify that every override calls ``super()``."""
+    self = wrapped.__self__  # type: ignore[attr-defined]
+    call_count = getattr(self, '_called', 0)
+    self._called = call_count + 1
+    wrapped(*args, **kwargs)
+    msg = f"Base '{wrapped.__name__}' was not called from '{self.__class__}'\nHint: Did you forget to call the super?"
+    assert self._called == call_count, msg
+
+
+def protected(check: bool = False) -> Callable[[MethodType], MethodType]:
+    """Return a decorator that marks a method as protected."""
+
+    def wrap(func: MethodType) -> MethodType:
+        args = inspect.getfullargspec(func)[0]
+        if not args:
+            msg = 'Can only use the protected decorator on member functions'
+            raise RuntimeError(msg)
+
+        if not check:
+            return func
+
+        @functools.wraps(func)
+        def wrapped_fn(self: Any, *args: Any, **kwargs: Any) -> Any:
+            try:
+                calling_instance = inspect.stack()[1][0].f_locals['self']
+                assert self is calling_instance
+            except (KeyError, AssertionError) as exception:
+                msg = f'Cannot access protected function {func.__name__} from outside class hierarchy'
+                raise RuntimeError(msg) from exception
+            return func(self, *args, **kwargs)
+
+        return cast(MethodType, wrapped_fn)
+
+    return wrap
+
+
 def override_decorator(check: bool = False) -> Callable[[MethodType], MethodType]:
     """Decorator to signal that a method from a base class is being overridden completely."""
 
     def wrap(func: MethodType) -> MethodType:
-        import inspect
-
         if isinstance(func, property):
             raise RuntimeError('Override must go after @property decorator')
 

--- a/src/aiida/common/loaders.py
+++ b/src/aiida/common/loaders.py
@@ -1,0 +1,104 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Load Python objects from persistent identifiers."""
+
+from __future__ import annotations
+
+import abc
+import importlib
+import inspect
+import types
+from collections import deque
+from typing import Any
+
+
+class ObjectLoader(abc.ABC):
+    """Interface for identifying and loading Python objects."""
+
+    @abc.abstractmethod
+    def load_object(self, identifier: str) -> Any:
+        """Load the object represented by an identifier."""
+
+    @abc.abstractmethod
+    def identify_object(self, obj: Any) -> str:
+        """Return the persistent identifier for an object."""
+
+
+class DefaultObjectLoader(ObjectLoader):
+    """Load module-level classes, functions, and constants."""
+
+    def load_object(self, identifier: str) -> Any:
+        """Load an object identified as ``module:name``."""
+        try:
+            module_name, name = identifier.split(':')
+        except ValueError as exception:
+            msg = f'identifier `{identifier}` has an invalid format.'
+            raise ImportError(msg) from exception
+
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError as exception:
+            msg = f"module '{module_name}' from identifier '{identifier}' could not be loaded"
+            raise ImportError(msg) from exception
+
+        try:
+            return getattr(module, name)
+        except AttributeError as exception:
+            msg = f"object '{name}' from identifier '{identifier}' could not be loaded"
+            raise ImportError(msg) from exception
+
+    def identify_object(self, obj: Any) -> str:
+        """Return an importable identifier for an object."""
+        identifier = f'{obj.__module__}:{obj.__name__}'
+        self.load_object(identifier)
+        return identifier
+
+
+OBJECT_LOADER: ObjectLoader | None = None
+
+
+def get_object_loader() -> ObjectLoader:
+    """Return the global object loader."""
+    global OBJECT_LOADER  # noqa: PLW0603
+    if OBJECT_LOADER is None:
+        OBJECT_LOADER = DefaultObjectLoader()
+    return OBJECT_LOADER
+
+
+def load_function(name: str, instance: Any | None = None) -> Any:
+    """Load a function from its fully qualified name."""
+    obj = load_object(name)
+    if inspect.ismethod(obj) and instance is not None:
+        return obj.__get__(instance, instance.__class__)  # type: ignore[attr-defined]
+    if inspect.ismethod(obj) or inspect.isfunction(obj):
+        return obj
+    raise ValueError(f"Invalid function name '{name}'")
+
+
+def load_object(fullname: str) -> Any:
+    """Load an object from a fully qualified name."""
+    obj, remainder = load_module(fullname)
+    for name in remainder:
+        try:
+            obj = getattr(obj, name)
+        except AttributeError as exception:
+            raise ValueError(f"Could not load object corresponding to '{fullname}'") from exception
+    return obj
+
+
+def load_module(fullname: str) -> tuple[types.ModuleType, deque[str]]:
+    """Load the longest importable module prefix from a fully qualified name."""
+    parts = fullname.split('.')
+    remainder: deque[str] = deque()
+    for _ in range(len(parts)):
+        try:
+            return importlib.import_module('.'.join(parts)), remainder
+        except ImportError:
+            remainder.appendleft(parts.pop())
+    raise ValueError(f"Could not load a module corresponding to '{fullname}'")

--- a/src/aiida/common/log.py
+++ b/src/aiida/common/log.py
@@ -137,11 +137,6 @@ def get_logging_config() -> dict[str, t.Any]:
                 'level': lambda: get_config_option('logging.disk_objectstore_loglevel'),
                 'propagate': False,
             },
-            'plumpy': {
-                'handlers': ['console'],
-                'level': lambda: get_config_option('logging.plumpy_loglevel'),
-                'propagate': False,
-            },
             'kiwipy': {
                 'handlers': ['console'],
                 'level': lambda: get_config_option('logging.kiwipy_loglevel'),
@@ -182,7 +177,6 @@ _HANDLER_TO_LOGGER: dict[str, tuple[str, ...]] = {
         'logging.verdi_loglevel',
         'logging.aiida_core_loglevel',
         'logging.disk_objectstore_loglevel',
-        'logging.plumpy_loglevel',
         'logging.kiwipy_loglevel',
         'logging.paramiko_loglevel',
         'logging.alembic_loglevel',

--- a/src/aiida/common/processes.py
+++ b/src/aiida/common/processes.py
@@ -1,0 +1,22 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Common process data structures."""
+
+from enum import Enum
+
+
+class ProcessState(Enum):
+    """State of a process."""
+
+    CREATED = 'created'
+    RUNNING = 'running'
+    WAITING = 'waiting'
+    FINISHED = 'finished'
+    EXCEPTED = 'excepted'
+    KILLED = 'killed'

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -66,10 +66,17 @@ def start_daemon_worker(foreground: bool = False, profile_name: str | None = Non
         LOGGER.info('Setting maximum recursion limit of daemon worker to %s', rlimit)
         sys.setrecursionlimit(rlimit)
 
+    shutdown_tasks: set[asyncio.Task[None]] = set()
+
+    def schedule_shutdown() -> None:
+        task = asyncio.create_task(shutdown_worker(runner))
+        shutdown_tasks.add(task)
+        task.add_done_callback(shutdown_tasks.discard)
+
     signals = (signal.SIGTERM, signal.SIGINT)
     for s in signals:
         # https://github.com/python/mypy/issues/12557
-        runner.loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown_worker(runner)))  # type: ignore[misc]
+        runner.loop.add_signal_handler(s, schedule_shutdown)
 
     try:
         LOGGER.info('Starting a daemon worker')

--- a/src/aiida/engine/persistence.py
+++ b/src/aiida/engine/persistence.py
@@ -8,16 +8,15 @@
 ###########################################################################
 """Definition of AiiDA's process persister and the necessary object loaders."""
 
-import importlib
 import logging
 import traceback
 from collections.abc import Hashable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import plumpy.loaders
-import plumpy.persistence
-from plumpy.exceptions import PersistenceError
-
+from aiida.common.loaders import DefaultObjectLoader as ObjectLoader
+from aiida.common.loaders import get_object_loader
+from aiida.engine.processes import persistence as process_persistence
+from aiida.engine.processes.exceptions import PersistenceError
 from aiida.orm.utils import serialize
 
 if TYPE_CHECKING:
@@ -26,47 +25,9 @@ if TYPE_CHECKING:
 __all__ = ('AiiDAPersister', 'ObjectLoader', 'get_object_loader')
 
 LOGGER = logging.getLogger(__name__)
-OBJECT_LOADER = None
 
 
-class ObjectLoader(plumpy.loaders.DefaultObjectLoader):
-    """Custom object loader for `aiida-core`."""
-
-    def load_object(self, identifier: str) -> Any:
-        """Attempt to load the object identified by the given `identifier`.
-
-        .. note:: We override the `plumpy.DefaultObjectLoader` to be able to throw an `ImportError` instead of a
-            `ValueError` which in the context of `aiida-core` is not as apt, since we are loading classes.
-
-        :param identifier: concatenation of module and resource name
-        :return: loaded object
-        :raises ImportError: if the object cannot be loaded
-        """
-        module_name, name = identifier.split(':')
-        try:
-            module = importlib.import_module(module_name)
-        except ImportError:
-            raise ImportError(f"module '{module_name}' from identifier '{identifier}' could not be loaded")
-
-        try:
-            return getattr(module, name)
-        except AttributeError:
-            raise ImportError(f"object '{name}' from identifier '{identifier}' could not be loaded")
-
-
-def get_object_loader() -> ObjectLoader:
-    """Return the global AiiDA object loader.
-
-    :return: The global object loader
-
-    """
-    global OBJECT_LOADER  # noqa: PLW0603
-    if OBJECT_LOADER is None:
-        OBJECT_LOADER = ObjectLoader()
-    return OBJECT_LOADER
-
-
-class AiiDAPersister(plumpy.persistence.Persister):
+class AiiDAPersister(process_persistence.Persister):
     """Persister to take saved process instance states and persisting them to the database."""
 
     def save_checkpoint(self, process: 'Process', tag: str | None = None):  # type: ignore[override]
@@ -82,7 +43,9 @@ class AiiDAPersister(plumpy.persistence.Persister):
             raise NotImplementedError('Checkpoint tags not supported yet')
 
         try:
-            bundle = plumpy.persistence.Bundle(process, plumpy.persistence.LoadSaveContext(loader=get_object_loader()))
+            bundle = process_persistence.Bundle(
+                process, process_persistence.LoadSaveContext(loader=get_object_loader())
+            )
         except ImportError:
             # Couldn't create the bundle
             raise PersistenceError(f"Failed to create a bundle for '{process}': {traceback.format_exc()}")
@@ -94,7 +57,7 @@ class AiiDAPersister(plumpy.persistence.Persister):
 
         return bundle
 
-    def load_checkpoint(self, pid: Hashable, tag: str | None = None) -> plumpy.persistence.Bundle:
+    def load_checkpoint(self, pid: Hashable, tag: str | None = None) -> process_persistence.Bundle:
         """Load a process from a persisted checkpoint by its process id.
 
         :param pid: the process id of the :class:`plumpy.Process`

--- a/src/aiida/engine/persistence.py
+++ b/src/aiida/engine/persistence.py
@@ -60,10 +60,10 @@ class AiiDAPersister(process_persistence.Persister):
     def load_checkpoint(self, pid: Hashable, tag: str | None = None) -> process_persistence.Bundle:
         """Load a process from a persisted checkpoint by its process id.
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow retrieving a specific sub checkpoint
         :return: a bundle with the process state
-        :rtype: :class:`plumpy.Bundle`
+        :rtype: :class:`aiida.engine.processes.persistence.Bundle`
         :raises: :class:`PersistenceError` Raised if there was a problem loading the checkpoint
         """
         from aiida.common.exceptions import MultipleObjectsError, NotExistent
@@ -105,7 +105,7 @@ class AiiDAPersister(process_persistence.Persister):
     def delete_checkpoint(self, pid: Hashable, tag: str | None = None) -> None:
         """Delete a persisted process checkpoint, where no error will be raised if the checkpoint does not exist.
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow retrieving a specific sub checkpoint
         """
         from aiida.orm import load_node

--- a/src/aiida/engine/processes/calcjobs/calcjob.py
+++ b/src/aiida/engine/processes/calcjobs/calcjob.py
@@ -18,9 +18,6 @@ import shutil
 from collections.abc import Hashable
 from typing import Any
 
-import plumpy.ports
-import plumpy.process_states
-
 from aiida import orm
 from aiida.common import AttributeDict, exceptions
 from aiida.common.datastructures import CalcInfo, FileCopyOperation
@@ -28,6 +25,7 @@ from aiida.common.folders import Folder
 from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
 from aiida.common.typing import FilePath
+from aiida.engine.processes import states as process_states
 from aiida.engine.processes.calcjobs.importer import CalcJobImporter
 from aiida.engine.processes.calcjobs.monitors import CalcJobMonitor
 from aiida.engine.processes.calcjobs.tasks import UPLOAD_COMMAND, Waiting
@@ -594,7 +592,7 @@ class CalcJob(Process):
             return AttributeDict()
 
     @classmethod
-    def get_state_classes(cls) -> dict[Hashable, type[plumpy.process_states.State]]:
+    def get_state_classes(cls) -> dict[Hashable, type[process_states.State]]:
         """A mapping of the State constants to the corresponding state class.
 
         Overrides the waiting state with the Calcjob specific version.
@@ -618,7 +616,7 @@ class CalcJob(Process):
         super().on_terminated()
 
     @override
-    async def run(self) -> plumpy.process_states.Stop | int | plumpy.process_states.Wait:
+    async def run(self) -> process_states.Stop | int | process_states.Wait:
         """Run the calculation job.
 
         This means invoking the `presubmit` and storing the temporary folder in the node's repository. Then we move the
@@ -630,7 +628,7 @@ class CalcJob(Process):
         """
         if self.inputs.metadata.dry_run:
             await self._perform_dry_run()
-            return plumpy.process_states.Stop(None, True)
+            return process_states.Stop(None, True)
 
         if 'remote_folder' in self.inputs:
             exit_code = await self._perform_import()
@@ -649,7 +647,7 @@ class CalcJob(Process):
             return self.node.exit_status
 
         # Launch the upload operation
-        return plumpy.process_states.Wait(msg='Waiting to upload', data=UPLOAD_COMMAND)
+        return process_states.Wait(msg='Waiting to upload', data=UPLOAD_COMMAND)
 
     def prepare_for_submission(self, folder: Folder) -> CalcInfo:
         """Prepare the calculation for submission.
@@ -1078,7 +1076,7 @@ class CalcJob(Process):
                 try:
                     with_mpi = self.spec().inputs['metadata']['options']['withmpi'].default  # type: ignore[index]
                 except RuntimeError:
-                    # ``plumpy.InputPort.default`` raises a ``RuntimeError`` if no default has been set. This is bad
+                    # ``InputPort.default`` raises a ``RuntimeError`` if no default has been set. This is bad
                     # design and should be changed, but we have to deal with it like this for now.
                     with_mpi = False
 

--- a/src/aiida/engine/processes/calcjobs/tasks.py
+++ b/src/aiida/engine/processes/calcjobs/tasks.py
@@ -523,7 +523,7 @@ class Waiting(states.Waiting):
 
     async def execute(self) -> states.State | state_machine.State:  # type: ignore[override]
         """Override the execute coroutine of the base `Waiting` state.
-        Using the plumpy state machine the waiting state is repeatedly re-entered with different commands.
+        The process state machine repeatedly re-enters the waiting state with different commands.
         The waiting state is not always the same instance, it could be re-instantiated when re-entering this method,
         therefor any newly created attribute in each command block
         (e.g. `SUBMIT_COMMAND`, `UPLOAD_COMMAND`, etc.) will be lost, and is not usable in other blocks.

--- a/src/aiida/engine/processes/calcjobs/tasks.py
+++ b/src/aiida/engine/processes/calcjobs/tasks.py
@@ -17,18 +17,16 @@ import tempfile
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-import plumpy
-import plumpy.futures
-import plumpy.persistence
-import plumpy.process_states
-
 from aiida.common.datastructures import CalcJobState
 from aiida.common.exceptions import FeatureNotAvailable, StashingError, TransportTaskException
 from aiida.common.folders import SandboxFolder
 from aiida.engine import utils
 from aiida.engine.daemon import execmanager
+from aiida.engine.processes import persistence as process_persistence
+from aiida.engine.processes import state_machine, states
 from aiida.engine.processes.calcjobs.monitors import CalcJobMonitorAction, CalcJobMonitorResult, CalcJobMonitors
 from aiida.engine.processes.exit_code import ExitCode
+from aiida.engine.processes.generic import futures
 from aiida.engine.processes.process import ProcessState
 from aiida.engine.transports import TransportQueue
 from aiida.engine.utils import InterruptableFuture, interruptable_task
@@ -102,13 +100,13 @@ async def task_upload_job(process: CalcJob, transport_queue: TransportQueue, can
 
     try:
         logger.info(f'scheduled request to upload CalcJob<{node.pk}>')
-        ignore_exceptions = (plumpy.futures.CancelledError, PreSubmitException, plumpy.process_states.Interruption)
+        ignore_exceptions = (futures.CancelledError, PreSubmitException, states.Interruption)
         skip_submit = await utils.exponential_backoff_retry(
             do_upload, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=ignore_exceptions
         )
     except PreSubmitException:
         raise
-    except (plumpy.futures.CancelledError, plumpy.process_states.Interruption):
+    except (futures.CancelledError, states.Interruption):
         raise
     except Exception as exception:
         logger.warning(f'uploading CalcJob<{node.pk}> failed')
@@ -150,11 +148,11 @@ async def task_submit_job(node: CalcJobNode, transport_queue: TransportQueue, ca
 
     try:
         logger.info(f'scheduled request to submit CalcJob<{node.pk}>')
-        ignore_exceptions = (plumpy.futures.CancelledError, plumpy.process_states.Interruption)
+        ignore_exceptions = (futures.CancelledError, states.Interruption)
         result = await utils.exponential_backoff_retry(
             do_submit, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=ignore_exceptions
         )
-    except (plumpy.futures.CancelledError, plumpy.process_states.Interruption):
+    except (futures.CancelledError, states.Interruption):
         raise
     except Exception as exception:
         logger.warning(f'submitting CalcJob<{node.pk}> failed')
@@ -208,11 +206,11 @@ async def task_update_job(node: CalcJobNode, job_manager, cancellable: Interrupt
 
     try:
         logger.info(f'scheduled request to update CalcJob<{node.pk}>')
-        ignore_exceptions = (plumpy.futures.CancelledError, plumpy.process_states.Interruption)
+        ignore_exceptions = (futures.CancelledError, states.Interruption)
         job_done = await utils.exponential_backoff_retry(
             do_update, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=ignore_exceptions
         )
-    except (plumpy.futures.CancelledError, plumpy.process_states.Interruption):
+    except (futures.CancelledError, states.Interruption):
         raise
     except Exception as exception:
         logger.warning(f'updating CalcJob<{node.pk}> failed')
@@ -258,11 +256,11 @@ async def task_monitor_job(
 
     try:
         logger.info(f'scheduled request to monitor CalcJob<{node.pk}>')
-        ignore_exceptions = (plumpy.futures.CancelledError, plumpy.process_states.Interruption)
+        ignore_exceptions = (futures.CancelledError, states.Interruption)
         monitor_result = await utils.exponential_backoff_retry(
             do_monitor, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=ignore_exceptions
         )
-    except (plumpy.futures.CancelledError, plumpy.process_states.Interruption):
+    except (futures.CancelledError, states.Interruption):
         raise
     except Exception as exception:
         logger.warning(f'monitoring CalcJob<{node.pk}> failed')
@@ -327,11 +325,11 @@ async def task_retrieve_job(
 
     try:
         logger.info(f'scheduled request to retrieve CalcJob<{node.pk}>')
-        ignore_exceptions = (plumpy.futures.CancelledError, plumpy.process_states.Interruption)
+        ignore_exceptions = (futures.CancelledError, states.Interruption)
         result = await utils.exponential_backoff_retry(
             do_retrieve, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=ignore_exceptions
         )
-    except (plumpy.futures.CancelledError, plumpy.process_states.Interruption):
+    except (futures.CancelledError, states.Interruption):
         raise
     except Exception as exception:
         logger.warning(f'retrieving CalcJob<{node.pk}> failed')
@@ -378,9 +376,9 @@ async def task_stash_job(node: CalcJobNode, transport_queue: TransportQueue, can
             initial_interval,
             max_attempts,
             logger=node.logger,
-            ignore_exceptions=(plumpy.process_states.Interruption, StashingError),
+            ignore_exceptions=(states.Interruption, StashingError),
         )
-    except plumpy.process_states.Interruption:
+    except states.Interruption:
         raise
     except StashingError as exception:
         # Log to the node so the failure shows up in ``verdi process report``, then re-raise so the ``Waiting`` state
@@ -419,9 +417,9 @@ async def task_unstash_job(node: CalcJobNode, transport_queue: TransportQueue, c
             initial_interval,
             max_attempts,
             logger=node.logger,
-            ignore_exceptions=plumpy.process_states.Interruption,
+            ignore_exceptions=states.Interruption,
         )
-    except plumpy.process_states.Interruption:
+    except states.Interruption:
         raise
     except Exception as exception:
         logger.warning(f'unstashing calculation<{node.pk}> failed')
@@ -463,7 +461,7 @@ async def task_kill_job(node: CalcJobNode, transport_queue: TransportQueue, canc
     try:
         logger.info(f'scheduled request to kill CalcJob<{node.pk}>')
         result = await utils.exponential_backoff_retry(do_kill, initial_interval, max_attempts, logger=node.logger)
-    except plumpy.process_states.Interruption:
+    except states.Interruption:
         raise
     except Exception as exception:
         logger.warning(f'killing CalcJob<{node.pk}> failed')
@@ -474,8 +472,8 @@ async def task_kill_job(node: CalcJobNode, transport_queue: TransportQueue, canc
         return result
 
 
-@plumpy.persistence.auto_persist('msg', 'data', '_command', '_monitor_result')
-class Waiting(plumpy.process_states.Waiting):
+@process_persistence.auto_persist('msg', 'data', '_command', '_monitor_result')
+class Waiting(states.Waiting):
     """The waiting state for the `CalcJob` process."""
 
     def __init__(
@@ -488,7 +486,7 @@ class Waiting(plumpy.process_states.Waiting):
         """:param process: The process this state belongs to"""
         super().__init__(process, done_callback, msg, data)
         self._task: InterruptableFuture | None = None
-        self._killing: plumpy.futures.Future | None = None
+        self._killing: futures.Future | None = None
         self._command: str | None = None
         self._monitor_result: CalcJobMonitorResult | None = None
         self._monitors: CalcJobMonitors | None = None
@@ -523,7 +521,7 @@ class Waiting(plumpy.process_states.Waiting):
         self._task = None
         self._killing = None
 
-    async def execute(self) -> plumpy.process_states.State | plumpy.base.state_machine.State:  # type: ignore[override]
+    async def execute(self) -> states.State | state_machine.State:  # type: ignore[override]
         """Override the execute coroutine of the base `Waiting` state.
         Using the plumpy state machine the waiting state is repeatedly re-entered with different commands.
         The waiting state is not always the same instance, it could be re-instantiated when re-entering this method,
@@ -550,7 +548,7 @@ class Waiting(plumpy.process_states.Waiting):
 
         node = self.process.node
         transport_queue = self.process.runner.transport
-        result: plumpy.process_states.State = self
+        result: states.State = self
 
         process_status = f'Waiting for transport task: {self._command}'
         node.set_process_status(process_status)
@@ -626,17 +624,17 @@ class Waiting(plumpy.process_states.Waiting):
                 raise RuntimeError('Unknown waiting command')
 
         except TransportTaskException as exception:
-            raise plumpy.process_states.PauseInterruption(f'Pausing after failed transport task: {exception}')
+            raise states.PauseInterruption(f'Pausing after failed transport task: {exception}')
         except StashingError as exception:
             exit_code = self.process.exit_codes.ERROR_STASHING_FAILED.format(message=str(exception))
             return self.create_state(ProcessState.RUNNING, self.process.terminate, exit_code)
-        except plumpy.process_states.KillInterruption as exception:
+        except states.KillInterruption as exception:
             node.set_process_status(str(exception))
             return self.retrieve(monitor_result=self._monitor_result)
-        except (plumpy.futures.CancelledError, asyncio.CancelledError):
+        except (futures.CancelledError, asyncio.CancelledError):
             node.set_process_status(f'Transport task {self._command} was cancelled')
             raise
-        except plumpy.process_states.Interruption:
+        except states.Interruption:
             node.set_process_status(f'Transport task {self._command} was interrupted')
             raise
         else:
@@ -730,9 +728,7 @@ class Waiting(plumpy.process_states.Waiting):
             ProcessState.WAITING, None, msg=msg, data={'command': RETRIEVE_COMMAND, 'monitor_result': monitor_result}
         )
 
-    def parse(
-        self, retrieved_temporary_folder: str, exit_code: ExitCode | None = None
-    ) -> plumpy.process_states.Running:
+    def parse(self, retrieved_temporary_folder: str, exit_code: ExitCode | None = None) -> states.Running:
         """Return the `Running` state that will parse the `CalcJob`.
 
         :param retrieved_temporary_folder: temporary folder used in retrieving that can be used during parsing.
@@ -741,14 +737,14 @@ class Waiting(plumpy.process_states.Waiting):
             ProcessState.RUNNING, self.process.parse, retrieved_temporary_folder, exit_code
         )
 
-    def interrupt(self, reason: Any) -> plumpy.futures.Future | None:  # type: ignore[override]
+    def interrupt(self, reason: Any) -> futures.Future | None:  # type: ignore[override]
         """Interrupt the `Waiting` state by calling interrupt on the transport task `InterruptableFuture`."""
         if self._task is not None:
             self._task.interrupt(reason)
 
-        if isinstance(reason, plumpy.process_states.KillInterruption):
+        if isinstance(reason, states.KillInterruption):
             if self._killing is None:
-                self._killing = plumpy.futures.Future()
+                self._killing = futures.Future()
             return self._killing
 
         return None

--- a/src/aiida/engine/processes/communications.py
+++ b/src/aiida/engine/processes/communications.py
@@ -1,0 +1,841 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Communication helpers and process-level controllers."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from collections.abc import Callable, Hashable, Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+import kiwipy
+
+from aiida.common import loaders
+from aiida.engine.processes import events, persistence
+from aiida.engine.processes.generic import futures
+from aiida.engine.processes.persistence import PID_TYPE
+from aiida.engine.utils import ensure_coroutine
+
+__all__: tuple[str, ...] = ()
+
+RemoteException = kiwipy.RemoteException
+DeliveryFailed = kiwipy.DeliveryFailed
+TaskRejected = kiwipy.TaskRejected
+Communicator = kiwipy.Communicator
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.generic.process import Process
+
+    # identifiers for subscribers
+    ID_TYPE = Hashable
+    Subscriber = Callable[..., Any]
+    # RPC subscriber params: communicator, msg
+    RpcSubscriber = Callable[[kiwipy.Communicator, Any], Any]
+    # Task subscriber params: communicator, task
+    TaskSubscriber = Callable[[kiwipy.Communicator, Any], Any]
+    # Broadcast subscribers params: communicator, body, sender, subject, correlation id
+    BroadcastSubscriber = Callable[[kiwipy.Communicator, Any, Any, Any, ID_TYPE], Any]
+
+
+def plum_to_kiwi_future(plum_future: futures.Future) -> kiwipy.Future:
+    """
+    Return a kiwi future that resolves to the outcome of the plum future
+
+    :param plum_future: the plum future
+    :return: the kiwipy future
+
+    """
+    kiwi_future = kiwipy.Future()
+
+    def on_done(_plum_future: futures.Future) -> None:
+        with kiwipy.capture_exceptions(kiwi_future):
+            if plum_future.cancelled():
+                kiwi_future.cancel()
+            else:
+                result = plum_future.result()
+                # Did we get another future?  In which case convert it too
+                if isinstance(result, futures.Future):
+                    result = plum_to_kiwi_future(result)
+                kiwi_future.set_result(result)
+
+    plum_future.add_done_callback(on_done)
+    return kiwi_future
+
+
+def convert_to_comm(
+    callback: Subscriber, loop: asyncio.AbstractEventLoop | None = None
+) -> Callable[..., kiwipy.Future]:
+    """
+    Take a callback function and converted it to one that will schedule a callback
+    on the given even loop and return a kiwi future representing the future outcome
+    of the original method.
+
+    :param callback: the function to convert
+    :param loop: the even loop to schedule the callback in
+    :return: a new callback function that returns a future
+    """
+    if isinstance(callback, kiwipy.BroadcastFilter):
+        # if the broadcast is filtered for this callback,
+        # we don't want to go through the (costly) process
+        # of setting up async tasks and callbacks
+
+        def _passthrough(*args: Any, **kwargs: Any) -> bool:
+            sender = kwargs.get('sender', args[1])
+            subject = kwargs.get('subject', args[2])
+            return callback.is_filtered(sender, subject)
+    else:
+
+        def _passthrough(*args: Any, **kwargs: Any) -> bool:
+            return False
+
+    coro = ensure_coroutine(callback)
+
+    def converted(communicator: kiwipy.Communicator, *args: Any, **kwargs: Any) -> kiwipy.Future:
+        if _passthrough(*args, **kwargs):
+            kiwi_future = kiwipy.Future()
+            kiwi_future.set_result(None)
+            return kiwi_future
+
+        msg_fn = functools.partial(coro, communicator, *args, **kwargs)
+        task_future = futures.create_task(msg_fn, loop)
+        return plum_to_kiwi_future(task_future)
+
+    return converted
+
+
+def wrap_communicator(
+    communicator: kiwipy.Communicator, loop: asyncio.AbstractEventLoop | None = None
+) -> LoopCommunicator:
+    """
+    Wrap a communicator such that all callbacks made to any subscribers are scheduled on the
+    given event loop.
+
+    If the communicator is already an equivalent communicator wrapper then it will not be
+    wrapped again.
+
+    :param communicator: the communicator to wrap
+    :param loop: the event loop to schedule callbacks on
+
+    :return: a communicator wrapper
+
+    """
+    if isinstance(communicator, LoopCommunicator) and communicator.loop() is loop:
+        return communicator
+
+    return LoopCommunicator(communicator, loop)
+
+
+class LoopCommunicator(kiwipy.Communicator):
+    """Wrapper around a `kiwipy.Communicator` that schedules any subscriber messages on a given event loop."""
+
+    def __init__(self, communicator: kiwipy.Communicator, loop: asyncio.AbstractEventLoop | None = None):
+        """
+        :param communicator: The kiwipy communicator
+        :param loop: The event loop to schedule callbacks on
+
+        """
+        assert communicator is not None
+
+        self._communicator = communicator
+        self._loop = loop or events.get_or_create_event_loop()
+
+    def loop(self) -> asyncio.AbstractEventLoop:
+        return self._loop
+
+    def add_rpc_subscriber(self, subscriber: RpcSubscriber, identifier: ID_TYPE | None = None) -> ID_TYPE:
+        converted = convert_to_comm(subscriber, self._loop)
+        return self._communicator.add_rpc_subscriber(converted, identifier)
+
+    def remove_rpc_subscriber(self, identifier: ID_TYPE) -> None:
+        return self._communicator.remove_rpc_subscriber(identifier)
+
+    def add_task_subscriber(self, subscriber: TaskSubscriber, identifier: ID_TYPE | None = None) -> ID_TYPE:
+        converted = convert_to_comm(subscriber, self._loop)
+        return self._communicator.add_task_subscriber(converted, identifier)
+
+    def remove_task_subscriber(self, identifier: ID_TYPE) -> None:
+        return self._communicator.remove_task_subscriber(identifier)
+
+    def add_broadcast_subscriber(self, subscriber: BroadcastSubscriber, identifier: ID_TYPE | None = None) -> ID_TYPE:
+        converted = convert_to_comm(subscriber, self._loop)
+        return self._communicator.add_broadcast_subscriber(converted, identifier)
+
+    def remove_broadcast_subscriber(self, identifier: ID_TYPE) -> None:
+        return self._communicator.remove_broadcast_subscriber(identifier)
+
+    def task_send(self, task: Any, no_reply: bool = False) -> kiwipy.Future:
+        return self._communicator.task_send(task, no_reply)
+
+    def rpc_send(self, recipient_id: ID_TYPE, msg: Any) -> kiwipy.Future:
+        return self._communicator.rpc_send(recipient_id, msg)
+
+    def broadcast_send(
+        self,
+        body: Any | None,
+        sender: str | None = None,
+        subject: str | None = None,
+        correlation_id: ID_TYPE | None = None,
+    ) -> futures.Future:
+        return self._communicator.broadcast_send(body, sender, subject, correlation_id)
+
+    def is_closed(self) -> bool:
+        """Return `True` if the communicator was closed"""
+        return self._communicator.is_closed()
+
+    def close(self) -> None:
+        """Close a communicator, free up all resources and do not allow any further operations"""
+        self._communicator.close()
+
+
+ProcessResult = Any
+ProcessStatus = Any
+
+INTENT_KEY = 'intent'
+MESSAGE_TEXT_KEY = 'message'
+FORCE_KILL_KEY = 'force_kill'
+
+
+class Intent:
+    """Intent constants for a process message"""
+
+    PLAY: str = 'play'
+    PAUSE: str = 'pause'
+    KILL: str = 'kill'
+    STATUS: str = 'status'
+
+
+MessageType = dict[str, Any]
+
+
+class MessageBuilder:
+    """MessageBuilder will construct different messages that can passing over communicator."""
+
+    @classmethod
+    def play(cls, text: str | None = None) -> MessageType:
+        """The play message send over communicator."""
+        return {
+            INTENT_KEY: Intent.PLAY,
+            MESSAGE_TEXT_KEY: text,
+        }
+
+    @classmethod
+    def pause(cls, text: str | None = None) -> MessageType:
+        """The pause message send over communicator."""
+        return {
+            INTENT_KEY: Intent.PAUSE,
+            MESSAGE_TEXT_KEY: text,
+        }
+
+    @classmethod
+    def kill(cls, text: str | None = None, force_kill: bool = False) -> MessageType:
+        """The kill message send over communicator."""
+        return {
+            INTENT_KEY: Intent.KILL,
+            MESSAGE_TEXT_KEY: text,
+            FORCE_KILL_KEY: force_kill,
+        }
+
+    @classmethod
+    def status(cls, text: str | None = None) -> MessageType:
+        """The status message send over communicator."""
+        return {
+            INTENT_KEY: Intent.STATUS,
+            MESSAGE_TEXT_KEY: text,
+        }
+
+
+TASK_KEY = 'task'
+TASK_ARGS = 'args'
+PERSIST_KEY = 'persist'
+# Launch
+PROCESS_CLASS_KEY = 'process_class'
+ARGS_KEY = 'init_args'
+KWARGS_KEY = 'init_kwargs'
+NOWAIT_KEY = 'nowait'
+# Continue
+PID_KEY = 'pid'
+TAG_KEY = 'tag'
+# Task types
+LAUNCH_TASK = 'launch'
+CONTINUE_TASK = 'continue'
+CREATE_TASK = 'create'
+
+LOGGER = logging.getLogger(__name__)
+
+
+def create_launch_body(
+    process_class: str,
+    init_args: Sequence[Any] | None = None,
+    init_kwargs: dict[str, Any] | None = None,
+    persist: bool = False,
+    loader: loaders.ObjectLoader | None = None,
+    nowait: bool = True,
+) -> dict[str, Any]:
+    """
+    Create a message body for the launch action
+
+    :param process_class: the class of the process to launch
+    :param init_args: any initialisation positional arguments
+    :param init_kwargs: any initialisation keyword arguments
+    :param persist: persist this process if True, otherwise don't
+    :param loader: the loader to use to load the persisted process
+    :param nowait: wait for the process to finish before completing the task, otherwise just return the PID
+    :return: a dictionary with the body of the message to launch the process
+    :rtype: dict
+    """
+    if loader is None:
+        loader = loaders.get_object_loader()
+
+    msg_body = {
+        TASK_KEY: LAUNCH_TASK,
+        TASK_ARGS: {
+            PROCESS_CLASS_KEY: loader.identify_object(process_class),
+            PERSIST_KEY: persist,
+            NOWAIT_KEY: nowait,
+            ARGS_KEY: init_args,
+            KWARGS_KEY: init_kwargs,
+        },
+    }
+    return msg_body
+
+
+def create_continue_body(pid: PID_TYPE, tag: str | None = None, nowait: bool = False) -> dict[str, Any]:
+    """
+    Create a message body to continue an existing process
+    :param pid: the pid of the existing process
+    :param tag: the optional persistence tag
+    :param nowait: wait for the process to finish before completing the task, otherwise just return the PID
+    :return: a dictionary with the body of the message to continue the process
+
+    """
+    msg_body = {TASK_KEY: CONTINUE_TASK, TASK_ARGS: {PID_KEY: pid, NOWAIT_KEY: nowait, TAG_KEY: tag}}
+    return msg_body
+
+
+def create_create_body(
+    process_class: str,
+    init_args: Sequence[Any] | None = None,
+    init_kwargs: dict[str, Any] | None = None,
+    persist: bool = False,
+    loader: loaders.ObjectLoader | None = None,
+) -> dict[str, Any]:
+    """
+    Create a message body to create a new process
+    :param process_class: the class of the process to launch
+    :param init_args: any initialisation positional arguments
+    :param init_kwargs: any initialisation keyword arguments
+    :param persist: persist this process if True, otherwise don't
+    :param loader: the loader to use to load the persisted process
+    :return: a dictionary with the body of the message to launch the process
+
+    """
+    if loader is None:
+        loader = loaders.get_object_loader()
+
+    msg_body = {
+        TASK_KEY: CREATE_TASK,
+        TASK_ARGS: {
+            PROCESS_CLASS_KEY: loader.identify_object(process_class),
+            PERSIST_KEY: persist,
+            ARGS_KEY: init_args,
+            KWARGS_KEY: init_kwargs,
+        },
+    }
+    return msg_body
+
+
+class RemoteProcessController:
+    """
+    Control remote processes using coroutines that will send messages and wait
+    (in a non-blocking way) for their response
+    """
+
+    def __init__(self, communicator: kiwipy.Communicator) -> None:
+        self._communicator = communicator
+
+    async def get_status(self, pid: PID_TYPE) -> ProcessStatus:
+        """
+        Get the status of a process with the given PID
+        :param pid: the process id
+        :return: the status response from the process
+        """
+        future = self._communicator.rpc_send(pid, MessageBuilder.status())
+        result = await asyncio.wrap_future(future)
+        return result
+
+    async def pause_process(self, pid: PID_TYPE, msg_text: str | None = None) -> ProcessResult:
+        """
+        Pause the process
+
+        :param pid: the pid of the process to pause
+        :param msg: optional pause message
+        :return: True if paused, False otherwise
+        """
+        msg = MessageBuilder.pause(text=msg_text)
+
+        pause_future = self._communicator.rpc_send(pid, msg)
+        # rpc_send return a thread future from communicator
+        future = await asyncio.wrap_future(pause_future)
+        # future is just returned from rpc call which return a kiwipy future
+        result = await asyncio.wrap_future(future)
+        return result
+
+    async def play_process(self, pid: PID_TYPE) -> ProcessResult:
+        """
+        Play the process
+
+        :param pid: the pid of the process to play
+        :return: True if played, False otherwise
+        """
+        play_future = self._communicator.rpc_send(pid, MessageBuilder.play())
+        future = await asyncio.wrap_future(play_future)
+        result = await asyncio.wrap_future(future)
+        return result
+
+    async def kill_process(self, pid: PID_TYPE, msg_text: str | None = None, force_kill: bool = False) -> ProcessResult:
+        """
+        Kill the process
+
+        :param pid: the pid of the process to kill
+        :param msg: optional kill message
+        :return: True if killed, False otherwise
+        """
+        msg = MessageBuilder.kill(text=msg_text, force_kill=force_kill)
+
+        # Wait for the communication to go through
+        kill_future = self._communicator.rpc_send(pid, msg)
+        future = await asyncio.wrap_future(kill_future)
+        # Now wait for the kill to be enacted
+        result = await asyncio.wrap_future(future)
+        return result
+
+    async def continue_process(
+        self, pid: PID_TYPE, tag: str | None = None, nowait: bool = False, no_reply: bool = False
+    ) -> ProcessResult | None:
+        """
+        Continue the process
+
+        :param _communicator: the communicator
+        :param pid: the pid of the process to continue
+        :param tag: the checkpoint tag to continue from
+        """
+        message = create_continue_body(pid=pid, tag=tag, nowait=nowait)
+        # Wait for the communication to go through
+        continue_future = self._communicator.task_send(message, no_reply=no_reply)
+        future = await asyncio.wrap_future(continue_future)
+
+        if no_reply:
+            return None
+
+        # Now wait for the result of the task
+        result = await asyncio.wrap_future(future)
+        return result
+
+    async def launch_process(
+        self,
+        process_class: str,
+        init_args: Sequence[Any] | None = None,
+        init_kwargs: dict[str, Any] | None = None,
+        persist: bool = False,
+        loader: loaders.ObjectLoader | None = None,
+        nowait: bool = False,
+        no_reply: bool = False,
+    ) -> ProcessResult:
+        """
+        Launch a process given the class and constructor arguments
+
+        :param process_class: the class of the process to launch
+        :param init_args: the constructor positional arguments
+        :param init_kwargs: the constructor keyword arguments
+        :param persist: should the process be persisted
+        :param loader: the classloader to use
+        :param nowait: if True, don't wait for the process to send a response, just return the pid
+        :param no_reply: if True, this call will be fire-and-forget, i.e. no return value
+        :return: the result of launching the process
+        """
+
+        message = create_launch_body(process_class, init_args, init_kwargs, persist, loader, nowait)
+        launch_future = self._communicator.task_send(message, no_reply=no_reply)
+        future = await asyncio.wrap_future(launch_future)
+
+        if no_reply:
+            return
+
+        result = await asyncio.wrap_future(future)
+        return result
+
+    async def execute_process(
+        self,
+        process_class: str,
+        init_args: Sequence[Any] | None = None,
+        init_kwargs: dict[str, Any] | None = None,
+        loader: loaders.ObjectLoader | None = None,
+        nowait: bool = False,
+        no_reply: bool = False,
+    ) -> ProcessResult:
+        """
+        Execute a process.  This call will first send a create task and then a continue task over
+        the communicator.  This means that if communicator messages are durable then the process
+        will run until the end even if this interpreter instance ceases to exist.
+
+        :param process_class: the process class to execute
+        :param init_args: the positional arguments to the class constructor
+        :param init_kwargs: the keyword arguments to the class constructor
+        :param loader: the class loader to use
+        :param nowait: if True, don't wait for the process to send a response
+        :param no_reply: if True, this call will be fire-and-forget, i.e. no return value
+        :return: the result of executing the process
+        """
+
+        message = create_create_body(process_class, init_args, init_kwargs, persist=True, loader=loader)
+
+        create_future = self._communicator.task_send(message)
+        future = await asyncio.wrap_future(create_future)
+        pid: PID_TYPE = await asyncio.wrap_future(future)
+
+        message = create_continue_body(pid, nowait=nowait)
+        continue_future = self._communicator.task_send(message, no_reply=no_reply)
+        future = await asyncio.wrap_future(continue_future)
+
+        if no_reply:
+            return
+
+        result = await asyncio.wrap_future(future)
+        return result
+
+
+class RemoteProcessThreadController:
+    """
+    A class that can be used to control and launch remote processes
+    """
+
+    def __init__(self, communicator: kiwipy.Communicator):
+        """
+        Create a new process controller
+
+        :param communicator: the communicator to use
+
+        """
+        self._communicator = communicator
+
+    def get_status(self, pid: PID_TYPE) -> kiwipy.Future:
+        """Get the status of a process with the given PID.
+
+        :param pid: the process id
+        :return: the status response from the process
+        """
+        return self._communicator.rpc_send(pid, MessageBuilder.status())
+
+    def pause_process(self, pid: PID_TYPE, msg_text: str | None = None) -> kiwipy.Future:
+        """
+        Pause the process
+
+        :param pid: the pid of the process to pause
+        :param msg: optional pause message
+        :return: a response future from the process to be paused
+
+        """
+        msg = MessageBuilder.pause(text=msg_text)
+
+        return self._communicator.rpc_send(pid, msg)
+
+    def pause_all(self, msg_text: str | None) -> None:
+        """
+        Pause all processes that are subscribed to the same communicator
+
+        :param msg: an optional pause message
+        """
+        msg = MessageBuilder.pause(text=msg_text)
+        self._communicator.broadcast_send(msg, subject=Intent.PAUSE)
+
+    def play_process(self, pid: PID_TYPE) -> kiwipy.Future:
+        """
+        Play the process
+
+        :param pid: the pid of the process to pause
+        :return: a response future from the process to be played
+
+        """
+        return self._communicator.rpc_send(pid, MessageBuilder.play())
+
+    def play_all(self) -> None:
+        """
+        Play all processes that are subscribed to the same communicator
+        """
+        self._communicator.broadcast_send(None, subject=Intent.PLAY)
+
+    def kill_process(self, pid: PID_TYPE, msg_text: str | None = None, force_kill: bool = False) -> kiwipy.Future:
+        """
+        Kill the process
+
+        :param pid: the pid of the process to kill
+        :param msg: optional kill message
+        :return: a response future from the process to be killed
+        """
+        msg = MessageBuilder.kill(text=msg_text, force_kill=force_kill)
+        return self._communicator.rpc_send(pid, msg)
+
+    def kill_all(self, msg_text: str | None) -> None:
+        """
+        Kill all processes that are subscribed to the same communicator
+
+        :param msg: an optional pause message
+        """
+        msg = MessageBuilder.kill(msg_text)
+
+        self._communicator.broadcast_send(msg, subject=Intent.KILL)
+
+    def continue_process(
+        self, pid: PID_TYPE, tag: str | None = None, nowait: bool = False, no_reply: bool = False
+    ) -> None | PID_TYPE | ProcessResult:
+        message = create_continue_body(pid=pid, tag=tag, nowait=nowait)
+        return self.task_send(message, no_reply=no_reply)
+
+    def launch_process(
+        self,
+        process_class: str,
+        init_args: Sequence[Any] | None = None,
+        init_kwargs: dict[str, Any] | None = None,
+        persist: bool = False,
+        loader: loaders.ObjectLoader | None = None,
+        nowait: bool = False,
+        no_reply: bool = False,
+    ) -> None | PID_TYPE | ProcessResult:
+        """
+        Launch the process
+
+        :param process_class: the process class to launch
+        :param init_args: positional arguments to the process constructor
+        :param init_kwargs: keyword arguments to the process constructor
+        :param persist: should the process be persisted
+        :param loader: the class loader to use
+        :param nowait: if True only return when the process finishes
+        :param no_reply: don't send a reply to the sender
+        :return: the pid of the created process or the outputs (if nowait=False)
+        """
+        message = create_launch_body(process_class, init_args, init_kwargs, persist, loader, nowait)
+        return self.task_send(message, no_reply=no_reply)
+
+    def execute_process(
+        self,
+        process_class: str,
+        init_args: Sequence[Any] | None = None,
+        init_kwargs: dict[str, Any] | None = None,
+        loader: loaders.ObjectLoader | None = None,
+        nowait: bool = False,
+        no_reply: bool = False,
+    ) -> None | PID_TYPE | ProcessResult:
+        """
+        Execute a process.  This call will first send a create task and then a continue task over
+        the communicator.  This means that if communicator messages are durable then the process
+        will run until the end even if this interpreter instance ceases to exist.
+
+        :param process_class: the process class to execute
+        :param init_args: the positional arguments to the class constructor
+        :param init_kwargs: the keyword arguments to the class constructor
+        :param loader: the class loader to use
+        :param nowait: if True, don't wait for the process to send a response
+        :param no_reply: if True, this call will be fire-and-forget, i.e. no return value
+        :return: the result of executing the process
+        """
+
+        message = create_create_body(process_class, init_args, init_kwargs, persist=True, loader=loader)
+
+        execute_future = kiwipy.Future()
+        create_future = futures.unwrap_kiwi_future(self._communicator.task_send(message))
+
+        def on_created(_: Any) -> None:
+            with kiwipy.capture_exceptions(execute_future):
+                pid: PID_TYPE = create_future.result()
+                continue_future = self.continue_process(pid, nowait=nowait, no_reply=no_reply)
+                kiwipy.chain(continue_future, execute_future)
+
+        create_future.add_done_callback(on_created)
+        return execute_future
+
+    def task_send(self, message: Any, no_reply: bool = False) -> Any | None:
+        """
+        Send a task to be performed using the communicator
+
+        :param message: the task message
+        :param no_reply: if True, this call will be fire-and-forget, i.e. no return value
+        :return: the response from the remote side (if no_reply=False)
+        """
+        return self._communicator.task_send(message, no_reply=no_reply)
+
+
+class ProcessLauncher:
+    """
+    Takes incoming task messages and uses them to launch processes.
+
+    Expected format of task:
+
+    For launch::
+
+        {
+            'task': <LAUNCH_TASK>
+            'process_class': <Process class to launch>
+            'args': <tuple of positional args for process constructor>
+            'kwargs': <dict of keyword args for process constructor>.
+            'nowait': True or False
+        }
+
+    For continue::
+
+        {
+            'task': <CONTINUE_TASK>
+            'pid': <Process ID>
+            'nowait': True or False
+        }
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop | None = None,
+        persister: persistence.Persister | None = None,
+        load_context: persistence.LoadSaveContext | None = None,
+        loader: loaders.ObjectLoader | None = None,
+    ) -> None:
+        self._loop = loop
+        self._persister = persister
+        self._load_context = load_context if load_context is not None else persistence.LoadSaveContext()
+
+        if loader is not None:
+            self._loader = loader
+            self._load_context = self._load_context.copyextend(loader=loader)
+        else:
+            self._loader = loaders.get_object_loader()
+
+    async def __call__(self, communicator: kiwipy.Communicator, task: dict[str, Any]) -> PID_TYPE | ProcessResult:
+        """
+        Receive a task.
+        :param task: The task message
+        """
+        task_type = task[TASK_KEY]
+        if task_type == LAUNCH_TASK:
+            return await self._launch(communicator, **task.get(TASK_ARGS, {}))
+        if task_type == CONTINUE_TASK:
+            return await self._continue(communicator, **task.get(TASK_ARGS, {}))
+        if task_type == CREATE_TASK:
+            return await self._create(communicator, **task.get(TASK_ARGS, {}))
+
+        raise TaskRejected
+
+    async def _launch(
+        self,
+        _communicator: kiwipy.Communicator,
+        process_class: str,
+        persist: bool,
+        nowait: bool,
+        init_args: Sequence[Any] | None = None,
+        init_kwargs: dict[str, Any] | None = None,
+    ) -> PID_TYPE | ProcessResult:
+        """
+        Launch the process
+
+        :param _communicator: the communicator
+        :param process_class: the process class to launch
+        :param persist: should the process be persisted
+        :param nowait: if True only return when the process finishes
+        :param init_args: positional arguments to the process constructor
+        :param init_kwargs: keyword arguments to the process constructor
+        :return: the pid of the created process or the outputs (if nowait=False)
+        """
+        if persist and not self._persister:
+            raise TaskRejected('Cannot persist process, no persister')
+
+        if init_args is None:
+            init_args = ()
+        if init_kwargs is None:
+            init_kwargs = {}
+
+        proc_class = self._loader.load_object(process_class)
+        proc = proc_class(*init_args, **init_kwargs)
+        if persist and self._persister is not None:
+            self._persister.save_checkpoint(proc)
+
+        if nowait:
+            # XXX: can return a reference and gracefully use task to cancel itself when the upper call stack fails
+            asyncio.ensure_future(proc.step_until_terminated())  # noqa: RUF006
+            return proc.pid
+
+        await proc.step_until_terminated()
+
+        return proc.future().result()
+
+    async def _continue(
+        self, _communicator: kiwipy.Communicator, pid: PID_TYPE, nowait: bool, tag: str | None = None
+    ) -> PID_TYPE | ProcessResult:
+        """
+        Continue the process
+
+        :param _communicator: the communicator
+        :param pid: the pid of the process to continue
+        :param nowait: if True don't wait for the process to complete
+        :param tag: the checkpoint tag to continue from
+        """
+        if not self._persister:
+            LOGGER.warning('rejecting task: cannot continue process<%d> because no persister is available', pid)
+            raise TaskRejected('Cannot continue process, no persister')
+
+        # Do not catch exceptions here, because if these operations fail, the continue task should except and bubble up
+        saved_state = self._persister.load_checkpoint(pid, tag)
+        proc = cast('Process', saved_state.unbundle(self._load_context))
+
+        if nowait:
+            # XXX: can return a reference and gracefully use task to cancel itself when the upper call stack fails
+            asyncio.ensure_future(proc.step_until_terminated())  # noqa: RUF006
+            return proc.pid
+
+        await proc.step_until_terminated()
+
+        return proc.future().result()
+
+    async def _create(
+        self,
+        _communicator: kiwipy.Communicator,
+        process_class: str,
+        persist: bool,
+        init_args: Sequence[Any] | None = None,
+        init_kwargs: dict[str, Any] | None = None,
+    ) -> PID_TYPE:
+        """
+        Create the process
+
+        :param _communicator: the communicator
+        :param process_class: the process class to create
+        :param persist: should the process be persisted
+        :param init_args: positional arguments to the process constructor
+        :param init_kwargs: keyword arguments to the process constructor
+        :return: the pid of the created process
+        """
+        if persist and not self._persister:
+            raise TaskRejected('Cannot persist process, no persister')
+
+        if init_args is None:
+            init_args = ()
+        if init_kwargs is None:
+            init_kwargs = {}
+
+        proc_class = self._loader.load_object(process_class)
+        proc = proc_class(*init_args, **init_kwargs)
+        if persist and self._persister is not None:
+            self._persister.save_checkpoint(proc)
+
+        return proc.pid

--- a/src/aiida/engine/processes/communications.py
+++ b/src/aiida/engine/processes/communications.py
@@ -96,8 +96,8 @@ def convert_to_comm(
         # of setting up async tasks and callbacks
 
         def _passthrough(*args: Any, **kwargs: Any) -> bool:
-            sender = kwargs.get('sender', args[1])
-            subject = kwargs.get('subject', args[2])
+            sender = kwargs['sender'] if 'sender' in kwargs else args[1]
+            subject = kwargs['subject'] if 'subject' in kwargs else args[2]
             return callback.is_filtered(sender, subject)
     else:
 

--- a/src/aiida/engine/processes/communications.py
+++ b/src/aiida/engine/processes/communications.py
@@ -375,7 +375,8 @@ class RemoteProcessController:
         :param pid: the process id
         :return: the status response from the process
         """
-        future = self._communicator.rpc_send(pid, MessageBuilder.status())
+        status_future = self._communicator.rpc_send(pid, MessageBuilder.status())
+        future = await asyncio.wrap_future(status_future)
         result = await asyncio.wrap_future(future)
         return result
 

--- a/src/aiida/engine/processes/communications.py
+++ b/src/aiida/engine/processes/communications.py
@@ -719,6 +719,7 @@ class ProcessLauncher:
         self._loop = loop
         self._persister = persister
         self._load_context = load_context if load_context is not None else persistence.LoadSaveContext()
+        self._step_tasks: set[asyncio.Task[Any]] = set()
 
         if loader is not None:
             self._loader = loader
@@ -776,7 +777,9 @@ class ProcessLauncher:
 
         if nowait:
             # XXX: can return a reference and gracefully use task to cancel itself when the upper call stack fails
-            asyncio.ensure_future(proc.step_until_terminated())  # noqa: RUF006
+            task = asyncio.create_task(proc.step_until_terminated())
+            self._step_tasks.add(task)
+            task.add_done_callback(self._step_tasks.discard)
             return proc.pid
 
         await proc.step_until_terminated()
@@ -804,7 +807,9 @@ class ProcessLauncher:
 
         if nowait:
             # XXX: can return a reference and gracefully use task to cancel itself when the upper call stack fails
-            asyncio.ensure_future(proc.step_until_terminated())  # noqa: RUF006
+            task = asyncio.create_task(proc.step_until_terminated())
+            self._step_tasks.add(task)
+            task.add_done_callback(self._step_tasks.discard)
             return proc.pid
 
         await proc.step_until_terminated()

--- a/src/aiida/engine/processes/communications.py
+++ b/src/aiida/engine/processes/communications.py
@@ -280,7 +280,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def create_launch_body(
-    process_class: str,
+    process_class: type[Process],
     init_args: Sequence[Any] | None = None,
     init_kwargs: dict[str, Any] | None = None,
     persist: bool = False,
@@ -329,7 +329,7 @@ def create_continue_body(pid: PID_TYPE, tag: str | None = None, nowait: bool = F
 
 
 def create_create_body(
-    process_class: str,
+    process_class: type[Process],
     init_args: Sequence[Any] | None = None,
     init_kwargs: dict[str, Any] | None = None,
     persist: bool = False,
@@ -449,7 +449,7 @@ class RemoteProcessController:
 
     async def launch_process(
         self,
-        process_class: str,
+        process_class: type[Process],
         init_args: Sequence[Any] | None = None,
         init_kwargs: dict[str, Any] | None = None,
         persist: bool = False,
@@ -482,7 +482,7 @@ class RemoteProcessController:
 
     async def execute_process(
         self,
-        process_class: str,
+        process_class: type[Process],
         init_args: Sequence[Any] | None = None,
         init_kwargs: dict[str, Any] | None = None,
         loader: loaders.ObjectLoader | None = None,
@@ -609,7 +609,7 @@ class RemoteProcessThreadController:
 
     def launch_process(
         self,
-        process_class: str,
+        process_class: type[Process],
         init_args: Sequence[Any] | None = None,
         init_kwargs: dict[str, Any] | None = None,
         persist: bool = False,
@@ -634,7 +634,7 @@ class RemoteProcessThreadController:
 
     def execute_process(
         self,
-        process_class: str,
+        process_class: type[Process],
         init_args: Sequence[Any] | None = None,
         init_kwargs: dict[str, Any] | None = None,
         loader: loaders.ObjectLoader | None = None,

--- a/src/aiida/engine/processes/communications.py
+++ b/src/aiida/engine/processes/communications.py
@@ -665,7 +665,10 @@ class RemoteProcessThreadController:
             with kiwipy.capture_exceptions(execute_future):
                 pid: PID_TYPE = create_future.result()
                 continue_future = self.continue_process(pid, nowait=nowait, no_reply=no_reply)
-                kiwipy.chain(continue_future, execute_future)
+                if no_reply:
+                    execute_future.set_result(None)
+                else:
+                    kiwipy.chain(continue_future, execute_future)
 
         create_future.add_done_callback(on_created)
         return execute_future

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -9,12 +9,12 @@ import typing as t
 
 import kiwipy
 from kiwipy import communications
-from plumpy.futures import unwrap_kiwi_future
 
 from aiida.brokers import Broker
 from aiida.common.exceptions import AiidaException
 from aiida.common.log import AIIDA_LOGGER
 from aiida.engine.daemon.client import DaemonException, get_daemon_client
+from aiida.engine.processes.generic.futures import unwrap_kiwi_future
 from aiida.manage.manager import get_manager
 from aiida.orm import ProcessNode, QueryBuilder
 from aiida.tools.query.calculation import CalculationQueryBuilder

--- a/src/aiida/engine/processes/event_helper.py
+++ b/src/aiida/engine/processes/event_helper.py
@@ -1,0 +1,69 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Helpers for process events."""
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from aiida.engine.processes import persistence
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.listener import ProcessListener
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@persistence.auto_persist('_listeners', '_listener_type')
+class EventHelper(persistence.Savable):
+    def __init__(self, listener_type: 'type[ProcessListener]'):
+        assert listener_type is not None, 'Must provide valid listener type'
+
+        self._listener_type = listener_type
+        self._listeners: set[ProcessListener] = set()
+
+    def add_listener(self, listener: 'ProcessListener') -> None:
+        assert isinstance(listener, self._listener_type), 'Listener is not of right type'
+        self._listeners.add(listener)
+
+    def remove_listener(self, listener: 'ProcessListener') -> None:
+        self._listeners.discard(listener)
+
+    def remove_all_listeners(self) -> None:
+        self._listeners.clear()
+
+    @property
+    def listeners(self) -> 'set[ProcessListener]':
+        return self._listeners
+
+    def fire_event(self, event_function: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Call an event method on all listeners.
+
+        :param event_function: the method of the ProcessListener
+        :param args: arguments to pass to the method
+        :param kwargs: keyword arguments to pass to the method
+
+        """
+        if event_function is None:
+            raise ValueError('Must provide valid event method')
+
+        # Make a copy of the list for iteration just in case it changes in a callback
+        for listener in list(self.listeners):
+            try:
+                getattr(listener, event_function.__name__)(*args, **kwargs)
+            except Exception as exception:
+                _LOGGER.error("Listener '%s' produced an exception:\n%s", listener, exception)

--- a/src/aiida/engine/processes/events.py
+++ b/src/aiida/engine/processes/events.py
@@ -1,0 +1,90 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Event and loop related classes and functions"""
+
+import asyncio
+import sys
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any
+
+__all__: tuple[str, ...] = ()
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.generic.process import Process
+
+
+def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
+    """Get the running event loop, or the current set loop, or create and set a new one.
+    Note: aiida should never call on asyncio.get_event_loop() directly.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    try:
+        # See issue https://github.com/aiidateam/plumpy/issues/336
+        loop = asyncio.get_event_loop()
+        if not loop.is_closed():
+            return loop
+    except RuntimeError:
+        pass
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+class ProcessCallback:
+    """Object returned by callback registration methods."""
+
+    __slots__ = ('__weakref__', '_args', '_callback', '_cancelled', '_kwargs', '_process')
+
+    def __init__(
+        self, process: 'Process', callback: Callable[..., Any], args: Sequence[Any], kwargs: dict[str, Any]
+    ) -> None:
+        self._process: Process = process
+        self._callback: Callable[..., Any] = callback
+        self._args: Sequence[Any] = args
+        self._kwargs: dict[str, Any] = kwargs
+        self._cancelled: bool = False
+
+    def cancel(self) -> None:
+        if not self._cancelled:
+            self._cancelled = True
+            self._done()
+
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+    async def run(self) -> None:
+        """Run the callback"""
+        if not self._cancelled:
+            try:
+                await self._callback(*self._args, **self._kwargs)
+            except Exception:
+                exc_info = sys.exc_info()
+                self._process.callback_excepted(self._callback, exc_info[1], exc_info[2])
+            finally:
+                self._done()
+
+    def _done(self) -> None:
+        self._cleanup()
+
+    def _cleanup(self) -> None:
+        self._process = None  # type: ignore[assignment]
+        self._callback = None  # type: ignore[assignment]
+        self._args = None  # type: ignore[assignment]
+        self._kwargs = None  # type: ignore[assignment]

--- a/src/aiida/engine/processes/exceptions.py
+++ b/src/aiida/engine/processes/exceptions.py
@@ -1,0 +1,49 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+
+__all__: tuple[str, ...] = ()
+
+
+class KilledError(Exception):
+    """The process was killed."""
+
+
+class InvalidStateError(Exception):
+    """
+    Raised when an operation is attempted that requires the process to be in a state
+    that is different from the current state
+    """
+
+
+class UnsuccessfulResult:
+    """The result of the process was unsuccessful"""
+
+    def __init__(self, result: int | None = None):
+        """Initialise.
+
+        :param result: the exit code of the process
+
+        """
+        self.result = result
+
+
+class PersistenceError(Exception):
+    """Raised when there is a problem persisting the process"""
+
+
+class ClosedError(Exception):
+    """Raised when an mutable operation is attempted on a closed process"""

--- a/src/aiida/engine/processes/functions.py
+++ b/src/aiida/engine/processes/functions.py
@@ -352,7 +352,7 @@ class FunctionProcess(Process):
 
         def define(cls, spec):
             """Define the spec dynamically"""
-            from plumpy.ports import UNSPECIFIED
+            from aiida.engine.processes.generic.ports import UNSPECIFIED
 
             super().define(spec)
 
@@ -555,7 +555,7 @@ class FunctionProcess(Process):
         # The remaining inputs have to be keyword arguments.
         kwargs.update(**inputs)
 
-        from plumpy import run_with_portal
+        from aiida.engine.processes.greenback import run_with_portal
 
         result = await run_with_portal(self._func, *args, **kwargs)
 

--- a/src/aiida/engine/processes/futures.py
+++ b/src/aiida/engine/processes/futures.py
@@ -48,6 +48,7 @@ class ProcessFuture(asyncio.Future):
 
         assert not (poll_interval is None and communicator is None), 'Must poll or have a communicator to use'
 
+        self._polling_task: asyncio.Task[None] | None = None
         node = load_node(pk=pk)
 
         if node.is_terminated:
@@ -70,10 +71,14 @@ class ProcessFuture(asyncio.Future):
 
             # Start polling
             if poll_interval is not None:
-                loop.create_task(self._poll_process(node, poll_interval))
+                self._polling_task = loop.create_task(self._poll_process(node, poll_interval))
 
     def cleanup(self) -> None:
         """Clean up the future by removing broadcast subscribers from the communicator if it still exists."""
+        if self._polling_task is not None:
+            self._polling_task.cancel()
+            self._polling_task = None
+
         if self._communicator is not None:
             self._communicator.remove_broadcast_subscriber(self._broadcast_identifier)
             self._communicator = None

--- a/src/aiida/engine/processes/futures.py
+++ b/src/aiida/engine/processes/futures.py
@@ -6,13 +6,13 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Futures that can poll or receive broadcasted messages while waiting for a task to be completed."""
+"""Futures for waiting on AiiDA processes."""
 
 import asyncio
 
 import kiwipy
-from plumpy import get_or_create_event_loop
 
+from aiida.engine.processes.events import get_or_create_event_loop
 from aiida.orm import Node, load_node
 
 __all__ = ('ProcessFuture',)

--- a/src/aiida/engine/processes/generic/__init__.py
+++ b/src/aiida/engine/processes/generic/__init__.py
@@ -1,0 +1,9 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Generic process-engine implementations."""

--- a/src/aiida/engine/processes/generic/futures.py
+++ b/src/aiida/engine/processes/generic/futures.py
@@ -1,0 +1,120 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Generic process-engine future helpers."""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import kiwipy
+
+from aiida.engine.processes.events import get_or_create_event_loop
+from aiida.engine.processes.exceptions import InvalidStateError
+
+__all__: tuple[str, ...] = ()
+
+CancelledError = kiwipy.CancelledError
+
+
+copy_future = kiwipy.copy_future
+chain = kiwipy.chain
+gather = asyncio.gather
+
+Future = asyncio.Future
+
+
+class CancellableAction(Future):
+    """
+    An action that can be launched and potentially cancelled
+    """
+
+    def __init__(self, action: Callable[..., Any], cookie: Any = None):
+        super().__init__()
+        self._action = action
+        self._cookie = cookie
+
+    @property
+    def cookie(self) -> Any:
+        """A cookie that can be used to correlate the actions with something"""
+        return self._cookie
+
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        """Run the action
+
+        :param args: the positional arguments to the action
+        :param kwargs: the keyword arguments to the action
+        """
+        if self.done():
+            raise InvalidStateError('Action has already been ran')
+
+        try:
+            with kiwipy.capture_exceptions(self):
+                self.set_result(self._action(*args, **kwargs))
+        finally:
+            self._action = None  # type: ignore[assignment]
+
+
+def create_task(coro: Callable[[], Awaitable[Any]], loop: asyncio.AbstractEventLoop | None = None) -> Future:
+    """
+    Schedule a call to a coro in the event loop and wrap the outcome
+    in a future.
+
+    :param coro: a function which creates the coroutine to schedule
+    :param loop: the event loop to schedule it in
+    :return: the future representing the outcome of the coroutine
+
+    """
+    loop = loop or get_or_create_event_loop()
+
+    future = loop.create_future()
+
+    async def run_task() -> None:
+        with kiwipy.capture_exceptions(future):
+            res = await coro()
+            future.set_result(res)
+
+    asyncio.run_coroutine_threadsafe(run_task(), loop)
+    return future
+
+
+def unwrap_kiwi_future(future: kiwipy.Future) -> kiwipy.Future:
+    """
+    Create a kiwi future that represents the final results of a nested series of futures,
+    meaning that if the futures provided itself resolves to a future the returned
+    future will not resolve to a value until the final chain of futures is not a future
+    but a concrete value.  If at any point in the chain a future resolves to an exception
+    then the returned future will also resolve to that exception.
+
+    :param future: the future to unwrap
+    :return: the unwrapping future
+
+    """
+    unwrapping = kiwipy.Future()
+
+    def unwrap(fut: kiwipy.Future) -> None:
+        if fut.cancelled():
+            unwrapping.cancel()
+        else:
+            with kiwipy.capture_exceptions(unwrapping):
+                result = fut.result()
+                if isinstance(result, kiwipy.Future):
+                    result.add_done_callback(unwrap)
+                else:
+                    unwrapping.set_result(result)
+
+    future.add_done_callback(unwrap)
+    return unwrapping

--- a/src/aiida/engine/processes/generic/futures.py
+++ b/src/aiida/engine/processes/generic/futures.py
@@ -42,8 +42,13 @@ class CancellableAction(Future):
     An action that can be launched and potentially cancelled
     """
 
-    def __init__(self, action: Callable[..., Any], cookie: Any = None):
-        super().__init__()
+    def __init__(
+        self,
+        action: Callable[..., Any],
+        cookie: Any = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ):
+        super().__init__(loop=loop)
         self._action = action
         self._cookie = cookie
 

--- a/src/aiida/engine/processes/generic/ports.py
+++ b/src/aiida/engine/processes/generic/ports.py
@@ -1,0 +1,827 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Generic process port implementations."""
+
+from __future__ import annotations
+
+import collections
+import copy
+import inspect
+import json
+import logging
+import warnings
+from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
+from typing import Any, cast
+
+from aiida.common.extendeddicts import AttributesFrozendict
+from aiida.common.lang import type_check
+
+__all__: tuple[str, ...] = ()
+
+
+def is_mutable_property(cls: Any, attribute: str) -> bool:
+    """Return whether an attribute is a settable property."""
+    try:
+        value = getattr(cls, attribute)
+    except AttributeError:
+        return False
+    return isinstance(value, property) and value.fset is not None
+
+
+_LOGGER = logging.getLogger(__name__)
+UNSPECIFIED = ()
+
+VALIDATOR_SIGNATURE_DEPRECATION_WARNING = """the validator `{}` has a signature that only takes a single argument.
+    This has been deprecated and the new signature is `validator(value, port)` where the `port` argument will be the
+    port instance to which the validator has been assigned."""
+
+VALIDATOR_TYPE = Callable[[Any, 'Port'], str | None]
+
+
+class PortValidationError(Exception):
+    """Error when validation fails on a port"""
+
+    def __init__(self, message: str, port: str) -> None:
+        """
+        :param message: validation error message
+        :param port: the port where the validation error occurred
+
+        """
+        super().__init__(f"Error occurred validating port '{port}': {message}")
+        self._message = message
+        self._port = port
+
+    @property
+    def message(self) -> str:
+        """
+        Get the validation error message
+
+        :return: the error message
+
+        """
+        return self._message
+
+    @property
+    def port(self) -> str:
+        """
+        Get the port breadcrumbs
+
+        :return: the port where the error occurred
+
+        """
+        return self._port
+
+
+class Port:
+    """
+    Specifications relating to a general input/output value including
+    properties like whether it is required, valid types, the help string, etc.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        valid_type: type[Any] | None = None,
+        help: str | None = None,
+        required: bool = True,
+        validator: VALIDATOR_TYPE | None = None,
+    ) -> None:
+        self._name = name
+        self._valid_type = valid_type
+        self._help = help
+        self._required = required
+        self._validator = validator
+
+    def __str__(self) -> str:
+        """Get the string representing this port.
+
+        :return: the string representation
+
+        """
+        return json.dumps(self.get_description())
+
+    def get_description(self) -> dict[str, Any]:
+        """Return a description of the Port, which will be a dictionary of its attributes
+
+        :returns: a dictionary of the stringified Port attributes
+
+        """
+        description = {
+            'name': f'{self.name}',
+            'required': str(self.required),
+        }
+
+        if self.valid_type:
+            description['valid_type'] = f'{self.valid_type}'
+        if self.help:
+            description['help'] = f'{self.help.strip()}'
+
+        return description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def valid_type(self) -> type[Any] | None:
+        """Get the valid value type for this port if one is specified
+
+        :return: the value value type
+
+        """
+        return self._valid_type
+
+    @valid_type.setter
+    def valid_type(self, valid_type: type[Any] | None) -> None:
+        """Set the valid value type for this port
+
+        :param valid_type: the value valid type
+
+        """
+        self._valid_type = valid_type
+
+    @property
+    def help(self) -> str | None:
+        """Get the help string for this port
+
+        :return: the help string
+
+        """
+        return self._help
+
+    @help.setter
+    def help(self, help: str | None) -> None:
+        """Set the help string for this port
+
+        :param help: the help string
+
+        """
+        self._help = help
+
+    @property
+    def required(self) -> bool:
+        """Is this port required?
+
+        :return: True if required, False otherwise
+
+        """
+        return self._required
+
+    @required.setter
+    def required(self, required: bool) -> None:
+        """Set whether this port is required or not
+
+        :return: True if required, False otherwise
+
+        """
+        self._required = required
+
+    @property
+    def validator(self) -> VALIDATOR_TYPE | None:
+        """Get the validator for this port
+
+        :return: the validator
+        :rtype: typing.Callable[[typing.Any], typing.Tuple[bool, typing.Optional[str]]]
+        """
+        return self._validator
+
+    @validator.setter
+    def validator(self, validator: VALIDATOR_TYPE | None) -> None:
+        """Set the validator for this port
+
+        :param validator: a validator function
+
+        """
+        self._validator = validator
+
+    def validate(self, value: Any, breadcrumbs: Sequence[str] = ()) -> PortValidationError | None:
+        """Validate a value to see if it is valid for this port
+
+        :param value: the value to check
+        :param breadcrumbs: a tuple of the path to having reached this point in validation
+
+        """
+        validation_error = None
+
+        if value is UNSPECIFIED and self._required:
+            validation_error = f"required value was not provided for '{self.name}'"
+        elif value is not UNSPECIFIED and self._valid_type is not None and not isinstance(value, self._valid_type):
+            validation_error = (
+                f"value '{self.name}' is not of the right type. Got '{type(value)}', expected '{self._valid_type}'"
+            )
+
+        if not validation_error and self.validator is not None and value is not UNSPECIFIED:
+            spec = inspect.getfullargspec(self.validator)
+            if len(spec[0]) == 1:
+                warnings.warn(VALIDATOR_SIGNATURE_DEPRECATION_WARNING.format(self.validator.__name__))
+                result = self.validator(value)  # type: ignore[call-arg]
+            else:
+                result = self.validator(value, self)
+            if result is not None:
+                assert isinstance(result, str), 'Validator returned non string type'
+                validation_error = result
+
+        if validation_error is not None:
+            breadcrumbs = (*breadcrumbs, self.name)
+            return PortValidationError(validation_error, breadcrumbs_to_port(breadcrumbs))
+
+        return None
+
+
+class InputPort(Port):
+    """
+    A simple input port for a value being received by a process
+    """
+
+    @staticmethod
+    def required_override(required: bool, default: Any) -> bool:
+        """
+        If a default is specified an input should no longer be marked
+        as required. Otherwise the input should always be marked explicitly
+        to be not required even if a default is specified.
+        """
+        if default is UNSPECIFIED:
+            return required
+
+        return False
+
+    def __init__(
+        self,
+        name: str,
+        valid_type: type[Any] | None = None,
+        help: str | None = None,
+        default: Any = UNSPECIFIED,
+        required: bool = True,
+        validator: VALIDATOR_TYPE | None = None,
+    ) -> None:
+        super().__init__(
+            name,
+            valid_type=valid_type,
+            help=help,
+            required=InputPort.required_override(required, default),
+            validator=validator,
+        )
+
+        if required is not InputPort.required_override(required, default):
+            _LOGGER.debug(
+                "the required attribute for the input port '%s' was overridden because a default was specified", name
+            )
+
+        if default is not UNSPECIFIED:
+            # Only validate the default value if it is not a callable. If it is a callable its return value will always
+            # be validated when the port is validated upon process construction, if the default is was actually used.
+            if not callable(default):
+                validation_error = self.validate(default)
+                if validation_error:
+                    raise ValueError(f'Invalid default value: {validation_error.message}')
+
+        self._default = default
+
+    def has_default(self) -> bool:
+        return self._default is not UNSPECIFIED
+
+    @property
+    def default(self) -> Any:
+        if not self.has_default():
+            raise RuntimeError('No default')
+        return self._default
+
+    @default.setter
+    def default(self, default: Any) -> None:
+        self._default = default
+
+    def get_description(self) -> dict[str, str]:
+        """
+        Return a description of the InputPort, which will be a dictionary of its attributes
+
+        :returns: a dictionary of the stringified InputPort attributes
+        """
+        description = super().get_description()
+
+        if self.has_default():
+            description['default'] = f'{self.default}'
+
+        return description
+
+
+class OutputPort(Port):
+    pass
+
+
+class PortNamespace(collections.abc.MutableMapping, Port):
+    """
+    A container for Ports. Effectively it maintains a dictionary whose members are
+    either a Port or yet another PortNamespace. This allows for the nesting of ports
+    """
+
+    NAMESPACE_SEPARATOR = '.'
+
+    def __init__(
+        self,
+        name: str = '',  # Note this was set to None, but that would fail if you tried to compute breadcrumbs
+        help: str | None = None,
+        required: bool = True,
+        validator: VALIDATOR_TYPE | None = None,
+        valid_type: type[Any] | None = None,
+        default: Any = UNSPECIFIED,
+        dynamic: bool = False,
+        populate_defaults: bool = True,
+    ) -> None:
+        """Construct a port namespace.
+
+        :param name: the name of the namespace
+        :param help: the help string
+        :param required: boolean, if `True` the validation will fail if no value is specified for this namespace
+        :param validator: an optional validator for the namespace
+        :param valid_type: optional tuple of valid types in the case of a dynamic namespace. Setting this to anything
+            other than `None` will automatically force `dynamic` to be set to `True`.
+        :param default: default value for the port
+        :param dynamic: boolean, if `True`, the namespace will accept values even when no explicit port is defined
+        :param populate_defaults: boolean, when set to `False`, the populating of defaults for this namespace is skipped
+            entirely, including all nested namespaces, if no explicit value is passed for this port in the parent
+            namespace. As soon as a value is specified in the parent namespace for this port, even if it is empty, this
+            property is ignored and the population of defaults is always performed.
+        """
+        super().__init__(name=name, help=help, required=required, validator=validator, valid_type=valid_type)
+        self._ports: dict[str, Port | PortNamespace] = {}
+        self.default = default
+        self.populate_defaults = populate_defaults
+        self.valid_type = valid_type
+
+        # Do not override `dynamic` if the `valid_type` is not `None` because the setter will have set it properly
+        if valid_type is None:
+            self.dynamic = dynamic
+
+    def __str__(self) -> str:
+        return json.dumps(self.get_description(), sort_keys=True, indent=4)
+
+    def __iter__(self) -> Iterator[str]:
+        return self._ports.__iter__()
+
+    def __len__(self) -> int:
+        return len(self._ports)
+
+    def __delitem__(self, key: str) -> None:
+        del self._ports[key]
+
+    def __getitem__(self, key: str) -> Port | PortNamespace:
+        return self._ports[key]
+
+    def __setitem__(self, key: str, port: Port | PortNamespace) -> None:
+        if not isinstance(port, Port):
+            raise TypeError('port needs to be an instance of Port')
+        self._ports[key] = port
+
+    @property
+    def ports(self) -> dict[str, Port | PortNamespace]:
+        return self._ports
+
+    def has_default(self) -> bool:
+        return self._default is not UNSPECIFIED
+
+    @property
+    def default(self) -> Any:
+        return self._default
+
+    @default.setter
+    def default(self, default: Any) -> None:
+        self._default = default
+
+    @property
+    def dynamic(self) -> bool:
+        return self._dynamic
+
+    @dynamic.setter
+    def dynamic(self, dynamic: bool) -> None:
+        self._dynamic = dynamic
+
+    @property
+    def valid_type(self) -> type[Any] | None:
+        return super().valid_type
+
+    @valid_type.setter
+    def valid_type(self, valid_type: type[Any] | None) -> None:
+        """Set the `valid_type` for the `PortNamespace`.
+
+        If the `valid_type` is None, the `dynamic` property will be set to `False`, in all other cases `dynamic` will be
+        set to True.
+
+        :param valid_type: a tuple or single valid type that the namespace accepts
+        """
+        if valid_type is not None:
+            self.dynamic = True
+
+        super(PortNamespace, self.__class__).valid_type.fset(self, valid_type)  # type: ignore[attr-defined]
+
+    @property
+    def populate_defaults(self) -> bool:
+        return self._populate_defaults
+
+    @populate_defaults.setter
+    def populate_defaults(self, populate_defaults: bool) -> None:
+        self._populate_defaults = populate_defaults
+
+    def get_description(self) -> dict[str, dict[str, Any]]:
+        """
+        Return a dictionary with a description of the ports this namespace contains
+        Nested PortNamespaces will be properly recursed and Ports will print their properties in a list
+
+        :returns: a dictionary of descriptions of the Ports contained within this PortNamespace
+        """
+        description = {
+            '_attrs': {
+                'default': self.default,
+                'dynamic': self.dynamic,
+                'valid_type': str(self.valid_type),
+                'required': str(self.required),
+                'help': self.help,
+            }
+        }
+
+        for name, port in self._ports.items():
+            description[name] = port.get_description()
+
+        return description
+
+    def get_port(self, name: str, create_dynamically: bool = False) -> Port | PortNamespace:
+        """Retrieve a declared, potentially namespaced port without modifying this namespace.
+
+        Dynamic runtime outputs are validated and stored by
+        :meth:`aiida.engine.processes.generic.process.Process.out`; they are not
+        materialized as declarations in this namespace.
+
+        :param name: name (potentially namespaced) of the port to retrieve.
+        :param create_dynamically: deprecated and ignored. Passing ``True`` emits a deprecation warning.
+        :returns: declared port or port namespace.
+        :raises ValueError: if the port or namespace does not exist.
+        """
+        if create_dynamically:
+            warnings.warn(
+                'the `create_dynamically` argument is deprecated and ignored; dynamic runtime outputs should be '
+                'emitted through `Process.out`',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if not isinstance(name, str):
+            raise ValueError(f'name has to be a string type, not {type(name)}')
+
+        if not name:
+            raise ValueError('name cannot be an empty string')
+
+        namespace = name.split(self.NAMESPACE_SEPARATOR)
+        port_name = namespace.pop(0)
+
+        if port_name not in self:
+            raise ValueError(f"port '{port_name}' does not exist in port namespace '{self.name}'")
+
+        if namespace:
+            portnamespace = cast(PortNamespace, self[port_name])
+            return portnamespace.get_port(self.NAMESPACE_SEPARATOR.join(namespace))
+
+        return self[port_name]
+
+    def create_port_namespace(self, name: str, **kwargs: Any) -> PortNamespace:
+        """
+        Create and return a new port namespace in this namespace. If the name is namespaced, the sub-namespaces will
+        be created recursively, except if one of the namespaces is already occupied at any level by
+        a Port in which case a ValueError will be thrown
+
+        :param name: name (potentially namespaced) of the port to create and return
+        :param kwargs: constructor arguments used only for the construction of the terminal port namespace
+        :returns: port namespace
+        :raises: ValueError if any sub namespace is occupied by a non-namespace port
+        """
+        if not isinstance(name, str):
+            raise ValueError(f'name has to be a string type, not {type(name)}')
+
+        if not name:
+            raise ValueError('name cannot be an empty string')
+
+        namespace = name.split(self.NAMESPACE_SEPARATOR)
+        port_name = namespace.pop(0)
+
+        if port_name in self and not isinstance(self[port_name], PortNamespace):
+            raise ValueError(f"the name '{port_name}' in '{self.name}' already contains a Port")
+
+        # If this is True, the (sub) port namespace does not yet exist, so we create it
+        if port_name not in self:
+            # If there still is a `namespace`, we create a sub namespace, *without* the constructor arguments
+            if namespace:
+                self[port_name] = self.__class__(port_name)
+
+            # Otherwise it is the terminal port and we construct *with* the keyword arugments
+            else:
+                self[port_name] = self.__class__(port_name, **kwargs)
+
+        if namespace:
+            portnamespace = cast(PortNamespace, self[port_name])
+            return portnamespace.create_port_namespace(self.NAMESPACE_SEPARATOR.join(namespace), **kwargs)
+
+        return cast(PortNamespace, self[port_name])
+
+    def absorb(
+        self,
+        port_namespace: PortNamespace,
+        exclude: Sequence[str] | None = None,
+        include: Sequence[str] | None = None,
+        namespace_options: dict[str, Any] | None = None,
+    ) -> list[str]:
+        """Absorb another PortNamespace instance into oneself, including all its mutable properties and ports.
+
+        Mutable properties of self will be overwritten with those of the port namespace that is to be absorbed.
+        The same goes for the ports, meaning that any ports with a key that already exists in self will
+        be overwritten. The namespace_options dictionary can be used to yet override the mutable properties of
+        the port namespace that is to be absorbed. The exclude and include tuples can be used to exclude or
+        include certain ports and both are mutually exclusive.
+
+        :param port_namespace: instance of PortNamespace that is to be absorbed into self
+        :param exclude: input keys to exclude from being exposed
+        :param include: input keys to include as exposed inputs
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
+        :return: list of the names of the ports that were absorbed
+        """
+
+        if not isinstance(port_namespace, PortNamespace):
+            raise ValueError('port_namespace has to be an instance of PortNamespace')
+
+        if exclude is not None and include is not None:
+            raise ValueError('exclude and include are mutually exclusive')
+
+        if exclude is not None:
+            type_check(exclude, Sequence)
+        elif include is not None:
+            type_check(include, Sequence)
+
+        if namespace_options is None:
+            namespace_options = {}
+
+        # Overload mutable attributes of PortNamespace unless overridden by value in namespace_options
+        for attr in dir(port_namespace):
+            if is_mutable_property(PortNamespace, attr):
+                setattr(self, attr, namespace_options.pop(attr, getattr(port_namespace, attr)))
+
+        if namespace_options:
+            raise ValueError(
+                f'the namespace_options {list(namespace_options.keys())}, is not a supported PortNamespace property'
+            )
+
+        absorbed_ports = []
+
+        for port_name, port in port_namespace.items():
+            # If the current port name occurs in the exclude list, simply skip it entirely, there is no need to consider
+            # any of the nested ports it might have, even if it is a port namespace
+            if exclude and port_name in exclude:
+                continue
+
+            if isinstance(port, PortNamespace):
+                # If the name does not appear at the start of any of the include rules we continue:
+                if include and not any(rule.startswith(port_name) for rule in include):
+                    continue
+
+                # Determine the sub exclude and include rules for this specific namespace
+                sub_exclude = self.strip_namespace(port_name, self.NAMESPACE_SEPARATOR, exclude)
+                sub_include = self.strip_namespace(port_name, self.NAMESPACE_SEPARATOR, include)
+
+                # Create a new namespace at `port_name` and copy the original port namespace itself such that we keep
+                # all its mutable properties, but reset its ports, since those will be taken care of by the recursive
+                # absorb call that will properly consider the include and exclude rules
+                self[port_name] = copy.copy(port)
+                portnamespace = cast(PortNamespace, self[port_name])
+                portnamespace._ports = {}
+                portnamespace.absorb(port, sub_exclude, sub_include)
+            else:
+                # If include rules are specified but the port name does not appear, simply skip it
+                if include and port_name not in include:
+                    continue
+
+                self[port_name] = copy.deepcopy(port)
+
+            absorbed_ports.append(port_name)
+
+        return absorbed_ports
+
+    def project(self, port_values: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        """
+        Project a (nested) dictionary of port values onto the port dictionary of this PortNamespace.
+        That is to say, return those keys of the dictionary that are shared by this PortNamespace.
+        If a matching key corresponds to another PortNamespace, this method will be called recursively,
+        passing the sub dictionary belonging to that port name.
+
+        :param port_values: a dictionary where keys are port names and values are actual input values
+        """
+        result: MutableMapping[str, Any] = {}
+
+        for name, value in port_values.items():
+            if name in self.ports:
+                if isinstance(value, PortNamespace):
+                    port = self[name]
+                    assert isinstance(port, PortNamespace)
+                    result[name] = port.project(value)
+                else:
+                    result[name] = value
+
+        return result
+
+    def validate(
+        self, port_values: Mapping[str, Any] | None = None, breadcrumbs: Sequence[str] = ()
+    ) -> PortValidationError | None:
+        """
+        Validate the namespace port itself and subsequently all the port_values it contains
+
+        :param port_values: an arbitrarily nested dictionary of parsed port values
+        :param breadcrumbs: a tuple of the path to having reached this point in validation
+        :return: None or tuple containing 0: error string 1: tuple of breadcrumb strings to where the validation failed
+        """
+
+        breadcrumbs_local = (*breadcrumbs, self.name)
+        message: str | None
+
+        if not port_values:
+            port_values = {}
+
+        if not isinstance(port_values, collections.abc.Mapping):
+            # Defensive check: the port values originate from user input, so the annotation is not guaranteed
+            message = f'specified value is of type {type(port_values)} which is not sub class of `Mapping`'  # type: ignore[unreachable]
+            return PortValidationError(message, breadcrumbs_to_port(breadcrumbs_local))
+
+        # Turn the port values into a normal dictionary and create a shallow copy. The `validate_ports` method to which
+        # the `port_values` will be passed, will pop the values corresponding to explicit ports. This is necessary for
+        # the `validate_dynamic_ports` to correctly detect any implicit ports. However, the `validator` will expect the
+        # entire original input namespace to be there. Since the latter has to be called after the ports have been
+        # validated, we need to create a clone of the port values here.
+        port_values = dict(port_values)
+        port_values_clone = port_values.copy()
+
+        # If the namespace is not required and there are no port_values specified, consider it valid
+        if not port_values and not self.required:
+            return None
+
+        # In all other cases, validate all input ports explicitly specified in this port namespace
+        validation_error = self.validate_ports(port_values, breadcrumbs_local)
+        if validation_error:
+            return validation_error
+
+        # If any port_values remain, validate against the dynamic properties of the namespace
+        validation_error = self.validate_dynamic_ports(port_values, breadcrumbs)
+        if validation_error:
+            return validation_error
+
+        # Validate the validator after the ports themselves, as it most likely will rely on the port values
+        if self.validator is not None:
+            spec = inspect.getfullargspec(self.validator)
+            if len(spec[0]) == 1:
+                warnings.warn(VALIDATOR_SIGNATURE_DEPRECATION_WARNING.format(self.validator.__name__))
+                message = self.validator(port_values_clone)  # type: ignore[call-arg]
+            else:
+                message = self.validator(port_values_clone, self)
+            if message is not None:
+                assert isinstance(message, str), (
+                    f"Validator returned something other than None or str: '{type(message)}'"
+                )
+                return PortValidationError(message, breadcrumbs_to_port(breadcrumbs_local))
+
+        return None
+
+    def pre_process(self, port_values: MutableMapping[str, Any]) -> AttributesFrozendict:
+        """Map port values onto the port namespace, filling in values for ports with a default.
+
+        :param port_values: the dictionary with supplied port values
+        :return: an AttributesFrozenDict with pre-processed port value mapping, complemented with port default values
+        """
+        for name, port in self.items():
+            # If the port was not specified in the inputs values and the port is a namespace with the property
+            # `populate_defaults=False`, we skip the pre-processing and do not populate defaults.
+            if name not in port_values and isinstance(port, PortNamespace) and not port.populate_defaults:
+                continue
+
+            if name not in port_values:
+                if port.has_default():
+                    default = port.default
+                    if callable(default):
+                        port_value = default()
+                    else:
+                        port_value = default
+
+                # If a namespace containing ports, create an empty dictionary so its ports can be considered recursively
+                elif isinstance(port, PortNamespace) and port.ports:
+                    port_value = {}
+                else:
+                    continue
+            else:
+                port_value = port_values[name]
+
+            if isinstance(port, PortNamespace):
+                port_values[name] = port.pre_process(port_value)
+            else:
+                port_values[name] = port_value
+
+        return AttributesFrozendict(port_values)
+
+    def validate_ports(
+        self, port_values: MutableMapping[str, Any], breadcrumbs: Sequence[str]
+    ) -> PortValidationError | None:
+        """
+        Validate port values with respect to the explicitly defined ports of the port namespace.
+        Ports values that are matched to an actual Port will be popped from the dictionary
+
+        :param port_values: an arbitrarily nested dictionary of parsed port values
+        :param breadcrumbs: a tuple of breadcrumbs showing the path to to the value being validated
+
+        :return: None or tuple containing 0: error string 1: tuple of breadcrumb strings to where the validation failed
+
+        """
+        for name, port in self._ports.items():
+            validation_error = port.validate(port_values.pop(name, UNSPECIFIED), breadcrumbs)
+            if validation_error:
+                return validation_error
+        return None
+
+    def validate_dynamic_ports(
+        self, port_values: MutableMapping[str, Any], breadcrumbs: Sequence[str] = ()
+    ) -> PortValidationError | None:
+        """
+        Validate port values with respect to the dynamic properties of the port namespace. It will
+        check if the namespace is actually dynamic and if all values adhere to the valid types of
+        the namespace if those are specified
+
+        :param port_values: an arbitrarily nested dictionary of parsed port values
+        :type port_values: dict
+        :param breadcrumbs: a tuple of the path to having reached this point in validation
+        :type breadcrumbs: typing.Tuple[str]
+        :return: if invalid returns a string with the reason for the validation failure, otherwise None
+        :rtype: typing.Optional[str]
+        """
+        if port_values and not self.dynamic:
+            msg = f'Unexpected ports {port_values}, for a non dynamic namespace'
+            return PortValidationError(msg, breadcrumbs_to_port((*breadcrumbs, self.name)))
+
+        if self.valid_type is None:
+            return None
+
+        if isinstance(port_values, dict):
+            for key, value in port_values.items():
+                result = self.validate_dynamic_ports(value, (*breadcrumbs, self.name, key))
+                if result is not None:
+                    return result
+        elif not isinstance(port_values, self.valid_type):
+            msg = f'Invalid type {type(port_values)} for dynamic port value: expected {self.valid_type}'
+            return PortValidationError(msg, breadcrumbs_to_port(breadcrumbs))
+
+        return None
+
+    @staticmethod
+    def strip_namespace(namespace: str, separator: str, rules: Sequence[str] | None = None) -> list[str] | None:
+        """Filter given exclude/include rules staring with namespace and strip the first level.
+
+        For example if the namespace is `base` and the rules are::
+
+            ('base.a', 'base.sub.b','relax.base.c', 'd')
+
+        the function will return::
+
+            ('a', 'sub.c')
+
+        If the rules are `None`, that is what is returned as well.
+
+        :param namespace: the string name of the namespace
+        :param separator: the namespace separator string
+        :param rules: the list or tuple of exclude or include rules to strip
+        :return: `None` if `rules=None` or the list of stripped rules
+        """
+        if rules is None:
+            return rules
+
+        stripped = []
+
+        prefix = f'{namespace}{separator}'
+
+        for rule in rules:
+            if rule.startswith(prefix):
+                stripped.append(rule[len(prefix) :])
+
+        return stripped
+
+
+def breadcrumbs_to_port(breadcrumbs: Sequence[str]) -> str:
+    """Convert breadcrumbs to a string representing the port
+
+    :param breadcrumbs: a tuple of the path to the port
+    :return: the port string
+
+    """
+    return PortNamespace.NAMESPACE_SEPARATOR.join(breadcrumbs)

--- a/src/aiida/engine/processes/generic/process.py
+++ b/src/aiida/engine/processes/generic/process.py
@@ -653,16 +653,16 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         self._setup_event_hooks()
 
-        # Runtime variables, set initial states
-        self._future = persistence.SavableFuture()
-        self._event_helper = EventHelper(ProcessListener)
-        self._logger = None
-        self._communicator = None
-
         if 'loop' in load_context:
             self._loop = load_context.loop
         else:
             self._loop = events.get_or_create_event_loop()
+
+        # Runtime variables, set initial states
+        self._future = persistence.SavableFuture(loop=self._loop)
+        self._event_helper = EventHelper(ProcessListener)
+        self._logger = None
+        self._communicator = None
 
         self._state: process_states.State = self.recreate_state(saved_state['_state'])
 
@@ -842,7 +842,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         self._pausing = None
 
         # Create a future to represent the duration of the paused state
-        self._paused = persistence.SavableFuture()
+        self._paused = persistence.SavableFuture(loop=self._loop)
 
         # Save the current status and potentially overwrite it with the passed message
         self._pre_paused_status = self.status

--- a/src/aiida/engine/processes/generic/process.py
+++ b/src/aiida/engine/processes/generic/process.py
@@ -118,7 +118,7 @@ def ensure_not_closed(func: Callable[..., Any]) -> Callable[..., Any]:
 )
 class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMeta):
     """
-    The Process class is the base for any unit of work in plumpy.
+    The Process class is the base for any unit of work in the process engine.
 
     A process can be in one of the following states:
 

--- a/src/aiida/engine/processes/generic/process.py
+++ b/src/aiida/engine/processes/generic/process.py
@@ -1029,35 +1029,16 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
             with kiwipy.capture_exceptions(kiwi_future):
                 try:
                     result = await run_with_portal(callback, *args, **kwargs)
-                except Exception as exc:
-                    import inspect
-                    import traceback
+                except Exception:
+                    self.logger.exception(
+                        "Process<%s>: error invoking callback '%s'", self.pid, getattr(callback, '__name__', callback)
+                    )
+                    raise
 
-                    # Get traceback as a string
-                    tb_str = ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+                while asyncio.isfuture(result):
+                    result = await result
 
-                    # Attempt to get file and line number where the callback is defined
-                    # Note: This might fail for certain built-in or dynamically generated functions.
-                    # If it fails, just skip that part.
-                    try:
-                        source_file = inspect.getfile(callback)
-                        # getsourcelines returns a tuple (list_of_source_lines, starting_line_number)
-                        _, start_line = inspect.getsourcelines(callback)
-                        callback_location = f'{source_file}:{start_line}'
-                    except Exception:
-                        callback_location = '<unknown location>'
-
-                    # Include the callback name, file/line info, and the full traceback in the message
-                    raise RuntimeError(
-                        f"Error invoking callback '{callback.__name__}' at {callback_location}.\n"
-                        f'Exception: {type(exc).__name__}: {exc}\n\n'
-                        f'Full Traceback:\n{tb_str}'
-                    ) from exc
-                else:
-                    while asyncio.isfuture(result):
-                        result = await result
-
-                    kiwi_future.set_result(result)
+                kiwi_future.set_result(result)
 
         # Schedule the task and give back a kiwi future
         asyncio.run_coroutine_threadsafe(run_callback(), self.loop)

--- a/src/aiida/engine/processes/generic/process.py
+++ b/src/aiida/engine/processes/generic/process.py
@@ -1150,7 +1150,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         """
         if isinstance(exception, process_states.PauseInterruption):
             do_pause = functools.partial(self._do_pause, exception.msg)
-            return futures.CancellableAction(do_pause, cookie=exception)
+            return futures.CancellableAction(do_pause, cookie=exception, loop=self.loop)
 
         if isinstance(exception, process_states.KillInterruption):
 
@@ -1162,7 +1162,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
                 finally:
                     self._killing = None
 
-            return futures.CancellableAction(do_kill, cookie=exception)
+            return futures.CancellableAction(do_kill, cookie=exception, loop=self.loop)
 
         raise ValueError(f"Got unknown interruption type '{type(exception)}'")
 

--- a/src/aiida/engine/processes/generic/process.py
+++ b/src/aiida/engine/processes/generic/process.py
@@ -317,6 +317,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         self._event_helper = EventHelper(ProcessListener)
         self._logger = logger
         self._communicator = communicator
+        self._tasks: set[asyncio.Task[Any]] = set()
 
     @super_check
     def init(self) -> None:
@@ -463,7 +464,9 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
             loop=self.loop,
             communicator=self._communicator,
         )
-        self.loop.create_task(process.step_until_terminated())
+        task = self.loop.create_task(process.step_until_terminated())
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
         return process
 
     # region State introspection methods
@@ -562,7 +565,9 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         """
         args = (callback,) + args
         handle = events.ProcessCallback(self, self._run_task, args, kwargs)
-        self.loop.create_task(handle.run())
+        task = self.loop.create_task(handle.run())
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
         return handle
 
     def callback_excepted(
@@ -663,6 +668,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         self._event_helper = EventHelper(ProcessListener)
         self._logger = None
         self._communicator = None
+        self._tasks = set()
 
         self._state: process_states.State = self.recreate_state(saved_state['_state'])
 

--- a/src/aiida/engine/processes/generic/process.py
+++ b/src/aiida/engine/processes/generic/process.py
@@ -1,0 +1,1484 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""The main Process module"""
+
+import abc
+import asyncio
+import contextlib
+import copy
+import enum
+import functools
+import logging
+import re
+import sys
+import time
+import uuid
+import warnings
+from collections.abc import Awaitable, Callable, Generator, Hashable, Sequence
+from contextvars import ContextVar
+from types import TracebackType
+from typing import (
+    Any,
+    Optional,
+    TypeVar,
+    cast,
+)
+
+import kiwipy
+import yaml
+from aio_pika.exceptions import ChannelInvalidStateError, ConnectionClosed
+
+from aiida.common.extendeddicts import AttributesFrozendict
+from aiida.common.lang import call_with_super_check, super_check
+from aiida.common.lang import protected as protected_decorator
+from aiida.common.processes import ProcessState
+from aiida.engine.processes import communications as process_comms
+from aiida.engine.processes import events, exceptions, persistence, state_machine
+from aiida.engine.processes import states as process_states
+from aiida.engine.processes.communications import FORCE_KILL_KEY, MESSAGE_TEXT_KEY, MessageBuilder, MessageType
+from aiida.engine.processes.event_helper import EventHelper
+from aiida.engine.processes.generic import futures, ports
+from aiida.engine.processes.generic.spec import ProcessSpec
+from aiida.engine.processes.greenback import run_until_complete, run_with_portal
+from aiida.engine.processes.listener import ProcessListener
+from aiida.engine.processes.persistence import PID_TYPE, SAVED_STATE_TYPE
+from aiida.engine.processes.settings import check_protected
+from aiida.engine.processes.state_machine import StateEntryFailed, StateMachine, event
+from aiida.engine.utils import ensure_coroutine
+
+protected = protected_decorator(check=check_protected)
+
+T = TypeVar('T')
+
+__all__: tuple[str, ...] = ()
+
+_LOGGER = logging.getLogger(__name__)
+PROCESS_STACK: ContextVar[list['Process']] = ContextVar('process stack', default=[])
+
+
+class BundleKeys:
+    """
+    String keys used by the process to save its state in the state bundle.
+
+    See :meth:`aiida.engine.processes.generic.process.Process.save_instance_state` and
+    :meth:`aiida.engine.processes.generic.process.Process.load_instance_state`.
+
+    """
+
+    INPUTS_RAW = 'INPUTS_RAW'
+    INPUTS_PARSED = 'INPUTS_PARSED'
+    OUTPUTS = 'OUTPUTS'
+
+
+class ProcessStateMachineMeta(abc.ABCMeta, state_machine.StateMachineMeta):
+    pass
+
+
+# Make ProcessStateMachineMeta instances (classes) YAML - able
+yaml.representer.Representer.add_representer(
+    ProcessStateMachineMeta,
+    yaml.representer.Representer.represent_name,  # type: ignore[arg-type]
+)
+
+
+def ensure_not_closed(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator to check that the process is not closed before running the method."""
+
+    @functools.wraps(func)
+    def func_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if self._closed:
+            raise exceptions.ClosedError('Process is closed')
+        return func(self, *args, **kwargs)
+
+    return func_wrapper
+
+
+@persistence.auto_persist(
+    '_pid',
+    '_creation_time',
+    '_future',
+    '_paused',
+    '_status',
+    '_pre_paused_status',
+    '_event_helper',
+)
+class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMeta):
+    """
+    The Process class is the base for any unit of work in plumpy.
+
+    A process can be in one of the following states:
+
+    * CREATED
+    * RUNNING
+    * WAITING
+    * FINISHED
+    * EXCEPTED
+    * KILLED
+
+    as defined in the :class:`~aiida.engine.processes.states.ProcessState` enum.
+
+    ::
+
+                          ___
+                         |   v
+        CREATED (x) --- RUNNING (x) --- FINISHED (o)
+                         |   ^          /
+                         v   |         /
+                        WAITING (x) --
+                         |   ^
+                          ---
+
+        * -- EXCEPTED (o)
+        * -- KILLED (o)
+
+    * (o): terminal state
+    * (x): non terminal state
+
+    When a Process enters a state is always gets a corresponding message, e.g.
+    on entering RUNNING it will receive the on_run message. These are
+    always called immediately after that state is entered but before being
+    executed.
+    """
+
+    # Static class stuff ######################
+    _spec_class = ProcessSpec
+    # Default placeholders, will be populated in init()
+    _stepping = False
+    _pausing: futures.CancellableAction | None = None
+    _paused: persistence.SavableFuture | None = None
+    _killing: futures.CancellableAction | None = None
+    _interrupt_action: futures.CancellableAction | None = None
+    _closed = False
+    _cleanups: list[Callable[[], None]] | None = None
+
+    __called: bool = False
+
+    @classmethod
+    def current(cls) -> Optional['Process']:
+        """
+        Get the currently running process i.e. the one at the top of the stack
+
+        :return: the currently running process
+
+        """
+        if PROCESS_STACK.get():
+            return PROCESS_STACK.get()[-1]
+
+        return None
+
+    @classmethod
+    def get_states(cls) -> Sequence[type[process_states.State]]:
+        """Return all allowed states of the process."""
+        state_classes = cls.get_state_classes()
+        return (
+            state_classes[ProcessState.CREATED],
+            *[state for state in state_classes.values() if state.LABEL != ProcessState.CREATED],
+        )
+
+    @classmethod
+    def get_state_classes(cls) -> dict[Hashable, type[process_states.State]]:
+        # A mapping of the State constants to the corresponding state class
+        return {
+            ProcessState.CREATED: process_states.Created,
+            ProcessState.RUNNING: process_states.Running,
+            ProcessState.WAITING: process_states.Waiting,
+            ProcessState.FINISHED: process_states.Finished,
+            ProcessState.EXCEPTED: process_states.Excepted,
+            ProcessState.KILLED: process_states.Killed,
+        }
+
+    @classmethod
+    def spec(cls) -> ProcessSpec:
+        try:
+            return cls.__getattribute__(cls, '_spec')
+        except AttributeError:
+            try:
+                cls._spec: ProcessSpec = cls._spec_class()  # type: ignore[attr-defined, misc]
+                cls.__called: bool = False  # type: ignore[misc]
+                cls.define(cls._spec)  # type: ignore[attr-defined]
+                assert cls.__called, (
+                    f'Process.define() was not called by {cls}\nHint: Did you forget to call the superclass method in '
+                    'your define? Try: super().define(spec)'
+                )
+                return cls._spec  # type: ignore[attr-defined]
+            except Exception:
+                del cls._spec  # type: ignore[attr-defined]
+                cls.__called = False
+                raise
+
+    @classmethod
+    def get_name(cls) -> str:
+        """Return the process class name."""
+        return cls.__name__
+
+    @classmethod
+    def define(cls, _spec: ProcessSpec) -> None:
+        """Define the specification of the process.
+
+        Normally should be overridden by subclasses.
+        """
+        cls.__called = True
+
+    @classmethod
+    def get_description(cls) -> dict[str, Any]:
+        """
+        Get a human readable description of what this :class:`Process` does.
+
+        :return: The description.
+
+        """
+        description: dict[str, Any] = {}
+
+        if cls.__doc__:
+            description['description'] = cls.__doc__.strip()
+
+        spec_description = cls.spec().get_description()
+        if spec_description:
+            description['spec'] = spec_description
+
+        return description
+
+    @classmethod
+    def recreate_from(
+        cls,
+        saved_state: SAVED_STATE_TYPE,
+        load_context: persistence.LoadSaveContext | None = None,
+    ) -> 'Process':
+        """
+        Recreate a process from a saved state, passing any positional and
+        keyword arguments on to load_instance_state
+
+        :param saved_state: The saved state to load from
+        :param load_context: The load context to use
+        :return: An instance of the object with its state loaded from the save state.
+
+        """
+        process = cast(Process, super().recreate_from(saved_state, load_context))
+        call_with_super_check(process.init)
+        return process
+
+    def __init__(
+        self,
+        inputs: dict | None = None,
+        pid: PID_TYPE | None = None,
+        logger: logging.Logger | None = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        communicator: kiwipy.Communicator | None = None,
+    ) -> None:
+        """
+        The signature of the constructor should not be changed by subclassing processes.
+
+        :param inputs: A dictionary of the process inputs
+        :param pid: The process ID, can be manually set, if not a unique pid will be chosen
+        :param logger: An optional logger for the process to use
+        :param loop: The event loop
+        :param communicator: The (optional) communicator
+
+        """
+        super().__init__()
+
+        # Don't allow the spec to be changed anymore
+        self.spec().seal()
+
+        self._loop = loop if loop is not None else events.get_or_create_event_loop()
+
+        self._setup_event_hooks()
+
+        self._status: str | None = None  # May hold a current status message
+        self._pre_paused_status: str | None = (
+            None  # Save status when a pause message replaces it, such that it can be restored
+        )
+        self._paused = None
+
+        # Input/output
+        self._raw_inputs = None if inputs is None else AttributesFrozendict(inputs)
+        self._pid = pid
+        self._parsed_inputs: AttributesFrozendict | None = None
+        self._outputs: dict[str, Any] = {}
+        self._uuid: uuid.UUID | None = None
+        self._creation_time: float | None = None
+
+        # Runtime variables
+        self._future = persistence.SavableFuture(loop=self._loop)
+        self._event_helper = EventHelper(ProcessListener)
+        self._logger = logger
+        self._communicator = communicator
+
+    @super_check
+    def init(self) -> None:
+        """Common initialisation logic, after create or load, goes here.
+
+        This method is called in :class:`aiida.engine.processes.state_machine.StateMachineMeta`
+        """
+        self._cleanups = []  # a list of functions to be ran on terminated
+
+        if self._communicator is not None:
+            try:
+                identifier = self._communicator.add_rpc_subscriber(self.message_receive, identifier=str(self.pid))
+                self.add_cleanup(functools.partial(self._communicator.remove_rpc_subscriber, identifier))
+            except kiwipy.TimeoutError:
+                self.logger.exception('Process<%s>: failed to register as an RPC subscriber', self.pid)
+
+            try:
+                # filter out state change broadcasts
+                subscriber = kiwipy.BroadcastFilter(self.broadcast_receive, subject=re.compile(r'^(?!state_changed).*'))
+                identifier = self._communicator.add_broadcast_subscriber(subscriber, identifier=str(self.pid))
+                self.add_cleanup(functools.partial(self._communicator.remove_broadcast_subscriber, identifier))
+            except kiwipy.TimeoutError:
+                self.logger.exception(
+                    'Process<%s>: failed to register as a broadcast subscriber',
+                    self.pid,
+                )
+
+        if not self._future.done():
+
+            def try_killing(future: futures.Future) -> None:
+                if future.cancelled():
+                    if not self.kill('Killed by future being cancelled'):
+                        self.logger.warning(
+                            'Process<%s>: Failed to kill process on future cancel',
+                            self.pid,
+                        )
+
+            self._future.add_done_callback(try_killing)
+
+    def _setup_event_hooks(self) -> None:
+        """Set the event hooks to process, when it is created or loaded(recreated)."""
+        event_hooks = {
+            state_machine.StateEventHook.ENTERING_STATE: lambda _s, _h, state: self.on_entering(
+                cast(process_states.State, state)
+            ),
+            state_machine.StateEventHook.ENTERED_STATE: lambda _s, _h, from_state: self.on_entered(
+                cast(process_states.State | None, from_state)
+            ),
+            state_machine.StateEventHook.EXITING_STATE: lambda _s, _h, _state: self.on_exiting(),
+        }
+        for hook, callback in event_hooks.items():
+            self.add_state_event_callback(hook, callback)
+
+    @property
+    def creation_time(self) -> float | None:
+        """
+        The creation time of this Process as returned by time.time() when instantiated
+        :return: The creation time
+        """
+        return self._creation_time
+
+    @property
+    def pid(self) -> PID_TYPE | None:
+        """Return the pid of the process."""
+        return self._pid
+
+    @property
+    def uuid(self) -> uuid.UUID | None:
+        """Return the UUID of the process"""
+        return self._uuid
+
+    @property
+    def raw_inputs(self) -> AttributesFrozendict | None:
+        """The `AttributesFrozendict` of inputs (if not None)."""
+        return self._raw_inputs
+
+    @property
+    def inputs(self) -> AttributesFrozendict | None:
+        """Return the parsed inputs."""
+        return self._parsed_inputs
+
+    @property
+    def outputs(self) -> dict[str, Any]:
+        """
+        Get the current outputs emitted by the Process.  These may grow over
+        time as the process runs.
+
+        :return: A mapping of {output_port: value} outputs
+
+        """
+        return self._outputs
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return the logger for this class.
+
+        If not set, return the default logger.
+
+        :return: The logger.
+
+        """
+        if self._logger is not None:
+            return self._logger
+
+        return _LOGGER
+
+    @property
+    def status(self) -> str | None:
+        """Return the status massage of the process."""
+        return self._status
+
+    def set_status(self, status: str | None) -> None:
+        """Set the status message of the process."""
+        self._status = status
+
+    @property
+    def paused(self) -> bool:
+        """Return whether the process was being paused."""
+        return self._paused is not None
+
+    def future(self) -> persistence.SavableFuture:
+        """Return a savable future representing an eventual result of an asynchronous operation.
+
+        The result is set at the terminal state.
+        """
+        return self._future
+
+    @ensure_not_closed
+    def launch(
+        self,
+        process_class: type['Process'],
+        inputs: dict | None = None,
+        pid: PID_TYPE | None = None,
+        logger: logging.Logger | None = None,
+    ) -> 'Process':
+        """Start running the nested process.
+
+        The process is started asynchronously, without blocking other task in the event loop.
+        """
+        process = process_class(
+            inputs=inputs,
+            pid=pid,
+            logger=logger,
+            loop=self.loop,
+            communicator=self._communicator,
+        )
+        self.loop.create_task(process.step_until_terminated())
+        return process
+
+    # region State introspection methods
+
+    def has_terminated(self) -> bool:
+        """Return whether the process was terminated."""
+        return self._state.is_terminal()
+
+    def result(self) -> Any:
+        """
+        Get the result from the process if it is finished.
+        If the process was killed then a KilledError will be raise.
+        If the process has excepted then the failing exception will be raised.
+        If in any other state this will raise an InvalidStateError.
+        :return: The result of the process
+        """
+        if isinstance(self._state, process_states.Finished):
+            return self._state.result
+        if isinstance(self._state, process_states.Killed):
+            raise exceptions.KilledError(self._state.msg)
+        if isinstance(self._state, process_states.Excepted):
+            raise (self._state.exception or Exception('process excepted'))
+
+        raise exceptions.InvalidStateError
+
+    def successful(self) -> bool:
+        """
+        Returns whether the result of the process is considered successful
+        Will raise if the process is not in the FINISHED state
+        """
+        try:
+            return self._state.successful  # type: ignore[attr-defined]
+        except AttributeError as exception:
+            raise exceptions.InvalidStateError('process is not in the finished state') from exception
+
+    @property
+    def is_successful(self) -> bool:
+        """Return whether the result of the process is considered successful.
+
+        :return: boolean, True if the process is in `Finished` state with `successful` attribute set to `True`
+        """
+        try:
+            return self._state.successful  # type: ignore[attr-defined]
+        except AttributeError:
+            return False
+
+    def killed(self) -> bool:
+        """Return whether the process is killed."""
+        return self.state == ProcessState.KILLED
+
+    def killed_msg(self) -> MessageType | None:
+        """Return the killed message."""
+        if isinstance(self._state, process_states.Killed):
+            return self._state.msg
+
+        raise exceptions.InvalidStateError('Has not been killed')
+
+    def exception(self) -> BaseException | None:
+        """Return exception, if the process is terminated in excepted state."""
+        if isinstance(self._state, process_states.Excepted):
+            return self._state.exception
+
+        return None
+
+    @property
+    def is_excepted(self) -> bool:
+        """Return whether the process excepted.
+
+        :return: boolean, True if the process is in ``EXCEPTED`` state.
+        """
+        return self.state == ProcessState.EXCEPTED
+
+    def done(self) -> bool:
+        """Return True if the call was successfully killed or finished running.
+
+        .. deprecated:: 0.18.6
+            Use the `has_terminated` method instead
+        """
+        warnings.warn('method is deprecated, use `has_terminated` instead', DeprecationWarning)
+        return self._state.is_terminal()
+
+    # endregion
+
+    # region loop methods
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """Return the event loop of the process."""
+        return self._loop
+
+    def call_soon(self, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> events.ProcessCallback:
+        """
+        Schedule a callback to what is considered an internal process function
+        (this needn't be a method).
+        If it raises an exception it will cause the process to fail.
+        """
+        args = (callback,) + args
+        handle = events.ProcessCallback(self, self._run_task, args, kwargs)
+        self.loop.create_task(handle.run())
+        return handle
+
+    def callback_excepted(
+        self,
+        _callback: Callable[..., Any],
+        exception: BaseException | None,
+        trace: TracebackType | None,
+    ) -> None:
+        if self.state != ProcessState.EXCEPTED:
+            self.fail(exception, trace)
+
+    @contextlib.contextmanager
+    def _process_scope(self) -> Generator[None, None, None]:
+        """
+        This context manager function is used to make sure the process stack is correct
+        meaning that globally someone can ask for Process.current() to get the last process
+        that is on the call stack.
+        """
+        stack_copy = PROCESS_STACK.get().copy()
+        stack_copy.append(self)
+        PROCESS_STACK.set(stack_copy)
+        try:
+            yield None
+        finally:
+            assert Process.current() is self, (
+                'Somehow, the process at the top of the stack is not me, but another process! '
+                f'({self} != {Process.current()})'
+            )
+            stack_copy = PROCESS_STACK.get().copy()
+            stack_copy.pop()
+            PROCESS_STACK.set(stack_copy)
+
+    async def _run_task(self, callback: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        """
+        This method should be used to run all Process related functions and coroutines.
+        If there is an exception the process will enter the EXCEPTED state.
+
+        :param callback: A function or coroutine
+        :param args: Optional positional arguments passed to fn
+        :param kwargs:  Optional keyword arguments passed to fn
+        :return: The value as returned by fn
+        """
+        # Make sure execute is a coroutine
+        coro = ensure_coroutine(callback)
+        with self._process_scope():
+            result = await coro(*args, **kwargs)
+        return result
+
+    # endregion
+
+    # region Persistence
+
+    def save_instance_state(
+        self,
+        out_state: SAVED_STATE_TYPE,
+        save_context: persistence.LoadSaveContext,
+    ) -> None:
+        """
+        Ask the process to save its current instance state.
+
+        :param out_state: A bundle to save the state to
+        :param save_context: The save context
+        """
+        super().save_instance_state(out_state, save_context)
+
+        out_state['_state'] = self._state.save()
+
+        # Inputs/outputs
+        if self.raw_inputs is not None:
+            out_state[BundleKeys.INPUTS_RAW] = self.encode_input_args(self.raw_inputs)
+
+        if self.inputs is not None:
+            out_state[BundleKeys.INPUTS_PARSED] = self.encode_input_args(self.inputs)
+
+        if self.outputs:
+            out_state[BundleKeys.OUTPUTS] = self.encode_input_args(self.outputs)
+
+    @protected
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        """Load the process from its saved instance state.
+
+        :param saved_state: A bundle to load the state from
+        :param load_context: The load context
+
+        """
+        # First make sure the state machine constructor is called
+        super().__init__()
+
+        self._setup_event_hooks()
+
+        # Runtime variables, set initial states
+        self._future = persistence.SavableFuture()
+        self._event_helper = EventHelper(ProcessListener)
+        self._logger = None
+        self._communicator = None
+
+        if 'loop' in load_context:
+            self._loop = load_context.loop
+        else:
+            self._loop = events.get_or_create_event_loop()
+
+        self._state: process_states.State = self.recreate_state(saved_state['_state'])
+
+        if 'communicator' in load_context:
+            self._communicator = load_context.communicator
+
+        if 'logger' in load_context:
+            self._logger = load_context.logger
+
+        # Need to call this here as things downstream may rely on us having the runtime variable above
+        super().load_instance_state(saved_state, load_context)
+
+        # Inputs/outputs
+        try:
+            decoded = self.decode_input_args(saved_state[BundleKeys.INPUTS_RAW])
+            self._raw_inputs = AttributesFrozendict(decoded)
+        except KeyError:
+            self._raw_inputs = None
+
+        try:
+            decoded = self.decode_input_args(saved_state[BundleKeys.INPUTS_PARSED])
+            self._parsed_inputs = AttributesFrozendict(decoded)
+        except KeyError:
+            self._parsed_inputs = None
+
+        try:
+            decoded = self.decode_input_args(saved_state[BundleKeys.OUTPUTS])
+            self._outputs = decoded
+        except KeyError:
+            self._outputs = {}
+
+    # endregion
+
+    def add_process_listener(self, listener: ProcessListener) -> None:
+        """Add a process listener to the process.
+
+        The listener defines the actions to take when the process is triggering
+        the specific state condition.
+
+        """
+        assert listener != self, 'Cannot listen to yourself!'  # type: ignore[comparison-overlap]
+        self._event_helper.add_listener(listener)
+
+    def remove_process_listener(self, listener: ProcessListener) -> None:
+        """Remove a process listener from the process."""
+        self._event_helper.remove_listener(listener)
+
+    @protected
+    def set_logger(self, logger: logging.Logger) -> None:
+        """Set the logger of the process."""
+        self._logger = logger
+
+    @protected
+    def log_with_pid(self, level: int, msg: str) -> None:
+        """Log the message with the process pid."""
+        self.logger.log(level, '%s: %s', self.pid, msg)
+
+    # region Events
+
+    def on_entering(self, state: process_states.State) -> None:
+        # Map these onto direct functions that the subclass can implement
+        state_label = state.LABEL
+        if state_label == ProcessState.CREATED:
+            call_with_super_check(self.on_create)
+        elif state_label == ProcessState.RUNNING:
+            call_with_super_check(self.on_run)
+        elif state_label == ProcessState.WAITING:
+            call_with_super_check(self.on_wait, state.data)  # type: ignore[attr-defined]
+        elif state_label == ProcessState.FINISHED:
+            call_with_super_check(self.on_finish, state.result, state.successful)  # type: ignore[attr-defined]
+        elif state_label == ProcessState.KILLED:
+            call_with_super_check(self.on_kill, state.msg)  # type: ignore[attr-defined]
+        elif state_label == ProcessState.EXCEPTED:
+            call_with_super_check(self.on_except, state.get_exc_info())  # type: ignore[attr-defined]
+
+    def on_entered(self, from_state: process_states.State | None) -> None:
+        # Map these onto direct functions that the subclass can implement
+        state_label = self._state.LABEL
+        if state_label == ProcessState.RUNNING:
+            call_with_super_check(self.on_running)
+        elif state_label == ProcessState.WAITING:
+            call_with_super_check(self.on_waiting)
+        elif state_label == ProcessState.FINISHED:
+            call_with_super_check(self.on_finished)
+        elif state_label == ProcessState.EXCEPTED:
+            call_with_super_check(self.on_excepted)
+        elif state_label == ProcessState.KILLED:
+            call_with_super_check(self.on_killed)
+
+        if self._communicator and isinstance(self.state, enum.Enum):
+            from_label = cast(enum.Enum, from_state.LABEL).value if from_state is not None else None
+            subject = f'state_changed.{from_label}.{self.state.value}'
+            self.logger.info('Process<%s>: Broadcasting state change: %s', self.pid, subject)
+            try:
+                self._communicator.broadcast_send(body=None, sender=self.pid, subject=subject)
+            except (ConnectionClosed, ChannelInvalidStateError):
+                message = 'Process<%s>: no connection available to broadcast state change from %s to %s'
+                self.logger.warning(message, self.pid, from_label, self.state.value)
+            except kiwipy.TimeoutError:
+                message = 'Process<%s>: sending broadcast of state change from %s to %s timed out'
+                self.logger.warning(message, self.pid, from_label, self.state.value)
+
+    def on_exiting(self) -> None:
+        state = self.state
+        if state == ProcessState.WAITING:
+            call_with_super_check(self.on_exit_waiting)
+        elif state == ProcessState.RUNNING:
+            call_with_super_check(self.on_exit_running)
+
+    @super_check
+    def on_create(self) -> None:
+        """Entering the CREATED state."""
+        self._creation_time = time.time()
+
+        def recursively_copy_dictionaries(value: Any) -> Any:
+            """Recursively copy the mapping but only create copies of the dictionaries not the values."""
+            if isinstance(value, dict):
+                return {key: recursively_copy_dictionaries(subvalue) for key, subvalue in value.items()}
+            return value
+
+        # This will parse the inputs with respect to the input portnamespace of the spec and validate them. The
+        # ``pre_process`` method of the inputs port namespace modifies its argument in place, and since the
+        # ``_raw_inputs`` should not be modified, we pass a clone of it. Note that we only need a clone of the nested
+        # dictionaries, so we don't use ``copy.deepcopy`` (which might seem like the obvious choice) as that will also
+        # create a clone of the values, which we don't want.
+        raw_inputs = recursively_copy_dictionaries(dict(self._raw_inputs)) if self._raw_inputs else {}
+        self._parsed_inputs = self.spec().inputs.pre_process(raw_inputs)
+        result = self.spec().inputs.validate(self._parsed_inputs)
+
+        if result is not None:
+            raise ValueError(result)
+
+        # Set up a process ID
+        self._uuid = uuid.uuid4()
+        if self._pid is None:
+            self._pid = self._uuid
+
+    @super_check
+    def on_exit_running(self) -> None:
+        """Exiting the RUNNING state."""
+
+    @super_check
+    def on_exit_waiting(self) -> None:
+        """Exiting the WAITING state."""
+
+    @super_check
+    def on_run(self) -> None:
+        """Entering the RUNNING state."""
+
+    @super_check
+    def on_running(self) -> None:
+        """Entered the RUNNING state."""
+        self._fire_event(ProcessListener.on_process_running)
+
+    def on_output_emitting(self, output_port: str, value: Any) -> None:
+        """Output is about to be emitted."""
+
+    def on_output_emitted(self, output_port: str, value: Any, dynamic: bool) -> None:
+        self._event_helper.fire_event(ProcessListener.on_output_emitted, self, output_port, value, dynamic)
+
+    @super_check
+    def on_wait(self, awaitables: Sequence[Awaitable]) -> None:
+        """Entering the WAITING state."""
+
+    @super_check
+    def on_waiting(self) -> None:
+        """Entered the WAITING state."""
+        self._fire_event(ProcessListener.on_process_waiting)
+
+    @super_check
+    def on_pausing(self, msg: str | None = None) -> None:
+        """The process is being paused."""
+
+    @super_check
+    def on_paused(self, msg: str | None = None) -> None:
+        """The process was paused."""
+        self._pausing = None
+
+        # Create a future to represent the duration of the paused state
+        self._paused = persistence.SavableFuture()
+
+        # Save the current status and potentially overwrite it with the passed message
+        self._pre_paused_status = self.status
+        if msg is not None:
+            self.set_status(msg)
+
+        self._fire_event(ProcessListener.on_process_paused)
+
+    @super_check
+    def on_playing(self) -> None:
+        """The process was played."""
+        # Done being paused
+        if self._paused is not None:
+            self._paused.set_result(True)
+        self._paused = None
+
+        self.set_status(self._pre_paused_status)
+        self._pre_paused_status = None
+
+        self._fire_event(ProcessListener.on_process_played)
+
+    @super_check
+    def on_finish(self, result: Any, successful: bool) -> None:
+        """Entering the FINISHED state."""
+        if successful:
+            validation_error = self.spec().outputs.validate(self.outputs)
+            if validation_error:
+                state_cls = self.get_states_map()[ProcessState.FINISHED]
+                finished_state = state_cls(self, result=result, successful=False)
+                raise StateEntryFailed(finished_state)
+
+        self.future().set_result(self.outputs)
+
+    @super_check
+    def on_finished(self) -> None:
+        """Entered the FINISHED state."""
+        self._fire_event(ProcessListener.on_process_finished, self.future().result())
+
+    @super_check
+    def on_except(self, exc_info: tuple[Any, Exception, TracebackType]) -> None:
+        """Entering the EXCEPTED state."""
+        exception = exc_info[1]
+        exception.__traceback__ = exc_info[2]
+
+        # It is possible that we already got into a finished state and the future result was set, in which case, we
+        # should reset it before setting the exception or else ``asyncio`` will raise an exception.
+        future = self.future()
+
+        if future.done():
+            self._future = persistence.SavableFuture(loop=self._loop)
+        self.future().set_exception(exception)
+
+    @super_check
+    def on_excepted(self) -> None:
+        """Entered the EXCEPTED state."""
+        self._fire_event(ProcessListener.on_process_excepted, str(self.future().exception()))
+
+    @super_check
+    def on_kill(self, msg: MessageType | None) -> None:
+        """Entering the KILLED state."""
+        if msg is None:
+            msg_txt = ''
+        else:
+            msg_txt = msg[MESSAGE_TEXT_KEY] or ''
+
+        self.set_status(msg_txt)
+        self.future().set_exception(exceptions.KilledError(msg_txt))
+
+    @super_check
+    def on_killed(self) -> None:
+        """Entered the KILLED state."""
+        self._killing = None
+        self.future().exception()  # exception must be retrieved
+        self._fire_event(ProcessListener.on_process_killed, self.killed_msg())
+
+    def on_terminated(self) -> None:
+        """Call when a terminal state is reached."""
+        super().on_terminated()
+        self.close()
+
+    @super_check
+    def on_close(self) -> None:
+        """
+        Called when the Process is being closed an will not be ran anymore.  This is an opportunity
+        to free any runtime resources
+        """
+        try:
+            for cleanup in self._cleanups or []:
+                try:
+                    cleanup()
+                except Exception:
+                    self.logger.exception('Process<%s>: Exception calling cleanup method %s', self.pid, cleanup)
+            self._cleanups = None
+        finally:
+            self._event_callbacks = {}
+            self._closed = True
+
+    def _fire_event(self, evt: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        self._event_helper.fire_event(evt, self, *args, **kwargs)
+
+    # endregion
+
+    # region Communication
+
+    def message_receive(self, _comm: kiwipy.Communicator, msg: MessageType) -> Any:
+        """
+        Coroutine called when the process receives a message from the communicator
+
+        :param _comm: the communicator that sent the message
+        :param msg: the message
+        :return: the outcome of processing the message, the return value will be sent back as a response to the sender
+        """
+        self.logger.debug(
+            "Process<%s>: received RPC message with communicator '%s': %r",
+            self.pid,
+            _comm,
+            msg,
+        )
+
+        intent = msg[process_comms.INTENT_KEY]
+
+        if intent == process_comms.Intent.PLAY:
+            return self._schedule_rpc(self.play)
+        if intent == process_comms.Intent.PAUSE:
+            return self._schedule_rpc(self.pause, msg_text=msg.get(process_comms.MESSAGE_TEXT_KEY, None))
+        if intent == process_comms.Intent.KILL:
+            default_message = MessageBuilder.kill()
+            text = msg.get(process_comms.MESSAGE_TEXT_KEY, default_message.get(MESSAGE_TEXT_KEY))
+            force_kill = msg.get(process_comms.FORCE_KILL_KEY, default_message.get(FORCE_KILL_KEY))
+            return self._schedule_rpc(self.kill, msg_text=text, force_kill=force_kill)
+        if intent == process_comms.Intent.STATUS:
+            status_info: dict[str, Any] = {}
+            self.get_status_info(status_info)
+            return status_info
+
+        # Didn't match any known intents
+        raise RuntimeError('Unknown intent')
+
+    def broadcast_receive(
+        self, _comm: kiwipy.Communicator, msg: MessageType, sender: Any, subject: Any, correlation_id: Any
+    ) -> kiwipy.Future | None:
+        """
+        Coroutine called when the process receives a message from the communicator
+
+        :param _comm: the communicator that sent the message
+        :param msg: the message
+        """
+
+        self.logger.debug(
+            "Process<%s>: received broadcast message '%s' with communicator '%s': %r",
+            self.pid,
+            subject,
+            _comm,
+            msg,
+        )
+
+        # If we get a message we recognise then action it, otherwise ignore
+        if subject == process_comms.Intent.PLAY:
+            return self._schedule_rpc(self.play)
+        if subject == process_comms.Intent.PAUSE:
+            return self._schedule_rpc(self.pause, msg_text=msg.get(process_comms.MESSAGE_TEXT_KEY, None))
+        if subject == process_comms.Intent.KILL:
+            return self._schedule_rpc(self.kill, msg_text=msg.get(process_comms.MESSAGE_TEXT_KEY, None))
+        return None
+
+    def _schedule_rpc(self, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> kiwipy.Future:
+        """
+        Schedule a call to a callback as a result of an RPC communication call, this will return
+        a future that resolves to the final result (even after one or more layer of futures being
+        returned) of the callback.
+
+        The callback will be scheduled at the working
+        thread where the process event loop runs.
+
+        :param callback: the callback function or coroutine
+        :param args: the positional arguments to the callback
+        :param kwargs: the keyword arguments to the callback
+        :return: a kiwi future that resolves to the outcome of the callback
+
+        """
+        kiwi_future = kiwipy.Future()
+
+        async def run_callback() -> None:
+            with kiwipy.capture_exceptions(kiwi_future):
+                try:
+                    result = await run_with_portal(callback, *args, **kwargs)
+                except Exception as exc:
+                    import inspect
+                    import traceback
+
+                    # Get traceback as a string
+                    tb_str = ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+                    # Attempt to get file and line number where the callback is defined
+                    # Note: This might fail for certain built-in or dynamically generated functions.
+                    # If it fails, just skip that part.
+                    try:
+                        source_file = inspect.getfile(callback)
+                        # getsourcelines returns a tuple (list_of_source_lines, starting_line_number)
+                        _, start_line = inspect.getsourcelines(callback)
+                        callback_location = f'{source_file}:{start_line}'
+                    except Exception:
+                        callback_location = '<unknown location>'
+
+                    # Include the callback name, file/line info, and the full traceback in the message
+                    raise RuntimeError(
+                        f"Error invoking callback '{callback.__name__}' at {callback_location}.\n"
+                        f'Exception: {type(exc).__name__}: {exc}\n\n'
+                        f'Full Traceback:\n{tb_str}'
+                    ) from exc
+                else:
+                    while asyncio.isfuture(result):
+                        result = await result
+
+                    kiwi_future.set_result(result)
+
+        # Schedule the task and give back a kiwi future
+        asyncio.run_coroutine_threadsafe(run_callback(), self.loop)
+
+        return kiwi_future
+
+    # endregion
+
+    @ensure_not_closed
+    def add_cleanup(self, cleanup: Callable[[], None]) -> None:
+        """Add callback, which will be run when the process is being closed."""
+        assert self._cleanups is not None
+        self._cleanups.append(cleanup)
+
+    def close(self) -> None:
+        """
+        Calling this method indicates that this process should not ran anymore and will trigger
+        any runtime resources (such as the communicator connection) to be cleaned up.  The state
+        of the process will still be accessible.
+
+        It is safe to call this method multiple times.
+        """
+        if self._closed:
+            return
+
+        call_with_super_check(self.on_close)
+
+    # region State related methods
+
+    def transition_failed(
+        self,
+        initial_state: Hashable,
+        final_state: Hashable,
+        exception: Exception,
+        trace: TracebackType,
+    ) -> None:
+        # If we are creating, then reraise instead of failing.
+        if final_state == ProcessState.CREATED:
+            raise exception.with_traceback(trace)
+
+        new_state = self._create_state_instance(ProcessState.EXCEPTED, exception=exception, trace_back=trace)
+        self.transition_to(new_state)
+
+    def pause(self, msg_text: str | None = None) -> bool | futures.CancellableAction:
+        """Pause the process.
+
+        :param msg: an optional message to set as the status. The current status will be saved in the private
+            `_pre_paused_status attribute`, such that it can be restored when the process is played again.
+
+        :return: False if process is already terminated,
+                 True if already paused or pausing,
+                 a `CancellableAction` to pause if the process was running steps
+        """
+        if self.has_terminated():
+            return False
+
+        if self.paused:
+            # Already paused
+            return True
+
+        if self._pausing is not None:
+            # Already pausing
+            return self._pausing
+
+        if self._stepping:
+            # Ask the step function to pause by setting this flag and giving the
+            # caller back a future
+            interrupt_exception = process_states.PauseInterruption(msg_text)
+            self._set_interrupt_action_from_exception(interrupt_exception)
+            self._pausing = self._interrupt_action
+            # Try to interrupt the state
+            self._state.interrupt(interrupt_exception)
+            return cast(futures.CancellableAction, self._interrupt_action)
+
+        msg = MessageBuilder.pause(msg_text)
+        return self._do_pause(state_msg=msg)
+
+    def _do_pause(self, state_msg: MessageType | None, next_state: process_states.State | None = None) -> bool:
+        """Carry out the pause procedure, optionally transitioning to the next state first"""
+        try:
+            if next_state is not None:
+                self.transition_to(next_state)
+
+            if state_msg is None:
+                msg_text = ''
+            else:
+                msg_text = state_msg[MESSAGE_TEXT_KEY]
+
+            call_with_super_check(self.on_pausing, msg_text)
+            call_with_super_check(self.on_paused, msg_text)
+        finally:
+            self._pausing = None
+
+        return True
+
+    def _create_interrupt_action(self, exception: process_states.Interruption) -> futures.CancellableAction:
+        """
+        Create an interrupt action from the corresponding interrupt exception
+
+        :param exception: The interrupt exception
+        :return: The interrupt action
+
+        """
+        if isinstance(exception, process_states.PauseInterruption):
+            do_pause = functools.partial(self._do_pause, exception.msg)
+            return futures.CancellableAction(do_pause, cookie=exception)
+
+        if isinstance(exception, process_states.KillInterruption):
+
+            def do_kill(_next_state: process_states.State) -> Any:
+                try:
+                    new_state = self._create_state_instance(ProcessState.KILLED, msg=exception.msg)
+                    self.transition_to(new_state)
+                    return True
+                finally:
+                    self._killing = None
+
+            return futures.CancellableAction(do_kill, cookie=exception)
+
+        raise ValueError(f"Got unknown interruption type '{type(exception)}'")
+
+    def _set_interrupt_action(self, new_action: futures.CancellableAction | None) -> None:
+        """
+        Set the interrupt action cancelling the current one if it exists
+        :param new_action: The new interrupt action to set
+        """
+        if self._interrupt_action is not None:
+            self._interrupt_action.cancel()
+        self._interrupt_action = new_action
+
+    def _set_interrupt_action_from_exception(self, interrupt_exception: process_states.Interruption) -> None:
+        """Set an interrupt action from the corresponding interrupt exception"""
+        action = self._create_interrupt_action(interrupt_exception)
+        self._set_interrupt_action(action)
+
+    def play(self) -> bool:
+        """
+        Play a process. Returns True if after this call the process is playing, False otherwise
+
+        :return: True if playing, False otherwise
+        """
+        if not self.paused:
+            if self._pausing is not None:
+                # Not going to pause after all
+                self._pausing.cancel()
+                self._pausing = None
+                self._set_interrupt_action(None)
+            return True
+
+        call_with_super_check(self.on_playing)
+        return True
+
+    @event(from_states=process_states.Waiting)
+    def resume(self, *args: Any) -> None:
+        """Start running the process again."""
+        return self._state.resume(*args)  # type: ignore[attr-defined]
+
+    @event(to_states=process_states.Excepted)
+    def fail(self, exception: BaseException | None, trace_back: TracebackType | None) -> None:
+        """
+        Fail the process in response to an exception
+        :param exception: The exception that caused the failure
+        :param trace_back: Optional exception traceback
+        """
+        new_state = self._create_state_instance(ProcessState.EXCEPTED, exception=exception, trace_back=trace_back)
+        self.transition_to(new_state)
+
+    def kill(self, msg_text: str | None = None, force_kill: bool = False) -> bool | asyncio.Future:
+        """
+        Kill the process
+        :param msg: An optional kill message
+        """
+        if self.state == ProcessState.KILLED:
+            # Already killed
+            return True
+
+        if self.has_terminated():
+            # Can't kill
+            return False
+
+        if self._killing:
+            self._killing.cancel()
+
+        if force_kill:
+            msg = MessageBuilder.kill(msg_text, force_kill=force_kill)
+            new_state = self._create_state_instance(ProcessState.KILLED, msg=msg)
+            self.transition_to(new_state)
+
+            return True
+
+        if self._stepping:
+            # Ask the step function to pause by setting this flag and giving the
+            # caller back a future
+            interrupt_exception = process_states.KillInterruption(msg_text, force_kill)
+            self._set_interrupt_action_from_exception(interrupt_exception)
+            self._killing = self._interrupt_action
+            self._state.interrupt(interrupt_exception)
+            return cast(futures.CancellableAction, self._interrupt_action)
+
+        msg = MessageBuilder.kill(text=msg_text, force_kill=force_kill)
+        new_state = self._create_state_instance(ProcessState.KILLED, msg=msg)
+        self.transition_to(new_state)
+        return True
+
+    @property
+    def is_killing(self) -> bool:
+        """Return if the process is already being killed."""
+        return self._killing is not None
+
+    # endregion
+
+    def create_initial_state(self) -> process_states.State:
+        """This method is here to override its superclass.
+
+        Automatically enter the CREATED state when the process is created.
+
+        :return: A Created state
+        """
+        return cast(
+            process_states.State,
+            self.get_state_class(ProcessState.CREATED)(self, self.run),
+        )
+
+    def recreate_state(self, saved_state: persistence.Bundle) -> process_states.State:
+        """
+        Create a state object from a saved state
+
+        :param saved_state: The saved state
+        :return: An instance of the object with its state loaded from the save state.
+        """
+        load_context = persistence.LoadSaveContext(process=self)
+        return cast(process_states.State, persistence.Savable.load(saved_state, load_context))
+
+    # endregion
+
+    # region Execution related methods
+
+    async def run(self) -> Any:
+        """This function will be run when the process is triggered.
+        It should be overridden by a subclass.
+        """
+
+    @ensure_not_closed
+    def execute(self) -> dict[str, Any] | None:
+        """Execute the process synchronously.
+
+        :return: None if not terminated, otherwise `self.outputs`
+        """
+        if self.has_terminated():
+            return self.future().result()
+
+        run_until_complete(self.loop, self.step_until_terminated())
+
+        return self.future().result()
+
+    @ensure_not_closed
+    async def step(self) -> None:
+        """Run a step.
+
+        The step is run synchronously with steps in its own process,
+        and asynchronously with steps in other processes.
+
+        The execute function running in this method is dependent on the state of the process.
+
+        """
+        assert not self.has_terminated(), 'Cannot step, already terminated'
+
+        if self.paused and self._paused is not None:
+            await self._paused
+
+        try:
+            self._stepping = True
+            next_state = None
+            try:
+                next_state = await self._run_task(self._state.execute)
+            except process_states.Interruption as exception:
+                # If the interruption was caused by a call to a Process method then there should
+                # be an interrupt action ready to be executed, so just check if the cookie matches
+                # that of the exception i.e. if it is the _same_ interruption.  If not cancel and
+                # build the interrupt action below
+                if self._interrupt_action is not None:
+                    if self._interrupt_action.cookie is not exception:
+                        self._set_interrupt_action_from_exception(exception)
+                else:
+                    self._set_interrupt_action_from_exception(exception)
+
+            except KeyboardInterrupt:
+                raise
+            except Exception:
+                # Overwrite the next state to go to excepted directly
+                next_state = self.create_state(ProcessState.EXCEPTED, *sys.exc_info()[1:])
+                self._set_interrupt_action(None)
+
+            if self._interrupt_action and not self._interrupt_action.cancelled():
+                self._interrupt_action.run(next_state)
+            else:
+                # Everything nominal so transition to the next state
+                self.transition_to(next_state)
+
+        finally:
+            self._stepping = False
+            self._set_interrupt_action(None)
+
+    async def step_until_terminated(self) -> None:
+        """If the process has not terminated,
+        run the current step and wait until the step finished.
+
+        This is the function run by the event loop (not ``step``).
+
+        """
+        while not self.has_terminated():
+            await self.step()
+
+    # endregion
+
+    @ensure_not_closed
+    @protected
+    def out(self, output_port: str, value: Any) -> None:
+        """
+        Record an output value for a specific output port. If the output port matches an
+        explicitly defined Port it will be validated against that. If not it will be validated
+        against the PortNamespace, which means it will be checked for dynamicity and whether
+        the type of the value is valid
+
+        Emitting an output never changes the process specification. The specification is built once per process
+        class and shared by all its instances, so a port added here would validate the outputs of every later
+        instance of that class.
+
+        :param output_port: the name of the output port, can be namespaced
+        :param value: the value for the output port
+        :raises: ValueError if the output value is not validated against the port
+        """
+        self.on_output_emitting(output_port, value)
+
+        namespace_separator = self.spec().namespace_separator
+
+        output_path = output_port.split(namespace_separator)
+        port_name = output_path[-1]
+        namespace = output_path[:-1]
+
+        unresolved_path = output_path.copy()
+        port_namespace = self.spec().outputs
+
+        # For output_path == ['sub', 'a', 'b'], where only sub is declared, this leaves
+        # port_namespace as sub and unresolved_path as ['a', 'b'].
+        while len(unresolved_path) > 1:
+            namespace_name = unresolved_path[0]
+
+            if namespace_name not in port_namespace:
+                if not port_namespace.dynamic:
+                    raise ValueError(
+                        f"port '{namespace_name}' does not exist in port namespace '{port_namespace.name}'"
+                    )
+                break
+
+            port = port_namespace[namespace_name]
+            if not isinstance(port, ports.PortNamespace):
+                raise ValueError(
+                    f"port '{namespace_name}' in port namespace '{port_namespace.name}' is not a namespace"
+                )
+
+            port_namespace = port
+            unresolved_path.pop(0)
+
+        port_key = namespace_separator.join(unresolved_path)
+        is_declared_output = port_key in port_namespace
+        if is_declared_output:
+            validation_error = port_namespace[port_key].validate(value)
+            is_dynamic_output = False
+        else:
+            # potentially dynamic output
+            validation_error = port_namespace.validate_dynamic_ports({port_key: value})
+            is_dynamic_output = True
+
+        if validation_error:
+            msg = f"Error validating output '{value}' for port '{validation_error.port}': {validation_error.message}"
+            raise ValueError(msg)
+
+        output_namespace = self._outputs
+        for sub_space in namespace:
+            output_namespace = output_namespace.setdefault(sub_space, {})
+
+        output_namespace[port_name] = value
+        self.on_output_emitted(output_port, value, is_dynamic_output)
+
+    @protected
+    def encode_input_args(self, inputs: Any) -> Any:
+        """
+        Encode input arguments such that they may be saved in a :class:`aiida.engine.processes.persistence.Bundle`.
+        The encoded inputs should contain no reference to the inputs that were passed in.
+        This often will mean making a deepcopy of the input dictionary.
+
+        :param inputs: A mapping of the inputs as passed to the process
+        :return: The encoded inputs
+        """
+        return copy.deepcopy(inputs)
+
+    @protected
+    def decode_input_args(self, encoded: Any) -> Any:
+        """
+        Decode saved input arguments as they came from the saved instance state
+        :class:`aiida.engine.processes.persistence.Bundle`.
+        The decoded inputs should contain no reference to the encoded inputs that were passed in.
+        This often will mean making a deepcopy of the encoded input dictionary.
+
+        :param encoded:
+        :return: The decoded input args
+        """
+        return copy.deepcopy(encoded)
+
+    def get_status_info(self, out_status_info: dict) -> None:
+        """Return updated status information of process.
+
+        :param out_status_info: the old status
+
+        """
+        out_status_info.update(
+            {
+                'ctime': self.creation_time,
+                'paused': self.paused,
+                'process_string': str(self),
+                'state': str(self.state),
+            }
+        )

--- a/src/aiida/engine/processes/generic/spec.py
+++ b/src/aiida/engine/processes/generic/spec.py
@@ -36,7 +36,7 @@ EXPOSED_TYPE = dict[str | None, dict[type['Process'], Sequence[str]]]
 
 class ProcessSpec:
     """
-    A class that defines the specifications of a :class:`plumpy.Process`,
+    A class that defines the specifications of a :class:`aiida.engine.processes.generic.process.Process`,
     this includes what its inputs, outputs, etc are.
 
     All methods to modify the spec should have declarative names describe the

--- a/src/aiida/engine/processes/generic/spec.py
+++ b/src/aiida/engine/processes/generic/spec.py
@@ -301,4 +301,5 @@ class ProcessSpec:
             port_namespace = destination
 
         absorbed_ports = port_namespace.absorb(source, exclude, include, namespace_options)
-        expose_memory[namespace][process_class] = absorbed_ports
+        exposed_ports = expose_memory[namespace][process_class]
+        expose_memory[namespace][process_class] = list(dict.fromkeys((*exposed_ports, *absorbed_ports)))

--- a/src/aiida/engine/processes/generic/spec.py
+++ b/src/aiida/engine/processes/generic/spec.py
@@ -1,0 +1,304 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Generic process specification implementation."""
+
+from __future__ import annotations
+
+import collections
+import json
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+from aiida.engine.processes.generic.ports import InputPort, OutputPort, Port, PortNamespace
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.generic.process import Process
+
+__all__: tuple[str, ...] = ()
+
+EXPOSED_TYPE = dict[str | None, dict[type['Process'], Sequence[str]]]
+
+
+class ProcessSpec:
+    """
+    A class that defines the specifications of a :class:`plumpy.Process`,
+    this includes what its inputs, outputs, etc are.
+
+    All methods to modify the spec should have declarative names describe the
+    spec e.g.: input, output
+
+    Every Process class has one of these.
+    """
+
+    NAME_INPUTS_PORT_NAMESPACE: str = 'inputs'
+    NAME_OUTPUTS_PORT_NAMESPACE: str = 'outputs'
+    PORT_NAMESPACE_TYPE = PortNamespace
+    INPUT_PORT_TYPE = InputPort
+    OUTPUT_PORT_TYPE = OutputPort
+
+    def __init__(self) -> None:
+        self._ports: PortNamespace = self.PORT_NAMESPACE_TYPE()
+        # self._validator = None  # this is never used
+        self._sealed: bool = False
+        self._logger = logging.getLogger(__name__)
+
+        # Create the input and output port namespace
+        self._ports.create_port_namespace(self.NAME_INPUTS_PORT_NAMESPACE)
+        self._ports.create_port_namespace(self.NAME_OUTPUTS_PORT_NAMESPACE)
+        self._exposed_inputs: EXPOSED_TYPE = collections.defaultdict(lambda: collections.defaultdict(list))
+        self._exposed_outputs: EXPOSED_TYPE = collections.defaultdict(lambda: collections.defaultdict(list))
+
+    def __str__(self) -> str:
+        return json.dumps(self.get_description(), sort_keys=True, indent=4)
+
+    @property
+    def namespace_separator(self) -> str:
+        return self.PORT_NAMESPACE_TYPE.NAMESPACE_SEPARATOR
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
+
+    def seal(self) -> None:
+        """
+        Seal this specification disallowing any further changes
+        """
+        self._sealed = True
+
+    @property
+    def sealed(self) -> bool:
+        """
+        Indicates if the spec is sealed or not
+
+        :return: True if sealed, False otherwise
+        :rtype: bool
+        """
+        return self._sealed
+
+    def get_description(self) -> dict[str, Any]:
+        """
+        Get a description of this process specification
+
+        :return: a dictionary with the descriptions of the input and output port namespaces
+        """
+        description = {'inputs': self.inputs.get_description(), 'outputs': self.outputs.get_description()}
+
+        return description
+
+    @property
+    def ports(self) -> PortNamespace:
+        return self._ports
+
+    @property
+    def inputs(self) -> PortNamespace:
+        """
+        Get the input port namespace of the process specification
+
+        :return: the input PortNamespace
+        """
+        return cast(PortNamespace, self._ports[self.NAME_INPUTS_PORT_NAMESPACE])
+
+    @property
+    def outputs(self) -> PortNamespace:
+        """
+        Get the output port namespace of the process specification
+
+        :return: the outputs PortNamespace
+        """
+        return cast(PortNamespace, self._ports[self.NAME_OUTPUTS_PORT_NAMESPACE])
+
+    def _create_port(
+        self, port_namespace: PortNamespace, port_class: type[Port | PortNamespace], name: str, **kwargs: Any
+    ) -> None:
+        """
+        Create a new Port of a given class and name in a given PortNamespace
+
+        :param port_namespace: PortNamespace to which to add the port
+        :param port_class: class of the Port to create
+        :param name: name of the port to create
+        :param kwargs: options for the port
+        """
+        if self.sealed:
+            raise RuntimeError('Cannot add an output port after the spec has been sealed')
+
+        namespace_parts = name.split(self.namespace_separator)
+        port_name = namespace_parts.pop()
+
+        if namespace_parts:
+            namespace = self.namespace_separator.join(namespace_parts)
+            port_namespace = port_namespace.create_port_namespace(namespace)
+
+        port_namespace[port_name] = port_class(port_name, **kwargs)
+
+    def input(self, name: str, **kwargs: Any) -> None:
+        """
+        Define an input port in the input port namespace
+
+        :param name: name of the input port to create
+        :param kwargs: options for the input port
+        """
+        self._create_port(self.inputs, self.INPUT_PORT_TYPE, name, **kwargs)
+
+    def output(self, name: str, **kwargs: Any) -> None:
+        """
+        Define an output port in the output port namespace
+
+        :param name: name of the output port to create
+        :param kwargs: options for the output port
+        """
+        self._create_port(self.outputs, self.OUTPUT_PORT_TYPE, name, **kwargs)
+
+    def input_namespace(self, name: str, **kwargs: Any) -> None:
+        """
+        Create a new PortNamespace in the input port namespace. The keyword arguments will be
+        passed to the PortNamespace constructor. Any intermediate port namespaces that need to
+        be created for a nested namespace, will take constructor defaults
+
+        :param name: namespace of the new port namespace
+        :param kwargs: keyword arguments for the PortNamespace constructor
+        """
+        self._create_port(self.inputs, self.PORT_NAMESPACE_TYPE, name, **kwargs)
+
+    def output_namespace(self, name: str, **kwargs: Any) -> None:
+        """
+        Create a new PortNamespace in the output port namespace. The keyword arguments will be
+        passed to the PortNamespace constructor. Any intermediate port namespaces that need to
+        be created for a nested namespace, will take constructor defaults
+
+        :param name: namespace of the new port namespace
+        :param kwargs: keyword arguments for the PortNamespace constructor
+        """
+        self._create_port(self.outputs, self.PORT_NAMESPACE_TYPE, name, **kwargs)
+
+    def has_input(self, name: str) -> bool:
+        """
+        Return whether the input port namespace contains a port with the given name
+
+        :param name: key of the port in the input port namespace
+        """
+        return name in self.inputs
+
+    def has_output(self, name: str) -> bool:
+        """
+        Return whether the output port namespace contains a port with the given name
+
+        :param name: key of the port in the output port namespace
+        """
+        return name in self.outputs
+
+    def expose_inputs(
+        self,
+        process_class: type[Process],
+        namespace: str | None = None,
+        exclude: Sequence[str] | None = None,
+        include: Sequence[str] | None = None,
+        namespace_options: dict | None = None,
+    ) -> None:
+        """
+        This method allows one to automatically add the inputs from another Process to this ProcessSpec.
+        The optional namespace argument can be used to group the exposed inputs in a separated PortNamespace.
+        The exclude and include arguments can be used to restrict the set of ports that are exposed. Note that
+        these two options are mutually exclusive.
+
+        :param process_class: the Process class whose inputs to expose
+        :param namespace: a namespace in which to place the exposed inputs
+        :param exclude: input ports that are to be excluded
+        :param include: input ports that are to be included
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
+        """
+        self._expose_ports(
+            process_class=process_class,
+            source=process_class.spec().inputs,
+            destination=self.inputs,
+            expose_memory=self._exposed_inputs,
+            namespace=namespace,
+            exclude=exclude,
+            include=include,
+            namespace_options=namespace_options,
+        )
+
+    def expose_outputs(
+        self,
+        process_class: type[Process],
+        namespace: str | None = None,
+        exclude: Sequence[str] | None = None,
+        include: Sequence[str] | None = None,
+        namespace_options: dict | None = None,
+    ) -> None:
+        """
+        This method allows one to automatically add the ouputs from another Process to this ProcessSpec.
+        The optional namespace argument can be used to group the exposed outputs in a separated PortNamespace.
+        The exclude and include arguments can be used to restrict the set of ports that are exposed. Note that
+        these two options are mutually exclusive.
+
+        :param process_class: the Process class whose outputs to expose
+        :param namespace: a namespace in which to place the exposed outputs
+        :param exclude: input ports that are to be excluded
+        :param include: input ports that are to be included
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
+        """
+        self._expose_ports(
+            process_class=process_class,
+            source=process_class.spec().outputs,
+            destination=self.outputs,
+            expose_memory=self._exposed_outputs,
+            namespace=namespace,
+            exclude=exclude,
+            include=include,
+            namespace_options=namespace_options,
+        )
+
+    @staticmethod
+    def _expose_ports(
+        process_class: type[Process],
+        source: PortNamespace,
+        destination: PortNamespace,
+        expose_memory: EXPOSED_TYPE,
+        namespace: str | None,
+        exclude: Sequence[str] | None,
+        include: Sequence[str] | None,
+        namespace_options: dict | None = None,
+    ) -> None:
+        """
+        Expose ports from a source PortNamespace of the ProcessSpec of a Process class into the destination
+        PortNamespace of this ProcessSpec. If the namespace is specified, the ports will be exposed in that sub
+        namespace. The set of ports can be restricted using the mutually exclusive exclude and include tuples.
+        The namespace_options will be used to override the properties of the PortNamespace into which the ports
+        are exposed, whether that has been newly created or existed already.
+
+        :param process_class: the Process class whose outputs to expose
+        :param source: the PortNamespace whose ports are to be exposed
+        :param destination: the PortNamespace into which the ports are to be exposed
+        :param namespace: a namespace in which to place PortNamespace with the exposed outputs
+        :param exclude: input ports that are to be excluded
+        :param include: input ports that are to be included
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
+        """
+        if namespace_options is None:
+            namespace_options = {}
+
+        if exclude and include is not None:
+            raise ValueError('exclude and include are mutually exclusive')
+
+        if namespace:
+            port_namespace = destination.create_port_namespace(namespace)
+        else:
+            port_namespace = destination
+
+        absorbed_ports = port_namespace.absorb(source, exclude, include, namespace_options)
+        expose_memory[namespace][process_class] = absorbed_ports

--- a/src/aiida/engine/processes/greenback.py
+++ b/src/aiida/engine/processes/greenback.py
@@ -14,11 +14,12 @@
 #                                                                         #
 # The Plumpy license is reproduced in open_source_licenses.txt.         #
 ###########################################################################
-"""Async/sync bridge for plumpy, built on greenback.
+# mypy: ignore-errors
+"""Async/sync bridge for the process engine, built on greenback.
 
-This module is the sole interface to greenback within the plumpy/aiida ecosystem.
+This module is the sole interface to greenback within AiiDA.
 All greenback usage should go through these wrappers so that the underlying
-library remains an implementation detail of plumpy.
+library remains an implementation detail of the process engine.
 """
 
 import asyncio

--- a/src/aiida/engine/processes/greenback.py
+++ b/src/aiida/engine/processes/greenback.py
@@ -1,0 +1,70 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Async/sync bridge for plumpy, built on greenback.
+
+This module is the sole interface to greenback within the plumpy/aiida ecosystem.
+All greenback usage should go through these wrappers so that the underlying
+library remains an implementation detail of plumpy.
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+import greenback
+
+__all__: tuple[str, ...] = ()
+
+_T = TypeVar('_T')
+
+
+def has_portal() -> bool:
+    """Return True if ``sync_await()`` can be called in the current context."""
+    return greenback.has_portal()
+
+
+def sync_await(awaitable: Awaitable[_T]) -> _T:
+    """Await *awaitable* from synchronous code. Requires an active portal."""
+    return greenback.await_(awaitable)
+
+
+async def run_with_portal(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    """Run sync *fn* in a greenback portal so it can call ``sync_await()``."""
+    return await greenback.with_portal_run_sync(fn, *args, **kwargs)
+
+
+async def ensure_portal() -> None:
+    """Ensure a greenback portal is active on the current asyncio task (no-op if one exists)."""
+    await greenback.ensure_portal()
+
+
+def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]) -> _T:
+    """Run *awaitable* to completion, even if the event loop is already running."""
+    if loop.is_running():
+        if greenback.has_portal():
+            return greenback.await_(awaitable)
+        raise RuntimeError(
+            'Cannot run awaitable: event loop is running but no greenback portal '
+            'is available. If running in a Jupyter notebook, call load_profile() '
+            'in a prior cell.'
+        )
+
+    async def _with_portal() -> _T:
+        await greenback.ensure_portal()
+        return await awaitable
+
+    return loop.run_until_complete(_with_portal())

--- a/src/aiida/engine/processes/launcher.py
+++ b/src/aiida/engine/processes/launcher.py
@@ -5,12 +5,14 @@ import logging
 import traceback
 
 import kiwipy
-import plumpy
+
+from aiida.engine.processes.communications import ProcessLauncher as BaseProcessLauncher
+from aiida.engine.processes.exceptions import KilledError
 
 LOGGER = logging.getLogger(__name__)
 
 
-class ProcessLauncher(plumpy.ProcessLauncher):
+class ProcessLauncher(BaseProcessLauncher):
     """A sub class of :class:`plumpy.ProcessLauncher` to launch a ``Process``.
 
     It overrides the _continue method to make sure the node corresponding to the task can be loaded and
@@ -79,7 +81,7 @@ class ProcessLauncher(plumpy.ProcessLauncher):
             elif node.is_excepted:
                 future.set_exception(PastException(node.exception))
             elif node.is_killed:
-                future.set_exception(plumpy.KilledError())
+                future.set_exception(KilledError())
 
             return future.result()
 

--- a/src/aiida/engine/processes/launcher.py
+++ b/src/aiida/engine/processes/launcher.py
@@ -1,4 +1,4 @@
-"""A sub class of ``plumpy.ProcessLauncher`` to launch a ``Process``."""
+"""Process launcher with AiiDA-specific process-node handling."""
 
 import asyncio
 import logging
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ProcessLauncher(BaseProcessLauncher):
-    """A sub class of :class:`plumpy.ProcessLauncher` to launch a ``Process``.
+    """Subclass of :class:`aiida.engine.processes.communications.ProcessLauncher` for AiiDA processes.
 
     It overrides the _continue method to make sure the node corresponding to the task can be loaded and
     that if it is already marked as terminated, it is not continued but the future is reconstructed and returned

--- a/src/aiida/engine/processes/listener.py
+++ b/src/aiida/engine/processes/listener.py
@@ -1,0 +1,126 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+import abc
+from typing import TYPE_CHECKING, Any
+
+from aiida.common.lang import protected as protected_decorator
+from aiida.engine.processes import persistence
+from aiida.engine.processes.persistence import SAVED_STATE_TYPE
+from aiida.engine.processes.settings import check_protected
+
+__all__: tuple[str, ...] = ()
+
+protected = protected_decorator(check=check_protected)
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.generic.process import Process
+
+
+@persistence.auto_persist('_params')
+class ProcessListener(persistence.Savable, metaclass=abc.ABCMeta):
+    # region Persistence methods
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._params: dict[str, Any] = {}
+
+    def init(self, **kwargs: Any) -> None:
+        self._params = kwargs
+
+    @protected
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self.init(**saved_state['_params'])
+
+    # endregion
+
+    def on_process_created(self, process: 'Process') -> None:
+        """
+        Called when the process has been started
+
+        :param process: The process
+
+        """
+
+    def on_process_running(self, process: 'Process') -> None:
+        """
+        Called when the process is about to enter the RUNNING state
+
+        :param process: The process
+
+        """
+
+    def on_process_waiting(self, process: 'Process') -> None:
+        """
+        Called when the process is about to enter the WAITING state
+
+        :param process: The process
+
+        """
+
+    def on_process_paused(self, process: 'Process') -> None:
+        """
+        Called when the process is about to re-enter the RUNNING state
+
+        :param process: The process
+
+        """
+
+    def on_process_played(self, process: 'Process') -> None:
+        """
+        Called when the process is about to re-enter the RUNNING state
+
+        :param process: The process
+
+        """
+
+    def on_output_emitted(self, process: 'Process', output_port: str, value: Any, dynamic: bool) -> None:
+        """
+        Called when the process has emitted an output value
+
+        :param process: The process
+        :param output_port: The output port that the value was outputted on
+        :param value: The value that was outputted
+        :param dynamic: True if the port is dynamic, False otherwise
+
+        """
+
+    def on_process_finished(self, process: 'Process', outputs: Any) -> None:
+        """
+        Called when the process has finished successfully
+
+        :param process: The process
+        :param outputs: The process outputs
+
+        """
+
+    def on_process_excepted(self, process: 'Process', reason: str) -> None:
+        """
+        Called when the process has excepted
+
+        :param process: The process
+        :param reason: A string of the exception message
+
+        """
+
+    def on_process_killed(self, process: 'Process', msg: str) -> None:
+        """
+        Called when the process was killed
+
+        :param process: The process
+
+        """

--- a/src/aiida/engine/processes/mixins.py
+++ b/src/aiida/engine/processes/mixins.py
@@ -55,4 +55,4 @@ class ContextMixin(persistence.Savable):
         try:
             self._context = AttributeDict(saved_state[self.CONTEXT])
         except KeyError:
-            pass
+            self._context = None

--- a/src/aiida/engine/processes/mixins.py
+++ b/src/aiida/engine/processes/mixins.py
@@ -1,0 +1,58 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+from typing import Any
+
+from aiida.common.extendeddicts import AttributeDict
+from aiida.engine.processes import persistence
+from aiida.engine.processes.persistence import SAVED_STATE_TYPE
+
+__all__: tuple[str, ...] = ()
+
+
+class ContextMixin(persistence.Savable):
+    """
+    Add a context to a Process.  The contents of the context will be saved
+    in the instance state unlike standard instance variables.
+    """
+
+    CONTEXT: str = '_context'
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._context: AttributeDict | None = AttributeDict()
+
+    @property
+    def ctx(self) -> AttributeDict | None:
+        return self._context
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        """Add the instance state to ``out_state``.
+        .. important::
+
+            The instance state will contain a pointer to the ``ctx``,
+            and so should be deep copied or serialised before persisting.
+        """
+        super().save_instance_state(out_state, save_context)
+        if self._context is not None:
+            out_state[self.CONTEXT] = self._context.__dict__
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        try:
+            self._context = AttributeDict(saved_state[self.CONTEXT])
+        except KeyError:
+            pass

--- a/src/aiida/engine/processes/persistence.py
+++ b/src/aiida/engine/processes/persistence.py
@@ -37,6 +37,7 @@ import yaml
 from aiida.common import loaders
 from aiida.common.lang import call_with_super_check, super_check, type_check
 from aiida.engine.processes import events
+from aiida.engine.processes.exceptions import PersistenceError
 from aiida.engine.processes.generic import futures
 
 __all__: tuple[str, ...] = ()
@@ -660,8 +661,7 @@ class SavableFuture(futures.Future, Savable):
 
         if state == asyncio.futures._PENDING:  # type: ignore[attr-defined]
             obj = cls(loop=loop)
-
-        if state == asyncio.futures._FINISHED:  # type: ignore[attr-defined]
+        elif state == asyncio.futures._FINISHED:  # type: ignore[attr-defined]
             obj = cls(loop=loop)
             result = saved_state['_result']
 
@@ -670,10 +670,12 @@ class SavableFuture(futures.Future, Savable):
                 obj.set_exception(exception)
             except KeyError:
                 obj.set_result(result)
-
-        if state == asyncio.futures._CANCELLED:  # type: ignore[attr-defined]
+        elif state == asyncio.futures._CANCELLED:  # type: ignore[attr-defined]
             obj = cls(loop=loop)
             obj.cancel()
+        else:
+            msg = f'Unsupported future state: {state}'
+            raise PersistenceError(msg)
 
         return obj
 

--- a/src/aiida/engine/processes/persistence.py
+++ b/src/aiida/engine/processes/persistence.py
@@ -636,7 +636,7 @@ class SavableFuture(futures.Future, Savable):
 
     def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: LoadSaveContext) -> None:
         super().save_instance_state(out_state, save_context)
-        if self.done() and self.exception() is not None:
+        if self.done() and not self.cancelled() and self.exception() is not None:
             out_state['exception'] = self.exception()
 
     @classmethod

--- a/src/aiida/engine/processes/persistence.py
+++ b/src/aiida/engine/processes/persistence.py
@@ -25,7 +25,9 @@ import fnmatch
 import inspect
 import os
 import pickle
+import stat
 import uuid
+import warnings
 from collections.abc import Callable, Generator, Hashable, Iterable, MutableMapping
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
@@ -177,10 +179,7 @@ _PICKLE_SUFFIX = 'pickle'
 
 
 class PicklePersister(Persister):
-    """
-    Implementation of the abstract Persister class that stores Process states
-    in pickles on a filesystem.
-    """
+    """Persist process states as pickles in a trusted, private directory."""
 
     def __init__(self, pickle_directory: str):
         """
@@ -192,24 +191,32 @@ class PicklePersister(Persister):
         """
         super().__init__()
 
-        try:
-            PicklePersister.ensure_pickle_directory(pickle_directory)
-        except OSError:
-            raise ValueError(f'failed to create the pickle directory at {pickle_directory}')
+        PicklePersister.ensure_pickle_directory(pickle_directory)
 
         self._pickle_directory = pickle_directory
 
     @staticmethod
     def ensure_pickle_directory(dirpath: str) -> None:
-        """
-        Will attempt to create the directory at dirpath and raise if it fails, except
-        if the exception arose because the directory already existed
+        """Ensure that the pickle directory exists with owner-only permissions.
+
+        If the directory already exists with more permissive permissions, they
+        are changed to ``rwx------`` and a warning is raised.
         """
         try:
-            os.makedirs(dirpath)
+            os.makedirs(dirpath, mode=stat.S_IRWXU)
         except OSError as exception:
             if exception.errno != errno.EEXIST:
-                raise
+                msg = f'failed to create the pickle directory at {dirpath}'
+                raise ValueError(msg) from exception
+
+            if stat.S_IMODE(os.stat(dirpath).st_mode) != stat.S_IRWXU:
+                msg = f'Changing permissions of the pickle directory {dirpath} to rwx------.'
+                warnings.warn(msg, UserWarning, stacklevel=2)
+                try:
+                    os.chmod(dirpath, stat.S_IRWXU)
+                except OSError as exception:
+                    msg = f'failed to change permissions of the pickle directory at {dirpath}'
+                    raise ValueError(msg) from exception
 
     @staticmethod
     def load_pickle(filepath: str) -> 'PersistedPickle':

--- a/src/aiida/engine/processes/persistence.py
+++ b/src/aiida/engine/processes/persistence.py
@@ -1,0 +1,678 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Persistence support for process state."""
+
+import abc
+import asyncio
+import collections
+import copy
+import errno
+import fnmatch
+import inspect
+import os
+import pickle
+import uuid
+from collections.abc import Callable, Generator, Hashable, Iterable, MutableMapping
+from types import MethodType
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+
+import yaml
+
+from aiida.common import loaders
+from aiida.common.lang import call_with_super_check, super_check, type_check
+from aiida.engine.processes import events
+from aiida.engine.processes.generic import futures
+
+__all__: tuple[str, ...] = ()
+
+PersistedCheckpoint = collections.namedtuple('PersistedCheckpoint', ['pid', 'tag'])
+SAVED_STATE_TYPE = MutableMapping[str, Any]
+PID_TYPE = Hashable
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.generic.process import Process
+
+
+def uuid_representer(dumper, data):
+    return dumper.represent_scalar('!uuid', str(data))
+
+
+def uuid_constructor(loader, node):
+    value = loader.construct_scalar(node)
+    return uuid.UUID(value)
+
+
+yaml.add_representer(uuid.UUID, uuid_representer)
+yaml.add_constructor('!uuid', uuid_constructor)
+
+
+class Bundle(dict):
+    def __init__(self, savable: 'Savable', save_context: Optional['LoadSaveContext'] = None, dereference: bool = False):
+        """
+        Create a bundle from a savable.  Optionally keep information about the
+        class loader that can be used to load the classes in the bundle.
+
+        :param savable: The savable object to bundle
+        :param save_context: The optional save context to use
+        :param dereference: Remove refrences from the data, by deep copying
+
+        """
+        super().__init__()
+        if dereference:
+            self.update(copy.deepcopy(savable.save(save_context)))
+        else:
+            self.update(savable.save(save_context))
+
+    def unbundle(self, load_context: Optional['LoadSaveContext'] = None) -> 'Savable':
+        """
+        This method loads the class of the object and calls its recreate_from
+        method passing the positional and keyword arguments.
+
+        :param load_context: The optional load context
+        :return: An instance of the Savable
+
+        """
+        return Savable.load(self, load_context)
+
+
+_BUNDLE_TAG = '!plumpy:Bundle'
+
+
+def _bundle_representer(dumper: yaml.Dumper, node: Any) -> Any:
+    return dumper.represent_mapping(_BUNDLE_TAG, node)
+
+
+def _bundle_constructor(loader: yaml.Loader, data: Any) -> Generator[Bundle, None, None]:
+    result = Bundle.__new__(Bundle)
+    yield result
+    mapping = loader.construct_mapping(data)
+    result.update(mapping)
+
+
+yaml.add_representer(Bundle, _bundle_representer)
+yaml.add_constructor(_BUNDLE_TAG, _bundle_constructor)  # type: ignore[arg-type]
+
+
+class Persister(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def save_checkpoint(self, process: 'Process', tag: str | None = None) -> None:
+        """
+        Persist a Process instance
+
+        :param process: :class:`plumpy.Process`
+        :param tag: optional checkpoint identifier to allow distinguishing
+            multiple checkpoints for the same process
+        :raises: :class:`aiida.engine.processes.exceptions.PersistenceError` Raised if saving the checkpoint fails
+        """
+
+    @abc.abstractmethod
+    def load_checkpoint(self, pid: PID_TYPE, tag: str | None = None) -> Bundle:
+        """
+        Load a process from a persisted checkpoint by its process id
+
+        :param pid: the process id of the :class:`plumpy.Process`
+        :param tag: optional checkpoint identifier to allow retrieving
+            a specific sub checkpoint for the corresponding process
+        :return: a bundle with the process state
+
+        :raises: :class:`aiida.engine.processes.exceptions.PersistenceError` Raised if loading the checkpoint fails
+        """
+
+    @abc.abstractmethod
+    def get_checkpoints(self) -> list[PersistedCheckpoint]:
+        """
+        Return a list of all the current persisted process checkpoints
+        with each element containing the process id and optional checkpoint tag
+
+        :return: list of PersistedCheckpoint
+        """
+
+    @abc.abstractmethod
+    def get_process_checkpoints(self, pid: PID_TYPE) -> list[PersistedCheckpoint]:
+        """
+        Return a list of all the current persisted process checkpoints for the
+        specified process with each element containing the process id and
+        optional checkpoint tag
+
+        :param pid: the process pid
+        :return: list of PersistedCheckpoint tuples
+        """
+
+    @abc.abstractmethod
+    def delete_checkpoint(self, pid: PID_TYPE, tag: str | None = None) -> None:
+        """
+        Delete a persisted process checkpoint. No error will be raised if
+        the checkpoint does not exist
+
+        :param pid: the process id of the :class:`plumpy.Process`
+        :param tag: optional checkpoint identifier to allow retrieving
+            a specific sub checkpoint for the corresponding process
+        """
+
+    @abc.abstractmethod
+    def delete_process_checkpoints(self, pid: PID_TYPE) -> None:
+        """
+        Delete all persisted checkpoints related to the given process id
+
+        :param pid: the process id of the :class:`plumpy.Process`
+        """
+
+
+PersistedPickle = collections.namedtuple('PersistedPickle', ['checkpoint', 'bundle'])
+_PICKLE_SUFFIX = 'pickle'
+
+
+class PicklePersister(Persister):
+    """
+    Implementation of the abstract Persister class that stores Process states
+    in pickles on a filesystem.
+    """
+
+    def __init__(self, pickle_directory: str):
+        """
+        Instantiate a PicklePersister object that will persist processes by
+        writing their bundles to a pickle in a directory specified by the
+        argument 'pickle_directory'
+
+        :param pickle_directory: the full path to the directory where pickles will be written
+        """
+        super().__init__()
+
+        try:
+            PicklePersister.ensure_pickle_directory(pickle_directory)
+        except OSError:
+            raise ValueError(f'failed to create the pickle directory at {pickle_directory}')
+
+        self._pickle_directory = pickle_directory
+
+    @staticmethod
+    def ensure_pickle_directory(dirpath: str) -> None:
+        """
+        Will attempt to create the directory at dirpath and raise if it fails, except
+        if the exception arose because the directory already existed
+        """
+        try:
+            os.makedirs(dirpath)
+        except OSError as exception:
+            if exception.errno != errno.EEXIST:
+                raise
+
+    @staticmethod
+    def load_pickle(filepath: str) -> 'PersistedPickle':
+        """
+        Load a pickle from disk
+
+        :param filepath: absolute filepath to the pickle
+        :returns: the loaded pickle
+
+        """
+        with open(filepath, 'r+b') as handle:
+            persisted_pickle = pickle.load(handle)
+
+        return persisted_pickle
+
+    @staticmethod
+    def pickle_filename(pid: PID_TYPE, tag: str | None = None) -> str:
+        """
+        Returns the relative filepath of the pickle for the given process id
+        and optional checkpoint tag
+        """
+        if tag is not None:
+            filename = f'{pid}.{tag}.{_PICKLE_SUFFIX}'
+        else:
+            filename = f'{pid}.{_PICKLE_SUFFIX}'
+
+        return filename
+
+    def _pickle_filepath(self, pid: PID_TYPE, tag: str | None = None) -> str:
+        """
+        Returns the full filepath of the pickle for the given process id
+        and optional checkpoint tag
+        """
+        return os.path.join(self._pickle_directory, PicklePersister.pickle_filename(pid, tag))
+
+    def save_checkpoint(self, process: 'Process', tag: str | None = None) -> None:
+        """
+        Persist a process to a pickle on disk
+
+        :param process: :class:`plumpy.Process`
+        :param tag: optional checkpoint identifier to allow distinguishing
+            multiple checkpoints for the same process
+        """
+        bundle = Bundle(process)
+        checkpoint = PersistedCheckpoint(process.pid, tag)
+        persisted_pickle = PersistedPickle(checkpoint, bundle)
+
+        with open(self._pickle_filepath(process.pid, tag), 'w+b') as handle:
+            pickle.dump(persisted_pickle, handle)
+
+    def load_checkpoint(self, pid: PID_TYPE, tag: str | None = None) -> Bundle:
+        """
+        Load a process from a persisted checkpoint by its process id
+
+        :param pid: the process id of the :class:`plumpy.Process`
+        :param tag: optional checkpoint identifier to allow retrieving
+            a specific sub checkpoint for the corresponding process
+        :return: a bundle with the process state
+
+        """
+        filepath = self._pickle_filepath(pid, tag)
+        checkpoint = PicklePersister.load_pickle(filepath)
+
+        return checkpoint.bundle
+
+    def get_checkpoints(self) -> list[PersistedCheckpoint]:
+        """
+        Return a list of all the current persisted process checkpoints
+        with each element containing the process id and optional checkpoint tag
+
+        :return: list of PersistedCheckpoint
+        """
+        checkpoints = []
+        file_pattern = f'*.{_PICKLE_SUFFIX}'
+
+        for _, _, files in os.walk(self._pickle_directory):
+            for filename in fnmatch.filter(files, file_pattern):
+                filepath = os.path.join(self._pickle_directory, filename)
+                persisted_pickle = PicklePersister.load_pickle(filepath)
+                checkpoints.append(persisted_pickle.checkpoint)
+
+        return checkpoints
+
+    def get_process_checkpoints(self, pid: PID_TYPE) -> list[PersistedCheckpoint]:
+        """
+        Return a list of all the current persisted process checkpoints for the
+        specified process with each element containing the process id and
+        optional checkpoint tag
+
+        :param pid: the process pid
+        :return: list of PersistedCheckpoint
+        """
+        return [c for c in self.get_checkpoints() if c.pid == pid]
+
+    def delete_checkpoint(self, pid: PID_TYPE, tag: str | None = None) -> None:
+        """
+        Delete a persisted process checkpoint. No error will be raised if
+        the checkpoint does not exist
+
+        :param pid: the process id of the :class:`plumpy.Process`
+        :param tag: optional checkpoint identifier to allow retrieving
+            a specific sub checkpoint for the corresponding process
+        """
+        pickle_filepath = self._pickle_filepath(pid, tag)
+
+        try:
+            os.remove(pickle_filepath)
+        except OSError:
+            pass
+
+    def delete_process_checkpoints(self, pid: PID_TYPE) -> None:
+        """
+        Delete all persisted checkpoints related to the given process id
+
+        :param pid: the process id of the :class:`plumpy.Process`
+        """
+        for checkpoint in self.get_process_checkpoints(pid):
+            self.delete_checkpoint(checkpoint.pid, checkpoint.tag)
+
+
+class InMemoryPersister(Persister):
+    """Mainly to be used in testing/debugging"""
+
+    def __init__(self, loader: loaders.ObjectLoader | None = None) -> None:
+        super().__init__()
+        self._checkpoints: dict[PID_TYPE, dict[str | None, Bundle]] = {}
+        self._save_context = LoadSaveContext(loader=loader)
+
+    def save_checkpoint(self, process: 'Process', tag: str | None = None) -> None:
+        self._checkpoints.setdefault(process.pid, {})[tag] = Bundle(process, self._save_context, dereference=True)
+
+    def load_checkpoint(self, pid: PID_TYPE, tag: str | None = None) -> Bundle:
+        return self._checkpoints[pid][tag]
+
+    def get_checkpoints(self) -> list[PersistedCheckpoint]:
+        cps = []
+        for pid in self._checkpoints:
+            cps.extend(self.get_process_checkpoints(pid))
+        return cps
+
+    def get_process_checkpoints(self, pid: PID_TYPE) -> list[PersistedCheckpoint]:
+        cps = []
+        try:
+            for tag, _ in self._checkpoints[pid].items():
+                cps.append(PersistedCheckpoint(pid, tag))
+        except KeyError:
+            pass
+        return cps
+
+    def delete_checkpoint(self, pid: PID_TYPE, tag: str | None = None) -> None:
+        try:
+            del self._checkpoints[pid][tag]
+        except KeyError:
+            pass
+
+    def delete_process_checkpoints(self, pid: PID_TYPE) -> None:
+        if pid in self._checkpoints:
+            del self._checkpoints[pid]
+
+
+SavableClsType = TypeVar('SavableClsType', bound='type[Savable]')
+
+
+def auto_persist(*members: str) -> Callable[[SavableClsType], SavableClsType]:
+    def wrapped(savable: SavableClsType) -> SavableClsType:
+        if savable._auto_persist is None:
+            savable._auto_persist = set()
+        else:
+            savable._auto_persist = set(savable._auto_persist)
+        savable.auto_persist(*members)
+        return savable
+
+    return wrapped
+
+
+def _ensure_object_loader(context: Optional['LoadSaveContext'], saved_state: SAVED_STATE_TYPE) -> 'LoadSaveContext':
+    """
+    Given a LoadSaveContext this method will ensure that it has a valid class loader
+    using the following priorities:
+    1) The one that is already in the context
+    2) One that is found in the saved state
+    3) The default global class loader from loaders.get_object_loader()
+    :param context:
+    :param saved_state:
+    :return:
+    """
+    if context is None:
+        context = LoadSaveContext()
+
+    assert isinstance(context, LoadSaveContext)
+
+    if context.loader is not None:
+        return context
+
+    # 2) Try getting from saved_state
+    default_loader = loaders.get_object_loader()
+    try:
+        loader_identifier = Savable.get_custom_meta(saved_state, META__OBJECT_LOADER)
+    except ValueError:
+        # 3) Fall back to default
+        loader = default_loader
+    else:
+        loader = default_loader.load_object(loader_identifier)
+
+    return context.copyextend(loader=loader)
+
+
+class LoadSaveContext:
+    def __init__(self, loader: loaders.ObjectLoader | None = None, **kwargs: Any) -> None:
+        self._values = dict(**kwargs)
+        self.loader = loader
+
+    def __getattr__(self, item: str) -> Any:
+        try:
+            return self._values[item]
+        except KeyError:
+            raise AttributeError(f"item '{item}' not found")
+
+    def __iter__(self) -> Iterable[Any]:
+        return self._value.__iter__()
+
+    def __contains__(self, item: Any) -> bool:
+        return self._values.__contains__(item)
+
+    def copyextend(self, **kwargs: Any) -> 'LoadSaveContext':
+        """Add additional information to the context by making a copy with the new values"""
+        extended = self._values.copy()
+        extended.update(kwargs)
+        loader = extended.pop('loader', self.loader)
+        return LoadSaveContext(loader=loader, **extended)
+
+
+META: str = '!!meta'
+META__CLASS_NAME: str = 'class_name'
+META__OBJECT_LOADER: str = 'object_loader'
+META__USER: str = 'user'
+META__TYPES: str = 'types'
+META__TYPE__METHOD: str = 'm'
+META__TYPE__SAVABLE: str = 'S'
+
+
+class Savable:
+    CLASS_NAME: str = 'class_name'
+
+    _auto_persist: set[str] | None = None
+    _persist_configured = False
+
+    @staticmethod
+    def load(saved_state: SAVED_STATE_TYPE, load_context: LoadSaveContext | None = None) -> 'Savable':
+        """
+        Load a `Savable` from a saved instance state.  The load context is a way of passing
+        runtime data to the object being loaded.
+
+        :param saved_state: The saved state
+        :param load_context: Additional runtime state that can be passed into when loading.
+            The type and content (if any) is completely user defined
+        :return: The loaded Savable instance
+
+        """
+        load_context = _ensure_object_loader(load_context, saved_state)
+        assert load_context.loader is not None  # required for type checking
+        try:
+            class_name = Savable._get_class_name(saved_state)
+            load_cls = load_context.loader.load_object(class_name)
+        except KeyError:
+            raise ValueError('Class name not found in saved state')
+        else:
+            return load_cls.recreate_from(saved_state, load_context)
+
+    @classmethod
+    def auto_persist(cls, *members: str) -> None:
+        if cls._auto_persist is None:
+            cls._auto_persist = set()
+        cls._auto_persist.update(members)
+
+    @classmethod
+    def persist(cls) -> None:
+        pass
+
+    @classmethod
+    def recreate_from(cls, saved_state: SAVED_STATE_TYPE, load_context: LoadSaveContext | None = None) -> 'Savable':
+        """
+        Recreate a :class:`Savable` from a saved state using an optional load context.
+
+        :param saved_state: The saved state
+        :param load_context: An optional load context
+
+        :return: The recreated instance
+
+        """
+        load_context = _ensure_object_loader(load_context, saved_state)
+        obj = cls.__new__(cls)
+        call_with_super_check(obj.load_instance_state, saved_state, load_context)
+        return obj
+
+    @super_check
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: LoadSaveContext) -> None:
+        self._ensure_persist_configured()
+        if self._auto_persist is not None:
+            self.load_members(self._auto_persist, saved_state, load_context)
+
+    @super_check
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: LoadSaveContext) -> None:
+        self._ensure_persist_configured()
+        if self._auto_persist is not None:
+            self.save_members(self._auto_persist, out_state)
+
+    def save(self, save_context: LoadSaveContext | None = None) -> SAVED_STATE_TYPE:
+        out_state: SAVED_STATE_TYPE = {}
+
+        if save_context is None:
+            save_context = LoadSaveContext()
+
+        type_check(save_context, LoadSaveContext)
+
+        default_loader = loaders.get_object_loader()
+        # If the user has specified a class loader, then save it in the saved state
+        if save_context.loader is not None:
+            loader_class = default_loader.identify_object(save_context.loader.__class__)
+            Savable.set_custom_meta(out_state, META__OBJECT_LOADER, loader_class)
+            loader = save_context.loader
+        else:
+            loader = default_loader
+
+        Savable._set_class_name(out_state, loader.identify_object(self.__class__))
+        call_with_super_check(self.save_instance_state, out_state, save_context)
+        return out_state
+
+    def save_members(self, members: Iterable[str], out_state: SAVED_STATE_TYPE) -> None:
+        for member in members:
+            value = getattr(self, member)
+            if inspect.ismethod(value):
+                if value.__self__ is not self:
+                    raise TypeError('Cannot persist methods of other classes')
+                Savable._set_meta_type(out_state, member, META__TYPE__METHOD)
+                value = value.__name__
+            elif isinstance(value, Savable):
+                Savable._set_meta_type(out_state, member, META__TYPE__SAVABLE)
+                value = value.save()
+            else:
+                value = copy.deepcopy(value)
+            out_state[member] = value
+
+    def load_members(
+        self, members: Iterable[str], saved_state: SAVED_STATE_TYPE, load_context: LoadSaveContext | None = None
+    ) -> None:
+        for member in members:
+            setattr(self, member, self._get_value(saved_state, member, load_context))
+
+    def _ensure_persist_configured(self) -> None:
+        if not self._persist_configured:
+            self.persist()
+            self._persist_configured = True
+
+    # region Metadata getter/setters
+
+    @staticmethod
+    def set_custom_meta(out_state: SAVED_STATE_TYPE, name: str, value: Any) -> None:
+        user_dict = Savable._get_create_meta(out_state).setdefault(META__USER, {})
+        user_dict[name] = value
+
+    @staticmethod
+    def get_custom_meta(saved_state: SAVED_STATE_TYPE, name: str) -> Any:
+        try:
+            return saved_state[META][name]
+        except KeyError:
+            raise ValueError(f"Unknown meta key '{name}'")
+
+    @staticmethod
+    def _get_create_meta(out_state: SAVED_STATE_TYPE) -> dict[str, Any]:
+        return out_state.setdefault(META, {})
+
+    @staticmethod
+    def _set_class_name(out_state: SAVED_STATE_TYPE, name: str) -> None:
+        Savable._get_create_meta(out_state)[META__CLASS_NAME] = name
+
+    @staticmethod
+    def _get_class_name(saved_state: SAVED_STATE_TYPE) -> str:
+        return Savable._get_create_meta(saved_state)[META__CLASS_NAME]
+
+    @staticmethod
+    def _set_meta_type(out_state: SAVED_STATE_TYPE, name: str, type_spec: Any) -> None:
+        type_dict = Savable._get_create_meta(out_state).setdefault(META__TYPES, {})
+        type_dict[name] = type_spec
+
+    @staticmethod
+    def _get_meta_type(saved_state: SAVED_STATE_TYPE, name: str) -> Any:
+        try:
+            return saved_state[META][META__TYPES][name]
+        except KeyError:
+            pass
+
+    # endregion
+
+    def _get_value(
+        self, saved_state: SAVED_STATE_TYPE, name: str, load_context: LoadSaveContext | None
+    ) -> Union[MethodType, 'Savable']:
+        value = saved_state[name]
+
+        typ = Savable._get_meta_type(saved_state, name)
+        if typ == META__TYPE__METHOD:
+            value = getattr(self, value)
+        elif typ == META__TYPE__SAVABLE:
+            value = Savable.load(value, load_context)
+
+        return value
+
+
+@auto_persist('_state', '_result')
+class SavableFuture(futures.Future, Savable):
+    """
+    A savable future.
+
+    .. note: This does not save any assigned done callbacks.
+    """
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        if self.done() and self.exception() is not None:
+            out_state['exception'] = self.exception()
+
+    @classmethod
+    def recreate_from(cls, saved_state: SAVED_STATE_TYPE, load_context: LoadSaveContext | None = None) -> 'Savable':
+        """
+        Recreate a :class:`Savable` from a saved state using an optional load context.
+
+        :param saved_state: The saved state
+        :param load_context: An optional load context
+
+        :return: The recreated instance
+
+        """
+        load_context = _ensure_object_loader(load_context, saved_state)
+
+        try:
+            loop = load_context.loop
+        except AttributeError:
+            loop = events.get_or_create_event_loop()
+
+        state = saved_state['_state']
+
+        if state == asyncio.futures._PENDING:  # type: ignore[attr-defined]
+            obj = cls(loop=loop)
+
+        if state == asyncio.futures._FINISHED:  # type: ignore[attr-defined]
+            obj = cls(loop=loop)
+            result = saved_state['_result']
+
+            try:
+                exception = saved_state['exception']
+                obj.set_exception(exception)
+            except KeyError:
+                obj.set_result(result)
+
+        if state == asyncio.futures._CANCELLED:  # type: ignore[attr-defined]
+            obj = cls(loop=loop)
+            obj.cancel()
+
+        return obj
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        if self._callbacks:
+            # typing says asyncio.Future._callbacks needs to be called, but in the python 3.7 code it is a simple list
+            for callback in self._callbacks:
+                self.remove_done_callback(callback)  # type: ignore[arg-type]

--- a/src/aiida/engine/processes/persistence.py
+++ b/src/aiida/engine/processes/persistence.py
@@ -89,11 +89,11 @@ class Bundle(dict):
         return Savable.load(self, load_context)
 
 
-_BUNDLE_TAG = '!plumpy:Bundle'
+BUNDLE_TAG = '!aiida:bundle'
 
 
 def _bundle_representer(dumper: yaml.Dumper, node: Any) -> Any:
-    return dumper.represent_mapping(_BUNDLE_TAG, node)
+    return dumper.represent_mapping(BUNDLE_TAG, node)
 
 
 def _bundle_constructor(loader: yaml.Loader, data: Any) -> Generator[Bundle, None, None]:
@@ -104,7 +104,7 @@ def _bundle_constructor(loader: yaml.Loader, data: Any) -> Generator[Bundle, Non
 
 
 yaml.add_representer(Bundle, _bundle_representer)
-yaml.add_constructor(_BUNDLE_TAG, _bundle_constructor)  # type: ignore[arg-type]
+yaml.add_constructor(BUNDLE_TAG, _bundle_constructor)  # type: ignore[arg-type]
 
 
 class Persister(metaclass=abc.ABCMeta):
@@ -113,7 +113,7 @@ class Persister(metaclass=abc.ABCMeta):
         """
         Persist a Process instance
 
-        :param process: :class:`plumpy.Process`
+        :param process: :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow distinguishing
             multiple checkpoints for the same process
         :raises: :class:`aiida.engine.processes.exceptions.PersistenceError` Raised if saving the checkpoint fails
@@ -124,7 +124,7 @@ class Persister(metaclass=abc.ABCMeta):
         """
         Load a process from a persisted checkpoint by its process id
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow retrieving
             a specific sub checkpoint for the corresponding process
         :return: a bundle with the process state
@@ -158,7 +158,7 @@ class Persister(metaclass=abc.ABCMeta):
         Delete a persisted process checkpoint. No error will be raised if
         the checkpoint does not exist
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow retrieving
             a specific sub checkpoint for the corresponding process
         """
@@ -168,7 +168,7 @@ class Persister(metaclass=abc.ABCMeta):
         """
         Delete all persisted checkpoints related to the given process id
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         """
 
 
@@ -249,7 +249,7 @@ class PicklePersister(Persister):
         """
         Persist a process to a pickle on disk
 
-        :param process: :class:`plumpy.Process`
+        :param process: :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow distinguishing
             multiple checkpoints for the same process
         """
@@ -264,7 +264,7 @@ class PicklePersister(Persister):
         """
         Load a process from a persisted checkpoint by its process id
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow retrieving
             a specific sub checkpoint for the corresponding process
         :return: a bundle with the process state
@@ -309,7 +309,7 @@ class PicklePersister(Persister):
         Delete a persisted process checkpoint. No error will be raised if
         the checkpoint does not exist
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         :param tag: optional checkpoint identifier to allow retrieving
             a specific sub checkpoint for the corresponding process
         """
@@ -324,7 +324,7 @@ class PicklePersister(Persister):
         """
         Delete all persisted checkpoints related to the given process id
 
-        :param pid: the process id of the :class:`plumpy.Process`
+        :param pid: the process id of the :class:`aiida.engine.processes.generic.process.Process`
         """
         for checkpoint in self.get_process_checkpoints(pid):
             self.delete_checkpoint(checkpoint.pid, checkpoint.tag)

--- a/src/aiida/engine/processes/ports.py
+++ b/src/aiida/engine/processes/ports.py
@@ -6,7 +6,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""AiiDA specific implementation of plumpy Ports and PortNamespaces for the ProcessSpec."""
+"""AiiDA-specific process ports."""
 
 from __future__ import annotations
 
@@ -15,10 +15,9 @@ import warnings
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from plumpy import ports
-from plumpy.ports import breadcrumbs_to_port
-
 from aiida.common.links import validate_link_label
+from aiida.engine.processes.generic import ports
+from aiida.engine.processes.generic.ports import breadcrumbs_to_port
 from aiida.orm import Data, Node, to_aiida_type
 
 __all__ = (
@@ -31,9 +30,10 @@ __all__ = (
     'WithSerialize',
 )
 
+OutputPort = ports.OutputPort
+
 PORT_NAME_MAX_CONSECUTIVE_UNDERSCORES = 1
 PORT_NAMESPACE_SEPARATOR = '__'  # The character sequence to represent a nested port namespace in a flat link label
-OutputPort = ports.OutputPort
 
 
 class WithNonDb:

--- a/src/aiida/engine/processes/ports.py
+++ b/src/aiida/engine/processes/ports.py
@@ -135,8 +135,9 @@ class WithSerialize:
 
 
 class InputPort(WithMetadata, WithSerialize, WithNonDb, ports.InputPort):
-    """Sub class of plumpy.InputPort which mixes in the WithSerialize and WithNonDb mixins to support automatic
-    value serialization to database storable types and support non database storable input types as well.
+    """Subclass of :class:`aiida.engine.processes.generic.ports.InputPort` with serialization and non-database support.
+
+    Values can be serialized automatically to database-storable types, while inputs can also be marked as non-storable.
 
     The mixins have to go before the main port class in the superclass order to make sure they have the chance to
     process their specific keywords.
@@ -180,7 +181,7 @@ class InputPort(WithMetadata, WithSerialize, WithNonDb, ports.InputPort):
 
 
 class CalcJobOutputPort(ports.OutputPort):
-    """Sub class of plumpy.OutputPort which adds the `_pass_to_parser` attribute."""
+    """Output port for calcjobs that adds the ``_pass_to_parser`` attribute."""
 
     def __init__(self, *args, **kwargs) -> None:
         pass_to_parser = kwargs.pop('pass_to_parser', False)
@@ -193,7 +194,7 @@ class CalcJobOutputPort(ports.OutputPort):
 
 
 class PortNamespace(WithMetadata, WithNonDb, ports.PortNamespace):
-    """Sub class of plumpy.PortNamespace which implements the serialize method to support automatic recursive
+    """Subclass of :class:`aiida.engine.processes.generic.ports.PortNamespace` supporting automatic recursive
     serialization of a given mapping onto the ports of the PortNamespace.
     """
 

--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -26,27 +26,27 @@ from typing import (
 )
 from uuid import UUID
 
-import plumpy.exceptions
-import plumpy.futures
-import plumpy.persistence
-import plumpy.processes
+from aio_pika.exceptions import ConnectionClosed
 from kiwipy.communications import UnroutableError
-from plumpy import run_until_complete
-from plumpy.process_states import Finished, ProcessState
-from plumpy.processes import ConnectionClosed  # type: ignore[attr-defined]
-from plumpy.processes import Process as PlumpyProcess
-from plumpy.utils import AttributesFrozendict
 
 from aiida import orm
 from aiida.common import exceptions
-from aiida.common.extendeddicts import AttributeDict
+from aiida.common.extendeddicts import AttributeDict, AttributesFrozendict
 from aiida.common.lang import classproperty, override
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
+from aiida.common.processes import ProcessState
+from aiida.engine.processes import exceptions as process_exceptions
+from aiida.engine.processes import persistence as process_persistence
+from aiida.engine.processes import states as process_states
 from aiida.engine.processes.builder import ProcessBuilder
 from aiida.engine.processes.exit_code import ExitCode, ExitCodesNamespace
+from aiida.engine.processes.generic import futures
+from aiida.engine.processes.generic.process import Process as ProcessBase
+from aiida.engine.processes.greenback import run_until_complete
 from aiida.engine.processes.ports import PORT_NAMESPACE_SEPARATOR, InputPort, OutputPort, PortNamespace
 from aiida.engine.processes.process_spec import ProcessSpec
+from aiida.engine.processes.states import Finished
 from aiida.engine.processes.utils import prune_mapping
 from aiida.engine.utils import InterruptableFuture
 from aiida.orm.implementation.utils import clean_value
@@ -59,8 +59,8 @@ if TYPE_CHECKING:
 __all__ = ('Process', 'ProcessState')
 
 
-@plumpy.persistence.auto_persist('_parent_pid', '_enable_persistence')
-class Process(PlumpyProcess):
+@process_persistence.auto_persist('_parent_pid', '_enable_persistence')
+class Process(ProcessBase):
     """This class represents an AiiDA process which can be executed and will
     have full provenance saved in the database.
     """
@@ -267,7 +267,7 @@ class Process(PlumpyProcess):
                 return None
             try:
                 self.runner.persister.save_checkpoint(self)
-            except plumpy.exceptions.PersistenceError:
+            except process_exceptions.PersistenceError:
                 self.logger.exception(
                     'Exception trying to save checkpoint, this means you will '
                     'not be able to restart in case of a crash until the next successful checkpoint.'
@@ -275,11 +275,11 @@ class Process(PlumpyProcess):
 
     @override
     def save_instance_state(
-        self, out_state: MutableMapping[str, Any], save_context: plumpy.persistence.LoadSaveContext | None
+        self, out_state: MutableMapping[str, Any], save_context: process_persistence.LoadSaveContext
     ) -> None:
         """Save instance state.
 
-        See documentation of :meth:`!plumpy.processes.Process.save_instance_state`.
+        See documentation of :meth:`!ProcessBase.save_instance_state`.
         """
         super().save_instance_state(out_state, save_context)
 
@@ -297,7 +297,7 @@ class Process(PlumpyProcess):
 
     @override
     def load_instance_state(
-        self, saved_state: MutableMapping[str, Any], load_context: plumpy.persistence.LoadSaveContext
+        self, saved_state: MutableMapping[str, Any], load_context: process_persistence.LoadSaveContext | None
     ) -> None:
         """Load instance state.
 
@@ -307,6 +307,7 @@ class Process(PlumpyProcess):
         """
         from aiida.manage import manager
 
+        load_context = load_context or process_persistence.LoadSaveContext()
         if 'runner' in load_context:
             self._runner = load_context.runner
         else:
@@ -323,7 +324,7 @@ class Process(PlumpyProcess):
 
         self.node.logger.info(f'Loaded process<{self.node.pk}> from saved state')
 
-    def kill(self, msg_text: str | None = None, force_kill: bool = False) -> bool | plumpy.futures.Future:
+    def kill(self, msg_text: str | None = None, force_kill: bool = False) -> bool | futures.Future:
         """Kill the process and all the children calculations it called
 
         :param msg: message
@@ -384,10 +385,10 @@ class Process(PlumpyProcess):
 
             if killing:
                 # We are waiting for things to be killed, so return the 'gathered' future
-                kill_future = plumpy.futures.gather(*killing)
+                kill_future = futures.gather(*killing)
                 result = self.loop.create_future()
 
-                def done(done_future: plumpy.futures.Future):
+                def done(done_future: futures.Future):
                     is_all_killed = all(done_future.result())
                     result.set_result(is_all_killed)
 
@@ -418,7 +419,7 @@ class Process(PlumpyProcess):
         Ensuring the portal here covers every way a process is driven, including the continuation tasks that the
         broker creates and that never pass through the runner.
         """
-        from plumpy import ensure_portal
+        from aiida.engine.processes.greenback import ensure_portal
 
         await ensure_portal()
         await super().step_until_terminated()
@@ -462,10 +463,8 @@ class Process(PlumpyProcess):
         self._pid = self._create_and_setup_db_record()
 
     @override
-    def on_entered(self, from_state: plumpy.process_states.State | None) -> None:
+    def on_entered(self, from_state: process_states.State | None) -> None:
         """After entering a new state, save a checkpoint and update the latest process state change timestamp."""
-        from plumpy import ProcessState
-
         from aiida.engine.utils import set_process_state_change_timestamp
 
         if self._state.LABEL is ProcessState.EXCEPTED:

--- a/src/aiida/engine/processes/process_spec.py
+++ b/src/aiida/engine/processes/process_spec.py
@@ -6,18 +6,17 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""AiiDA specific implementation of plumpy's ProcessSpec."""
-
-import plumpy.process_spec
+"""AiiDA-specific process specifications."""
 
 from aiida.engine.processes.exit_code import ExitCode, ExitCodesNamespace
+from aiida.engine.processes.generic import spec
 from aiida.engine.processes.ports import CalcJobOutputPort, InputPort, PortNamespace
 from aiida.orm import Dict
 
 __all__ = ('CalcJobProcessSpec', 'ProcessSpec')
 
 
-class ProcessSpec(plumpy.process_spec.ProcessSpec):
+class ProcessSpec(spec.ProcessSpec):
     """Default process spec for process classes defined in `aiida-core`.
 
     This sub class defines custom classes for input ports and port namespaces. It also adds support for the definition

--- a/src/aiida/engine/processes/settings.py
+++ b/src/aiida/engine/processes/settings.py
@@ -1,0 +1,20 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Settings for process execution."""
+
+check_protected: bool = False
+check_override: bool = False

--- a/src/aiida/engine/processes/state_machine.py
+++ b/src/aiida/engine/processes/state_machine.py
@@ -1,0 +1,426 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""The state machine for processes"""
+
+from __future__ import annotations
+
+import enum
+import functools
+import inspect
+import logging
+import os
+import sys
+from collections.abc import Callable, Hashable, Iterable, Sequence
+from types import TracebackType
+from typing import (
+    Any,
+    Optional,
+)
+
+from aiida.common.lang import call_with_super_check, super_check
+from aiida.engine.processes.exceptions import InvalidStateError
+from aiida.engine.processes.generic.futures import Future
+
+__all__: tuple[str, ...] = ()
+
+_LOGGER = logging.getLogger(__name__)
+
+LABEL_TYPE = enum.Enum | str | None
+EVENT_CALLBACK_TYPE = Callable[['StateMachine', Hashable, Optional['State']], None]
+
+
+class StateMachineError(Exception):
+    """Base class for state machine errors"""
+
+
+class StateEntryFailed(Exception):  # noqa: N818
+    """
+    Failed to enter a state, can provide the next state to go to via this exception
+    """
+
+    def __init__(self, state: State, *args: Any, **kwargs: Any) -> None:
+        super().__init__('failed to enter state')
+        self.state = state
+        self.args = args
+        self.kwargs = kwargs
+
+
+class EventError(StateMachineError):
+    def __init__(self, evt: str, msg: str):
+        super().__init__(msg)
+        self.event = evt
+
+
+class TransitionFailed(Exception):  # noqa: N818
+    """A state transition failed"""
+
+    def __init__(
+        self, initial_state: State, final_state: State | None = None, traceback_str: str | None = None
+    ) -> None:
+        self.initial_state = initial_state
+        self.final_state = final_state
+        self.traceback_str = traceback_str
+        super().__init__(self._format_msg())
+
+    def _format_msg(self) -> str:
+        msg = [f'{self.initial_state} -> {self.final_state}']
+        if self.traceback_str is not None:
+            msg.append(self.traceback_str)
+        return '\n'.join(msg)
+
+
+def event(
+    from_states: str | type[State] | Iterable[type[State]] = '*',
+    to_states: str | type[State] | Iterable[type[State]] = '*',
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """A decorator to check for correct transitions, raising ``EventError`` on invalid transitions."""
+    if from_states != '*':
+        if inspect.isclass(from_states):
+            from_states = (from_states,)
+        if not all(issubclass(state, State) for state in from_states):  # type: ignore[arg-type]
+            raise TypeError(f'from_states: {from_states}')
+    if to_states != '*':
+        if inspect.isclass(to_states):
+            to_states = (to_states,)
+        if not all(issubclass(state, State) for state in to_states):  # type: ignore[arg-type]
+            raise TypeError(f'to_states: {to_states}')
+
+    def wrapper(wrapped: Callable[..., Any]) -> Callable[..., Any]:
+        evt_label = wrapped.__name__
+
+        @functools.wraps(wrapped)
+        def transition(self: Any, *a: Any, **kw: Any) -> Any:
+            initial = self._state
+
+            if from_states != '*' and not any(isinstance(self._state, state) for state in from_states):  # type: ignore[arg-type]
+                raise EventError(evt_label, f'Event {evt_label} invalid in state {initial.LABEL}')
+
+            result = wrapped(self, *a, **kw)
+            if not (result is False or isinstance(result, Future)):
+                if to_states != '*' and not any(isinstance(self._state, state) for state in to_states):  # type: ignore[arg-type]
+                    if self._state == initial:
+                        raise EventError(evt_label, 'Machine did not transition')
+
+                    raise EventError(
+                        evt_label,
+                        f'Event produced invalid state transition from {initial.LABEL} to {self._state.LABEL}',
+                    )
+
+            return result
+
+        return transition
+
+    if inspect.isfunction(from_states):  # type: ignore[unreachable]
+        # Support the bare ``@event`` form, where ``from_states`` is the decorated function
+        return wrapper(from_states)  # type: ignore[unreachable]
+
+    return wrapper
+
+
+class State:
+    LABEL: LABEL_TYPE = None
+    # A set containing the labels of states that can be entered
+    # from this one
+    ALLOWED: set[LABEL_TYPE] = set()
+
+    @classmethod
+    def is_terminal(cls) -> bool:
+        return not cls.ALLOWED
+
+    def __init__(self, state_machine: StateMachine, *args: Any, **kwargs: Any):
+        """
+        :param state_machine: The process this state belongs to
+        """
+        self.state_machine = state_machine
+        self.in_state: bool = False
+
+    def __str__(self) -> str:
+        return str(self.LABEL)
+
+    @property
+    def label(self) -> LABEL_TYPE:
+        """Convenience property to get the state label"""
+        return self.LABEL
+
+    @super_check
+    def enter(self) -> None:
+        """Entering the state"""
+
+    def execute(self) -> State | None:
+        """
+        Execute the state, performing the actions that this state is responsible for.
+        :returns: a state to transition to or None if finished.
+        """
+
+    @super_check
+    def exit(self) -> None:
+        """Exiting the state"""
+        if self.is_terminal():
+            raise InvalidStateError(f'Cannot exit a terminal state {self.LABEL}')
+
+    def create_state(self, state_label: Hashable, *args: Any, **kwargs: Any) -> State:
+        return self.state_machine.create_state(state_label, *args, **kwargs)
+
+    def do_enter(self) -> None:
+        call_with_super_check(self.enter)
+        self.in_state = True
+
+    def do_exit(self) -> None:
+        call_with_super_check(self.exit)
+        self.in_state = False
+
+
+class StateEventHook(enum.Enum):
+    """
+    Hooks that can be used to register callback at various points in the state transition
+    procedure.  The callback will be passed a state instance whose meaning will differ depending
+    on the hook as commented below.
+    """
+
+    ENTERING_STATE = 0  # State passed will be the state that is being entered
+    ENTERED_STATE = 1  # State passed will be the last state that we entered from
+    EXITING_STATE = 2  # State passed will be the next state that will be entered (or None for terminal)
+
+
+class StateMachineMeta(type):
+    def __call__(cls, *args: Any, **kwargs: Any) -> StateMachine:
+        """
+        Create the state machine and enter the initial state.
+
+        :param args: Any positional arguments to be passed to the constructor
+        :param kwargs: Any keyword arguments to be passed to the constructor
+        :return: An instance of the state machine
+        """
+        inst: StateMachine = super().__call__(*args, **kwargs)
+        inst.transition_to(inst.create_initial_state())
+        call_with_super_check(inst.init)
+        return inst
+
+
+class StateMachine(metaclass=StateMachineMeta):
+    STATES: Sequence[type[State]] | None = None
+    _STATES_MAP: dict[Hashable, type[State]] | None = None
+
+    _transitioning = False
+    _transition_failing = False
+
+    @classmethod
+    def get_states_map(cls) -> dict[Hashable, type[State]]:
+        cls.__ensure_built()
+        assert cls._STATES_MAP is not None  # required for type checking
+        return cls._STATES_MAP
+
+    @classmethod
+    def get_states(cls) -> Sequence[type[State]]:
+        if cls.STATES is not None:
+            return cls.STATES
+
+        raise RuntimeError('States not defined')
+
+    @classmethod
+    def initial_state_label(cls) -> LABEL_TYPE:
+        cls.__ensure_built()
+        assert cls.STATES is not None
+        return cls.STATES[0].LABEL
+
+    @classmethod
+    def get_state_class(cls, label: LABEL_TYPE) -> type[State]:
+        cls.__ensure_built()
+        assert cls._STATES_MAP is not None
+        return cls._STATES_MAP[label]
+
+    @classmethod
+    def __ensure_built(cls) -> None:
+        try:
+            # Check if it's already been built (and therefore sealed)
+            if cls.__getattribute__(cls, 'sealed'):
+                return
+        except AttributeError:
+            pass
+
+        cls.STATES = cls.get_states()
+        assert isinstance(cls.STATES, Iterable)
+
+        # Build the states map
+        cls._STATES_MAP = {}
+        for state_cls in cls.STATES:
+            assert issubclass(state_cls, State)
+            label = state_cls.LABEL
+            assert label not in cls._STATES_MAP, f"Duplicate label '{label}'"
+            cls._STATES_MAP[label] = state_cls
+
+        # should class initialise sealed = False?
+        cls.sealed = True  # type: ignore[attr-defined]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__ensure_built()
+        self._state: State | None = None
+        self._exception_handler = None  # Note this appears to never be used
+        self.set_debug(not sys.flags.ignore_environment and bool(os.environ.get('PYTHONSMDEBUG')))
+        self._transitioning = False
+        self._event_callbacks: dict[Hashable, list[EVENT_CALLBACK_TYPE]] = {}
+
+    @super_check
+    def init(self) -> None:
+        """Called after entering initial state in `__call__` method of `StateMachineMeta`"""
+
+    def __str__(self) -> str:
+        return f'<{self.__class__.__name__}> ({self.state})'
+
+    def create_initial_state(self) -> State:
+        return self.get_state_class(self.initial_state_label())(self)
+
+    @property
+    def state(self) -> LABEL_TYPE | None:
+        if self._state is None:
+            return None
+        return self._state.LABEL
+
+    def add_state_event_callback(self, hook: Hashable, callback: EVENT_CALLBACK_TYPE) -> None:
+        """
+        Add a callback to be called on a particular state event hook.
+        The callback should have form fn(state_machine, hook, state)
+
+        :param hook: The state event hook
+        :param callback: The callback function
+        """
+        self._event_callbacks.setdefault(hook, []).append(callback)
+
+    def remove_state_event_callback(self, hook: Hashable, callback: EVENT_CALLBACK_TYPE) -> None:
+        if getattr(self, '_closed', False):
+            # if the process is closed, then all callbacks have already been removed
+            return None
+        try:
+            self._event_callbacks[hook].remove(callback)
+        except (KeyError, ValueError):
+            raise ValueError(f"Callback not set for hook '{hook}'")
+
+    def _fire_state_event(self, hook: Hashable, state: State | None) -> None:
+        for callback in self._event_callbacks.get(hook, []):
+            callback(self, hook, state)
+
+    @super_check
+    def on_terminated(self) -> None:
+        """Called when a terminal state is entered"""
+
+    def transition_to(self, new_state: State | None, **kwargs: Any) -> None:
+        """Transite to the new state.
+
+        The new target state will be create lazily when the state is not yet instantiated,
+        which will happened for states not in the expect path such as pause and kill.
+        The arguments are passed to the state class to create state instance.
+        (process arg does not need to pass since it will always call with 'self' as process)
+        """
+        assert not self._transitioning, 'Cannot call transition_to when already transitioning state'
+
+        if new_state is None:
+            # early return if the new state is `None`
+            # it can happened when transit from terminal state
+            return None
+
+        initial_state_label = self._state.LABEL if self._state is not None else None
+        label = None
+        try:
+            self._transitioning = True
+            label = new_state.LABEL
+
+            # If the previous transition failed, do not try to exit it but go straight to next state
+            if not self._transition_failing:
+                self._exit_current_state(new_state)
+
+            try:
+                self._enter_next_state(new_state)
+            except StateEntryFailed as exception:
+                new_state = exception.state
+                label = new_state.LABEL
+                self._exit_current_state(new_state)
+                self._enter_next_state(new_state)
+
+            if self._state is not None and self._state.is_terminal():
+                call_with_super_check(self.on_terminated)
+        except Exception:
+            self._transitioning = False
+            if self._transition_failing:
+                raise
+            self._transition_failing = True
+            self.transition_failed(initial_state_label, label, *sys.exc_info()[1:])
+        finally:
+            self._transition_failing = False
+            self._transitioning = False
+
+    def transition_failed(
+        self,
+        initial_state: Hashable,
+        final_state: Hashable,
+        exception: Exception,
+        trace: TracebackType,
+    ) -> None:
+        """Called when a state transitions fails.
+
+        This method can be overwritten to change the default behaviour which is to raise the exception.
+
+        :param exception: The transition failed exception.
+        """
+        raise exception.with_traceback(trace)
+
+    def get_debug(self) -> bool:
+        return self._debug
+
+    def set_debug(self, enabled: bool) -> None:
+        self._debug: bool = enabled
+
+    def create_state(self, state_label: Hashable, *args: Any, **kwargs: Any) -> State:
+        # XXX: this method create state from label, which is duplicate as _create_state_instance and less generic
+        # because the label is defined after the state and required to be know before calling this function.
+        # This method should be replaced by `_create_state_instance`.
+        # aiida-core using this method for its Waiting state override.
+        try:
+            return self.get_states_map()[state_label](self, *args, **kwargs)
+        except KeyError:
+            raise ValueError(f'{state_label} is not a valid state')
+
+    def _exit_current_state(self, next_state: State) -> None:
+        """Exit the given state"""
+
+        # If we're just being constructed we may not have a state yet to exit,
+        # in which case check the new state is the initial state
+        if self._state is None:
+            if next_state.label != self.initial_state_label():
+                raise RuntimeError(f"Cannot enter state '{next_state}' as the initial state")
+            return  # Nothing to exit
+
+        if next_state.LABEL not in self._state.ALLOWED:
+            raise RuntimeError(f'Cannot transition from {self._state.LABEL} to {next_state.label}')
+        self._fire_state_event(StateEventHook.EXITING_STATE, next_state)
+        self._state.do_exit()
+
+    def _enter_next_state(self, next_state: State) -> None:
+        last_state = self._state
+        self._fire_state_event(StateEventHook.ENTERING_STATE, next_state)
+        # Enter the new state
+        next_state.do_enter()
+        self._state = next_state
+        self._fire_state_event(StateEventHook.ENTERED_STATE, last_state)
+
+    def _create_state_instance(self, state_cls: Hashable, **kwargs: Any) -> State:
+        if state_cls not in self.get_states_map():
+            raise ValueError(f'{state_cls} is not a valid state')
+
+        cls = self.get_states_map()[state_cls]
+
+        return cls(self, **kwargs)

--- a/src/aiida/engine/processes/state_machine.py
+++ b/src/aiida/engine/processes/state_machine.py
@@ -246,8 +246,8 @@ class StateMachine(metaclass=StateMachineMeta):
     @classmethod
     def __ensure_built(cls) -> None:
         try:
-            # Check if it's already been built (and therefore sealed)
-            if cls.__getattribute__(cls, 'sealed'):
+            # Check if the state map has already been built
+            if cls.__getattribute__(cls, '_states_built'):
                 return
         except AttributeError:
             pass
@@ -263,8 +263,7 @@ class StateMachine(metaclass=StateMachineMeta):
             assert label not in cls._STATES_MAP, f"Duplicate label '{label}'"
             cls._STATES_MAP[label] = state_cls
 
-        # should class initialise sealed = False?
-        cls.sealed = True  # type: ignore[attr-defined]
+        cls._states_built = True  # type: ignore[attr-defined]
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/aiida/engine/processes/state_machine.py
+++ b/src/aiida/engine/processes/state_machine.py
@@ -214,6 +214,7 @@ class StateMachineMeta(type):
 class StateMachine(metaclass=StateMachineMeta):
     STATES: Sequence[type[State]] | None = None
     _STATES_MAP: dict[Hashable, type[State]] | None = None
+    _states_built = False
 
     _transitioning = False
     _transition_failing = False
@@ -245,12 +246,8 @@ class StateMachine(metaclass=StateMachineMeta):
 
     @classmethod
     def __ensure_built(cls) -> None:
-        try:
-            # Check if the state map has already been built
-            if cls.__getattribute__(cls, '_states_built'):
-                return
-        except AttributeError:
-            pass
+        if cls.__dict__.get('_states_built', False):
+            return
 
         cls.STATES = cls.get_states()
         assert isinstance(cls.STATES, Iterable)
@@ -263,7 +260,7 @@ class StateMachine(metaclass=StateMachineMeta):
             assert label not in cls._STATES_MAP, f"Duplicate label '{label}'"
             cls._STATES_MAP[label] = state_cls
 
-        cls._states_built = True  # type: ignore[attr-defined]
+        cls._states_built = True
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/aiida/engine/processes/states.py
+++ b/src/aiida/engine/processes/states.py
@@ -29,16 +29,8 @@ from yaml.loader import Loader
 
 from aiida.common.loaders import load_function
 from aiida.common.processes import ProcessState
-from aiida.engine.processes.communications import MessageBuilder, MessageType
-
-try:
-    import tblib
-
-    _HAS_TBLIB: bool = True
-except ImportError:
-    _HAS_TBLIB = False
-
 from aiida.engine.processes import exceptions, persistence, state_machine
+from aiida.engine.processes.communications import MessageBuilder, MessageType
 from aiida.engine.processes.generic import futures
 from aiida.engine.processes.persistence import SAVED_STATE_TYPE, auto_persist
 from aiida.engine.utils import ensure_coroutine
@@ -388,6 +380,7 @@ class Excepted(State):
         super().__init__(process)
         self.exception = exception
         self.traceback = trace_back
+        self.traceback_string = ''.join(traceback.format_tb(trace_back)) if trace_back is not None else None
 
     def __str__(self) -> str:
         exception = traceback.format_exception_only(type(self.exception) if self.exception else None, self.exception)[0]
@@ -396,19 +389,15 @@ class Excepted(State):
     def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
         super().save_instance_state(out_state, save_context)
         out_state[self.EXC_VALUE] = yaml.dump(self.exception)
-        if self.traceback is not None:
-            out_state[self.TRACEBACK] = ''.join(traceback.format_tb(self.traceback))
+        if self.traceback_string is not None:
+            out_state[self.TRACEBACK] = self.traceback_string
 
     def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
         super().load_instance_state(saved_state, load_context)
+        # Process checkpoints are trusted input; restoring arbitrary exception classes requires the unsafe loader.
         self.exception = yaml.load(saved_state[self.EXC_VALUE], Loader=Loader)
-        if _HAS_TBLIB:
-            try:
-                self.traceback = tblib.Traceback.from_string(saved_state[self.TRACEBACK], strict=False)
-            except KeyError:
-                self.traceback = None
-        else:
-            self.traceback = None
+        self.traceback = None
+        self.traceback_string = saved_state.get(self.TRACEBACK)
 
     def get_exc_info(
         self,

--- a/src/aiida/engine/processes/states.py
+++ b/src/aiida/engine/processes/states.py
@@ -325,7 +325,8 @@ class Waiting(State):
 
     def interrupt(self, reason: Any) -> None:
         # This will cause the future in execute() to raise the exception
-        self._waiting_future.set_exception(reason)
+        if not self._waiting_future.done():
+            self._waiting_future.set_exception(reason)
 
     async def execute(self) -> State:  # type: ignore[override]
         try:

--- a/src/aiida/engine/processes/states.py
+++ b/src/aiida/engine/processes/states.py
@@ -307,7 +307,7 @@ class Waiting(State):
         self.done_callback = done_callback
         self.msg = msg
         self.data = data
-        self._waiting_future: futures.Future = futures.Future()
+        self._waiting_future: futures.Future = process.loop.create_future()
 
     def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
         super().save_instance_state(out_state, save_context)
@@ -321,7 +321,7 @@ class Waiting(State):
             self.done_callback = getattr(self.process, callback_name)
         else:
             self.done_callback = None
-        self._waiting_future = futures.Future()
+        self._waiting_future = load_context.process.loop.create_future()
 
     def interrupt(self, reason: Any) -> None:
         # This will cause the future in execute() to raise the exception
@@ -335,7 +335,8 @@ class Waiting(State):
             # Deal with the interruption (by raising) but make sure our internal
             # state is back to how it was before the interruption so that we can be
             # re-executed
-            self._waiting_future = futures.Future()
+            # Recreate on the same loop the original future was created on, i.e. the process loop
+            self._waiting_future = self._waiting_future.get_loop().create_future()
             raise
 
         if result == NULL:

--- a/src/aiida/engine/processes/states.py
+++ b/src/aiida/engine/processes/states.py
@@ -1,0 +1,464 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""Process state machine states."""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from collections.abc import Awaitable, Callable
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from yaml.loader import Loader
+
+from aiida.common.loaders import load_function
+from aiida.common.processes import ProcessState
+from aiida.engine.processes.communications import MessageBuilder, MessageType
+
+try:
+    import tblib
+
+    _HAS_TBLIB: bool = True
+except ImportError:
+    _HAS_TBLIB = False
+
+from aiida.engine.processes import exceptions, persistence, state_machine
+from aiida.engine.processes.generic import futures
+from aiida.engine.processes.persistence import SAVED_STATE_TYPE, auto_persist
+from aiida.engine.utils import ensure_coroutine
+
+__all__: tuple[str, ...] = ()
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.generic.process import Process
+
+
+class __NULL:
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, self.__class__)
+
+
+NULL = __NULL()
+
+
+class Interruption(Exception):  # noqa: N818
+    pass
+
+
+class KillInterruption(Interruption):
+    def __init__(self, msg_text: str | None, force_kill: bool = False):
+        super().__init__(msg_text)
+        msg = MessageBuilder.kill(text=msg_text, force_kill=force_kill)
+
+        self.msg: MessageType = msg
+        self.force_kill: bool = force_kill
+
+
+class PauseInterruption(Interruption):
+    def __init__(self, msg_text: str | None):
+        super().__init__(msg_text)
+        msg = MessageBuilder.pause(text=msg_text)
+
+        self.msg: MessageType = msg
+
+
+# region Commands
+
+
+class Command(persistence.Savable):
+    pass
+
+
+@auto_persist('msg')
+class Kill(Command):
+    def __init__(self, msg: MessageType | None = None):
+        super().__init__()
+        self.msg = msg
+
+
+class Pause(Command):
+    pass
+
+
+@auto_persist('msg', 'data')
+class Wait(Command):
+    def __init__(
+        self,
+        continue_fn: Callable[..., Any] | None = None,
+        msg: Any | None = None,
+        data: Any | None = None,
+    ):
+        super().__init__()
+        self.continue_fn = continue_fn
+        self.msg = msg
+        self.data = data
+
+
+@auto_persist('result')
+class Stop(Command):
+    def __init__(self, result: Any, successful: bool) -> None:
+        super().__init__()
+        self.result = result
+        self.successful = successful
+
+
+@auto_persist('args', 'kwargs')
+class Continue(Command):
+    CONTINUE_FN = 'continue_fn'
+
+    def __init__(self, continue_fn: Callable[..., Any], *args: Any, **kwargs: Any):
+        super().__init__()
+        self.continue_fn = continue_fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        out_state[self.CONTINUE_FN] = self.continue_fn.__name__
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        try:
+            self.continue_fn = load_function(saved_state[self.CONTINUE_FN])
+        except ValueError:
+            process = load_context.process
+            self.continue_fn = getattr(process, saved_state[self.CONTINUE_FN])
+
+
+# endregion
+
+# region States
+
+
+@auto_persist('in_state')
+class State(state_machine.State, persistence.Savable):
+    @property
+    def process(self) -> state_machine.StateMachine:
+        """
+        :return: The process
+        """
+        return self.state_machine
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self.state_machine = load_context.process
+
+    def interrupt(self, reason: Any) -> None:
+        pass
+
+
+@auto_persist('args', 'kwargs')
+class Created(State):
+    LABEL = ProcessState.CREATED
+    ALLOWED = {ProcessState.RUNNING, ProcessState.KILLED, ProcessState.EXCEPTED}
+
+    RUN_FN = 'run_fn'
+
+    def __init__(self, process: Process, run_fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        super().__init__(process)
+        assert run_fn is not None
+        self.run_fn = run_fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        out_state[self.RUN_FN] = self.run_fn.__name__
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self.run_fn = getattr(self.process, saved_state[self.RUN_FN])
+
+    def execute(self) -> state_machine.State:
+        return self.create_state(ProcessState.RUNNING, self.run_fn, *self.args, **self.kwargs)
+
+
+@auto_persist('args', 'kwargs')
+class Running(State):
+    LABEL = ProcessState.RUNNING
+    ALLOWED = {
+        ProcessState.RUNNING,
+        ProcessState.WAITING,
+        ProcessState.FINISHED,
+        ProcessState.KILLED,
+        ProcessState.EXCEPTED,
+    }
+
+    RUN_FN = 'run_fn'  # The key used to store the function to run
+    COMMAND = 'command'  # The key used to store an upcoming command
+
+    # Class level defaults
+    _command: None | Kill | Stop | Wait | Continue = None
+    _running: bool = False
+    _run_handle = None
+
+    def __init__(
+        self, process: Process, run_fn: Callable[..., Awaitable[Any] | Any], *args: Any, **kwargs: Any
+    ) -> None:
+        super().__init__(process)
+        assert run_fn is not None
+        self.run_fn = ensure_coroutine(run_fn)
+        # We wrap `run_fn` to a coroutine so we can apply await on it,
+        # even it if it was not a coroutine in the first place.
+        # This allows the same usage of async and non-async function
+        # with the await syntax while not changing the program logic.
+        self.args = args
+        self.kwargs = kwargs
+        self._run_handle = None
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        out_state[self.RUN_FN] = self.run_fn.__name__
+        if self._command is not None:
+            out_state[self.COMMAND] = self._command.save()
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self.run_fn = ensure_coroutine(getattr(self.process, saved_state[self.RUN_FN]))
+        if self.COMMAND in saved_state:
+            self._command = persistence.Savable.load(saved_state[self.COMMAND], load_context)  # type: ignore[assignment]
+
+    def interrupt(self, reason: Any) -> None:
+        pass
+
+    async def execute(self) -> State:  # type: ignore[override]
+        if self._command is not None:
+            command = self._command
+        else:
+            try:
+                try:
+                    self._running = True
+                    result = await self.run_fn(*self.args, **self.kwargs)
+                finally:
+                    self._running = False
+            except Interruption:
+                # Let this bubble up to the caller
+                raise
+            except Exception:
+                excepted = self.create_state(ProcessState.EXCEPTED, *sys.exc_info()[1:])
+                return cast(State, excepted)
+            else:
+                if not isinstance(result, Command):
+                    if isinstance(result, exceptions.UnsuccessfulResult):
+                        result = Stop(result.result, False)
+                    else:
+                        # Got passed a basic return type
+                        result = Stop(result, True)
+
+                command = result
+
+        next_state = self._action_command(command)
+        return next_state
+
+    def _action_command(self, command: Kill | Stop | Wait | Continue) -> State:
+        if isinstance(command, Kill):
+            state = self.create_state(ProcessState.KILLED, command.msg)
+        # elif isinstance(command, Pause):
+        #     self.pause()
+        elif isinstance(command, Stop):
+            state = self.create_state(ProcessState.FINISHED, command.result, command.successful)
+        elif isinstance(command, Wait):
+            state = self.create_state(ProcessState.WAITING, command.continue_fn, command.msg, command.data)
+        elif isinstance(command, Continue):
+            state = self.create_state(ProcessState.RUNNING, command.continue_fn, *command.args)
+        else:
+            raise ValueError('Unrecognised command')
+
+        return cast(State, state)  # casting from base.State to process.State
+
+
+@auto_persist('msg', 'data')
+class Waiting(State):
+    LABEL = ProcessState.WAITING
+    ALLOWED = {
+        ProcessState.RUNNING,
+        ProcessState.WAITING,
+        ProcessState.KILLED,
+        ProcessState.EXCEPTED,
+        ProcessState.FINISHED,
+    }
+
+    DONE_CALLBACK = 'DONE_CALLBACK'
+
+    _interruption = None
+
+    def __str__(self) -> str:
+        state_info = super().__str__()
+        if self.msg is not None:
+            state_info += f' ({self.msg})'
+        return state_info
+
+    def __init__(
+        self,
+        process: Process,
+        done_callback: Callable[..., Any] | None,
+        msg: str | None = None,
+        data: Any | None = None,
+    ) -> None:
+        super().__init__(process)
+        self.done_callback = done_callback
+        self.msg = msg
+        self.data = data
+        self._waiting_future: futures.Future = futures.Future()
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        if self.done_callback is not None:
+            out_state[self.DONE_CALLBACK] = self.done_callback.__name__
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        callback_name = saved_state.get(self.DONE_CALLBACK, None)
+        if callback_name is not None:
+            self.done_callback = getattr(self.process, callback_name)
+        else:
+            self.done_callback = None
+        self._waiting_future = futures.Future()
+
+    def interrupt(self, reason: Any) -> None:
+        # This will cause the future in execute() to raise the exception
+        self._waiting_future.set_exception(reason)
+
+    async def execute(self) -> State:  # type: ignore[override]
+        try:
+            result = await self._waiting_future
+        except Interruption:
+            # Deal with the interruption (by raising) but make sure our internal
+            # state is back to how it was before the interruption so that we can be
+            # re-executed
+            self._waiting_future = futures.Future()
+            raise
+
+        if result == NULL:
+            next_state = self.create_state(ProcessState.RUNNING, self.done_callback)
+        else:
+            next_state = self.create_state(ProcessState.RUNNING, self.done_callback, result)
+
+        return cast(State, next_state)  # casting from base.State to process.State
+
+    def resume(self, value: Any = NULL) -> None:
+        assert self._waiting_future is not None, 'Not yet waiting'
+
+        if self._waiting_future.done():
+            return
+
+        self._waiting_future.set_result(value)
+
+
+class Excepted(State):
+    """
+    Excepted state, can optionally provide exception and trace_back
+
+    :param exception: The exception instance
+    :param trace_back: An optional exception traceback
+    """
+
+    LABEL = ProcessState.EXCEPTED
+
+    EXC_VALUE = 'ex_value'
+    TRACEBACK = 'traceback'
+
+    def __init__(
+        self,
+        process: Process,
+        exception: BaseException | None,
+        trace_back: TracebackType | None = None,
+    ):
+        """
+        :param process: The associated process
+        :param exception: The exception instance
+        :param trace_back: An optional exception traceback
+        """
+        super().__init__(process)
+        self.exception = exception
+        self.traceback = trace_back
+
+    def __str__(self) -> str:
+        exception = traceback.format_exception_only(type(self.exception) if self.exception else None, self.exception)[0]
+        return super().__str__() + f'({exception})'
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        out_state[self.EXC_VALUE] = yaml.dump(self.exception)
+        if self.traceback is not None:
+            out_state[self.TRACEBACK] = ''.join(traceback.format_tb(self.traceback))
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self.exception = yaml.load(saved_state[self.EXC_VALUE], Loader=Loader)
+        if _HAS_TBLIB:
+            try:
+                self.traceback = tblib.Traceback.from_string(saved_state[self.TRACEBACK], strict=False)
+            except KeyError:
+                self.traceback = None
+        else:
+            self.traceback = None
+
+    def get_exc_info(
+        self,
+    ) -> tuple[type[BaseException] | None, BaseException | None, TracebackType | None]:
+        """
+        Recreate the exc_info tuple and return it
+        """
+        return (
+            type(self.exception) if self.exception else None,
+            self.exception,
+            self.traceback,
+        )
+
+
+@auto_persist('result', 'successful')
+class Finished(State):
+    """State for process is finished.
+
+    :param result: The result of process
+    :param successful: Boolean for the exit code is ``0`` the process is successful.
+    """
+
+    LABEL = ProcessState.FINISHED
+
+    def __init__(self, process: Process, result: Any, successful: bool) -> None:
+        super().__init__(process)
+        self.result = result
+        self.successful = successful
+
+
+@auto_persist('msg')
+class Killed(State):
+    """
+    Represents a state where a process has been killed.
+
+    This state is used to indicate that a process has been terminated and can optionally
+    include a message providing details about the termination.
+
+    :param msg: An optional message explaining the reason for the process termination.
+    """
+
+    LABEL = ProcessState.KILLED
+
+    def __init__(self, process: Process, msg: MessageType | None):
+        """
+        :param process: The associated process
+        :param msg: Optional kill message
+        """
+        super().__init__(process)
+        self.msg = msg
+
+
+# endregion

--- a/src/aiida/engine/processes/states.py
+++ b/src/aiida/engine/processes/states.py
@@ -276,7 +276,7 @@ class Running(State):
         elif isinstance(command, Wait):
             state = self.create_state(ProcessState.WAITING, command.continue_fn, command.msg, command.data)
         elif isinstance(command, Continue):
-            state = self.create_state(ProcessState.RUNNING, command.continue_fn, *command.args)
+            state = self.create_state(ProcessState.RUNNING, command.continue_fn, *command.args, **command.kwargs)
         else:
             raise ValueError('Unrecognised command')
 

--- a/src/aiida/engine/processes/workchains/awaitable.py
+++ b/src/aiida/engine/processes/workchains/awaitable.py
@@ -10,14 +10,13 @@
 
 from enum import Enum
 
-from plumpy.utils import AttributesDict
-
+from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import ProcessNode
 
 __all__ = ('Awaitable', 'AwaitableAction', 'AwaitableTarget', 'construct_awaitable')
 
 
-class Awaitable(AttributesDict):
+class Awaitable(AttributeDict):
     """An attribute dictionary that represents an action that a Process could be waiting for to finish."""
 
 
@@ -57,7 +56,7 @@ def construct_awaitable(target: Awaitable | ProcessNode) -> Awaitable:
         raise ValueError(f'invalid class for awaitable target: {type(target)}')
 
     awaitable = Awaitable(
-        **{
+        {
             'pk': target.pk,
             'action': AwaitableAction.ASSIGN,
             'target': awaitable_target,

--- a/src/aiida/engine/processes/workchains/outline.py
+++ b/src/aiida/engine/processes/workchains/outline.py
@@ -1,0 +1,583 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+#                                                                         #
+# Portions of this file are derived from Plumpy.                         #
+# Copyright (c), 2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE          #
+# (Theory and Simulation of Materials (THEOS) and National Centre for    #
+# Computational Design and Discovery of Novel Materials (NCCR MARVEL)), #
+# Switzerland and ROBERT BOSCH LLC, USA. All rights reserved.            #
+#                                                                         #
+# The Plumpy license is reproduced in open_source_licenses.txt.         #
+###########################################################################
+"""WorkChain outline instructions and steppers."""
+
+from __future__ import annotations
+
+import abc
+import collections
+import inspect
+import re
+from collections.abc import Callable, Mapping, MutableSequence, Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+from aiida.engine.processes import persistence
+from aiida.engine.processes.generic.spec import ProcessSpec
+from aiida.engine.processes.persistence import SAVED_STATE_TYPE
+
+if TYPE_CHECKING:
+    from aiida.engine.processes.workchains.workchain import WorkChain
+
+__all__: tuple[str, ...] = ()
+
+PREDICATE_TYPE = Callable[['WorkChain'], bool]
+WC_COMMAND_TYPE = Callable[['WorkChain'], Any]
+EXIT_CODE_TYPE = int
+
+
+class WorkChainSpec(ProcessSpec):
+    def __init__(self) -> None:
+        super().__init__()
+        self._outline: _Instruction | _FunctionCall | None = None
+
+    def get_description(self) -> dict[str, str]:
+        description = super().get_description()
+
+        if self._outline:
+            description['outline'] = self._outline.get_description()
+
+        return description
+
+    def outline(self, *commands: _Instruction | WC_COMMAND_TYPE) -> None:
+        """
+        Define the outline that describes this work chain.
+
+        :param commands: One or more functions that make up this work chain.
+        """
+        if len(commands) == 1:
+            # There is only a single instruction
+            self._outline = _ensure_instruction(commands[0])
+        else:
+            # There are multiple instructions
+            self._outline = _Block(commands)
+
+    def get_outline(self) -> _Instruction | _FunctionCall:
+        assert self._outline is not None, 'outline not yet loaded'
+        return self._outline
+
+
+class Stepper(persistence.Savable, metaclass=abc.ABCMeta):
+    def __init__(self, workchain: WorkChain) -> None:
+        self._workchain = workchain
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self._workchain = load_context.workchain
+
+    @abc.abstractmethod
+    def step(self) -> tuple[bool, Any]:
+        """
+        Execute on step of the instructions.
+        :return: A 2-tuple with entries:
+            0. True if the stepper has finished, False otherwise
+            1. The return value from the executed step
+
+        """
+
+
+class _Instruction(metaclass=abc.ABCMeta):
+    """
+    This class represents an instruction in a workchain. To step through the
+    step you need to get a stepper by calling ``create_stepper()`` from which
+    you can call the :class:`~Stepper.step()` method.
+    """
+
+    @abc.abstractmethod
+    def create_stepper(self, workchain: WorkChain) -> Stepper:
+        """Create a new stepper for this instruction"""
+
+    @abc.abstractmethod
+    def recreate_stepper(self, saved_state: SAVED_STATE_TYPE, workchain: WorkChain) -> Stepper:
+        """Recreate a stepper from a previously saved state"""
+
+    def __str__(self) -> str:
+        return str(self.get_description())
+
+    @abc.abstractmethod
+    def get_description(self) -> Any:
+        """
+        Get a text description of these instructions.
+        :return: The description
+
+        """
+
+
+class _FunctionStepper(Stepper):
+    def __init__(self, workchain: WorkChain, fn: WC_COMMAND_TYPE):
+        super().__init__(workchain)
+        self._fn = fn
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        out_state['_fn'] = self._fn.__name__
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self._fn = getattr(self._workchain.__class__, saved_state['_fn'])
+
+    def step(self) -> tuple[bool, Any]:
+        return True, self._fn(self._workchain)
+
+    def __str__(self) -> str:
+        return self._fn.__name__
+
+
+class _FunctionCall(_Instruction):
+    def __init__(self, func: WC_COMMAND_TYPE) -> None:
+        try:
+            args = inspect.getfullargspec(func)[0]
+        except TypeError:
+            raise TypeError(f'func is not a function, got {type(func)}')
+        if len(args) != 1:
+            raise TypeError('Step must take one argument only: self')
+
+        self._fn = func
+
+    def create_stepper(self, workchain: WorkChain) -> _FunctionStepper:
+        return _FunctionStepper(workchain, self._fn)
+
+    def recreate_stepper(self, saved_state: SAVED_STATE_TYPE, workchain: WorkChain) -> _FunctionStepper:
+        load_context = persistence.LoadSaveContext(workchain=workchain, func_spec=self)
+        return cast(_FunctionStepper, _FunctionStepper.recreate_from(saved_state, load_context))
+
+    def get_description(self) -> str:
+        desc = self._fn.__name__
+        if self._fn.__doc__:
+            doc = re.sub(r'\n\s*', ' ', self._fn.__doc__).strip()
+            desc += f'({doc})'
+
+        return desc
+
+
+STEPPER_STATE = 'stepper_state'
+
+
+@persistence.auto_persist('_pos')
+class _BlockStepper(Stepper):
+    def __init__(self, block: Sequence[_Instruction], workchain: WorkChain) -> None:
+        super().__init__(workchain)
+        self._block = block
+        self._pos: int = 0
+        self._child_stepper: Stepper | None = self._block[0].create_stepper(self._workchain)
+
+    def step(self) -> tuple[bool, Any]:
+        assert not self.finished() and self._child_stepper is not None, "Can't call step after the block is finished"
+
+        finished, result = self._child_stepper.step()
+        if finished:
+            self.next_instruction()
+
+        return self.finished(), result
+
+    def next_instruction(self) -> None:
+        assert not self.finished()
+        self._pos += 1
+        if self.finished():
+            self._child_stepper = None
+        else:
+            self._child_stepper = self._block[self._pos].create_stepper(self._workchain)
+
+    def finished(self) -> bool:
+        return self._pos == len(self._block)
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        if self._child_stepper is not None:
+            out_state[STEPPER_STATE] = self._child_stepper.save()
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self._block = load_context.block_instruction
+        stepper_state = saved_state.get(STEPPER_STATE, None)
+        self._child_stepper = None
+        if stepper_state is not None:
+            self._child_stepper = self._block[self._pos].recreate_stepper(stepper_state, self._workchain)
+
+    def __str__(self) -> str:
+        return str(self._pos) + ':' + str(self._child_stepper)
+
+
+class _Block(_Instruction, collections.abc.Sequence):
+    """
+    Represents a block of instructions i.e. a sequential list of instructions.
+    """
+
+    def __init__(self, instructions: Sequence[_Instruction | WC_COMMAND_TYPE]) -> None:
+        # Build up the list of commands
+        comms: MutableSequence[_Instruction | _FunctionCall] = []
+        for instruction in instructions:
+            if not isinstance(instruction, _Instruction):
+                # Assume it's a function call
+                comms.append(_FunctionCall(instruction))
+            else:
+                comms.append(instruction)
+
+        self._instruction: MutableSequence[_Instruction | _FunctionCall] = comms
+
+    def __getitem__(self, index: int) -> _Instruction | _FunctionCall:  # type: ignore[override]
+        return self._instruction[index]
+
+    def __len__(self) -> int:
+        return len(self._instruction)
+
+    def create_stepper(self, workchain: WorkChain) -> _BlockStepper:
+        return _BlockStepper(self, workchain)
+
+    def recreate_stepper(self, saved_state: SAVED_STATE_TYPE, workchain: WorkChain) -> _BlockStepper:
+        load_context = persistence.LoadSaveContext(workchain=workchain, block_instruction=self)
+        return cast(_BlockStepper, _BlockStepper.recreate_from(saved_state, load_context))
+
+    def get_description(self) -> list[str]:
+        return [instruction.get_description() for instruction in self._instruction]
+
+
+class _Conditional:
+    """
+    Object that represents some condition with the corresponding body to be
+    executed if the condition is met e.g.:
+    if(condition):
+      body
+
+    or
+
+    while(condition):
+      body
+    """
+
+    def __init__(self, parent: _Instruction, predicate: PREDICATE_TYPE, label: str) -> None:
+        self._parent = parent
+        self._predicate = predicate
+        self._body: _Block | None = None
+        self._label = label
+
+    @property
+    def body(self) -> _Block:
+        assert self._body is not None, 'Instructions have not yet been set'
+        return self._body
+
+    @property
+    def predicate(self) -> PREDICATE_TYPE:
+        return self._predicate
+
+    def is_true(self, workflow: WorkChain) -> bool:
+        result = self._predicate(workflow)
+
+        if not hasattr(result, '__bool__'):
+            import warnings
+
+            warnings.warn(
+                f'The conditional predicate `{self._predicate.__name__}` returned `{result}` which is not boolean-like.'
+                ' The return value should be `True` or `False` or implement the `__bool__` method. This behavior is '
+                'deprecated and will soon start raising an exception.',
+                UserWarning,
+            )
+
+        return result
+
+    def __call__(self, *instructions: _Instruction | WC_COMMAND_TYPE) -> _Instruction:
+        assert self._body is None, 'Instructions have already been set'
+        self._body = _Block(instructions)
+        return self._parent
+
+    def __str__(self) -> str:
+        return self._label + '(' + self.predicate.__name__ + ')'
+
+
+@persistence.auto_persist('_pos')
+class _IfStepper(Stepper):
+    def __init__(self, if_instruction: _If, workchain: WorkChain) -> None:
+        super().__init__(workchain)
+        self._if_instruction = if_instruction
+        self._pos = 0
+        self._child_stepper: Stepper | None = None
+
+    def step(self) -> tuple[bool, Any]:
+        if self.finished():
+            return True, None
+
+        if self._child_stepper is None:
+            # Check the conditions until we find one that is true or we get to the end and
+            # none are true in which case we set pos to past the end
+            for conditional in self._if_instruction:
+                if conditional.is_true(self._workchain):
+                    break
+                self._pos += 1
+
+            if self.finished():
+                return True, None
+
+            self._child_stepper = self._if_instruction[self._pos].body.create_stepper(self._workchain)
+        assert self._child_stepper is not None
+        finished, retval = self._child_stepper.step()
+        if finished:
+            self._pos = len(self._if_instruction)
+            self._child_stepper = None
+
+        return self.finished(), retval
+
+    def finished(self) -> bool:
+        return self._pos == len(self._if_instruction)
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        if self._child_stepper is not None:
+            out_state[STEPPER_STATE] = self._child_stepper.save()
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self._if_instruction = load_context.if_instruction
+        stepper_state = saved_state.get(STEPPER_STATE, None)
+        self._child_stepper = None
+        if stepper_state is not None:
+            self._child_stepper = self._if_instruction[self._pos].body.recreate_stepper(stepper_state, self._workchain)
+
+    def __str__(self) -> str:
+        string = str(self._if_instruction[self._pos])
+        if self._child_stepper is not None:
+            string += '(' + str(self._child_stepper) + ')'
+
+        return string
+
+
+class _If(_Instruction, collections.abc.Sequence):
+    def __init__(self, condition: PREDICATE_TYPE) -> None:
+        super().__init__()
+        self._ifs: list[_Conditional] = [_Conditional(self, condition, label=if_.__name__)]
+        self._sealed = False
+
+    def __getitem__(self, idx: int) -> _Conditional:  # type: ignore[override]
+        return self._ifs[idx]
+
+    def __len__(self) -> int:
+        return len(self._ifs)
+
+    def __call__(self, *commands: _Instruction | WC_COMMAND_TYPE) -> _If:
+        """
+        This is how the commands for the if(...) body are set
+        :param commands: The commands to run on the original if.
+        :return: This instance.
+        """
+        self._ifs[0](*commands)
+        return self
+
+    def elif_(self, condition: PREDICATE_TYPE) -> _Conditional:
+        self._ifs.append(_Conditional(self, condition, label=self.elif_.__name__))
+        return self._ifs[-1]
+
+    def else_(self, *commands: _Instruction | WC_COMMAND_TYPE) -> _If:
+        assert not self._sealed
+        # Create a dummy conditional that always returns True
+        cond = _Conditional(self, lambda wf: True, label=self.else_.__name__)
+        cond(*commands)
+        self._ifs.append(cond)
+        # Can't do any more after the else
+        self._sealed = True
+        return self
+
+    def create_stepper(self, workchain: WorkChain) -> _IfStepper:
+        return _IfStepper(self, workchain)
+
+    def recreate_stepper(self, saved_state: SAVED_STATE_TYPE, workchain: WorkChain) -> _IfStepper:
+        load_context = persistence.LoadSaveContext(workchain=workchain, if_instruction=self)
+        return cast(_IfStepper, _IfStepper.recreate_from(saved_state, load_context))
+
+    def get_description(self) -> Mapping[str, Any]:
+        description = collections.OrderedDict()
+
+        description[f'if({self._ifs[0].predicate.__name__})'] = self._ifs[0].body.get_description()
+        for conditional in self._ifs[1:]:
+            description[f'elif({conditional.predicate.__name__})'] = conditional.body.get_description()
+
+        return description
+
+
+class _WhileStepper(Stepper):
+    def __init__(self, while_instruction: _While, workchain: WorkChain) -> None:
+        super().__init__(workchain)
+        self._while_instruction = while_instruction
+        self._child_stepper: _BlockStepper | None = None
+
+    def step(self) -> tuple[bool, Any]:
+        # Do we need to check the condition?
+        if self._child_stepper is None:
+            # Should we go into the loop body?
+            if self._while_instruction.is_true(self._workchain):
+                self._child_stepper = self._while_instruction.body.create_stepper(self._workchain)
+            else:  # Nope...we're done
+                return True, None
+        assert self._child_stepper is not None
+        finished, result = self._child_stepper.step()
+        if finished:
+            self._child_stepper = None
+
+        return False, result
+
+    def save_instance_state(self, out_state: SAVED_STATE_TYPE, save_context: persistence.LoadSaveContext) -> None:
+        super().save_instance_state(out_state, save_context)
+        if self._child_stepper is not None:
+            out_state[STEPPER_STATE] = self._child_stepper.save()
+
+    def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
+        super().load_instance_state(saved_state, load_context)
+        self._while_instruction = load_context.while_instruction
+        stepper_state = saved_state.get(STEPPER_STATE, None)
+        self._child_stepper = None
+        if stepper_state is not None:
+            self._child_stepper = self._while_instruction.body.recreate_stepper(stepper_state, self._workchain)
+
+    def __str__(self) -> str:
+        string = str(self._while_instruction)
+        if self._child_stepper is not None:
+            string += '(' + str(self._child_stepper) + ')'
+
+        return string
+
+
+class _While(_Conditional, _Instruction, collections.abc.Sequence):
+    def __init__(self, predicate: PREDICATE_TYPE) -> None:
+        super().__init__(self, predicate, label=while_.__name__)
+
+    def __getitem__(self, idx: int) -> _While:  # type: ignore[override]
+        assert idx == 0
+        return self
+
+    def __len__(self) -> int:
+        return 1
+
+    def create_stepper(self, workchain: WorkChain) -> _WhileStepper:
+        return _WhileStepper(self, workchain)
+
+    def recreate_stepper(self, saved_state: SAVED_STATE_TYPE, workchain: WorkChain) -> _WhileStepper:
+        load_context = persistence.LoadSaveContext(workchain=workchain, while_instruction=self)
+        return cast(_WhileStepper, _WhileStepper.recreate_from(saved_state, load_context))
+
+    def get_description(self) -> dict[str, Any]:
+        return {f'while({self.predicate.__name__})': self.body.get_description()}
+
+
+class _PropagateReturn(BaseException):
+    def __init__(self, exit_code: EXIT_CODE_TYPE | None) -> None:
+        super().__init__()
+        self.exit_code = exit_code
+
+
+class _ReturnStepper(Stepper):
+    def __init__(self, return_instruction: _Return, workchain: WorkChain) -> None:
+        super().__init__(workchain)
+        self._return_instruction = return_instruction
+
+    def step(self) -> tuple[bool, Any]:
+        """
+        Raise a _PropagateReturn exception where the value is the exit code set
+        in the _Return instruction upon instantiation
+        """
+        raise _PropagateReturn(self._return_instruction._exit_code)
+
+
+class _Return(_Instruction):
+    """
+    A return instruction to tell the workchain to stop stepping through the
+    outline and cease execution immediately.
+    """
+
+    def __init__(self, exit_code: EXIT_CODE_TYPE | None = None) -> None:
+        super().__init__()
+        self._exit_code = exit_code
+
+    def __call__(self, exit_code: EXIT_CODE_TYPE) -> _Return:
+        return _Return(exit_code)
+
+    def create_stepper(self, workchain: WorkChain) -> _ReturnStepper:
+        return _ReturnStepper(self, workchain)
+
+    def recreate_stepper(self, saved_state: SAVED_STATE_TYPE, workchain: WorkChain) -> _ReturnStepper:
+        return _ReturnStepper(self, workchain)
+
+    def get_description(self) -> str:
+        """
+        Get a text description of these instructions.
+        :return: The description
+
+        """
+        return 'Return from the outline immediately'
+
+
+def if_(condition: PREDICATE_TYPE) -> _If:
+    """
+    A conditional that can be used in a workchain outline.
+
+    Use as::
+
+      if_(cls.conditional)(
+        cls.step1,
+        cls.step2
+      )
+
+    Each step can, of course, also be any valid workchain step e.g. conditional.
+
+    :param condition: The workchain method that will return True or False
+    """
+    return _If(condition)
+
+
+def while_(condition: PREDICATE_TYPE) -> _While:
+    """
+    A while loop that can be used in a workchain outline.
+
+    Use as::
+
+      while_(cls.conditional)(
+        cls.step1,
+        cls.step2
+      )
+
+    Each step can, of course, also be any valid workchain step e.g. conditional.
+
+    :param condition: The workchain method that will return True or False
+    """
+    return _While(condition)
+
+
+return_ = _Return()
+"""
+A global singleton that contains a Return instruction that allows to exit
+out of the workchain outline directly with None as exit code
+To set a specific exit code, call it with the desired exit code
+
+Use as::
+
+  if_(cls.conditional)(
+    return_
+  )
+
+or::
+
+  if_(cls.conditional)(
+    return_(EXIT_CODE)
+  )
+
+:param exit_code: an integer exit code to pass as the return value, None by default
+"""
+
+
+def _ensure_instruction(command: Any) -> _Instruction | _FunctionCall:
+    # There is only a single instruction
+    if isinstance(command, _Instruction):
+        return command
+
+    # It must be a direct function call
+    return _FunctionCall(command)

--- a/src/aiida/engine/processes/workchains/outline.py
+++ b/src/aiida/engine/processes/workchains/outline.py
@@ -37,6 +37,7 @@ __all__: tuple[str, ...] = ()
 PREDICATE_TYPE = Callable[['WorkChain'], bool]
 WC_COMMAND_TYPE = Callable[['WorkChain'], Any]
 EXIT_CODE_TYPE = int
+STEPPER_STATE = 'stepper_state'
 
 
 class WorkChainSpec(ProcessSpec):
@@ -161,9 +162,6 @@ class _FunctionCall(_Instruction):
             desc += f'({doc})'
 
         return desc
-
-
-STEPPER_STATE = 'stepper_state'
 
 
 @persistence.auto_persist('_pos')

--- a/src/aiida/engine/processes/workchains/workchain.py
+++ b/src/aiida/engine/processes/workchains/workchain.py
@@ -151,7 +151,7 @@ class WorkChain(Process, metaclass=Protect):
         :param out_state: state to save in
 
         :param save_context:
-        :type save_context: :class:`!plumpy.persistence.LoadSaveContext`
+        :type save_context: :class:`!aiida.engine.processes.persistence.LoadSaveContext`
 
         """
         super().save_instance_state(out_state, save_context)

--- a/src/aiida/engine/processes/workchains/workchain.py
+++ b/src/aiida/engine/processes/workchains/workchain.py
@@ -66,7 +66,11 @@ class Protect(ProcessStateMachineMeta):
         :raises RuntimeError: If the new class defines (i.e. overrides) a method that was decorated with ``final``.
         """
         private = {
-            key for base in bases for key, value in vars(base).items() if callable(value) and mcs.__is_final(value)
+            key
+            for base in bases
+            for parent in base.__mro__
+            for key, value in vars(parent).items()
+            if callable(value) and mcs.__is_final(value)
         }
         for key in namespace:
             if key in private:
@@ -293,6 +297,12 @@ class WorkChain(Process, metaclass=Protect):
             self._pre_paused_status = status
         else:
             self.set_status(status)
+
+    @override
+    @Protect.final
+    async def step(self) -> None:
+        """Advance the process state machine by one step."""
+        await super().step()
 
     @override
     @Protect.final

--- a/src/aiida/engine/processes/workchains/workchain.py
+++ b/src/aiida/engine/processes/workchains/workchain.py
@@ -15,20 +15,19 @@ import functools
 import logging
 import typing as t
 
-from plumpy import run_with_portal
-from plumpy.persistence import auto_persist
-from plumpy.process_states import Continue, Wait
-from plumpy.processes import ProcessStateMachineMeta
-from plumpy.workchains import Stepper, _PropagateReturn, if_, return_, while_
-from plumpy.workchains import WorkChainSpec as PlumpyWorkChainSpec
-
 from aiida.common import exceptions
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import override
 from aiida.engine.processes.exit_code import ExitCode
+from aiida.engine.processes.generic.process import ProcessStateMachineMeta
+from aiida.engine.processes.greenback import run_with_portal
+from aiida.engine.processes.persistence import auto_persist
 from aiida.engine.processes.process import Process, ProcessState
 from aiida.engine.processes.process_spec import ProcessSpec
+from aiida.engine.processes.states import Continue, Wait
 from aiida.engine.processes.workchains.awaitable import Awaitable, AwaitableAction, AwaitableTarget, construct_awaitable
+from aiida.engine.processes.workchains.outline import Stepper, _PropagateReturn, if_, return_, while_
+from aiida.engine.processes.workchains.outline import WorkChainSpec as ProcessWorkChainSpec
 from aiida.orm import Node, ProcessNode, WorkChainNode
 from aiida.orm.utils import load_node
 
@@ -38,7 +37,7 @@ if t.TYPE_CHECKING:
 __all__ = ('WorkChain', 'if_', 'return_', 'while_')
 
 
-class WorkChainSpec(ProcessSpec, PlumpyWorkChainSpec):
+class WorkChainSpec(ProcessSpec, ProcessWorkChainSpec):
     pass
 
 
@@ -173,7 +172,7 @@ class WorkChain(Process, metaclass=Protect):
         self._stepper = None
         stepper_state = saved_state.get(self._STEPPER_STATE, None)
         if stepper_state is not None:
-            self._stepper = self.spec().get_outline().recreate_stepper(stepper_state, self)  # type: ignore[arg-type]
+            self._stepper = self.spec().get_outline().recreate_stepper(stepper_state, self)
 
         self.set_logger(self.node.logger)
 
@@ -298,7 +297,7 @@ class WorkChain(Process, metaclass=Protect):
     @override
     @Protect.final
     async def run(self) -> t.Any:
-        self._stepper = self.spec().get_outline().create_stepper(self)  # type: ignore[arg-type]
+        self._stepper = self.spec().get_outline().create_stepper(self)
         return await run_with_portal(self._do_step)
 
     def _do_step(self) -> t.Any:

--- a/src/aiida/engine/runners.py
+++ b/src/aiida/engine/runners.py
@@ -88,6 +88,7 @@ class Runner:
         self._job_manager = manager.JobManager(self._transport)
         self._persister = persister
         self._plugin_version_provider = PluginVersionProvider()
+        self._process_tasks: set[asyncio.Task[Any]] = set()
 
         if communicator is not None:
             self._communicator = wrap_communicator(communicator, self._loop)
@@ -200,7 +201,9 @@ class Runner:
             process_inited.close()
             self.controller.continue_process(process_inited.pid, nowait=False, no_reply=True)
         else:
-            self.loop.create_task(process_inited.step_until_terminated())
+            task = self.loop.create_task(process_inited.step_until_terminated())
+            self._process_tasks.add(task)
+            task.add_done_callback(self._process_tasks.discard)
 
         return process_inited.node
 
@@ -218,7 +221,9 @@ class Runner:
 
         inputs = utils.prepare_inputs(inputs, **kwargs)
         process_inited = self.instantiate_process(process, **inputs)
-        self.loop.create_task(process_inited.step_until_terminated())
+        task = self.loop.create_task(process_inited.step_until_terminated())
+        self._process_tasks.add(task)
+        task.add_done_callback(self._process_tasks.discard)
         return process_inited.node
 
     def _run(

--- a/src/aiida/engine/runners.py
+++ b/src/aiida/engine/runners.py
@@ -20,16 +20,15 @@ from collections.abc import Callable
 from typing import Any, NamedTuple
 
 import kiwipy
-from plumpy import run_until_complete
-from plumpy.communications import wrap_communicator
-from plumpy.events import get_or_create_event_loop
-from plumpy.persistence import Persister
-from plumpy.process_comms import RemoteProcessThreadController
 
 from aiida.common import exceptions
 from aiida.engine import transports, utils
 from aiida.engine.processes import Process, ProcessBuilder, ProcessState, futures
 from aiida.engine.processes.calcjobs import manager
+from aiida.engine.processes.communications import RemoteProcessThreadController, wrap_communicator
+from aiida.engine.processes.events import get_or_create_event_loop
+from aiida.engine.processes.greenback import run_until_complete
+from aiida.engine.processes.persistence import Persister
 from aiida.orm import ProcessNode, load_node
 from aiida.plugins.utils import PluginVersionProvider
 

--- a/src/aiida/engine/transports.py
+++ b/src/aiida/engine/transports.py
@@ -16,8 +16,7 @@ import traceback
 from collections.abc import AsyncIterator, Awaitable, Hashable
 from typing import TYPE_CHECKING
 
-from plumpy import get_or_create_event_loop
-
+from aiida.engine.processes.events import get_or_create_event_loop
 from aiida.orm import AuthInfo
 
 if TYPE_CHECKING:
@@ -71,7 +70,7 @@ class TransportQueue:
         :return: A future that can be yielded to give the transport
         """
 
-        from plumpy import ensure_portal
+        from aiida.engine.processes.greenback import ensure_portal
 
         # NOTE: We need to ensure the portal here only because
         # our scheduler has only a sync interface and _get_jobs_from_scheduler is using that

--- a/src/aiida/engine/utils.py
+++ b/src/aiida/engine/utils.py
@@ -92,6 +92,18 @@ def instantiate_process(runner: Runner, process: Process | type[Process] | Proce
 class InterruptableFuture(asyncio.Future):
     """A future that can be interrupted by calling `interrupt`."""
 
+    _task: asyncio.Task[Any] | None = None
+
+    def _retain_task(self, task: asyncio.Task[Any]) -> None:
+        """Retain the task until it completes."""
+        self._task = task
+        task.add_done_callback(self._release_task)
+
+    def _release_task(self, task: asyncio.Task[Any]) -> None:
+        """Release the completed task."""
+        if self._task is task:
+            self._task = None
+
     def interrupt(self, reason: Exception) -> None:
         """This method should be called to interrupt the coroutine represented by this InterruptableFuture."""
         self.set_exception(reason)
@@ -112,12 +124,17 @@ class InterruptableFuture(asyncio.Future):
         :return: The result of the coroutine
         """
         task = asyncio.ensure_future(coro)
-        wait_iter = asyncio.as_completed({self, task})
-        result = await next(wait_iter)
-        if self.done():
-            raise RuntimeError(f"This interruptible future had it's result set unexpectedly to '{result}'")
+        try:
+            wait_iter = asyncio.as_completed({self, task})
+            result = await next(wait_iter)
+            if self.done():
+                raise RuntimeError(f"This interruptible future had it's result set unexpectedly to '{result}'")
 
-        return result
+            return result
+        finally:
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
 
 
 def interruptable_task(
@@ -152,7 +169,7 @@ def interruptable_task(
             if not future.done():
                 future.set_result(result)
 
-    loop.create_task(execute_coroutine())
+    future._retain_task(loop.create_task(execute_coroutine()))
 
     return future
 

--- a/src/aiida/engine/utils.py
+++ b/src/aiida/engine/utils.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import inspect
 import logging
 from collections.abc import Awaitable, Callable, Iterator
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from plumpy import get_or_create_event_loop
+from aiida.engine.processes.events import get_or_create_event_loop
 
 if TYPE_CHECKING:
     from aiida.engine.processes import Process, ProcessBuilder
@@ -157,18 +158,24 @@ def interruptable_task(
 
 
 def ensure_coroutine(fct: Callable[..., Any]) -> Callable[..., Awaitable[Any]]:
-    """Ensure that the given function ``fct`` is a coroutine
+    """Return a coroutine function for a callable."""
+    if not callable(fct):
+        # Defensive check: callers can reach this with values loaded from a persisted state
+        msg = 'fct must be callable'  # type: ignore[unreachable]
+        raise TypeError(msg)
 
-    If the passed function is not already a coroutine, it will be made to be a coroutine
-
-    :param fct: the function
-    :returns: the coroutine
-    """
-    if inspect.iscoroutinefunction(fct):
+    # The second check catches instances of a class with an ``async def __call__``
+    if inspect.iscoroutinefunction(fct) or inspect.iscoroutinefunction(fct.__call__):  # type: ignore[operator]
         return fct
 
-    async def wrapper(*args, **kwargs):
-        return fct(*args, **kwargs)
+    if inspect.isclass(fct):
+        fct = fct.__call__
+
+    from aiida.engine.processes.greenback import run_with_portal
+
+    @functools.wraps(fct)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return await run_with_portal(fct, *args, **kwargs)
 
     return wrapper
 

--- a/src/aiida/manage/configuration/config.py
+++ b/src/aiida/manage/configuration/config.py
@@ -198,11 +198,6 @@ class ProfileOptionsSchema(BaseModel, defer_build=True):
             'requires_daemon_restart': True,
         },
     )
-    logging__plumpy_loglevel: AdvancedLogLevels = Field(
-        cast(AdvancedLogLevels, 'INHERIT'),
-        description='Minimum level for the `plumpy` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',
-        json_schema_extra={'advanced': True, 'requires_daemon_restart': True},
-    )
     logging__kiwipy_loglevel: AdvancedLogLevels = Field(
         cast(AdvancedLogLevels, 'INHERIT'),
         description='Minimum level for the `kiwipy` logger. If `INHERIT`, inherits `logging.aiida_loglevel`.',

--- a/src/aiida/manage/configuration/migrations/migrations.py
+++ b/src/aiida/manage/configuration/migrations/migrations.py
@@ -33,10 +33,10 @@ ConfigType = dict[str, Any]
 # When the configuration file format is changed in a backwards-incompatible way, the oldest compatible version should
 # be set to the new current version.
 
-CURRENT_CONFIG_VERSION = 10
-OLDEST_COMPATIBLE_CONFIG_VERSION = 10
+CURRENT_CONFIG_VERSION = 11
+OLDEST_COMPATIBLE_CONFIG_VERSION = 11
 # Highest configuration version for which this code can run downgrade migrations, even if it cannot load it.
-MAXIMUM_DOWNGRADE_CONFIG_VERSION = 10
+MAXIMUM_DOWNGRADE_CONFIG_VERSION = 11
 
 CONFIG_LOGGER = AIIDA_LOGGER.getChild('config')
 
@@ -470,6 +470,35 @@ class RenameRmqAndLogging(SingleMigration):
             self._remove_v10_only_options(options)
 
 
+class MergePlumpyLogLevel(SingleMigration):
+    """Merge the plumpy log-level option into the aiida-core log level."""
+
+    down_revision = 10
+    down_compatible = 10
+    up_revision = 11
+    up_compatible = 11
+
+    @staticmethod
+    def _upgrade_options(options: dict[str, Any]) -> None:
+        if (value := options.pop('logging.plumpy_loglevel', None)) is not None:
+            options.setdefault('logging.aiida_core_loglevel', value)
+
+    @staticmethod
+    def _downgrade_options(options: dict[str, Any]) -> None:
+        if (value := options.get('logging.aiida_core_loglevel')) is not None:
+            options.setdefault('logging.plumpy_loglevel', value)
+
+    def upgrade(self, config: ConfigType) -> None:
+        self._upgrade_options(config.get('options', {}))
+        for profile in config.get('profiles', {}).values():
+            self._upgrade_options(profile.get('options', {}))
+
+    def downgrade(self, config: ConfigType) -> None:
+        self._downgrade_options(config.get('options', {}))
+        for profile in config.get('profiles', {}).values():
+            self._downgrade_options(profile.get('options', {}))
+
+
 MIGRATIONS = (
     Initial,
     AddProfileUuid,
@@ -481,6 +510,7 @@ MIGRATIONS = (
     AddTestProfileKey,
     AddPrefixToStorageBackendTypes,
     RenameRmqAndLogging,
+    MergePlumpyLogLevel,
 )
 
 

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
     import asyncio
 
     from kiwipy.rmq import RmqThreadCommunicator
-    from plumpy.process_comms import RemoteProcessThreadController
 
     from aiida.brokers.broker import Broker
     from aiida.engine.daemon.client import DaemonClient
     from aiida.engine.persistence import AiiDAPersister
+    from aiida.engine.processes.communications import RemoteProcessThreadController
     from aiida.engine.runners import Runner
     from aiida.manage.configuration.config import Config
     from aiida.manage.configuration.profile import Profile
@@ -180,7 +180,7 @@ class Manager:
             if getattr(IPythonKernel, '_aiida_portal_patched', False):
                 return  # Already patched
 
-            from plumpy import ensure_portal
+            from aiida.engine.processes.greenback import ensure_portal
 
             _orig_do_execute = IPythonKernel.do_execute
 
@@ -422,7 +422,7 @@ class Manager:
         :return: the process controller instance
 
         """
-        from plumpy.process_comms import RemoteProcessThreadController
+        from aiida.engine.processes.communications import RemoteProcessThreadController
 
         if self._process_controller is None:
             self._process_controller = RemoteProcessThreadController(self.get_communicator())
@@ -495,10 +495,9 @@ class Manager:
         :return: a runner configured to work in the daemon configuration
 
         """
-        from plumpy.persistence import LoadSaveContext
-
-        from aiida.engine import persistence
+        from aiida.common.loaders import get_object_loader
         from aiida.engine.processes.launcher import ProcessLauncher
+        from aiida.engine.processes.persistence import LoadSaveContext
 
         runner = self.create_runner(broker_submit=True, loop=loop)
         runner_loop = runner.loop
@@ -508,7 +507,7 @@ class Manager:
             loop=runner_loop,
             persister=self.get_persister(),
             load_context=LoadSaveContext(runner=runner),
-            loader=persistence.get_object_loader(),
+            loader=get_object_loader(),
         )
 
         assert runner.communicator is not None, 'communicator not set for runner'

--- a/src/aiida/manage/tests/pytest_fixtures.py
+++ b/src/aiida/manage/tests/pytest_fixtures.py
@@ -33,7 +33,6 @@ import typing as t
 import uuid
 import warnings
 
-import plumpy
 import pytest
 import wrapt
 from importlib_metadata import EntryPoint, EntryPoints
@@ -42,9 +41,11 @@ from aiida import plugins
 from aiida.common.exceptions import NotExistent
 from aiida.common.lang import type_check
 from aiida.common.log import AIIDA_LOGGER
+from aiida.common.processes import ProcessState
 from aiida.common.warnings import warn_deprecation
 from aiida.engine import Process, ProcessBuilder, submit
 from aiida.engine.daemon.client import DaemonClient, DaemonNotRunningException, DaemonTimeoutException
+from aiida.engine.processes.events import get_or_create_event_loop
 from aiida.manage import Profile, get_manager, get_profile
 from aiida.manage.manager import Manager
 from aiida.orm import Computer, ProcessNode, User
@@ -409,7 +410,7 @@ def clear_database_before_test_class(aiida_profile):
 @pytest.fixture(scope='function')
 def temporary_event_loop():
     """Create a temporary loop for independent test case"""
-    current = plumpy.get_or_create_event_loop()
+    current = get_or_create_event_loop()
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
@@ -726,7 +727,7 @@ def submit_and_await(started_daemon_client):
 
     def _factory(
         submittable: Process | ProcessBuilder | ProcessNode,
-        state: plumpy.ProcessState = plumpy.ProcessState.FINISHED,
+        state: ProcessState = ProcessState.FINISHED,
         timeout: int = 20,
         **kwargs,
     ):

--- a/src/aiida/orm/entities.py
+++ b/src/aiida/orm/entities.py
@@ -27,12 +27,11 @@ from typing import (
 )
 
 import pydantic as pdt
-from plumpy.base.utils import call_with_super_check, super_check
 from typing_extensions import Self
 
 from aiida.common import exceptions, log
 from aiida.common.exceptions import InvalidOperation
-from aiida.common.lang import classproperty, type_check
+from aiida.common.lang import call_with_super_check, classproperty, super_check, type_check
 from aiida.common.pydantic import get_metadata
 from aiida.common.warnings import warn_deprecation
 from aiida.manage import get_manager

--- a/src/aiida/orm/nodes/data/enum.py
+++ b/src/aiida/orm/nodes/data/enum.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 import typing as t
 from enum import Enum
 
-from plumpy.loaders import get_object_loader
-
 from aiida.common.lang import type_check
+from aiida.common.loaders import get_object_loader
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.orm.nodes.data.data import Data
 from aiida.orm.pydantic import OrmMetadataField, OrmModel

--- a/src/aiida/orm/nodes/process/process.py
+++ b/src/aiida/orm/nodes/process/process.py
@@ -14,11 +14,10 @@ import enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from plumpy.process_states import ProcessState
-
 from aiida.common import exceptions
 from aiida.common.lang import classproperty
 from aiida.common.links import LinkType
+from aiida.common.processes import ProcessState
 from aiida.orm.nodes.caching import NodeCaching
 from aiida.orm.nodes.links import NodeLinks
 from aiida.orm.nodes.node import Node

--- a/src/aiida/orm/utils/serialize.py
+++ b/src/aiida/orm/utils/serialize.py
@@ -37,7 +37,7 @@ _NODE_LINKS_MANAGER_TAG = '!aiida_node_links_manager'
 _GROUP_TAG = '!aiida_group'
 _COMPUTER_TAG = '!aiida_computer'
 _ATTRIBUTE_DICT_TAG = '!aiida_attributedict'
-_PLUMPY_ATTRIBUTES_FROZENDICT_TAG = '!plumpy:attributes_frozendict'
+_ATTRIBUTES_FROZENDICT_TAG = '!aiida:attributes_frozendict'
 
 
 def represent_enum(dumper: yaml.Dumper, enum: Enum) -> yaml.ScalarNode:
@@ -198,12 +198,8 @@ yaml.add_representer(Enum, represent_enum, Dumper=AiiDADumper)
 yaml.add_representer(Bundle, represent_bundle, Dumper=AiiDADumper)
 yaml.add_representer(AttributeDict, partial(represent_mapping, _ATTRIBUTE_DICT_TAG), Dumper=AiiDADumper)
 yaml.add_constructor(_ATTRIBUTE_DICT_TAG, partial(mapping_constructor, AttributeDict), Loader=AiiDALoader)
-yaml.add_representer(
-    AttributesFrozendict, partial(represent_mapping, _PLUMPY_ATTRIBUTES_FROZENDICT_TAG), Dumper=AiiDADumper
-)
-yaml.add_constructor(
-    _PLUMPY_ATTRIBUTES_FROZENDICT_TAG, partial(mapping_constructor, AttributesFrozendict), Loader=AiiDALoader
-)
+yaml.add_representer(AttributesFrozendict, partial(represent_mapping, _ATTRIBUTES_FROZENDICT_TAG), Dumper=AiiDADumper)
+yaml.add_constructor(_ATTRIBUTES_FROZENDICT_TAG, partial(mapping_constructor, AttributesFrozendict), Loader=AiiDALoader)
 yaml.add_constructor(BUNDLE_TAG, bundle_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_NODE_TAG, node_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_NODE_LINKS_MANAGER_TAG, node_links_manager_constructor, Loader=AiiDALoader)

--- a/src/aiida/orm/utils/serialize.py
+++ b/src/aiida/orm/utils/serialize.py
@@ -27,7 +27,7 @@ from aiida import orm
 from aiida.common import AttributeDict
 from aiida.common.extendeddicts import AttributesFrozendict
 from aiida.common.loaders import get_object_loader
-from aiida.engine.processes.persistence import Bundle
+from aiida.engine.processes.persistence import BUNDLE_TAG, Bundle
 from aiida.orm.utils.managers import NodeLinksManager
 
 _ENUM_TAG = '!enum'
@@ -38,7 +38,6 @@ _GROUP_TAG = '!aiida_group'
 _COMPUTER_TAG = '!aiida_computer'
 _ATTRIBUTE_DICT_TAG = '!aiida_attributedict'
 _PLUMPY_ATTRIBUTES_FROZENDICT_TAG = '!plumpy:attributes_frozendict'
-_PLUMPY_BUNDLE = '!plumpy:bundle'
 
 
 def represent_enum(dumper: yaml.Dumper, enum: Enum) -> yaml.ScalarNode:
@@ -153,13 +152,13 @@ def mapping_constructor(
 
 
 def represent_bundle(dumper: yaml.Dumper, bundle: Bundle) -> yaml.MappingNode:
-    """Represent an `plumpy.Bundle` in yaml."""
+    """Represent a :class:`aiida.engine.processes.persistence.Bundle` in YAML."""
     as_dict = dict(bundle)
-    return dumper.represent_mapping(_PLUMPY_BUNDLE, as_dict)
+    return dumper.represent_mapping(BUNDLE_TAG, as_dict)
 
 
 def bundle_constructor(loader: yaml.Loader, bundle: yaml.Node) -> Bundle:
-    """Construct an `plumpy.Bundle` from the representation."""
+    """Construct an :class:`aiida.engine.processes.persistence.Bundle` from the representation."""
     yaml_node = loader.construct_mapping(bundle)  # type: ignore[arg-type]
     bundle_inst = Bundle.__new__(Bundle)
     bundle_inst.update(yaml_node)
@@ -205,7 +204,7 @@ yaml.add_representer(
 yaml.add_constructor(
     _PLUMPY_ATTRIBUTES_FROZENDICT_TAG, partial(mapping_constructor, AttributesFrozendict), Loader=AiiDALoader
 )
-yaml.add_constructor(_PLUMPY_BUNDLE, bundle_constructor, Loader=AiiDALoader)
+yaml.add_constructor(BUNDLE_TAG, bundle_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_NODE_TAG, node_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_NODE_LINKS_MANAGER_TAG, node_links_manager_constructor, Loader=AiiDALoader)
 yaml.add_constructor(_GROUP_TAG, group_constructor, Loader=AiiDALoader)

--- a/src/aiida/orm/utils/serialize.py
+++ b/src/aiida/orm/utils/serialize.py
@@ -22,11 +22,12 @@ from functools import partial
 from typing import Any, Protocol, overload
 
 import yaml
-from plumpy import Bundle, get_object_loader
-from plumpy.utils import AttributesFrozendict
 
 from aiida import orm
 from aiida.common import AttributeDict
+from aiida.common.extendeddicts import AttributesFrozendict
+from aiida.common.loaders import get_object_loader
+from aiida.engine.processes.persistence import Bundle
 from aiida.orm.utils.managers import NodeLinksManager
 
 _ENUM_TAG = '!enum'

--- a/src/aiida/sphinxext/process.py
+++ b/src/aiida/sphinxext/process.py
@@ -14,14 +14,13 @@ from collections.abc import Iterable, Mapping
 from docutils import nodes
 from docutils.core import publish_doctree
 from docutils.parsers.rst import directives
-from plumpy.ports import OutputPort
 from sphinx import addnodes
 from sphinx.ext.autodoc import ClassDocumenter
 from sphinx.util.docutils import SphinxDirective
 
 from aiida.common.utils import get_object_from_string
 from aiida.engine import Process
-from aiida.engine.processes.ports import InputPort, PortNamespace
+from aiida.engine.processes.ports import InputPort, OutputPort, PortNamespace
 from aiida.manage.configuration import load_profile
 
 

--- a/src/aiida/transports/transport.py
+++ b/src/aiida/transports/transport.py
@@ -1878,8 +1878,7 @@ class AsyncTransport(Transport):
 
     def run_command_blocking(self, func, *args, **kwargs):
         """Run an async transport method synchronously."""
-        from plumpy import run_until_complete
-
+        from aiida.engine.processes.greenback import run_until_complete
         from aiida.manage import get_manager
 
         loop = get_manager().get_runner().loop

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -9,11 +9,11 @@
 """Tests for ``verdi devel rabbitmq``."""
 
 import pytest
-from plumpy.process_comms import RemoteProcessThreadController
 
 from aiida.cmdline.commands import cmd_rabbitmq
 from aiida.engine import ProcessState, submit
 from aiida.engine.processes import control
+from aiida.engine.processes.communications import RemoteProcessThreadController
 from aiida.orm import Int
 
 

--- a/tests/common/test_lang.py
+++ b/tests/common/test_lang.py
@@ -1,0 +1,46 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for utilities that extend the Python language."""
+
+import pytest
+
+from aiida.common.lang import call_with_super_check, super_check
+
+
+class Root:
+    @super_check
+    def method(self) -> None:
+        pass
+
+    def invoke(self) -> None:
+        call_with_super_check(self.method)
+
+
+class CallsSuper(Root):
+    def method(self) -> None:
+        super().method()
+
+
+class DoesNotCallSuper(Root):
+    def method(self) -> None:
+        pass
+
+
+def test_super_check() -> None:
+    CallsSuper().invoke()
+
+
+def test_super_check_missing_super() -> None:
+    with pytest.raises(AssertionError, match='Did you forget to call the super'):
+        DoesNotCallSuper().invoke()
+
+
+def test_super_check_without_checked_call() -> None:
+    with pytest.raises(AssertionError, match='was not called through call_with_super_check'):
+        CallsSuper().method()

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -64,7 +64,6 @@ class TestValidateHandler:
             'logging.aiida_loglevel': 'INFO',
             'logging.aiida_core_loglevel': 'INHERIT',
             'logging.disk_objectstore_loglevel': 'INHERIT',
-            'logging.plumpy_loglevel': 'INHERIT',
             'logging.kiwipy_loglevel': 'INHERIT',
         }
         config = Mock(get_option=lambda name, scope=None: levels.get(name, 'WARNING'))
@@ -111,7 +110,6 @@ def test_configure_logging_inherits_aiida_loglevel_for_inherited_loggers(monkeyp
     assert captured_config['loggers']['aiida']['level'] == 'ERROR'
     assert captured_config['loggers']['verdi']['level'] == 'ERROR'
     assert captured_config['loggers']['disk_objectstore']['level'] == 'ERROR'
-    assert captured_config['loggers']['plumpy']['level'] == 'ERROR'
     assert captured_config['loggers']['kiwipy']['level'] == 'ERROR'
 
 
@@ -120,7 +118,6 @@ def test_configure_logging_respects_explicit_inherited_logger_levels(monkeypatch
     """Explicit logger levels should override the inherited ``logging.aiida_loglevel``."""
     isolated_config.set_option('logging.aiida_loglevel', 'ERROR')
     isolated_config.set_option('logging.aiida_core_loglevel', 'CRITICAL')
-    isolated_config.set_option('logging.plumpy_loglevel', 'WARNING')
 
     captured_config = {}
     monkeypatch.setattr(logging.config, 'dictConfig', captured_config.update)
@@ -128,7 +125,6 @@ def test_configure_logging_respects_explicit_inherited_logger_levels(monkeypatch
     log.configure_logging()
 
     assert captured_config['loggers']['aiida']['level'] == 'CRITICAL'
-    assert captured_config['loggers']['plumpy']['level'] == 'WARNING'
     assert captured_config['loggers']['disk_objectstore']['level'] == 'ERROR'
 
 
@@ -159,8 +155,8 @@ class TestVerbosityOverridesCliHandler:
             log.CLI_ACTIVE = original_cli_active
             log.CLI_LOG_LEVEL = original_cli_log_level
 
-        # The cli handler level should be overridden to DEBUG
         assert captured_config['handlers']['cli']['level'] == 'DEBUG'
+        assert captured_config['loggers']['aiida']['level'] == 'DEBUG'
 
     def test_cli_log_level_none_keeps_default(self):
         """When ``CLI_LOG_LEVEL`` is None, the ``cli`` handler level should remain the default."""

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -23,6 +23,7 @@ import pytest
 from aiida import orm
 from aiida.common import CalcJobState, LinkType, StashMode, exceptions
 from aiida.common.datastructures import FileCopyOperation
+from aiida.common.processes import ProcessState
 from aiida.engine import CalcJob, CalcJobImporter, ExitCode, Process, launch
 from aiida.engine.processes.calcjobs.calcjob import validate_monitors, validate_stash_options
 from aiida.engine.processes.calcjobs.monitors import CalcJobMonitorAction, CalcJobMonitorResult
@@ -1367,8 +1368,6 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
 
     This is a regression test for https://github.com/aiidateam/aiida-core/issues/5882.
     """
-    import plumpy
-
     daemon_client.start_daemon()
 
     # Launch a job with a one second sleep to ensure it doesn't finish before we get the chance to restart the daemon.
@@ -1376,13 +1375,13 @@ def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_a
     builder = get_calcjob_builder()
     builder.metadata.options.sleep = 1
     builder.monitors = {'monitor': orm.Dict({'entry_point': 'core.always_kill', 'disabled': True})}
-    node = submit_and_await(builder, plumpy.ProcessState.WAITING)
+    node = submit_and_await(builder, ProcessState.WAITING)
 
     daemon_client.restart_daemon(wait=True)
 
     # The full stop/restart/reload/resume/finish cycle is heavy, so allow more than the fixture default: under CPU
     # contention the post-restart wait alone approaches the 10 seconds this test used to allow.
-    submit_and_await(node, plumpy.ProcessState.FINISHED, timeout=30)
+    submit_and_await(node, ProcessState.FINISHED, timeout=30)
 
     assert node.is_finished_ok, node.exit_status
 

--- a/tests/engine/processes/generic/test_process.py
+++ b/tests/engine/processes/generic/test_process.py
@@ -1,0 +1,23 @@
+"""Tests for internal process futures."""
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from aiida.engine.processes.generic.process import Process
+from aiida.engine.processes.states import KillInterruption, PauseInterruption
+
+
+@pytest.mark.parametrize('interruption', [PauseInterruption(None), KillInterruption(None)])
+def test_interrupt_action_uses_process_loop(interruption):
+    """Test pause and kill actions bind to the process event loop."""
+    loop = asyncio.new_event_loop()
+    process = Mock(loop=loop)
+
+    try:
+        action = Process._create_interrupt_action(process, interruption)
+
+        assert action.get_loop() is loop
+    finally:
+        loop.close()

--- a/tests/engine/processes/test_communications.py
+++ b/tests/engine/processes/test_communications.py
@@ -1,0 +1,26 @@
+"""Tests for process communication helpers."""
+
+from unittest.mock import Mock
+
+import kiwipy
+
+from aiida.engine.processes.communications import RemoteProcessThreadController
+
+
+def test_execute_process_no_reply():
+    """Test executing a process without a reply resolves the returned future."""
+    create_future = kiwipy.Future()
+    create_future.set_result(1)
+
+    communicator = Mock(spec=kiwipy.Communicator)
+    communicator.task_send.side_effect = [create_future, None]
+
+    loader = Mock()
+    loader.identify_object.return_value = 'tests:DummyProcess'
+
+    controller = RemoteProcessThreadController(communicator)
+    execute_future = controller.execute_process(object, loader=loader, no_reply=True)
+
+    assert execute_future.result() is None
+    assert communicator.task_send.call_count == 2
+    assert communicator.task_send.call_args_list[1].kwargs == {'no_reply': True}

--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -1,11 +1,11 @@
 """Tests for the :mod:`aiida.engine.processes.control` module."""
 
 import pytest
-from plumpy.process_comms import RemoteProcessThreadController
 
 from aiida.engine import ProcessState
 from aiida.engine.launch import submit
 from aiida.engine.processes import control
+from aiida.engine.processes.communications import RemoteProcessThreadController
 from aiida.orm import Int
 from tests.utils.processes import WaitProcess
 

--- a/tests/engine/processes/test_mixins.py
+++ b/tests/engine/processes/test_mixins.py
@@ -1,0 +1,15 @@
+"""Tests for process mixins."""
+
+from unittest.mock import Mock
+
+from aiida.engine.processes import persistence
+from aiida.engine.processes.mixins import ContextMixin
+
+
+def test_restore_without_context():
+    """Test restoring saved state without a context initializes the attribute."""
+    load_context = persistence.LoadSaveContext(loader=Mock())
+
+    restored = ContextMixin.recreate_from({}, load_context)
+
+    assert restored.ctx is None

--- a/tests/engine/processes/test_state_machine.py
+++ b/tests/engine/processes/test_state_machine.py
@@ -1,0 +1,26 @@
+"""Tests for the process state machine."""
+
+from aiida.engine.processes.state_machine import State, StateMachine
+
+
+def test_state_map_is_built_per_class():
+    """Test a subclass builds its own state map after its parent's map is built."""
+
+    class ParentState(State):
+        LABEL = 'parent'
+
+    class ChildState(State):
+        LABEL = 'child'
+
+    class ParentStateMachine(StateMachine):
+        @classmethod
+        def get_states(cls):
+            return (ParentState,)
+
+    class ChildStateMachine(ParentStateMachine):
+        @classmethod
+        def get_states(cls):
+            return (ChildState,)
+
+    assert ParentStateMachine.get_states_map() == {'parent': ParentState}
+    assert ChildStateMachine.get_states_map() == {'child': ChildState}

--- a/tests/engine/processes/test_states.py
+++ b/tests/engine/processes/test_states.py
@@ -2,7 +2,34 @@
 
 from unittest.mock import Mock
 
-from aiida.engine.processes.states import Continue, ProcessState, Running
+import yaml
+
+from aiida.engine.processes import persistence
+from aiida.engine.processes.states import Continue, Excepted, ProcessState, Running
+
+
+def test_excepted_state_restores_formatted_traceback():
+    """Test persisted tracebacks are restored as formatted text without a live traceback."""
+
+    def create_exception():
+        try:
+            raise ValueError('failure')
+        except ValueError as exception:
+            return exception
+
+    exception = create_exception()
+    state = Excepted(Mock(), exception, exception.__traceback__)
+    saved_state = {
+        'in_state': False,
+        Excepted.EXC_VALUE: yaml.dump(exception),
+        Excepted.TRACEBACK: state.traceback_string,
+    }
+    load_context = persistence.LoadSaveContext(loader=Mock(), process=Mock())
+
+    restored = Excepted.recreate_from(saved_state, load_context)
+
+    assert restored.traceback is None
+    assert restored.traceback_string == state.traceback_string
 
 
 def test_continue_forwards_keyword_arguments():

--- a/tests/engine/processes/test_states.py
+++ b/tests/engine/processes/test_states.py
@@ -1,0 +1,20 @@
+"""Tests for process states and commands."""
+
+from unittest.mock import Mock
+
+from aiida.engine.processes.states import Continue, ProcessState, Running
+
+
+def test_continue_forwards_keyword_arguments():
+    """Test a continue command forwards positional and keyword arguments."""
+
+    def continue_fn(*args, **kwargs):
+        pass
+
+    running = Running.__new__(Running)
+    running.create_state = Mock()
+    command = Continue(continue_fn, 'value', keyword='value')
+
+    running._action_command(command)
+
+    running.create_state.assert_called_once_with(ProcessState.RUNNING, continue_fn, 'value', keyword='value')

--- a/tests/engine/processes/test_states.py
+++ b/tests/engine/processes/test_states.py
@@ -1,11 +1,27 @@
 """Tests for process states and commands."""
 
+import asyncio
 from unittest.mock import Mock
 
 import yaml
 
 from aiida.engine.processes import persistence
-from aiida.engine.processes.states import Continue, Excepted, ProcessState, Running
+from aiida.engine.processes.states import NULL, Continue, Excepted, ProcessState, Running, Waiting
+
+
+def test_interrupt_completed_waiting_future():
+    """Test interrupting an already resumed waiting state does not raise."""
+    loop = asyncio.new_event_loop()
+    waiting = Waiting.__new__(Waiting)
+    waiting._waiting_future = loop.create_future()
+
+    try:
+        waiting.resume()
+        waiting.interrupt(RuntimeError('interrupt'))
+
+        assert waiting._waiting_future.result() is NULL
+    finally:
+        loop.close()
 
 
 def test_excepted_state_restores_formatted_traceback():

--- a/tests/engine/test_class_loader.py
+++ b/tests/engine/test_class_loader.py
@@ -25,6 +25,13 @@ class TestCalcJob:
         yield
         assert Process.current() is None
 
+    def test_legacy_plumpy_identifier(self):
+        """Test identifiers stored before plumpy was integrated are no longer supported."""
+        loader = aiida.engine.persistence.get_object_loader()
+
+        with pytest.raises(ImportError, match=r"module 'plumpy\.process_states'"):
+            loader.load_object('plumpy.process_states:Running')
+
     def test_class_loader(self):
         """Test that CalculationFactory works."""
         process = CalculationFactory('core.templatereplacer')

--- a/tests/engine/test_daemon.py
+++ b/tests/engine/test_daemon.py
@@ -11,8 +11,8 @@
 import asyncio
 
 import pytest
-from plumpy.process_states import ProcessState
 
+from aiida.common.processes import ProcessState
 from aiida.manage import get_manager
 from tests.utils import processes as test_processes
 

--- a/tests/engine/test_manager.py
+++ b/tests/engine/test_manager.py
@@ -12,9 +12,9 @@ import asyncio
 import time
 
 import pytest
-from plumpy import get_or_create_event_loop
 
 from aiida.engine.processes.calcjobs.manager import JobManager, JobsList
+from aiida.engine.processes.events import get_or_create_event_loop
 from aiida.engine.transports import TransportQueue
 from aiida.orm import User
 

--- a/tests/engine/test_persistence.py
+++ b/tests/engine/test_persistence.py
@@ -8,11 +8,12 @@
 ###########################################################################
 """Test persisting via the AiiDAPersister."""
 
-import plumpy
 import pytest
 
+from aiida.common.processes import ProcessState
 from aiida.engine import Process, run
 from aiida.engine.persistence import AiiDAPersister
+from aiida.engine.processes.persistence import Bundle
 from tests.utils.processes import DummyProcess
 
 
@@ -30,13 +31,13 @@ class TestProcess:
     def test_save_load(self):
         """Test load saved state."""
         process = DummyProcess()
-        saved_state = plumpy.Bundle(process)
+        saved_state = Bundle(process)
         process.close()
 
         loaded_process = saved_state.unbundle()
         run(loaded_process)
 
-        assert loaded_process.state == plumpy.ProcessState.FINISHED
+        assert loaded_process.state == ProcessState.FINISHED
 
 
 @pytest.mark.requires_broker

--- a/tests/engine/test_persistence.py
+++ b/tests/engine/test_persistence.py
@@ -8,13 +8,31 @@
 ###########################################################################
 """Test persisting via the AiiDAPersister."""
 
+import asyncio
+
 import pytest
 
 from aiida.common.processes import ProcessState
 from aiida.engine import Process, run
 from aiida.engine.persistence import AiiDAPersister
-from aiida.engine.processes.persistence import Bundle
+from aiida.engine.processes.persistence import Bundle, LoadSaveContext, SavableFuture
 from tests.utils.processes import DummyProcess
+
+
+def test_cancelled_savable_future():
+    """Test a cancelled savable future can be saved and recreated."""
+    loop = asyncio.new_event_loop()
+
+    try:
+        future = SavableFuture(loop=loop)
+        future.cancel()
+
+        restored = Bundle(future).unbundle(LoadSaveContext(loop=loop))
+
+        assert isinstance(restored, SavableFuture)
+        assert restored.cancelled()
+    finally:
+        loop.close()
 
 
 @pytest.mark.requires_broker

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -10,13 +10,15 @@
 
 import threading
 
-import plumpy
 import pytest
-from plumpy.utils import AttributesFrozendict
 
 from aiida import orm
+from aiida.common.extendeddicts import AttributesFrozendict
 from aiida.common.lang import override
 from aiida.engine import ExitCode, ExitCodesNamespace, Process, WorkChain, run, run_get_node, run_get_pk
+from aiida.engine.processes.generic import process as process_core
+from aiida.engine.processes.greenback import has_portal
+from aiida.engine.processes.persistence import Bundle
 from aiida.engine.processes.ports import PortNamespace
 from aiida.manage import get_manager
 from aiida.manage.caching import disable_caching, enable_caching
@@ -179,8 +181,9 @@ class TestProcess:
     def test_on_finish_node_updated_before_broadcast(self, monkeypatch):
         """Tests if the process state and output has been updated in the database before a broadcast is invoked.
 
-        In plumpy.Process.on_entered the state update is broadcasted. When a process is finished this results in the
-        next process being run. If the next process will access the process that just finished, it can result in not
+        In ``process_core.Process.on_entered`` the state update is broadcasted.
+        When a process is finished this results in the next process being run.
+        If the next process will access the process that just finished, it can result in not
         being able to retrieve the outputs or correct process state because this information has yet not been updated
         them in the database.
         """
@@ -189,19 +192,19 @@ class TestProcess:
         # By monkeypatching the parent class we can check the state when the
         # parents class method is invoked and check if the state has be
         # correctly updated.
-        original_on_entered = copy.deepcopy(plumpy.Process.on_entered)
+        original_on_entered = copy.deepcopy(process_core.Process.on_entered)
 
         def on_entered(self, from_state):
             if self._state.LABEL.value == 'finished':
                 assert self.node.is_finished_ok, (
-                    'Node state should have been updated before plumpy.Process.on_entered is invoked.'
+                    'Node state should have been updated before process_core.Process.on_entered is invoked.'
                 )
                 assert self.node.outputs.result.value == 2, (
-                    'Outputs should have been attached before plumpy.Process.on_entered is invoked.'
+                    'Outputs should have been attached before process_core.Process.on_entered is invoked.'
                 )
             original_on_entered(self, from_state)
 
-        monkeypatch.setattr(plumpy.Process, 'on_entered', on_entered)
+        monkeypatch.setattr(process_core.Process, 'on_entered', on_entered)
         # Ensure that process has run correctly otherwise the asserts in the
         # monkeypatched member function have been skipped
         assert run_get_node(test_processes.AddProcess, a=1, b=1).node.is_finished_ok, 'Process should not fail.'
@@ -211,7 +214,7 @@ class TestProcess:
         """Test save instance's state."""
         proc = test_processes.DummyProcess()
         # Save the instance state
-        bundle = plumpy.Bundle(proc)
+        bundle = Bundle(proc)
         proc.close()
         bundle.unbundle()
 
@@ -639,11 +642,11 @@ class PortalProbeWorkChain(WorkChain):
         spec.outline(cls.a_step)
 
     def a_step(self):
-        PortalProbeWorkChain.portal_in_step = plumpy.has_portal()
+        PortalProbeWorkChain.portal_in_step = has_portal()
 
     def on_terminated(self):
         super().on_terminated()
-        PortalProbeWorkChain.portal_in_on_terminated = plumpy.has_portal()
+        PortalProbeWorkChain.portal_in_on_terminated = has_portal()
 
 
 def test_portal_available_in_on_terminated():

--- a/tests/engine/test_process_spec.py
+++ b/tests/engine/test_process_spec.py
@@ -10,7 +10,7 @@
 
 import pytest
 
-from aiida.engine import Process
+from aiida.engine import Process, ProcessSpec
 from aiida.orm import Data, Node
 
 
@@ -26,6 +26,32 @@ class TestProcessSpec:
         self.spec.outputs.valid_type = Data
         yield
         assert Process.current() is None
+
+    @pytest.mark.parametrize(
+        ('expose_method', 'memory_attribute'),
+        (
+            ('expose_inputs', '_exposed_inputs'),
+            ('expose_outputs', '_exposed_outputs'),
+        ),
+    )
+    def test_repeated_exposure_accumulates_ports(self, expose_method, memory_attribute):
+        """Test repeated calls accumulate the exposed ports for a process class."""
+
+        class ChildProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super().define(spec)
+                spec.input('first')
+                spec.input('second')
+                spec.output('first')
+                spec.output('second')
+
+        spec = ProcessSpec()
+        expose = getattr(spec, expose_method)
+        expose(ChildProcess, include=('first',))
+        expose(ChildProcess, include=('second',))
+
+        assert getattr(spec, memory_attribute)[None][ChildProcess] == ['first', 'second']
 
     def test_dynamic_input(self):
         """Test a process spec with dynamic input enabled."""

--- a/tests/engine/test_rmq.py
+++ b/tests/engine/test_rmq.py
@@ -10,7 +10,6 @@
 
 import asyncio
 
-import plumpy
 import pytest
 
 from aiida.engine import ProcessState
@@ -42,7 +41,7 @@ class TestProcessControl:
             await self.wait_for_process(calc_node)
 
             assert calc_node.is_finished_ok
-            assert calc_node.process_state.value == plumpy.ProcessState.FINISHED.value
+            assert calc_node.process_state.value == ProcessState.FINISHED.value
 
         self.runner.loop.run_until_complete(do_submit())
 
@@ -56,7 +55,7 @@ class TestProcessControl:
             calc_node = self.runner.submit(test_processes.AddProcess, a=term_a, b=term_b)
             await self.wait_for_process(calc_node)
             assert calc_node.is_finished_ok
-            assert calc_node.process_state.value == plumpy.ProcessState.FINISHED.value
+            assert calc_node.process_state.value == ProcessState.FINISHED.value
 
         self.runner.loop.run_until_complete(do_launch())
 
@@ -72,7 +71,7 @@ class TestProcessControl:
             await self.wait_for_process(calc_node)
 
             assert not calc_node.is_finished_ok
-            assert calc_node.process_state.value == plumpy.ProcessState.EXCEPTED.value
+            assert calc_node.process_state.value == ProcessState.EXCEPTED.value
 
         self.runner.loop.run_until_complete(do_exception())
 

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -10,11 +10,11 @@
 
 import threading
 
-import plumpy
 import pytest
 
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from aiida.engine import Process, launch
+from aiida.engine.processes.generic.futures import Future
 from aiida.manage.caching import enable_caching
 from aiida.orm import Int, Str, WorkflowNode
 
@@ -54,7 +54,7 @@ def test_call_on_process_finish(runner):
     """Test call on calculation finish."""
     loop = runner.loop
     proc = Proc(runner=runner, inputs={'a': Str('input')})
-    future = plumpy.Future()
+    future = Future()
     event = threading.Event()
 
     def calc_done():

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -12,10 +12,10 @@ import asyncio
 import contextlib
 
 import pytest
-from plumpy import get_or_create_event_loop
 
 from aiida import orm
 from aiida.engine import calcfunction, workfunction
+from aiida.engine.processes.events import get_or_create_event_loop
 from aiida.engine.utils import (
     InterruptableFuture,
     exponential_backoff_retry,

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -1625,8 +1625,9 @@ class TestDefaultUniqueness:
         def define(cls, spec):
             super().define(spec)
             spec.input('a', valid_type=Bool, default=lambda: Bool(True))
+            spec.outline(cls.execute)
 
-        def step(self):
+        def execute(self):
             pass
 
     def test_unique_default_inputs(self):
@@ -1758,17 +1759,12 @@ class TestWorkChainEvents:
         assert listener.called == {'running', 'waiting', 'killed'}
 
 
-def test_illegal_override_run():
-    """Test that overriding a protected workchain method raises a ``RuntimeError``."""
-    with pytest.raises(RuntimeError, match='the method `run` is protected cannot be overridden'):
+@pytest.mark.parametrize('method_name', ('run', 'step'))
+def test_illegal_override_protected_method(method_name):
+    """Test that overriding an inherited protected workchain method raises a ``RuntimeError``."""
 
-        class IllegalWorkChain(WorkChain):
-            """Work chain that illegally overrides the ``run`` method."""
+    class IntermediateWorkChain(WorkChain):
+        pass
 
-            @classmethod
-            def define(cls, spec):
-                super().define(spec)
-                spec.outline(cls.run)
-
-            async def run(self):
-                pass
+    with pytest.raises(RuntimeError, match=rf'the method `{method_name}` is protected cannot be overridden'):
+        type('IllegalWorkChain', (IntermediateWorkChain,), {method_name: lambda _: None})

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -12,7 +12,6 @@
 import asyncio
 import inspect
 
-import plumpy
 import pytest
 
 from aiida import orm
@@ -21,14 +20,18 @@ from aiida.common.links import LinkType
 from aiida.common.utils import Capturing
 from aiida.engine import ExitCode, Process, ToContext, WorkChain, append_, calcfunction, if_, launch, return_, while_
 from aiida.engine.persistence import ObjectLoader
+from aiida.engine.processes.exceptions import ClosedError, KilledError
+from aiida.engine.processes.generic.futures import Future
+from aiida.engine.processes.listener import ProcessListener
+from aiida.engine.processes.persistence import Bundle
 from aiida.manage import enable_caching, get_manager
 from aiida.orm import Bool, Float, Int, Str, load_node
 
 
 def run_until_paused(proc):
     """Set up a future that will be resolved when process is paused"""
-    listener = plumpy.ProcessListener()
-    paused = plumpy.Future()
+    listener = ProcessListener()
+    paused = Future()
 
     if proc.paused:
         paused.set_result(True)
@@ -48,8 +51,8 @@ def run_until_waiting(proc):
     """Set up a future that will be resolved on entering the WAITING state"""
     from aiida.engine import ProcessState
 
-    listener = plumpy.ProcessListener()
-    in_waiting = plumpy.Future()
+    listener = ProcessListener()
+    in_waiting = Future()
 
     if proc.state == ProcessState.WAITING:
         in_waiting.set_result(True)
@@ -747,7 +750,7 @@ class TestWorkchain:
             assert not workchain.ctx.s2
 
             # Now bundle the workchain
-            bundle = plumpy.Bundle(workchain)
+            bundle = Bundle(workchain)
             # Need to close the process before recreating a new instance
             workchain.close()
 
@@ -757,7 +760,7 @@ class TestWorkchain:
             assert not workchain2.ctx.s2
 
             # check bundling again creates the same saved state
-            bundle2 = plumpy.Bundle(workchain2)
+            bundle2 = Bundle(workchain2)
             assert bundle == bundle2
 
             # run the loaded workchain to completion
@@ -1159,7 +1162,7 @@ class TestWorkChainAbort:
             assert process.paused
             process.kill()
 
-            with pytest.raises(plumpy.ClosedError):
+            with pytest.raises(ClosedError):
                 launch.run(process)
 
         runner.schedule(process)
@@ -1239,7 +1242,7 @@ class TestWorkChainAbortChildren:
             if asyncio.isfuture(result):
                 await result
 
-            with pytest.raises(plumpy.KilledError):
+            with pytest.raises(KilledError):
                 await process.future()
 
         runner.schedule(process)
@@ -1684,7 +1687,7 @@ class TestWorkChainEvents:
             if self.inputs.outcome.value == 'excepted':
                 raise RuntimeError('Intentional exception for testing.')
 
-    class ProcessListenerTester(plumpy.ProcessListener):
+    class ProcessListenerTester(ProcessListener):
         """Record which process listener events have fired."""
 
         def __init__(self):
@@ -1744,7 +1747,7 @@ class TestWorkChainEvents:
                 if asyncio.isfuture(result):
                     await result
 
-                with pytest.raises(plumpy.KilledError):
+                with pytest.raises(KilledError):
                     await workflow.future()
 
             runner.schedule(workflow)

--- a/tests/engine/test_zeromq.py
+++ b/tests/engine/test_zeromq.py
@@ -14,7 +14,6 @@ so they run with the ZeroMQ broker backend.
 
 import asyncio
 
-import plumpy
 import pytest
 
 from aiida.engine import ProcessState
@@ -43,7 +42,7 @@ class TestProcessControl:
             await self.wait_for_process(calc_node)
 
             assert calc_node.is_finished_ok
-            assert calc_node.process_state.value == plumpy.ProcessState.FINISHED.value
+            assert calc_node.process_state.value == ProcessState.FINISHED.value
 
         self.runner.loop.run_until_complete(do_submit())
 
@@ -57,7 +56,7 @@ class TestProcessControl:
             calc_node = self.runner.submit(test_processes.AddProcess, a=term_a, b=term_b)
             await self.wait_for_process(calc_node)
             assert calc_node.is_finished_ok
-            assert calc_node.process_state.value == plumpy.ProcessState.FINISHED.value
+            assert calc_node.process_state.value == ProcessState.FINISHED.value
 
         self.runner.loop.run_until_complete(do_launch())
 
@@ -74,7 +73,7 @@ class TestProcessControl:
             await self.wait_for_process(calc_node)
 
             assert not calc_node.is_finished_ok
-            assert calc_node.process_state.value == plumpy.ProcessState.EXCEPTED.value
+            assert calc_node.process_state.value == ProcessState.EXCEPTED.value
 
         self.runner.loop.run_until_complete(do_exception())
 

--- a/tests/manage/configuration/migrations/test_migrations.py
+++ b/tests/manage/configuration/migrations/test_migrations.py
@@ -112,7 +112,7 @@ def test_migrate_full(load_config_sample, monkeypatch):
     """Test the full config migration."""
     config_initial = load_config_sample('input/0.json')
     # this should be always the most recent version
-    config_target = load_config_sample('reference/10.json')
+    config_target = load_config_sample('reference/11.json')
 
     # This change is necessary for the migration to version 2.
     monkeypatch.setattr(uuid, 'uuid4', lambda: uuid.UUID(hex='0' * 32))
@@ -132,8 +132,8 @@ def test_migrate_full_downgrade(load_config_sample, monkeypatch):
     """
     monkeypatch.setattr(uuid, 'uuid4', lambda: uuid.UUID(hex='0' * 32))
 
-    upgraded = upgrade_config(load_config_sample('input/0.json'), 10, migrations=(m for m in MIGRATIONS))
-    assert upgraded['CONFIG_VERSION']['CURRENT'] == 10
+    upgraded = upgrade_config(load_config_sample('input/0.json'), 11, migrations=(m for m in MIGRATIONS))
+    assert upgraded['CONFIG_VERSION']['CURRENT'] == 11
 
     downgraded = downgrade_config(upgraded, 0, migrations=(m for m in MIGRATIONS))
     assert downgraded['CONFIG_VERSION']['CURRENT'] == 0
@@ -320,6 +320,50 @@ def test_rename_rmq_and_logging_downgrade_resolves_inherit_levels():
 
     other_options = migrated['profiles']['other']['options']
     assert other_options['logging.circus_loglevel'] == 'ERROR'
+
+
+def test_merge_plumpy_log_level_round_trip():
+    """Upgrade should merge plumpy levels into aiida-core and downgrade should copy them back."""
+    config = {
+        'CONFIG_VERSION': {'CURRENT': 10, 'OLDEST_COMPATIBLE': 10},
+        'profiles': {
+            'default': {
+                'options': {'logging.plumpy_loglevel': 'DEBUG'},
+            }
+        },
+        'options': {'logging.plumpy_loglevel': 'ERROR'},
+    }
+
+    migrated = upgrade_config(config, 11)
+
+    assert migrated['options'] == {'logging.aiida_core_loglevel': 'ERROR'}
+    assert migrated['profiles']['default']['options'] == {'logging.aiida_core_loglevel': 'DEBUG'}
+
+    downgraded = downgrade_config(migrated, 10)
+
+    assert downgraded['options'] == {
+        'logging.aiida_core_loglevel': 'ERROR',
+        'logging.plumpy_loglevel': 'ERROR',
+    }
+    assert downgraded['profiles']['default']['options'] == {
+        'logging.aiida_core_loglevel': 'DEBUG',
+        'logging.plumpy_loglevel': 'DEBUG',
+    }
+
+
+def test_merge_plumpy_log_level_preserves_explicit_aiida_core_level():
+    """An existing aiida-core level should take precedence over the removed plumpy level."""
+    config = {
+        'CONFIG_VERSION': {'CURRENT': 10, 'OLDEST_COMPATIBLE': 10},
+        'options': {
+            'logging.aiida_core_loglevel': 'CRITICAL',
+            'logging.plumpy_loglevel': 'DEBUG',
+        },
+    }
+
+    migrated = upgrade_config(config, 11)
+
+    assert migrated['options'] == {'logging.aiida_core_loglevel': 'CRITICAL'}
 
 
 def test_merge_storage_backends_downgrade_profile(empty_config, profile_factory, caplog):

--- a/tests/manage/configuration/migrations/test_samples/input/10.json
+++ b/tests/manage/configuration/migrations/test_samples/input/10.json
@@ -1,0 +1,35 @@
+{
+  "CONFIG_VERSION": { "CURRENT": 10, "OLDEST_COMPATIBLE": 10 },
+  "default_profile": "default",
+  "profiles": {
+    "default": {
+      "default_user_email": "email@aiida.net",
+      "PROFILE_UUID": "00000000000000000000000000000000",
+      "storage": {
+        "backend": "core.psql_dos",
+        "config": {
+          "database_engine": "postgresql_psycopg2",
+          "database_password": "some_random_password",
+          "database_name": "aiidadb_qs_some_user",
+          "database_hostname": "localhost",
+          "database_port": "5432",
+          "database_username": "aiida_qs_greschd",
+          "repository_uri": "file:////home/some_user/.aiida/repository-quicksetup/"
+        },
+        "_v6_backend": "django"
+      },
+      "process_control": {
+        "backend": "rabbitmq",
+        "config": {
+          "broker_protocol": "amqp",
+          "broker_username": "guest",
+          "broker_password": "guest",
+          "broker_host": "127.0.0.1",
+          "broker_port": 5672,
+          "broker_virtual_host": ""
+        }
+      },
+      "test_profile": false
+    }
+  }
+}

--- a/tests/manage/configuration/migrations/test_samples/reference/11.json
+++ b/tests/manage/configuration/migrations/test_samples/reference/11.json
@@ -1,0 +1,35 @@
+{
+  "CONFIG_VERSION": { "CURRENT": 11, "OLDEST_COMPATIBLE": 11 },
+  "default_profile": "default",
+  "profiles": {
+    "default": {
+      "default_user_email": "email@aiida.net",
+      "PROFILE_UUID": "00000000000000000000000000000000",
+      "storage": {
+        "backend": "core.psql_dos",
+        "config": {
+          "database_engine": "postgresql_psycopg2",
+          "database_password": "some_random_password",
+          "database_name": "aiidadb_qs_some_user",
+          "database_hostname": "localhost",
+          "database_port": "5432",
+          "database_username": "aiida_qs_greschd",
+          "repository_uri": "file:////home/some_user/.aiida/repository-quicksetup/"
+        },
+        "_v6_backend": "django"
+      },
+      "process_control": {
+        "backend": "rabbitmq",
+        "config": {
+          "broker_protocol": "amqp",
+          "broker_username": "guest",
+          "broker_password": "guest",
+          "broker_host": "127.0.0.1",
+          "broker_port": 5672,
+          "broker_virtual_host": ""
+        }
+      },
+      "test_profile": false
+    }
+  }
+}

--- a/tests/manage/configuration/test_options.py
+++ b/tests/manage/configuration/test_options.py
@@ -58,7 +58,6 @@ class TestConfigurationOptions:
             'logging.aiida_core_loglevel',
             'logging.verdi_loglevel',
             'logging.disk_objectstore_loglevel',
-            'logging.plumpy_loglevel',
             'logging.kiwipy_loglevel',
             'logging.paramiko_loglevel',
             'logging.alembic_loglevel',

--- a/tests/orm/models/test_models.py
+++ b/tests/orm/models/test_models.py
@@ -7,12 +7,12 @@ import typing as t
 
 import numpy as np
 import pytest
-from plumpy import get_object_loader
 from typing_extensions import NotRequired
 
 from aiida import orm
 from aiida.common.datastructures import StashMode
 from aiida.common.exceptions import UnsupportedSchemaError
+from aiida.engine.persistence import get_object_loader
 from aiida.orm.pydantic import OrmModel
 
 orm_to_test = (

--- a/tests/utils/memory.py
+++ b/tests/utils/memory.py
@@ -10,8 +10,9 @@
 
 import asyncio
 
-from plumpy import get_or_create_event_loop
 from pympler import muppy
+
+from aiida.engine.processes.events import get_or_create_event_loop
 
 
 def get_instances(classes, delay=0.0):

--- a/tests/utils/processes.py
+++ b/tests/utils/processes.py
@@ -8,9 +8,8 @@
 ###########################################################################
 """Utilities for testing components from the workflow engine"""
 
-import plumpy
-
 from aiida.engine import Process
+from aiida.engine.processes.states import Wait
 from aiida.orm import Bool, CalcJobNode, Data, WorkflowNode
 
 
@@ -75,7 +74,7 @@ class WaitProcess(Process):
     _node_class = WorkflowNode
 
     async def run(self):
-        return plumpy.Wait(self.next_step)
+        return Wait(self.next_step)
 
     def next_step(self):
         pass

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,8 @@ dependencies = [
     { name = "disk-objectstore" },
     { name = "docstring-parser" },
     { name = "graphviz" },
+    { name = "greenback" },
+    { name = "greenlet" },
     { name = "importlib-metadata" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -53,7 +55,6 @@ dependencies = [
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "paramiko" },
     { name = "pgsu" },
-    { name = "plumpy" },
     { name = "psutil" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
@@ -231,6 +232,8 @@ requires-dist = [
     { name = "flask-restful", marker = "extra == 'rest'", specifier = "~=0.3.10" },
     { name = "graphviz", specifier = "~=0.19" },
     { name = "gsrd", marker = "extra == 'tutorials'", specifier = ">=0.2.0" },
+    { name = "greenback", specifier = "~=1.0" },
+    { name = "greenlet", specifier = ">=3.2.4" },
     { name = "gssapi", marker = "extra == 'ssh-kerberos'", specifier = "~=1.6" },
     { name = "importlib-metadata", specifier = "~=6.0" },
     { name = "ipykernel", marker = "extra == 'tests'", specifier = "~=6.9" },
@@ -252,7 +255,6 @@ requires-dist = [
     { name = "pg8000", marker = "extra == 'tests'", specifier = "~=1.13" },
     { name = "pgsu", specifier = "~=0.3.0" },
     { name = "pgtest", marker = "extra == 'tests'", specifier = "~=1.3,>=1.3.1" },
-    { name = "plumpy", specifier = "~=0.26.0" },
     { name = "pre-commit", marker = "extra == 'pre-commit'", specifier = "~=3.5" },
     { name = "psutil", specifier = "~=7.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.0.2,<4" },
@@ -2402,7 +2404,7 @@ name = "jinxed"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/d7/6e6d474ec5eaeca6a61acc17766bb19563b3a372b4b9d92910078f5fe49f/jinxed-2.1.0.tar.gz", hash = "sha256:7e755b831faa2443d44fb4ce7c0202eb9c3ed39bd5bf1193365888f4f6092b54", size = 61287, upload-time = "2026-07-03T15:46:48.153Z" }
 wheels = [
@@ -4687,21 +4689,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "plumpy"
-version = "0.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenback" },
-    { name = "greenlet" },
-    { name = "kiwipy", extra = ["rmq"] },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/19/f3719840ec54880e6cf88f3a88c9ecf3aed0468d3e971339a354e95318f3/plumpy-0.26.0.tar.gz", hash = "sha256:5d0bb443c3983f43295be5306aec97d09e8005a27d1d645deacf08da84afb6e1", size = 230207, upload-time = "2026-02-24T14:38:08.475Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/44/b6be39f1225b3a741c4e8a2b48039a8e95f514016eb0f5d092722a7c0949/plumpy-0.26.0-py3-none-any.whl", hash = "sha256:07d5558ead4bdc064c6092236e59f4328f70d24b52eb810e913c491841c6336f", size = 75911, upload-time = "2026-02-24T14:38:06.913Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
So the first commit is an integration following the plan below. I think one cannot review this more effectively rather than by looking at the integration plan below and deciding if it makes sense and check for some cases if it was done correctly. Then the next few commits are changes that affect logic that was purely on the aiida side (e.g. plumpy loglevel). Then the remaining commits are fixes of plumpy code. Because coderabbit picked up a lot of valid issues, I fixed them here.

### plumpy code

Commit 1 

See first commit for the whole integration plan. I tried to have in this commit a plain migration with almost no behavior change or bug fixes of the existing code. Because for checkpoints we use `plumpy` as tag, I changed this to aiida. This is quite a strong behavioral change, because it means you cannot load any checkpoint from an old aiida version but its acceptable for v3. Maybe we add into the storage migration a warning about this and delete them, so its clear to users. Technically its not related to storage but its the one thing every user is required to do.

### plumpy-related code purely on the AiiDA side

Commits 2..6

Are also part of the integration but considers more changes that affect logic purely on the aiida side (the logging level for example).
```
- `_PLUMPY_ATTRIBUTES_FROZENDICT_TAG` YAML tag → renamed to `_ATTRIBUTES_FROZENDICT_TAG` with value `!aiida:attributes_frozendict` in `src/aiida/orm/utils/serialize.py`
- `logging.plumpy_loglevel` → renamed to `logging.engine_loglevel`, now controlling the `aiida.engine` logger hierarchy. Also requires updates of the configuration format → version 11 with the reversible `RenamePlumpyLogLevel` migration in `src/aiida/manage/configuration/migrations/migrations.py`
- `plumpy` undesired-import check → removed from `src/aiida/cmdline/commands/cmd_devel.py` because the external package is no longer imported
- Python docstrings referencing external `plumpy` classes → updated to reference the corresponding in-tree AiiDA classes
```

### bug fixes of plumpy code

Commits 7..HEAD

Note that commit b8b2f1a6e23f35ac8696dea6a810bb64e7e22a94 also fixes a certain kind of bug (task is not referenced and can be garbage collected) in other parts of the code that is not related to this integration.

Upcoming work:
- In migration script (maybe verdi storage migrate) include check if checkpoints still exist and ask user to delete them because the old checkpoints don't work anymore.
- There is some usage of plumpy's ProcessListener consider this in what is user API of engine. But defining engine user API is a different thing.
- Now the `logging.plumpy_loglevel` is absorbed by `logging.aiida_core_loglevel`. If we need a finer control we need to change the logging logic. I am not sure if there is a need for different loglevel for different modules, so I am defaulting to the simplest solution for now
- Resolve type ignore, these are inherited from plumpy and I did not want to resolve in this PR the ones that introduce behavior change.