### PR TITLE
Proof of concept redesign ORM model layer with user API separation and performance in mind

### DIFF
--- a/orm_model_redesign/README.md
+++ b/orm_model_redesign/README.md
@@ -1,0 +1,39 @@
+## Motivation
+
+### Performance
+
+The schema generation is expensive and is only needed when orm classes leave the process boundary.
+There are two use cases that fulfill this constraint which are CLI usage (`Computer` and `Code` creation, maybe extended by `Profile`) and the REST API.
+The schema generation should only happen for these use cases.
+
+### User API
+
+Workflow developers are supposed to only extend the data nodes, so any logic we expose there should be simple.
+Data nodes do not require a CLI model, only `Computer`, `Code`, and `Profile` do, so  we can put any logic deciding if a field is part of the CLI model into a different field.
+For the REST API model its a bit more tricky, while the logic for each data node is **mostly** the same (Add the attributes and only reference the files in the repository so we apply some file transfer logic when sending or receiving files), there is the valid use case to validate the construction of the orm class froma POST request.
+So the workflow developer still ideally puts the validation on the attribute type into the field and not in the `__init__` constructor
+For example fo StructureData this would mean that the `__init__` constructor still converts ase to the cell, but then any validation on top (e.g. `_get_valid_cell`) would need to be defined in the field definition.
+So overall this is the motivation to have attribute field (in PoC `AttributeField`) as part of user API keeping its option minimal to reduce burden on workflow developer and a more generic field (in PoC called `ColumnField`) as part of core API which defines behavior of the field when converted to a pydantic field in the building of the CLI and REST API model.
+
+## Implementation details
+
+I want that the initialization through the `__init__` constructor and the model deserialization are consistent.
+While in the model deserialzation its applied by pydantic automatically, in the python object we don't have any mechanisum like this.
+I don't want that the user explicitely needs to call the validator of the field that is to error prone.
+Therefore I introduced `self.base.columns.<column_field_name>` following the usage of the attributes.
+When one sets a column field in the python object the validator is triggered automatically.
+The same behavior has been implemented for the attributes.
+
+I introduced `_attribute_fields` in `DataNode` so it is clear that this is part of the user API. while the `_column_fields` is only defined in the core API.
+Effectively, these fields are just merged later one when building the model, the distinction is purely motivated due to API separation concerns.
+
+I kept the information how the `ColumnField` is converted to a `RestApiField` or `CliField` in the member variables of `ColumnField`.
+When buildling for example the `RestApiModel`, we first convert `AttributeField`s and `ColumnField`s to `RestApiField` to then convert these to `pydantic.Field`.
+It is just exists for code reusabilty but in principle all information lies in `ColumnField` and `AttributeField` to convert to a `pydantic.Field`. 
+
+## Breaking changes
+
+I did not want to include back the `orm_to_cli`, `cli_to_orm` and vice versa for the REST API in the fields because it introduces complexity that is not needed.
+Why do we need to convert them before serializing?
+The fields type is already restricted through the database serializability and introducing such options is another potential point of failure in the round trip (I think the existing code is buggy for commands that have a whitespace in an argument e.g. `mpirun -np 4 myapp --extra-args "-O3 -unbuffered"`).
+This breaks the exsting CLI format for Computer (`mpirun_command` is stored as string in the json and as list of strings in the orm class) but overall the downstream effects seem minimal to me.

--- a/orm_model_redesign/__init__.py
+++ b/orm_model_redesign/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone proof of concept for the ORM field-declaration design."""

--- a/orm_model_redesign/__main__.py
+++ b/orm_model_redesign/__main__.py
@@ -1,0 +1,197 @@
+"""Walkthrough of the design, one function per decision.
+
+python -m poc
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Sequence
+
+from pydantic import ValidationError
+
+from poc.cmdline._core.models import build_cli_model, cli_deserialize, cli_serialize
+from poc.orm._core.fields import BaseField
+from poc.orm.computers import Computer
+from poc.orm.fields import AttributeField
+from poc.orm.nodes import Bool, Data, Int, Node, Str
+from poc.restapi._core.models import read_only_fields, rest_deserialize, rest_serialize, rest_validate
+
+
+def show(label: str, value: t.Any) -> None:
+    print(f'  {label:50} {value}')
+
+
+def section(number: int, title: str, where: str) -> None:
+    print(f'\n{number}. {title}\n   ({where})')
+
+
+def query_view() -> None:
+    """A declaration is a value; its query view is a separate object."""
+    declaration, field = Int._field_declarations['value'], Int.fields.value
+    show('Int._field_declarations["value"]', f'{type(declaration).__name__} -- ordinary ==, safe as a dict key')
+    show('Int.fields.value    (its query view)', f'{type(field).__name__} -- == builds a filter')
+    show('field.declaration is declaration', field.declaration is declaration)
+    show(
+        'declarations of different classes stay distinct',
+        Int._field_declarations['value'] != Str._field_declarations['value'],
+    )
+    show('{Int value declaration: 1}[Str value declaration]', 'KeyError -- not conflated')
+    show('Int.fields.value == 42', (Int.fields.value == 42).as_dict())
+    show('Node.fields.label == "x"', (Node.fields.label == 'x').as_dict())
+    show('(value > 1) & (label == "x")', ((Int.fields.value > 1) & (Node.fields.label == 'x')).as_dict())
+    show('(label == "x") & Bool.fields.value', ((Node.fields.label == 'x') & Bool.fields.value).as_dict())
+    show('QbFields / QbFieldFilters', 'aiida.orm.fields, unchanged -- only what they hold changes')
+
+
+def validation_of_declaration_correctness_at_class_definition() -> None:
+    """Declarations are validated when the class is defined."""
+    try:
+
+        class Broken(Data):
+            _attribute_fields: t.ClassVar[Sequence[BaseField]] = (AttributeField('not an identifier', int),)
+    except ValueError as exc:
+        show('a name that is not an identifier', f'ValueError: {exc}')
+    show('two names over one backend key', 'unrepresentable -- the name is the key')
+    try:
+        Node(no_such_column=1)
+    except ValueError as exc:
+        show('a column the schema does not have', f'ValueError: {exc}')
+
+
+def _positive(value: float) -> float:
+    """Reject a setpoint no thermostat could hold."""
+    if value <= 0:
+        msg = f'a temperature must be above absolute zero, got {value}'
+        raise ValueError(msg)
+    return value
+
+
+def data_plugin() -> None:
+    """A data plugin declares attributes, and nothing else."""
+
+    class Trajectory(Data):
+        """A data plugin, declared outside `aiida-core`."""
+
+        _attribute_fields: t.ClassVar[Sequence[BaseField]] = (
+            AttributeField('frames', list, 'The frames of the trajectory'),
+            AttributeField('temperature', float, 'The thermostat setpoint', validator=_positive),
+        )
+
+        def __init__(self, frames: list, temperature: float, **kwargs: t.Any) -> None:
+            super().__init__(**kwargs)
+            self.base.attributes.set('frames', frames)
+            self.base.attributes.set('temperature', temperature)
+
+    trajectory = Trajectory(frames=[1, 2, 3], temperature=300.0, uuid='t-1', label='md-run')
+
+    show('all it declares', sorted(f.name for f in Trajectory._attribute_fields))
+    show(
+        'no cli_* or rest_api_* option among them',
+        not any(f.cli.exclude or f.rest_api.read_only for f in Trajectory._attribute_fields),
+    )
+    show('yet GET works', {k: v for k, v in rest_serialize(trajectory).items() if k not in ('ctime', 'attributes')})
+    show('and read-only is inherited from Node', sorted(read_only_fields(Trajectory)))
+    show('the CLI needs no model for it', 'a data node is exported by format, not by field')
+    show('the name stays free for an accessor', 'a declaration names itself; it is not a class attribute')
+    show('and it owns its own construction', 'from_model passes values; __init__ decides')
+    try:
+        rest_validate(Trajectory, {'label': '', 'source': None, 'attributes': {}, 'frames': [], 'temperature': -5.0})
+    except ValidationError as exc:
+        show('a declared validator guards writes', exc.errors()[0]['msg'])
+
+
+def validation_of_attribute_value_on_set() -> None:
+    """A declared validator runs wherever a value enters."""
+    body = {
+        'label': 'localhost',
+        'description': '',
+        'hostname': 'localhost',
+        'transport_type': 'core.local',
+        'scheduler_type': 'core.direct',
+        'mpirun_command': [],
+    }
+    show('PUT with a good hostname', type(rest_validate(Computer, body)).__name__)
+    try:
+        rest_validate(Computer, {**body, 'hostname': 'local host'})
+    except ValidationError as exc:
+        show('PUT with a bad one', exc.errors()[0]['msg'])
+    show('why the declaration and not __init__', 'a PUT replaces values; it never constructs')
+    show('so it runs for POST and CLI import too', 'every layer model wires the same check in')
+
+    node = Int(42, uuid='u-2', label='fine')
+    for how, write in (
+        ('node.label = ...', lambda: setattr(node, 'label', 'two\nlines')),
+        ('base.columns.set(...)', lambda: node.base.columns.set('label', 'two\nlines')),
+    ):
+        try:
+            write()
+        except ValueError as exc:
+            show(f'and for a direct write, {how}', f'ValueError: {exc}')
+    node.base.attributes.set('undeclared', 'anything')
+    show('an undeclared key has nothing to check', 'undeclared' in node.base.attributes.all)
+
+
+def cli_round_trip() -> None:
+    """ORM object -> CLI model -> YAML, and back."""
+    computer = Computer(
+        uuid='u-1',
+        label='localhost',
+        hostname='localhost.localdomain',
+        transport_type='core.local',
+        scheduler_type='core.direct',
+        mpirun_command=['mpirun', '-np', '4'],
+    )
+
+    payload = cli_serialize(computer)
+    rebuilt = cli_deserialize(Computer, payload)
+
+    show('what `verdi computer export` writes', payload)
+    show('and `verdi computer import` rebuilds', f'{rebuilt.label} {rebuilt.backend_entity.mpirun_command}')
+    show('lossless', cli_serialize(rebuilt) == payload)
+    show('published under its declared name', 'no aliases; the file follows the fields')
+    show('rendered by pydantic, not by us', 'a list stays a list; the file follows the values')
+    show('excluded by cli_exclude', 'uuid -- a fresh import carries no identity')
+    show('the model class, for options and schema', build_cli_model(Computer).__name__)
+
+
+def rest_requests() -> None:
+    """GET and POST, over the same declarations."""
+    stored = Int(42, uuid='u-1', label='the answer')
+
+    # GET /nodes/u-1 -- the read model, so identity is included
+    body = rest_serialize(stored)
+    show('GET  -> body', {k: v for k, v in body.items() if k != 'ctime'})
+    show('     read model includes identity', 'uuid' in body)
+
+    # POST /nodes -- the write model, so identity is refused rather than ignored
+    posted = rest_deserialize(Int, {'label': 'from a client', 'value': 7, 'source': None, 'attributes': {}})
+    show('POST -> ORM object', f'{posted!r} label={posted.label!r}')
+    show('     write model excludes', sorted(read_only_fields(Int)))
+    try:
+        rest_deserialize(Int, {'label': 'x', 'value': 7, 'source': None, 'attributes': {}, 'uuid': 'smuggled'})
+    except ValidationError as exc:
+        show('POST with a read-only field', f'{type(exc).__name__}: {exc.errors()[0]["type"]}')
+    show('constructed by Entity.from_model', 'no override -- Int is field-shaped')
+    show('from_model only passes values', "what to do with them is `__init__`'s business")
+
+
+#: Each section, with the module it is about. The docstring is the section title.
+SECTIONS: t.Final = (
+    (query_view, 'poc.orm._core.qb_fields'),
+    (validation_of_declaration_correctness_at_class_definition, 'poc.orm._core.entities'),
+    (data_plugin, 'poc.orm.nodes.data'),
+    (cli_round_trip, 'poc.cmdline._core.models'),
+    (validation_of_attribute_value_on_set, 'poc.orm._core.fields'),
+    (rest_requests, 'poc.restapi._core.models'),
+)
+
+
+def main() -> None:
+    for number, (run, where) in enumerate(SECTIONS, start=1):
+        section(number, (run.__doc__ or '').rstrip('.'), where)
+        run()
+
+
+if __name__ == '__main__':
+    main()

--- a/orm_model_redesign/cmdline/__init__.py
+++ b/orm_model_redesign/cmdline/__init__.py
@@ -1,0 +1,1 @@
+"""The command line interface. Mirrors ``aiida.cmdline``."""

--- a/orm_model_redesign/cmdline/_core/__init__.py
+++ b/orm_model_redesign/cmdline/_core/__init__.py
@@ -1,0 +1,1 @@
+"""Internals of ``poc.cmdline``. Nothing here is public API."""

--- a/orm_model_redesign/cmdline/_core/models.py
+++ b/orm_model_redesign/cmdline/_core/models.py
@@ -1,0 +1,61 @@
+"""CLI-owned projection of the ORM declarations. Private: a user never imports this.
+
+The layer that round-trips: ``verdi computer export`` writes a YAML file and
+``verdi computer import`` reads it back, so this is the one place the parsing direction is needed.
+
+Today ``cmd_computer.py`` builds the payload as a dict literal that renames two fields and joins a
+third. Each of those is a ``cli_`` option on ``Computer``'s own declarations, and this module only
+assembles what the class already states.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Mapping
+
+from poc.common._core.pydantic import AiidaBaseModel, build_model, published_values
+from poc.orm._core.entities import Entity
+
+__all__ = ('CliModel', 'build_cli_model', 'cli_deserialize', 'cli_serialize')
+
+EntityType = t.TypeVar('EntityType', bound=Entity)
+
+
+class CliModel(AiidaBaseModel):
+    """Base for the models the CLI exports and imports."""
+
+
+def build_cli_model(cls: type[t.Any]) -> type[AiidaBaseModel]:
+    """Return the model class the CLI exports and imports an entity as.
+
+    Public because the model *class* is useful on its own -- it is what a command would generate
+    its options and its ``--help`` from, and what a JSON schema would come from.
+    """
+    return build_model(
+        f'{cls.__name__}Cli',
+        cls._field_declarations,
+        {name: declaration.cli for name, declaration in cls._field_declarations.items()},
+        base=CliModel,
+    )
+
+
+def cli_serialize(entity: Entity) -> dict[str, t.Any]:
+    """Return what ``verdi <entity> export`` writes: ORM object -> model -> payload."""
+    cls = type(entity)
+    model = build_cli_model(cls)(
+        **published_values(entity, {name: declaration.cli for name, declaration in cls._field_declarations.items()})
+    )
+    return model.model_dump()
+
+
+def cli_deserialize(cls: type[EntityType], payload: Mapping[str, t.Any]) -> EntityType:
+    """Return what ``verdi <entity> import`` constructs: payload -> validated model -> ORM object.
+
+    The class is passed rather than read from the payload. ``verdi computer import`` is already a
+    computer command, so the type is never in question, and the files double as the hand-written
+    ``--config`` input to ``verdi computer setup`` -- a required type key would be noise a user
+    has to write, and would break every config file that predates it.
+    """
+    model = build_cli_model(cls).model_validate(payload)
+    from_cli_model = getattr(cls, 'from_cli_model', None)
+    return from_cli_model(model) if from_cli_model is not None else cls.from_model(model)

--- a/orm_model_redesign/common/__init__.py
+++ b/orm_model_redesign/common/__init__.py
@@ -1,0 +1,1 @@
+"""What several subsystems need without a database. Mirrors ``aiida.common``."""

--- a/orm_model_redesign/common/_core/__init__.py
+++ b/orm_model_redesign/common/_core/__init__.py
@@ -1,0 +1,1 @@
+"""Internals of ``poc.common``. Nothing here is public API."""

--- a/orm_model_redesign/common/_core/fields.py
+++ b/orm_model_redesign/common/_core/fields.py
@@ -1,0 +1,89 @@
+"""What one layer does with one declaration.
+
+A :class:`~poc.orm._core.fields.BaseField` says what the backend stores. A :class:`LayerField`
+says what a consuming layer does with it: the name it publishes under, and whether it publishes it
+at all.
+
+There is a class per layer rather than one shared one. They have a common base because both
+answer "publish this, under what name", but ``read_only`` is a question only a client-serving API
+asks -- a CLI file a user edits has no notion of a field they may read but not write. Folding it
+into one class meant the CLI carrying an option it ignores, and the next option either layer needs
+would land in the other's vocabulary too.
+
+Neither states any serialisation: every declared type is one pydantic already renders and parses,
+and a field has to be database-serialisable anyway, which is the stricter requirement.
+
+They live in ``common`` rather than in either layer so that an entity can declare its projection
+without importing ``poc.cmdline`` or ``poc.restapi``.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+__all__ = ('CliField', 'LayerField', 'RestApiField')
+
+
+class LayerField:
+    """What every layer answers about a field: whether to publish it, and under what name."""
+
+    __slots__ = ('_exclude', '_name')
+
+    def __init__(self, *, name: str | None = None, exclude: bool = False) -> None:
+        self._name = name
+        self._exclude = exclude
+
+    @property
+    def name(self) -> str | None:
+        """The name this layer publishes the field under, where it differs from the declared one."""
+        return self._name
+
+    @property
+    def exclude(self) -> bool:
+        """Whether this layer leaves the field out entirely."""
+        return self._exclude
+
+    def _options(self) -> dict[str, t.Any]:
+        """Return the options this class was built from, so a copy can vary one of them."""
+        return {'name': self._name, 'exclude': self._exclude}
+
+    def replace(self, **changes: t.Any) -> t.Self:
+        """Return a copy of this view with the given options changed."""
+        return type(self)(**{**self._options(), **changes})
+
+    def __repr__(self) -> str:
+        stated = ', '.join(f'{key}={value!r}' for key, value in self._options().items() if value)
+        return f'{type(self).__name__}({stated})'
+
+
+class CliField(LayerField):
+    """How the CLI publishes one declaration, in a file a user edits and re-imports.
+
+    Only the setup entities need these -- ``Computer``, the code classes, ``Group``. A data node is
+    exported and imported through a format converter specific to its type, so no data plugin
+    declares one.
+    """
+
+    __slots__ = ()
+
+
+class RestApiField(LayerField):
+    """How the REST API publishes one declaration.
+
+    Adds the one question only this layer asks: whether a client may write the field, or whether
+    AiiDA sets it and a write should be refused.
+    """
+
+    __slots__ = ('_read_only',)
+
+    def __init__(self, *, name: str | None = None, exclude: bool = False, read_only: bool = False) -> None:
+        super().__init__(name=name, exclude=exclude)
+        self._read_only = read_only
+
+    @property
+    def read_only(self) -> bool:
+        """Whether a client may not write this field; AiiDA sets it."""
+        return self._read_only
+
+    def _options(self) -> dict[str, t.Any]:
+        return {**super()._options(), 'read_only': self._read_only}

--- a/orm_model_redesign/common/_core/pydantic.py
+++ b/orm_model_redesign/common/_core/pydantic.py
@@ -1,0 +1,92 @@
+"""Building a pydantic model from field declarations. Mirrors ``aiida.common.pydantic``.
+
+This is the piece with a genuine claim on a shared home. Three layers project the same
+declarations -- REST and the CLI's export/import -- and each was hand-rolling a dict literal
+over the same field names. What they share is the *builder*; what
+stays theirs is which fields, under which names, serialised how.
+
+In ``aiida`` this module already exists and already holds ``AiidaBaseModel``; the builder is
+currently in ``aiida.restapi.models._builder``, where the CLI cannot reach it.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, create_model
+from pydantic.functional_validators import AfterValidator
+
+from poc.common._core.fields import LayerField
+from poc.orm._core.fields import MISSING, BaseField, ColumnField
+
+__all__ = ('AiidaBaseModel', 'build_model', 'published_values')
+
+
+class AiidaBaseModel(BaseModel):
+    """Base class for models built over the ORM declarations."""
+
+    model_config = ConfigDict(extra='forbid')
+
+
+def _annotation(declaration: BaseField) -> t.Any:
+    """Return the annotation for a field, carrying whatever the declaration says it must satisfy.
+
+    Rendering and parsing are pydantic's, not ours: every declared type is one it already handles,
+    and a value has to be database-serialisable before it gets here.
+    """
+    if declaration.validator is None:
+        return declaration.dtype
+    return t.Annotated[declaration.dtype, AfterValidator(declaration.validator)]
+
+
+#: What a declaration with no layer entry gets: published under its own name, value untouched.
+_PUBLISH_AS_IS: t.Final = LayerField()
+
+
+def build_model(
+    name: str,
+    declarations: Mapping[str, BaseField],
+    layer_options: Mapping[str, LayerField],
+    *,
+    base: type[AiidaBaseModel] = AiidaBaseModel,
+) -> type[AiidaBaseModel]:
+    """Build a model from the declarations and one layer's view of them.
+
+    :param declarations: what the backend stores, from ``Entity._field_declarations``.
+    :param layer_options: what this layer does with each, keyed by declared name. A declaration
+        with no entry is published as it stands.
+    """
+    definitions: dict[str, t.Any] = {}
+
+    for key, declaration in declarations.items():
+        options = layer_options.get(key, _PUBLISH_AS_IS)
+        if options.exclude:
+            continue
+        # `Field()` is typed to return the default's own type, so pin this or the first branch
+        # decides what the other two may assign.
+        info: t.Any
+        default = declaration.default if isinstance(declaration, ColumnField) else MISSING
+        factory = declaration.default_factory if isinstance(declaration, ColumnField) else None
+        if factory is not None:
+            info = Field(default_factory=factory, description=declaration.doc)
+        elif default is MISSING:
+            info = Field(description=declaration.doc)
+        else:
+            info = Field(default, description=declaration.doc)
+        definitions[key] = (_annotation(declaration), info)
+
+    return t.cast('type[AiidaBaseModel]', create_model(name, __base__=base, **definitions))
+
+
+def published_values(entity: t.Any, layer_options: Mapping[str, LayerField]) -> dict[str, t.Any]:
+    """Return the stored values a layer publishes, ready to hand to its model.
+
+    Just the stored values of the fields the layer keeps; rendering them is pydantic's job.
+    """
+    declarations = type(entity)._field_declarations
+    return {
+        name: declaration.read(entity)
+        for name, declaration in declarations.items()
+        if not layer_options.get(name, _PUBLISH_AS_IS).exclude
+    }

--- a/orm_model_redesign/orm/__init__.py
+++ b/orm_model_redesign/orm/__init__.py
@@ -1,0 +1,12 @@
+"""Public ORM entities and the data-plugin declaration API.
+
+``AttributeField`` and ``Data._attribute_fields`` form the supported subclass API.
+Core declaration types, collection machinery, and query-field implementations remain under
+``poc.orm._core`` and are not re-exported here.
+"""
+
+from poc.orm.computers import Computer
+from poc.orm.fields import AttributeField
+from poc.orm.nodes import Bool, Data, Int, Node, Str
+
+__all__ = ('AttributeField', 'Bool', 'Computer', 'Data', 'Int', 'Node', 'Str')

--- a/orm_model_redesign/orm/_core/__init__.py
+++ b/orm_model_redesign/orm/_core/__init__.py
@@ -1,0 +1,1 @@
+"""Internals of ``poc.orm``. Nothing here is public API."""

--- a/orm_model_redesign/orm/_core/entities.py
+++ b/orm_model_redesign/orm/_core/entities.py
@@ -1,0 +1,85 @@
+"""Collecting declarations onto a class. Mirrors ``aiida.orm.entities``.
+
+There are two declaration channels. Core entities declare their fixed schema in ``_column_fields``;
+data subclasses declare their open attributes in ``_attribute_fields``. The latter is a protected
+subclass API: plugin authors may define it, but ordinary users have no reason to access it.
+
+Both channels are collected across the MRO into the internal ``_field_declarations`` mapping. A
+declaration is deliberately not installed under its own name, leaving that name free for a property
+where the stored value and Python value differ.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing as t
+from collections.abc import Mapping, Sequence
+
+from poc.orm._core.fields import BaseField
+from poc.orm._core.qb_fields import QbField, QbFields
+
+
+class Entity:
+    """Base class that collects the declarations of itself and its bases."""
+
+    #: Fixed-schema declarations introduced by a core entity class.
+    _column_fields: t.ClassVar[Sequence[BaseField]] = ()
+
+    #: Complete internal declaration mapping, collected across the MRO.
+    _field_declarations: t.ClassVar[Mapping[str, BaseField]] = {}
+
+    #: The row this entity is backed by. Every entity has one, and it is what a ``ColumnField``
+    #: reads through; the subclass decides its type.
+    backend_entity: t.Any
+
+    #: The query view of the collected declarations, one ``QbField`` per declaration.
+    fields: t.ClassVar[QbFields] = QbFields()
+
+    def __init_subclass__(cls, **kwargs: t.Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._collect_fields()
+
+    @classmethod
+    def _collect_fields(cls) -> None:
+        """Collect the declarations, base classes first so a subclass narrows what it inherits."""
+        declarations: dict[str, BaseField] = {}
+
+        for klass in reversed(cls.__mro__):
+            for channel, is_attribute in (('_column_fields', False), ('_attribute_fields', True)):
+                for declaration in vars(klass).get(channel, ()):
+                    if not isinstance(declaration, BaseField) or declaration.is_attribute is not is_attribute:
+                        kind = 'AttributeField' if is_attribute else 'ColumnField'
+                        msg = f'`{klass.__name__}.{channel}` accepts only {kind} declarations'
+                        raise TypeError(msg)
+                    declarations[declaration.name] = declaration
+
+        cls._field_declarations = declarations
+        cls.fields = QbFields(cls._build_query_fields(declarations))
+
+    @classmethod
+    def from_model(cls, model: t.Any) -> t.Self:
+        """Return an entity built from a validated model of any layer.
+
+        **Which arguments ``__init__`` takes is a fact about this class, not about the layer that
+        produced the model**, so it is answered here once rather than in every consuming layer.
+        A layer that *encodes* a value differently has already normalised it, in its layer field's
+        ``deserialize``, so what arrives here is a domain value whoever asked.
+
+        All this does is hand those values to the constructor. It deliberately does no more: there
+        is no general recipe for building an entity -- a constructor may take a ``Computer`` and
+        store a primary key, or a directory that becomes repository content, or arguments that are
+        no field at all. Whatever a class needs beyond "pass the values through" is that class's
+        to write, by overriding this or by taking the arguments in ``__init__``.
+        """
+        accepted = inspect.signature(cls.__init__).parameters
+        takes_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in accepted.values())
+        published = type(model).model_fields
+        return cls(**{name: getattr(model, name) for name in published if takes_kwargs or name in accepted})
+
+    @classmethod
+    def _build_query_fields(cls, declarations: Mapping[str, BaseField]) -> dict[str, QbField]:
+        """Build the query view of the declarations.
+
+        A hook, so ``Node`` can wire up its attributes namespace.
+        """
+        return {name: QbField.from_spec(declaration) for name, declaration in declarations.items()}

--- a/orm_model_redesign/orm/_core/fields.py
+++ b/orm_model_redesign/orm/_core/fields.py
@@ -1,0 +1,280 @@
+"""The declaration machinery. Nothing here is public API.
+
+``BaseField`` is the abstract base every declaration derives from, and ``ColumnField`` is the
+kind only ``aiida-core`` may declare: the columns are fixed by the storage schema, so a plugin
+has none to add. The one kind a plugin *can* declare, ``AttributeField``, lives next door in
+``poc.orm.fields``, which is the whole of the public surface.
+
+A ``ColumnField`` also carries what each consuming layer does with it, under a ``cli_`` or
+``rest_api_`` prefix. They sit on the declaration rather than in a second mapping per entity
+because a layer needs *most* fields -- a round trip that dropped them would not round-trip -- so
+naming the few exceptions at the field is less to write than restating the field in a layer's
+table. The prefix keeps them decoupled on the way out: ``declaration.cli`` and ``declaration.rest_api`` hand
+each layer its own view and neither sees the other's.
+
+An ``AttributeField`` has none of them, and that is the point of D13: a data plugin declares what
+it stores and nothing about how anything publishes it. The CLI's field projection is for the setup
+entities, which are all columns, and every data node serves the same way over REST. So attributes
+publish as they stand, and a plugin cannot say otherwise because there is no keyword to say it
+with.
+
+A declaration is a **value**: it states facts about what the backend stores -- the type, the
+documentation, the default, and the key it is held under -- and it reads that value back. It has
+no opinion about querying, and no opinion about what any layer may do with the value.
+
+Because it is a plain value, it compares and hashes like one, which matters: two declarations from
+different classes must not be interchangeable as dictionary keys.
+
+The query-side view of a declaration lives in ``poc.orm._core.qb_fields`` as ``QbField``.
+"""
+
+from __future__ import annotations
+
+import abc
+import datetime
+import types
+import typing as t
+from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+
+from poc.common._core.fields import CliField, RestApiField
+
+__all__ = ('MISSING', 'BaseField', 'ColumnField', 'ImmutableStorable', 'MutableStorable', 'StorableType')
+
+#: What a backend can hold. Containers are the covariant ``Mapping``/``Sequence`` rather than
+#: ``dict``/``list``, or invariance would reject ``list[str]``.
+Storable: t.TypeAlias = 'Mapping[t.Any, t.Any] | Sequence[t.Any] | str | bool | int | float | None | datetime.datetime'
+
+#: What ``default`` may be: a storable value that is *immutable*, so stating it once on the
+#: declaration is safe. Anything mutable belongs in ``default_factory`` instead, and the two
+#: annotations together make that choice a type error rather than a convention.
+ImmutableStorable: t.TypeAlias = (
+    'str | bool | int | float | None | datetime.datetime | tuple[t.Any, ...] | frozenset[t.Any]'
+)
+
+#: What ``default_factory`` must produce: a storable value that is *mutable*, and so unsafe to
+#: share between entities. Named for mutability rather than for being a container, because that is
+#: the reason a factory is needed at all -- ``tuple`` and ``str`` are containers and are perfectly
+#: safe stated directly as ``default``.
+MutableStorable: t.TypeAlias = 'MutableMapping[t.Any, t.Any] | MutableSequence[t.Any]'
+
+#: The annotation for ``dtype``: a type a backend can store, or a union of them.
+#:
+#: ``types.UnionType`` is there because ``str | None`` is a union object rather than a ``type``,
+#: and a hundred declarations are shaped that way. It is what makes a static checker reject
+#: ``AttributeField(SomeClass)`` at the declaration rather than at serialisation -- and it does
+#: reject ``SomeClass | None`` too, since the expression's type still names the class.
+StorableType: t.TypeAlias = 'type[Storable] | types.UnionType'
+
+
+class _Missing:
+    """Sentinel marking the absence of a default."""
+
+    def __repr__(self) -> str:
+        return 'MISSING'
+
+
+MISSING: t.Final = _Missing()
+
+#: What a layer does with a field it has said nothing about: publish it under its own name.
+_CLI_AS_IS: t.Final = CliField()
+_REST_AS_IS: t.Final = RestApiField()
+
+
+class BaseField(abc.ABC):
+    """Declaration of a persisted field.
+
+    Declare an :class:`AttributeField` or a :class:`ColumnField`; this class cannot be instantiated,
+    so there is no neutral default to fall into.
+    """
+
+    __slots__ = ('_doc', '_dtype', '_name', '_validator')
+
+    def __init__(
+        self,
+        name: str,
+        dtype: StorableType,
+        doc: str = '',
+        *,
+        validator: t.Callable[[t.Any], t.Any] | None = None,
+    ) -> None:
+        if not name.isidentifier():
+            msg = f'`{name}` is not a valid python identifier'
+            raise ValueError(msg)
+        self._name = name
+        self._dtype = dtype
+        self._doc = doc
+        self._validator = validator
+
+    # -- a value ----------------------------------------------------------------------------
+
+    def __eq__(self, other: object) -> bool:
+        """Ordinary equality. The query-building `==` lives on ``QbField``, not here."""
+        if not isinstance(other, BaseField):
+            return NotImplemented
+        return (type(self), self._name, self._dtype) == (type(other), other._name, other._dtype)
+
+    def __hash__(self) -> int:
+        return hash((type(self), self._name, self._dtype))
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}({self.backend_key!r}, dtype={self._dtype!r})'
+
+    # -- the facts --------------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """The field name, which is also the key the backend holds the value under.
+
+        Stated on the declaration rather than by the key of a mapping that holds it: one of the
+        two would otherwise have to be kept in step with the other, and nothing would notice if
+        they drifted.
+        """
+        return self._name
+
+    @property
+    def dtype(self) -> t.Any:
+        return self._dtype
+
+    @property
+    def cli(self) -> CliField:
+        """Return how the CLI publishes this field. Published as it stands unless a column."""
+        return _CLI_AS_IS
+
+    @property
+    def rest_api(self) -> RestApiField:
+        """Return how the REST API publishes this field. Published as it stands unless a column."""
+        return _REST_AS_IS
+
+    @property
+    def validator(self) -> t.Callable[[t.Any], t.Any] | None:
+        """Return the check a value of this field must pass, if it has one.
+
+        Optional, and the one piece of *logic* a declaration carries -- D1 otherwise admits only
+        facts. It earns the exception by having no other home: a ``PUT`` replaces a stored value
+        without going through ``__init__``, so a check written there would never run, and writing
+        it once per layer would mean the same rule stated twice and able to drift.
+
+        It raises rather than returning a verdict, and it runs wherever a value enters: every
+        layer model wires it in, so a REST ``POST`` and ``PUT`` and a CLI import all get it.
+        """
+        return self._validator
+
+    @property
+    def doc(self) -> str:
+        return self._doc
+
+    @property
+    @abc.abstractmethod
+    def is_attribute(self) -> bool:
+        """Whether the backend holds the value in the open attributes namespace."""
+
+    @property
+    @abc.abstractmethod
+    def backend_key(self) -> str:
+        """The key the backend holds the value under."""
+
+    # -- read access ------------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def read(self, instance: t.Any) -> t.Any:
+        """Return the value the backend holds for this field on ``instance``.
+
+        Declarations are values held in the internal declaration mapping, never under their own names, so
+        ``getattr`` does not reach them and every reader goes through here.
+        """
+
+
+class ColumnField(BaseField):
+    """A field the backend holds in a column of the table backing the entity.
+
+    The columns are fixed by the storage schema and its migrations, so these belong to the core
+    entity classes; a plugin has no column to declare.
+
+    Unlike an attribute, a column has a schema behind it, so its default is a *fact about what the
+    backend stores* rather than a decision about what to write -- which is why the two options
+    live here and not on the base.
+    """
+
+    __slots__ = (
+        '_cli_exclude',
+        '_cli_name',
+        '_default',
+        '_default_factory',
+        '_rest_api_exclude',
+        '_rest_api_name',
+        '_rest_api_read_only',
+    )
+
+    def __init__(
+        self,
+        name: str,
+        dtype: StorableType,
+        doc: str = '',
+        *,
+        default: ImmutableStorable | _Missing = MISSING,
+        default_factory: t.Callable[[], MutableStorable] | None = None,
+        cli_name: str | None = None,
+        cli_exclude: bool = False,
+        rest_api_name: str | None = None,
+        rest_api_exclude: bool = False,
+        rest_api_read_only: bool = False,
+        **kwargs: t.Any,
+    ) -> None:
+        if default is not MISSING and default_factory is not None:
+            msg = 'cannot specify both `default` and `default_factory`'
+            raise ValueError(msg)
+        super().__init__(name, dtype, doc, **kwargs)
+        self._default = default
+        self._default_factory = default_factory
+        self._cli_name = cli_name
+        self._cli_exclude = cli_exclude
+        self._rest_api_name = rest_api_name
+        self._rest_api_exclude = rest_api_exclude
+        self._rest_api_read_only = rest_api_read_only
+
+    @property
+    def cli(self) -> CliField:
+        """Return how the CLI publishes this column.
+
+        Assembled on access rather than in ``__init__``. A declaration holds the options as the
+        plain values they were given, and only the layer that is building a model turns them into
+        a view -- so importing the ORM does not construct one of these per field per layer for
+        something most callers never look at.
+        """
+        return CliField(name=self._cli_name, exclude=self._cli_exclude)
+
+    @property
+    def rest_api(self) -> RestApiField:
+        """Return how the REST API publishes this column. Assembled on access, as ``cli`` is."""
+        return RestApiField(
+            name=self._rest_api_name,
+            exclude=self._rest_api_exclude,
+            read_only=self._rest_api_read_only,
+        )
+
+    @property
+    def default(self) -> ImmutableStorable | _Missing:
+        """The value the schema supplies when none is given, where it is immutable."""
+        return self._default
+
+    @property
+    def default_factory(self) -> t.Callable[[], MutableStorable] | None:
+        """The factory a mutable default is built by.
+
+        Paired with ``default`` rather than folded into it. Pydantic would in fact copy a mutable
+        default per model instance, so ``default=[]`` is safe where it is *used* -- but the
+        declaration itself would hold one list forever and hand every reader an alias into it, and
+        a mutable default in a class body reads as a bug whether or not it is one.
+        """
+        return self._default_factory
+
+    @property
+    def is_attribute(self) -> bool:
+        return False
+
+    @property
+    def backend_key(self) -> str:
+        return self._name
+
+    def read(self, instance: t.Any) -> t.Any:
+        return getattr(instance.backend_entity, self._name)

--- a/orm_model_redesign/orm/_core/implementation/__init__.py
+++ b/orm_model_redesign/orm/_core/implementation/__init__.py
@@ -1,0 +1,6 @@
+"""The storage backend. Mirrors ``aiida.orm.implementation``."""
+
+from poc.orm._core.implementation.computers import BackendComputer
+from poc.orm._core.implementation.nodes import BackendNode
+
+__all__ = ('BackendComputer', 'BackendNode')

--- a/orm_model_redesign/orm/_core/implementation/computers.py
+++ b/orm_model_redesign/orm/_core/implementation/computers.py
@@ -1,0 +1,38 @@
+"""Toy backend computer. Mirrors ``aiida.orm.implementation.computers``.
+
+A computer has columns and no attributes blob, which is why every one of its declarations is a
+``ColumnField`` and why it is the natural entity to test a projection against.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+__all__ = ('BackendComputer',)
+
+
+class BackendComputer:
+    """The row backing a computer."""
+
+    COLUMNS: t.Final = (
+        'uuid',
+        'label',
+        'description',
+        'hostname',
+        'transport_type',
+        'scheduler_type',
+        'mpirun_command',
+    )
+
+    def __init__(self, **columns: t.Any) -> None:
+        unknown = set(columns) - set(self.COLUMNS)
+        if unknown:
+            msg = f'no such column(s): {sorted(unknown)}'
+            raise ValueError(msg)
+        self.uuid: str = columns.get('uuid', '')
+        self.label: str = columns.get('label', '')
+        self.description: str = columns.get('description', '')
+        self.hostname: str = columns.get('hostname', '')
+        self.transport_type: str = columns.get('transport_type', '')
+        self.scheduler_type: str = columns.get('scheduler_type', '')
+        self.mpirun_command: list[str] = columns.get('mpirun_command', [])

--- a/orm_model_redesign/orm/_core/implementation/nodes.py
+++ b/orm_model_redesign/orm/_core/implementation/nodes.py
@@ -1,0 +1,36 @@
+"""Toy backend node. Mirrors ``aiida.orm.implementation.nodes``.
+
+The shape that matters to the design: a **fixed set of columns**, owned by the schema and its
+migrations, one of which holds an **open attributes blob** whose keys are whatever was put there.
+That asymmetry is the whole reason there are two kinds of field declaration.
+
+The columns are named attributes rather than a dictionary, because that is what they are in the
+backend, and it is what makes ``ColumnField`` a plain ``getattr``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import typing as t
+
+__all__ = ('BackendNode',)
+
+
+class BackendNode:
+    """The row backing a node."""
+
+    #: The columns this table has. A plugin cannot add to these; a migration would have to.
+    COLUMNS: t.Final = ('uuid', 'label', 'ctime', 'attributes')
+
+    def __init__(self, **columns: t.Any) -> None:
+        unknown = set(columns) - set(self.COLUMNS)
+        if unknown:
+            msg = f'no such column(s): {sorted(unknown)}'
+            raise ValueError(msg)
+        self.uuid: str = columns.get('uuid', '')
+        self.label: str = columns.get('label', '')
+        # A real backend stamps this on insert, so the column is never null and the
+        # declaration can say `datetime` rather than `datetime | None`.
+        self.ctime: datetime.datetime = columns.get('ctime') or datetime.datetime.now(tz=datetime.timezone.utc)
+        #: The open namespace. Its keys are whatever was stored, declared or not.
+        self.attributes: dict[str, t.Any] = columns.get('attributes', {})

--- a/orm_model_redesign/orm/_core/nodes/__init__.py
+++ b/orm_model_redesign/orm/_core/nodes/__init__.py
@@ -1,0 +1,5 @@
+"""Internal node implementation."""
+
+from poc.orm._core.nodes.node import Node
+
+__all__ = ('Node',)

--- a/orm_model_redesign/orm/_core/nodes/attributes.py
+++ b/orm_model_redesign/orm/_core/nodes/attributes.py
@@ -1,0 +1,58 @@
+"""Interface to a node's attributes. Mirrors ``aiida.orm.nodes.attributes``.
+
+This is the manager an ``AttributeField`` reads through, reached as ``node.base.attributes``. It
+is modelled here only so that :meth:`~poc.orm.fields.AttributeField._read` can be the same
+line it is in ``aiida``.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+if t.TYPE_CHECKING:
+    from poc.orm._core.nodes.node import Node
+
+__all__ = ('NodeAttributes',)
+
+_NO_DEFAULT: t.Final = object()
+
+
+class NodeAttributes:
+    """Interface to the attributes of a node instance."""
+
+    def __init__(self, node: Node) -> None:
+        self._node = node
+        self._backend_node = node.backend_entity
+
+    @property
+    def all(self) -> dict[str, t.Any]:
+        """Return the complete attributes dictionary, declared keys and undeclared alike."""
+        return self._backend_node.attributes
+
+    def get(self, key: str, default: t.Any = _NO_DEFAULT) -> t.Any:
+        """Return the value of an attribute.
+
+        :raises AttributeError: if the attribute is not set and no default is given.
+        """
+        try:
+            return self._backend_node.attributes[key]
+        except KeyError:
+            if default is _NO_DEFAULT:
+                raise AttributeError(key) from None
+            return default
+
+    def set(self, key: str, value: t.Any) -> None:
+        """Set an attribute, running whatever its declaration states it must satisfy.
+
+        The namespace is open, so any key is accepted -- an undeclared one simply has nothing to
+        check against, which is C2 rather than an oversight.
+
+        :raises ValueError: if the key is declared with a validator and the value does not pass.
+        """
+        declaration = type(self._node)._field_declarations.get(key)
+        if declaration is not None and declaration.validator is not None:
+            value = declaration.validator(value)
+        self._backend_node.attributes[key] = value
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._backend_node.attributes

--- a/orm_model_redesign/orm/_core/nodes/columns.py
+++ b/orm_model_redesign/orm/_core/nodes/columns.py
@@ -1,0 +1,44 @@
+"""Interface to a node's columns, reached as ``node.base.columns``.
+
+The counterpart to ``node.base.attributes``, and new: in ``aiida`` the columns are reached only
+through hand-written properties on ``Node``, so there is no single point a write passes through.
+Giving them a namespace gives writes one, which is where a declared ``validator`` runs.
+
+The public accessors do not go away -- ``node.label`` stays a property, and delegates here. What
+changes is that the property is a *spelling* rather than the only path, so a value cannot reach
+the backend without being checked.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+if t.TYPE_CHECKING:
+    from poc.orm._core.entities import Entity
+
+__all__ = ('EntityColumns',)
+
+
+class EntityColumns:
+    """Interface to the fixed columns of an entity."""
+
+    def __init__(self, entity: Entity) -> None:
+        self._entity = entity
+        self._backend_entity = entity.backend_entity
+
+    def get(self, key: str) -> t.Any:
+        """Return the stored value of a column."""
+        return getattr(self._backend_entity, key)
+
+    def set(self, key: str, value: t.Any) -> None:
+        """Set a column, running whatever its declaration states it must satisfy.
+
+        :raises ValueError: if the declaration has a validator and the value does not pass it.
+        """
+        declaration = type(self._entity)._field_declarations.get(key)
+        if declaration is not None and declaration.validator is not None:
+            value = declaration.validator(value)
+        setattr(self._backend_entity, key, value)
+
+    def __contains__(self, key: str) -> bool:
+        return key in type(self._entity)._field_declarations

--- a/orm_model_redesign/orm/_core/nodes/node.py
+++ b/orm_model_redesign/orm/_core/nodes/node.py
@@ -1,0 +1,89 @@
+"""The core entity. Mirrors ``aiida.orm.nodes.node``.
+
+Everything here is a :class:`ColumnField`, because these are the columns the storage schema
+actually has. Their Python accessors are hand-written properties, so the declarations live in
+``_column_fields`` and exist to describe and to query, not to read.
+
+The two ways into the backend are the two a declaration uses: ``backend_entity`` for the columns,
+``base.attributes`` for the open namespace one of those columns holds.
+"""
+
+from __future__ import annotations
+
+import datetime
+import typing as t
+from collections.abc import Mapping, Sequence
+from functools import cached_property
+
+from poc.orm._core.entities import Entity
+from poc.orm._core.fields import BaseField, ColumnField
+from poc.orm._core.implementation import BackendNode
+from poc.orm._core.nodes.attributes import NodeAttributes
+from poc.orm._core.nodes.columns import EntityColumns
+from poc.orm._core.qb_fields import QbAttributesField, QbField
+
+__all__ = ('Node', 'NodeBase')
+
+
+def _no_newlines(value: str) -> str:
+    """Reject a label that would break every listing that prints one per line."""
+    if '\n' in value:
+        msg = f'a label may not contain a newline, got {value!r}'
+        raise ValueError(msg)
+    return value
+
+
+class NodeBase:
+    """The namespace of a node's sub-managers, reached as ``node.base``."""
+
+    def __init__(self, node: Node) -> None:
+        self._node = node
+
+    @cached_property
+    def attributes(self) -> NodeAttributes:
+        """Return an interface to interact with the attributes of this node."""
+        return NodeAttributes(self._node)
+
+    @cached_property
+    def columns(self) -> EntityColumns:
+        """Return an interface to interact with the columns of this node."""
+        return EntityColumns(self._node)
+
+
+class Node(Entity):
+    """An entity backed by a row: fixed columns plus an open attributes blob."""
+
+    _column_fields: t.ClassVar[Sequence[BaseField]] = (
+        ColumnField('uuid', str, 'The UUID of the node', rest_api_read_only=True),
+        ColumnField('label', str, 'The node label', default='', validator=_no_newlines),
+        ColumnField('ctime', datetime.datetime, 'The creation time of the node', rest_api_read_only=True),
+        ColumnField('attributes', dict[str, t.Any], 'The node attributes', default_factory=dict),
+    )
+
+    def __init__(self, **columns: t.Any) -> None:
+        self.backend_entity = BackendNode(**columns)
+
+    @cached_property
+    def base(self) -> NodeBase:
+        """Return the namespace of this node's sub-managers."""
+        return NodeBase(self)
+
+    @property
+    def uuid(self) -> str:
+        return self.base.columns.get('uuid')
+
+    @property
+    def label(self) -> str:
+        return self.base.columns.get('label')
+
+    @label.setter
+    def label(self, value: str) -> None:
+        self.base.columns.set('label', value)
+
+    @classmethod
+    def _build_query_fields(cls, declarations: Mapping[str, BaseField]) -> dict[str, QbField]:
+        """Expose the attribute-backed fields as children of the ``attributes`` field."""
+        fields = super()._build_query_fields(declarations)
+        children = {name: field for name, field in fields.items() if declarations[name].is_attribute}
+        fields['attributes'] = QbAttributesField(declarations['attributes'], children)
+        return fields

--- a/orm_model_redesign/orm/_core/qb_fields.py
+++ b/orm_model_redesign/orm/_core/qb_fields.py
@@ -1,0 +1,335 @@
+"""The query-side view of a declaration. Mirrors ``aiida.orm.fields``, renamed.
+
+The module name is the one proposal here: everything in it is ``Qb``-prefixed, and ``fields``
+does not say so -- particularly once ``fields`` sits beside it holding declarations that are
+also, in every ordinary sense, fields.
+
+Nothing else in this module is new. ``QbField``, ``QbAttributesField``, ``QbFieldFilters`` and
+``QbFields`` keep the names and the behaviour they have in ``aiida.orm.fields`` -- the refactor
+does not touch the query layer, it only changes *what* ``QbFields`` holds and where a query field
+comes from.
+
+The two differences from the shipped module, both consequences of decisions recorded in the README:
+
+* the seven-class ``QbField`` hierarchy is one class consulting :func:`operators_for`, so the type
+  selects the operators through a table rather than through inheritance;
+* a ``QbField`` *wraps* a :class:`~poc.orm.fields.BaseField` instead of being one, which is
+  what lets the declaration stay an ordinary value with an ordinary ``==``.
+
+``QbFieldFilters`` is reproduced as it stands, minus its ``singledispatchmethod`` dispatch, which
+is spelled with ``isinstance`` here to keep the walkthrough readable.
+"""
+
+from __future__ import annotations
+
+import datetime
+import typing as t
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pprint import pformat
+
+if t.TYPE_CHECKING:
+    from poc.orm._core.fields import BaseField
+
+__all__ = ('QbAttributesField', 'QbField', 'QbFieldFilters', 'QbFields')
+
+_ORDERED_TYPES: t.Final = (int, float, datetime.datetime)
+_TEXT_TYPES: t.Final = (str, t.Literal)
+_SEQUENCE_TYPES: t.Final = (list, tuple, Sequence)
+
+
+def root_type(dtype: t.Any) -> t.Any:
+    """Resolve the primitive root of an annotation.
+
+    >>> root_type(list[str]) -> list
+    >>> root_type(str | None) -> str
+    """
+    origin = t.get_origin(dtype)
+    if origin is None:
+        return dtype
+    if origin is t.Union:
+        return root_type(t.get_args(dtype)[0])
+    return origin
+
+
+def operators_for(dtype: t.Any) -> frozenset[str]:
+    """Return the operator groups a value of this type admits.
+
+    This is the ``QbNumericField`` / ``QbStrField`` / ... hierarchy as a table: the groups a type
+    admits used to be decided by which subclass ``add_field`` returned.
+
+    A deliberately open type admits everything except the boolean operators, which need a value
+    the backend stores as ``True``.
+
+    .. note:: The table is a judgement call, not a fact about the backend. It currently refuses
+        ``<`` on a text field, although the backend orders strings perfectly well -- inherited
+        from the ``QbStrField`` it replaces, and worth revisiting.
+    """
+    root = root_type(dtype)
+    if root is bool:
+        return frozenset({'boolean'})
+    if root in _ORDERED_TYPES:
+        return frozenset({'ordering'})
+    if root in _SEQUENCE_TYPES:
+        return frozenset({'array'})
+    if root in _TEXT_TYPES:
+        return frozenset({'text'})
+    if root is dict:
+        return frozenset({'mapping'})
+    return frozenset({'ordering', 'text', 'array', 'mapping'})
+
+
+class QbField:
+    """The query field for a declaration: its key, and the operators its type admits."""
+
+    __slots__ = ('_backend_key', '_dtype', '_key', '_operators', '_spec')
+
+    def __init__(self, key: str, backend_key: str, dtype: t.Any, declaration: BaseField | None = None) -> None:
+        self._key = key
+        self._backend_key = backend_key
+        self._dtype = dtype
+        self._operators = operators_for(dtype)
+        self._spec = declaration
+
+    @classmethod
+    def from_spec(cls, declaration: BaseField) -> QbField:
+        """Build the query field for a declaration."""
+        return cls(declaration.name, declaration.backend_key, declaration.dtype, declaration)
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    @property
+    def backend_key(self) -> str:
+        return self._backend_key
+
+    @property
+    def dtype(self) -> t.Any:
+        return self._dtype
+
+    @property
+    def declaration(self) -> BaseField | None:
+        """The declaration this field queries, if it has one; nested keys do not."""
+        return self._spec
+
+    def _require(self, group: str, operator: str) -> None:
+        """Reject an operator the declared type does not admit.
+
+        :raises TypeError: so a nonsense comparison fails here rather than becoming a filter that
+            silently matches nothing.
+        """
+        if group not in self._operators:
+            msg = f'`{operator}` is not supported by field `{self._key}` of type `{self._dtype}`'
+            raise TypeError(msg)
+
+    def _filter(self, operator: str, value: t.Any) -> QbFieldFilters:
+        return QbFieldFilters(((self, operator, value),))
+
+    def __eq__(self, value: t.Any) -> QbFieldFilters:  # type: ignore[override]
+        return self._filter('==', value)
+
+    def __ne__(self, value: t.Any) -> QbFieldFilters:  # type: ignore[override]
+        return self._filter('!==', value)
+
+    def __lt__(self, value: t.Any) -> QbFieldFilters:
+        self._require('ordering', '<')
+        return self._filter('<', value)
+
+    def __gt__(self, value: t.Any) -> QbFieldFilters:
+        self._require('ordering', '>')
+        return self._filter('>', value)
+
+    def __hash__(self) -> int:
+        return hash((self._key, self._backend_key))
+
+    def like(self, value: str) -> QbFieldFilters:
+        self._require('text', 'like')
+        return self._filter('like', value)
+
+    def contains(self, value: t.Any) -> QbFieldFilters:
+        self._require('array', 'contains')
+        return self._filter('contains', value)
+
+    def has_key(self, value: str) -> QbFieldFilters:
+        self._require('mapping', 'has_key')
+        return self._filter('has_key', value)
+
+    def as_filter(self) -> QbFieldFilters:
+        self._require('boolean', 'as_filter')
+        return self._filter('==', True)
+
+    def __invert__(self) -> QbFieldFilters:
+        self._require('boolean', '~')
+        return self._filter('!==', True)
+
+    def __and__(self, other: t.Any) -> QbFieldFilters:
+        return self.as_filter() & other
+
+    def __rand__(self, other: t.Any) -> QbFieldFilters:
+        return other & self.as_filter()
+
+    def __getitem__(self, key: str) -> QbField:
+        """Return the query field for a nested key. It has no declaration behind it."""
+        self._require('mapping', '[]')
+        return QbField(f'{self._key}.{key}', f'{self._backend_key}.{key}', t.Any)
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}({self._backend_key!r}, dtype={self._dtype!r})'
+
+
+class QbAttributesField(QbField):
+    """The ``attributes`` query field, exposing the fields declared within it.
+
+    Nested lookup resolves to a declared field where one exists, so that
+    ``Int.fields.attributes.value is Int.fields.value``, and otherwise falls back to an untyped
+    field -- which is how the open keys stay queryable without being declared.
+    """
+
+    __slots__ = ('_children',)
+
+    def __init__(self, declaration: BaseField, children: Mapping[str, QbField] | None = None) -> None:
+        super().__init__(declaration.name, declaration.backend_key, declaration.dtype, declaration)
+        self._children = dict(children or {})
+
+    def with_children(self, children: Mapping[str, QbField]) -> QbAttributesField:
+        """Return a copy of this field holding the given declared children."""
+        assert self._spec is not None
+        return type(self)(self._spec, children)
+
+    def __getattr__(self, key: str) -> QbField:
+        # `__slots__` lookups never reach here, so a leading underscore is a genuine miss.
+        if key.startswith('_'):
+            raise AttributeError(key)
+        try:
+            return self._children[key]
+        except KeyError:
+            raise AttributeError(key) from None
+
+    def __getitem__(self, key: str) -> QbField:
+        if key in self._children:
+            return self._children[key]
+        return QbField(key, f'attributes.{key}', t.Any)
+
+    def __dir__(self) -> list[str]:
+        return sorted(self._children)
+
+
+class QbFieldFilters:
+    """A representation of a list of fields and their comparators."""
+
+    __slots__ = ('filters',)
+
+    def __init__(self, filters: Sequence[tuple[QbField, str, t.Any]] | dict[str, t.Any]) -> None:
+        self.filters: dict[str, t.Any] = {}
+        self.add_filters(filters)
+
+    def add_filters(self, filters: Sequence[tuple[QbField, str, t.Any]] | dict[str, t.Any]) -> None:
+        if isinstance(filters, dict):
+            self.filters.update(filters)
+            return
+        for field, comparator, value in filters:
+            key = field.backend_key
+            if key in self.filters:
+                self.filters['and'] = [{key: self.filters.pop(key)}, {key: {comparator: value}}]
+            else:
+                self.filters[key] = {comparator: value}
+
+    def as_dict(self) -> dict[str, t.Any]:
+        """Return the filters dictionary."""
+        return self.filters
+
+    def items(self) -> t.ItemsView[str, t.Any]:
+        """Return an items view of the filters, for use in the ``QueryBuilder``."""
+        return self.filters.items()
+
+    def __getitem__(self, key: str) -> t.Any:
+        return self.filters[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.filters
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, QbFieldFilters):
+            msg = f'cannot compare QbFieldFilters to {type(other)}'
+            raise TypeError(msg)
+        return self.filters == other.filters
+
+    def __and__(self, other: t.Any) -> QbFieldFilters:
+        """``a & b`` -> {'and': [`a.filters`, `b.filters`]}."""
+        if not isinstance(other, QbFieldFilters):
+            # Defer to the right operand, so a boolean field can turn itself into a filter through
+            # its reflected operator rather than being special-cased here.
+            return NotImplemented
+        return self._resolve_redundancy(other, 'and') or QbFieldFilters({'and': [self.filters, other.filters]})
+
+    def __or__(self, other: t.Any) -> QbFieldFilters:
+        """``a | b`` -> {'or': [`a.filters`, `b.filters`]}."""
+        if not isinstance(other, QbFieldFilters):
+            return NotImplemented
+        return self._resolve_redundancy(other, 'or') or QbFieldFilters({'or': [self.filters, other.filters]})
+
+    def __invert__(self) -> QbFieldFilters:
+        """``~(a > b)`` -> ``a !> b``; ``~(a !> b)`` -> ``a > b``."""
+        filters = deepcopy(self.filters)
+        for logical, negated in (('and', '!and'), ('or', '!or'), ('!and', 'and'), ('!or', 'or')):
+            if logical in filters:
+                filters[negated] = filters.pop(logical)
+                return QbFieldFilters(filters)
+        key, args = next(iter(filters.items()))
+        operator, value = next(iter(args.items()))
+        filters[key] = {operator[1:] if '!' in operator else f'!{operator}': value}
+        return QbFieldFilters(filters)
+
+    def _resolve_redundancy(self, other: QbFieldFilters, logical: str) -> QbFieldFilters | None:
+        """Flatten into an existing logical group rather than nesting another one."""
+        if other == self:
+            return self
+        if logical in self.filters:
+            self[logical].append(other.filters)
+            return self
+        if logical in other:
+            other[logical].insert(0, self.filters)
+            return other
+        return None
+
+    def __repr__(self) -> str:
+        return f'QbFieldFilters({self.filters})'
+
+
+class QbFields:
+    """A read-only mapping from a name to the query field of an entity."""
+
+    __isabstractmethod__ = False
+
+    def __init__(self, fields: Mapping[str, QbField] | None = None) -> None:
+        self._fields: dict[str, QbField] = dict(fields or {})
+
+    def keys(self) -> list[str]:
+        """Return the backend keys, sorted; an attribute-backed one is prefixed ``attributes.``."""
+        return sorted(field.backend_key for field in self._fields.values())
+
+    def __getitem__(self, key: str) -> QbField:
+        return self._fields[key]
+
+    def __getattr__(self, key: str) -> QbField:
+        try:
+            return self._fields[key]
+        except KeyError:
+            raise AttributeError(key) from None
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._fields
+
+    def __len__(self) -> int:
+        return len(self._fields)
+
+    def __iter__(self) -> t.Iterator[str]:
+        return iter(self._fields)
+
+    def __dir__(self) -> list[str]:
+        """Return the names, for tab completion."""
+        return sorted(self._fields)
+
+    def __repr__(self) -> str:
+        return pformat({key: repr(value) for key, value in self._fields.items()}, width=500)

--- a/orm_model_redesign/orm/computers.py
+++ b/orm_model_redesign/orm/computers.py
@@ -1,0 +1,64 @@
+"""The computer entity. Mirrors ``aiida.orm.computers``.
+
+Here to give the projection layers something with no attributes at all: every declaration is a
+``ColumnField``, and two of them are published by the CLI under a different name than the one the
+schema uses, which is what makes it a real test of whether a name map is enough.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Sequence
+
+from poc.orm._core.entities import Entity
+from poc.orm._core.fields import BaseField, ColumnField
+from poc.orm._core.implementation.computers import BackendComputer
+
+__all__ = ('Computer',)
+
+
+def _no_whitespace(value: str) -> str:
+    """Reject a hostname that could not be dialled.
+
+    On the declaration rather than in ``__init__`` because a REST ``PUT`` replaces the stored
+    value without constructing anything, so a check written there would never run.
+    """
+    if value != value.strip() or ' ' in value:
+        msg = f'a hostname may not contain whitespace, got {value!r}'
+        raise ValueError(msg)
+    return value
+
+
+class Computer(Entity):
+    """A computer AiiDA can run calculations on."""
+
+    _column_fields: t.ClassVar[Sequence[BaseField]] = (
+        ColumnField('uuid', str, 'The UUID of the computer', cli_exclude=True, rest_api_read_only=True),
+        ColumnField('label', str, 'The computer label'),
+        ColumnField('description', str, 'What the computer is', default=''),
+        ColumnField('hostname', str, 'The hostname to connect to', validator=_no_whitespace),
+        ColumnField('transport_type', str, 'Entry point name of the transport'),
+        ColumnField('scheduler_type', str, 'Entry point name of the scheduler'),
+        ColumnField('mpirun_command', list[str], 'The command to run in parallel', default_factory=list),
+    )
+
+    def __init__(self, **columns: t.Any) -> None:
+        self.backend_entity = BackendComputer(**columns)
+
+    @property
+    def label(self) -> str:
+        return self.backend_entity.label
+
+    @classmethod
+    def from_cli_model(cls, model: t.Any) -> Computer:
+        """Return a computer built from what ``verdi computer import`` read.
+
+        Only the setup entities need this: ``Computer``, the code classes, ``Group``. A data node
+        is exported and imported through a format converter (``_prepare_<fmt>`` and its parsers),
+        which is specific to the data type and does not generalise -- so no data plugin has to
+        implement anything here.
+        """
+        computer = cls.from_model(model)
+        # A freshly imported computer is a new one, so it does not carry the exporter's identity.
+        computer.backend_entity.uuid = ''
+        return computer

--- a/orm_model_redesign/orm/fields.py
+++ b/orm_model_redesign/orm/fields.py
@@ -1,0 +1,44 @@
+"""The one declaration a data plugin writes. Mirrors ``aiida.orm.field_spec``, narrowed.
+
+This module is the public surface of the declaration layer, and it holds exactly one class. The
+abstract base and the column kind are internals: a plugin cannot declare a column, so exporting
+``ColumnField`` would promise a stability guarantee for something it has no business using.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from poc.orm._core.fields import BaseField
+
+__all__ = ('AttributeField',)
+
+
+class AttributeField(BaseField):
+    """A field the backend holds in the entity's open ``attributes``.
+
+    This is what a data plugin declares, and the only kind it can: the attributes are the only
+    part of the row a plugin may add to. It is therefore **the user-facing kind**, and it is kept
+    to what a plugin author must state -- the type, and what the value means.
+
+    It carries no default. There is no schema behind an attribute to supply one, so a default
+    would be a decision about what to write, and writing is ``__init__``'s job (D4).
+    """
+
+    __slots__ = ()
+
+    @property
+    def is_attribute(self) -> bool:
+        return True
+
+    @property
+    def backend_key(self) -> str:
+        return f'attributes.{self._name}'
+
+    def read(self, instance: t.Any) -> t.Any:
+        """Return the stored value.
+
+        :raises AttributeError: if the key is not set. There is no declared fallback: what an
+            unset attribute should read as is the owning class's decision, made in ``__init__``.
+        """
+        return instance.base.attributes.get(self._name)

--- a/orm_model_redesign/orm/nodes/__init__.py
+++ b/orm_model_redesign/orm/nodes/__init__.py
@@ -1,0 +1,6 @@
+"""Public node entities and the ``Data`` plugin extension base."""
+
+from poc.orm._core.nodes import Node
+from poc.orm.nodes.data import Bool, Data, Int, Str
+
+__all__ = ('Bool', 'Data', 'Int', 'Node', 'Str')

--- a/orm_model_redesign/orm/nodes/data/__init__.py
+++ b/orm_model_redesign/orm/nodes/data/__init__.py
@@ -1,0 +1,6 @@
+"""The ``Data`` plugin extension base and concrete data types."""
+
+from poc.orm.nodes.data.data import Data
+from poc.orm.nodes.data.primitives import Bool, Int, Str
+
+__all__ = ('Bool', 'Data', 'Int', 'Str')

--- a/orm_model_redesign/orm/nodes/data/data.py
+++ b/orm_model_redesign/orm/nodes/data/data.py
@@ -1,0 +1,43 @@
+"""The base for data plugins. Mirrors ``aiida.orm.nodes.data.data``.
+
+Everything a plugin adds is an :class:`AttributeField`, since the attributes are the only part of
+the row it may add to. ``AttributeField`` is also the plugin's *only* option -- it cannot reach
+for a column by accident, because the kind is the type.
+
+Declarations go in ``_attribute_fields``, the protected subclass API for data plugins. This leaves
+each declared name free for whatever accessor the class wants to expose.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Sequence
+
+from poc.orm._core.fields import BaseField
+from poc.orm._core.nodes.node import Node
+from poc.orm.fields import AttributeField
+
+__all__ = ('Data',)
+
+
+class Data(Node):
+    """A base for data plugins.
+
+    Subclasses declare stored values through ``_attribute_fields``. This is a protected subclass
+    API: it is supported for plugin classes to define, but ordinary users should use ``fields``
+    for query introspection instead.
+    """
+
+    _attribute_fields: t.ClassVar[Sequence[BaseField]] = (
+        AttributeField('source', dict | None, 'Where the data came from'),
+    )
+
+    def __init__(self, source: dict[str, t.Any] | None = None, **columns: t.Any) -> None:
+        super().__init__(**columns)
+        # The declaration states that a `source` is stored. What it starts out as is this
+        # constructor's decision, which is why the declaration carries no default.
+        self.base.attributes.set('source', source)
+
+    @property
+    def source(self) -> dict[str, t.Any] | None:
+        return self.base.attributes.get('source')

--- a/orm_model_redesign/orm/nodes/data/primitives/__init__.py
+++ b/orm_model_redesign/orm/nodes/data/primitives/__init__.py
@@ -1,0 +1,8 @@
+"""Primitive data types."""
+
+from poc.orm.nodes.data.primitives.base import BaseType
+from poc.orm.nodes.data.primitives.bool import Bool
+from poc.orm.nodes.data.primitives.int import Int
+from poc.orm.nodes.data.primitives.str import Str
+
+__all__ = ('BaseType', 'Bool', 'Int', 'Str')

--- a/orm_model_redesign/orm/nodes/data/primitives/base.py
+++ b/orm_model_redesign/orm/nodes/data/primitives/base.py
@@ -1,0 +1,36 @@
+"""A container for a single python value. Mirrors ``aiida.orm.nodes.data.base``."""
+
+from __future__ import annotations
+
+import typing as t
+
+from poc.orm.nodes.data.data import Data
+
+__all__ = ('BaseType',)
+
+
+class BaseType(Data):
+    """Holds a single value of ``_type``.
+
+    Converting an incoming value to that type is **this class's** rule, applied once when the node
+    is constructed. It is not a capability of the declaration: the declaration only records that
+    an ``Int`` holds an ``int``, which is a fact about what is stored.
+    """
+
+    _type: t.ClassVar[type]
+
+    def __init__(self, value: t.Any = None, **columns: t.Any) -> None:
+        super().__init__(**columns)
+        self.base.attributes.set('value', self._type() if value is None else self._type(value))
+
+    @property
+    def value(self) -> t.Any:
+        """Return the stored value.
+
+        A property rather than the declaration itself: the declaration lives in
+        ``_attribute_fields``, so the name is the class's to spend as it likes.
+        """
+        return self.base.attributes.get('value')
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}({self.value!r})'

--- a/orm_model_redesign/orm/nodes/data/primitives/bool.py
+++ b/orm_model_redesign/orm/nodes/data/primitives/bool.py
@@ -1,0 +1,24 @@
+"""A boolean value. Mirrors ``aiida.orm.nodes.data.bool``."""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Sequence
+
+from poc.orm._core.fields import BaseField
+from poc.orm.fields import AttributeField
+from poc.orm.nodes.data.primitives.base import BaseType
+
+__all__ = ('Bool',)
+
+
+class Bool(BaseType):
+    """Holds a ``bool``.
+
+    The one type whose query field admits the boolean operators, so ``Bool.fields.value`` can turn
+    itself into a filter through ``as_filter()``, ``&`` or ``~``.
+    """
+
+    _type = bool
+
+    _attribute_fields: t.ClassVar[Sequence[BaseField]] = (AttributeField('value', bool, 'The value of the boolean'),)

--- a/orm_model_redesign/orm/nodes/data/primitives/int.py
+++ b/orm_model_redesign/orm/nodes/data/primitives/int.py
@@ -1,0 +1,20 @@
+"""An integer value. Mirrors ``aiida.orm.nodes.data.int``."""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Sequence
+
+from poc.orm._core.fields import BaseField
+from poc.orm.fields import AttributeField
+from poc.orm.nodes.data.primitives.base import BaseType
+
+__all__ = ('Int',)
+
+
+class Int(BaseType):
+    """Holds an ``int``."""
+
+    _type = int
+
+    _attribute_fields: t.ClassVar[Sequence[BaseField]] = (AttributeField('value', int, 'The value of the integer'),)

--- a/orm_model_redesign/orm/nodes/data/primitives/str.py
+++ b/orm_model_redesign/orm/nodes/data/primitives/str.py
@@ -1,0 +1,20 @@
+"""A string value. Mirrors ``aiida.orm.nodes.data.str``."""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Sequence
+
+from poc.orm._core.fields import BaseField
+from poc.orm.fields import AttributeField
+from poc.orm.nodes.data.primitives.base import BaseType
+
+__all__ = ('Str',)
+
+
+class Str(BaseType):
+    """Holds a ``str``."""
+
+    _type = str
+
+    _attribute_fields: t.ClassVar[Sequence[BaseField]] = (AttributeField('value', str, 'The value of the string'),)

--- a/orm_model_redesign/restapi/__init__.py
+++ b/orm_model_redesign/restapi/__init__.py
@@ -1,0 +1,1 @@
+"""An application layer consuming the ORM declarations. Mirrors ``aiida.restapi``."""

--- a/orm_model_redesign/restapi/_core/__init__.py
+++ b/orm_model_redesign/restapi/_core/__init__.py
@@ -1,0 +1,1 @@
+"""Internals of ``poc.restapi``. Nothing here is public API."""

--- a/orm_model_redesign/restapi/_core/models.py
+++ b/orm_model_redesign/restapi/_core/models.py
@@ -1,0 +1,89 @@
+"""REST-owned projection of the ORM declarations. Private: a user never imports this.
+
+Which fields a client may write is a decision of this layer, but it is *stated* on the entity, as
+a ``rest_api_read_only`` option on the declaration. Nothing here is keyed by class name, so a class
+this layer has never heard of is served as correctly as one it ships with.
+
+The same three pieces as ``poc.cmdline._core.models``: a model builder, and a pair of functions taking
+an entity to a payload and back. The asymmetry is that REST reads far more often than it writes,
+so there are two model classes rather than one.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Mapping
+
+from poc.common._core.fields import RestApiField
+from poc.common._core.pydantic import AiidaBaseModel, build_model, published_values
+from poc.orm._core.entities import Entity
+
+__all__ = (
+    'RestApiModel',
+    'build_rest_read_model',
+    'build_rest_write_model',
+    'read_only_fields',
+    'rest_deserialize',
+    'rest_serialize',
+    'rest_validate',
+)
+
+EntityType = t.TypeVar('EntityType', bound=Entity)
+
+
+class RestApiModel(AiidaBaseModel):
+    """Base for the models the REST API serves."""
+
+
+def _fields(cls: type[t.Any]) -> dict[str, RestApiField]:
+    """Return this layer's view of every declaration, as the declarations themselves state it."""
+    return {name: declaration.rest_api for name, declaration in cls._field_declarations.items()}
+
+
+def read_only_fields(cls: type[t.Any]) -> frozenset[str]:
+    """Return the fields of an ORM class that a client may not write."""
+    return frozenset({name for name, field in _fields(cls).items() if field.read_only})
+
+
+def build_rest_read_model(cls: type[t.Any]) -> type[AiidaBaseModel]:
+    """Return the model class a client reads an entity as.
+
+    Public within this layer because the model *class* is what a JSON schema and the API docs
+    come from, not only what a response is built with.
+    """
+    return build_model(f'{cls.__name__}Read', cls._field_declarations, _fields(cls), base=RestApiModel)
+
+
+def build_rest_write_model(cls: type[t.Any]) -> type[AiidaBaseModel]:
+    """Return the model class for the fields a client may set."""
+    fields = dict(_fields(cls))
+    for name in read_only_fields(cls):
+        fields[name] = fields[name].replace(exclude=True)
+    return build_model(f'{cls.__name__}Write', cls._field_declarations, fields, base=RestApiModel)
+
+
+def rest_serialize(entity: Entity) -> dict[str, t.Any]:
+    """Return what a ``GET`` returns: ORM object -> model -> payload."""
+    cls = type(entity)
+    model = build_rest_read_model(cls)(**published_values(entity, _fields(cls)))
+    return model.model_dump()
+
+
+def rest_validate(cls: type[t.Any], payload: Mapping[str, t.Any]) -> AiidaBaseModel:
+    """Return the validated body of a ``PUT``, without constructing anything.
+
+    A ``PUT`` replaces the values of an entity that already exists, so it never reaches
+    ``__init__``. Whatever a declaration states in its ``validator`` runs here instead.
+    """
+    return build_rest_write_model(cls).model_validate(payload)
+
+
+def rest_deserialize(cls: type[EntityType], payload: Mapping[str, t.Any]) -> EntityType:
+    """Return what a ``POST`` constructs: payload -> validated model -> ORM object.
+
+    The class is passed rather than read from the payload, as in the CLI: the route already names
+    the entity type, so nothing is in question by the time this is reached.
+    """
+    model = build_rest_write_model(cls).model_validate(payload)
+    from_rest_model = getattr(cls, 'from_rest_model', None)
+    return from_rest_model(model) if from_rest_model is not None else cls.from_model(model)


### PR DESCRIPTION
Please check out the `README.md`, and look at structure (what is in core API and what is user API), and how are the `ColumnField`s and `AttributeField`s converted to `pydantic.Field`s that are used to build the CLI and REST API model model.