### PR TITLE
🐛 Missing greenback portal on state transitions

### DIFF
--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -412,6 +412,18 @@ class Process(PlumpyProcess):
             self._task = None
 
     @override
+    async def step_until_terminated(self) -> None:
+        """Keep a greenback portal open for as long as this process is being stepped.
+
+        Ensuring the portal here covers every way a process is driven, including the continuation tasks that the
+        broker creates and that never pass through the runner.
+        """
+        from plumpy import ensure_portal
+
+        await ensure_portal()
+        await super().step_until_terminated()
+
+    @override
     def out(self, output_port: str, value: Any = None) -> None:
         """Attach output to output port.
 

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -16,8 +16,9 @@ from plumpy.utils import AttributesFrozendict
 
 from aiida import orm
 from aiida.common.lang import override
-from aiida.engine import ExitCode, ExitCodesNamespace, Process, run, run_get_node, run_get_pk
+from aiida.engine import ExitCode, ExitCodesNamespace, Process, WorkChain, run, run_get_node, run_get_pk
 from aiida.engine.processes.ports import PortNamespace
+from aiida.manage import get_manager
 from aiida.manage.caching import disable_caching, enable_caching
 from aiida.orm import to_aiida_type
 from aiida.orm.nodes.caching import NodeCaching
@@ -624,3 +625,32 @@ def test_auto_default_serializer():
     assert AutoSerializeProcess.spec().inputs['non_metadata_input'].serializer is to_aiida_type
     assert AutoSerializeProcess.spec().inputs['metadata_input'].serializer is None
     assert AutoSerializeProcess.spec().inputs['custom_input'].serializer is custom_serializer
+
+
+class PortalProbeWorkChain(WorkChain):
+    """Record whether a greenback portal is available in an outline step and in ``on_terminated``."""
+
+    portal_in_step = None
+    portal_in_on_terminated = None
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.outline(cls.a_step)
+
+    def a_step(self):
+        PortalProbeWorkChain.portal_in_step = plumpy.has_portal()
+
+    def on_terminated(self):
+        super().on_terminated()
+        PortalProbeWorkChain.portal_in_on_terminated = plumpy.has_portal()
+
+
+def test_portal_available_in_on_terminated():
+    """A portal must still be available once the process transitions to a terminal state."""
+    runner = get_manager().get_runner()
+    process = runner.instantiate_process(PortalProbeWorkChain)
+    runner.loop.run_until_complete(process.step_until_terminated())
+
+    assert PortalProbeWorkChain.portal_in_step is True
+    assert PortalProbeWorkChain.portal_in_on_terminated is True


### PR DESCRIPTION
The bug #7360 reveals an execution path occurring with `core.async_ssh` and `BaseRestartWorkchain` with `clean_workdir` True (see commit message for whole callstack). In this execution path we don't update the event loop to open a greenback portal. We only updated the `Runner.step_until_terminate` to open the portal. This covered the main concerns for nested processes executed with `engine.run` and for calling a ProcessFunction (calcfunction) inside a WorkChain. But `Runner.step_until_terminate` is completely avoided  when we continue a process through the `ProcessLauncher` (This is for submitting typical behavior: We save checkpoint on python client, then worker picks up and continues). While `WorkChain.run` also opens the portal, the `transition_to` is executed outside of that logic. Maybe as pseudo code highlighting the logic 
```
class Process
  def step(self):
      self.execute -> self.step -> open portal and closes after finishes
      # ...
      self.transition_to(..) -> on_terminated -> async transport runs blocking open -> run_until_complete -> RuntimeError
```

We don't have yet a test for the `BaseRestartWorkchain` in the production tests so this was not caught there. For the next bigger release I will add such a test so these things are caught. Note this also affects aiida 2.8, so needs a patch there too.