### PR TITLE
Disable execution of tutorial temporarily

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,6 +116,9 @@ myst_heading_anchors = 4
 nb_execution_show_tb = 'READTHEDOCS' in os.environ
 nb_merge_streams = True
 
+# TODO: Remove before v3 release issue #7594
+nb_execution_excludepatterns = ['tutorials/module*.md']
+
 # The tutorial setup cell creates a ``.aiida-tutorial/`` sandbox with a live daemon whose broker
 # heartbeat file is rewritten ~1/s. Left under the sphinx-watched source tree that would make
 # ``sphinx-autobuild`` loop forever, so relocate it into the git-ignored ``docs/build/`` via the


### PR DESCRIPTION
Because the workgraph integration is still open to be done we have a cyclic dependency where workgraph depends on aiida-core but aiida-core depends on workgraph through the tutorials. Until the workgraph migration has been done we disable the execution of the tutorial. I made an issue to not forget to revert this change #7594 before release v3