### PR TITLE
Fix development warnings not showing in verdi

### DIFF
--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -17,11 +17,12 @@ LOAD_LIMIT=0.3
 MAX_NUMBER_ATTEMPTS=5
 
 iteration=0
+TIMEFORMAT=%R
 
 while true; do
 
     iteration=$((iteration+1))
-    load_time=$(/usr/bin/time -q -f "%e" $VERDI -h 2>&1 > /dev/null)
+    load_time=$( { time "$VERDI" -h > /dev/null 2>&1; } 2>&1 )
 
     if (( $(echo "$load_time < $LOAD_LIMIT" | bc -l) )); then
         echo "SUCCESS: loading time $load_time at iteration $iteration below $LOAD_LIMIT"

--- a/.github/workflows/verdi.sh
+++ b/.github/workflows/verdi.sh
@@ -13,7 +13,7 @@ VERDI=`which verdi`
 # Typically these types of tests are fragile. But with a load limit of more than twice
 # the ideal loading time, if exceeded, should give a reasonably sure indication
 # that the loading of `verdi` is unacceptably slowed down.
-LOAD_LIMIT=0.3
+LOAD_LIMIT=0.4
 MAX_NUMBER_ATTEMPTS=5
 
 iteration=0

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ AiiDA (www.aiida.net) is a workflow manager for computational science with a str
 ## Installation
 
 Please see AiiDA's [documentation](https://aiida-core.readthedocs.io/en/latest/).
+**Warning:** Do not use AiiDA directly from the GitHub `main` branch. It changes rapidly and may put your AiiDA storage in an unrecoverable state.
 
 ## How to contribute [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![GitHub issues by-label](https://img.shields.io/github/issues/aiidateam/aiida-core/good%20first%20issue)](https://github.com/aiidateam/aiida-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 

--- a/src/aiida/cmdline/commands/cmd_verdi.py
+++ b/src/aiida/cmdline/commands/cmd_verdi.py
@@ -17,7 +17,10 @@ from aiida.cmdline.params import options, types
 
 # Pass the version explicitly to ``version_option`` otherwise editable installs can show the wrong version number
 @click.group(cls=VerdiCommandGroup, context_settings={'help_option_names': ['--help', '-h']})
-@options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
+# The top-level `--profile` option is only resolved here. The actual profile loading is performed ahead of normal
+# Click dispatch in `VerdiCommandGroup.parse_args`, such that `verdi --help` and other eager-exit paths behave the
+# same as regular command invocations.
+@options.PROFILE(type=types.ProfileParamType(), expose_value=False)
 @options.VERBOSITY()
 @click.version_option(__version__, package_name='aiida_core', message='AiiDA version %(version)s')
 def verdi():

--- a/src/aiida/cmdline/groups/verdi.py
+++ b/src/aiida/cmdline/groups/verdi.py
@@ -11,6 +11,7 @@ import click
 
 from aiida.cmdline.params import options
 from aiida.cmdline.utils.echo import echo_deprecated
+from aiida.common import log
 from aiida.common.exceptions import ConfigurationError
 from aiida.common.extendeddicts import AttributeDict
 from aiida.manage.configuration import get_config
@@ -123,6 +124,13 @@ class VerdiCommandGroup(click.Group):
 
     context_class = VerdiContext
     command_class = VerdiCommand
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """Parse arguments for the ``verdi`` command."""
+        if ctx.parent is None and not ctx.resilient_parsing:
+            log.CLI_ACTIVE = True
+
+        return super().parse_args(ctx, args)
 
     @staticmethod
     def add_verbosity_option(cmd: click.Command) -> click.Command:

--- a/src/aiida/cmdline/groups/verdi.py
+++ b/src/aiida/cmdline/groups/verdi.py
@@ -12,7 +12,7 @@ import click
 from aiida.cmdline.params import options
 from aiida.cmdline.utils.echo import echo_deprecated
 from aiida.common import log
-from aiida.common.exceptions import ConfigurationError
+from aiida.common.exceptions import ConfigurationError, ProfileConfigurationError
 from aiida.common.extendeddicts import AttributeDict
 from aiida.manage.configuration import get_config
 
@@ -126,9 +126,30 @@ class VerdiCommandGroup(click.Group):
     command_class = VerdiCommand
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        """Parse arguments for the ``verdi`` command."""
+        """Parse arguments for the ``verdi`` command.
+
+        For the top-level command, parse the raw arguments once up front in order to resolve the selected profile and
+        load it before Click handles eager options such as ``--help``. This keeps profile-dependent CLI behavior, such
+        as version warnings and logging setup, consistent throughout the rest of command processing.
+        """
         if ctx.parent is None and not ctx.resilient_parsing:
+            from aiida.manage import get_manager
+
             log.CLI_ACTIVE = True
+
+            parser = self.make_parser(ctx)
+            opts, _, _ = parser.parse_args(list(args))
+            # Use the canonical parameter name of the top-level `verdi --profile` option. The option itself only
+            # resolves the requested profile; actual loading is centralized here so eager Click exit paths behave the
+            # same as normal command execution.
+            profile_name = opts.get(options.PROFILE_OPTION_NAME)
+            manager = get_manager()
+
+            try:
+                manager.load_profile(profile_name)
+            except (ConfigurationError, ProfileConfigurationError):
+                if profile_name is not None:
+                    raise
 
         return super().parse_args(ctx, args)
 

--- a/src/aiida/cmdline/params/options/__init__.py
+++ b/src/aiida/cmdline/params/options/__init__.py
@@ -98,6 +98,7 @@ __all__ = (
     'PROCESS_STATE',
     'PROFILE',
     'PROFILE_ONLY_CONFIG',
+    'PROFILE_OPTION_NAME',
     'PROFILE_SET_DEFAULT',
     'PROJECT',
     'RAW',

--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -201,11 +201,9 @@ def set_log_level(ctx: click.Context, _param: click.Parameter, value: t.Any) -> 
 
     Note that we cannot use the most obvious approach of directly setting the level on the various loggers. The reason
     is that after this callback is finished, the :meth:`aiida.common.log.configure_logging` method can be called again,
-    for example when the database backend is loaded, and this will undo this change. So instead, we set to globals in
-    the :mod:`aiida.common.log` module: ``CLI_ACTIVE`` and ``CLI_LOG_LEVEL``. The ``CLI_ACTIVE`` global is always set to
-    ``True``. The ``configure_logging`` function will interpret this as the code being executed through a ``verdi``
-    call. The ``CLI_LOG_LEVEL`` global is only set if an explicit value is set for the ``--verbosity`` option. In this
-    case, it is set to the specified log level and ``configure_logging`` will then set this log level for all loggers.
+    for example when the database backend is loaded, and this will undo this change. So instead, we set the
+    ``CLI_LOG_LEVEL`` global in :mod:`aiida.common.log`. If an explicit value is set for the ``--verbosity`` option, it
+    is set to the specified log level and ``configure_logging`` will then set this log level for all loggers.
 
     This approach tightly couples the generic :mod:`aiida.common.log` module to the :mod:`aiida.cmdline` module, which
     is not the cleanest, but given that other module code can undo the logging configuration by calling that method,

--- a/src/aiida/cmdline/params/options/main.py
+++ b/src/aiida/cmdline/params/options/main.py
@@ -108,6 +108,7 @@ __all__ = (
     'PROCESS_STATE',
     'PROFILE',
     'PROFILE_ONLY_CONFIG',
+    'PROFILE_OPTION_NAME',
     'PROFILE_SET_DEFAULT',
     'PROJECT',
     'RAW',
@@ -248,10 +249,12 @@ VERBOSITY = OverridableOption(
     help='Set the verbosity of the output.',
 )
 
+PROFILE_OPTION_NAME = 'profile'
+
 PROFILE = OverridableOption(
     '-p',
     '--profile',
-    'profile',
+    PROFILE_OPTION_NAME,
     type=types.ProfileParamType(),
     default=defaults.get_default_profile,
     cls=CallableDefaultOption,

--- a/src/aiida/cmdline/params/types/profile.py
+++ b/src/aiida/cmdline/params/types/profile.py
@@ -35,7 +35,6 @@ class ProfileParamType(LabelStringType):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         self._cannot_exist = kwargs.pop('cannot_exist', False)
-        self._load_profile = kwargs.pop('load_profile', False)  # If True, will load the profile converted from value
         super().__init__(*args, **kwargs)
 
     @staticmethod
@@ -45,7 +44,7 @@ class ProfileParamType(LabelStringType):
     def convert(self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None) -> Profile:  # type: ignore[override]
         """Attempt to match the given value to a valid profile."""
         from aiida.common.exceptions import MissingConfigurationError, ProfileConfigurationError
-        from aiida.manage.configuration import Profile, load_profile
+        from aiida.manage.configuration import Profile
 
         try:
             config = ctx.obj.config  # type: ignore[union-attr]
@@ -73,9 +72,6 @@ class ProfileParamType(LabelStringType):
         else:
             if self._cannot_exist:
                 self.fail(str(f'the profile `{value}` already exists'))
-
-        if self._load_profile:
-            load_profile(profile.name)
 
         ctx.obj.profile = profile  # type: ignore[union-attr]
 

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -515,7 +515,7 @@ class Manager:
 
         return runner
 
-    def check_version(self):
+    def check_version(self) -> None:
         """Check the currently installed version of ``aiida-core`` and warn if it is a development version.
 
         The ``aiida-core`` package maintains the protocol that the ``main`` branch carries a development version number,
@@ -526,14 +526,23 @@ class Manager:
         from packaging.version import parse
 
         from aiida import __version__
-        from aiida.cmdline.utils import echo
+        from aiida.common.log import CLI_ACTIVE
 
         # Showing of the warning can be turned off by setting the following option to false.
         show_warning = self.get_option('warnings.development_version')
         version = parse(__version__)
 
         if (version.is_prerelease or version.is_postrelease) and show_warning:
-            echo.echo_warning(f'You are currently using a development version of AiiDA: {version}')
-            echo.echo_warning('Be aware that this is not recommended for production and is not officially supported.')
-            echo.echo_warning('Databases used with this version may not be compatible with future releases of AiiDA')
-            echo.echo_warning('as you might not be able to automatically migrate your data.\n')
+            message = (
+                f'You are currently using a development version of AiiDA: {version}. '
+                'Be aware that this is not recommended for production and is not officially supported. '
+                'Databases used with this version may not be compatible with future releases of AiiDA '
+                'as you might not be able to automatically migrate your data.\n'
+            )
+
+            if CLI_ACTIVE:
+                from aiida.cmdline.utils import echo
+
+                echo.echo_warning(message)
+            else:
+                self.logger.warning(message)

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -529,8 +529,7 @@ class Manager:
         from aiida.cmdline.utils import echo
 
         # Showing of the warning can be turned off by setting the following option to false.
-        assert self._profile is not None
-        show_warning = self._profile.get_option('warnings.development_version')
+        show_warning = self.get_option('warnings.development_version')
         version = parse(__version__)
 
         if (version.is_prerelease or version.is_postrelease) and show_warning:

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -542,7 +542,7 @@ class Manager:
 
         if (version.is_prerelease or version.is_postrelease) and show_warning:
             message = (
-                f'You are currently using a development version of AiiDA: {version}. '
+                f'You are using a development version of AiiDA ({version}). '
                 'Be aware that this is not recommended for production and is not officially supported. '
                 'Databases used with this version may not be compatible with future releases of AiiDA '
                 'as you might not be able to automatically migrate your data.\n'

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -144,7 +144,7 @@ class Manager:
 
         # Check whether a development version is being run. Note that needs to be called after ``configure_logging``
         # because this function relies on the logging being properly configured for the warning to show.
-        self.check_version()
+        self._check_version()
         self._setup_event_loop_in_ipython()
 
         return self._profile
@@ -520,9 +520,17 @@ class Manager:
 
         The ``aiida-core`` package maintains the protocol that the ``main`` branch carries a development version number,
         appending `.dev0` to the version of the next anticipated release. Support branches that backport fixes on top of
-        a release use a post release number, appending `.post0`. This method prints a warning whenever the currently
-        installed version is such a development or post release and not an actual release.
+        a release use a post release number, appending `.post0`. This method emits a warning whenever the currently
+        installed version is such a development or post release and not an actual release. The warning is emitted
+        through the CLI utilities when a ``verdi`` command is being executed and through the manager logger otherwise.
+
+        If no profile is currently loaded, the default profile is loaded first to ensure that logging is configured
+        before the warning is emitted, so it does not get lost.
         """
+        self.load_profile()
+        self._check_version()
+
+    def _check_version(self) -> None:
         from packaging.version import parse
 
         from aiida import __version__

--- a/src/aiida/tools/pytest_fixtures/__init__.py
+++ b/src/aiida/tools/pytest_fixtures/__init__.py
@@ -4,6 +4,7 @@
 # fmt: off
 
 from aiida.tools.pytest_fixtures.broker import run_aiida_broker_service, run_aiida_broker_service_for_profile
+from aiida.tools.pytest_fixtures.cli import check_verdi_group_option_names
 from aiida.tools.pytest_fixtures.configuration import (
     aiida_config,
     aiida_config_factory,
@@ -51,6 +52,7 @@ __all__ = (
     'aiida_profile_clean_class',
     'aiida_profile_factory',
     'aiida_profile_tmp',
+    'check_verdi_group_option_names',
     'config_psql_dos',
     'config_sqlite_dos',
     'daemon_client',

--- a/src/aiida/tools/pytest_fixtures/cli.py
+++ b/src/aiida/tools/pytest_fixtures/cli.py
@@ -1,0 +1,57 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""CLI-related pytest fixtures and checks."""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+
+def assert_verdi_group_option_names_do_not_overlap_with_ancestors() -> None:
+    """Assert built-in and plugin-provided ``verdi`` groups do not reuse ancestor option names."""
+    from aiida.cmdline.commands import cmd_verdi
+
+    ignored_option_names = {'verbosity'}
+
+    def recurse(
+        command: click.Command, path: tuple[str, ...] = (), ancestor_option_names: tuple[set[str], ...] = ()
+    ) -> None:
+        if not isinstance(command, click.Group):
+            return
+
+        command_name = command.name or '<unnamed>'
+        current_path = path + (command_name,)
+        own_option_names = {
+            parameter.name
+            for parameter in command.params
+            if isinstance(parameter, click.Option)
+            and parameter.name is not None
+            and parameter.name not in ignored_option_names
+        }
+        inherited_option_names = set().union(*ancestor_option_names) if ancestor_option_names else set()
+        overlap = own_option_names & inherited_option_names
+
+        assert not overlap, f'group `{" ".join(current_path)}` reuses ancestor option names: {sorted(overlap)}'
+
+        context = click.Context(command)
+
+        for command_name in command.list_commands(context):
+            subcommand = command.get_command(context, command_name)
+            if subcommand is None:
+                continue
+            recurse(subcommand, current_path, (*ancestor_option_names, own_option_names))
+
+    recurse(cmd_verdi.verdi)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def check_verdi_group_option_names() -> None:
+    """Check the ``verdi`` CLI tree for ancestor/descendant option-name collisions."""
+    assert_verdi_group_option_names_do_not_overlap_with_ancestors()

--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -192,6 +192,10 @@ def aiida_config(tmp_path_factory, aiida_config_factory):
     :returns :class:`~aiida.manage.configuration.config.Config`: The loaded temporary config.
     """
     with aiida_config_factory(tmp_path_factory.mktemp(secrets.token_hex(16))) as config:
+        # Test suites should not emit development-version warnings by default. Individual tests can still enable the
+        # option explicitly when they need to assert the warning behavior.
+        config.set_option('warnings.development_version', False)
+        config.store()
         yield config
 
 

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -84,6 +84,13 @@ def test_verdi_with_unknown_profile_fails(config_with_profile_factory, run_cli_c
     assert 'profile `profile-does-not-exist` does not exist' in str(result.exception)
 
 
+def test_group_option_names_do_not_overlap_with_ancestors():
+    """Test built-in `verdi` groups do not reuse ancestor option parameter names."""
+    from aiida.tools.pytest_fixtures.cli import assert_verdi_group_option_names_do_not_overlap_with_ancestors
+
+    assert_verdi_group_option_names_do_not_overlap_with_ancestors()
+
+
 @pytest.mark.usefixtures('config_with_profile')
 def test_invalid_cmd_matches(run_cli_command):
     """Test that verdi with an invalid command will return matches if somewhat close"""

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -33,7 +33,7 @@ def test_verdi_with_empty_profile_list(run_cli_command):
     run_cli_command(cmd_verdi.verdi, ['-h'], use_subprocess=False)
 
 
-@pytest.mark.parametrize('arguments', [['profile', '--help']])
+@pytest.mark.parametrize('arguments', [['--help'], ['profile', '--help']])
 def test_verdi_shows_development_warning(monkeypatch, config_with_profile_factory, run_cli_command, arguments):
     """Regression test: ``verdi`` help commands show the development-version warning from the global config."""
     config = config_with_profile_factory(load=False)

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -45,6 +45,45 @@ def test_verdi_shows_development_warning(monkeypatch, config_with_profile_factor
     assert 'You are using a development version of AiiDA (1.0.0.dev0).' in result.output
 
 
+def test_verdi_with_profile_loads_selected_profile(monkeypatch, empty_config, profile_factory, run_cli_command):
+    """Test ``verdi --profile`` loads the explicitly selected profile."""
+    default_profile = profile_factory('default')
+    explicit_profile = profile_factory('explicit')
+    empty_config.add_profile(default_profile)
+    empty_config.add_profile(explicit_profile)
+    empty_config.set_default_profile(default_profile.name, overwrite=True)
+    empty_config.set_option('warnings.development_version', False)
+    explicit_profile.set_option('warnings.development_version', True)
+    empty_config.store()
+    monkeypatch.setattr(aiida, '__version__', '1.0.0.dev0')
+
+    result = run_cli_command(
+        cmd_verdi.verdi,
+        ['--profile', explicit_profile.name, '--help'],
+        use_subprocess=False,
+        initialize_ctx_obj=False,
+    )
+
+    assert 'You are using a development version of AiiDA (1.0.0.dev0).' in result.output
+    assert 'Usage: verdi [OPTIONS] COMMAND [ARGS]...' in result.output
+
+
+def test_verdi_with_unknown_profile_fails(config_with_profile_factory, run_cli_command):
+    """Test ``verdi --profile`` fails for a profile that does not exist."""
+    config_with_profile_factory(load=False)
+
+    result = run_cli_command(
+        cmd_verdi.verdi,
+        ['--profile', 'profile-does-not-exist', '--help'],
+        use_subprocess=False,
+        initialize_ctx_obj=False,
+        raises=True,
+    )
+
+    assert result.exception is not None
+    assert 'profile `profile-does-not-exist` does not exist' in str(result.exception)
+
+
 @pytest.mark.usefixtures('config_with_profile')
 def test_invalid_cmd_matches(run_cli_command):
     """Test that verdi with an invalid command will return matches if somewhat close"""

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -42,7 +42,7 @@ def test_verdi_shows_development_warning(monkeypatch, config_with_profile_factor
 
     result = run_cli_command(cmd_verdi.verdi, arguments, use_subprocess=False, initialize_ctx_obj=False)
 
-    assert 'You are currently using a development version of AiiDA: 1.0.0.dev0.' in result.output
+    assert 'You are using a development version of AiiDA (1.0.0.dev0).' in result.output
 
 
 @pytest.mark.usefixtures('config_with_profile')

--- a/tests/cmdline/commands/test_verdi.py
+++ b/tests/cmdline/commands/test_verdi.py
@@ -11,6 +11,7 @@
 import click
 import pytest
 
+import aiida
 from aiida import get_version
 from aiida.cmdline.commands import cmd_verdi
 
@@ -30,6 +31,18 @@ def test_verdi_with_empty_profile_list(run_cli_command):
     # Run verdi command with updated CONFIG featuring an empty profile list
     CONFIG.dictionary[CONFIG.KEY_PROFILES] = {}
     run_cli_command(cmd_verdi.verdi, ['-h'], use_subprocess=False)
+
+
+@pytest.mark.parametrize('arguments', [['profile', '--help']])
+def test_verdi_shows_development_warning(monkeypatch, config_with_profile_factory, run_cli_command, arguments):
+    """Regression test: ``verdi`` help commands show the development-version warning from the global config."""
+    config = config_with_profile_factory(load=False)
+    config.set_option('warnings.development_version', True)
+    monkeypatch.setattr(aiida, '__version__', '1.0.0.dev0')
+
+    result = run_cli_command(cmd_verdi.verdi, arguments, use_subprocess=False, initialize_ctx_obj=False)
+
+    assert 'You are currently using a development version of AiiDA: 1.0.0.dev0.' in result.output
 
 
 @pytest.mark.usefixtures('config_with_profile')

--- a/tests/manage/configuration/test_configuration.py
+++ b/tests/manage/configuration/test_configuration.py
@@ -33,52 +33,59 @@ def test_create_profile(isolated_config, tmp_path, entry_point):
     assert profile_name in isolated_config.profile_names
 
 
-def test_check_version_release(monkeypatch, capsys, isolated_config):
-    """Test that ``Manager.check_version`` prints nothing for a release version.
+def test_check_version_release(monkeypatch, isolated_config):
+    """Test that ``Manager.check_version`` emits nothing for a release version."""
+    from unittest.mock import MagicMock
 
-    If a warning is emitted, it should be printed to stdout. So even though it will go through the logging system, the
-    logging configuration of AiiDA will interfere with that of pytest and the ultimately the output will simply be
-    written to stdout, so we use the ``capsys`` fixture and not the ``caplog`` one.
-    """
     version = '1.0.0'
     monkeypatch.setattr(aiida, '__version__', version)
 
     # Explicitly setting the default in case the test profile has it changed.
     isolated_config.set_option('warnings.development_version', True)
 
-    get_manager().check_version()
-    captured = capsys.readouterr()
-    assert not captured.err
-    assert not captured.out
+    manager = get_manager()
+    mock_warning = MagicMock()
+    monkeypatch.setattr('aiida.cmdline.utils.echo.echo_warning', mock_warning)
+    monkeypatch.setattr(manager.logger, 'warning', MagicMock())
+
+    manager.check_version()
+    mock_warning.assert_not_called()
+    manager.logger.warning.assert_not_called()
 
 
 @pytest.mark.parametrize('version', ('1.0.0.dev0', '1.0.0.post0'))
 @pytest.mark.parametrize('suppress_warning', (True, False))
 @pytest.mark.usefixtures('isolated_config')
-def test_check_version_development(monkeypatch, suppress_warning, version):
-    """Test that ``Manager.check_version`` prints a warning for a development or post release version.
+def test_check_version_development(monkeypatch, suppress_warning, version, manager):
+    """Test that ``Manager.check_version`` warns for a development or post release version.
 
     The ``main`` branch carries a ``.dev0`` version and support branches a ``.post0`` version; both should trigger the
     warning. It can be suppressed by setting the option ``warnings.development_version`` to ``False``.
     """
     from unittest.mock import MagicMock
 
+    from aiida.common import log
+
     monkeypatch.setattr(aiida, '__version__', version)
 
-    manager = get_manager()
     manager._profile.set_option('warnings.development_version', not suppress_warning)
 
-    mock_warning = MagicMock()
-    monkeypatch.setattr('aiida.cmdline.utils.echo.echo_warning', mock_warning)
+    mock_echo_warning = MagicMock()
+    mock_logger_warning = MagicMock()
+    monkeypatch.setattr('aiida.cmdline.utils.echo.echo_warning', mock_echo_warning)
+    monkeypatch.setattr(manager.logger, 'warning', mock_logger_warning)
 
+    monkeypatch.setattr(log, 'CLI_ACTIVE', False)
     manager.check_version()
 
     if suppress_warning:
-        mock_warning.assert_not_called()
+        mock_echo_warning.assert_not_called()
+        mock_logger_warning.assert_not_called()
     else:
-        mock_warning.assert_called()
-        first_call_msg = mock_warning.call_args_list[0][0][0]
-        assert f'You are currently using a development version of AiiDA: {version}' in first_call_msg
+        mock_echo_warning.assert_not_called()
+        mock_logger_warning.assert_called_once()
+        first_call_msg = mock_logger_warning.call_args_list[0][0][0]
+        assert f'You are using a development version of AiiDA ({version}).' in first_call_msg
 
 
 def test_profile_context(config_with_profile, profile_factory):


### PR DESCRIPTION
When we load profile in verdi, we load the  profile only in the --profile option but click bypasses any option parsing for verdi --help . Also there was a bug that we did not load the config option from the global config but only profile so the development warning just never kicked in anymore if you did not define the flag in the profile config. Now I parse ahead of time to load the profile to load the config to check the version and decide if one should show a warning. But this is a bit brittle, because u change global state in a parse function that depends on an option that is defined elsewhere, so you need to reference this properly, so the logic is somehow connected. Also we do not have tests for uniqueness of options, so someone could by accident just overwrite the --profile option any by that breaking the load profile mechanism in the parsing, so there are now tests that validate uniqueness. But plugin developer can extend verdi (at least soon) so they need to also do this checking, so i need to add the tests as autouse fixture so they are run for workflow developers.

Regarding the latest commit f15a389f90405c0dc8bab6ee50d2ccc1d12425a0 . I ran the verdi benchmarks on [this CI run](https://github.com/agoscinski/aiida-core/actions/runs/33855076543/job/100966375506) without the changes of this PR, only changing the benchmarked command from `verdi` to `verdi profile` and  u see similar timings as we have now in this PR. I am actually surprised that the verdi CI is not flaky.