### PR TITLE
Preserve node annotations from cache

### DIFF
--- a/src/aiida/orm/nodes/node.py
+++ b/src/aiida/orm/nodes/node.py
@@ -819,8 +819,10 @@ class Node(Entity['BackendNode', NodeCollection['Node']], metaclass=AbstractNode
         if cache_node.base.links.get_outgoing(link_type=LinkType.RETURN).all():
             raise ValueError('Cannot use cache from nodes with RETURN links.')
 
-        self.label = cache_node.label
-        self.description = cache_node.description
+        if not self.label:
+            self.label = cache_node.label
+        if not self.description:
+            self.description = cache_node.description
 
         # Make sure to reinitialize the repository instance of the clone to that of the source node.
         self.base.repository._copy(cache_node.base.repository)

--- a/tests/orm/nodes/test_node.py
+++ b/tests/orm/nodes/test_node.py
@@ -978,6 +978,32 @@ class TestNodeCaching:
         assert clone.base.caching.get_cache_source() == data.uuid
         assert data.base.caching.get_hash() == clone.base.caching.get_hash()
 
+    def test_store_from_cache_preserves_label_description(self):
+        """Test storing a node from cache preserves its own label and description."""
+        data = Data(label='source label', description='source description').store()
+        clone = data.clone()
+        clone.label = 'clone label'
+        clone.description = 'clone description'
+
+        clone._store_from_cache(data)
+
+        assert clone.label == 'clone label'
+        assert clone.description == 'clone description'
+
+    def test_store_from_cache_inherits_empty_label_description(self):
+        """Test storing a node from cache inherits the label and description if empty."""
+        data = Data(label='source label', description='source description').store()
+        clone = data.clone()
+        clone.label = ''
+        clone.description = ''
+
+        assert not clone.label and not clone.description
+
+        clone._store_from_cache(data)
+
+        assert clone.label == 'source label'
+        assert clone.description == 'source description'
+
     def test_hashing_errors(self, caplog, monkeypatch):
         """Tests that ``compute_hash`` fails in an expected manner."""
         from aiida.orm.nodes.caching import NodeCaching


### PR DESCRIPTION
Fixes #7580

When storing a node from cache, preserve label and description values already set on the new node instead of overwriting them with the cache source's annotations. Empty labels/descriptions still inherit the cache source values.

Tested with:
- uv run --no-dev --with pytest --with pytest-benchmark --with pytest-cov --with pytest-instafail --with pytest-timeout --with sphinx pytest tests/orm/nodes/test_node.py -k store_from_cache
- uv tool run ruff format --check src/aiida/orm/nodes/node.py tests/orm/nodes/test_node.py
- uv tool run ruff check --ignore PLC0415 src/aiida/orm/nodes/node.py tests/orm/nodes/test_node.py
- git diff --check