### PR TITLE
🔧 Fix parallel coverage source paths

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -73,7 +73,7 @@ jobs:
         AIIDA_TEST_PROFILE: test_aiida
         AIIDA_WARN_v3: 1
       run: |
-        pytest -n auto --db-backend ${{ matrix.database-backend }} --broker-backend ${{ matrix.broker-backend }} -m 'not nightly' tests/ ${{ matrix.python-version == '3.14' && '--cov aiida' || '' }}
+        pytest -n auto --db-backend ${{ matrix.database-backend }} --broker-backend ${{ matrix.broker-backend }} -m 'not nightly' tests/ ${{ matrix.python-version == '3.14' && '--cov=src/aiida' || '' }}
 
     - name: Upload coverage report
       if: matrix.python-version == 3.14 && github.repository == 'aiidateam/aiida-core'
@@ -215,10 +215,10 @@ jobs:
       run: .github/workflows/setup_ssh.sh
 
     - name: Test new pytest fixtures
-      run: pytest -v --cov aiida --noconftest tests/tools/pytest_fixtures/
+      run: pytest -v --cov=src/aiida --noconftest tests/tools/pytest_fixtures/
 
     - name: Test legacy pytest fixtures
-      run: pytest --cov aiida --noconftest .github/test_legacy_pytest_fixtures.py
+      run: pytest --cov=src/aiida --noconftest .github/test_legacy_pytest_fixtures.py
 
     - name: Upload coverage report
       if: github.repository == 'aiidateam/aiida-core'


### PR DESCRIPTION
Pass pytest-cov the explicit src/aiida source root so xdist workers combine migration coverage correctly while retaining parallel test execution. I am not exactly sure what the exact logic is, but once u start subprocesses codecov needs the correct naming to track the changes correctly. I had the issue when including tests for the db migration and alembic was started in another process and the codecov could not track the coverage correctly. As you can see in the increase in coverage, this change improves the coverage. There are still some issues in coverage that I am investigating that are related to coverage on asynchronous tests that produce different unstable coverages.