### PR TITLE
🧪 Stabilize daemon pytest fixture tests

### DIFF
--- a/tests/tools/pytest_fixtures/test_daemon.py
+++ b/tests/tools/pytest_fixtures/test_daemon.py
@@ -1,24 +1,38 @@
 """Tests for the :mod:`aiida.tools.pytest_fixtures.daemon` module."""
 
+from aiida.engine.daemon.client import DaemonTimeoutException
+
 # This is needed when we run this file in isolation using
 # the `--noconftest` pytest option in the 'test-pytest-fixtures' CI job.
 pytest_plugins = ['aiida.tools.pytest_fixtures']
 
 
-def test_daemon_client(daemon_client):
+def test_daemon_client(stopped_daemon_client):
     """Test that the ``daemon_client`` fixture can start and stop the daemon."""
-    if daemon_client.is_daemon_running:
-        daemon_client.stop_daemon(wait=True)
+    stopped_daemon_client.start_daemon()
+    stopped_daemon_client._await_condition(
+        lambda: stopped_daemon_client.is_daemon_running,
+        DaemonTimeoutException('The daemon failed to start.'),
+    )
 
-    daemon_client.start_daemon()
-    daemon_client.stop_daemon(wait=True)
+    stopped_daemon_client.stop_daemon(wait=True)
+    stopped_daemon_client._await_condition(
+        lambda: not stopped_daemon_client.is_daemon_running,
+        DaemonTimeoutException('The daemon failed to stop.'),
+    )
 
 
 def test_started_daemon_client(started_daemon_client):
     """Test that the ``started_daemon_client`` fixture starts the daemon."""
-    assert started_daemon_client.is_daemon_running
+    started_daemon_client._await_condition(
+        lambda: started_daemon_client.is_daemon_running,
+        DaemonTimeoutException('The daemon failed to start.'),
+    )
 
 
 def test_stopped_daemon_client(stopped_daemon_client):
     """Test that the ``stopped_daemon_client`` fixture stops the daemon."""
-    assert not stopped_daemon_client.is_daemon_running
+    stopped_daemon_client._await_condition(
+        lambda: not stopped_daemon_client.is_daemon_running,
+        DaemonTimeoutException('The daemon failed to stop.'),
+    )


### PR DESCRIPTION
Wait for daemon state transitions instead of relying on immediate status checks, which can race with Circus process shutdown.