### PR TITLE
🐛 Fix flaky behavior in pytest fixtures due to reset storage and timeouts

### DIFF
--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -168,9 +168,10 @@ def aiida_profile_factory():
                     except DaemonException:
                         pass
 
-            default_user_email = config.get_profile(profile.name).default_user_email or email
-            manager.get_profile_storage()._clear()
-            manager.reset_profile()
+            active_profile = manager.get_profile()
+            if active_profile is None or active_profile.name != profile.name:
+                active_profile = config.get_profile(profile.name)
+            default_user_email = active_profile.default_user_email or email
 
             User(email=default_user_email).store()
 

--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -168,10 +168,11 @@ def aiida_profile_factory():
                     except DaemonException:
                         pass
 
+            default_user_email = config.get_profile(profile.name).default_user_email or email
             manager.get_profile_storage()._clear()
             manager.reset_profile()
 
-            User(email=profile.default_user_email or email).store()
+            User(email=default_user_email).store()
 
         # Add the ``reset_storage`` method, such that users can empty the storage through the ``Profile`` instance that
         # is returned by this fixture.

--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -159,21 +159,28 @@ def aiida_profile_factory():
             from aiida.engine.daemon.client import DaemonException, get_daemon_client
             from aiida.orm import User
 
-            if broker_backend:
-                daemon_client = get_daemon_client()
-
-                if daemon_client.is_daemon_running:
-                    try:
-                        daemon_client.stop_daemon(wait=True)
-                    except DaemonException:
-                        pass
-
             active_profile = manager.get_profile()
-            if active_profile is None or active_profile.name != profile.name:
-                active_profile = config.get_profile(profile.name)
-            default_user_email = active_profile.default_user_email or email
+            target_profile = (
+                active_profile
+                if active_profile is not None and active_profile.name == profile.name
+                else config.get_profile(profile.name)
+            )
 
-            User(email=default_user_email).store()
+            with profile_context(target_profile, allow_switch=True):
+                if broker_backend:
+                    daemon_client = get_daemon_client()
+
+                    if daemon_client.is_daemon_running:
+                        try:
+                            daemon_client.stop_daemon(wait=True)
+                        except DaemonException:
+                            pass
+
+                default_user_email = target_profile.default_user_email or email
+                manager.get_profile_storage()._clear()
+                manager.reset_profile()
+
+                User(email=default_user_email).store()
 
         # Add the ``reset_storage`` method, such that users can empty the storage through the ``Profile`` instance that
         # is returned by this fixture.

--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -6,6 +6,7 @@ import contextlib
 import os
 import pathlib
 import secrets
+import time
 import typing as t
 
 import pytest
@@ -156,7 +157,7 @@ def aiida_profile_factory():
             This ensures that the contents of the profile are reset as well as the ``Manager``, which may hold
             references to data that will be destroyed. The daemon will also be stopped if it was running.
             """
-            from aiida.engine.daemon.client import DaemonException, get_daemon_client
+            from aiida.engine.daemon.client import DaemonException, DaemonTimeoutException, get_daemon_client
             from aiida.orm import User
 
             active_profile = manager.get_profile()
@@ -175,6 +176,17 @@ def aiida_profile_factory():
                             daemon_client.stop_daemon(wait=True)
                         except DaemonException:
                             pass
+
+                        # ``stop_daemon(wait=True)`` returns once the stop is requested, but the
+                        # daemon process may still be shutting down and briefly report as running.
+                        # Wait until it is confirmed stopped so reset does not clear storage
+                        # underneath a live worker that retains the old default user.
+                        start_time = time.monotonic()
+                        while daemon_client.is_daemon_running:
+                            if time.monotonic() - start_time > 5:
+                                msg = 'The daemon failed to stop before resetting storage.'
+                                raise DaemonTimeoutException(msg)
+                            time.sleep(0.1)
 
                 default_user_email = target_profile.default_user_email or email
                 manager.get_profile_storage()._clear()

--- a/tests/brokers/test_zeromq_communicator.py
+++ b/tests/brokers/test_zeromq_communicator.py
@@ -11,6 +11,8 @@
 from __future__ import annotations
 
 import time
+import typing as t
+from collections.abc import Callable
 from concurrent.futures import Future
 from pathlib import Path
 
@@ -40,6 +42,50 @@ def get_router_endpoint(broker: ZeromqBroker) -> str:
     """Construct the router endpoint from the broker service socket file."""
     sockets_path = Path((broker._service_dir / 'broker.sockets').read_text().strip())
     return f'ipc://{sockets_path}/router.sock'
+
+
+T = t.TypeVar('T')
+
+
+def await_condition(condition: Callable[[], T], *, timeout: float = 5.0, interval: float = 0.05) -> T:
+    """Poll ``condition`` until it returns a truthy value or raise on timeout.
+
+    Mirrors :meth:`aiida.engine.daemon.client.DaemonClient._await_condition` (which is
+    private and daemon-specific, so not reusable here) and the ``await_condition`` helper
+    in ``tests/cmdline/commands/test_process.py``.
+    """
+    start_time = time.monotonic()
+    while not (result := condition()):
+        if time.monotonic() - start_time > timeout:
+            raise TimeoutError(f'Condition {condition} did not become truthy within {timeout} seconds.')
+        time.sleep(interval)
+    return result
+
+
+def rpc_send_and_await(sender: ZeromqCommunicator, recipient: str, message: t.Any, *, timeout: float = 5.0) -> t.Any:
+    """Send an RPC and await the response, retrying while the broker registration is pending.
+
+    The ``SUBSCRIBE_RPC`` message is processed by the broker asynchronously, so an RPC sent
+    immediately after subscribing may fail with ``Recipient not found``. Retry until the broker
+    has registered the subscriber or the deadline expires. Other errors are re-raised immediately.
+    """
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while True:
+        future = sender.rpc_send(recipient, message)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            msg = f'RPC to {recipient!r} did not succeed within {timeout} seconds.'
+            raise TimeoutError(msg) from last_error
+        try:
+            return future.result(timeout=remaining)
+        # The broker surfaces errors as a generic ``Exception`` with a string payload, so the payload
+        # must be inspected to distinguish a pending registration from a genuine handler failure.
+        except Exception as exc:
+            if not isinstance(exc, TimeoutError) and 'Recipient not found' not in str(exc):
+                raise
+            last_error = exc
+            time.sleep(0.05)
 
 
 class TestZeromqCommunicatorLifecycle:
@@ -240,8 +286,9 @@ class TestZeromqCommunicatorRoundTrip:
         """
         sender, worker = sender_and_worker
 
+        # No wait needed: the broker persists the task and acks immediately, dispatching
+        # to the worker once its subscription arrives.
         worker.add_task_subscriber(lambda comm, body: body.get('x', 0) * 2, identifier='worker')
-        time.sleep(0.5)
 
         future = sender.task_send({'x': 21})
         assert future is not None
@@ -258,10 +305,8 @@ class TestZeromqCommunicatorRoundTrip:
             return f'echo: {msg}'
 
         worker.add_rpc_subscriber(handle_rpc, identifier='echo-service')
-        time.sleep(0.5)
 
-        future = sender.rpc_send('echo-service', 'hello')
-        result = future.result(timeout=5.0)
+        result = rpc_send_and_await(sender, 'echo-service', 'hello')
         assert result == 'echo: hello'
 
     def test_broadcast_round_trip(self, sender_and_worker):
@@ -274,12 +319,15 @@ class TestZeromqCommunicatorRoundTrip:
 
         worker.add_broadcast_subscriber(on_broadcast, identifier='listener')
         worker.add_task_subscriber(lambda c, t: None, identifier='worker')
-        time.sleep(0.5)
 
-        sender.broadcast_send(body='ping', subject='test.ping')
-        time.sleep(1.0)
-
-        assert len(received) >= 1
+        # Broadcasts are fire-and-forget: if the worker's subscription has not reached the
+        # broker yet, a single send is dropped. Re-send until receipt or timeout.
+        deadline = time.monotonic() + 5.0
+        while not received:
+            sender.broadcast_send(body='ping', subject='test.ping')
+            time.sleep(0.1)
+            if time.monotonic() >= deadline:
+                raise TimeoutError('Broadcast was not received within 5 seconds.')
         assert received[0] == ('ping', 'test.ping')
 
     def test_task_with_deferred_future(self, sender_and_worker):
@@ -291,8 +339,8 @@ class TestZeromqCommunicatorRoundTrip:
             f.set_result(body.get('val', 0) + 100)
             return f
 
+        # No wait needed: the broker persists the task and acks immediately (see above).
         worker.add_task_subscriber(handle_task, identifier='worker')
-        time.sleep(0.5)
 
         future = sender.task_send({'val': 5})
         # Sender gets immediate zeromq_broker acknowledgment, not the worker's deferred result
@@ -309,10 +357,8 @@ class TestZeromqCommunicatorRoundTrip:
             return f
 
         worker.add_rpc_subscriber(handle_rpc, identifier='deferred-svc')
-        time.sleep(0.5)
 
-        future = sender.rpc_send('deferred-svc', 'test')
-        result = future.result(timeout=5.0)
+        result = rpc_send_and_await(sender, 'deferred-svc', 'test')
         assert result == 'deferred: test'
 
     def test_rpc_subscriber_exception(self, sender_and_worker):
@@ -323,8 +369,20 @@ class TestZeromqCommunicatorRoundTrip:
             raise ValueError('handler error')
 
         worker.add_rpc_subscriber(handle_rpc, identifier='error-svc')
-        time.sleep(0.5)
 
-        future = sender.rpc_send('error-svc', 'test')
-        with pytest.raises(Exception, match='handler error'):
-            future.result(timeout=5.0)
+        # Retry while the subscription is still propagating; only the handler error is expected.
+        # The inner timeout is deliberately shorter than the outer one to allow retries.
+        def rpc_raises_handler_error():
+            future = sender.rpc_send('error-svc', 'test')
+            try:
+                future.result(timeout=0.5)
+            # The broker surfaces errors as a generic ``Exception`` with a string payload.
+            except Exception as exc:
+                if 'Recipient not found' in str(exc):
+                    return False
+                if 'handler error' in str(exc):
+                    return True
+                raise
+            return False
+
+        await_condition(rpc_raises_handler_error, timeout=5.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,7 +228,9 @@ def capture_aiida_and_verdi_logs(request, monkeypatch):
 
 
 @pytest.fixture(scope='session')
-def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql_dos, config_sqlite_dos):
+def aiida_profile(
+    pytestconfig, tmp_path_factory, aiida_config, aiida_profile_factory, config_psql_dos, config_sqlite_dos
+):
     """Create and load a profile with the specified storage and broker backends.
 
     This overrides the ``aiida_profile`` fixture provided by ``aiida-core`` which runs with ``core.sqlite_dos`` and
@@ -257,7 +259,8 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
 
     if db_backend is TestDbBackend.SQLITE:
         storage = 'core.sqlite_dos'
-        config = config_sqlite_dos()
+        worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+        config = config_sqlite_dos(tmp_path_factory.mktemp(f'test_sqlite_dos_storage_{worker_id}'))
     elif db_backend is TestDbBackend.PSQL:
         storage = 'core.psql_dos'
         config = config_psql_dos()

--- a/tests/tools/pytest_fixtures/test_configuration.py
+++ b/tests/tools/pytest_fixtures/test_configuration.py
@@ -60,12 +60,12 @@ def test_aiida_profile_tmp(aiida_profile, aiida_profile_tmp):
     assert aiida_profile_tmp.uuid != aiida_profile.uuid
 
 
-def test_profile_reset_storage_uses_configured_default_user(aiida_profile_tmp):
-    """Test that resetting a profile honours a default user changed through its configuration."""
-    config = get_config()
-    configured_profile = config.get_profile(aiida_profile_tmp.name)
-    configured_profile.default_user_email = 'updated@localhost'
-    config.store()
+def test_profile_reset_storage_uses_active_default_user(aiida_profile_tmp):
+    """Test that resetting a profile honours its active default user."""
+    from aiida.manage import get_manager
+
+    user = orm.User(email='updated@localhost').store()
+    get_manager().set_default_user_email(aiida_profile_tmp, user.email)
 
     aiida_profile_tmp.reset_storage()
 

--- a/tests/tools/pytest_fixtures/test_configuration.py
+++ b/tests/tools/pytest_fixtures/test_configuration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from aiida import orm
 from aiida.manage.configuration import get_config, load_config
 from aiida.manage.configuration.settings import DEFAULT_CONFIG_FILE_NAME
 
@@ -57,6 +58,18 @@ def test_aiida_profile_tmp(aiida_profile, aiida_profile_tmp):
     assert isinstance(aiida_profile_tmp, Profile)
     assert aiida_profile_tmp.is_test_profile
     assert aiida_profile_tmp.uuid != aiida_profile.uuid
+
+
+def test_profile_reset_storage_uses_configured_default_user(aiida_profile_tmp):
+    """Test that resetting a profile honours a default user changed through its configuration."""
+    config = get_config()
+    configured_profile = config.get_profile(aiida_profile_tmp.name)
+    configured_profile.default_user_email = 'updated@localhost'
+    config.store()
+
+    aiida_profile_tmp.reset_storage()
+
+    assert orm.User.collection.get_default().email == 'updated@localhost'
 
 
 @pytest.mark.requires_psql

--- a/tests/tools/pytest_fixtures/test_configuration.py
+++ b/tests/tools/pytest_fixtures/test_configuration.py
@@ -72,6 +72,17 @@ def test_profile_reset_storage_uses_active_default_user(aiida_profile_tmp):
     assert orm.User.collection.get_default().email == 'updated@localhost'
 
 
+def test_profile_reset_storage_isolates_inactive_profile(aiida_config, aiida_profile_factory):
+    """Test that resetting an inactive profile leaves the active storage unchanged."""
+    with aiida_profile_factory(aiida_config, email='active@localhost'):
+        with aiida_profile_factory(aiida_config, email='inactive@localhost') as inactive_profile:
+            pass
+
+        inactive_profile.reset_storage()
+
+        assert orm.User.collection.get_default().email == 'active@localhost'
+
+
 @pytest.mark.requires_psql
 def test_aiida_profile_factory_psql_dos(aiida_config, aiida_profile_factory, config_psql_dos):
     """Test that the factory creates and resets a ``core.psql_dos`` profile."""


### PR DESCRIPTION
It does not only contain changes in pytest fixtures but because I recently merged the legacy pytest fixture tests into the new ones https://github.com/aiidateam/aiida-core/pull/7623, a lot of flakiness of these test got into our total test suite. My understanding is that because we now have legacy pytest fixtures and new pytest fixtures in one test, the chance of flaky behavior increased. That is why this behavior only appeared after the integration. But its all hard to rationally grasp because this flaky behavior is nondeterministic. In the end I mainly check if the changes made sense and if they remove the errors when running CI repeatedly. There are probably still some inherent logically mistakes we have in the tests and these are more like fixes on the surface but I cannot spend more time on this. These fixes remove the flakiness in my other PRs.