### PR TITLE
Scope daemon start/stops function-wise instead of whole session

### DIFF
--- a/src/aiida/tools/pytest_fixtures/daemon.py
+++ b/src/aiida/tools/pytest_fixtures/daemon.py
@@ -2,16 +2,85 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import pathlib
 import typing as t
 
+import psutil
 import pytest
 
 if t.TYPE_CHECKING:
     from aiida.engine import Process, ProcessBuilder
     from aiida.engine.daemon.client import DaemonClient
     from aiida.orm import ProcessNode
+
+LOGGER = logging.getLogger('tests.daemon')
+
+
+def _kill_daemon_processes(daemon_client: DaemonClient) -> None:
+    """Forcefully terminate leftover daemon processes after a graceful stop failed.
+
+    A wedged circus keeps its PID file, so ``is_daemon_running`` stays ``True`` and every later stop, start or
+    status call fails, poisoning all remaining tests on the worker. SIGKILL the circus process tree identified
+    through the PID file and clean up its runtime files best-effort, so the next start begins from scratch.
+    Never raises: callers fall through to a fresh start or report the original timeout.
+    """
+    from aiida.engine.daemon.client import DaemonException
+
+    pid = daemon_client.get_daemon_pid()
+    process = None
+    if pid is not None:
+        try:
+            # Raises if the PID is stale or recycled, in which case it must never be killed.
+            daemon_client._check_pid_file()
+            process = psutil.Process(pid)
+        except DaemonException:
+            process = None
+        except psutil.NoSuchProcess:
+            process = None
+
+    if process is not None:
+        try:
+            targets = [process, *process.children(recursive=True)]
+            for target in targets:
+                with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                    target.kill()
+            _, alive = psutil.wait_procs(targets, timeout=10)
+            for target in alive:
+                with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                    LOGGER.warning('Daemon process survived SIGKILL: pid=%s cmdline=%s', target.pid, target.cmdline())
+        except Exception as exception:  # best-effort cleanup must never raise
+            LOGGER.warning('Failed to kill leftover daemon processes: %s', exception)
+
+    with contextlib.suppress(OSError):
+        pathlib.Path(daemon_client.circus_pid_file).unlink(missing_ok=True)
+    with contextlib.suppress(OSError):
+        daemon_client.delete_circus_socket_directory()
+
+
+def _stop_daemon(daemon_client: DaemonClient, message: str) -> None:
+    """Stop the daemon, forcefully killing leftovers if graceful shutdown fails.
+
+    A wedged circus keeps its PID file, so without the kill fallback every later stop, start or status call on
+    the worker fails and poisons all remaining tests. Fail fast with the default timeout: consumers are marked
+    non-strict xfail where flakiness is expected, so a slow stop still passes within the window.
+    """
+    from aiida.engine.daemon.client import DaemonException, DaemonTimeoutException
+
+    if not daemon_client.is_daemon_running:
+        return
+    try:
+        daemon_client.stop_daemon(wait=True)
+        # Give an additional grace period by manually waiting for the daemon to be stopped. In certain unit test
+        # scenarios, the built in wait time in ``daemon_client.stop_daemon`` is not sufficient and even though the
+        # daemon is stopped, ``daemon_client.is_daemon_running`` will return false for a little bit longer.
+        daemon_client._await_condition(
+            lambda: not daemon_client.is_daemon_running,
+            DaemonTimeoutException(message),
+        )
+    except DaemonException:
+        _kill_daemon_processes(daemon_client)
 
 
 @pytest.fixture(scope='session')
@@ -28,24 +97,13 @@ def daemon_client(aiida_profile):
 
     """
     from aiida.engine.daemon import get_daemon_client
-    from aiida.engine.daemon.client import DaemonNotRunningException, DaemonTimeoutException
 
     daemon_client = get_daemon_client(aiida_profile.name)
 
     try:
         yield daemon_client
     finally:
-        try:
-            daemon_client.stop_daemon(wait=True)
-        except DaemonNotRunningException:
-            pass
-        # Give an additional grace period by manually waiting for the daemon to be stopped. In certain unit test
-        # scenarios, the built in wait time in ``daemon_client.stop_daemon`` is not sufficient and even though the
-        # daemon is stopped, ``daemon_client.is_daemon_running`` will return false for a little bit longer.
-        daemon_client._await_condition(
-            lambda: not daemon_client.is_daemon_running,
-            DaemonTimeoutException('The daemon failed to stop.'),
-        )
+        _stop_daemon(daemon_client, 'The daemon failed to stop.')
 
 
 @pytest.fixture
@@ -62,19 +120,7 @@ def started_daemon_client(daemon_client: DaemonClient):
             assert started_daemon_client.is_daemon_running
 
     """
-    from aiida.engine.daemon.client import DaemonTimeoutException
-
-    if daemon_client.is_daemon_running:
-        daemon_client.stop_daemon(wait=True)
-        # Give an additional grace period by manually waiting for the daemon to be stopped. In certain unit test
-        # scenarios, the built in wait time in ``daemon_client.stop_daemon`` is not sufficient and even though the
-        # daemon is stopped, ``daemon_client.is_daemon_running`` will return false for a little bit longer.
-        # Fail fast with the default timeout: every consumer of this fixture is marked non-strict xfail, so a
-        # wedged daemon is reported without burning suite time, while a slow stop still passes within the window.
-        daemon_client._await_condition(
-            lambda: not daemon_client.is_daemon_running,
-            DaemonTimeoutException('The daemon failed to stop before restarting.'),
-        )
+    _stop_daemon(daemon_client, 'The daemon failed to stop before restarting.')
     daemon_client.start_daemon()
     assert daemon_client.is_daemon_running
 
@@ -94,17 +140,7 @@ def stopped_daemon_client(daemon_client: DaemonClient):
             assert not stopped_daemon_client.is_daemon_running
 
     """
-    from aiida.engine.daemon.client import DaemonTimeoutException
-
-    if daemon_client.is_daemon_running:
-        daemon_client.stop_daemon(wait=True)
-        # Give an additional grace period by manually waiting for the daemon to be stopped. In certain unit test
-        # scenarios, the built in wait time in ``daemon_client.stop_daemon`` is not sufficient and even though the
-        # daemon is stopped, ``daemon_client.is_daemon_running`` will return false for a little bit longer.
-        daemon_client._await_condition(
-            lambda: not daemon_client.is_daemon_running,
-            DaemonTimeoutException('The daemon failed to stop.'),
-        )
+    _stop_daemon(daemon_client, 'The daemon failed to stop.')
 
     yield daemon_client
 

--- a/src/aiida/tools/pytest_fixtures/daemon.py
+++ b/src/aiida/tools/pytest_fixtures/daemon.py
@@ -50,7 +50,11 @@ def daemon_client(aiida_profile):
 
 @pytest.fixture
 def started_daemon_client(daemon_client: DaemonClient):
-    """Ensure that the daemon is running for the test profile and return the associated client.
+    """Ensure a freshly restarted daemon for the test profile and return the associated client.
+
+    The daemon caches profile state at startup, so a worker left running by an earlier test may no longer match
+    the current profile. Restarting per test trades ~1s of runtime for a worker that always matches the test.
+    Tests that only need the client should use ``daemon_client`` to avoid the restart cost.
 
     Usage::
 
@@ -58,9 +62,21 @@ def started_daemon_client(daemon_client: DaemonClient):
             assert started_daemon_client.is_daemon_running
 
     """
-    if not daemon_client.is_daemon_running:
-        daemon_client.start_daemon()
-        assert daemon_client.is_daemon_running
+    from aiida.engine.daemon.client import DaemonTimeoutException
+
+    if daemon_client.is_daemon_running:
+        daemon_client.stop_daemon(wait=True)
+        # Give an additional grace period by manually waiting for the daemon to be stopped. In certain unit test
+        # scenarios, the built in wait time in ``daemon_client.stop_daemon`` is not sufficient and even though the
+        # daemon is stopped, ``daemon_client.is_daemon_running`` will return false for a little bit longer.
+        # Fail fast with the default timeout: every consumer of this fixture is marked non-strict xfail, so a
+        # wedged daemon is reported without burning suite time, while a slow stop still passes within the window.
+        daemon_client._await_condition(
+            lambda: not daemon_client.is_daemon_running,
+            DaemonTimeoutException('The daemon failed to stop before restarting.'),
+        )
+    daemon_client.start_daemon()
+    assert daemon_client.is_daemon_running
 
     logger = logging.getLogger('tests.daemon:started_daemon_client')
     logger.debug(f'Daemon log file is located at: {daemon_client.daemon_log_file}')

--- a/tests/benchmark/test_engine.py
+++ b/tests/benchmark/test_engine.py
@@ -128,6 +128,7 @@ def test_workchain_local(benchmark, aiida_localhost, workchain, iterations, outg
 @pytest.mark.parametrize('workchain,iterations,outgoing', WORKCHAINS.values(), ids=WORKCHAINS.keys())
 @pytest.mark.usefixtures('started_daemon_client')
 @pytest.mark.benchmark(group='engine')
+@pytest.mark.flaky(reruns=2)
 def test_workchain_daemon(benchmark, submit_and_await, aiida_localhost, workchain, iterations, outgoing):
     """Benchmark Workchains, executed in the via a daemon runner."""
     code = InstalledCode(

--- a/tests/brokers/test_rabbitmq.py
+++ b/tests/brokers/test_rabbitmq.py
@@ -252,6 +252,7 @@ def test_add_broadcast_subscriber(communicator):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
+@pytest.mark.flaky(reruns=2)
 def test_duplicate_subscriber_identifier(aiida_code_installed, started_daemon_client, submit_and_await):
     """Test that a ``DuplicateSubscriberError`` in ``ProcessLauncher._continue`` does not except the process.
 

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -404,6 +404,7 @@ def test_build_process_label(generate_shell_calc_job, generate_shell_code):
     assert process._build_process_label() == f'ShellJob<{code.full_label}>'
 
 
+@pytest.mark.flaky(reruns=2)
 def test_submit_to_daemon(generate_shell_code, submit_and_await):
     """Test submitting a ``ShellJob`` to the daemon."""
     builder = generate_shell_code('echo').get_builder()
@@ -456,6 +457,7 @@ def test_parser_invalid_signature(generate_shell_calc_job, generate_shell_code):
         generate_shell_calc_job('core.shell', inputs={'code': generate_shell_code(), 'parser': lambda x: x})
 
 
+@pytest.mark.flaky(reruns=2)
 def test_parser_over_daemon(generate_shell_code, submit_and_await):
     """Test submitting a ``ShellJob`` with a custom parser over the daemon."""
     value = 'testing'

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -53,6 +53,7 @@ def test_daemon_start(run_cli_command, stopped_daemon_client):
 
 
 @pytest.mark.parametrize('options', ([], ['--reset']))
+@pytest.mark.flaky(reruns=2)
 def test_daemon_restart(run_cli_command, started_daemon_client, options):
     """Test ``verdi daemon restart`` both with and without ``--reset`` flag."""
     run_cli_command(cmd_daemon.restart, options)
@@ -102,6 +103,7 @@ def test_daemon_start_number_config(run_cli_command, stopped_daemon_client, isol
     )
 
 
+@pytest.mark.flaky(reruns=2)
 def test_daemon_stop(run_cli_command, started_daemon_client):
     """Test ``verdi daemon stop``."""
     result = run_cli_command(cmd_daemon.stop)
@@ -121,6 +123,7 @@ def test_foreground_multiple_workers(run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client', 'isolated_config')
+@pytest.mark.flaky(reruns=2)
 def test_daemon_status(run_cli_command):
     """Test ``verdi daemon status``."""
     result = run_cli_command(cmd_daemon.status)
@@ -163,6 +166,7 @@ def test_daemon_status_no_broker(run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client', 'isolated_config')
+@pytest.mark.flaky(reruns=2)
 def test_daemon_status_timeout(run_cli_command):
     """Test ``verdi daemon status`` with the ``--timeout`` option.
 

--- a/tests/cmdline/commands/test_devel.py
+++ b/tests/cmdline/commands/test_devel.py
@@ -40,6 +40,7 @@ def test_launch_add(run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_launch_add_daemon(run_cli_command, submit_and_await):
     """Test ``verdi devel launch-add`` with the ``--daemon`` flag."""
     result = run_cli_command(cmd_devel.devel_launch_arithmetic_add, ['--daemon'])
@@ -76,6 +77,7 @@ def test_launch_multiply_add(run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_launch_multiply_add_daemon(run_cli_command, submit_and_await):
     """Test ``verdi devel launch-multiply-add`` with the ``--daemon`` flag."""
     result = run_cli_command(cmd_devel.devel_launch_multiply_add, ['--daemon'])

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -182,6 +182,7 @@ def test_process_kill_failing_transport(
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_process_kill_failing_transport_failed_kill(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
 ):
@@ -888,6 +889,7 @@ class TestVerdiProcessCallRoot:
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_process_pause(submit_and_await, run_cli_command):
     """Test the ``verdi process pause`` command."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -905,6 +907,7 @@ def test_process_pause(submit_and_await, run_cli_command):
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_process_play(submit_and_await, run_cli_command):
     """Test the ``verdi process play`` command."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -924,6 +927,7 @@ def test_process_play(submit_and_await, run_cli_command):
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_process_play_all(submit_and_await, run_cli_command):
     """Test the ``verdi process play`` command with the ``--all`` option."""
     node_one = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -1009,6 +1013,7 @@ def test_process_kill(submit_and_await, run_cli_command, aiida_code_installed):
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_process_kill_all(submit_and_await, run_cli_command):
     """Test the ``verdi process kill --all`` command."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -1019,6 +1024,7 @@ def test_process_kill_all(submit_and_await, run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_process_repair_running_daemon(run_cli_command):
     """Test the ``verdi process repair`` command excepts when the daemon is running."""
     result = run_cli_command(cmd_process.process_repair, raises=True, use_subprocess=False)

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -1058,10 +1058,27 @@ def test_process_repair_additional_tasks(monkeypatch, run_cli_command):
     monkeypatch.setattr(process_control, 'get_active_processes', lambda *args, **kwargs: [1, 2])
     monkeypatch.setattr(process_control, 'get_process_tasks', lambda *args: [1, 2, 3])
 
+    acknowledged = []
+
+    class FakeOutcome:
+        def set_result(self, value):
+            acknowledged.append(value)
+
+    class FakeTask:
+        body = {'args': {'pid': 3}}
+
+        @contextmanager
+        def processing(self):
+            yield FakeOutcome()
+
+    monkeypatch.setattr(process_control, 'iterate_process_tasks', lambda *args: [FakeTask()])
+
     result = run_cli_command(cmd_process.process_repair, use_subprocess=False)
     assert 'There are process tasks for terminated processes:' in result.output
     assert 'Inconsistencies detected between database and broker.' in result.output
     assert 'Attempting to fix inconsistencies' in result.output
+    assert 'Acknowledged task `3`' in result.output
+    assert acknowledged == [False]
 
 
 @pytest.mark.usefixtures('stopped_daemon_client')

--- a/tests/cmdline/commands/test_rabbitmq.py
+++ b/tests/cmdline/commands/test_rabbitmq.py
@@ -25,6 +25,7 @@ def test_queues_list(run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_tasks_list_running_daemon(run_cli_command):
     """Test the ``tasks list`` command excepts when the daemon is running."""
     result = run_cli_command(cmd_rabbitmq.cmd_tasks_list, raises=True)
@@ -41,6 +42,7 @@ def test_tasks_list(monkeypatch, run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_tasks_analyze_running_daemon(run_cli_command):
     """Test the ``tasks analyze`` command excepts when the daemon is running.
 
@@ -70,6 +72,7 @@ def test_tasks_revive_without_daemon(run_cli_command):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
+@pytest.mark.flaky(reruns=2)
 def test_revive(run_cli_command, monkeypatch, aiida_code_installed, submit_and_await):
     """Test ``tasks revive``."""
     code = aiida_code_installed(default_calc_job_plugin='core.arithmetic.add', filepath_executable='/bin/bash')

--- a/tests/cmdline/commands/test_storage.py
+++ b/tests/cmdline/commands/test_storage.py
@@ -88,6 +88,7 @@ def tests_storage_migrate_interactive(run_cli_command):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def tests_storage_migrate_running_daemon(run_cli_command):
     """Test that ``verdi storage migrate`` raises if the daemon is running."""
     result = run_cli_command(cmd_storage.storage_migrate, raises=True)

--- a/tests/cmdline/commands/test_user.py
+++ b/tests/cmdline/commands/test_user.py
@@ -28,7 +28,7 @@ def create_user():
     }
 
 
-@pytest.mark.usefixtures('aiida_profile')
+@pytest.mark.usefixtures('aiida_profile_tmp')
 def test_user_list(run_cli_command):
     """Test `verdi user list`."""
     default_user = orm.User.collection.get_default()
@@ -36,7 +36,7 @@ def test_user_list(run_cli_command):
     assert default_user.email in result.output
 
 
-@pytest.mark.usefixtures('aiida_profile')
+@pytest.mark.usefixtures('aiida_profile_tmp')
 def test_user_configure_create(run_cli_command, create_user):
     """Create a new user with `verdi user configure`."""
     new_user = create_user
@@ -55,7 +55,7 @@ def test_user_configure_create(run_cli_command, create_user):
         assert val == getattr(user, key)
 
 
-@pytest.mark.usefixtures('aiida_profile')
+@pytest.mark.usefixtures('aiida_profile_tmp')
 def test_user_configure_update(run_cli_command, create_user):
     """Reconfigure an existing user with `verdi user configure`."""
     new_user = create_user
@@ -77,7 +77,7 @@ def test_user_configure_update(run_cli_command, create_user):
         assert val == getattr(default_user, key)
 
 
-@pytest.mark.usefixtures('aiida_profile')
+@pytest.mark.usefixtures('aiida_profile_tmp')
 def test_set_default(run_cli_command, create_user):
     """Reconfigure an existing user with `verdi user configure`."""
     new_user = orm.User(**create_user).store()

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -424,6 +424,7 @@ def test_change_workers_without_wait(started_daemon_client):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
+@pytest.mark.flaky(reruns=2)
 def test_change_workers_with_wait(started_daemon_client):
     """Test that with ``wait=True`` the workers have been spawned or stopped by the time the call returns."""
     number_workers = started_daemon_client.get_numprocesses()['numprocesses']

--- a/tests/engine/daemon/test_worker.py
+++ b/tests/engine/daemon/test_worker.py
@@ -25,6 +25,7 @@ def test_shutdown_worker(manager):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_logging_configuration(aiida_code_installed, submit_and_await):
     """Integration test to verify that the daemon has the logging properly configured including the ``DbLogHandler``.
 

--- a/tests/engine/processes/generic/test_futures.py
+++ b/tests/engine/processes/generic/test_futures.py
@@ -1,0 +1,23 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for :mod:`aiida.engine.processes.generic.futures`."""
+
+import kiwipy
+
+from aiida.engine.processes.generic.futures import unwrap_kiwi_future
+
+
+def test_unwrap_kiwi_future_cancelled():
+    """A cancelled future should cancel the unwrapping future."""
+    future: kiwipy.Future = kiwipy.Future()
+    unwrapped = unwrap_kiwi_future(future)
+
+    future.cancel()
+
+    assert unwrapped.cancelled()

--- a/tests/engine/processes/test_control.py
+++ b/tests/engine/processes/test_control.py
@@ -12,6 +12,7 @@ from tests.utils.processes import WaitProcess
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
 @pytest.mark.parametrize('action', (control.pause_processes, control.play_processes, control.kill_processes))
+@pytest.mark.flaky(reruns=2)
 def test_processes_all_exclusivity(submit_and_await, action):
     """Test that control methods raise if both ``processes`` is specified and ``all_entries=True``."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -30,6 +31,7 @@ def test_daemon_not_running(action, caplog):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_pause_processes(submit_and_await):
     """Test :func:`aiida.engine.processes.control.pause_processes`."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -41,6 +43,7 @@ def test_pause_processes(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_pause_processes_all_entries(submit_and_await):
     """Test :func:`aiida.engine.processes.control.pause_processes` with ``all_entries=True``."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -51,6 +54,7 @@ def test_pause_processes_all_entries(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_play_processes(submit_and_await):
     """Test :func:`aiida.engine.processes.control.play_processes`."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -64,6 +68,7 @@ def test_play_processes(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_play_processes_all_entries(submit_and_await):
     """Test :func:`aiida.engine.processes.control.play_processes` with ``all_entries=True``."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -77,6 +82,7 @@ def test_play_processes_all_entries(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_kill_processes(submit_and_await):
     """Test :func:`aiida.engine.processes.control.kill_processes`."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -88,6 +94,7 @@ def test_kill_processes(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_kill_processes_all_entries(submit_and_await):
     """Test :func:`aiida.engine.processes.control.kill_processes` with ``all_entries=True``."""
     node = submit_and_await(WaitProcess, ProcessState.WAITING)
@@ -98,6 +105,7 @@ def test_kill_processes_all_entries(submit_and_await):
 
 
 @pytest.mark.usefixtures('aiida_profile_clean', 'started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_revive(monkeypatch, aiida_code_installed, submit_and_await):
     """Test :func:`aiida.engine.processes.control.revive_processes`."""
     code = aiida_code_installed(default_calc_job_plugin='core.arithmetic.add', filepath_executable='/bin/bash')

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -80,6 +80,7 @@ class AddWorkChain(WorkChain):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_submit_wait(arithmetic_add_builder):
     """Test the ``wait`` argument of :meth:`aiida.engine.launch.submit`."""
     node = launch.submit(arithmetic_add_builder, wait=True, wait_interval=0.1)

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -1086,6 +1086,7 @@ class TestWorkchain:
                 assert called.base.caching.is_created_from_cache
                 assert called.base.caching.get_cache_source() in [n.uuid for n in node.called]
 
+    @pytest.mark.flaky(reruns=2)
     def test_member_calcfunction_daemon(self, entry_points, daemon_client, submit_and_await):
         """Test defining a calcfunction as a ``WorkChain`` member method submitted to the daemon."""
         entry_points.add(CalcFunctionWorkChain, 'aiida.workflows:testing.calcfunction.workchain')

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -266,6 +266,7 @@ def test_arguments_files():
     assert results['stdout'].get_content().strip() == content.split('\n', maxsplit=1)[0]
 
 
+@pytest.mark.flaky(reruns=2)
 def test_submit(submit_and_await):
     """Test the ``submit`` argument."""
     _, node = launch_shell_job('date', submit=True)
@@ -276,6 +277,7 @@ def test_submit(submit_and_await):
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_submit_inside_workchain():
     """Test the ``submit`` argument when used inside a work chain."""
     results, node = run_get_node(ShellWorkChain)
@@ -284,6 +286,7 @@ def test_submit_inside_workchain():
 
 
 @pytest.mark.usefixtures('started_daemon_client')
+@pytest.mark.flaky(reruns=2)
 def test_submit_inside_workfunction(submit_and_await):
     """Test the ``submit`` argument when used inside a work function."""
 


### PR DESCRIPTION
This adds restarts the tests for each test requiring the daemon. In principle it is not needed, if we would don't have side effects on session scoped fixtures in the tests but we have them and it is hard to detect them and fix all of them. The disadvantage is that this increases our testing time a bit because of the daemon restarts but it is not significant.  The time we loose to fix or restart flaky tests is much worse. Also an xfail is added in case the daemon is not reachable because for example the GitHub runners are overloaded again. There I added the logic to actually force kill the daemon if one stop the daemon regularly to avoid that an xfail leaves a unbound daemon process open when continuing running other tests.

There as an additional fix (third commit) that is not directly a test that is related to the daemon, but makes tests fail that start a daemon and keep it open fail because they change the session profile which is not registered when the daemon is started. Therefore these tests are changed to a function-scoped profile. With the preceding changes this should not happen anymore because the daemon would have been restarted between tests but in general it is good habit to scope tests correctly (if they change a resource of a session scope fixture and dont change it back, then they should use a function scoped fixture).