### PR TITLE
🧪 Change to correct use of usefixtures in fixtures

### DIFF
--- a/tests/cmdline/params/types/test_code.py
+++ b/tests/cmdline/params/types/test_code.py
@@ -25,8 +25,7 @@ def parameter_type():
 
 
 @pytest.fixture
-@pytest.mark.usefixtures('aiida_profile_clean')
-def setup_codes(aiida_localhost):
+def setup_codes(aiida_profile_clean, aiida_localhost):
     """Create some `Code` instances to test the `CodeParamType` parameter type for the command line infrastructure.
 
     We create an initial code with a random name and then on purpose create two code with a name that matches exactly

--- a/tests/manage/configuration/test_profile.py
+++ b/tests/manage/configuration/test_profile.py
@@ -68,8 +68,7 @@ TEST_GROUP_LABEL = 'test_profile_dump_group'
 
 
 @pytest.fixture
-@pytest.mark.usefixtures('aiida_profile_clean')
-def profile_with_minimal_data():
+def profile_with_minimal_data(aiida_profile_clean):
     """Create a profile with some test data."""
     # Get current profile
     from aiida import load_profile
@@ -88,8 +87,7 @@ def profile_with_minimal_data():
 
 
 @pytest.fixture
-@pytest.mark.usefixtures('aiida_profile_clean')
-def profile_with_actual_data(generate_calculation_node_io, generate_workchain_node_io):
+def profile_with_actual_data(aiida_profile_clean, generate_calculation_node_io, generate_workchain_node_io):
     """Create a profile with some test data."""
     # Get current profile
     from aiida import load_profile

--- a/tests/orm/nodes/process/test_process.py
+++ b/tests/orm/nodes/process/test_process.py
@@ -29,8 +29,7 @@ def test_exit_code():
 
 
 @pytest.fixture
-@pytest.mark.usefixtures('aiida_profile')
-def process_nodes():
+def process_nodes(aiida_profile):
     """Return a list of tuples of a process node and whether they should be a valid cache source."""
     entry_point = 'aiida.calculations:core.arithmetic.add'
 


### PR DESCRIPTION
`@pytest.mark.usefixtures` has no effect when applied to a fixture, so the markers on `setup_codes`, `profile_with_minimal_data`, `profile_with_actual_data` and `process_nodes` never ensured a cleaned profile and the fixtures kept starting from whatever the previous test had left behind. Requesting the fixture as an argument is what the rest of the suite does.