### PR TITLE
🧪 Replace daemon-timing xfails with flaky retries

### DIFF
--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -143,7 +143,8 @@ def await_condition(condition: t.Callable, timeout: int = 1) -> t.Any:
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_process_kill_failing_transport(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
 ):
@@ -225,7 +226,8 @@ def test_process_kill_failing_transport_failed_kill(
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_process_kill_failing_ebm_transport(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
 ):
@@ -266,7 +268,8 @@ def test_process_kill_failing_ebm_transport(
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_process_kill_failing_ebm_kill(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
 ):
@@ -937,7 +940,8 @@ def test_process_play_all(submit_and_await, run_cli_command):
 
 @pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_process_kill(submit_and_await, run_cli_command, aiida_code_installed):
     """Test the ``verdi process kill`` command.
     It tries to cover all the possible scenarios of killing a process.

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -396,7 +396,8 @@ class TestDaemonEnvInfo:
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_change_workers_without_wait(started_daemon_client):
     """Test that by default the calls return on acknowledgement, before the workers have been spawned or stopped."""
     client = started_daemon_client

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -1363,7 +1363,8 @@ def test_submit_return_exit_code(get_calcjob_builder, monkeypatch):
 
 
 @pytest.mark.requires_broker
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_and_await):
     """Test that a job can be restarted when it is launched and the daemon is restarted.
 

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -167,7 +167,8 @@ def test_await_processes_invalid():
 
 
 @pytest.mark.usefixtures('started_daemon_client')
-@pytest.mark.xfail(reason='Flaky: depends on daemon pick-up and termination timing', strict=False)
+# Flaky: depends on daemon pick-up and termination timing, retry once the daemon has settled.
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun='(?i)timed out|failed to reach')
 def test_await_processes(aiida_code_installed, caplog):
     """Test :func:`aiida.engine.launch.await_processes`."""
     builder = ArithmeticAddCalculation.get_builder()


### PR DESCRIPTION
The seven daemon-timing markers used `xfail(strict=False)`, which passes CI even when the test consistently fails and never retries. Use `pytest-rerunfailures` instead so timing flakes are retried twice after a short settle delay, while genuine assertion failures still fail fast via `only_rerun`.

There is one legitimate usage of `xfail` in the tests. A test that currently does not work but should actually work. We can fix this in the future and get rid of xfail.